### PR TITLE
[agent-c][issue #1846] Add stage-owned temporal timers

### DIFF
--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -216,7 +216,32 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 					if strings.TrimSpace(edge.EventType) != "" {
 						detail += " on " + strings.TrimSpace(edge.EventType)
 					}
+					if strings.TrimSpace(edge.After) != "" {
+						detail += " after " + strings.TrimSpace(edge.After)
+					}
+					if strings.TrimSpace(edge.TimerID) != "" {
+						detail += " timer " + strings.TrimSpace(edge.TimerID)
+					}
 					fmt.Fprintf(out, "      - %s -> %s (%s)\n", from, edge.To, strings.TrimSpace(detail))
+				}
+			}
+			if len(graph.Timers) > 0 {
+				fmt.Fprintln(out, "    timers:")
+				for _, timer := range graph.Timers {
+					parts := []string{
+						strings.TrimSpace(timer.Stage),
+						"after " + strings.TrimSpace(timer.After),
+					}
+					if strings.TrimSpace(timer.Emit) != "" {
+						parts = append(parts, "emit "+strings.TrimSpace(timer.Emit))
+					}
+					if strings.TrimSpace(timer.AdvancesTo) != "" {
+						parts = append(parts, "advances_to "+strings.TrimSpace(timer.AdvancesTo))
+					}
+					if strings.TrimSpace(timer.TimerID) != "" {
+						parts = append(parts, "(timer "+strings.TrimSpace(timer.TimerID)+")")
+					}
+					fmt.Fprintf(out, "      - %s\n", strings.Join(parts, " "))
 				}
 			}
 		}

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -218,6 +218,7 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	var foundOpenedAdvance bool
 	var foundAccumulateComplete bool
 	var foundAccumulateTimeout bool
+	var foundTimedAdvance bool
 	for _, edge := range graph.Edges {
 		if edge.Source == "handler.advances_to" && edge.NodeID == "support-node" && edge.EventType == "ticket.opened" && edge.To == "active" {
 			foundOpenedAdvance = true
@@ -228,6 +229,9 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		if edge.Source == "handler.accumulate.on_timeout" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "timed_out" {
 			foundAccumulateTimeout = true
 		}
+		if edge.Source == "timer" && edge.TimerID == "active.timed_out" && edge.After == "72h" && edge.To == "timed_out" {
+			foundTimedAdvance = true
+		}
 	}
 	if !foundOpenedAdvance {
 		t.Fatalf("graph edges = %#v, want ticket.opened handler.advances_to edge to active", graph.Edges)
@@ -237,6 +241,12 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	}
 	if !foundAccumulateTimeout {
 		t.Fatalf("graph edges = %#v, want ticket.closed handler.accumulate.on_timeout edge to timed_out", graph.Edges)
+	}
+	if !foundTimedAdvance {
+		t.Fatalf("graph edges = %#v, want stage timer edge to timed_out with delay", graph.Edges)
+	}
+	if len(graph.Timers) != 2 {
+		t.Fatalf("graph timers = %#v, want emit and advance stage timers", graph.Timers)
 	}
 
 	stdout.Reset()
@@ -258,6 +268,9 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		"handler.advances_to support-node on ticket.opened",
 		"handler.accumulate.on_complete support-node on ticket.closed",
 		"handler.accumulate.on_timeout support-node on ticket.closed",
+		"timer runtime on timer:active.timed_out after 72h timer active.timed_out",
+		"active after 48h emit ticket.sla_escalated (timer active.ticket.sla_escalated)",
+		"active after 72h advances_to timed_out (timer active.timed_out)",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("describe --graph output missing %q:\n%s", want, text)
@@ -353,7 +366,12 @@ name: support
 stages:
   waiting:
     initial: true
-  active: {}
+  active:
+    timers:
+      - after: 48h
+        emit: ticket.sla_escalated
+      - after: 72h
+        advances_to: timed_out
   review: {}
   timed_out: {}
   done:
@@ -370,6 +388,10 @@ ticket.opened:
 ticket.closed:
   swarm:
     source: external
+  entity_id: string
+ticket.sla_escalated:
+  swarm:
+    consumer: [operator]
   entity_id: string
 accumulate.timeout:
   swarm:

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -229,7 +229,7 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		if edge.Source == "handler.accumulate.on_timeout" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "timed_out" {
 			foundAccumulateTimeout = true
 		}
-		if edge.Source == "timer" && edge.TimerID == "active.timed_out" && edge.After == "72h" && edge.To == "timed_out" {
+		if edge.Source == "timer" && edge.TimerID == "support.active.timed_out" && edge.After == "72h" && edge.To == "timed_out" {
 			foundTimedAdvance = true
 		}
 	}
@@ -268,9 +268,9 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		"handler.advances_to support-node on ticket.opened",
 		"handler.accumulate.on_complete support-node on ticket.closed",
 		"handler.accumulate.on_timeout support-node on ticket.closed",
-		"timer runtime on timer:active.timed_out after 72h timer active.timed_out",
-		"active after 48h emit ticket.sla_escalated (timer active.ticket.sla_escalated)",
-		"active after 72h advances_to timed_out (timer active.timed_out)",
+		"timer runtime on timer:support.active.timed_out after 72h timer support.active.timed_out",
+		"active after 48h emit ticket.sla_escalated (timer support.active.ticket.sla_escalated)",
+		"active after 72h advances_to timed_out (timer support.active.timed_out)",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("describe --graph output missing %q:\n%s", want, text)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4338,6 +4338,13 @@ type servedMailboxDecisionFixture struct {
 
 func runServedMailboxDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
 	t.Helper()
+	runServedMailboxApproveDecisionLifecycleProof(t, rt)
+	runServedMailboxRejectDecisionLifecycleProof(t, rt)
+	runServedMailboxDeferDecisionLifecycleProof(t, rt)
+}
+
+func runServedMailboxApproveDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
 	fixture := seedServedMailboxDecisionFixture(t, rt.DB, rt.Backend)
 	keyPrefix := "issue-1885-" + rt.Backend + "-" + fixture.RunID
 
@@ -4367,6 +4374,13 @@ func runServedMailboxDecisionLifecycleProof(t *testing.T, rt servedControlProofR
 	if already.Data["code"] != apiv1.MailboxAlreadyDecidedCode {
 		t.Fatalf("%s mailbox.reject already-decided data = %#v, want %s", rt.Backend, already.Data, apiv1.MailboxAlreadyDecidedCode)
 	}
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle))
+}
+
+func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
+	fixture := seedServedMailboxDecisionFixture(t, rt.DB, rt.Backend)
+	keyPrefix := "issue-1885-" + rt.Backend + "-" + fixture.RunID
 
 	rejectKey := keyPrefix + "-reject"
 	rejected := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.reject", map[string]any{
@@ -4387,6 +4401,13 @@ func runServedMailboxDecisionLifecycleProof(t *testing.T, rt servedControlProofR
 	})
 	requireServedMailboxReplay(t, rejectReplay, rejected)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle))
+}
+
+func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
+	fixture := seedServedMailboxDecisionFixture(t, rt.DB, rt.Backend)
+	keyPrefix := "issue-1885-" + rt.Backend + "-" + fixture.RunID
 
 	deferKey := keyPrefix + "-defer"
 	deferred := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.defer", map[string]any{
@@ -4407,14 +4428,7 @@ func runServedMailboxDecisionLifecycleProof(t *testing.T, rt servedControlProofR
 	})
 	requireServedMailboxReplay(t, deferReplay, deferred)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
-
-	for _, scenarioID := range []string{
-		servedparity.ScenarioMailboxApproveDecisionLifecycle,
-		servedparity.ScenarioMailboxRejectDecisionLifecycle,
-		servedparity.ScenarioMailboxDeferDecisionLifecycle,
-	} {
-		requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(scenarioID))
-	}
+	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle))
 }
 
 func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) servedMailboxDecisionFixture {

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -240,6 +240,11 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "workflow node construction carries pipeline SQL dependency to explicit node/unit-of-work owners",
 		},
+		"internal/runtime/pipeline/workflow_timer_lifecycle.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          1846,
+			Reason:         "stage timer fire handling uses the selected workflow instance RunPipelineMutation owner to keep fired state and timed transition application in one unit of work",
+		},
 		"internal/runtime/pipeline/workflow_transitions.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -75,10 +75,11 @@ type FlowSourceFiles struct {
 }
 
 type StageGraphView struct {
-	FlowID   string               `json:"flow_id"`
-	FlowPath string               `json:"flow_path,omitempty"`
-	Nodes    []StageGraphNodeView `json:"nodes"`
-	Edges    []StageGraphEdgeView `json:"edges"`
+	FlowID   string                `json:"flow_id"`
+	FlowPath string                `json:"flow_path,omitempty"`
+	Nodes    []StageGraphNodeView  `json:"nodes"`
+	Edges    []StageGraphEdgeView  `json:"edges"`
+	Timers   []StageGraphTimerView `json:"timers,omitempty"`
 }
 
 type StageGraphNodeView struct {
@@ -94,6 +95,17 @@ type StageGraphEdgeView struct {
 	Source    string   `json:"source"`
 	NodeID    string   `json:"node_id,omitempty"`
 	EventType string   `json:"event_type,omitempty"`
+	TimerID   string   `json:"timer_id,omitempty"`
+	After     string   `json:"after,omitempty"`
+	Timed     bool     `json:"timed,omitempty"`
+}
+
+type StageGraphTimerView struct {
+	Stage      string `json:"stage"`
+	TimerID    string `json:"timer_id"`
+	After      string `json:"after"`
+	Emit       string `json:"emit,omitempty"`
+	AdvancesTo string `json:"advances_to,omitempty"`
 }
 
 type RequiredAgentsView struct {
@@ -390,7 +402,7 @@ func buildStageGraphs(source semanticview.Source, bundle *runtimecontracts.Workf
 		return nil
 	}
 	graphs := make([]StageGraphView, 0, len(bundle.FlowViews())+1)
-	if graph := buildStageGraphForFlow(source, "", "root", ""); len(graph.Nodes) > 0 || len(graph.Edges) > 0 {
+	if graph := buildStageGraphForFlow(source, "", "root", ""); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 {
 		graphs = append(graphs, graph)
 	}
 	for _, flow := range bundle.FlowViews() {
@@ -399,7 +411,7 @@ func buildStageGraphs(source semanticview.Source, bundle *runtimecontracts.Workf
 			continue
 		}
 		path := strings.Trim(strings.TrimSpace(flow.Path), "/")
-		if graph := buildStageGraphForFlow(source, flowID, flowID, path); len(graph.Nodes) > 0 || len(graph.Edges) > 0 {
+		if graph := buildStageGraphForFlow(source, flowID, flowID, path); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 {
 			graphs = append(graphs, graph)
 		}
 	}
@@ -430,6 +442,7 @@ func buildStageGraphForFlow(source semanticview.Source, flowID, label, path stri
 		FlowPath: strings.TrimSpace(path),
 		Nodes:    nodes,
 		Edges:    buildStageGraphEdgesForFlow(source, flowID, initial, states, terminalSet),
+		Timers:   buildStageGraphTimersForFlow(source, flowID),
 	}
 }
 
@@ -519,6 +532,12 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial str
 			}
 		}
 	}
+	for _, timer := range source.WorkflowTimers() {
+		if strings.TrimSpace(timer.FlowID) != strings.TrimSpace(flowID) || !timer.StageOwned || strings.TrimSpace(timer.AdvancesTo) == "" {
+			continue
+		}
+		edges = appendStageGraphTimedEdge(edges, []string{strings.TrimSpace(timer.Stage)}, timer.AdvancesTo, stateSet, timer)
+	}
 	sort.Slice(edges, func(i, j int) bool {
 		left := edges[i]
 		right := edges[j]
@@ -534,7 +553,13 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial str
 		if left.NodeID != right.NodeID {
 			return left.NodeID < right.NodeID
 		}
-		return left.EventType < right.EventType
+		if left.EventType != right.EventType {
+			return left.EventType < right.EventType
+		}
+		if left.TimerID != right.TimerID {
+			return left.TimerID < right.TimerID
+		}
+		return left.After < right.After
 	})
 	return edges
 }
@@ -556,6 +581,52 @@ func appendStageGraphEdge(edges []StageGraphEdgeView, from []string, target stri
 		NodeID:    strings.TrimSpace(nodeID),
 		EventType: strings.TrimSpace(eventType),
 	})
