### PR TITLE
[agent-g][issue #1885] Add mailbox decision served parity

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4103,6 +4103,15 @@ func TestServedParityHarnessRuntimeIngressControlLifecycle(t *testing.T) {
 	servedparity.RunScenarioGroup(t, scenarios, runServedRuntimeIngressControlBackendProof)
 }
 
+func TestServedParityHarnessMailboxDecisionLifecycle(t *testing.T) {
+	scenarios := []servedparity.Scenario{
+		servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle),
+		servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle),
+		servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle),
+	}
+	servedparity.RunScenarioGroup(t, scenarios, runServedMailboxDecisionBackendProof)
+}
+
 type servedControlProofRuntime struct {
 	Endpoint   string
 	DB         *sql.DB
@@ -4189,6 +4198,12 @@ func runServedRuntimeIngressControlBackendProof(t *testing.T, backend servedpari
 	t.Cleanup(runtimebus.ResumeRuntimeIngress)
 	rt := startServedControlProofRuntime(t, backend)
 	runServedRuntimeIngressControlLifecycleProof(t, rt)
+}
+
+func runServedMailboxDecisionBackendProof(t *testing.T, backend servedparity.Backend) {
+	t.Helper()
+	rt := startServedControlProofRuntime(t, backend)
+	runServedMailboxDecisionLifecycleProof(t, rt)
 }
 
 func runServedRunControlLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4307,6 +4322,538 @@ func runServedRuntimeIngressControlLifecycleProof(t *testing.T, rt servedControl
 	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, queued.EventID, "platform", "pipeline", "success", 1)
 	requireServedRunStatus(t, rt.Endpoint, queued.RunID, "running")
 	requireServedParitySettlementPostconditions(t, rt.Endpoint, queued.RunID, servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle))
