### PR TITLE
[agent-e][issue #1814] Add shared CLI display renderer

### DIFF
--- a/cmd/swarm/agent_deliveries_test.go
+++ b/cmd/swarm/agent_deliveries_test.go
@@ -52,8 +52,10 @@ func TestAgentDeliveriesUsesAgentDeliveryLifecycleAndRendersRows(t *testing.T) {
 	})
 	for _, want := range []string{
 		"Agent agent-1 deliveries",
-		"delivery: delivery_id=delivery-1 event_name=platform.agent_directive event_id=event-1 run_id=run-1 entity_id=entity-1 status=delivered delivery_created_at=2026-05-18T03:01:00Z delivery_started_at=2026-05-18T03:02:00Z delivery_delivered_at=2026-05-18T03:03:00Z retry_count=1 reason_code=- last_error=-",
-		"delivery: delivery_id=delivery-2 event_name=platform.agent_followup event_id=event-2 run_id=- entity_id=- status=pending delivery_created_at=2026-05-18T03:04:00Z delivery_started_at=- delivery_delivered_at=- retry_count=0 reason_code=queued last_error=waiting",
+		"DELIVERY_ID",
+		"delivery-1   platform.agent_directive",
+		"delivery-2   platform.agent_followup",
+		"queued       waiting",
 		"next_cursor=cursor-2",
 	} {
 		if !strings.Contains(stdout.String(), want) {
@@ -90,7 +92,7 @@ func TestAgentDeliveriesEmptyResult(t *testing.T) {
 		t.Fatalf("method = %q, want agent.delivery_lifecycle", captured.Method)
 	}
 	assertAgentDeliveriesParams(t, captured.Params, map[string]any{"agent_id": "agent-1"})
-	if !strings.Contains(stdout.String(), "No deliveries match the filter.") {
+	if !strings.Contains(stdout.String(), "No deliveries match the current filters.") {
 		t.Fatalf("stdout = %q, want empty result message", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "next_cursor=") {

--- a/cmd/swarm/agents.go
+++ b/cmd/swarm/agents.go
@@ -824,13 +824,9 @@ func writeAgentListResult(out io.Writer, result agentListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Agents) == 0 {
-		fmt.Fprintln(out, "No agents match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "AGENT_ID\tROLE\tTYPE\tSTATUS\tMODEL\tMODE\tSCOPE")
+	rows := make([][]string, 0, len(result.Agents))
 	for _, agent := range result.Agents {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			agent.AgentID,
 			agent.Role,
 			agent.Type,
@@ -838,38 +834,68 @@ func writeAgentListResult(out io.Writer, result agentListResult) {
 			agent.Model,
 			agent.Mode,
 			agent.SessionScope,
-		)
+		})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "AGENT_ID", KeyColumn: true},
+			{Header: "ROLE"},
+			{Header: "TYPE"},
+			{Header: "STATUS"},
+			{Header: "MODEL"},
+			{Header: "MODE"},
+			{Header: "SCOPE"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No agents match the current filters.",
+	})
 }
 
 func writeAgentDeliveryLifecycleListResult(out io.Writer, result agentDeliveryLifecycleListResult) {
 	if out == nil {
 		return
 	}
-	fmt.Fprintf(out, "Agent %s deliveries\n", result.AgentID)
-	if len(result.Deliveries) == 0 {
-		fmt.Fprintln(out, "No deliveries match the filter.")
-	} else {
-		for _, delivery := range result.Deliveries {
-			fmt.Fprintf(out, "delivery: delivery_id=%s event_name=%s event_id=%s run_id=%s entity_id=%s status=%s delivery_created_at=%s delivery_started_at=%s delivery_delivered_at=%s retry_count=%d reason_code=%s last_error=%s\n",
-				delivery.DeliveryID,
-				delivery.EventName,
-				delivery.EventID,
-				agentOptionalStringDash(delivery.RunID),
-				agentOptionalStringDash(delivery.EntityID),
-				delivery.Status,
-				delivery.DeliveryCreatedAt,
-				agentOptionalStringDash(delivery.DeliveryStartedAt),
-				agentOptionalStringDash(delivery.DeliveryDeliveredAt),
-				*delivery.RetryCount,
-				agentDash(delivery.ReasonCode),
-				agentDash(delivery.LastError),
-			)
-		}
+	writeCLITitle(out, fmt.Sprintf("Agent %s deliveries", result.AgentID))
+	rows := make([][]string, 0, len(result.Deliveries))
+	for _, delivery := range result.Deliveries {
+		rows = append(rows, []string{
+			delivery.DeliveryID,
+			delivery.EventName,
+			delivery.EventID,
+			agentOptionalStringDash(delivery.RunID),
+			agentOptionalStringDash(delivery.EntityID),
+			delivery.Status,
+			delivery.DeliveryCreatedAt,
+			agentOptionalStringDash(delivery.DeliveryStartedAt),
+			agentOptionalStringDash(delivery.DeliveryDeliveredAt),
+			fmt.Sprintf("%d", *delivery.RetryCount),
+			agentDash(delivery.ReasonCode),
+			agentDash(delivery.LastError),
+		})
 	}
+	footers := []string{}
 	if result.NextCursor != nil {
-		fmt.Fprintf(out, "next_cursor=%s\n", strings.TrimSpace(*result.NextCursor))
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", strings.TrimSpace(*result.NextCursor)))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "DELIVERY_ID", KeyColumn: true},
+			{Header: "EVENT"},
+			{Header: "EVENT_ID", KeyColumn: true},
+			{Header: "RUN"},
+			{Header: "ENTITY"},
+			{Header: "STATUS"},
+			{Header: "DELIVERY_CREATED_AT"},
+			{Header: "DELIVERY_STARTED_AT"},
+			{Header: "DELIVERY_DELIVERED_AT"},
+			{Header: "RETRY_COUNT"},
+			{Header: "REASON_CODE"},
+			{Header: "LAST_ERROR", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No deliveries match the current filters.",
+		FooterLines:  footers,
+	})
 }
 
 func writeAgentDiagnosisResult(out io.Writer, result agentDiagnosisResult) {

--- a/cmd/swarm/agents_test.go
+++ b/cmd/swarm/agents_test.go
@@ -78,7 +78,7 @@ func TestAgentsListEmptyResult(t *testing.T) {
 	if len(captured.Params) != 0 {
 		t.Fatalf("params = %#v, want empty", captured.Params)
 	}
-	if !strings.Contains(stdout.String(), "No agents match the filter.") {
+	if !strings.Contains(stdout.String(), "No agents match the current filters.") {
 		t.Fatalf("stdout = %q, want empty message", stdout.String())
 	}
 	if strings.TrimSpace(stderr.String()) != "" {

--- a/cmd/swarm/bundle.go
+++ b/cmd/swarm/bundle.go
@@ -844,33 +844,55 @@ func writeBundleListHuman(w io.Writer, result bundleListResult) {
 	if w == nil {
 		return
 	}
-	if len(result.Bundles) == 0 {
-		fmt.Fprintln(w, "No bundles found")
-	} else {
-		for _, bundle := range result.Bundles {
-			fmt.Fprintf(w, "bundle %s agents=%d has_data=%t data_size_bytes=%d ingested_at=%s",
-				bundle.BundleHash, bundle.AgentCount, bundle.HasData, bundle.DataSizeBytes, bundle.IngestedAt)
-			if rendered := compactJSONValue(bundle.Metadata); rendered != "{}" {
-				fmt.Fprintf(w, " metadata=%s", rendered)
-			}
-			fmt.Fprintln(w)
+	rows := make([][]string, 0, len(result.Bundles))
+	for _, bundle := range result.Bundles {
+		metadata := compactJSONValue(bundle.Metadata)
+		if metadata == "{}" {
+			metadata = ""
 		}
+		rows = append(rows, []string{
+			bundle.BundleHash,
+			fmt.Sprintf("%d", bundle.AgentCount),
+			fmt.Sprintf("%t", bundle.HasData),
+			fmt.Sprintf("%d", bundle.DataSizeBytes),
+			bundle.IngestedAt,
+			metadata,
+		})
 	}
+	footers := []string{}
 	if cursor := strings.TrimSpace(result.NextCursor); cursor != "" {
-		fmt.Fprintf(w, "next_cursor=%s\n", cursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", cursor))
 	}
+	writeCLITable(w, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "BUNDLE", KeyColumn: true},
+			{Header: "AGENTS"},
+			{Header: "HAS_DATA"},
+			{Header: "DATA_SIZE_BYTES"},
+			{Header: "INGESTED_AT"},
+			{Header: "METADATA", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No bundles found. Register one: swarm bundle register <path>",
+		FooterLines:  footers,
+	})
 }
 
 func writeBundleDetailHuman(w io.Writer, result bundleDetail) {
 	if w == nil {
 		return
 	}
-	fmt.Fprintf(w, "Bundle %s\n", result.BundleHash)
-	fmt.Fprintf(w, "agents=%d has_data=%t data_size_bytes=%d ingested_at=%s\n", result.AgentCount, result.HasData, result.DataSizeBytes, result.IngestedAt)
+	writeCLITitle(w, fmt.Sprintf("Bundle %s", result.BundleHash))
+	writeCLIFieldLine(w,
+		cliDetailField{Key: "agents", Value: fmt.Sprintf("%d", result.AgentCount)},
+		cliDetailField{Key: "has_data", Value: fmt.Sprintf("%t", result.HasData)},
+		cliDetailField{Key: "data_size_bytes", Value: fmt.Sprintf("%d", result.DataSizeBytes)},
+		cliDetailField{Key: "ingested_at", Value: result.IngestedAt},
+	)
 	if rendered := compactJSONValue(result.Metadata); rendered != "{}" {
-		fmt.Fprintf(w, "metadata=%s\n", rendered)
+		writeCLIFieldLine(w, cliDetailField{Key: "metadata", Value: rendered})
 	}
-	fmt.Fprintf(w, "parsed_json=%s\n", compactJSONValue(result.ParsedJSON))
+	writeCLIFieldLine(w, cliDetailField{Key: "parsed_json", Value: compactJSONValue(result.ParsedJSON)})
 	fmt.Fprintln(w, "content_yaml:")
 	fmt.Fprintln(w, strings.TrimRight(result.ContentYAML, "\n"))
 }
@@ -879,33 +901,39 @@ func writeBundleAgentsHuman(w io.Writer, result bundleAgentsResult) {
 	if w == nil {
 		return
 	}
-	if len(result.Agents) == 0 {
-		fmt.Fprintln(w, "No bundle agents found")
-		return
-	}
+	rows := make([][]string, 0, len(result.Agents))
 	for _, agent := range result.Agents {
-		fields := []string{fmt.Sprintf("agent %s", agent.AgentID)}
-		appendKV := func(key, value string) {
-			if strings.TrimSpace(value) != "" {
-				fields = append(fields, fmt.Sprintf("%s=%s", key, value))
-			}
-		}
-		appendKV("flow_instance", agent.FlowInstance)
-		appendKV("role", agent.Role)
-		appendKV("type", agent.Type)
-		appendKV("model", agent.Model)
-		appendKV("llm_backend", agent.LLMBackend)
-		appendKV("mode", agent.Mode)
-		appendKV("session_scope", agent.SessionScope)
-		appendKV("prompt_path", agent.PromptPath)
-		if len(agent.Subscriptions) > 0 {
-			fields = append(fields, "subscriptions="+strings.Join(agent.Subscriptions, ","))
-		}
-		if len(agent.Tools) > 0 {
-			fields = append(fields, "tools="+strings.Join(agent.Tools, ","))
-		}
-		fmt.Fprintln(w, strings.Join(fields, " "))
+		rows = append(rows, []string{
+			agent.AgentID,
+			agent.FlowInstance,
+			agent.Role,
+			agent.Type,
+			agent.Model,
+			agent.LLMBackend,
+			agent.Mode,
+			agent.SessionScope,
+			agent.PromptPath,
+			strings.Join(agent.Subscriptions, ","),
+			strings.Join(agent.Tools, ","),
+		})
 	}
+	writeCLITable(w, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "AGENT", KeyColumn: true},
+			{Header: "FLOW_INSTANCE"},
+			{Header: "ROLE"},
+			{Header: "TYPE"},
+			{Header: "MODEL"},
+			{Header: "LLM_BACKEND"},
+			{Header: "MODE"},
+			{Header: "SESSION_SCOPE"},
+			{Header: "PROMPT_PATH"},
+			{Header: "SUBSCRIPTIONS", Truncatable: true},
+			{Header: "TOOLS", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No bundle agents found.",
+	})
 }
 
 func writeBundleBuildHuman(w io.Writer, report runtimecontracts.BundleBuildReport) {

--- a/cmd/swarm/bundle_test.go
+++ b/cmd/swarm/bundle_test.go
@@ -58,9 +58,9 @@ func TestBundleCommandsUseCanonicalRPCAndRender(t *testing.T) {
 		args       []string
 		wantStdout []string
 	}{
-		{args: []string{"bundle", "list", "--limit", "2", "--cursor", "bundle-cursor-1"}, wantStdout: []string{"bundle " + bundleHash, "agents=2", "next_cursor=bundle-cursor-2"}},
+		{args: []string{"bundle", "list", "--limit", "2", "--cursor", "bundle-cursor-1"}, wantStdout: []string{bundleHash, "AGENTS", "2", "next_cursor=bundle-cursor-2"}},
 		{args: []string{"bundle", "show", bundleHash}, wantStdout: []string{"Bundle " + bundleHash, "content_yaml:", "agents:"}},
-		{args: []string{"bundle", "agents", bundleHash}, wantStdout: []string{"agent agent-alpha", "role=researcher", "model=regular", "subscriptions=scan.requested"}},
+		{args: []string{"bundle", "agents", bundleHash}, wantStdout: []string{"AGENT", "agent-alpha", "researcher", "regular", "scan.requested"}},
 	}
 	for _, command := range commands {
 		var stdout, stderr bytes.Buffer

--- a/cmd/swarm/cli_output.go
+++ b/cmd/swarm/cli_output.go
@@ -7,8 +7,11 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 const (
@@ -30,6 +33,49 @@ type cliTextRenderer func(io.Writer)
 type cliQuietRenderer func() ([]string, error)
 
 var cliANSISequencePattern = regexp.MustCompile("\x1b\\[[0-?]*[ -/]*[@-~]")
+
+type cliDisplayPolicy struct {
+	Color bool
+	Emoji bool
+}
+
+type cliTextOutputWriter struct {
+	out    io.Writer
+	policy cliDisplayPolicy
+}
+
+func (w cliTextOutputWriter) Write(p []byte) (int, error) {
+	if w.out == nil {
+		return len(p), nil
+	}
+	return w.out.Write(p)
+}
+
+func (w cliTextOutputWriter) displayPolicy() cliDisplayPolicy {
+	return w.policy
+}
+
+type cliDisplayPolicyProvider interface {
+	displayPolicy() cliDisplayPolicy
+}
+
+type cliTableColumn struct {
+	Header      string
+	KeyColumn   bool
+	Truncatable bool
+}
+
+type cliTable struct {
+	Columns      []cliTableColumn
+	Rows         [][]string
+	EmptyMessage string
+	FooterLines  []string
+}
+
+type cliDetailField struct {
+	Key   string
+	Value string
+}
 
 func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
 	cmd.Flags().BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
@@ -59,10 +105,15 @@ func (opts cliOutputOptions) colorDisabled() bool {
 }
 
 func (opts cliOutputOptions) textWriter(out io.Writer) io.Writer {
-	if !opts.colorDisabled() {
-		return out
+	policy := cliDisplayPolicy{
+		Color: !opts.colorDisabled() && cliOutputIsTerminal(out),
+		Emoji: !opts.colorDisabled() && cliOutputIsTerminal(out),
 	}
-	return cliANSITextWriter{out: out}
+	writer := out
+	if opts.colorDisabled() {
+		writer = cliANSITextWriter{out: out}
+	}
+	return cliTextOutputWriter{out: writer, policy: policy}
 }
 
 type cliANSITextWriter struct {
@@ -81,6 +132,150 @@ func (w cliANSITextWriter) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	return len(p), nil
+}
+
+func cliOutputIsTerminal(out io.Writer) bool {
+	file, ok := out.(*os.File)
+	if !ok || file == nil {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
+}
+
+func cliWriterDisplayPolicy(out io.Writer) cliDisplayPolicy {
+	if provider, ok := out.(cliDisplayPolicyProvider); ok {
+		return provider.displayPolicy()
+	}
+	return cliDisplayPolicy{}
+}
+
+func writeCLITable(out io.Writer, table cliTable) {
+	if out == nil {
+		return
+	}
+	if len(table.Rows) == 0 {
+		writeCLIEmptyState(out, table.EmptyMessage)
+		writeCLIFooterLines(out, table.FooterLines)
+		return
+	}
+	columns := table.Columns
+	if len(columns) == 0 {
+		for _, row := range table.Rows {
+			fmt.Fprintln(out, strings.Join(row, "  "))
+		}
+		writeCLIFooterLines(out, table.FooterLines)
+		return
+	}
+	widths := make([]int, len(columns))
+	for i, column := range columns {
+		widths[i] = cliDisplayWidth(column.Header)
+	}
+	normalizedRows := make([][]string, 0, len(table.Rows))
+	for _, row := range table.Rows {
+		normalized := make([]string, len(columns))
+		for i := range columns {
+			if i < len(row) {
+				normalized[i] = cliDisplayDash(row[i])
+			} else {
+				normalized[i] = "-"
+			}
+			if width := cliDisplayWidth(normalized[i]); width > widths[i] {
+				widths[i] = width
+			}
+		}
+		normalizedRows = append(normalizedRows, normalized)
+	}
+	writeCLITableRow(out, cliTableHeaders(columns), widths)
+	for _, row := range normalizedRows {
+		writeCLITableRow(out, row, widths)
+	}
+	writeCLIFooterLines(out, table.FooterLines)
+}
+
+func cliTableHeaders(columns []cliTableColumn) []string {
+	headers := make([]string, len(columns))
+	for i, column := range columns {
+		headers[i] = column.Header
+	}
+	return headers
+}
+
+func writeCLITableRow(out io.Writer, row []string, widths []int) {
+	for i, value := range row {
+		if i > 0 {
+			fmt.Fprint(out, "  ")
+		}
+		fmt.Fprint(out, value)
+		if i < len(row)-1 {
+			padding := widths[i] - cliDisplayWidth(value)
+			if padding > 0 {
+				fmt.Fprint(out, strings.Repeat(" ", padding))
+			}
+		}
+	}
+	fmt.Fprintln(out)
+}
+
+func writeCLIEmptyState(out io.Writer, message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "No rows match the current filters."
+	}
+	fmt.Fprintln(out, message)
+}
+
+func writeCLIFooterLines(out io.Writer, lines []string) {
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			fmt.Fprintln(out, line)
+		}
+	}
+}
+
+func writeCLITitle(out io.Writer, title string) {
+	if out == nil || strings.TrimSpace(title) == "" {
+		return
+	}
+	fmt.Fprintln(out, strings.TrimSpace(title))
+}
+
+func writeCLIFieldLine(out io.Writer, fields ...cliDetailField) {
+	if out == nil {
+		return
+	}
+	line := formatCLIFields(fields...)
+	if line == "" {
+		return
+	}
+	fmt.Fprintln(out, line)
+}
+
+func formatCLIFields(fields ...cliDetailField) string {
+	parts := make([]string, 0, len(fields))
+	for _, field := range fields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+		parts = append(parts, key+"="+cliDisplayDash(field.Value))
+	}
+	return strings.Join(parts, " ")
+}
+
+func cliDisplayDash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func cliDisplayWidth(value string) int {
+	value = string(cliANSISequencePattern.ReplaceAll([]byte(value), nil))
+	if value == "" {
+		return 0
+	}
+	return utf8.RuneCountInString(value)
 }
 
 func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {

--- a/cmd/swarm/cli_output_conformance_registry_test.go
+++ b/cmd/swarm/cli_output_conformance_registry_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -125,6 +126,36 @@ var cliOutputExpectedFactOwners = map[string]string{
 	"swarm bundle agents":   "/v1/rpc bundle.agents",
 	"swarm bundle register": "/v1/rpc bundle.register",
 	"swarm bundle delete":   "/v1/rpc bundle.delete",
+}
+
+var cliOutputSharedDisplayProofs = map[string][]string{
+	"writeAgentDeliveryLifecycleListResult":  {"writeCLITable"},
+	"writeAgentListResult":                   {"writeCLITable"},
+	"writeBundleAgentsHuman":                 {"writeCLITable"},
+	"writeBundleDetailHuman":                 {"writeCLIFieldLine"},
+	"writeBundleListHuman":                   {"writeCLITable"},
+	"writeConnectionsTable":                  {"writeCLITable"},
+	"writeContextListText":                   {"writeCLITable"},
+	"writeConversationDetailResult":          {"writeCLITable", "writeCLIFieldLine"},
+	"writeConversationListResult":            {"writeCLITable"},
+	"writeConversationTurnDetailResult":      {"writeCLIFieldLine"},
+	"writeDiagnosticRunList":                 {"writeCLITable"},
+	"writeDiagnosticRunTrace":                {"writeCLITable"},
+	"writeDiagnosticRunTraceDeliveryDetail":  {"writeCLITable"},
+	"writeDiagnosticRunTraceDeliverySummary": {"writeCLITable"},
+	"writeEntityAggregateResult":             {"writeCLITable"},
+	"writeEntityFullResult":                  {"writeCLIFieldLine"},
+	"writeEntityListResult":                  {"writeCLITable"},
+	"writeEventDeadLetterLine":               {"writeCLIFieldLine"},
+	"writeEventDetailResult":                 {"writeCLIFieldLine"},
+	"writeEventListResult":                   {"writeCLITable"},
+	"writeForkChatListResult":                {"writeCLITable"},
+	"writeForkChatSessionDetail":             {"writeCLITable"},
+	"writeForkChatSessionHeader":             {"writeCLIFieldLine"},
+	"writeMailboxDetailResult":               {"writeCLIFieldLine"},
+	"writeMailboxListResult":                 {"writeCLITable"},
+	"writeRuntimeIncidentListResult":         {"writeCLITable"},
+	"writeSecretsTable":                      {"writeCLITable"},
 }
 
 func cliOutputConformanceRegistryRows(t *testing.T) map[string]cliOutputConformanceRegistryRow {
@@ -403,6 +434,92 @@ func TestCLIOutputConformanceSharedRowsConsumeSharedOwner(t *testing.T) {
 	}
 }
 
+func TestCLIOutputConformanceMigratedDisplayWritersConsumeSharedRenderer(t *testing.T) {
+	calls := cliOutputFunctionCalls(t)
+	for fn, requiredCalls := range cliOutputSharedDisplayProofs {
+		fnCalls, ok := calls[fn]
+		if !ok {
+			t.Errorf("display proof function %s not found", fn)
+			continue
+		}
+		for _, required := range requiredCalls {
+			if !fnCalls[required] {
+				t.Errorf("%s does not call %s", fn, required)
+			}
+		}
+	}
+}
+
+func TestCLIOutputConformanceNoStaleTableRendererSplitRows(t *testing.T) {
+	rows := cliOutputConformanceRegistryRows(t)
+	for command, row := range rows {
+		if row.OwnerIssue == "#1814" {
+			t.Errorf("%s: command %q still points at #1814 after display renderer migration; split rows need a remaining non-stale owner", row.Key, command)
+		}
+	}
+}
+
+func TestCLIOutputConformanceNoUnclassifiedLiteralTabTables(t *testing.T) {
+	root := driftTestRepoRoot(t)
+	dir := filepath.Join(root, "cmd", "swarm")
+	allowedFiles := map[string]string{
+		"logs.go": "split to #1819 logs formatting",
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, imp := range file.Imports {
+			if imp.Path != nil && imp.Path.Value == strconv.Quote("text/tabwriter") && allowedFiles[name] == "" {
+				t.Errorf("%s imports text/tabwriter; table/list display must consume writeCLITable", name)
+			}
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !cliOutputIsFmtPrintCall(call) {
+				return true
+			}
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil || !strings.Contains(value, "\t") {
+					continue
+				}
+				if allowedFiles[name] != "" {
+					continue
+				}
+				t.Errorf("%s contains fmt print literal tab %q; table/list display must consume writeCLITable", name, value)
+			}
+			return true
+		})
+	}
+}
+
+func cliOutputIsFmtPrintCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "fmt" {
+		return false
+	}
+	return strings.HasPrefix(sel.Sel.Name, "Fprint")
+}
+
 func cliOutputFunctionCalls(t *testing.T) map[string]map[string]bool {
 	t.Helper()
 	root := driftTestRepoRoot(t)
@@ -440,7 +557,7 @@ func cliOutputFunctionCalls(t *testing.T) map[string]map[string]bool {
 					return true
 				}
 				switch ident.Name {
-				case "bindCLIOutputFlags", "renderCLIOutput":
+				case "bindCLIOutputFlags", "renderCLIOutput", "writeCLITable", "writeCLIFieldLine", "writeCLITitle", "writeCLIEmptyState":
 					calls[fn.Name.Name][ident.Name] = true
 				}
 				return true

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,6 +98,69 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 	}
 	if got := stdout.String(); got != "ok\n" {
 		t.Fatalf("verify --quiet stdout = %q, want ok", got)
+	}
+}
+
+func TestCLITableRendererAlignsAndRendersEmptyValues(t *testing.T) {
+	var out bytes.Buffer
+	writeCLITable(&out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "KEY", KeyColumn: true},
+			{Header: "VALUE"},
+		},
+		Rows: [][]string{
+			{"abc", ""},
+			{"longer", "ok"},
+		},
+	})
+	want := "KEY     VALUE\nabc     -\nlonger  ok\n"
+	if out.String() != want {
+		t.Fatalf("table output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestCLITableRendererDoesNotImplicitlyTruncateIdentifierColumns(t *testing.T) {
+	var out bytes.Buffer
+	id := "run_0123456789abcdef0123456789abcdef"
+	writeCLITable(&out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "RUN ID", KeyColumn: true},
+			{Header: "STATUS"},
+		},
+		Rows: [][]string{{id, "completed"}},
+	})
+	if !strings.Contains(out.String(), id) {
+		t.Fatalf("table output = %q, want full id %q", out.String(), id)
+	}
+}
+
+func TestCLITableRendererUsesActionableEmptyState(t *testing.T) {
+	var out bytes.Buffer
+	writeCLITable(&out, cliTable{
+		Columns:      []cliTableColumn{{Header: "ID"}},
+		EmptyMessage: "No runs found. Start one: swarm run start --event <event>",
+	})
+	want := "No runs found. Start one: swarm run start --event <event>\n"
+	if out.String() != want {
+		t.Fatalf("empty table output = %q, want %q", out.String(), want)
+	}
+}
+
+func TestCLITextWriterCarriesTTYGatedDisplayPolicy(t *testing.T) {
+	var out bytes.Buffer
+	writer := cliOutputOptions{}.textWriter(&out)
+	policy := cliWriterDisplayPolicy(writer)
+	if policy.Color || policy.Emoji {
+		t.Fatalf("non-tty display policy = %#v, want color and emoji disabled", policy)
+	}
+
+	out.Reset()
+	noColorWriter := cliOutputOptions{noColor: true}.textWriter(&out)
+	if _, err := fmt.Fprint(noColorWriter, "\x1b[31mred\x1b[0m"); err != nil {
+		t.Fatalf("write no-color text: %v", err)
+	}
+	if out.String() != "red" {
+		t.Fatalf("no-color writer output = %q, want ANSI stripped", out.String())
 	}
 }
 

--- a/cmd/swarm/connections.go
+++ b/cmd/swarm/connections.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
@@ -444,10 +443,9 @@ func writeConnectionsTable(out io.Writer, records []connectionRecord) {
 	if out == nil {
 		return
 	}
-	writer := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(writer, "KEY\tPROVIDER\tACCOUNT\tGRANT\tGRANT_MODEL\tTOKEN_REQUEST\tSTATUS\tEXPIRES_AT\tREQUIRED_BY")
+	rows := make([][]string, 0, len(records))
 	for _, record := range records {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			record.Key,
 			dash(record.Provider),
 			dash(record.Account),
@@ -457,9 +455,23 @@ func writeConnectionsTable(out io.Writer, records []connectionRecord) {
 			dash(record.Status),
 			dash(record.ExpiresAt),
 			dash(formatConnectionRequirements(record.RequiredBy)),
-		)
+		})
 	}
-	_ = writer.Flush()
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "KEY", KeyColumn: true},
+			{Header: "PROVIDER"},
+			{Header: "ACCOUNT"},
+			{Header: "GRANT"},
+			{Header: "GRANT_MODEL"},
+			{Header: "TOKEN_REQUEST"},
+			{Header: "STATUS"},
+			{Header: "EXPIRES_AT"},
+			{Header: "REQUIRED_BY"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No managed connections match the current filters. Add one: swarm connections connect <key>",
+	})
 }
 
 func formatConnectionRequirements(items []connectionRequirement) string {

--- a/cmd/swarm/context_command.go
+++ b/cmd/swarm/context_command.go
@@ -144,7 +144,7 @@ func writeContextListText(out io.Writer, report localContextRegistryReport) {
 		return
 	}
 	if len(report.Entries) == 0 {
-		fmt.Fprintf(out, "no contexts found\n")
+		writeCLIEmptyState(out, "No contexts found. Create one by running a command with --api or --config.")
 		if report.Status != "" && report.Status != "empty" {
 			fmt.Fprintf(out, "registry_status: %s\n", report.Status)
 			if report.Detail != "" {
@@ -153,11 +153,20 @@ func writeContextListText(out io.Writer, report localContextRegistryReport) {
 		}
 		return
 	}
-	fmt.Fprintf(out, "%-24s %-22s %-9s %s\n", "NAME", "STATUS", "TRANSPORT", "TARGET")
+	rows := make([][]string, 0, len(report.Entries))
 	for _, entry := range report.Entries {
 		target := contextEntryTarget(entry.Descriptor)
-		fmt.Fprintf(out, "%-24s %-22s %-9s %s\n", entry.Descriptor.Name, entry.Status, entry.Descriptor.Transport, target)
+		rows = append(rows, []string{entry.Descriptor.Name, entry.Status, entry.Descriptor.Transport, target})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "NAME", KeyColumn: true},
+			{Header: "STATUS"},
+			{Header: "TRANSPORT"},
+			{Header: "TARGET"},
+		},
+		Rows: rows,
+	})
 }
 
 func writeContextEntryText(out io.Writer, label string, entry localContextEntry) {

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -34,7 +34,7 @@ func TestContextListCommandSwarmDirFlagBypassesBrokenConfig(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
 	}
-	if !strings.Contains(out.String(), "no contexts found") {
+	if !strings.Contains(out.String(), "No contexts found.") {
 		t.Fatalf("output = %q, want empty registry", out.String())
 	}
 }
@@ -49,7 +49,7 @@ func TestContextListCommandSurfacesZeroEntryRegistryFailure(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
 	}
-	if !strings.Contains(out.String(), "no contexts found") {
+	if !strings.Contains(out.String(), "No contexts found.") {
 		t.Fatalf("output = %q, want empty-list marker", out.String())
 	}
 	if !strings.Contains(out.String(), "registry_status: invalid_descriptor") || !strings.Contains(out.String(), "detail:") {

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -639,13 +639,9 @@ func writeMailboxListResult(out io.Writer, result mailboxListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Items) == 0 {
-		fmt.Fprintln(out, "No mailbox items match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "MAILBOX_ID\tSTATUS\tPRIORITY\tTYPE\tSOURCE_EVENT\tENTITY\tCREATED\tDECISION")
+	rows := make([][]string, 0, len(result.Items))
 	for _, item := range result.Items {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			item.MailboxID,
 			item.Status,
 			item.Priority,
@@ -654,11 +650,27 @@ func writeMailboxListResult(out io.Writer, result mailboxListResult) {
 			mailboxDash(item.SourceEntityID),
 			item.CreatedAt,
 			mailboxDash(item.Decision),
-		)
+		})
 	}
+	footers := []string{}
 	if result.NextCursor != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "MAILBOX_ID", KeyColumn: true},
+			{Header: "STATUS"},
+			{Header: "PRIORITY"},
+			{Header: "TYPE"},
+			{Header: "SOURCE_EVENT", KeyColumn: true},
+			{Header: "ENTITY", KeyColumn: true},
+			{Header: "CREATED"},
+			{Header: "DECISION"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No mailbox items match the current filters.",
+		FooterLines:  footers,
+	})
 }
 
 func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