+}
+
+func appendStageGraphTimedEdge(edges []StageGraphEdgeView, from []string, target string, stateSet map[string]struct{}, timer runtimecontracts.WorkflowTimerContract) []StageGraphEdgeView {
+	edgeCount := len(edges)
+	edges = appendStageGraphEdge(edges, from, target, stateSet, "timer", "runtime", "timer:"+strings.TrimSpace(timer.ID))
+	if len(edges) == edgeCount {
+		return edges
+	}
+	edge := &edges[len(edges)-1]
+	edge.TimerID = strings.TrimSpace(timer.ID)
+	edge.After = strings.TrimSpace(timer.Delay)
+	edge.Timed = true
+	return edges
+}
+
+func buildStageGraphTimersForFlow(source semanticview.Source, flowID string) []StageGraphTimerView {
+	if source == nil {
+		return nil
+	}
+	out := make([]StageGraphTimerView, 0)
+	for _, timer := range source.WorkflowTimers() {
+		if strings.TrimSpace(timer.FlowID) != strings.TrimSpace(flowID) || !timer.StageOwned {
+			continue
+		}
+		emit := strings.TrimSpace(timer.Event)
+		if emit == runtimecontracts.WorkflowStageTimerInternalEvent {
+			emit = ""
+		}
+		out = append(out, StageGraphTimerView{
+			Stage:      strings.TrimSpace(timer.Stage),
+			TimerID:    strings.TrimSpace(timer.ID),
+			After:      strings.TrimSpace(timer.Delay),
+			Emit:       emit,
+			AdvancesTo: strings.TrimSpace(timer.AdvancesTo),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Stage != out[j].Stage {
+			return out[i].Stage < out[j].Stage
+		}
+		if out[i].After != out[j].After {
+			return out[i].After < out[j].After
+		}
+		return out[i].TimerID < out[j].TimerID
+	})
+	return out
 }
 
 func authoringStringSet(values []string) map[string]struct{} {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -186,6 +186,71 @@ func TestBuildShowsRequiredAgentProvenance(t *testing.T) {
 	}
 }
 
+func TestBuildStageGraphShowsStageTimersAndTimedEdges(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "awaiting_review", Initial: true},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{
+				{
+					ID:         "awaiting_review.review.sla_escalated",
+					Stage:      "awaiting_review",
+					Event:      "review.sla_escalated",
+					Owner:      "runtime",
+					StageOwned: true,
+					Delay:      "48h",
+					StartOn:    "state:awaiting_review",
+				},
+				{
+					ID:         "awaiting_review.expired",
+					Stage:      "awaiting_review",
+					Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
+					Owner:      "runtime",
+					StageOwned: true,
+					AdvancesTo: "expired",
+					Delay:      "{{marginal_park_days}}d",
+					StartOn:    "state:awaiting_review",
+				},
+			},
+		},
+	}
+
+	view, err := Build(context.Background(), semanticview.Wrap(bundle), BuildOptions{IncludeStageGraph: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(view.StageGraphs) != 1 {
+		t.Fatalf("StageGraphs = %#v, want one root graph", view.StageGraphs)
+	}
+	graph := view.StageGraphs[0]
+	if len(graph.Timers) != 2 {
+		t.Fatalf("graph timers = %#v, want both stage timers including emit-only", graph.Timers)
+	}
+	if graph.Timers[0].TimerID != "awaiting_review.expired" && graph.Timers[1].TimerID != "awaiting_review.expired" {
+		t.Fatalf("graph timers = %#v, want advances_to timer visible", graph.Timers)
+	}
+	var timedEdge StageGraphEdgeView
+	for _, edge := range graph.Edges {
+		if edge.TimerID == "awaiting_review.expired" {
+			timedEdge = edge
+			break
+		}
+	}
+	if timedEdge.TimerID == "" {
+		t.Fatalf("graph edges = %#v, want timed transition edge", graph.Edges)
+	}
+	if !timedEdge.Timed || timedEdge.After != "{{marginal_park_days}}d" || timedEdge.To != "expired" {
+		t.Fatalf("timed edge = %#v, want after-labeled transition to expired", timedEdge)
+	}
+}
+
 func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
 	flow := runtimecontracts.FlowContractView{
 		Path: "analysis",

--- a/internal/runtime/bootverify/workflow_stage_timer_checks_test.go
+++ b/internal/runtime/bootverify/workflow_stage_timer_checks_test.go
@@ -1,0 +1,95 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestTimerValidationAcceptsAdvanceOnlyStageTimerInternalEvent(t *testing.T) {
+	findings := stageTimerValidationFindings(runtimecontracts.WorkflowTimerContract{
+		ID:         "awaiting_review.expired",
+		Stage:      "awaiting_review",
+		Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
+		Owner:      "runtime",
+		StageOwned: true,
+		AdvancesTo: "expired",
+		Delay:      "48h",
+		StartOn:    "state:awaiting_review",
+	})
+	if len(findings) != 0 {
+		t.Fatalf("findings = %#v, want none for internal advance-only stage timer", findings)
+	}
+}
+
+func TestTimerValidationRejectsStageTimerUnknownAdvanceTarget(t *testing.T) {
+	findings := stageTimerValidationFindings(runtimecontracts.WorkflowTimerContract{
+		ID:         "awaiting_review.missing",
+		Stage:      "awaiting_review",
+		Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
+		Owner:      "runtime",
+		StageOwned: true,
+		AdvancesTo: "missing",
+		Delay:      "48h",
+		StartOn:    "state:awaiting_review",
+	})
+	if !stageTimerFindingContains(findings, "advances_to references unknown stage missing") {
+		t.Fatalf("findings = %#v, want unknown advances_to target", findings)
+	}
+}
+
+func TestTimerValidationRejectsLegacyStateTimerInStagesFlow(t *testing.T) {
+	source := semanticview.Wrap(stageTimerValidationBundle(runtimecontracts.WorkflowTimerContract{
+		ID:      "legacy_sla",
+		Stage:   "awaiting_review",
+		Event:   "timer.legacy_sla",
+		Owner:   "runtime",
+		Delay:   "48h",
+		StartOn: "state:awaiting_review",
+	}))
+	findings := checkTimerValidation(newCheckerContext(context.Background(), source, Options{}))
+	if !stageTimerFindingContains(findings, "legacy node-level start_on state:awaiting_review") {
+		t.Fatalf("findings = %#v, want legacy state timer fence", findings)
+	}
+}
+
+func stageTimerValidationFindings(timer runtimecontracts.WorkflowTimerContract) []Finding {
+	source := semanticview.Wrap(stageTimerValidationBundle(timer))
+	return checkTimerValidation(newCheckerContext(context.Background(), source, Options{}))
+}
+
+func stageTimerValidationBundle(timer runtimecontracts.WorkflowTimerContract) *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "awaiting_review", Initial: true},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"timer.legacy_sla": {
+				Swarm: runtimecontracts.EventSwarmMetadata{
+					Consumer: []string{"operator"},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{timer},
+		},
+	}
+}
+
+func stageTimerFindingContains(findings []Finding, want string) bool {
+	for _, finding := range findings {
+		if strings.Contains(finding.Message, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -17,6 +17,8 @@ func (c *checkerContext) timerValidation() []Finding {
 	}
 	c.timerLoaded = true
 	for _, timer := range c.source.WorkflowTimers() {
+		c.validateStageTimerSemantics(timer)
+		c.validateLegacyStageTimerFence(timer)
 		owner := strings.TrimSpace(timer.Owner)
 		if owner == "" {
 			c.timerFindings = append(c.timerFindings, Finding{
@@ -39,16 +41,18 @@ func (c *checkerContext) timerValidation() []Finding {
 				}
 			}
 		}
-		fireEvent := semanticview.ResolveFlowEventProof(c.source, timer.FlowID, timer.Event)
-		if !fireEvent.HasSchema {
-			c.timerFindings = append(c.timerFindings, Finding{
-				CheckID:  "timer_validation",
-				Severity: "error",
-				Message:  fmt.Sprintf("timer %s event %s missing from event catalog", timer.ID, timer.Event),
-				Location: strings.TrimSpace(timer.ID),
-			})
-		} else {
-			c.validateTimerFireEventConsumer(timer, fireEvent)
+		if !timerUsesInternalStageTimerEvent(timer) {
+			fireEvent := semanticview.ResolveFlowEventProof(c.source, timer.FlowID, timer.Event)
+			if !fireEvent.HasSchema {
+				c.timerFindings = append(c.timerFindings, Finding{
+					CheckID:  "timer_validation",
+					Severity: "error",
+					Message:  fmt.Sprintf("timer %s event %s missing from event catalog", timer.ID, timer.Event),
+					Location: strings.TrimSpace(timer.ID),
+				})
+			} else {
+				c.validateTimerFireEventConsumer(timer, fireEvent)
+			}
 		}
 		startTrigger, err := timeridentity.ParseStartTrigger(timer.StartOn)
 		if err != nil {
@@ -87,6 +91,96 @@ func (c *checkerContext) timerValidation() []Finding {
 		c.validateTimerCancelStateReachability(timer, startTrigger, cancelTrigger)
 	}
 	return c.timerFindings
+}
+
+func (c *checkerContext) validateStageTimerSemantics(timer runtimecontracts.WorkflowTimerContract) {
+	if !timer.StageOwned {
+		return
+	}
+	stage := strings.TrimSpace(timer.Stage)
+	if stage == "" || !containsString(flowStatesForTimer(c.source, timer.FlowID), stage) {
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s references unknown source stage %s", timer.ID, stage),
+			Location: strings.TrimSpace(timer.ID),
+		})
+	}
+	if strings.TrimSpace(timer.Delay) == "" {
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s missing after delay", timer.ID),
+			Location: strings.TrimSpace(timer.ID),
+		})
+	}
+	if timer.Recurring {
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s stage timers are one-shot; repeat/recurring is not supported", timer.ID),
+			Location: strings.TrimSpace(timer.ID),
+		})
+	}
+	if strings.TrimSpace(timer.AdvancesTo) != "" && !containsString(flowStatesForTimer(c.source, timer.FlowID), timer.AdvancesTo) {
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s advances_to references unknown stage %s", timer.ID, timer.AdvancesTo),
+			Location: strings.TrimSpace(timer.ID),
+		})
+	}
+}
+
+func (c *checkerContext) validateLegacyStageTimerFence(timer runtimecontracts.WorkflowTimerContract) {
+	if timer.StageOwned || !timerFlowDeclaresStageMapping(c.source, timer.FlowID) {
+		return
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "start_on", value: timer.StartOn},
+		{name: "cancel_on", value: timer.CancelOn},
+	} {
+		trigger, err := timeridentity.ParseCancelTrigger(field.value)
+		if field.name == "start_on" {
+			trigger, err = timeridentity.ParseStartTrigger(field.value)
+		}
+		if err != nil || trigger.Kind != timeridentity.TriggerKindState {
+			continue
+		}
+		c.timerFindings = append(c.timerFindings, Finding{
+			CheckID:  "timer_validation",
+			Severity: "error",
+			Message:  fmt.Sprintf("timer %s uses legacy node-level %s %s in a stages: flow; use stages.<stage>.timers instead", timer.ID, field.name, trigger.String()),
+			Location: strings.TrimSpace(timer.ID),
+		})
+	}
+}
+
+func timerUsesInternalStageTimerEvent(timer runtimecontracts.WorkflowTimerContract) bool {
+	return timer.StageOwned && strings.TrimSpace(timer.Event) == runtimecontracts.WorkflowStageTimerInternalEvent
+}
+
+type timerRootFlowSchemaProvider interface {
+	RootFlowSchema() (runtimecontracts.FlowSchemaDocument, bool)
+}
+
+func timerFlowDeclaresStageMapping(source semanticview.Source, flowID string) bool {
+	if source == nil {
+		return false
+	}
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		if provider, ok := source.(timerRootFlowSchemaProvider); ok {
+			schema, ok := provider.RootFlowSchema()
+			return ok && schema.StageDeclarations.Declared
+		}
+		return false
+	}
+	schema, ok := source.FlowSchemaByID(flowID)
+	return ok && schema.StageDeclarations.Declared
 }
 
 func (c *checkerContext) validateTimerTrigger(timer runtimecontracts.WorkflowTimerContract, field string, trigger timeridentity.Trigger) {

--- a/internal/runtime/bootverify/workflow_transition_runtime_checks.go
+++ b/internal/runtime/bootverify/workflow_transition_runtime_checks.go
@@ -29,6 +29,9 @@ func (c *checkerContext) transitionReferences() []Finding {
 				Message:  fmt.Sprintf("transition %s missing trigger", id),
 				Location: id,
 			})