+}
+
+type servedMailboxDecisionFixture struct {
+	RunID         string
+	EntityID      string
+	SourceEventID string
+	SourceFlow    string
+	ApproveID     string
+	RejectID      string
+	DeferID       string
+	DeferUntil    time.Time
+	DeferExpires  time.Time
+}
+
+func runServedMailboxDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
+	t.Helper()
+	fixture := seedServedMailboxDecisionFixture(t, rt.DB, rt.Backend)
+	keyPrefix := "issue-1885-" + rt.Backend + "-" + fixture.RunID
+
+	approveKey := keyPrefix + "-approve"
+	approved := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.approve", map[string]any{
+		"mailbox_id":       fixture.ApproveID,
+		"decision_payload": map[string]any{"approved": true},
+		"idempotency_key":  approveKey,
+	})
+	requireServedMailboxDecisionResultShape(t, approved, "decided", "mailbox.item_decided", false)
+	requireServedMailboxRawTerminalState(t, rt.DB, rt.Backend, fixture.ApproveID, "approved")
+	requireServedMailboxDetailState(t, rt.Endpoint, fixture.ApproveID, "decided", "approved", "approved")
+	requireServedMailboxTerminalEvent(t, rt.DB, rt.Backend, fixture, approved.DownstreamEventID, fixture.ApproveID, "approved", "", map[string]any{"approved": true})
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.approve", approveKey, 1)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.ApproveID, 1)
+	approveReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.approve", map[string]any{
+		"mailbox_id":       fixture.ApproveID,
+		"decision_payload": map[string]any{"approved": true},
+		"idempotency_key":  approveKey,
+	})
+	requireServedMailboxReplay(t, approveReplay, approved)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.ApproveID, 1)
+	already := requireServedJSONRPCError(t, rt.Endpoint, "mailbox.reject", map[string]any{
+		"mailbox_id": fixture.ApproveID,
+		"reason":     "already approved",
+	})
+	if already.Data["code"] != apiv1.MailboxAlreadyDecidedCode {
+		t.Fatalf("%s mailbox.reject already-decided data = %#v, want %s", rt.Backend, already.Data, apiv1.MailboxAlreadyDecidedCode)
+	}
+
+	rejectKey := keyPrefix + "-reject"
+	rejected := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.reject", map[string]any{
+		"mailbox_id":      fixture.RejectID,
+		"reason":          "not enough evidence",
+		"idempotency_key": rejectKey,
+	})
+	requireServedMailboxDecisionResultShape(t, rejected, "decided", "mailbox.item_decided", false)
+	requireServedMailboxRawTerminalState(t, rt.DB, rt.Backend, fixture.RejectID, "rejected")
+	requireServedMailboxDetailState(t, rt.Endpoint, fixture.RejectID, "decided", "rejected", "rejected")
+	requireServedMailboxTerminalEvent(t, rt.DB, rt.Backend, fixture, rejected.DownstreamEventID, fixture.RejectID, "rejected", "not enough evidence", nil)
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.reject", rejectKey, 1)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
+	rejectReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.reject", map[string]any{
+		"mailbox_id":      fixture.RejectID,
+		"reason":          "not enough evidence",
+		"idempotency_key": rejectKey,
+	})
+	requireServedMailboxReplay(t, rejectReplay, rejected)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
+
+	deferKey := keyPrefix + "-defer"
+	deferred := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.defer", map[string]any{
+		"mailbox_id":      fixture.DeferID,
+		"until":           fixture.DeferUntil.Format(time.RFC3339Nano),
+		"idempotency_key": deferKey,
+	})
+	requireServedMailboxDecisionResultShape(t, deferred, "deferred", "mailbox.item_deferred", false)
+	requireServedMailboxRawDeferredState(t, rt.DB, rt.Backend, fixture)
+	requireServedMailboxDetailState(t, rt.Endpoint, fixture.DeferID, "deferred", "", "deferred")
+	requireServedMailboxDeferredEvent(t, rt.DB, rt.Backend, fixture, deferred.DownstreamEventID)
+	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.defer", deferKey, 1)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
+	deferReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.defer", map[string]any{
+		"mailbox_id":      fixture.DeferID,
+		"until":           fixture.DeferUntil.Format(time.RFC3339Nano),
+		"idempotency_key": deferKey,
+	})
+	requireServedMailboxReplay(t, deferReplay, deferred)
+	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
+
+	for _, scenarioID := range []string{
+		servedparity.ScenarioMailboxApproveDecisionLifecycle,
+		servedparity.ScenarioMailboxRejectDecisionLifecycle,
+		servedparity.ScenarioMailboxDeferDecisionLifecycle,
+	} {
+		requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(scenarioID))
+	}
+}
+
+func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) servedMailboxDecisionFixture {
+	t.Helper()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	fixture := servedMailboxDecisionFixture{
+		RunID:         uuid.NewString(),
+		EntityID:      uuid.NewString(),
+		SourceEventID: uuid.NewString(),
+		SourceFlow:    "empire/review",
+		ApproveID:     uuid.NewString(),
+		RejectID:      uuid.NewString(),
+		DeferID:       uuid.NewString(),
+		DeferUntil:    time.Now().UTC().Add(1 * time.Hour).Truncate(time.Second),
+		DeferExpires:  time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second),
+	}
+	ctx := context.Background()
+	switch backend {
+	case "postgres":
+		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, fixture.RunID, now); err != nil {
+			t.Fatalf("seed postgres mailbox proof run: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, scope,
+				payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, 'review.requested', $3::uuid, $4, 'entity',
+				'{"request":true}'::jsonb, 'operator', 'external', $5
+			)
+		`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
+			t.Fatalf("seed postgres mailbox proof source event: %v", err)
+		}
+		if err := (&store.PostgresStore{DB: db}).UpsertPipelineReceipt(ctx, fixture.SourceEventID, "processed", ""); err != nil {
+			t.Fatalf("seed postgres mailbox proof source event pipeline receipt: %v", err)
+		}
+		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
+		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
+		seedServedMailboxDecisionItem(t, db, backend, fixture.DeferID, fixture, "operational_decision", "defer item", `{"title":"defer item"}`, &fixture.DeferExpires)
+	case "sqlite":
+		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, fixture.RunID, now); err != nil {
+			t.Fatalf("seed sqlite mailbox proof run: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO events (
+				event_id, run_id, event_name, entity_id, flow_instance, scope,
+				payload, produced_by, produced_by_type, created_at
+			) VALUES (
+				?, ?, 'review.requested', ?, ?, 'entity',
+				'{"request":true}', 'operator', 'external', ?
+			)
+		`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
+			t.Fatalf("seed sqlite mailbox proof source event: %v", err)
+		}
+		sqliteStore := &store.SQLiteRuntimeStore{SQLiteSchemaStore: &store.SQLiteSchemaStore{DB: db}}
+		if err := sqliteStore.UpsertPipelineReceipt(ctx, fixture.SourceEventID, "processed", ""); err != nil {
+			t.Fatalf("seed sqlite mailbox proof source event pipeline receipt: %v", err)
+		}
+		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
+		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
+		seedServedMailboxDecisionItem(t, db, backend, fixture.DeferID, fixture, "operational_decision", "defer item", `{"title":"defer item"}`, &fixture.DeferExpires)
+	default:
+		t.Fatalf("unknown mailbox proof backend %q", backend)
+	}
+	return fixture
+}
+
+func seedServedMailboxDecisionItem(t *testing.T, db *sql.DB, backend, mailboxID string, fixture servedMailboxDecisionFixture, itemType, summary, payload string, expiresAt *time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	var expires any
+	if expiresAt != nil {
+		expires = expiresAt.UTC()
+	}
+	switch backend {
+	case "postgres":
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO mailbox (
+				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+				from_agent, severity, summary, payload, status, notified, expires_at, created_at
+			) VALUES (
+				$1::uuid, $2::uuid, $3, 'entity', $4, $5::uuid,
+				'agent-g', 'urgent', $6, $7::jsonb, 'pending', false, $8, $9
+			)
+		`, mailboxID, fixture.EntityID, fixture.SourceFlow, itemType, fixture.SourceEventID, summary, payload, expires, time.Now().UTC().Add(-time.Minute)); err != nil {
+			t.Fatalf("seed postgres mailbox item %s: %v", itemType, err)
+		}
+	case "sqlite":
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO mailbox (
+				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
+				from_agent, severity, summary, payload, status, notified, expires_at, created_at
+			) VALUES (
+				?, ?, ?, 'entity', ?, ?,
+				'agent-g', 'urgent', ?, ?, 'pending', 0, ?, ?
+			)
+		`, mailboxID, fixture.EntityID, fixture.SourceFlow, itemType, fixture.SourceEventID, summary, payload, expires, time.Now().UTC().Add(-time.Minute)); err != nil {
+			t.Fatalf("seed sqlite mailbox item %s: %v", itemType, err)
+		}
+	default:
+		t.Fatalf("unknown mailbox proof backend %q", backend)
+	}
+}
+
+func requireServedMailboxDecisionResult(t *testing.T, endpoint, method string, params map[string]any) store.MailboxV1DecisionResult {
+	t.Helper()
+	var result store.MailboxV1DecisionResult
+	requireServedJSONRPCResult(t, endpoint, method, params, &result)
+	return result
+}
+
+func requireServedMailboxDecisionResultShape(t *testing.T, result store.MailboxV1DecisionResult, wantStatus, wantEventName string, wantReplayed bool) {
+	t.Helper()
+	if !result.OK || result.Status != wantStatus || result.DownstreamEventName != wantEventName || result.DownstreamEventID == "" || result.MailboxDecisionID == "" {
+		t.Fatalf("mailbox decision result = %#v, want ok status=%s event=%s with ids", result, wantStatus, wantEventName)
+	}
+	if result.IdempotencyReplayed != wantReplayed {
+		t.Fatalf("mailbox decision replay = %v, want %v: %#v", result.IdempotencyReplayed, wantReplayed, result)
+	}
+	if result.DownstreamSubscribers == nil || len(*result.DownstreamSubscribers) != 0 {
+		t.Fatalf("mailbox decision subscribers = %#v, want empty explicit subscriber list", result.DownstreamSubscribers)
+	}
+	if result.DownstreamSubscriberSource != "event_catalog" {
+		t.Fatalf("mailbox decision subscriber source = %q, want event_catalog", result.DownstreamSubscriberSource)
+	}
+}
+
+func requireServedMailboxReplay(t *testing.T, replay, original store.MailboxV1DecisionResult) {
+	t.Helper()
+	requireServedMailboxDecisionResultShape(t, replay, original.Status, original.DownstreamEventName, true)
+	if replay.DownstreamEventID != original.DownstreamEventID || replay.MailboxDecisionID != original.MailboxDecisionID {
+		t.Fatalf("mailbox replay result = %#v, want decision/event ids from %#v", replay, original)
+	}
+}
+
+type servedMailboxRawState struct {
+	Status        string
+	Decision      string
+	Notes         string
+	DecidedBy     string
+	DecidedAt     sql.NullTime
+	DeferredUntil sql.NullTime
+	ExpiresAt     sql.NullTime
+}
+
+func loadServedMailboxRawState(t *testing.T, db *sql.DB, backend, mailboxID string) servedMailboxRawState {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `
+			SELECT status, COALESCE(decision, ''), COALESCE(decision_notes, ''),
+			       COALESCE(decided_by, ''), decided_at, deferred_until, expires_at
+			FROM mailbox
+			WHERE item_id = $1::uuid
+		`
+		args = []any{mailboxID}
+	case "sqlite":
+		query = `
+			SELECT status, COALESCE(decision, ''), COALESCE(decision_notes, ''),
+			       COALESCE(decided_by, ''), decided_at, deferred_until, expires_at
+			FROM mailbox
+			WHERE item_id = ?
+		`
+		args = []any{mailboxID}
+	default:
+		t.Fatalf("unknown mailbox proof backend %q", backend)
+	}
+	var state servedMailboxRawState
+	var decidedAtRaw any
+	var deferredUntilRaw any
+	var expiresAtRaw any
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(
+		&state.Status,
+		&state.Decision,
+		&state.Notes,
+		&state.DecidedBy,
+		&decidedAtRaw,
+		&deferredUntilRaw,
+		&expiresAtRaw,
+	); err != nil {
+		t.Fatalf("%s load mailbox raw state %s: %v", backend, mailboxID, err)
+	}
+	state.DecidedAt = servedMailboxSQLNullTime(t, backend, "decided_at", decidedAtRaw)
+	state.DeferredUntil = servedMailboxSQLNullTime(t, backend, "deferred_until", deferredUntilRaw)
+	state.ExpiresAt = servedMailboxSQLNullTime(t, backend, "expires_at", expiresAtRaw)
+	return state
+}
+
+func servedMailboxSQLNullTime(t *testing.T, backend, field string, raw any) sql.NullTime {
+	t.Helper()
+	switch v := raw.(type) {
+	case nil:
+		return sql.NullTime{}
+	case time.Time:
+		if v.IsZero() {
+			return sql.NullTime{}
+		}
+		return sql.NullTime{Time: v.UTC(), Valid: true}
+	case string:
+		return servedMailboxParseSQLTimeString(t, backend, field, v)
+	case []byte:
+		return servedMailboxParseSQLTimeString(t, backend, field, string(v))
+	default:
+		t.Fatalf("%s mailbox %s unsupported timestamp value %T", backend, field, raw)
+		return sql.NullTime{}
+	}
+}
+
+func servedMailboxParseSQLTimeString(t *testing.T, backend, field, raw string) sql.NullTime {
+	t.Helper()
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return sql.NullTime{}
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+	}
+	var lastErr error
+	for _, layout := range formats {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			return sql.NullTime{Time: parsed.UTC(), Valid: true}
+		}
+		lastErr = err
+	}
+	t.Fatalf("%s mailbox %s parse timestamp %q: %v", backend, field, raw, lastErr)
+	return sql.NullTime{}
+}
+
+func requireServedMailboxRawTerminalState(t *testing.T, db *sql.DB, backend, mailboxID, wantDecision string) {
+	t.Helper()
+	state := loadServedMailboxRawState(t, db, backend, mailboxID)
+	if state.Status != "decided" || state.Decision != wantDecision || !state.DecidedAt.Valid || strings.TrimSpace(state.DecidedBy) == "" || state.DeferredUntil.Valid {
+		t.Fatalf("%s mailbox %s raw terminal state = %#v, want decided/%s with decided metadata and no deferred_until", backend, mailboxID, state, wantDecision)
+	}
+}
+
+func requireServedMailboxRawDeferredState(t *testing.T, db *sql.DB, backend string, fixture servedMailboxDecisionFixture) {
+	t.Helper()
+	state := loadServedMailboxRawState(t, db, backend, fixture.DeferID)
+	if state.Status != "pending" || state.Decision != "" || !state.DecidedAt.Valid || strings.TrimSpace(state.DecidedBy) == "" || !state.DeferredUntil.Valid || !state.ExpiresAt.Valid {
+		t.Fatalf("%s mailbox %s raw deferred state = %#v, want pending with deferred_until and unchanged expires_at", backend, fixture.DeferID, state)
+	}
+	if !state.DeferredUntil.Time.UTC().Equal(fixture.DeferUntil.UTC()) {
+		t.Fatalf("%s deferred_until = %s, want %s", backend, state.DeferredUntil.Time.UTC(), fixture.DeferUntil.UTC())
+	}
+	if !state.ExpiresAt.Time.UTC().Equal(fixture.DeferExpires.UTC()) {
+		t.Fatalf("%s expires_at = %s, want unchanged %s", backend, state.ExpiresAt.Time.UTC(), fixture.DeferExpires.UTC())
+	}
+}
+
+func requireServedMailboxDetailState(t *testing.T, endpoint, mailboxID, wantStatus, wantDecision, wantHistoryAction string) {
+	t.Helper()
+	var detail store.MailboxV1ItemDetail
+	requireServedJSONRPCResult(t, endpoint, "mailbox.get", map[string]any{"mailbox_id": mailboxID}, &detail)
+	if detail.Item.MailboxID != mailboxID || detail.Item.Status != wantStatus || detail.Item.Decision != wantDecision {
+		t.Fatalf("mailbox.get item = %#v, want id=%s status=%s decision=%s", detail.Item, mailboxID, wantStatus, wantDecision)
+	}
+	if wantStatus == "deferred" {
+		if detail.Item.DeferredUntil == "" || detail.Item.DecidedAt == "" {
+			t.Fatalf("mailbox.get deferred item missing deferred_until/decided_at: %#v", detail.Item)
+		}
+	} else if detail.Item.DecidedAt == "" {
+		t.Fatalf("mailbox.get terminal item missing decided_at: %#v", detail.Item)
+	}
+	if len(detail.History) < 2 {
+		t.Fatalf("mailbox.get history = %#v, want created plus decision/defer entry", detail.History)
+	}
+	last := detail.History[len(detail.History)-1]
+	if last.Action != wantHistoryAction || strings.TrimSpace(last.ActorTokenID) == "" || strings.TrimSpace(last.TS) == "" {
+		t.Fatalf("mailbox.get history last = %#v, want action=%s with actor/timestamp", last, wantHistoryAction)
+	}
+}
+
+type servedMailboxEventEvidence struct {
+	EventName      string
+	RunID          string
+	EntityID       string
+	FlowInstance   string
+	ProducedBy     string
+	ProducedByType string
+	SourceEventID  string
+	Payload        map[string]any
+}
+
+func loadServedMailboxEventEvidence(t *testing.T, db *sql.DB, backend, eventID string) servedMailboxEventEvidence {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `
+			SELECT event_name, COALESCE(run_id::text, ''), COALESCE(entity_id::text, ''),
+			       COALESCE(flow_instance, ''), COALESCE(produced_by, ''),
+			       COALESCE(produced_by_type, ''), COALESCE(source_event_id::text, ''),
+			       payload::text
+			FROM events
+			WHERE event_id = $1::uuid
+		`
+		args = []any{eventID}
+	case "sqlite":
+		query = `
+			SELECT event_name, COALESCE(run_id, ''), COALESCE(entity_id, ''),
+			       COALESCE(flow_instance, ''), COALESCE(produced_by, ''),
+			       COALESCE(produced_by_type, ''), COALESCE(source_event_id, ''),
+			       COALESCE(payload, '{}')
+			FROM events
+			WHERE event_id = ?
+		`
+		args = []any{eventID}
+	default:
+		t.Fatalf("unknown mailbox proof backend %q", backend)
+	}
+	var evidence servedMailboxEventEvidence
+	var payloadRaw string
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(
+		&evidence.EventName,
+		&evidence.RunID,
+		&evidence.EntityID,
+		&evidence.FlowInstance,
+		&evidence.ProducedBy,
+		&evidence.ProducedByType,
+		&evidence.SourceEventID,
+		&payloadRaw,
+	); err != nil {
+		t.Fatalf("%s load mailbox event evidence %s: %v", backend, eventID, err)
+	}
+	if err := json.Unmarshal([]byte(payloadRaw), &evidence.Payload); err != nil {
+		t.Fatalf("%s decode mailbox event payload %s: %v\n%s", backend, eventID, err, payloadRaw)
+	}
+	return evidence
+}
+
+func requireServedMailboxTerminalEvent(t *testing.T, db *sql.DB, backend string, fixture servedMailboxDecisionFixture, eventID, mailboxID, decision, reason string, decisionPayload map[string]any) {
+	t.Helper()
+	evidence := loadServedMailboxEventEvidence(t, db, backend, eventID)
+	if evidence.EventName != "mailbox.item_decided" || evidence.RunID != fixture.RunID || evidence.EntityID != fixture.EntityID || evidence.FlowInstance != fixture.SourceFlow || evidence.SourceEventID != fixture.SourceEventID {
+		t.Fatalf("%s terminal mailbox event evidence = %#v, want run/source/entity/flow lineage", backend, evidence)
+	}
+	if evidence.ProducedBy != "runtime" || evidence.ProducedByType != "platform" {
+		t.Fatalf("%s terminal mailbox event producer = %s/%s, want runtime/platform", backend, evidence.ProducedBy, evidence.ProducedByType)
+	}
+	payload := evidence.Payload
+	if _, ok := payload["payload"]; ok {
+		t.Fatalf("%s terminal mailbox event retained retired payload field: %#v", backend, payload)
+	}
+	if payload["mailbox_id"] != mailboxID || payload["decision"] != decision || payload["source_event_id"] != fixture.SourceEventID || payload["source_flow"] != fixture.SourceFlow || payload["source_entity_id"] != fixture.EntityID {
+		t.Fatalf("%s terminal mailbox event payload = %#v", backend, payload)
+	}
+	if payload["mailbox_decision_id"] == "" || payload["decided_by"] == "" || payload["decided_at"] == "" {
+		t.Fatalf("%s terminal mailbox event missing decision metadata: %#v", backend, payload)
+	}
+	mailboxPayload, ok := payload["mailbox_payload"].(map[string]any)
+	if !ok || strings.TrimSpace(fmt.Sprint(mailboxPayload["title"])) == "" {
+		t.Fatalf("%s terminal mailbox_payload = %#v, want object with title", backend, payload["mailbox_payload"])
+	}
+	if decision == "rejected" {
+		if payload["reason"] != reason {
+			t.Fatalf("%s reject reason = %#v, want %q in payload %#v", backend, payload["reason"], reason, payload)
+		}
+	} else if reasonField := strings.TrimSpace(fmt.Sprint(payload["reason"])); reasonField != "" && reasonField != "<nil>" {
+		t.Fatalf("%s approval payload unexpectedly has reason: %#v", backend, payload)
+	}
+	gotDecisionPayload, ok := payload["decision_payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s decision_payload = %#v, want object", backend, payload["decision_payload"])
+	}
+	if decisionPayload != nil {
+		for key, want := range decisionPayload {
+			if gotDecisionPayload[key] != want {
+				t.Fatalf("%s decision_payload[%s] = %#v, want %#v in %#v", backend, key, gotDecisionPayload[key], want, gotDecisionPayload)
+			}
+		}
+	}
+}
+
+func requireServedMailboxDeferredEvent(t *testing.T, db *sql.DB, backend string, fixture servedMailboxDecisionFixture, eventID string) {
+	t.Helper()
+	evidence := loadServedMailboxEventEvidence(t, db, backend, eventID)
+	if evidence.EventName != "mailbox.item_deferred" || evidence.RunID != fixture.RunID || evidence.EntityID != fixture.EntityID || evidence.FlowInstance != fixture.SourceFlow || evidence.SourceEventID != fixture.SourceEventID {
+		t.Fatalf("%s deferred mailbox event evidence = %#v, want run/source/entity/flow lineage", backend, evidence)
+	}
+	if evidence.ProducedBy != "runtime" || evidence.ProducedByType != "platform" {
+		t.Fatalf("%s deferred mailbox event producer = %s/%s, want runtime/platform", backend, evidence.ProducedBy, evidence.ProducedByType)
+	}
+	payload := evidence.Payload
+	if _, ok := payload["payload"]; ok {
+		t.Fatalf("%s deferred mailbox event retained retired payload field: %#v", backend, payload)
+	}
+	if payload["mailbox_id"] != fixture.DeferID || payload["source_event_id"] != fixture.SourceEventID || payload["source_flow"] != fixture.SourceFlow || payload["source_entity_id"] != fixture.EntityID {
+		t.Fatalf("%s deferred mailbox event payload = %#v", backend, payload)
+	}
+	if _, ok := payload["decision"]; ok {
+		t.Fatalf("%s deferred mailbox event unexpectedly has terminal decision: %#v", backend, payload)
+	}
+	if payload["mailbox_decision_id"] == "" || payload["deferred_by"] == "" || payload["deferred_at"] == "" {
+		t.Fatalf("%s deferred mailbox event missing defer metadata: %#v", backend, payload)
+	}
+	if payload["until"] != fixture.DeferUntil.Format(time.RFC3339Nano) {
+		t.Fatalf("%s deferred until = %#v, want %s in payload %#v", backend, payload["until"], fixture.DeferUntil.Format(time.RFC3339Nano), payload)
+	}
+	mailboxPayload, ok := payload["mailbox_payload"].(map[string]any)
+	if !ok || mailboxPayload["title"] != "defer item" {
+		t.Fatalf("%s deferred mailbox_payload = %#v, want defer item", backend, payload["mailbox_payload"])
+	}
+}
+
+func requireServedMailboxEventCount(t *testing.T, db *sql.DB, backend, eventName, mailboxID string, want int) {
+	t.Helper()
+	var query string
+	var args []any
+	switch backend {
+	case "postgres":
+		query = `SELECT COUNT(*) FROM events WHERE event_name = $1 AND payload->>'mailbox_id' = $2`
+		args = []any{eventName, mailboxID}
+	case "sqlite":
+		query = `SELECT COUNT(*) FROM events WHERE event_name = ? AND json_extract(payload, '$.mailbox_id') = ?`
+		args = []any{eventName, mailboxID}
+	default:
+		t.Fatalf("unknown mailbox proof backend %q", backend)
+	}
+	var got int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&got); err != nil {
+		t.Fatalf("%s count mailbox event %s/%s: %v", backend, eventName, mailboxID, err)
+	}
+	if got != want {
+		t.Fatalf("%s mailbox event count %s/%s = %d, want %d", backend, eventName, mailboxID, got, want)
+	}
 }
 
 func runServedDynamicAutoEmitBackendProof(t *testing.T, backend servedparity.Backend) {

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -752,14 +752,17 @@ func validatePublicSurfaceBackendMatrix(root string, matrix publicSurfaceBackend
 	if _, ok := activeTrackers[trackerKey(1386, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
 		problems = append(problems, "active_trackers missing #1386 runtime_store_backend_default_and_sqlite_portability")
 	}
-	if _, ok := activeTrackers[trackerKey(1783, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; !ok {
-		problems = append(problems, "active_trackers missing #1783 runtime_store_backend_default_and_sqlite_portability")
-	}
 	if _, ok := activeTrackers[trackerKey(1254, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
 		problems = append(problems, "active_trackers must not include closed #1254 runtime_store_backend_default_and_sqlite_portability")
 	}
 	if _, ok := activeTrackers[trackerKey(1255, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
 		problems = append(problems, "active_trackers must not include closed #1255 runtime_store_backend_default_and_sqlite_portability")
+	}
+	if _, ok := activeTrackers[trackerKey(1783, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
+		problems = append(problems, "active_trackers must not include closed #1783 runtime_store_backend_default_and_sqlite_portability")
+	}
+	if _, ok := activeTrackers[trackerKey(1864, "runtime_operations.runtime_store_backend_default_and_sqlite_portability")]; ok {
+		problems = append(problems, "active_trackers must not include closed #1864 runtime_store_backend_default_and_sqlite_portability")
 	}
 	if _, ok := activeTrackers[trackerKey(0, "operator_surfaces.v1_openrpc_api_conformance")]; !ok {
 		problems = append(problems, "active_trackers missing operator_surfaces.v1_openrpc_api_conformance watchlist")

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -39,12 +39,6 @@ active_trackers:
   - kind: github_issue
     issue: 1386
     watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
-  - kind: github_issue
-    issue: 1783
-    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
-  - kind: github_issue
-    issue: 1864
-    watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability
   - kind: watchlist
     issue: 0
     watchlist: operator_surfaces.v1_openrpc_api_conformance
@@ -134,17 +128,42 @@ mutating_api_parity_ledger:
       and explicit Postgres, including release of run-scoped queued work exactly
       through the EventBus owner, idempotency replay, and generic settlement.
   - method: mailbox.approve
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: mailbox_approve_decision_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessMailboxDecisionLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc mailbox.approve on default
+      SQLite and explicit Postgres, including terminal row state/projection,
+      mailbox.item_decided payload/lineage/metadata, idempotency replay without
+      duplicate events, already-decided error behavior, and generic settlement.
   - method: mailbox.reject
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: mailbox_reject_decision_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessMailboxDecisionLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc mailbox.reject on default
+      SQLite and explicit Postgres, including terminal row state/projection,
+      schema-visible rejection reason in mailbox.item_decided, idempotency replay
+      without duplicate events, and generic settlement.
   - method: mailbox.defer
-    classification: split_with_issue_ref
-    split_issue: 1386
-    proof_refs: [{kind: tracker, issue: 1386, watchlist: runtime_operations.runtime_store_backend_default_and_sqlite_portability}]
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: mailbox_defer_decision_lifecycle
+    proof_refs:
+      - kind: go_test
+        name: TestServedParityHarnessMailboxDecisionLifecycle
+    notes: >
+      Shared served harness proves real /v1/rpc mailbox.defer on default SQLite
+      and explicit Postgres, including non-terminal pending/deferred storage,
+      explicit deferred_until independent from expires_at, mailbox.item_deferred
+      payload/lineage/metadata, idempotency replay without duplicate events, and
+      generic settlement.
   - method: agent.send_directive
     classification: split_with_issue_ref
     split_issue: 1386

--- a/internal/servedparity/servedparity.go
+++ b/internal/servedparity/servedparity.go
@@ -30,6 +30,9 @@ const (
 	ScenarioRunContinueControlLifecycle          = "run_continue_control_lifecycle"
 	ScenarioRuntimePauseIngressLifecycle         = "runtime_pause_ingress_lifecycle"
 	ScenarioRuntimeResumeIngressLifecycle        = "runtime_resume_ingress_lifecycle"
+	ScenarioMailboxApproveDecisionLifecycle      = "mailbox_approve_decision_lifecycle"
+	ScenarioMailboxRejectDecisionLifecycle       = "mailbox_reject_decision_lifecycle"
+	ScenarioMailboxDeferDecisionLifecycle        = "mailbox_defer_decision_lifecycle"
 )
 
 type Scenario struct {
@@ -64,6 +67,9 @@ func Scenarios() []Scenario {
 		servedControlScenario(ScenarioRunContinueControlLifecycle, "run.continue", "TestServedParityHarnessRunControlLifecycle"),
 		servedControlScenario(ScenarioRuntimePauseIngressLifecycle, "runtime.pause", "TestServedParityHarnessRuntimeIngressControlLifecycle"),
 		servedControlScenario(ScenarioRuntimeResumeIngressLifecycle, "runtime.resume", "TestServedParityHarnessRuntimeIngressControlLifecycle"),
+		servedMailboxDecisionScenario(ScenarioMailboxApproveDecisionLifecycle, "mailbox.approve"),
+		servedMailboxDecisionScenario(ScenarioMailboxRejectDecisionLifecycle, "mailbox.reject"),
+		servedMailboxDecisionScenario(ScenarioMailboxDeferDecisionLifecycle, "mailbox.defer"),
 	}
 }
 
@@ -72,6 +78,20 @@ func servedControlScenario(id, apiMethod, testName string) Scenario {
 		ID:        id,
 		APIMethod: apiMethod,
 		TestName:  testName,
+		Backends:  append([]Backend(nil), RequiredBackends...),
+		Postconditions: []Postcondition{
+			PostconditionNoNonTerminalDeliveries,
+			PostconditionNoPendingPipelineEvents,
+			PostconditionNoUnfiredDueTimers,
+		},
+	}
+}
+
+func servedMailboxDecisionScenario(id, apiMethod string) Scenario {
+	return Scenario{
+		ID:        id,
+		APIMethod: apiMethod,
+		TestName:  "TestServedParityHarnessMailboxDecisionLifecycle",
 		Backends:  append([]Backend(nil), RequiredBackends...),
 		Postconditions: []Postcondition{
 			PostconditionNoNonTerminalDeliveries,

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -833,17 +833,15 @@ func (r mailboxV1Row) decisionEvent(eventID, decisionID, eventType, action, acto
 		EntityID:     strings.TrimSpace(r.EntityID),
 		FlowInstance: strings.TrimSpace(r.FlowInstance),
 	}
-	evt := events.NewChildEventWithLineage(
+	evt := events.NewRuntimeControlEvent(
 		strings.TrimSpace(eventID),
 		events.EventType(strings.TrimSpace(eventType)),
-		"mailbox_human",
+		"runtime",
 		"",
 		raw,
 		0,
-		events.EventLineage{
-			RunID:         strings.TrimSpace(r.RunID),
-			ParentEventID: strings.TrimSpace(r.SourceEventID),
-		},
+		strings.TrimSpace(r.RunID),
+		strings.TrimSpace(r.SourceEventID),
 		envelope,
 		now.UTC(),
 	)

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -130,6 +130,20 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	if !outcome.Result.OK || outcome.Result.Status != "decided" || outcome.Result.DownstreamEventID == "" || outcome.DecisionEvent == nil {
 		t.Fatalf("unexpected approve outcome=%#v", outcome)
 	}
+	if outcome.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || outcome.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("approval event source = %s/%s, want runtime_control/runtime", outcome.DecisionEvent.AdmissionClass(), outcome.DecisionEvent.SourceAgent())
+	}
+	var eventName, producedBy, producedByType string
+	if err := db.QueryRowContext(ctx, `
+		SELECT event_name, COALESCE(produced_by, ''), COALESCE(produced_by_type, '')
+		FROM events
+		WHERE event_id = $1::uuid
+	`, outcome.Result.DownstreamEventID).Scan(&eventName, &producedBy, &producedByType); err != nil {
+		t.Fatalf("load approval event producer: %v", err)
+	}
+	if eventName != "mailbox.item_decided" || producedBy != "runtime" || producedByType != "platform" {
+		t.Fatalf("approval event producer = %s/%s/%s, want mailbox.item_decided runtime/platform", eventName, producedBy, producedByType)
+	}
 	var approvalPayload map[string]any
 	if err := json.Unmarshal(outcome.DecisionEvent.Payload(), &approvalPayload); err != nil {
 		t.Fatalf("decode approval event payload: %v", err)
@@ -173,6 +187,9 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 	}
 	if rejected.Result.Status != "decided" || rejected.Result.DownstreamEventName != "mailbox.item_decided" || rejected.DecisionEvent == nil {
 		t.Fatalf("unexpected reject outcome=%#v", rejected)
+	}
+	if rejected.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || rejected.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("reject event source = %s/%s, want runtime_control/runtime", rejected.DecisionEvent.AdmissionClass(), rejected.DecisionEvent.SourceAgent())
 	}
 	var rejectedPayload map[string]any
 	if err := json.Unmarshal(rejected.DecisionEvent.Payload(), &rejectedPayload); err != nil {
@@ -237,15 +254,19 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 		}
 	}
 
-	if _, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+	deferredOutcome, err := s.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
 		MailboxID:         pastID,
 		Action:            "deferred",
 		ActorTokenID:      "actor-1",
 		DeferUntil:        now.Add(time.Hour),
 		Now:               now,
 		DecisionEventType: "mailbox.item_deferred",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("defer future: %v", err)
+	}
+	if deferredOutcome.DecisionEvent == nil || deferredOutcome.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || deferredOutcome.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("deferred event source = %#v, want runtime_control/runtime", deferredOutcome.DecisionEvent)
 	}
 	deferred, err := s.GetV1MailboxItem(ctx, pastID)
 	if err != nil {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1930,12 +1930,15 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	if !outcome.Result.OK || outcome.Result.Status != "decided" || outcome.Result.DownstreamEventName != "mailbox.item_decided" {
 		t.Fatalf("approval outcome = %+v, want decided downstream event", outcome.Result)
 	}
-	var eventName string
-	if err := store.DB.QueryRowContext(ctx, `SELECT event_name FROM events WHERE event_id = ?`, outcome.Result.DownstreamEventID).Scan(&eventName); err != nil {
+	if outcome.DecisionEvent == nil || outcome.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || outcome.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("approval event source = %#v, want runtime_control/runtime", outcome.DecisionEvent)
+	}
+	var eventName, producedBy, producedByType string
+	if err := store.DB.QueryRowContext(ctx, `SELECT event_name, COALESCE(produced_by, ''), COALESCE(produced_by_type, '') FROM events WHERE event_id = ?`, outcome.Result.DownstreamEventID).Scan(&eventName, &producedBy, &producedByType); err != nil {
 		t.Fatalf("load downstream event: %v", err)
 	}
-	if eventName != "mailbox.item_decided" {
-		t.Fatalf("downstream event_name = %q, want mailbox.item_decided", eventName)
+	if eventName != "mailbox.item_decided" || producedBy != "runtime" || producedByType != "platform" {
+		t.Fatalf("downstream event producer = %s/%s/%s, want mailbox.item_decided runtime/platform", eventName, producedBy, producedByType)
 	}
 	decided, err := store.GetV1MailboxItem(ctx, itemID)
 	if err != nil {
@@ -1984,6 +1987,9 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	if rejected.Result.Status != "decided" || rejected.Result.DownstreamEventName != "mailbox.item_decided" || rejected.DecisionEvent == nil {
 		t.Fatalf("rejected outcome = %+v, want decided downstream event", rejected)
 	}
+	if rejected.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || rejected.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("reject event source = %s/%s, want runtime_control/runtime", rejected.DecisionEvent.AdmissionClass(), rejected.DecisionEvent.SourceAgent())
+	}
 	var rejectedPayload map[string]any
 	if err := json.Unmarshal(rejected.DecisionEvent.Payload(), &rejectedPayload); err != nil {
 		t.Fatalf("decode reject event payload: %v", err)
@@ -2018,6 +2024,9 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	}
 	if deferred.Result.Status != "deferred" || deferred.Result.DownstreamEventName != "mailbox.item_deferred" || deferred.DecisionEvent == nil {
 		t.Fatalf("deferred outcome = %+v, want deferred downstream event", deferred)
+	}
+	if deferred.DecisionEvent.AdmissionClass() != events.EventAdmissionRuntimeControl || deferred.DecisionEvent.SourceAgent() != "runtime" {
+		t.Fatalf("defer event source = %s/%s, want runtime_control/runtime", deferred.DecisionEvent.AdmissionClass(), deferred.DecisionEvent.SourceAgent())
 	}
 	deferredDetail, err := store.GetV1MailboxItem(ctx, deferID)
 	if err != nil {


### PR DESCRIPTION
Closes #1885

## Summary
- Adds servedparity scenarios for mailbox.approve, mailbox.reject, and mailbox.defer, all running through real served /v1/rpc on default SQLite and explicit Postgres.
- Promotes the three mailbox decision matrix rows to dual_backend_served_proof with required backends and settlement postconditions.
- Corrects mailbox decision event construction to persist as platform-produced runtime-control events, matching the #1892 platform-spec baseline.

## Governing refs/context
- platform-spec.yaml#api_specification.conventions.mailbox.decision_event_routes
- platform-spec.yaml#api_specification.conventions.mailbox.decision_event_payload_contract
- platform-spec.yaml#api_specification.conventions.mailbox.decision_transaction_boundary
- platform-spec.yaml#api_specification.methods.mailbox.approve
- platform-spec.yaml#api_specification.methods.mailbox.reject
- platform-spec.yaml#api_specification.methods.mailbox.defer
- platform-spec.yaml#platform_events.catalog.mailbox.item_decided
- platform-spec.yaml#platform_events.catalog.mailbox.item_deferred
- #1885 approved Pre-Implementation Coverage Audit and gate comment
- #1888 / PR #1892 corrected mailbox decision-event baseline

## Semantic migration
- New canonical event-construction path for mailbox decision events: store MailboxAPIStore.DecideV1MailboxItem builds platform-produced runtime-control events for mailbox.item_decided and mailbox.item_deferred.
- Old path now invalid: mailbox decision events must not be constructed as child/agent events via NewChildEventWithLineage.
- Checked production paths: public /v1/rpc mailbox.approve/reject/defer route through internal/apiv1/operator_mailbox.go into the selected MailboxAPIStore for Postgres and SQLite; served proof reads persisted event evidence on both backends.
- Migration complete for the chosen class: all three public mailbox decision mutators now have registered served dual-backend proof.

## Proof
- PASS: SWARM_TEST_POSTGRES_DSN=host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable go test ./cmd/swarm -run TestServedParityHarnessMailboxDecisionLifecycle -count=1
- PASS: SWARM_TEST_POSTGRES_DSN=host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable go test ./internal/apiv1 -run 'TestOperatorMailbox|TestPublicSurfaceBackendMatrix' -count=1
- PASS: SWARM_TEST_POSTGRES_DSN=host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable go test ./internal/store -run 'TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners|TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner' -count=1
- PASS: go test ./internal/servedparity -run 'TestScenarioRegistryKeepsRequiredBackends|TestScenarios' -count=1
- ATTEMPTED: SWARM_TEST_POSTGRES_DSN=host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable go test ./...; local run timed out under concurrent host-Postgres test contention in unrelated packages. Isolated timeout repros passed: internal/apiv1 TestOperatorRunStartHandlersFailClosedBeforePersistence, internal/runtime/cataloge2e TestCatalogRequiredSmoke and TestTier5LifecycleCatalogFixtures_RealRuntime/test-timer-fire, internal/runtime/pipeline TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions.

## Non-claims
- Does not close #1386 or #1239.
- Does not promote replay, bundle lifecycle, fork lifecycle, agent-control, destructive reset, or test/admin setup families.