@@ -666,16 +678,23 @@ func writeMailboxDetailResult(out io.Writer, result mailboxDetailResult) {
 		return
 	}
 	item := result.Item
-	fmt.Fprintf(out, "Mailbox %s\n", item.MailboxID)
-	fmt.Fprintf(out, "status=%s priority=%s type=%s\n", item.Status, item.Priority, item.Type)
-	fmt.Fprintf(out, "source_event_id=%s source_flow=%s source_entity_id=%s created_at=%s\n",
-		mailboxDash(item.SourceEventID),
-		item.SourceFlow,
-		mailboxDash(item.SourceEntityID),
-		item.CreatedAt,
+	writeCLITitle(out, fmt.Sprintf("Mailbox %s", item.MailboxID))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "status", Value: item.Status},
+		cliDetailField{Key: "priority", Value: item.Priority},
+		cliDetailField{Key: "type", Value: item.Type},
+	)
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "source_event_id", Value: mailboxDash(item.SourceEventID)},
+		cliDetailField{Key: "source_flow", Value: item.SourceFlow},
+		cliDetailField{Key: "source_entity_id", Value: mailboxDash(item.SourceEntityID)},
+		cliDetailField{Key: "created_at", Value: item.CreatedAt},
 	)
 	if item.Decision != "" || item.DecidedAt != "" {
-		fmt.Fprintf(out, "decision=%s decided_at=%s\n", mailboxDash(item.Decision), mailboxDash(item.DecidedAt))
+		writeCLIFieldLine(out,
+			cliDetailField{Key: "decision", Value: mailboxDash(item.Decision)},
+			cliDetailField{Key: "decided_at", Value: mailboxDash(item.DecidedAt)},
+		)
 	}
 	writeMailboxDecisionSheet(out, *result.DecisionSheet)
 	writeMailboxObject(out, "payload", result.Payload)

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -228,9 +228,10 @@ func TestMailboxListSendsV1RPCRequestAndRendersResult(t *testing.T) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
 	for _, want := range []string{
-		"MAILBOX_ID\tSTATUS\tPRIORITY\tTYPE",
-		"mailbox-1\tpending\thigh\treview_request\t-\tentity-1",
-		"mailbox-2\tdecided\tnormal\treview_request",
+		"MAILBOX_ID",
+		"mailbox-1   pending  high      review_request  -",
+		"entity-1",
+		"mailbox-2   decided  normal    review_request",
 		"next_cursor=cursor-2",
 	} {
 		if !strings.Contains(stdout.String(), want) {
@@ -264,7 +265,7 @@ func TestMailboxListDefaultsToPendingAndRendersEmptyResult(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, map[string]any{"status": "pending"}) {
 		t.Fatalf("params = %#v, want pending default", captured.Params)
 	}
-	if !strings.Contains(stdout.String(), "No mailbox items match the filter.") {
+	if !strings.Contains(stdout.String(), "No mailbox items match the current filters.") {
 		t.Fatalf("stdout = %q, want empty message", stdout.String())
 	}
 }

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -604,26 +604,38 @@ func writeConversationListResult(out io.Writer, result conversationListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Conversations) == 0 {
-		fmt.Fprintln(out, "No conversations match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "SESSION_ID\tAGENT\tRUN\tSTATUS\tTURNS\tMESSAGES\tSTARTED\tENDED")
+	rows := make([][]string, 0, len(result.Conversations))
 	for _, item := range result.Conversations {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+		rows = append(rows, []string{
 			item.SessionID,
 			item.AgentID,
 			conversationDash(item.RunID),
 			item.Status,
-			item.TurnCount,
-			item.MessageCount,
+			fmt.Sprintf("%d", item.TurnCount),
+			fmt.Sprintf("%d", item.MessageCount),
 			item.StartedAt,
 			conversationDash(item.EndedAt),
-		)
+		})
 	}
+	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "SESSION_ID", KeyColumn: true},
+			{Header: "AGENT"},
+			{Header: "RUN"},
+			{Header: "STATUS"},
+			{Header: "TURNS"},
+			{Header: "MESSAGES"},
+			{Header: "STARTED"},
+			{Header: "ENDED"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No conversations match the current filters.",
+		FooterLines:  footers,
+	})
 }
 
 func writeConversationDetailResult(out io.Writer, result conversationDetail) {
@@ -631,32 +643,41 @@ func writeConversationDetailResult(out io.Writer, result conversationDetail) {
 		return
 	}
 	item := result.Conversation
-	fmt.Fprintf(out, "Conversation %s\n", item.SessionID)
-	fmt.Fprintf(out, "agent_id=%s run_id=%s status=%s turns=%d messages=%d started_at=%s ended_at=%s\n",
-		item.AgentID,
-		conversationDash(item.RunID),
-		item.Status,
-		item.TurnCount,
-		item.MessageCount,
-		item.StartedAt,
-		conversationDash(item.EndedAt),
+	writeCLITitle(out, fmt.Sprintf("Conversation %s", item.SessionID))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "agent_id", Value: item.AgentID},
+		cliDetailField{Key: "run_id", Value: conversationDash(item.RunID)},
+		cliDetailField{Key: "status", Value: item.Status},
+		cliDetailField{Key: "turns", Value: fmt.Sprintf("%d", item.TurnCount)},
+		cliDetailField{Key: "messages", Value: fmt.Sprintf("%d", item.MessageCount)},
+		cliDetailField{Key: "started_at", Value: item.StartedAt},
+		cliDetailField{Key: "ended_at", Value: conversationDash(item.EndedAt)},
 	)