+		} else if transitionTriggerIsTimerReference(c.source, transition.Trigger) {
+			// Timer-triggered transitions are derived from stage timer rows and are
+			// not event catalog entries. The timer owner is validated separately.
 		} else if !eventExists(c.source, strings.TrimSpace(transition.Trigger)) {
 			c.transitionRefFindings = append(c.transitionRefFindings, Finding{
 				CheckID:  "transition_reference_validation",
@@ -101,6 +104,19 @@ func (c *checkerContext) transitionReferences() []Finding {
 		}
 	}
 	return c.transitionRefFindings
+}
+
+func transitionTriggerIsTimerReference(source semanticview.Source, trigger string) bool {
+	trigger = strings.TrimSpace(trigger)
+	if !strings.HasPrefix(trigger, "timer:") {
+		return false
+	}
+	timerID := strings.TrimSpace(strings.TrimPrefix(trigger, "timer:"))
+	if timerID == "" || source == nil {
+		return false
+	}
+	timer, ok := source.WorkflowTimerByID(timerID)
+	return ok && timer.StageOwned
 }
 
 func (c *checkerContext) transitionOwnership() []Finding {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -20,7 +20,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		EntitySchema:           entitySchema,
 		Stages:                 deriveWorkflowStages(bundle.RootSchema, bundle.Paths.Flows, bundle.FlowSchemas),
 		TerminalStages:         deriveWorkflowTerminalStages(bundle.RootSchema, bundle.Paths.Flows, bundle.FlowSchemas),
-		Transitions:            nil,
+		Transitions:            deriveStageTimerTransitions(bundle),
 		Timers:                 deriveWorkflowSemanticTimers(bundle),
 		Guards:                 deriveWorkflowGuardEntries(bundle),
 		Actions:                deriveWorkflowActionEntries(bundle),
@@ -439,8 +439,83 @@ func deriveWorkflowSemanticTimers(bundle *WorkflowContractBundle) []WorkflowTime
 	for _, timer := range deriveNodeWorkflowTimers(bundle) {
 		addTimer(timer)
 	}
+	for _, timer := range deriveStageWorkflowTimers(bundle) {
+		addTimer(timer)
+	}
 	return out
 }
+
+const WorkflowStageTimerInternalEvent = "platform.stage_timer"
+
+func deriveStageWorkflowTimers(bundle *WorkflowContractBundle) []WorkflowTimerContract {
+	if bundle == nil {
+		return nil
+	}
+	type stageSchema struct {
+		FlowID string
+		Schema FlowSchemaDocument
+	}
+	schemas := make([]stageSchema, 0, len(bundle.FlowViews())+1)
+	if bundle.RootSchema != nil {
+		schemas = append(schemas, stageSchema{Schema: *bundle.RootSchema})
+	}
+	for _, flow := range bundle.FlowViews() {
+		flowID := strings.TrimSpace(flow.Paths.ID)
+		if flowID == "" {
+			continue
+		}
+		schemas = append(schemas, stageSchema{FlowID: flowID, Schema: flow.Schema})
+	}
+	out := make([]WorkflowTimerContract, 0)
+	for _, schema := range schemas {
+		if !schema.Schema.StageDeclarations.Declared {
+			continue
+		}
+		for _, stage := range schema.Schema.StageDeclarations.Entries {
+			stageID := strings.TrimSpace(stage.ID)
+			if stageID == "" {
+				continue
+			}
+			for _, row := range stage.Timers {
+				eventType := strings.TrimSpace(row.Emit)
+				if eventType == "" {
+					eventType = WorkflowStageTimerInternalEvent
+				}
+				out = append(out, WorkflowTimerContract{
+					ID:         strings.TrimSpace(row.ID),
+					Stage:      stageID,
+					Event:      eventType,
+					Owner:      "runtime",
+					FlowID:     strings.TrimSpace(schema.FlowID),
+					StageOwned: true,
+					AdvancesTo: strings.TrimSpace(row.AdvancesTo),
+					Delay:      strings.TrimSpace(row.After),
+					StartOn:    "state:" + stageID,
+				})
+			}
+		}
+	}
+	return out
+}
+
+func deriveStageTimerTransitions(bundle *WorkflowContractBundle) []WorkflowTransitionContract {
+	timers := deriveStageWorkflowTimers(bundle)
+	out := make([]WorkflowTransitionContract, 0, len(timers))
+	for _, timer := range timers {
+		if strings.TrimSpace(timer.AdvancesTo) == "" {
+			continue
+		}
+		out = append(out, WorkflowTransitionContract{
+			ID:      "timer:" + strings.TrimSpace(timer.ID),
+			From:    []string{strings.TrimSpace(timer.Stage)},
+			To:      strings.TrimSpace(timer.AdvancesTo),
+			Trigger: "timer:" + strings.TrimSpace(timer.ID),
+			Node:    "runtime",
+		})
+	}
+	return out
+}
+
 func deriveNodeWorkflowTimers(bundle *WorkflowContractBundle) []WorkflowTimerContract {
 	if bundle == nil {
 		return nil
@@ -522,6 +597,7 @@ func normalizeWorkflowSemanticTimer(bundle *WorkflowContractBundle, timer Workfl
 	timer.Owner = strings.TrimSpace(timer.Owner)
 	timer.FlowID = strings.TrimSpace(timer.FlowID)
 	timer.NodeID = strings.TrimSpace(timer.NodeID)
+	timer.AdvancesTo = strings.TrimSpace(timer.AdvancesTo)
 	timer.Action = strings.TrimSpace(timer.Action)
 	timer.Cancellation = strings.TrimSpace(timer.Cancellation)
 	timer.Delay = strings.TrimSpace(timer.Delay)
@@ -551,6 +627,10 @@ func mergeWorkflowSemanticTimer(existing, incoming WorkflowTimerContract) Workfl
 	}
 	if strings.TrimSpace(existing.NodeID) == "" {
 		existing.NodeID = incoming.NodeID
+	}
+	existing.StageOwned = existing.StageOwned || incoming.StageOwned
+	if strings.TrimSpace(existing.AdvancesTo) == "" {
+		existing.AdvancesTo = incoming.AdvancesTo
 	}
 	if strings.TrimSpace(existing.Action) == "" {
 		existing.Action = incoming.Action

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -481,8 +481,9 @@ func deriveStageWorkflowTimers(bundle *WorkflowContractBundle) []WorkflowTimerCo
 				if eventType == "" {
 					eventType = WorkflowStageTimerInternalEvent
 				}
+				timerID := stageWorkflowTimerSemanticID(schema.FlowID, row.ID)
 				out = append(out, WorkflowTimerContract{
-					ID:         strings.TrimSpace(row.ID),
+					ID:         timerID,
 					Stage:      stageID,
 					Event:      eventType,
 					Owner:      "runtime",
@@ -496,6 +497,15 @@ func deriveStageWorkflowTimers(bundle *WorkflowContractBundle) []WorkflowTimerCo
 		}
 	}
 	return out
+}
+
+func stageWorkflowTimerSemanticID(flowID, rowID string) string {
+	rowID = strings.TrimSpace(rowID)
+	flowID = strings.TrimSpace(flowID)
+	if rowID == "" || flowID == "" {
+		return rowID
+	}
+	return flowID + "." + rowID
 }
 
 func deriveStageTimerTransitions(bundle *WorkflowContractBundle) []WorkflowTransitionContract {

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -93,6 +93,73 @@ func TestWorkflowSemanticsDerivesTopLevelAndAccumulateCompletionTransitions(t *t
 	}
 }
 
+func TestWorkflowSemanticsDerivesStageTimersAndTimedTransitionEdges(t *testing.T) {
+	bundle := &WorkflowContractBundle{
+		RootSchema: &FlowSchemaDocument{
+			Name: "validation",
+			StageDeclarations: FlowStageDeclarations{
+				Declared: true,
+				Entries: []FlowStageDeclaration{
+					{
+						ID: "awaiting_review",
+						Timers: []FlowStageTimerDeclaration{
+							{
+								ID:    "awaiting_review.review.sla_escalated",
+								After: "48h",
+								Emit:  "review.sla_escalated",
+							},
+							{
+								ID:         "awaiting_review.expired",
+								After:      "{{marginal_park_days}}d",
+								AdvancesTo: "expired",
+							},
+						},
+					},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	timers := map[string]WorkflowTimerContract{}
+	for _, timer := range bundle.WorkflowTimers() {
+		timers[timer.ID] = timer
+	}
+	emitTimer, ok := timers["awaiting_review.review.sla_escalated"]
+	if !ok {
+		t.Fatalf("missing emit stage timer: %#v", timers)
+	}
+	if !emitTimer.StageOwned || emitTimer.Stage != "awaiting_review" || emitTimer.Event != "review.sla_escalated" || emitTimer.Delay != "48h" || emitTimer.StartOn != "state:awaiting_review" {
+		t.Fatalf("emit timer = %#v, want stage-owned timer lowering", emitTimer)
+	}
+	advanceTimer, ok := timers["awaiting_review.expired"]
+	if !ok {
+		t.Fatalf("missing advance stage timer: %#v", timers)
+	}
+	if !advanceTimer.StageOwned || advanceTimer.Event != WorkflowStageTimerInternalEvent || advanceTimer.AdvancesTo != "expired" || advanceTimer.Delay != "{{marginal_park_days}}d" {
+		t.Fatalf("advance timer = %#v, want internal event + advances_to lowering", advanceTimer)
+	}
+
+	var foundTransition bool
+	for _, transition := range bundle.WorkflowTransitions() {
+		if transition.ID != "timer:awaiting_review.expired" {
+			continue
+		}
+		foundTransition = true
+		if got, want := transition.From, []string{"awaiting_review"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("timer transition From = %#v, want %#v", got, want)
+		}
+		if transition.To != "expired" || transition.Trigger != "timer:awaiting_review.expired" || transition.Node != "runtime" {
+			t.Fatalf("timer transition = %#v, want runtime timed edge to expired", transition)
+		}
+	}
+	if !foundTransition {
+		t.Fatalf("missing timed transition edge: %#v", bundle.WorkflowTransitions())
+	}
+}
+
 func TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts(t *testing.T) {
 	bundle := &WorkflowContractBundle{
 		Nodes: map[string]SystemNodeContract{

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -3,6 +3,8 @@ package contracts
 import (
 	"reflect"
 	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 )
 
 func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) {
@@ -157,6 +159,83 @@ func TestWorkflowSemanticsDerivesStageTimersAndTimedTransitionEdges(t *testing.T
 	}
 	if !foundTransition {
 		t.Fatalf("missing timed transition edge: %#v", bundle.WorkflowTransitions())
+	}
+}
+
+func TestWorkflowSemanticsScopesStageTimerIDsByFlow(t *testing.T) {
+	review := FlowContractView{
+		Paths: FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+		Schema: FlowSchemaDocument{
+			StageDeclarations: FlowStageDeclarations{
+				Declared: true,
+				Entries: []FlowStageDeclaration{
+					{
+						ID: "pending",
+						Timers: []FlowStageTimerDeclaration{{
+							ID:         "pending.expired",
+							After:      "48h",
+							AdvancesTo: "expired",
+						}},
+					},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+	}
+	approval := FlowContractView{
+		Paths: FlowContractPaths{ID: "approval", Flow: "approval"},
+		Path:  "approval",
+		Schema: FlowSchemaDocument{
+			StageDeclarations: FlowStageDeclarations{
+				Declared: true,
+				Entries: []FlowStageDeclaration{
+					{
+						ID: "pending",
+						Timers: []FlowStageTimerDeclaration{{
+							ID:         "pending.expired",
+							After:      "72h",
+							AdvancesTo: "expired",
+						}},
+					},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+	}
+	bundle := &WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[FlowContractView]{
+			Root: &FlowContractView{
+				Children: []FlowContractView{review, approval},
+			},
+			ByID: map[string]*FlowContractView{
+				"review":   &review,
+				"approval": &approval,
+			},
+		},
+		FlowSchemas: map[string]FlowSchemaDocument{
+			"review":   review.Schema,
+			"approval": approval.Schema,
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	timers := map[string]WorkflowTimerContract{}
+	for _, timer := range bundle.WorkflowTimers() {
+		timers[timer.ID] = timer
+	}
+	for _, id := range []string{"review.pending.expired", "approval.pending.expired"} {
+		timer, ok := timers[id]
+		if !ok {
+			t.Fatalf("missing flow-scoped stage timer %q in %#v", id, timers)
+		}
+		if timer.FlowID == "" {
+			t.Fatalf("timer %q missing FlowID: %#v", id, timer)
+		}
+	}
+	if _, ok := timers["pending.expired"]; ok {
+		t.Fatalf("unscoped stage timer survived in semantic timers: %#v", timers)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_stages.go
+++ b/internal/runtime/contracts/workflow_contract_stages.go
@@ -82,6 +82,9 @@ func (d *FlowStageDeclarations) UnmarshalYAML(node *yaml.Node) error {
 		}
 		out = append(out, stage)
 	}
+	if err := validateStageTimerIDNamespace(out); err != nil {
+		return err
+	}
 	d.Entries = out
 	return nil
 }
@@ -175,6 +178,24 @@ func (s *FlowStageDeclaration) normalizeTimerIDs() error {
 			return fmt.Errorf("timers contains duplicate id %q; add explicit id values to disambiguate", timer.ID)
 		}
 		seen[timer.ID] = struct{}{}
+	}
+	return nil
+}
+
+func validateStageTimerIDNamespace(stages []FlowStageDeclaration) error {
+	seen := map[string]string{}
+	for _, stage := range stages {
+		stageID := strings.TrimSpace(stage.ID)
+		for _, timer := range stage.Timers {
+			id := strings.TrimSpace(timer.ID)
+			if id == "" {
+				continue
+			}
+			if previousStage, ok := seen[id]; ok {
+				return fmt.Errorf("stage timer id %q is declared in both stage %q and stage %q; timer ids must be unique within a flow", id, previousStage, stageID)
+			}
+			seen[id] = stageID
+		}
 	}
 	return nil
 }

--- a/internal/runtime/contracts/workflow_contract_stages.go
+++ b/internal/runtime/contracts/workflow_contract_stages.go
@@ -13,16 +13,32 @@ type FlowStageDeclarations struct {
 }
 
 type FlowStageDeclaration struct {
-	ID          string `yaml:"-"`
-	Initial     bool   `yaml:"initial"`
-	Terminal    bool   `yaml:"terminal"`
-	Description string `yaml:"description"`
+	ID          string                      `yaml:"-"`
+	Initial     bool                        `yaml:"initial"`
+	Terminal    bool                        `yaml:"terminal"`
+	Description string                      `yaml:"description"`
+	Timers      []FlowStageTimerDeclaration `yaml:"timers"`
+}
+
+type FlowStageTimerDeclaration struct {
+	ID         string `yaml:"id"`
+	After      string `yaml:"after"`
+	Emit       string `yaml:"emit"`
+	AdvancesTo string `yaml:"advances_to"`
 }
 
 var stageDeclarationFieldOptions = map[string]struct{}{
 	"initial":     {},
 	"terminal":    {},
 	"description": {},
+	"timers":      {},
+}
+
+var stageTimerFieldOptions = map[string]struct{}{
+	"id":          {},
+	"after":       {},
+	"emit":        {},
+	"advances_to": {},
 }
 
 func (d *FlowStageDeclarations) UnmarshalYAML(node *yaml.Node) error {
@@ -61,6 +77,9 @@ func (d *FlowStageDeclarations) UnmarshalYAML(node *yaml.Node) error {
 			return fmt.Errorf("stage %q: %w", key, err)
 		}
 		stage.ID = key
+		if err := stage.normalizeTimerIDs(); err != nil {
+			return fmt.Errorf("stage %q: %w", key, err)
+		}
 		out = append(out, stage)
 	}
 	d.Entries = out
@@ -95,6 +114,84 @@ func (s *FlowStageDeclaration) UnmarshalYAML(node *yaml.Node) error {
 	}
 	*s = FlowStageDeclaration(aux)
 	return nil
+}
+
+func (t *FlowStageTimerDeclaration) UnmarshalYAML(node *yaml.Node) error {
+	if t == nil {
+		return nil
+	}
+	if node == nil || node.Kind == 0 {
+		*t = FlowStageTimerDeclaration{}
+		return nil
+	}
+	if node.Kind == yaml.ScalarNode && strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		*t = FlowStageTimerDeclaration{}
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("stage timer declaration must be a mapping")
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if _, ok := stageTimerFieldOptions[key]; !ok {
+			return NewUndefinedFieldDiagnostic("stage timer", key, stageTimerFieldOptions)
+		}
+	}
+	type alias FlowStageTimerDeclaration
+	var aux alias
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*t = FlowStageTimerDeclaration(aux)
+	t.ID = strings.TrimSpace(t.ID)
+	t.After = strings.TrimSpace(t.After)
+	t.Emit = strings.TrimSpace(t.Emit)
+	t.AdvancesTo = strings.TrimSpace(t.AdvancesTo)
+	return nil
+}
+
+func (s *FlowStageDeclaration) normalizeTimerIDs() error {
+	if s == nil || len(s.Timers) == 0 {
+		return nil
+	}
+	stageID := strings.TrimSpace(s.ID)
+	seen := map[string]struct{}{}
+	for i := range s.Timers {
+		timer := &s.Timers[i]
+		if strings.TrimSpace(timer.After) == "" {
+			return fmt.Errorf("timer row %d missing after", i)
+		}
+		if strings.TrimSpace(timer.Emit) == "" && strings.TrimSpace(timer.AdvancesTo) == "" {
+			return fmt.Errorf("timer row %d must declare emit and/or advances_to", i)
+		}
+		if strings.TrimSpace(timer.ID) == "" {
+			timer.ID = timer.defaultID(stageID)
+		}
+		timer.ID = strings.TrimSpace(timer.ID)
+		if timer.ID == "" {
+			return fmt.Errorf("timer row %d could not derive stable id", i)
+		}
+		if _, ok := seen[timer.ID]; ok {
+			return fmt.Errorf("timers contains duplicate id %q; add explicit id values to disambiguate", timer.ID)
+		}
+		seen[timer.ID] = struct{}{}
+	}
+	return nil
+}
+
+func (t FlowStageTimerDeclaration) defaultID(stageID string) string {
+	stageID = strings.TrimSpace(stageID)
+	target := strings.TrimSpace(t.AdvancesTo)
+	if target == "" {
+		target = strings.TrimSpace(t.Emit)
+	}
+	if stageID == "" {
+		return target
+	}
+	if target == "" {
+		return stageID
+	}
+	return stageID + "." + target
 }
 
 func (d FlowStageDeclarations) StageIDs() []string {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1419,6 +1419,8 @@ type WorkflowTimerContract struct {
 	Owner        string `yaml:"owner"`
 	FlowID       string `yaml:"-"`
 	NodeID       string `yaml:"-"`
+	StageOwned   bool   `yaml:"-"`
+	AdvancesTo   string `yaml:"-"`
 	Action       string `yaml:"action"`
 	Cancellation string `yaml:"cancellation"`
 	Delay        string `yaml:"delay"`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -188,6 +188,77 @@ stages:
 	}
 }
 
+func TestFlowSchemaDocumentDecodeStageTimersUseCanonicalSyntax(t *testing.T) {
+	var doc FlowSchemaDocument
+	if err := yaml.Unmarshal([]byte(`
+name: validation
+stages:
+  awaiting_review:
+    timers:
+      - after: 48h
+        emit: review.sla_escalated
+      - after: "{{marginal_park_days}}d"
+        advances_to: expired
+  expired:
+    terminal: true
+`), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if len(doc.StageDeclarations.Entries) != 2 {
+		t.Fatalf("stages = %#v, want two stages", doc.StageDeclarations.Entries)
+	}
+	timers := doc.StageDeclarations.Entries[0].Timers
+	if len(timers) != 2 {
+		t.Fatalf("timers = %#v, want two timer rows", timers)
+	}
+	if got, want := timers[0].ID, "awaiting_review.review.sla_escalated"; got != want {
+		t.Fatalf("emit timer default ID = %q, want %q", got, want)
+	}
+	if got, want := timers[1].ID, "awaiting_review.expired"; got != want {
+		t.Fatalf("advance timer default ID = %q, want %q", got, want)
+	}
+	if got, want := timers[1].After, "{{marginal_park_days}}d"; got != want {
+		t.Fatalf("advance timer after = %q, want %q", got, want)
+	}
+}
+
+func TestFlowSchemaDocumentDecodeStageTimersRejectSupersededFields(t *testing.T) {
+	for _, field := range []string{"delay", "interrupting", "repeat"} {
+		t.Run(field, func(t *testing.T) {
+			var doc FlowSchemaDocument
+			err := yaml.Unmarshal([]byte(fmt.Sprintf(`
+name: validation
+stages:
+  awaiting_review:
+    timers:
+      - after: 48h
+        emit: review.sla_escalated
+        %s: true
+`, field)), &doc)
+			if err == nil || !strings.Contains(err.Error(), "not supported") {
+				t.Fatalf("yaml.Unmarshal error = %v, want unsupported field rejection", err)
+			}
+		})
+	}
+}
+
+func TestFlowSchemaDocumentDecodeStageTimersRequireExplicitIDOnDerivedCollision(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: validation
+stages:
+  awaiting_review:
+    timers:
+      - after: 48h
+        emit: review.sla_escalated
+      - after: 72h
+        emit: review.sla_escalated
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), "duplicate id") {
+		t.Fatalf("yaml.Unmarshal error = %v, want duplicate derived id rejection", err)
+	}
+}
+
 func TestFlowSchemaDocumentDecodeStagesExplicitEmpty(t *testing.T) {
 	var doc FlowSchemaDocument
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -259,6 +259,29 @@ stages:
 	}
 }
 
+func TestFlowSchemaDocumentDecodeStageTimersRejectExplicitIDCollisionAcrossStages(t *testing.T) {
+	var doc FlowSchemaDocument
+	err := yaml.Unmarshal([]byte(`
+name: validation
+stages:
+  awaiting_review:
+    timers:
+      - id: sla
+        after: 48h
+        emit: review.sla_escalated
+  parked:
+    timers:
+      - id: sla
+        after: 72h
+        advances_to: expired
+  expired:
+    terminal: true
+`), &doc)
+	if err == nil || !strings.Contains(err.Error(), `stage timer id "sla" is declared in both stage "awaiting_review" and stage "parked"`) {
+		t.Fatalf("yaml.Unmarshal error = %v, want cross-stage timer id rejection", err)
+	}
+}
+
 func TestFlowSchemaDocumentDecodeStagesExplicitEmpty(t *testing.T) {
 	var doc FlowSchemaDocument
 	if err := yaml.Unmarshal([]byte(`

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -206,6 +206,7 @@ type TimerState struct {
 	StartedBy string
 	Recurring bool
 	Cancelled bool
+	Fired     bool
 }
 
 type ExecutionRequest struct {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
@@ -213,13 +214,20 @@ func (pc *PipelineCoordinator) Intercept(ctx context.Context, evt events.Event) 
 	if eventType == "" {
 		return true, nil, nil
 	}
+	stageTimer, firedStageTimer, err := pc.handleWorkflowStageTimerFire(ctx, evt)
+	if err != nil {
+		return false, nil, err
+	}
+	if stageTimer && (!firedStageTimer || eventType == runtimecontracts.WorkflowStageTimerInternalEvent) {
+		return false, nil, nil
+	}
 	consume, handled := pc.interceptPolicy(ctx, eventType, evt)
 	if !handled {
 		return true, nil, nil
 	}
 	emitted := make([]events.Event, 0, 4)
 	ictx := context.WithValue(ctx, pipelineEmitCollectorKey{}, &emitted)
-	handled, err := pc.handleEventResult(ictx, evt)
+	handled, err = pc.handleEventResult(ictx, evt)
 	if evt.Type() == activityRequestEventType && err != nil {
 		return false, emitted, err
 	}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -156,6 +156,7 @@ func (r pipelineEngineStateRepo) LoadState(ctx context.Context, entityID identit
 					StartedBy: strings.TrimSpace(timer.StartedBy),
 					Recurring: timer.Recurring,
 					Cancelled: timer.Cancelled,
+					Fired:     timer.Fired,
 				})
 			}
 			return out, true, nil

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -186,8 +186,13 @@ func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identit
 	if entityID.IsZero() {
 		return nil
 	}
+	materializedState := false
 	if r.coordinator.workflowStore != nil && r.coordinator.workflowStore.Enabled() {
 		if err := r.ensureFlowOwnsEntity(ctx, entityID.String()); err != nil {
+			return err
+		}
+		_, hadState, err := r.coordinator.workflowStore.Load(ctx, entityID.String())
+		if err != nil {
 			return err
 		}
 		allowedFields := workflowEntitySchemaFields(r.coordinator.SemanticSource(), pipelineFlowScope(ctx))
@@ -196,12 +201,20 @@ func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identit
 		}); err != nil {
 			return err
 		}
+		if !hadState {
+			materializedState = true
+		}
 	}
 	if next := strings.TrimSpace(mutation.NextState); next != "" {
 		if err := r.coordinator.updateEntityState(ctx, entityID.String(), next, ""); err != nil {
 			return err
 		}
 		if err := r.coordinator.maybeDeactivateTerminalFlowInstance(ctx, entityID.String(), next); err != nil {
+			return err
+		}
+	}
+	if materializedState {
+		if err := r.coordinator.armWorkflowCurrentStageTimers(ctx, entityID.String(), ""); err != nil {
 			return err
 		}
 	}

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -3097,7 +3097,9 @@ func TestPipelineEngineTimerApplierPersistsTimersAndDefersSchedulerToPostCommit(
 		TaskID:    "timer-1",
 	}
 
-	pc.persistWorkflowTimerSchedule(ctx, sc)
+	if err := pc.persistWorkflowTimerSchedule(ctx, sc); err != nil {
+		t.Fatalf("persistWorkflowTimerSchedule: %v", err)
+	}
 	if got := len(store.upserts); got != 1 {
 		t.Fatalf("persisted schedules = %d, want 1", got)
 	}
@@ -3114,7 +3116,9 @@ func TestPipelineEngineTimerApplierPersistsTimersAndDefersSchedulerToPostCommit(
 
 	cancelActions := make([]func(), 0, 1)
 	cancelCtx := withPipelinePostCommitActions(context.Background(), &cancelActions)
-	pc.persistWorkflowTimerCancellation(cancelCtx, sc)
+	if err := pc.persistWorkflowTimerCancellation(cancelCtx, sc); err != nil {
+		t.Fatalf("persistWorkflowTimerCancellation: %v", err)
+	}
 	if got := len(store.cancels); got != 1 {
 		t.Fatalf("persisted cancels = %d, want 1", got)
 	}

--- a/internal/runtime/pipeline/workflow_condition_validation.go
+++ b/internal/runtime/pipeline/workflow_condition_validation.go
@@ -29,6 +29,9 @@ func ValidateConditionCEL(expression string, context WorkflowConditionContext) e
 	if normalized == "" {
 		return fmt.Errorf("workflow expression is empty")
 	}
+	if call := workflowConditionAmbientTimeCall(normalized); call != "" {
+		return fmt.Errorf("workflow expression uses ambient time call %s(); use stage timers for time-driven behavior", call)
+	}
 	env, err := celValidationEnv(context)
 	if err != nil {
 		return err
@@ -38,6 +41,32 @@ func ValidateConditionCEL(expression string, context WorkflowConditionContext) e
 		return issues.Err()
 	}
 	return nil
+}
+
+func workflowConditionAmbientTimeCall(expression string) string {
+	stripped := stripWorkflowExpressionStringLiterals(expression)
+	for _, name := range []string{"now", "timestamp"} {
+		for pos := 0; pos < len(stripped); {
+			idx := strings.Index(stripped[pos:], name)
+			if idx < 0 {
+				break
+			}
+			start := pos + idx
+			end := start + len(name)
+			pos = end
+			if start > 0 && isWorkflowConditionIdentifierPart(stripped[start-1]) {
+				continue
+			}
+			if end < len(stripped) && isWorkflowConditionIdentifierPart(stripped[end]) {
+				continue
+			}
+			next := skipWorkflowConditionWhitespace(stripped, end)
+			if next < len(stripped) && stripped[next] == '(' {
+				return name
+			}
+		}
+	}
+	return ""
 }
 
 func celValidationEnv(context WorkflowConditionContext) (*cel.Env, error) {

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -25,6 +25,23 @@ func TestValidateConditionCEL_RequiresExplicitScope(t *testing.T) {
 	}
 }
 
+func TestValidateConditionCEL_RejectsAmbientTimeAccess(t *testing.T) {
+	for _, expression := range []string{
+		`now() > payload.deadline`,
+		`timestamp("2026-07-09T00:00:00Z") > payload.deadline`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			err := ValidateConditionCEL(expression, WorkflowConditionContextRule)
+			if err == nil || !strings.Contains(err.Error(), "use stage timers") {
+				t.Fatalf("ValidateConditionCEL error = %v, want stage timer remediation", err)
+			}
+		})
+	}
+	if err := ValidateConditionCEL(`payload.label == "now()"`, WorkflowConditionContextRule); err != nil {
+		t.Fatalf("ValidateConditionCEL string literal = %v, want no ambient-time rejection", err)
+	}
+}
+
 func TestValidateConditionCEL_RejectsFanOutOutsideDataAccumulationExpressions(t *testing.T) {
 	if err := ValidateConditionCEL(`fan_out.count > 0`, WorkflowConditionContextGuard); err == nil {
 		t.Fatal("expected fan_out to be rejected in guard conditions")

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -94,6 +94,9 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 	if err := pc.instanceActivator(ctx, req); err != nil {
 		return err
 	}
+	if err := pc.armWorkflowCurrentStageTimers(ctx, instance.EntityID, ""); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -117,6 +117,7 @@ func TestCreateFlowInstanceArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
 	)
 	triggerCtx := workflowTriggerContext{Event: trigger}
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	beforeCreate := time.Now().UTC()
 
 	err := pc.createFlowInstance(ctx, triggerCtx, handlerExecutionPlan{
 		Template:       "review",
@@ -137,6 +138,10 @@ func TestCreateFlowInstanceArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
 	assertWorkflowTimerState(t, instance, "review.awaiting_review.expired", false)
 	if got := len(schedules.schedules); got != 1 {
 		t.Fatalf("persisted schedules = %d, want 1: %#v", got, schedules.schedules)
+	}
+	scheduledAt := schedules.schedules[0].At
+	if scheduledAt.Before(beforeCreate.Add(2*time.Hour)) || scheduledAt.After(time.Now().UTC().Add(2*time.Hour+time.Second)) {
+		t.Fatalf("schedule At = %s, want child-flow policy rendered delay near 2h after create", scheduledAt)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -14,6 +14,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -73,6 +74,69 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 	}
 	if captured.Instance.EntityID != FlowInstanceEntityID("review/inst-42") {
 		t.Fatalf("entity id = %q, want %q", captured.Instance.EntityID, FlowInstanceEntityID("review/inst-42"))
+	}
+}
+
+func TestCreateFlowInstanceArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
+	runID := uuid.NewString()
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	schedules := &recordingSchedulePersistence{}
+	source := semanticview.Wrap(stageTimerTemplateLifecycleBundle())
+	pc := &PipelineCoordinator{
+		module:             &pipelineFixtureWorkflowModule{source: source},
+		workflowStore:      store,
+		timerScheduleStore: schedules,
+		instanceActivator: func(ctx context.Context, req FlowInstanceActivationRequest) error {
+			return store.Upsert(ctx, WorkflowInstance{
+				InstanceID:      req.Instance.InstanceID,
+				StorageRef:      req.Instance.InstancePath,
+				WorkflowName:    req.Instance.TemplateID,
+				WorkflowVersion: "1.0.0",
+				CurrentState:    "awaiting_review",
+				Metadata: map[string]any{
+					"entity_id":        req.Instance.EntityID,
+					"instance_id":      req.Instance.InstanceID,
+					"flow_path":        req.Instance.InstancePath,
+					"parent_entity_id": req.Instance.ParentEntityID,
+				},
+			})
+		},
+	}
+	trigger := eventtest.RootIngress(
+		"",
+		events.EventType("spawn.requested"),
+		"",
+		"",
+		[]byte(`{"entity_id":"ent-1","instance_id":"inst-42","name":"alpha"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-1"),
+		time.Time{},
+	)
+	triggerCtx := workflowTriggerContext{Event: trigger}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+
+	err := pc.createFlowInstance(ctx, triggerCtx, handlerExecutionPlan{
+		Template:       "review",
+		InstanceIDFrom: "payload.instance_id",
+		InstanceIDPath: paths.Parse("payload.instance_id"),
+		ConfigFrom: &runtimecontracts.ConfigFromSpec{
+			Bindings: map[string]string{"name": "payload.name"},
+		},
+	}, testCreateFlowInstanceContext(triggerCtx))
+	if err != nil {
+		t.Fatalf("createFlowInstance: %v", err)
+	}
+	entityID := FlowInstanceEntityID("review/inst-42")
+	instance, ok, err := store.Load(ctx, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load created instance ok=%v err=%v", ok, err)
+	}
+	assertWorkflowTimerState(t, instance, "review.awaiting_review.expired", false)
+	if got := len(schedules.schedules); got != 1 {
+		t.Fatalf("persisted schedules = %d, want 1: %#v", got, schedules.schedules)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -67,6 +67,7 @@ type WorkflowTimerState struct {
 	StartedBy string    `json:"started_by,omitempty"`
 	Recurring bool      `json:"recurring,omitempty"`
 	Cancelled bool      `json:"cancelled,omitempty"`
+	Fired     bool      `json:"fired,omitempty"`
 }
 
 type workflowInstancePersistedProjection struct {
@@ -923,7 +924,9 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			return err
 		}
 		status := "active"
-		if timer.Cancelled {
+		if timer.Fired {
+			status = "fired"
+		} else if timer.Cancelled {
 			status = "cancelled"
 		}
 		if _, err := tx.ExecContext(ctx, `
@@ -1251,7 +1254,7 @@ func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, runI
 			fire_at,
 			COALESCE(fire_payload->>'started_by', ''),
 			recurring,
-			status = 'cancelled'
+			status
 		FROM timers
 		WHERE run_id = $1::uuid
 		  AND entity_id = $2::uuid
@@ -1266,6 +1269,7 @@ func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, runI
 	out := make([]WorkflowTimerState, 0, 4)
 	for rows.Next() {
 		var timer WorkflowTimerState
+		var status string
 		if err := rows.Scan(
 			&timer.TimerID,
 			&timer.EventType,
@@ -1273,10 +1277,13 @@ func (s *WorkflowInstanceStore) loadWorkflowTimersSpec(ctx context.Context, runI
 			&timer.FiresAt,
 			&timer.StartedBy,
 			&timer.Recurring,
-			&timer.Cancelled,
+			&status,
 		); err != nil {
 			return nil, err
 		}
+		status = strings.TrimSpace(status)
+		timer.Cancelled = status == "cancelled"
+		timer.Fired = status == "fired"
 		out = append(out, timer)
 	}
 	return out, rows.Err()

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -645,7 +645,9 @@ func (s *WorkflowInstanceStore) replaceWorkflowTimersSQLite(ctx context.Context,
 			return err
 		}
 		status := "active"
-		if timer.Cancelled {
+		if timer.Fired {
+			status = "fired"
+		} else if timer.Cancelled {
 			status = "cancelled"
 		}
 		if _, err := tx.ExecContext(ctx, `
@@ -665,7 +667,7 @@ func (s *WorkflowInstanceStore) replaceWorkflowTimersSQLite(ctx context.Context,
 
 func (s *WorkflowInstanceStore) loadWorkflowTimersSQLite(ctx context.Context, runID, entityID string) ([]WorkflowTimerState, error) {
 	rows, err := dbQueryContext(ctx, s.db, `
-		SELECT timer_name, fire_event, created_at, fire_at, COALESCE(json_extract(fire_payload, '$.started_by'), ''), recurring, status = 'cancelled'
+		SELECT timer_name, fire_event, created_at, fire_at, COALESCE(json_extract(fire_payload, '$.started_by'), ''), recurring, status
 		FROM timers
 		WHERE run_id = ? AND entity_id = ? AND owner_node = ? AND owner_agent IS NULL
 		ORDER BY created_at ASC, timer_name ASC
@@ -678,9 +680,13 @@ func (s *WorkflowInstanceStore) loadWorkflowTimersSQLite(ctx context.Context, ru
 	for rows.Next() {
 		var timer WorkflowTimerState
 		var createdRaw, firesRaw any
-		if err := rows.Scan(&timer.TimerID, &timer.EventType, &createdRaw, &firesRaw, &timer.StartedBy, &timer.Recurring, &timer.Cancelled); err != nil {
+		var status string
+		if err := rows.Scan(&timer.TimerID, &timer.EventType, &createdRaw, &firesRaw, &timer.StartedBy, &timer.Recurring, &status); err != nil {
 			return nil, err
 		}
+		status = strings.TrimSpace(status)
+		timer.Cancelled = status == "cancelled"
+		timer.Fired = status == "fired"
 		if at, ok, err := sqliteWorkflowTimeValue(createdRaw); err != nil {
 			return nil, err
 		} else if ok {

--- a/internal/runtime/pipeline/workflow_state_persistence.go
+++ b/internal/runtime/pipeline/workflow_state_persistence.go
@@ -69,8 +69,7 @@ func (pc *PipelineCoordinator) updateEntityState(ctx context.Context, entityID, 
 		return err
 	}
 	pc.notifyTestEntityStateUpdated(entityID, nextState)
-	pc.reconcileWorkflowStageTimers(ctx, entityID, currentState, nextState, sourceEvent)
-	return nil
+	return pc.reconcileWorkflowStageTimers(ctx, entityID, currentState, nextState, sourceEvent)
 }
 
 func (pc *PipelineCoordinator) applyWorkflowGateMutation(ctx context.Context, entityID, _sourceEvent, setGate string, clear bool) error {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -36,20 +37,18 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 		}
 		for i := range instance.TimerState {
 			timerState := &instance.TimerState[i]
-			if timerState.Cancelled {
+			if timerState.Cancelled || timerState.Fired {
 				continue
 			}
 			timer, ok := source.WorkflowTimerByID(timerState.TimerID)
-			cancelTrigger, ok := workflowTimerCancelTrigger(timer)
-			if !ok || !workflowTimerLifecycleMatches(cancelTrigger, nextStage, sourceEvent) {
+			if !ok || !workflowTimerShouldCancelOnTransition(timer, currentStage, nextStage, sourceEvent) {
 				continue
 			}
 			timerState.Cancelled = true
 			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
-			startTrigger, ok := workflowTimerStartTrigger(timer)
-			if !ok || !workflowTimerLifecycleMatches(startTrigger, nextStage, sourceEvent) {
+			if !workflowTimerShouldStartOnTransition(timer, nextStage, sourceEvent) {
 				continue
 			}
 			if workflowTimerStateActive(instance.TimerState, timer.ID) {
@@ -73,22 +72,107 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 		return err
 	}
 	for _, sc := range toCancel {
-		pc.persistWorkflowTimerCancellation(ctx, scheduleWithRunIDFromContext(ctx, sc))
+		if err := pc.persistWorkflowTimerCancellation(ctx, scheduleWithRunIDFromContext(ctx, sc)); err != nil {
+			return err
+		}
 	}
 	for _, sc := range toSchedule {
-		pc.persistWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, sc))
+		if err := pc.persistWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, sc)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (pc *PipelineCoordinator) reconcileWorkflowStageTimers(ctx context.Context, entityID, currentStage, nextStage, sourceEvent string) {
+func (pc *PipelineCoordinator) reconcileWorkflowStageTimers(ctx context.Context, entityID, currentStage, nextStage, sourceEvent string) error {
 	if err := pc.applyWorkflowTimerIntents(ctx, entityID, currentStage, nextStage, sourceEvent); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_projection_failed", "", sourceEvent, runtimeWorkflowID, entityID, map[string]any{
 			"stage":         strings.TrimSpace(nextStage),
 			"current_stage": strings.TrimSpace(currentStage),
 			"source_event":  strings.TrimSpace(sourceEvent),
 		}, err)
+		return err
 	}
+	return nil
+}
+
+func (pc *PipelineCoordinator) handleWorkflowStageTimerFire(ctx context.Context, evt events.Event) (bool, bool, error) {
+	if pc == nil || pc.workflowStore == nil || !pc.workflowStore.Enabled() {
+		return false, false, nil
+	}
+	source := pc.SemanticSource()
+	if source == nil {
+		return false, false, nil
+	}
+	timerID := strings.TrimSpace(evt.TaskID())
+	if timerID == "" {
+		if handle, ok := timeridentity.ParseTimerHandle(parsePayloadMap(evt.Payload())); ok && handle.Kind == timeridentity.TimerHandleWorkflowTimer {
+			timerID = strings.TrimSpace(handle.TimerID)
+		}
+	}
+	if timerID == "" {
+		return false, false, nil
+	}
+	timer, ok := source.WorkflowTimerByID(timerID)
+	if !ok || !timer.StageOwned {
+		return false, false, nil
+	}
+	entityID := workflowEventEntityID(evt)
+	if entityID == "" {
+		return true, false, fmt.Errorf("stage timer %s fired without entity_id", timerID)
+	}
+	fired := false
+	var lateBy time.Duration
+	err := pc.workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		currentStage := ""
+		nextStage := strings.TrimSpace(timer.AdvancesTo)
+		if err := pc.workflowStore.Mutate(txctx, entityID, func(instance *WorkflowInstance) {
+			currentStage = strings.TrimSpace(instance.CurrentState)
+			if currentStage != strings.TrimSpace(timer.Stage) {
+				return
+			}
+			for i := range instance.TimerState {
+				state := &instance.TimerState[i]
+				if strings.TrimSpace(state.TimerID) != timerID || state.Cancelled || state.Fired {
+					continue
+				}
+				state.Fired = true
+				if !state.FiresAt.IsZero() {
+					firedAt := evt.CreatedAt()
+					if firedAt.IsZero() {
+						firedAt = time.Now().UTC()
+					}
+					if firedAt.After(state.FiresAt) {
+						lateBy = firedAt.Sub(state.FiresAt)
+					}
+				}
+				if nextStage != "" {
+					instance.CurrentState = nextStage
+					instance.EnteredStageAt = time.Now().UTC()
+					instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), currentStage, nextStage, "timer:"+timerID))
+				}
+				fired = true
+				return
+			}
+		}); err != nil {
+			return err
+		}
+		if fired && nextStage != "" {
+			return pc.applyWorkflowTimerIntents(txctx, entityID, currentStage, nextStage, "timer:"+timerID)
+		}
+		return nil
+	})
+	if err != nil {
+		return true, fired, err
+	}
+	if fired && lateBy > time.Minute {
+		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_fired_late", strings.TrimSpace(evt.ID()), strings.TrimSpace(string(evt.Type())), runtimeWorkflowID, entityID, map[string]any{
+			"timer_id": strings.TrimSpace(timerID),
+			"stage":    strings.TrimSpace(timer.Stage),
+			"late_by":  lateBy.String(),
+		}, nil)
+	}
+	return true, fired, nil
 }
 
 func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context, entityID, sourceEvent string) {
@@ -121,10 +205,13 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 		}
 		for i := range instance.TimerState {
 			timerState := &instance.TimerState[i]
-			if timerState.Cancelled {
+			if timerState.Cancelled || timerState.Fired {
 				continue
 			}
 			timer, ok := source.WorkflowTimerByID(timerState.TimerID)
+			if !ok || timer.StageOwned {
+				continue
+			}
 			cancelTrigger, ok := workflowTimerCancelTrigger(timer)
 			if !ok || !workflowTimerLifecycleMatches(cancelTrigger, "", sourceEvent) {
 				continue
@@ -133,6 +220,9 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
 		}
 		for _, timer := range source.WorkflowTimers() {
+			if timer.StageOwned {
+				continue
+			}
 			startTrigger, ok := workflowTimerStartTrigger(timer)
 			if !ok || !workflowTimerLifecycleMatches(startTrigger, "", sourceEvent) {
 				continue
@@ -198,20 +288,35 @@ func (pc *PipelineCoordinator) reconcileAccumulationTimeoutSchedule(
 		sc.RunID = runID
 	}
 	if isAccumulationTimeoutEvent(evt.Type()) || !waiting {
-		pc.persistWorkflowTimerCancellation(ctx, sc)
-		return nil
+		return pc.persistWorkflowTimerCancellation(ctx, sc)
 	}
 	startedAt, ok := accumulationTimeoutStartedAt(stateBuckets, bucketRef)
 	if !ok {
 		return nil
 	}
 	sc.At = startedAt.Add(time.Duration(spec.TimeoutMS) * time.Millisecond)
-	pc.persistWorkflowTimerSchedule(ctx, sc)
-	return nil
+	return pc.persistWorkflowTimerSchedule(ctx, sc)
 }
 
 func workflowTimerLifecycleMatches(trigger timeridentity.Trigger, stage, sourceEvent string) bool {
 	return trigger.MatchesStage(stage) || trigger.MatchesEvent(sourceEvent)
+}
+
+func workflowTimerShouldCancelOnTransition(timer runtimecontracts.WorkflowTimerContract, currentStage, nextStage, sourceEvent string) bool {
+	if timer.StageOwned {
+		stage := strings.TrimSpace(timer.Stage)
+		return stage != "" && strings.TrimSpace(currentStage) == stage && strings.TrimSpace(nextStage) != stage
+	}
+	cancelTrigger, ok := workflowTimerCancelTrigger(timer)
+	return ok && workflowTimerLifecycleMatches(cancelTrigger, nextStage, sourceEvent)
+}
+
+func workflowTimerShouldStartOnTransition(timer runtimecontracts.WorkflowTimerContract, nextStage, sourceEvent string) bool {
+	if timer.StageOwned {
+		return strings.TrimSpace(timer.Stage) != "" && strings.TrimSpace(timer.Stage) == strings.TrimSpace(nextStage)
+	}
+	startTrigger, ok := workflowTimerStartTrigger(timer)
+	return ok && workflowTimerLifecycleMatches(startTrigger, nextStage, sourceEvent)
 }
 
 func accumulationTimeoutBucketRef(evt Event, nodeID, handlerEventKey string) (timeridentity.AccumulatorBucketRef, bool) {
@@ -295,7 +400,7 @@ func workflowTimerStateActive(items []WorkflowTimerState, timerID string) bool {
 		return false
 	}
 	for _, item := range items {
-		if strings.TrimSpace(item.TimerID) == timerID && !item.Cancelled {
+		if strings.TrimSpace(item.TimerID) == timerID && !item.Cancelled && !item.Fired {
 			return true
 		}
 	}
@@ -444,9 +549,9 @@ func (pc *PipelineCoordinator) cancelWorkflowTimerSchedule(ctx context.Context, 
 	}
 }
 
-func (pc *PipelineCoordinator) persistWorkflowTimerSchedule(ctx context.Context, sc Schedule) {
+func (pc *PipelineCoordinator) persistWorkflowTimerSchedule(ctx context.Context, sc Schedule) error {
 	if pc == nil {
-		return
+		return nil
 	}
 	if pc.timerScheduleStore != nil {
 		if err := pc.timerScheduleStore.UpsertSchedule(ctx, sc); err != nil {
@@ -454,6 +559,7 @@ func (pc *PipelineCoordinator) persistWorkflowTimerSchedule(ctx context.Context,
 				"task_id": strings.TrimSpace(sc.TaskID),
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
+			return err
 		}
 	}
 	if pc.timerScheduler != nil {
@@ -469,11 +575,12 @@ func (pc *PipelineCoordinator) persistWorkflowTimerSchedule(ctx context.Context,
 			register(ctx)
 		}
 	}
+	return nil
 }
 
-func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Context, sc Schedule) {
+func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Context, sc Schedule) error {
 	if pc == nil {
-		return
+		return nil
 	}
 	if pc.timerScheduleStore != nil {
 		if err := pc.timerScheduleStore.CancelScheduleExactTerminal(ctx, sc); err != nil {
@@ -482,7 +589,7 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 				"mode":    strings.TrimSpace(sc.Mode),
 			}, err)
 			if !TerminalTransitionApplied(err) {
-				return
+				return err
 			}
 		}
 	}
@@ -499,4 +606,5 @@ func (pc *PipelineCoordinator) persistWorkflowTimerCancellation(ctx context.Cont
 			cancel()
 		}
 	}
+	return nil
 }

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -45,7 +45,7 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 				continue
 			}
 			timerState.Cancelled = true
-			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
+			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source, timer.FlowID)))
 		}
 		for _, timer := range source.WorkflowTimers() {
 			if !workflowTimerShouldStartOnTransition(timer, nextStage, sourceEvent) {
@@ -54,7 +54,7 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 			if workflowTimerStateActive(instance.TimerState, timer.ID) {
 				continue
 			}
-			fireAt, ok := workflowTimerFireAt(timer, now, workflowTimerPolicy(source))
+			fireAt, ok := workflowTimerFireAt(timer, now, workflowTimerPolicy(source, timer.FlowID))
 			if !ok {
 				continue
 			}
@@ -66,7 +66,7 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 				StartedBy: "state:" + nextStage,
 				Recurring: timer.Recurring,
 			})
-			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source)))
+			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source, timer.FlowID)))
 		}
 	}); err != nil {
 		return err
@@ -242,7 +242,7 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 				continue
 			}
 			timerState.Cancelled = true
-			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source)))
+			toCancel = append(toCancel, workflowTimerSchedule(timer, entityID, instance.StorageRef, timerState.FiresAt, workflowTimerPolicy(source, timer.FlowID)))
 		}
 		for _, timer := range source.WorkflowTimers() {
 			if timer.StageOwned {
@@ -255,7 +255,7 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 			if workflowTimerStateActive(instance.TimerState, timer.ID) {
 				continue
 			}
-			fireAt, ok := workflowTimerFireAt(timer, now, workflowTimerPolicy(source))
+			fireAt, ok := workflowTimerFireAt(timer, now, workflowTimerPolicy(source, timer.FlowID))
 			if !ok {
 				continue
 			}
@@ -267,7 +267,7 @@ func (pc *PipelineCoordinator) reconcileWorkflowEventTimers(ctx context.Context,
 				StartedBy: "event:" + sourceEvent,
 				Recurring: timer.Recurring,
 			})
-			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source)))
+			toSchedule = append(toSchedule, workflowTimerSchedule(timer, entityID, instance.StorageRef, fireAt, workflowTimerPolicy(source, timer.FlowID)))
 		}
 	}); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_event_timer_projection_failed", "", sourceEvent, runtimeWorkflowID, entityID, map[string]any{
@@ -468,11 +468,11 @@ func workflowTimerRenderedDelay(delay string, policy map[string]any) string {
 	})
 }
 
-func workflowTimerPolicy(source semanticview.Source) map[string]any {
+func workflowTimerPolicy(source semanticview.Source, flowID string) map[string]any {
 	if source == nil {
 		return nil
 	}
-	return policyDocumentToMap(source.ResolvedPolicyForFlow(""))
+	return policyDocumentToMap(source.ResolvedPolicyForFlow(strings.TrimSpace(flowID)))
 }
 
 func workflowTimerSchedule(timer runtimecontracts.WorkflowTimerContract, entityID, flowInstance string, fireAt time.Time, policy map[string]any) Schedule {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle.go
@@ -84,6 +84,28 @@ func (pc *PipelineCoordinator) applyWorkflowTimerIntents(ctx context.Context, en
 	return nil
 }
 
+func (pc *PipelineCoordinator) armWorkflowCurrentStageTimers(ctx context.Context, entityID, sourceEvent string) error {
+	if pc == nil || pc.workflowStore == nil || !pc.workflowStore.Enabled() {
+		return nil
+	}
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return nil
+	}
+	instance, ok, err := pc.workflowStore.Load(ctx, entityID)
+	if err != nil || !ok {
+		return err
+	}
+	stage := strings.TrimSpace(instance.CurrentState)
+	if stage == "" {
+		return nil
+	}
+	if strings.TrimSpace(sourceEvent) == "" {
+		sourceEvent = "state:" + stage
+	}
+	return pc.applyWorkflowTimerIntents(ctx, entityID, "", stage, sourceEvent)
+}
+
 func (pc *PipelineCoordinator) reconcileWorkflowStageTimers(ctx context.Context, entityID, currentStage, nextStage, sourceEvent string) error {
 	if err := pc.applyWorkflowTimerIntents(ctx, entityID, currentStage, nextStage, sourceEvent); err != nil {
 		pc.logRuntimeWarn(ctx, runtimeWorkflowID, "workflow_timer_projection_failed", "", sourceEvent, runtimeWorkflowID, entityID, map[string]any{
@@ -158,7 +180,10 @@ func (pc *PipelineCoordinator) handleWorkflowStageTimerFire(ctx context.Context,
 			return err
 		}
 		if fired && nextStage != "" {
-			return pc.applyWorkflowTimerIntents(txctx, entityID, currentStage, nextStage, "timer:"+timerID)
+			if err := pc.applyWorkflowTimerIntents(txctx, entityID, currentStage, nextStage, "timer:"+timerID); err != nil {
+				return err
+			}
+			return pc.maybeDeactivateTerminalFlowInstance(txctx, entityID, nextStage)
 		}
 		return nil
 	})

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -139,6 +139,9 @@ func stageTimerTemplateLifecycleBundle() *runtimecontracts.WorkflowContractBundl
 	review := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
 		Path:  "review",
+		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
+			"sla_hours": {Value: 2},
+		}},
 	}
 	return &runtimecontracts.WorkflowContractBundle{
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
@@ -174,7 +177,7 @@ func stageTimerTemplateLifecycleBundle() *runtimecontracts.WorkflowContractBundl
 					FlowID:     "review",
 					StageOwned: true,
 					AdvancesTo: "expired",
-					Delay:      "72h",
+					Delay:      "{{sla_hours}}h",
 					StartOn:    "state:awaiting_review",
 				},
 			},

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -91,6 +92,66 @@ func newTimerLifecycleCoordinator(bus Bus, db *sql.DB, module WorkflowModule, st
 	return NewPipelineCoordinatorWithOptions(bus, db, opts)
 }
 
+func stageTimerLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "awaiting_review", Initial: true},
+					{ID: "expired", Terminal: true},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Timers: []runtimecontracts.WorkflowTimerContract{
+				{
+					ID:         "awaiting_review.review.sla_escalated",
+					Stage:      "awaiting_review",
+					Event:      "review.sla_escalated",
+					Owner:      "runtime",
+					StageOwned: true,
+					Delay:      "48h",
+					StartOn:    "state:awaiting_review",
+				},
+				{
+					ID:         "awaiting_review.expired",
+					Stage:      "awaiting_review",
+					Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
+					Owner:      "runtime",
+					StageOwned: true,
+					AdvancesTo: "expired",
+					Delay:      "72h",
+					StartOn:    "state:awaiting_review",
+				},
+			},
+		},
+	}
+}
+
+func assertWorkflowTimerState(t *testing.T, instance WorkflowInstance, timerID string, wantFired bool) {
+	t.Helper()
+	for _, timer := range instance.TimerState {
+		if strings.TrimSpace(timer.TimerID) != timerID {
+			continue
+		}
+		if timer.Fired != wantFired {
+			t.Fatalf("timer %s fired = %v, want %v in %#v", timerID, timer.Fired, wantFired, instance.TimerState)
+		}
+		return
+	}
+	t.Fatalf("timer %s missing from %#v", timerID, instance.TimerState)
+}
+
+func workflowTimerLifecycleLogContains(logs []RuntimeLogEntry, action string) bool {
+	for _, log := range logs {
+		if strings.TrimSpace(log.Action) == action {
+			return true
+		}
+	}
+	return false
+}
+
 func testActivePipelineSQLTxContext(t *testing.T, db *sql.DB, ctx context.Context) context.Context {
 	t.Helper()
 	tx, err := db.BeginTx(ctx, nil)
@@ -163,6 +224,124 @@ func TestWorkflowTimerFireAtSupportsPolicyRenderedDayDelay(t *testing.T) {
 	}
 	if want := now.Add(3 * 24 * time.Hour); !fireAt.Equal(want) {
 		t.Fatalf("fireAt = %s, want %s", fireAt, want)
+	}
+}
+
+func TestHandleWorkflowStageTimerFireMarksFiredAndAdvancesWithSQLiteStore(t *testing.T) {
+	runID := uuid.NewString()
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	if _, err := db.Exec(`INSERT INTO runs (run_id, status) VALUES (?, 'running')`, runID); err != nil {
+		t.Fatalf("seed sqlite run: %v", err)
+	}
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	source := semanticview.Wrap(stageTimerLifecycleBundle())
+	bus := &recordingPipelineBus{}
+	pc := &PipelineCoordinator{
+		bus:           bus,
+		module:        &pipelineFixtureWorkflowModule{source: source},
+		workflowStore: store,
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	now := time.Now().UTC().Round(time.Microsecond)
+
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      "ent-emit",
+		StorageRef:      "ent-emit",
+		WorkflowName:    "stage-timer-test",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "awaiting_review",
+		TimerState: []WorkflowTimerState{{
+			TimerID:   "awaiting_review.review.sla_escalated",
+			EventType: "review.sla_escalated",
+			CreatedAt: now.Add(-3 * time.Hour),
+			FiresAt:   now.Add(-2 * time.Hour),
+			StartedBy: "state:awaiting_review",
+		}},
+	}); err != nil {
+		t.Fatalf("seed emit workflow instance: %v", err)
+	}
+	emitEvt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType("review.sla_escalated"),
+		"runtime",
+		"awaiting_review.review.sla_escalated",
+		[]byte(`{"entity_id":"ent-emit"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-emit"),
+		now,
+	)
+	recognized, fired, err := pc.handleWorkflowStageTimerFire(ctx, emitEvt)
+	if err != nil {
+		t.Fatalf("handle emit stage timer: %v", err)
+	}
+	if !recognized || !fired {
+		t.Fatal("emit stage timer was not recognized")
+	}
+	emitInstance, ok, err := store.Load(ctx, "ent-emit")
+	if err != nil || !ok {
+		t.Fatalf("load emit instance ok=%v err=%v", ok, err)
+	}
+	if got := emitInstance.CurrentState; got != "awaiting_review" {
+		t.Fatalf("emit timer state = %q, want awaiting_review", got)
+	}
+	assertWorkflowTimerState(t, emitInstance, "awaiting_review.review.sla_escalated", true)
+
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      "ent-advance",
+		StorageRef:      "ent-advance",
+		WorkflowName:    "stage-timer-test",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "awaiting_review",
+		TimerState: []WorkflowTimerState{{
+			TimerID:   "awaiting_review.expired",
+			EventType: runtimecontracts.WorkflowStageTimerInternalEvent,
+			CreatedAt: now.Add(-3 * time.Hour),
+			FiresAt:   now.Add(-2 * time.Hour),
+			StartedBy: "state:awaiting_review",
+		}},
+	}); err != nil {
+		t.Fatalf("seed advance workflow instance: %v", err)
+	}
+	advanceEvt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(runtimecontracts.WorkflowStageTimerInternalEvent),
+		"runtime",
+		"awaiting_review.expired",
+		[]byte(`{"entity_id":"ent-advance"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "ent-advance"),
+		now,
+	)
+	recognized, fired, err = pc.handleWorkflowStageTimerFire(ctx, advanceEvt)
+	if err != nil {
+		t.Fatalf("handle advance stage timer: %v", err)
+	}
+	if !recognized || !fired {
+		t.Fatal("advance stage timer was not recognized")
+	}
+	advanceInstance, ok, err := store.Load(ctx, "ent-advance")
+	if err != nil || !ok {
+		t.Fatalf("load advance instance ok=%v err=%v", ok, err)
+	}
+	if got := advanceInstance.CurrentState; got != "expired" {
+		t.Fatalf("advance timer state = %q, want expired", got)
+	}
+	assertWorkflowTimerState(t, advanceInstance, "awaiting_review.expired", true)
+
+	if !workflowTimerLifecycleLogContains(bus.runtimeLogEntries(), "workflow_timer_fired_late") {
+		t.Fatalf("runtime logs = %#v, want late-fire diagnostic", bus.runtimeLogEntries())
+	}
+
+	recognized, fired, err = pc.handleWorkflowStageTimerFire(ctx, emitEvt)
+	if err != nil {
+		t.Fatalf("handle duplicate emit stage timer: %v", err)
+	}
+	if !recognized || fired {
+		t.Fatalf("duplicate emit stage timer recognized=%v fired=%v, want recognized stale no-op", recognized, fired)
 	}
 }
 
@@ -325,18 +504,19 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 }
 
 func TestRegisterWorkflowTimerSchedule_PostCommitClaimDropsPipelineTransaction(t *testing.T) {
-	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) {
+	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) error {
 		pc.registerWorkflowTimerSchedule(ctx, sc)
+		return nil
 	})
 }
 
 func TestPersistWorkflowTimerSchedule_PostCommitClaimDropsPipelineTransaction(t *testing.T) {
-	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) {
-		pc.persistWorkflowTimerSchedule(ctx, sc)
+	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) error {
+		return pc.persistWorkflowTimerSchedule(ctx, sc)
 	})
 }
 
-func assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t *testing.T, schedule func(*PipelineCoordinator, context.Context, Schedule)) {
+func assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t *testing.T, schedule func(*PipelineCoordinator, context.Context, Schedule) error) {
 	t.Helper()
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
@@ -368,7 +548,9 @@ func assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t *testi
 		TaskID:    "timer-1",
 	}
 
-	schedule(pc, ctx, sc)
+	if err := schedule(pc, ctx, sc); err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
 	if len(store.upsertTx) != 1 || !store.upsertTx[0] {
 		t.Fatalf("schedule upsert tx-active flags = %#v, want [true]", store.upsertTx)
 	}
@@ -408,7 +590,9 @@ func TestPersistWorkflowTimerCancellation_ReleasesClaimAfterCanonicalCancel(t *t
 		TaskID:       "timer-a",
 	}
 
-	pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc)
+	if err := pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc); err != nil {
+		t.Fatalf("persistWorkflowTimerCancellation: %v", err)
+	}
 
 	if got := store.cancelOwned; got != 1 {
 		t.Fatalf("cancel owned calls = %d, want 1", got)
@@ -445,7 +629,9 @@ func TestPersistWorkflowTimerCancellation_StillCancelsSchedulerWhenClaimReleaseF
 		t.Fatalf("Register(schedule): %v", err)
 	}
 
-	pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc)
+	if err := pc.persistWorkflowTimerCancellation(testPipelineCoordinatorRunContext(t, pc), sc); err != nil {
+		t.Fatalf("persistWorkflowTimerCancellation: %v", err)
+	}
 
 	if got := store.cancelOwned; got != 1 {
 		t.Fatalf("cancel owned calls = %d, want 1", got)

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -104,6 +106,10 @@ func stageTimerLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
 			},
 		},
 		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:           "stage-timer-test",
+			Version:        "1.0.0",
+			InitialStage:   "awaiting_review",
+			TerminalStages: []string{"expired"},
 			Timers: []runtimecontracts.WorkflowTimerContract{
 				{
 					ID:         "awaiting_review.review.sla_escalated",
@@ -119,6 +125,53 @@ func stageTimerLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
 					Stage:      "awaiting_review",
 					Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
 					Owner:      "runtime",
+					StageOwned: true,
+					AdvancesTo: "expired",
+					Delay:      "72h",
+					StartOn:    "state:awaiting_review",
+				},
+			},
+		},
+	}
+}
+
+func stageTimerTemplateLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
+	review := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Path:  "review",
+	}
+	return &runtimecontracts.WorkflowContractBundle{
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &runtimecontracts.FlowContractView{
+				Children: []runtimecontracts.FlowContractView{review},
+			},
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"review": &review,
+			},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"review": {Mode: "template"},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:         "stage-timer-test",
+			Version:      "1.0.0",
+			InitialStage: "awaiting_review",
+			FlowInitial: map[string]string{
+				"review": "awaiting_review",
+			},
+			FlowTerminal: map[string][]string{
+				"review": {"expired"},
+			},
+			FlowPrefix: map[string]string{
+				"review": "review",
+			},
+			Timers: []runtimecontracts.WorkflowTimerContract{
+				{
+					ID:         "review.awaiting_review.expired",
+					Stage:      "awaiting_review",
+					Event:      runtimecontracts.WorkflowStageTimerInternalEvent,
+					Owner:      "runtime",
+					FlowID:     "review",
 					StageOwned: true,
 					AdvancesTo: "expired",
 					Delay:      "72h",
@@ -342,6 +395,107 @@ func TestHandleWorkflowStageTimerFireMarksFiredAndAdvancesWithSQLiteStore(t *tes
 	}
 	if !recognized || fired {
 		t.Fatalf("duplicate emit stage timer recognized=%v fired=%v, want recognized stale no-op", recognized, fired)
+	}
+}
+
+func TestHandleWorkflowStageTimerFireDeactivatesTerminalTemplateFlow(t *testing.T) {
+	runID := uuid.NewString()
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	source := semanticview.Wrap(stageTimerTemplateLifecycleBundle())
+	var deactivated FlowInstanceDeactivationRequest
+	pc := &PipelineCoordinator{
+		module:        &pipelineFixtureWorkflowModule{source: source},
+		workflowStore: store,
+		instanceDeactivator: func(_ context.Context, req FlowInstanceDeactivationRequest) error {
+			deactivated = req
+			return nil
+		},
+	}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	now := time.Now().UTC().Round(time.Microsecond)
+	const flowPath = "review/inst-1"
+	entityID := FlowInstanceEntityID(flowPath)
+
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID:      "inst-1",
+		StorageRef:      flowPath,
+		WorkflowName:    "review",
+		WorkflowVersion: "1.0.0",
+		CurrentState:    "awaiting_review",
+		Metadata: map[string]any{
+			"entity_id":   entityID,
+			"instance_id": "inst-1",
+			"flow_path":   flowPath,
+		},
+		TimerState: []WorkflowTimerState{{
+			TimerID:   "review.awaiting_review.expired",
+			EventType: runtimecontracts.WorkflowStageTimerInternalEvent,
+			CreatedAt: now.Add(-3 * time.Hour),
+			FiresAt:   now.Add(-2 * time.Hour),
+			StartedBy: "state:awaiting_review",
+		}},
+	}); err != nil {
+		t.Fatalf("seed template workflow instance: %v", err)
+	}
+	evt := eventtest.RootIngress(
+		uuid.NewString(),
+		events.EventType(runtimecontracts.WorkflowStageTimerInternalEvent),
+		"runtime",
+		"review.awaiting_review.expired",
+		[]byte(`{"entity_id":"`+entityID+`"}`),
+		0,
+		runID,
+		"",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, entityID),
+		now,
+	)
+
+	recognized, fired, err := pc.handleWorkflowStageTimerFire(ctx, evt)
+	if err != nil {
+		t.Fatalf("handle advance stage timer: %v", err)
+	}
+	if !recognized || !fired {
+		t.Fatalf("recognized=%v fired=%v, want terminal timer fire", recognized, fired)
+	}
+	if deactivated.FinalState != "expired" {
+		t.Fatalf("deactivated final state = %q, want expired; req=%#v", deactivated.FinalState, deactivated)
+	}
+	if deactivated.Instance.InstancePath != flowPath {
+		t.Fatalf("deactivated instance path = %q, want %q", deactivated.Instance.InstancePath, flowPath)
+	}
+}
+
+func TestPipelineEngineStateRepoSaveStateArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
+	runID := uuid.NewString()
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	schedules := &recordingSchedulePersistence{}
+	source := semanticview.Wrap(stageTimerLifecycleBundle())
+	pc := &PipelineCoordinator{
+		module:             &pipelineFixtureWorkflowModule{source: source},
+		workflowStore:      store,
+		timerScheduleStore: schedules,
+	}
+	repo := pipelineEngineStateRepo{coordinator: pc}
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	entityID := identity.NormalizeEntityID("33333333-3333-3333-3333-333333333333")
+
+	if err := repo.SaveState(ctx, entityID, testEngineStateMutation(nil, nil, nil)); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	instance, ok, err := store.Load(ctx, entityID.String())
+	if err != nil || !ok {
+		t.Fatalf("load materialized instance ok=%v err=%v", ok, err)
+	}
+	if got := instance.CurrentState; got != "awaiting_review" {
+		t.Fatalf("materialized state = %q, want awaiting_review", got)
+	}
+	for _, id := range []string{"awaiting_review.review.sla_escalated", "awaiting_review.expired"} {
+		assertWorkflowTimerState(t, instance, id, false)
+	}
+	if got := len(schedules.schedules); got != 2 {
+		t.Fatalf("persisted schedules = %d, want 2: %#v", got, schedules.schedules)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1487,7 +1487,7 @@ func ensureLifecycleWorkflowSchedules(ctx context.Context, store runtimepipeline
 			continue
 		}
 		for _, timerState := range instance.TimerState {
-			if timerState.Cancelled {
+			if timerState.Cancelled || timerState.Fired {
 				continue
 			}
 			timerID := strings.TrimSpace(timerState.TimerID)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -237,6 +237,33 @@ contract_formats:
         `initial_state`, `states`, and `terminal_states` in the same schema.
         Legacy fields remain accepted as explicit legacy/kernel input until a
         later migration removes them from public authoring.
+      temporal_rows:
+        implementation_tracker: '#1846'
+        rule: >
+          A stage may declare one-shot temporal rows under
+          `stages.<stage>.timers`. Each row uses `after:` plus `emit:`,
+          `advances_to:`, or both. The timer arms when the entity enters the
+          owning stage and cancels when the entity leaves that stage. A row with
+          `advances_to` terminates the stage by lowering to the existing
+          transition-edge model; an emit-only row does not leave the stage. The
+          author does not write `interrupting`; the presence of `advances_to`
+          defines the stage-ending behavior.
+        syntax: |
+          stages:
+            awaiting_review:
+              timers:
+                - after: 48h
+                  emit: review.sla_escalated
+                - after: "{{marginal_park_days}}d"
+                  advances_to: expired
+        row_identity: >
+          `id:` is optional. When absent, the platform derives a stable ID from
+          `<stage>.<emit-event-or-advance-target>`. Duplicate derived IDs are a
+          boot error; authors must add explicit IDs to disambiguate collisions.
+        invalid_forms: >
+          Stage timer rows reject superseded spellings including `delay`,
+          `interrupting`, `repeat`, and `recurring`. Stage timer rows are
+          one-shot in this slice.
   entity_schema:
     description: |
       `package.yaml.entity_schema` is retired. Authoritative entity
@@ -3144,7 +3171,9 @@ handler_specification:
         description: string — human-readable description
         state_schema: map — fields the node persists per entity (accumulator state)
         state_table: string — table name for node state persistence
-        timers: list of timer declarations (see timer_model)
+        timers: legacy/kernel timer declarations (see timer_model). Staged lifecycle
+          timer authoring for flows using `stages:` is owned by
+          `stages.<stage>.timers`, not node-level state timers.
         gate_state: map — gate field definitions for this node (boolean flags on entity)
       effective_semantics:
         id: YAML map key, with same-value explicit id accepted during migration
@@ -5311,9 +5340,12 @@ engine:
           must satisfy the external tool-provider dispatch grammar. They do not make CLI native_tools.web_search valid.
   timer_model:
     description: Timers are durable delayed events. The platform schedules them and fires them as regular events entering
-      the event loop. Timers are declared in nodes.yaml.
+      the event loop. Canonical staged lifecycle timer authoring lives under `stages.<stage>.timers`; lower-level
+      node timers remain kernel/legacy declarations for non-staged or platform-owned schedules.
     declaration:
-      description: Timers are declared per system node in nodes.yaml.
+      description: >
+        Public staged lifecycle timers are declared as stage-resident rows in schema.yaml. Legacy/kernel timers are
+        declared per system node in nodes.yaml.
       fields:
         id: Unique timer name
         event: Event name to fire when timer expires (e.g., timer.scan_timeout)
@@ -5331,22 +5363,49 @@ engine:
       invalid_forms:
       - "Unprefixed trigger values are boot errors. The platform does not infer state-vs-event intent from bare strings."
       - "Prefixes other than state: and event: are boot errors."
+      stage_timer_authoring:
+        fields:
+          after: Canonical duration string or policy-rendered duration. The platform evaluates it once on stage entry
+            and persists the resulting fire_at.
+          emit: Optional event to emit when the timer fires.
+          advances_to: Optional target stage. Presence of this field lowers to a timed transition edge and ends the
+            source stage when the timer fires.
+          id: Optional stable row ID. If omitted, defaults to `<stage>.<emit-event-or-advance-target>`.
+        invalid_fields: [delay, interrupting, repeat, recurring]
     lifecycle:
-    - 1. Timer starts when the entity enters the start_on state, the start_on event fires, or start_on is boot and platform startup schedules it.
+    - 1. Timer starts when the entity enters the owning stage for stage timer rows, when the entity enters the
+      start_on state, when the start_on event fires, or when start_on is boot and platform startup schedules it.
     - 2. Platform renders the timer delay at start time and persists the timer. State/event timers persist run/entity or
       flow scope plus fire_at. Boot-start timers persist as global schedules with entity_id, flow_instance, and run_id NULL.
       Non-recurring boot timers persist a one-shot fire_at. Recurring boot timers persist the recurring schedule interval.
       Active timers keep the persisted fire_at or recurrence value; later policy/config changes do not rewrite already scheduled
       timers unless a separate explicit reschedule primitive is defined.
-    - 3. When fire_at is reached, platform emits the timer event into the event loop.
-    - 4. Timer event is a regular event — routed to subscribers, processed by handlers.
-    - 5. If cancel_on state is reached or cancel_on event fires before fire_at, timer is cancelled. cancel_on is invalid
-      for start_on boot timers until an explicit global cancellation primitive is specified.
-    - 6. Recurring timers restart after firing unless cancelled.
-    crash_recovery: Timers are persisted. On restart, platform checks for expired timers and fires them.
+    - 3. Stage timers cancel durably when the entity leaves the owning stage before fire_at. The schedule/cancel intent
+      is part of the same lifecycle mutation unit as the stage transition; persistence failure is fatal to the mutation.
+    - 4. When fire_at is reached, platform emits the timer event into the event loop. Advance-only stage timers use the
+      internal event `platform.stage_timer`; user-authored emit timers use their declared event and remain visible to
+      downstream consumers.
+    - 5. Timer event is a regular event for user-authored emit timers — routed to subscribers, processed by handlers.
+      For advance-only stage timers, the runtime consumes the internal event and applies the derived timed transition.
+    - 6. If cancel_on state is reached or cancel_on event fires before fire_at, a legacy/kernel timer is cancelled.
+      cancel_on is invalid for start_on boot timers until an explicit global cancellation primitive is specified.
+    - 7. Recurring timers restart after firing unless cancelled. Stage timer rows do not support repeat/recurring behavior
+      in this slice.
+    crash_recovery: >
+      Timers are persisted. On restart, platform checks for expired timers and fires them. Overdue stage timers fire late
+      by contract and record a typed runtime diagnostic including the timer ID, stage, and lateness instead of pretending
+      punctual delivery.
+    replay_and_fork: >
+      Replay and fork reconstruct stage timer facts from recorded timer state under the run/fork admission rules. Fired
+      and cancelled stage timers are not rescheduled as active work.
     boot_validation:
       start_on: start_on must match state:<name>, event:<name>, or boot. Any other form is a boot error.
       cancel_on: cancel_on must match state:<name> or event:<name>. boot is not valid.
+      stage_timers: >
+        Stage timer source and advances_to target must reference declared stages in the owning flow. The internal
+        `platform.stage_timer` event used for advance-only rows does not require authored event-catalog membership.
+        In a flow that declares `stages:`, node-level timers using `start_on: state:*` or `cancel_on: state:*` are
+        rejected as legacy staged authoring; use `stages.<stage>.timers`.
       boot_start: start_on boot creates a global startup schedule. Recurring and non-recurring boot timers are valid only
         when cancel_on is absent. A boot-start timer with cancel_on is a boot error because no entity/run-scoped cancellation
         context exists for that global schedule.
@@ -5366,9 +5425,10 @@ engine:
         cancel state from that activation state. Missing activation proof or any derived activation state with no
         post-activation path is a boot error. start_on boot state-cancel reachability is left to explicit boot-start
         scheduling semantics and is not closed by this rule.
-    example: "timers:\n  - id: sla_timeout\n    event: timer.sla_breach\n    delay: \"{{sla_timeout_hours}}h\"\
-      \n    start_on: state:assigned\n    cancel_on: state:resolved\n    recurring: false\n  - id: daily_report\n\
-      \    event: timer.daily_report\n    delay: \"{{report_interval_hours}}h\"\n    start_on: boot\n    recurring: true"
+    example: "stages:\n  awaiting_review:\n    timers:\n      - after: 48h\n        emit: review.sla_escalated\n\
+      \      - after: \"{{marginal_park_days}}d\"\n        advances_to: expired\n  expired:\n    terminal: true\n\
+      \n# Legacy/kernel timer example:\ntimers:\n  - id: daily_report\n    event: timer.daily_report\n    delay: \"{{report_interval_hours}}h\"\
+      \n    start_on: boot\n    recurring: true"
   expression_language:
     description: All guard checks, rule conditions, filter conditions, and on_complete branch conditions are evaluated using
       CEL (Common Expression Language). CEL is a non-Turing-complete, safe expression language designed for policy evaluation.
@@ -5381,6 +5441,9 @@ engine:
       policy: Policy values from flow policy.yaml merged with root policy.yaml
       fan_out: Available after fan_out step (e.g., fan_out.count)
       accumulated: Available inside on_complete after accumulation (list of received items)
+    ambient_time: >
+      CEL guard/rule/filter/on_complete conditions must not call ambient time functions such as `now()` or
+      `timestamp()`. Time-driven behavior is authored with stage timers so fire_at is evaluated once and persisted.
     supported_operators:
     - 'Comparison: ==, !=, <, <=, >, >='
     - 'Logical: &&, ||, !'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -260,6 +260,8 @@ contract_formats:
           `id:` is optional. When absent, the platform derives a stable ID from
           `<stage>.<emit-event-or-advance-target>`. Duplicate derived IDs are a
           boot error; authors must add explicit IDs to disambiguate collisions.
+          Runtime semantic timer IDs are scoped by the owning flow for non-root
+          flows so common local stage/timer IDs in sibling flows do not merge.
         invalid_forms: >
           Stage timer rows reject superseded spellings including `delay`,
           `interrupting`, `repeat`, and `recurring`. Stage timer rows are

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -260,8 +260,10 @@ contract_formats:
           `id:` is optional. When absent, the platform derives a stable ID from
           `<stage>.<emit-event-or-advance-target>`. Duplicate derived IDs are a
           boot error; authors must add explicit IDs to disambiguate collisions.
-          Runtime semantic timer IDs are scoped by the owning flow for non-root
-          flows so common local stage/timer IDs in sibling flows do not merge.
+          Timer row IDs, whether derived or explicit, must be unique within the
+          owning flow's semantic timer namespace. Runtime semantic timer IDs
+          are scoped by the owning flow for non-root flows so common local
+          stage/timer IDs in sibling flows do not merge.
         invalid_forms: >
           Stage timer rows reject superseded spellings including `delay`,
           `interrupting`, `repeat`, and `recurring`. Stage timer rows are
@@ -5368,7 +5370,7 @@ engine:
       stage_timer_authoring:
         fields:
           after: Canonical duration string or policy-rendered duration. The platform evaluates it once on stage entry
-            and persists the resulting fire_at.
+            against the owning flow's merged policy context and persists the resulting fire_at.
           emit: Optional event to emit when the timer fires.
           advances_to: Optional target stage. Presence of this field lowers to a timed transition edge and ends the
             source stage when the timer fires.


### PR DESCRIPTION
## Summary

Closes #1846.

Adds the approved PR1 temporal-row surface under `stages.<stage>.timers`:

```yaml
stages:
  awaiting_review:
    timers:
      - after: 48h
        emit: review.sla_escalated
      - after: "{{marginal_park_days}}d"
        advances_to: expired
```

The row lowers into the existing timer kernel and transition-edge model. Emit-only rows fire the configured event and stay in the stage; rows with `advances_to` derive a visible `timer:<id>` transition edge and advance through the runtime lifecycle path.

## Governing refs / context

- Issue #1846 design lock: https://github.com/division-sh/swarm/issues/1846#issuecomment-4920803317
- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1846#issuecomment-4920834562
- Gate C approval: https://github.com/division-sh/swarm/issues/1846#issuecomment-4920876728
- Authoritative spec updated in this PR: `platform-spec.yaml` sections `flow_schema.stages_authoring.temporal_rows`, `timer_model`, and `expression_language.ambient_time`.
- Adjacent contracts used: #1845 stage authoring, #1873 transition carrier/graph model, and #1723 replay/fork timer reconstruction classification.

## Semantic migration

- New canonical authoring owner: `stages.<stage>.timers` for stage-resident temporal rows.
- Runtime owner: `WorkflowTimerContract` plus the existing timer kernel for durable scheduling, with timer-driven `advances_to` lowered into `WorkflowTransitionContract` edges.
- Old producer/reader/writer paths now invalid: stage-timer fields `delay`, `interrupting`, `repeat`, and `recurring` fail closed; node-level state timers in a `stages:` flow using `start_on: state:*` / `cancel_on: state:*` fail closed and must move to `stages.<stage>.timers`.
- Production paths checked: YAML decode, semantic lowering, bootverify, runtime timer fire/cancel/fired state, SQLite workflow-store persistence, authoring view, `swarm describe --graph`, CEL validation, and `platform-spec.yaml`.
- Migration completeness: complete for the approved first slice. Low-level non-stage node timers remain as kernel/legacy surface for non-staged/event/accumulator timer uses.

## Validation

- `go test ./internal/runtime/contracts ./internal/runtime/authoringview ./internal/runtime/bootverify ./internal/runtime/pipeline ./cmd/swarm -run 'Test(FlowSchemaDocumentDecodeStageTimers|WorkflowSemanticsDerivesStageTimers|BuildStageGraphShowsStageTimers|ValidateConditionCEL_RejectsAmbientTimeAccess|TimerValidation.*StageTimer|HandleWorkflowStageTimerFireMarksFired|DescribeCommandGraphRendersStageGraph|VerifyCommandAcceptsAccumulatorTransitionCarrierFixture|SelectedRawSQLBoundaryInventoryIsClassified)'`
- `git diff --check origin/master...HEAD`
- `go test ./...` was run on the rebased branch. Local run is blocked by Docker/Postgres availability (`failed to connect to the docker API at unix:///var/run/docker.sock`) in Postgres-backed packages; the focused supported-surface proof above passes.