-	if len(result.Turns) == 0 {
-		fmt.Fprintln(out, "No turns recorded.")
-		return
-	}
-	fmt.Fprintln(out, "TURN\tTURN_ID\tEVENT_ID\tEVENT_TYPE\tPARSE_OK\tLATENCY_MS\tERROR")
+	rows := make([][]string, 0, len(result.Turns))
 	for _, turn := range result.Turns {
-		fmt.Fprintf(out, "%d\t%s\t%s\t%s\t%t\t%d\t%s\n",
-			turn.TurnIndex,
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", turn.TurnIndex),
 			turn.TurnID,
 			turn.TriggerEventID,
 			turn.TriggerEventType,
-			*turn.ParseOK,
-			*turn.LatencyMS,
+			fmt.Sprintf("%t", *turn.ParseOK),
+			fmt.Sprintf("%d", *turn.LatencyMS),
 			conversationDash(turn.Error),
-		)
+		})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "TURN"},
+			{Header: "TURN_ID", KeyColumn: true},
+			{Header: "EVENT_ID", KeyColumn: true},
+			{Header: "EVENT_TYPE"},
+			{Header: "PARSE_OK"},
+			{Header: "LATENCY_MS"},
+			{Header: "ERROR", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No turns recorded.",
+	})
 }
 
 func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDetail) {
@@ -665,34 +686,34 @@ func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDet
 	}
 	session := result.Session
 	turn := result.Turn
-	fmt.Fprintf(out, "Conversation %s turn %d\n", session.SessionID, turn.TurnIndex)
-	fmt.Fprintf(out, "turn_id=%s agent_id=%s run_id=%s status=%s started_at=%s completed_at=%s duration_ms=%d parse_ok=%t outcome=%s error=%s\n",
-		turn.TurnID,
-		session.AgentID,
-		conversationDash(session.RunID),
-		session.Status,
-		turn.StartedAt,
-		turn.CompletedAt,
-		*turn.DurationMS,
-		*turn.ParseOK,
-		conversationDash(turn.Outcome),
-		conversationDash(turn.Error),
+	writeCLITitle(out, fmt.Sprintf("Conversation %s turn %d", session.SessionID, turn.TurnIndex))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "turn_id", Value: turn.TurnID},
+		cliDetailField{Key: "agent_id", Value: session.AgentID},
+		cliDetailField{Key: "run_id", Value: conversationDash(session.RunID)},
+		cliDetailField{Key: "status", Value: session.Status},
+		cliDetailField{Key: "started_at", Value: turn.StartedAt},
+		cliDetailField{Key: "completed_at", Value: turn.CompletedAt},
+		cliDetailField{Key: "duration_ms", Value: fmt.Sprintf("%d", *turn.DurationMS)},
+		cliDetailField{Key: "parse_ok", Value: fmt.Sprintf("%t", *turn.ParseOK)},
+		cliDetailField{Key: "outcome", Value: conversationDash(turn.Outcome)},
+		cliDetailField{Key: "error", Value: conversationDash(turn.Error)},
 	)
 	dispatch := turn.DispatchMetadata
-	fmt.Fprintf(out, "dispatch trigger_event_id=%s trigger_event_type=%s entity_id=%s task_id=%s run_id=%s\n",
-		conversationDash(dispatch.TriggerEventID),
-		conversationDash(dispatch.TriggerEventType),
-		conversationDash(dispatch.EntityID),
-		conversationDash(dispatch.TaskID),
-		conversationDash(dispatch.RunID),
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "dispatch.trigger_event_id", Value: conversationDash(dispatch.TriggerEventID)},
+		cliDetailField{Key: "dispatch.trigger_event_type", Value: conversationDash(dispatch.TriggerEventType)},
+		cliDetailField{Key: "dispatch.entity_id", Value: conversationDash(dispatch.EntityID)},
+		cliDetailField{Key: "dispatch.task_id", Value: conversationDash(dispatch.TaskID)},
+		cliDetailField{Key: "dispatch.run_id", Value: conversationDash(dispatch.RunID)},
 	)
-	fmt.Fprintf(out, "advertised_tools=%s runtime_log_entries=%d turn_blocks_raw=%s\n",
-		conversationListDash(turn.AdvertisedTools),
-		len(turn.RuntimeLogEntries),
-		conversationCompactJSON(result.TurnBlocksRaw),
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "advertised_tools", Value: conversationListDash(turn.AdvertisedTools)},
+		cliDetailField{Key: "runtime_log_entries", Value: fmt.Sprintf("%d", len(turn.RuntimeLogEntries))},
+		cliDetailField{Key: "turn_blocks_raw", Value: conversationCompactJSON(result.TurnBlocksRaw)},
 	)
 	if strings.TrimSpace(turn.AssistantVisibleOutput) != "" {
-		fmt.Fprintf(out, "assistant_visible_output=%s\n", strings.TrimSpace(turn.AssistantVisibleOutput))
+		writeCLIFieldLine(out, cliDetailField{Key: "assistant_visible_output", Value: strings.TrimSpace(turn.AssistantVisibleOutput)})
 	}
 	if len(turn.RuntimeLogEntries) > 0 {
 		fmt.Fprintln(out, "Runtime logs:")

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -87,7 +87,7 @@ func TestConversationsListEmptyResultOmitsUnsetParams(t *testing.T) {
 	if len(captured.Params) != 0 {
 		t.Fatalf("params = %#v, want empty", captured.Params)
 	}
-	if !strings.Contains(stdout.String(), "No conversations match the filter.") {
+	if !strings.Contains(stdout.String(), "No conversations match the current filters.") {
 		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
 	}
 }
@@ -117,8 +117,9 @@ func TestConversationViewUsesConversationGetAndRendersTurns(t *testing.T) {
 	for _, want := range []string{
 		"Conversation sess-1",
 		"agent_id=agent-1 run_id=run-1 status=active turns=1 messages=2",
-		"TURN\tTURN_ID",
-		"1\tturn-1\tevent-1\ttask.started\ttrue\t150\t-",
+		"TURN  TURN_ID",
+		"1     turn-1",
+		"task.started  true      150",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
@@ -155,7 +156,7 @@ func TestConversationTurnUsesConversationGetTurnAndRendersDeepTurn(t *testing.T)
 	for _, want := range []string{
 		"Conversation sess-1 turn 2",
 		"turn_id=turn-2",
-		"dispatch trigger_event_id=event-2 trigger_event_type=task.completed",
+		"dispatch.trigger_event_id=event-2 dispatch.trigger_event_type=task.completed",
 		"advertised_tools=emit_done,read_state runtime_log_entries=1",
 		"assistant_visible_output=done",
 		"log_id=log-1",

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -1361,24 +1361,34 @@ func writeDiagnosticRunList(out io.Writer, result diagnosticRunListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Runs) == 0 {
-		fmt.Fprintln(out, "no runs")
-	} else {
-		fmt.Fprintln(out, "RUN ID\tSTATUS\tSTARTED\tEVENTS\tENTITIES\tTRIGGER")
-		for _, run := range result.Runs {
-			fmt.Fprintf(out, "%s\t%s\t%s\t%d\t%d\t%s\n",
-				run.RunID,
-				run.Status,
-				run.StartedAt,
-				intPointerValue(run.EventCount),
-				intPointerValue(run.EntityCount),
-				run.TriggerEventType,
-			)
-		}
+	rows := make([][]string, 0, len(result.Runs))
+	for _, run := range result.Runs {
+		rows = append(rows, []string{
+			run.RunID,
+			run.Status,
+			run.StartedAt,
+			fmt.Sprintf("%d", intPointerValue(run.EventCount)),
+			fmt.Sprintf("%d", intPointerValue(run.EntityCount)),
+			run.TriggerEventType,
+		})
 	}
+	footers := []string{}
 	if result.NextCursor != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "RUN ID", KeyColumn: true},
+			{Header: "STATUS"},
+			{Header: "STARTED"},
+			{Header: "EVENTS"},
+			{Header: "ENTITIES"},
+			{Header: "TRIGGER"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No runs found. Start one: swarm run start --event <event>",
+		FooterLines:  footers,
+	})
 }
 
 func writeDiagnosticRunHeader(out io.Writer, run diagnosticRunHeader) {
@@ -1460,24 +1470,34 @@ func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTr
 		return
 	}
 	fmt.Fprintf(out, "run trace: run_id=%s\n", runID)
-	if len(result.Trace) == 0 {
-		fmt.Fprintln(out, "no trace rows")
-	} else if deliveryDetail {
+	if deliveryDetail {
 		writeDiagnosticRunTraceDeliveryDetail(out, result.Trace)
 	} else {
-		fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY\tSUBSCRIBER\tSESSION\tTURN")
+		rows := make([][]string, 0, len(result.Trace))
 		for _, row := range result.Trace {
-			fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s/%s\t%s\t%s\n",
+			rows = append(rows, []string{
 				row.EventCreatedAt,
 				row.EventName,
 				row.EventID,
 				emptyDash(row.DeliveryStatus),
-				emptyDash(row.SubscriberType),
-				emptyDash(row.SubscriberID),
+				emptyDash(row.SubscriberType) + "/" + emptyDash(row.SubscriberID),
 				emptyDash(row.SessionID),
 				emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
-			)
+			})
 		}
+		writeCLITable(out, cliTable{
+			Columns: []cliTableColumn{
+				{Header: "EVENT AT"},
+				{Header: "EVENT"},
+				{Header: "EVENT ID", KeyColumn: true},
+				{Header: "DELIVERY"},
+				{Header: "SUBSCRIBER"},
+				{Header: "SESSION"},
+				{Header: "TURN"},
+			},
+			Rows:         rows,
+			EmptyMessage: "No trace rows found for this run.",
+		})
 	}
 	if result.NextCursor != "" {
 		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
@@ -1495,39 +1515,54 @@ func writeDiagnosticRunTraceDeliverySummary(out io.Writer, runID string, result 
 		result.NonDeliveryRows,
 	)
 	if len(result.Groups) == 0 {
-		fmt.Fprintln(out, "no delivery rows")
+		writeCLIEmptyState(out, "No delivery rows found for this trace.")
 		return
 	}
-	fmt.Fprintln(out, "SUBSCRIBER\tPENDING\tIN_PROGRESS\tDELIVERED\tFAILED\tDEAD_LETTER\tAVG_QUEUE_WAIT\tMAX_QUEUE_WAIT\tAVG_EXECUTION_TIME\tMAX_EXECUTION_TIME\tQUEUE_UNAVAILABLE\tEXECUTION_UNAVAILABLE")
+	rows := make([][]string, 0, len(result.Groups))
 	for _, group := range result.Groups {
-		fmt.Fprintf(out, "%s/%s\t%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s\t%d\t%d\n",
-			group.SubscriberType,
-			group.SubscriberID,
-			group.StatusCounts["pending"],
-			group.StatusCounts["in_progress"],
-			group.StatusCounts["delivered"],
-			group.StatusCounts["failed"],
-			group.StatusCounts["dead_letter"],
+		rows = append(rows, []string{
+			group.SubscriberType + "/" + group.SubscriberID,
+			fmt.Sprintf("%d", group.StatusCounts["pending"]),
+			fmt.Sprintf("%d", group.StatusCounts["in_progress"]),
+			fmt.Sprintf("%d", group.StatusCounts["delivered"]),
+			fmt.Sprintf("%d", group.StatusCounts["failed"]),
+			fmt.Sprintf("%d", group.StatusCounts["dead_letter"]),
 			traceDurationAverage(group.QueueWait),
 			traceDurationMax(group.QueueWait),
 			traceDurationAverage(group.ExecutionTime),
 			traceDurationMax(group.ExecutionTime),
-			group.UnavailableQueue,
-			group.UnavailableExec,
-		)
+			fmt.Sprintf("%d", group.UnavailableQueue),
+			fmt.Sprintf("%d", group.UnavailableExec),
+		})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "SUBSCRIBER"},
+			{Header: "PENDING"},
+			{Header: "IN_PROGRESS"},
+			{Header: "DELIVERED"},
+			{Header: "FAILED"},
+			{Header: "DEAD_LETTER"},
+			{Header: "AVG_QUEUE_WAIT"},
+			{Header: "MAX_QUEUE_WAIT"},
+			{Header: "AVG_EXECUTION_TIME"},
+			{Header: "MAX_EXECUTION_TIME"},
+			{Header: "QUEUE_UNAVAILABLE"},
+			{Header: "EXECUTION_UNAVAILABLE"},
+		},
+		Rows: rows,
+	})
 }
 
 func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTraceRow) {
-	fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tDELIVERY ID\tSUBSCRIBER\tSTATUS\tREASON\tDELIVERY CREATED\tDELIVERY STARTED\tDELIVERY DELIVERED\tQUEUE WAIT\tEXECUTION TIME\tSESSION\tTURN")
+	tableRows := make([][]string, 0, len(rows))
 	for _, row := range rows {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		tableRows = append(tableRows, []string{
 			row.EventCreatedAt,
 			row.EventName,
 			row.EventID,
 			emptyDash(row.DeliveryID),
-			emptyDash(row.SubscriberType),
-			emptyDash(row.SubscriberID),
+			emptyDash(row.SubscriberType) + "/" + emptyDash(row.SubscriberID),
 			emptyDash(row.DeliveryStatus),
 			emptyDash(row.DeliveryReasonCode),
 			emptyDash(row.DeliveryCreatedAt),
@@ -1537,8 +1572,28 @@ func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTr
 			traceDuration(row.DeliveryStartedAt, row.DeliveryDeliveredAt),
 			emptyDash(row.SessionID),
 			emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
-		)
+		})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "EVENT AT"},
+			{Header: "EVENT"},
+			{Header: "EVENT ID", KeyColumn: true},
+			{Header: "DELIVERY ID", KeyColumn: true},
+			{Header: "SUBSCRIBER"},
+			{Header: "STATUS"},
+			{Header: "REASON"},
+			{Header: "DELIVERY CREATED"},
+			{Header: "DELIVERY STARTED"},
+			{Header: "DELIVERY DELIVERED"},
+			{Header: "QUEUE WAIT"},
+			{Header: "EXECUTION TIME"},
+			{Header: "SESSION"},
+			{Header: "TURN"},
+		},
+		Rows:         tableRows,
+		EmptyMessage: "No delivery rows found for this trace.",
+	})
 }
 
 func traceDurationAverage(stats diagnosticTraceDurationStats) string {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -575,9 +575,10 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 	}
 	for _, want := range []string{
 		"run trace delivery summary: run_id=run-1 snapshot=point-in-time trace_rows=4 delivery_rows=3 non_delivery_rows=1",
-		"SUBSCRIBER\tPENDING\tIN_PROGRESS\tDELIVERED\tFAILED\tDEAD_LETTER",
-		"agent/agent-1\t0\t1\t1\t0\t0\t2.5s\t3s\t5s\t5s\t0\t1",
-		"node/node-1\t0\t0\t0\t1\t0\t-\t-\t-\t-\t1\t1",
+		"SUBSCRIBER",
+		"IN_PROGRESS",
+		"agent/agent-1",
+		"node/node-1",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())

--- a/cmd/swarm/entities.go
+++ b/cmd/swarm/entities.go
@@ -467,27 +467,40 @@ func writeEntityListResult(out io.Writer, result entityListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Entities) == 0 {
-		fmt.Fprintln(out, "No entities match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "ENTITY_ID\tRUN_ID\tFLOW\tTYPE\tSTATE\tREVISION\tUPDATED\tSLUG\tNAME")
+	rows := make([][]string, 0, len(result.Entities))
 	for _, entity := range result.Entities {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			entity.EntityID,
 			entity.RunID,
 			entity.FlowInstance,
 			entity.EntityType,
 			entity.CurrentState,
-			entity.Revision,
+			fmt.Sprintf("%d", entity.Revision),
 			entity.UpdatedAt,
 			entityDash(entity.Slug),
 			entityDash(entity.Name),
-		)
+		})
 	}
+	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "ENTITY_ID", KeyColumn: true},
+			{Header: "RUN_ID", KeyColumn: true},
+			{Header: "FLOW"},
+			{Header: "TYPE"},
+			{Header: "STATE"},
+			{Header: "REVISION"},
+			{Header: "UPDATED"},
+			{Header: "SLUG"},
+			{Header: "NAME"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No entities match the current filters.",
+		FooterLines:  footers,
+	})
 }
 
 func writeEntityFullResult(out io.Writer, result entityFull) {
@@ -495,28 +508,27 @@ func writeEntityFullResult(out io.Writer, result entityFull) {
 		return
 	}
 	entity := result.Entity
-	fmt.Fprintf(out, "Entity %s\n", entity.EntityID)
-	fmt.Fprintf(out, "run_id=%s flow=%s type=%s state=%s revision=%d created_at=%s updated_at=%s\n",
-		entity.RunID,
-		entity.FlowInstance,
-		entity.EntityType,
-		entity.CurrentState,
-		entity.Revision,
-		entity.CreatedAt,
-		entity.UpdatedAt,
+	writeCLITitle(out, fmt.Sprintf("Entity %s", entity.EntityID))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "run_id", Value: entity.RunID},
+		cliDetailField{Key: "flow", Value: entity.FlowInstance},
+		cliDetailField{Key: "type", Value: entity.EntityType},
+		cliDetailField{Key: "state", Value: entity.CurrentState},
+		cliDetailField{Key: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
+		cliDetailField{Key: "created_at", Value: entity.CreatedAt},
+		cliDetailField{Key: "updated_at", Value: entity.UpdatedAt},
 	)
-	fmt.Fprintf(out, "slug=%s name=%s\n", entityDash(entity.Slug), entityDash(entity.Name))
-	fmt.Fprintf(out, "fields=%s\n", entityCompactJSON(result.Fields))
-	fmt.Fprintf(out, "gates=%s\n", entityCompactJSON(result.Gates))
-	fmt.Fprintf(out, "accumulated=%s\n", entityCompactJSON(result.Accumulated))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "slug", Value: entityDash(entity.Slug)},
+		cliDetailField{Key: "name", Value: entityDash(entity.Name)},
+	)
+	writeCLIFieldLine(out, cliDetailField{Key: "fields", Value: entityCompactJSON(result.Fields)})
+	writeCLIFieldLine(out, cliDetailField{Key: "gates", Value: entityCompactJSON(result.Gates)})
+	writeCLIFieldLine(out, cliDetailField{Key: "accumulated", Value: entityCompactJSON(result.Accumulated)})
 }
 
 func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {
 	if out == nil {
-		return
-	}
-	if len(result.Counts) == 0 {
-		fmt.Fprintln(out, "No entity aggregate rows match the filter.")
 		return
 	}
 	keys := make([]string, 0, len(result.Counts))
@@ -524,10 +536,18 @@ func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	fmt.Fprintln(out, "GROUP\tCOUNT")
+	rows := make([][]string, 0, len(keys))
 	for _, key := range keys {
-		fmt.Fprintf(out, "%s\t%d\n", entityDash(key), result.Counts[key])
+		rows = append(rows, []string{entityDash(key), fmt.Sprintf("%d", result.Counts[key])})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "GROUP"},
+			{Header: "COUNT"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No entity aggregate rows match the current filters.",
+	})
 }
 
 func entityListAPIErrorClassifier() cliAPIErrorClassifier {

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -95,7 +95,7 @@ func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
 	if len(captured.Params) != 0 {
 		t.Fatalf("params = %#v, want empty", captured.Params)
 	}
-	if !strings.Contains(stdout.String(), "No entities match the filter.") {
+	if !strings.Contains(stdout.String(), "No entities match the current filters.") {
 		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
 	}
 }
@@ -175,7 +175,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("entity aggregate code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"GROUP\tCOUNT", "vertical\t2"} {
+	for _, want := range []string{"GROUP", "COUNT", "vertical  2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entity aggregate stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -251,7 +251,7 @@ func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
 	if len(captured[0].Params) != 0 {
 		t.Fatalf("default params = %#v, want empty for server-owned default group", captured[0].Params)
 	}
-	if !strings.Contains(stdout.String(), "GROUP\tCOUNT") || !strings.Contains(stdout.String(), "collecting\t2") {
+	if !strings.Contains(stdout.String(), "GROUP") || !strings.Contains(stdout.String(), "COUNT") || !strings.Contains(stdout.String(), "collecting  2") {
 		t.Fatalf("stdout = %q, want aggregate table", stdout.String())
 	}
 

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -845,61 +845,71 @@ func writeEventListResult(out io.Writer, result eventListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Events) == 0 {
-		fmt.Fprintln(out, "No events match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "EVENT AT\tEVENT\tEVENT ID\tRUN\tENTITY\tDELIVERIES\tDEAD_LETTERS")
+	rows := make([][]string, 0, len(result.Events))
 	for _, event := range result.Events {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+		rows = append(rows, []string{
 			event.CreatedAt,
 			event.EventName,
 			event.EventID,
 			eventObservationDash(event.RunID),
 			eventObservationDash(event.EntityID),
-			len(event.Deliveries),
-			len(event.DeadLetters),
-		)
+			fmt.Sprintf("%d", len(event.Deliveries)),
+			fmt.Sprintf("%d", len(event.DeadLetters)),
+		})
 	}
+	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "EVENT AT"},
+			{Header: "EVENT"},
+			{Header: "EVENT ID", KeyColumn: true},
+			{Header: "RUN"},
+			{Header: "ENTITY"},
+			{Header: "DELIVERIES"},
+			{Header: "DEAD_LETTERS"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No events match the current filters. Publish one: swarm event publish <event>",
+		FooterLines:  footers,
+	})
 }
 
 func writeEventDetailResult(out io.Writer, event eventFull) {
 	if out == nil {
 		return
 	}
-	fmt.Fprintf(out, "Event %s\n", event.EventID)
-	fmt.Fprintf(out, "event_name=%s created_at=%s source=%s run_id=%s entity_id=%s source_event_id=%s\n",
-		event.EventName,
-		event.CreatedAt,
-		event.Source,
-		eventObservationDash(event.RunID),
-		eventObservationDash(event.EntityID),
-		eventObservationDash(event.SourceEventID),
+	writeCLITitle(out, fmt.Sprintf("Event %s", event.EventID))
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "event_name", Value: event.EventName},
+		cliDetailField{Key: "created_at", Value: event.CreatedAt},
+		cliDetailField{Key: "source", Value: event.Source},
+		cliDetailField{Key: "run_id", Value: eventObservationDash(event.RunID)},
+		cliDetailField{Key: "entity_id", Value: eventObservationDash(event.EntityID)},
+		cliDetailField{Key: "source_event_id", Value: eventObservationDash(event.SourceEventID)},
 	)
-	fmt.Fprintf(out, "payload=%s\n", eventObservationCompactJSON(event.Payload))
+	writeCLIFieldLine(out, cliDetailField{Key: "payload", Value: eventObservationCompactJSON(event.Payload)})
 	if len(event.Deliveries) == 0 {
 		fmt.Fprintln(out, "deliveries: none")
 	} else {
 		fmt.Fprintln(out, "deliveries:")
 		for _, delivery := range event.Deliveries {
-			fmt.Fprintf(out, "  delivery_id=%s subscriber=%s/%s status=%s session_id=%s created_at=%s started_at=%s finished_at=%s reason_code=%s last_error=%s retry_count=%d retry_eligible=%t terminal=%t dead_letters=%d\n",
-				delivery.DeliveryID,
-				delivery.SubscriberType,
-				delivery.SubscriberID,
-				delivery.Status,
-				eventObservationDash(delivery.SessionID),
-				eventObservationDash(delivery.CreatedAt),
-				eventObservationDash(delivery.StartedAt),
-				eventObservationDash(delivery.FinishedAt),
-				eventObservationDash(delivery.ReasonCode),
-				eventObservationDash(delivery.LastError),
-				*delivery.RetryCount,
-				*delivery.RetryEligible,
-				*delivery.Terminal,
-				len(delivery.DeadLetters),
+			writeCLIFieldLine(out,
+				cliDetailField{Key: "delivery_id", Value: delivery.DeliveryID},
+				cliDetailField{Key: "subscriber", Value: delivery.SubscriberType + "/" + delivery.SubscriberID},
+				cliDetailField{Key: "status", Value: delivery.Status},
+				cliDetailField{Key: "session_id", Value: eventObservationDash(delivery.SessionID)},
+				cliDetailField{Key: "created_at", Value: eventObservationDash(delivery.CreatedAt)},
+				cliDetailField{Key: "started_at", Value: eventObservationDash(delivery.StartedAt)},
+				cliDetailField{Key: "finished_at", Value: eventObservationDash(delivery.FinishedAt)},
+				cliDetailField{Key: "reason_code", Value: eventObservationDash(delivery.ReasonCode)},
+				cliDetailField{Key: "last_error", Value: eventObservationDash(delivery.LastError)},
+				cliDetailField{Key: "retry_count", Value: fmt.Sprintf("%d", *delivery.RetryCount)},
+				cliDetailField{Key: "retry_eligible", Value: fmt.Sprintf("%t", *delivery.RetryEligible)},
+				cliDetailField{Key: "terminal", Value: fmt.Sprintf("%t", *delivery.Terminal)},
+				cliDetailField{Key: "dead_letters", Value: fmt.Sprintf("%d", len(delivery.DeadLetters))},
 			)
 			for _, deadLetter := range delivery.DeadLetters {
 				writeEventDeadLetterLine(out, "    delivery_dead_letter", deadLetter)
@@ -917,15 +927,18 @@ func writeEventDetailResult(out io.Writer, event eventFull) {
 }
 
 func writeEventDeadLetterLine(out io.Writer, prefix string, deadLetter eventDeadLetter) {
-	fmt.Fprintf(out, "%s dead_letter_id=%s failure_type=%s retry_count=%d chain_depth=%d created_at=%s handler_node=%s error=%s\n",
-		prefix,
-		deadLetter.DeadLetterID,
-		deadLetter.FailureType,
-		*deadLetter.RetryCount,
-		*deadLetter.ChainDepth,
-		deadLetter.CreatedAt,
-		eventObservationDash(deadLetter.HandlerNode),
-		eventObservationDash(deadLetter.ErrorMessage),
+	label := strings.TrimSpace(prefix)
+	if label == "" {
+		label = "dead_letter"
+	}
+	writeCLIFieldLine(out,
+		cliDetailField{Key: label + ".dead_letter_id", Value: deadLetter.DeadLetterID},
+		cliDetailField{Key: label + ".failure_type", Value: deadLetter.FailureType},
+		cliDetailField{Key: label + ".retry_count", Value: fmt.Sprintf("%d", *deadLetter.RetryCount)},
+		cliDetailField{Key: label + ".chain_depth", Value: fmt.Sprintf("%d", *deadLetter.ChainDepth)},
+		cliDetailField{Key: label + ".created_at", Value: deadLetter.CreatedAt},
+		cliDetailField{Key: label + ".handler_node", Value: eventObservationDash(deadLetter.HandlerNode)},
+		cliDetailField{Key: label + ".error", Value: eventObservationDash(deadLetter.ErrorMessage)},
 	)
 }
 

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -122,8 +122,8 @@ func TestEventViewUsesEventGetV1RPC(t *testing.T) {
 		"retry_count=2",
 		"retry_eligible=false",
 		"terminal=true",
-		"delivery_dead_letter dead_letter_id=delivery-dead-1",
-		"dead_letter_id=dead-1",
+		"delivery_dead_letter.dead_letter_id=delivery-dead-1",
+		"dead_letter.dead_letter_id=dead-1",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())

--- a/cmd/swarm/forkchat.go
+++ b/cmd/swarm/forkchat.go
@@ -868,48 +868,67 @@ func writeForkChatListResult(out io.Writer, result forkChatListResult) {
 	if out == nil {
 		return
 	}
-	if len(result.Forks) == 0 {
-		fmt.Fprintln(out, "No forkchat sessions match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "FORK_ID\tSOURCE_SESSION\tSOURCE_AGENT\tSTATE\tTURNS\tEXPIRES_AT")
+	rows := make([][]string, 0, len(result.Forks))
 	for _, fork := range result.Forks {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%s\n",
+		rows = append(rows, []string{
 			fork.ForkID,
 			fork.SourceSessionID,
 			fork.SourceAgentID,
 			fork.State,
-			len(fork.Turns),
+			fmt.Sprintf("%d", len(fork.Turns)),
 			fork.ExpiresAt,
-		)
+		})
 	}
+	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "FORK_ID", KeyColumn: true},
+			{Header: "SOURCE_SESSION"},
+			{Header: "SOURCE_AGENT"},
+			{Header: "STATE"},
+			{Header: "TURNS"},
+			{Header: "EXPIRES_AT"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No forkchat sessions match the current filters. Start one: swarm forkchat new <session-id>",
+		FooterLines:  footers,
+	})
 }
 
 func writeForkChatSessionDetail(out io.Writer, fork forkChatSession) {
 	if out == nil {
 		return
 	}
-	fmt.Fprintf(out, "Fork %s\n", fork.ForkID)
+	writeCLITitle(out, fmt.Sprintf("Fork %s", fork.ForkID))
 	writeForkChatSessionHeader(out, fork)
-	if len(fork.Turns) == 0 {
-		fmt.Fprintln(out, "No forkchat turns recorded.")
-		return
-	}
-	fmt.Fprintln(out, "TURN\tTURN_ID\tPARSE_OK\tLATENCY_MS\tTOOL_CALLS\tASSISTANT\tERROR")
+	rows := make([][]string, 0, len(fork.Turns))
 	for _, turn := range fork.Turns {
-		fmt.Fprintf(out, "%d\t%s\t%t\t%d\t%d\t%s\t%s\n",
-			turn.TurnIndex,
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", turn.TurnIndex),
 			turn.TurnID,
-			*turn.ParseOK,
-			*turn.LatencyMS,
-			len(turn.ToolCalls),
+			fmt.Sprintf("%t", *turn.ParseOK),
+			fmt.Sprintf("%d", *turn.LatencyMS),
+			fmt.Sprintf("%d", len(turn.ToolCalls)),
 			conversationDash(forkChatAssistantMessage(turn)),
 			conversationDash(turn.Error),
-		)
+		})
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "TURN"},
+			{Header: "TURN_ID", KeyColumn: true},
+			{Header: "PARSE_OK"},
+			{Header: "LATENCY_MS"},
+			{Header: "TOOL_CALLS"},
+			{Header: "ASSISTANT", Truncatable: true},
+			{Header: "ERROR", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No forkchat turns recorded.",
+	})
 }
 
 func writeForkChatChatResult(out io.Writer, result forkChatChatResult) {
@@ -932,22 +951,22 @@ func writeForkChatDeleteResult(out io.Writer, result forkChatDeleteResult) {
 }
 
 func writeForkChatSessionHeader(out io.Writer, fork forkChatSession) {
-	fmt.Fprintf(out, "source_session_id=%s source_agent_id=%s source_run_id=%s state=%s created_by=%s expires_at=%s\n",
-		fork.SourceSessionID,
-		fork.SourceAgentID,
-		conversationDash(fork.SourceRunID),
-		fork.State,
-		fork.CreatedBy,
-		fork.ExpiresAt,
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "source_session_id", Value: fork.SourceSessionID},
+		cliDetailField{Key: "source_agent_id", Value: fork.SourceAgentID},
+		cliDetailField{Key: "source_run_id", Value: conversationDash(fork.SourceRunID)},
+		cliDetailField{Key: "state", Value: fork.State},
+		cliDetailField{Key: "created_by", Value: fork.CreatedBy},
+		cliDetailField{Key: "expires_at", Value: fork.ExpiresAt},
 	)
 	point := fork.ForkPoint
-	fmt.Fprintf(out, "fork_point kind=%s turn_index=%d turn_id=%s event_id=%s at=%s selected_at=%s\n",
-		point.Kind,
-		point.TurnIndex,
-		point.TurnID,
-		conversationDash(point.EventID),
-		conversationDash(point.At),
-		point.SelectedAt,
+	writeCLIFieldLine(out,
+		cliDetailField{Key: "fork_point.kind", Value: point.Kind},
+		cliDetailField{Key: "fork_point.turn_index", Value: fmt.Sprintf("%d", point.TurnIndex)},
+		cliDetailField{Key: "fork_point.turn_id", Value: point.TurnID},
+		cliDetailField{Key: "fork_point.event_id", Value: conversationDash(point.EventID)},
+		cliDetailField{Key: "fork_point.at", Value: conversationDash(point.At)},
+		cliDetailField{Key: "fork_point.selected_at", Value: point.SelectedAt},
 	)
 }
 

--- a/cmd/swarm/incidents.go
+++ b/cmd/swarm/incidents.go
@@ -201,25 +201,36 @@ func writeRuntimeIncidentListResult(out io.Writer, result runtimeIncidentListRes
 	if out == nil {
 		return
 	}
-	if len(result.Incidents) == 0 {
-		fmt.Fprintln(out, "No runtime incidents match the filter.")
-		return
-	}
-	fmt.Fprintln(out, "LAST SEEN\tLEVEL\tCOMPONENT\tERROR\tCOUNT\tINCIDENT ID\tSAMPLE")
+	rows := make([][]string, 0, len(result.Incidents))
 	for _, incident := range result.Incidents {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+		rows = append(rows, []string{
 			incident.LastSeen,
 			incident.Level,
 			incident.Component,
 			runtimeIncidentDash(incident.ErrorCode),
-			incident.Count,
+			fmt.Sprintf("%d", incident.Count),
 			incident.IncidentID,
 			runtimeIncidentSampleMessage(incident),
-		)
+		})
 	}
+	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "LAST SEEN"},
+			{Header: "LEVEL"},
+			{Header: "COMPONENT"},
+			{Header: "ERROR"},
+			{Header: "COUNT"},
+			{Header: "INCIDENT ID", KeyColumn: true},
+			{Header: "SAMPLE", Truncatable: true},
+		},
+		Rows:         rows,
+		EmptyMessage: "No runtime incidents match the current filters.",
+		FooterLines:  footers,
+	})
 }
 
 func runtimeIncidentErrorClassifier() cliAPIErrorClassifier {

--- a/cmd/swarm/incidents_test.go
+++ b/cmd/swarm/incidents_test.go
@@ -91,7 +91,7 @@ func TestIncidentsOmitOptionalParamsWhenUnset(t *testing.T) {
 	if len(captured.Params) != 0 {
 		t.Fatalf("params = %#v, want empty map", captured.Params)
 	}
-	if !strings.Contains(stdout.String(), "No runtime incidents match the filter.") {
+	if !strings.Contains(stdout.String(), "No runtime incidents match the current filters.") {
 		t.Fatalf("stdout = %q, want empty-state text", stdout.String())
 	}
 }

--- a/cmd/swarm/secrets.go
+++ b/cmd/swarm/secrets.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
@@ -499,10 +498,9 @@ func writeSecretsTable(out io.Writer, records []secretRecord) {
 	if out == nil {
 		return
 	}
-	writer := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(writer, "KEY\tSOURCE\tWRITABLE\tSHADOWED\tPRESENT\tUPDATED_AT\tREQUIRED_BY")
+	rows := make([][]string, 0, len(records))
 	for _, record := range records {
-		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			record.Key,
 			dash(record.Source),
 			yesNo(record.Writable),
@@ -510,9 +508,21 @@ func writeSecretsTable(out io.Writer, records []secretRecord) {
 			yesNo(record.Present),
 			dash(record.UpdatedAt),
 			dash(formatSecretRequirements(record.RequiredBy)),
-		)
+		})
 	}
-	_ = writer.Flush()
+	writeCLITable(out, cliTable{
+		Columns: []cliTableColumn{
+			{Header: "KEY", KeyColumn: true},
+			{Header: "SOURCE"},
+			{Header: "WRITABLE"},
+			{Header: "SHADOWED"},
+			{Header: "PRESENT"},
+			{Header: "UPDATED_AT"},
+			{Header: "REQUIRED_BY"},
+		},
+		Rows:         rows,
+		EmptyMessage: "No secrets match the current filters. Add one: swarm secrets set <key>",
+	})
 }
 
 func formatSecretRequirements(items []secretRequirement) string {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -14957,6 +14957,48 @@ cli_specification:
           mode parsing, stdout/stderr policy, JSON/NDJSON encoding, quiet rendering, and exception enforcement.
           Command-local writers may provide command-specific facts and text renderers, but they MUST NOT each
           reinterpret output-mode semantics independently.
+        display_renderer_rule: >
+          Successful human table/list/repeated-row/detail-display output MUST consume one shared `cmd/swarm`
+          display renderer for column alignment, empty values, empty list states, color/no-color policy,
+          emoji-vocabulary policy, and truncation declarations. Command owners keep owning facts, row order,
+          filtering, and business vocabulary. The display renderer MUST NOT reorder rows, shorten identifiers by
+          default, hide fields, or infer semantics not supplied by the command's canonical fact owner.
+        row_model_rule: >
+          For migrated read/list/detail surfaces, default text and JSON MUST derive from the same validated command
+          result or row/detail model. A command MUST NOT assemble separate fact interpretations for human table rows
+          and JSON output. Human default text may omit fields for readability, but it cannot invent alternate field
+          values or abbreviate identifiers unless a command row explicitly owns that lossy projection.
+        table_policy:
+          alignment: Space-aligned columns with at least two spaces between columns; literal-tab TSV is not a
+            supported table rendering policy for public CLI read/list output.
+          empty_value: Empty string values render as `-` in human tables/details. JSON preserves the canonical
+            empty/null value from the fact owner.
+          empty_state: Empty successful lists render a single author-facing sentence with the applicable filter
+            context and, when the command has an obvious creation path, a concrete next command. Blank tables are
+            invalid.
+          identifier_columns: ID/key/hash columns MUST NOT be implicitly truncated. Short-ID adoption waits for the
+            ID-prefix resolver owner and must remain drillable.
+          truncation: Truncatable columns must be declared by the table owner. Terminal width alone is not authority
+            to truncate an identifier or semantic key.
+          ordering: Row order is fact semantics owned by the command/API owner; the shared display renderer MUST
+            render rows in the order supplied by that owner.
+        color_and_emoji_policy:
+          color: >
+            Human default text may use ANSI color only when stdout is an interactive TTY and neither `--no-color`
+            nor `NO_COLOR` suppresses it. JSON, NDJSON, quiet output, and non-TTY output MUST NOT depend on ANSI
+            color for meaning.
+          emoji: >
+            Emoji status marks share the same gating and suppression rules as color. They may augment, but never
+            replace, complete plain text. The allowed semantic vocabulary is limited to success/settled, failed,
+            warning/blocked, and inactive classes; implementation of emoji marks is optional for the first #1814
+            slice.
+        sibling_exclusions:
+        - Logs formatting and log table policy remain owned by #1819.
+        - Broad short-ID adoption and ID-prefix drillability remain owned by #1815.
+        - Run-trace business-event fidelity and runtime-log hiding remain owned by #1816.
+        - Vocabulary/status/detail-depth rewrites remain owned by #1817/#1820.
+        - Arg/Cobra error rendering remains owned by #1818.
+        - Mutation summaries and streaming/follow rendering are not table/display closure proof for #1814.
         canonical_fact_rule: >
           Runtime-state commands render facts returned by their canonical API owner at /v1/rpc or /v1/ws. They
           MUST NOT read DB/store/runtime/EventBus state locally, recompute status, or enrich JSON/quiet output
@@ -14987,8 +15029,9 @@ cli_specification:
             pass must stay `split` with an owner issue until that owner lands.
           classification_values:
             shared_output: >
-              The command consumes the shared `cmd/swarm` output-mode/color owner for successful output. It accepts
-              `--json`, `--quiet`, and `--no-color` through the shared helper path.
+              The command consumes the shared `cmd/swarm` output-mode/color owner for successful output and, when it
+              renders table/list/detail human text, consumes the shared display renderer. It accepts `--json`,
+              `--quiet`, and `--no-color` through the shared helper path.
             exception: >
               The command is an explicit help/process/retired-style surface that does not consume output modes and
               is governed by an exception rule.
@@ -15061,8 +15104,8 @@ cli_specification:
             secrets_list:
               command: swarm secrets list
               classification: split
-              owner_issue: '#1814'
-              reason: secret list table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: secret list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             secrets_check:
               command: swarm secrets check
               classification: split
@@ -15090,8 +15133,8 @@ cli_specification:
             connections_status:
               command: swarm connections status
               classification: split
-              owner_issue: '#1814'
-              reason: status table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: connection status table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             connections_disconnect:
               command: swarm connections disconnect
               classification: split
@@ -15144,8 +15187,8 @@ cli_specification:
             trace:
               command: swarm run trace
               classification: split
-              owner_issue: '#1814'
-              reason: trace table/follow rendering remains on the shared table/display migration path.
+              owner_issue: '#1816'
+              reason: trace tables consume the shared display renderer; trace fidelity/follow behavior remains on the dedicated trace owner before full shared-output classification.
             run_fork:
               command: swarm run fork
               classification: shared_output
@@ -15161,12 +15204,12 @@ cli_specification:
               command: swarm mailbox list
               classification: split
               owner_issue: '#1712'
-              reason: mailbox discovery output is implemented but not routed through the shared output-mode owner.
+              reason: mailbox list display consumes the shared display renderer; full shared output-mode route-through remains part of the CLI output umbrella.
             mailbox_view:
               command: swarm mailbox view
               classification: split
               owner_issue: '#1712'
-              reason: mailbox detail output is implemented but not routed through the shared output-mode owner.
+              reason: mailbox detail shell consumes the shared display renderer; decision-sheet depth and full shared output-mode route-through remain part of the CLI output umbrella.
             mailbox_approve:
               command: swarm mailbox approve
               classification: split
@@ -15220,8 +15263,8 @@ cli_specification:
             agents_list:
               command: swarm agent list
               classification: split
-              owner_issue: '#1814'
-              reason: agent list table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: agent list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             agent_view:
               command: swarm agent view
               classification: split
@@ -15236,7 +15279,7 @@ cli_specification:
               command: swarm agent deliveries
               classification: split
               owner_issue: '#1817'
-              reason: agent delivery detail vocabulary/sectioning remains on the vocabulary/status-detail migration path.
+              reason: agent delivery table/default text consumes the shared display renderer; vocabulary/sectioning remains on the vocabulary/status-detail migration path.
             agent_restart:
               command: swarm agent restart
               classification: split
@@ -15264,8 +15307,8 @@ cli_specification:
             events_list:
               command: swarm event list
               classification: split
-              owner_issue: '#1814'
-              reason: event list table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: event list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             events_follow:
               command: swarm event follow
               classification: split
@@ -15274,8 +15317,8 @@ cli_specification:
             event_view:
               command: swarm event view
               classification: split
-              owner_issue: '#1814'
-              reason: event detail text remains on the display-policy migration path.
+              owner_issue: '#1821'
+              reason: event detail shell consumes the shared display renderer; full shared output-mode route-through remains pending.
             event_replay:
               command: swarm event replay
               classification: split
@@ -15401,18 +15444,18 @@ cli_specification:
             entities_list:
               command: swarm entity list
               classification: split
-              owner_issue: '#1814'
-              reason: entity list table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: entity list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             entity_view:
               command: swarm entity view
               classification: split
-              owner_issue: '#1814'
-              reason: entity detail text remains on the display-policy migration path.
+              owner_issue: '#1821'
+              reason: entity detail shell consumes the shared display renderer; full shared output-mode route-through remains pending.
             entity_aggregate:
               command: swarm entity aggregate
               classification: split
-              owner_issue: '#1814'
-              reason: entity aggregate table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: entity aggregate table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             logs:
               command: swarm logs
               classification: split
@@ -15421,8 +15464,8 @@ cli_specification:
             incidents:
               command: swarm incidents
               classification: split
-              owner_issue: '#1814'
-              reason: incident table/default text remains on the table-renderer migration path.
+              owner_issue: '#1821'
+              reason: incident table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             context:
               command: swarm context
               classification: exception
@@ -15435,8 +15478,8 @@ cli_specification:
             context_list:
               command: swarm context list
               classification: split
-              owner_issue: '#1814'
-              reason: context list output remains on the table/display migration path.
+              owner_issue: '#1821'
+              reason: context list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
             context_prune:
               command: swarm context prune
               classification: split


### PR DESCRIPTION
## Summary

Adds the shared CLI table/display renderer and migrates the approved #1814 read/list/detail display slice to consume it.

## Governing Context

- Closes #1814.
- Part of #1712 and #1821.
- Binding gate: #1814 issue thread, latest `approved as first slice` lead comment.
- Exact spec authority: `platform-spec.yaml#cli_specification.foundations.output_contract`.

## Semantic Migration

- New canonical owner: `cmd/swarm/cli_output.go` shared display helpers plus `platform-spec.yaml#cli_specification.foundations.output_contract.shared_renderer_contract`.
- Old invalid paths: command-local literal-tab/table writers and local `tabwriter` table owners for public successful read/list/detail display output.
- Production paths checked: secrets/connections/run trace/run list/agent list and deliveries/event/entity/incidents/context/conversation/bundle/mailbox/forkchat displays, plus repo-wide literal-tab/`tabwriter` conformance guard.
- Migration completeness: complete for the approved #1814 display-renderer class. Rows that still lack full shared output-mode route-through remain split to non-#1814 owners with repaired reasons.

## Verification

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- Focused CLI/spec tests after final rebase: `go test ./cmd/swarm ./internal/apispec -run 'TestCLIOutput|TestDiagnosticRunTraceDeliverySummaryText|TestConversation|TestEntity|TestMailbox|TestAgent|TestBundle|TestContext|TestIncidents|TestCLI'`

## Notes

- No logs formatting changes; logs remain split to #1819.
- No broad short-ID adoption; #1815 remains the drillability owner.
- No trace-fidelity, vocabulary/deep-detail, arg-error, mutation-summary, or streaming/follow behavior changes.