### PR TITLE
[agent-f][issue #1898] GitHub App issue-comment bot loop

### DIFF
--- a/cmd/swarm/connections.go
+++ b/cmd/swarm/connections.go
@@ -20,8 +20,11 @@ type connectionsConnectOptions struct {
 	provider          string
 	authURL           string
 	tokenURL          string
+	apiBaseURL        string
 	clientID          string
 	clientSecretStdin bool
+	privateKeyStdin   bool
+	installationID    string
 	redirectURL       string
 	account           string
 	scopes            []string
@@ -39,27 +42,31 @@ type connectionsStatusOptions struct {
 }
 
 type connectionRecord struct {
-	Key          string                                     `json:"key"`
-	Provider     string                                     `json:"provider,omitempty"`
-	Account      string                                     `json:"account,omitempty"`
-	GrantType    string                                     `json:"grant_type,omitempty"`
-	Scopes       []string                                   `json:"scopes,omitempty"`
-	GrantModel   string                                     `json:"grant_model,omitempty"`
-	TokenRequest managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
-	Status       string                                     `json:"status"`
-	Failure      string                                     `json:"failure,omitempty"`
-	ExpiresAt    string                                     `json:"expires_at,omitempty"`
-	UpdatedAt    string                                     `json:"updated_at,omitempty"`
-	Present      bool                                       `json:"present"`
-	RequiredBy   []connectionRequirement                    `json:"required_by,omitempty"`
+	Key            string                                     `json:"key"`
+	Provider       string                                     `json:"provider,omitempty"`
+	Account        string                                     `json:"account,omitempty"`
+	GrantType      string                                     `json:"grant_type,omitempty"`
+	InstallationID string                                     `json:"installation_id,omitempty"`
+	APIBaseURL     string                                     `json:"api_base_url,omitempty"`
+	Scopes         []string                                   `json:"scopes,omitempty"`
+	GrantModel     string                                     `json:"grant_model,omitempty"`
+	TokenRequest   managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	Status         string                                     `json:"status"`
+	Failure        string                                     `json:"failure,omitempty"`
+	ExpiresAt      string                                     `json:"expires_at,omitempty"`
+	UpdatedAt      string                                     `json:"updated_at,omitempty"`
+	Present        bool                                       `json:"present"`
+	RequiredBy     []connectionRequirement                    `json:"required_by,omitempty"`
 }
 
 type connectionRequirement struct {
-	Kind         string                                     `json:"kind"`
-	Name         string                                     `json:"name"`
-	Scopes       []string                                   `json:"scopes,omitempty"`
-	GrantModel   string                                     `json:"grant_model,omitempty"`
-	TokenRequest managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	Kind                string                                     `json:"kind"`
+	Name                string                                     `json:"name"`
+	GrantType           string                                     `json:"grant_type,omitempty"`
+	Scopes              []string                                   `json:"scopes,omitempty"`
+	GrantModel          string                                     `json:"grant_model,omitempty"`
+	TokenRequest        managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	InstallationIDInput string                                     `json:"installation_id_input,omitempty"`
 }
 
 type connectionsStatusResult struct {
@@ -101,7 +108,7 @@ func newConnectionsConnectCommand(ctx context.Context, repo string) *cobra.Comma
 		Short: "Start or complete a managed credential grant.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			secret, err := readConnectionClientSecret(cmd.InOrStdin(), opts)
+			secret, privateKey, err := readConnectionSecrets(cmd.InOrStdin(), opts)
 			if err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
@@ -212,17 +219,39 @@ func newConnectionsConnectCommand(ctx context.Context, repo string) *cobra.Comma
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "connection connected: key=%s status=%s\n", output.Connection.Key, output.Connection.Status)
 				return nil
+			case runtimemanagedcredentials.GrantGitHubAppInstallation:
+				record, err := source.ConnectGitHubAppInstallation(ctx, runtimemanagedcredentials.GitHubAppInstallationRequest{
+					Key:            key,
+					Provider:       firstNonEmpty(opts.provider, "github"),
+					APIBaseURL:     opts.apiBaseURL,
+					ClientID:       opts.clientID,
+					InstallationID: opts.installationID,
+					PrivateKey:     privateKey,
+					Account:        opts.account,
+				})
+				if err != nil {
+					return returnSecretsRuntimeError(cmd.ErrOrStderr(), err)
+				}
+				output := connectionsConnectResult{Connection: connectionRecordFromDescriptor(record.Descriptor(), true, nil)}
+				if opts.asJSON {
+					return encodeSecretsJSON(cmd.OutOrStdout(), output)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "connection connected: key=%s status=%s\n", output.Connection.Key, output.Connection.Status)
+				return nil
 			default:
-				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("--grant must be %s, %s, or %s", runtimemanagedcredentials.GrantAuthorizationCode, runtimemanagedcredentials.GrantAuthorizationCodePKCE, runtimemanagedcredentials.GrantClientCredentials))
+				return returnCLIValidationError(cmd.ErrOrStderr(), fmt.Errorf("--grant must be %s, %s, %s, or %s", runtimemanagedcredentials.GrantAuthorizationCode, runtimemanagedcredentials.GrantAuthorizationCodePKCE, runtimemanagedcredentials.GrantClientCredentials, runtimemanagedcredentials.GrantGitHubAppInstallation))
 			}
 		},
 	}
-	cmd.Flags().StringVar(&opts.grant, "grant", opts.grant, "Grant type: authorization_code, authorization_code_pkce, or client_credentials")
+	cmd.Flags().StringVar(&opts.grant, "grant", opts.grant, "Grant type: authorization_code, authorization_code_pkce, client_credentials, or github_app_installation")
 	cmd.Flags().StringVar(&opts.provider, "provider", "", "Provider label for operator status")
 	cmd.Flags().StringVar(&opts.authURL, "auth-url", "", "OAuth authorization URL")
 	cmd.Flags().StringVar(&opts.tokenURL, "token-url", "", "OAuth token URL")
+	cmd.Flags().StringVar(&opts.apiBaseURL, "api-base-url", "", "Provider API base URL for app-installation grants")
 	cmd.Flags().StringVar(&opts.clientID, "client-id", "", "OAuth client ID")
 	cmd.Flags().BoolVar(&opts.clientSecretStdin, "client-secret-stdin", false, "Read the OAuth client secret from stdin")
+	cmd.Flags().BoolVar(&opts.privateKeyStdin, "private-key-stdin", false, "Read the app private key from stdin")
+	cmd.Flags().StringVar(&opts.installationID, "installation-id", "", "Provider app installation id")
 	cmd.Flags().StringVar(&opts.redirectURL, "redirect-url", "", "OAuth redirect URL for authorization_code grants")
 	cmd.Flags().StringVar(&opts.account, "account", "", "Connected provider account label")
 	cmd.Flags().StringSliceVar(&opts.scopes, "scope", nil, "Required OAuth scope; repeat or comma-separate")
@@ -328,15 +357,34 @@ func newConnectionsDisconnectCommand(ctx context.Context, repo string) *cobra.Co
 	return cmd
 }
 
-func readConnectionClientSecret(in io.Reader, opts connectionsConnectOptions) (string, error) {
-	if !opts.clientSecretStdin {
-		return "", nil
+func readConnectionSecrets(in io.Reader, opts connectionsConnectOptions) (string, string, error) {
+	if opts.clientSecretStdin && opts.privateKeyStdin {
+		return "", "", fmt.Errorf("--client-secret-stdin and --private-key-stdin cannot both read from stdin")
 	}
+	if opts.privateKeyStdin {
+		privateKey, err := readConnectionPrivateKey(in)
+		return "", privateKey, err
+	}
+	if !opts.clientSecretStdin {
+		return "", "", nil
+	}
+	raw, err := io.ReadAll(in)
+	if err != nil {
+		return "", "", err
+	}
+	return strings.TrimSpace(string(raw)), "", nil
+}
+
+func readConnectionPrivateKey(in io.Reader) (string, error) {
 	raw, err := io.ReadAll(in)
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(raw)), nil
+	privateKey := strings.TrimSpace(string(raw))
+	if privateKey == "" {
+		return "", fmt.Errorf("private key is required")
+	}
+	return privateKey, nil
 }
 
 func readConnectionAuthCode(in io.Reader, codeStdin bool) (string, error) {
@@ -411,16 +459,18 @@ func connectionRecords(ctx context.Context, store runtimemanagedcredentials.Stor
 
 func connectionRecordFromDescriptor(desc runtimemanagedcredentials.Descriptor, present bool, requiredBy []runtimemanagedcredentials.Requirement) connectionRecord {
 	record := connectionRecord{
-		Key:          strings.TrimSpace(desc.Key),
-		Provider:     strings.TrimSpace(desc.Provider),
-		Account:      strings.TrimSpace(desc.Account),
-		GrantType:    strings.TrimSpace(desc.GrantType),
-		Scopes:       append([]string{}, desc.Scopes...),
-		GrantModel:   strings.TrimSpace(desc.GrantModel),
-		TokenRequest: managedcredentialmodel.NormalizeTokenRequestProfile(desc.TokenRequest),
-		Status:       strings.TrimSpace(desc.Status),
-		Failure:      strings.TrimSpace(desc.Failure),
-		Present:      present,
+		Key:            strings.TrimSpace(desc.Key),
+		Provider:       strings.TrimSpace(desc.Provider),
+		Account:        strings.TrimSpace(desc.Account),
+		GrantType:      strings.TrimSpace(desc.GrantType),
+		InstallationID: strings.TrimSpace(desc.InstallationID),
+		APIBaseURL:     strings.TrimSpace(desc.APIBaseURL),
+		Scopes:         append([]string{}, desc.Scopes...),
+		GrantModel:     strings.TrimSpace(desc.GrantModel),
+		TokenRequest:   managedcredentialmodel.NormalizeTokenRequestProfile(desc.TokenRequest),
+		Status:         strings.TrimSpace(desc.Status),
+		Failure:        strings.TrimSpace(desc.Failure),
+		Present:        present,
 	}
 	if !desc.ExpiresAt.IsZero() {
 		record.ExpiresAt = desc.ExpiresAt.Format(time.RFC3339)
@@ -430,11 +480,13 @@ func connectionRecordFromDescriptor(desc runtimemanagedcredentials.Descriptor, p
 	}
 	for _, item := range requiredBy {
 		record.RequiredBy = append(record.RequiredBy, connectionRequirement{
-			Kind:         strings.TrimSpace(item.Kind),
-			Name:         strings.TrimSpace(item.Name),
-			Scopes:       append([]string{}, item.Scopes...),
-			GrantModel:   strings.TrimSpace(item.GrantModel),
-			TokenRequest: managedcredentialmodel.NormalizeTokenRequestProfile(item.TokenRequest),
+			Kind:                strings.TrimSpace(item.Kind),
+			Name:                strings.TrimSpace(item.Name),
+			GrantType:           strings.TrimSpace(item.GrantType),
+			Scopes:              append([]string{}, item.Scopes...),
+			GrantModel:          strings.TrimSpace(item.GrantModel),
+			TokenRequest:        managedcredentialmodel.NormalizeTokenRequestProfile(item.TokenRequest),
+			InstallationIDInput: strings.TrimSpace(item.InstallationIDInput),
 		})
 	}
 	return record
@@ -473,7 +525,10 @@ func formatConnectionRequirements(items []connectionRequirement) string {
 		if item.Kind == "" || item.Name == "" {
 			continue
 		}
-		details := make([]string, 0, 3)
+		details := make([]string, 0, 5)
+		if grantType := strings.TrimSpace(item.GrantType); grantType != "" {
+			details = append(details, "grant_type="+grantType)
+		}
 		if len(item.Scopes) > 0 {
 			details = append(details, "scopes="+strings.Join(item.Scopes, ","))
 		}
@@ -482,6 +537,9 @@ func formatConnectionRequirements(items []connectionRequirement) string {
 		}
 		if summary := managedcredentialmodel.TokenRequestProfileSummary(item.TokenRequest); summary != managedcredentialmodel.TokenRequestProfileSummary(managedcredentialmodel.DefaultTokenRequestProfile()) {
 			details = append(details, "token_request="+summary)
+		}
+		if input := strings.TrimSpace(item.InstallationIDInput); input != "" {
+			details = append(details, "installation_id_input="+input)
 		}
 		if len(details) > 0 {
 			parts = append(parts, item.Kind+":"+item.Name+"("+strings.Join(details, ";")+")")

--- a/internal/providerconnectors/packs/github/connector.yaml
+++ b/internal/providerconnectors/packs/github/connector.yaml
@@ -1,0 +1,41 @@
+provider: github
+tools:
+  github.create_issue_comment:
+    category: provider_connector
+    description: create GitHub issue comments
+    handler_type: http
+    effect_class: non_idempotent_write
+    managed_credential:
+      key: github_app
+      grant_type: github_app_installation
+      grant_model: installation_grant
+      installation_id_input: installation_id
+    input_schema:
+      type: object
+      properties:
+        installation_id:
+          type: string
+        owner:
+          type: string
+        repo:
+          type: string
+        issue_number:
+          type: integer
+        body:
+          type: string
+      required:
+        - installation_id
+        - owner
+        - repo
+        - issue_number
+        - body
+    output_schema:
+      type: object
+    http:
+      method: POST
+      url: https://api.github.com/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/comments
+      headers:
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: "2022-11-28"
+      body:
+        body: "{{input.body}}"

--- a/internal/providerconnectors/packs/github/pack.yaml
+++ b/internal/providerconnectors/packs/github/pack.yaml
@@ -1,0 +1,22 @@
+id: provider.github.connector
+version: 0.1.0
+platform_version: ">=0.7.0 <0.8.0"
+type: connector
+manifest_hash: sha256:dca6952b20e5521326b7cb83ef85fbf3390d0c29f9b68bee65ba66ce2445b25d
+provenance:
+  source: platform
+capabilities:
+  can:
+    call_provider_action: github.create_issue_comment
+    lower_through_activity: true
+    journal_activity_attempts: true
+  cannot:
+    - bypass activity_attempts
+    - retry non_idempotent_write automatically
+    - expose credential values
+requires:
+  managed_credentials:
+    - github_app
+tests:
+  - providerconnectors/github_pack
+  - runtime/github_app_issue_comment_supported_surface

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -18,13 +18,15 @@ import (
 const Category = "provider_connector"
 
 type RequirementStatus struct {
-	Kind         string
-	Name         string
-	Status       string
-	Bound        bool
-	Scopes       []string
-	GrantModel   string
-	TokenRequest managedcredentialmodel.TokenRequestProfile
+	Kind                string
+	Name                string
+	Status              string
+	Bound               bool
+	GrantType           string
+	Scopes              []string
+	GrantModel          string
+	TokenRequest        managedcredentialmodel.TokenRequestProfile
+	InstallationIDInput string
 }
 
 type Surface struct {
@@ -137,6 +139,17 @@ func validateTool(toolID string, tool runtimecontracts.ToolSchemaEntry) []error 
 		key := strings.TrimSpace(tool.ManagedCredential.Key)
 		if key == "" {
 			errs = append(errs, fmt.Errorf("%s managed_credential.key is required", context))
+		}
+		if err := runtimemanagedcredentials.ValidateRequiredGrantType(tool.ManagedCredential.GrantType); err != nil {
+			errs = append(errs, fmt.Errorf("%s managed_credential.%s", context, err.Error()))
+		}
+		grantType := runtimemanagedcredentials.NormalizeGrantType(tool.ManagedCredential.GrantType)
+		installationIDInput := strings.TrimSpace(tool.ManagedCredential.InstallationIDInput)
+		if grantType == runtimemanagedcredentials.GrantGitHubAppInstallation && installationIDInput == "" {
+			errs = append(errs, fmt.Errorf("%s managed_credential.installation_id_input is required for grant_type %s", context, grantType))
+		}
+		if installationIDInput != "" && grantType != runtimemanagedcredentials.GrantGitHubAppInstallation {
+			errs = append(errs, fmt.Errorf("%s managed_credential.installation_id_input requires grant_type %s", context, runtimemanagedcredentials.GrantGitHubAppInstallation))
 		}
 		if err := managedcredentialmodel.ValidateGrantModel(tool.ManagedCredential.GrantModel); err != nil {
 			errs = append(errs, fmt.Errorf("%s managed_credential.%s", context, err.Error()))
@@ -319,6 +332,7 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 	if tool.ManagedCredential != nil {
 		key := strings.TrimSpace(tool.ManagedCredential.Key)
 		if key != "" {
+			requiredGrantType := runtimemanagedcredentials.NormalizeGrantType(tool.ManagedCredential.GrantType)
 			requiredGrantModel := managedcredentialmodel.NormalizeGrantModel(tool.ManagedCredential.GrantModel)
 			requiredTokenRequest := managedcredentialmodel.NormalizeTokenRequestProfile(tool.ManagedCredential.TokenRequest)
 			storeKey := key
@@ -336,6 +350,12 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 					desc := record.Descriptor()
 					status = strings.ToUpper(strings.TrimSpace(desc.Status))
 					bound = desc.Status == runtimemanagedcredentials.StatusConnected
+					if bound {
+						if err := runtimemanagedcredentials.GrantTypeCovers(desc.GrantType, requiredGrantType); err != nil {
+							status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
+							bound = false
+						}
+					}
 					if bound {
 						if err := managedcredentialmodel.GrantModelCovers(desc.GrantModel, requiredGrantModel); err != nil {
 							status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
@@ -358,13 +378,15 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 				status = "UNBOUND"
 			}
 			requires = append(requires, RequirementStatus{
-				Kind:         "managed_credential",
-				Name:         key,
-				Status:       status,
-				Bound:        bound,
-				Scopes:       append([]string{}, tool.ManagedCredential.Scopes...),
-				GrantModel:   requiredGrantModel,
-				TokenRequest: requiredTokenRequest,
+				Kind:                "managed_credential",
+				Name:                key,
+				Status:              status,
+				Bound:               bound,
+				GrantType:           requiredGrantType,
+				Scopes:              append([]string{}, tool.ManagedCredential.Scopes...),
+				GrantModel:          requiredGrantModel,
+				TokenRequest:        requiredTokenRequest,
+				InstallationIDInput: strings.TrimSpace(tool.ManagedCredential.InstallationIDInput),
 			})
 		}
 	}

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -87,6 +87,42 @@ func TestValidateSourceRejectsMixedStaticAndManagedProviderConnectorCredentials(
 	}
 }
 
+func TestValidateSourceRejectsGitHubAppInstallationWithoutInputCarrier(t *testing.T) {
+	tool := slackConnectorTool("https://api.github.test/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/comments")
+	tool.ManagedCredential = &runtimecontracts.ManagedCredentialRef{
+		Key:        "github_app",
+		GrantType:  runtimemanagedcredentials.GrantGitHubAppInstallation,
+		GrantModel: managedcredentialmodel.GrantModelInstallation,
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"github.create_issue_comment": tool,
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, "managed_credential.installation_id_input is required") {
+		t.Fatalf("ValidateSource errors = %q, want installation_id_input requirement", joined)
+	}
+}
+
+func TestValidateSourceRejectsInstallationInputOnNonGitHubAppCredential(t *testing.T) {
+	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
+	tool.ManagedCredential.InstallationIDInput = "installation_id"
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"slack.post_message": tool,
+		},
+	})
+
+	errs := ValidateSource(source)
+	joined := joinErrors(errs)
+	if !strings.Contains(joined, "managed_credential.installation_id_input requires grant_type github_app_installation") {
+		t.Fatalf("ValidateSource errors = %q, want grant_type guarded installation input", joined)
+	}
+}
+
 func TestValidateSourceRejectsSlackPostMessageWithoutRequiredResponseSuccess(t *testing.T) {
 	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
 	tool.ResponseSuccess = nil
@@ -413,6 +449,37 @@ func TestDefaultPackRegistryLoadsMicrosoftGraphManagedCredentialPack(t *testing.
 	}
 }
 
+func TestDefaultPackRegistryLoadsGitHubAppInstallationPack(t *testing.T) {
+	tool, ok := BuiltinTool("github", "github.create_issue_comment")
+	if !ok {
+		t.Fatal("BuiltinTool github.create_issue_comment not found")
+	}
+	if !isProviderConnector(tool) {
+		t.Fatalf("builtin GitHub tool category = %q, want %q", tool.Category, Category)
+	}
+	if tool.ManagedCredential == nil || tool.ManagedCredential.Key != "github_app" {
+		t.Fatalf("builtin GitHub managed credential = %#v, want github_app", tool.ManagedCredential)
+	}
+	if tool.ManagedCredential.GrantType != runtimemanagedcredentials.GrantGitHubAppInstallation {
+		t.Fatalf("builtin GitHub grant_type = %q, want github_app_installation", tool.ManagedCredential.GrantType)
+	}
+	if tool.ManagedCredential.GrantModel != managedcredentialmodel.GrantModelInstallation {
+		t.Fatalf("builtin GitHub grant_model = %q, want installation_grant", tool.ManagedCredential.GrantModel)
+	}
+	if tool.ManagedCredential.InstallationIDInput != "installation_id" {
+		t.Fatalf("builtin GitHub installation_id_input = %q, want installation_id", tool.ManagedCredential.InstallationIDInput)
+	}
+	if tool.HTTP == nil || tool.HTTP.Method != "POST" || !strings.Contains(tool.HTTP.URL, "/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/comments") {
+		t.Fatalf("builtin GitHub http = %#v, want create issue comment endpoint", tool.HTTP)
+	}
+	if len(tool.Credentials) != 0 {
+		t.Fatalf("builtin GitHub static credentials = %#v, want none", tool.Credentials)
+	}
+	if strings.Contains(tool.HTTP.URL, "secret") || strings.Contains(tool.HTTP.URL, "token") {
+		t.Fatal("builtin GitHub tool leaked a concrete credential value")
+	}
+}
+
 func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *testing.T) {
 	ctx := context.Background()
 	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
@@ -458,6 +525,56 @@ func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *t
 	}
 	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("mismatch requirement = %#v, want fail-closed token profile mismatch", mismatch)
+	}
+}
+
+func TestGitHubConnectorPackReportsInstallationGrantRequirement(t *testing.T) {
+	ctx := context.Background()
+	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{
+			projectScopeWithConnectorPackImport(".", "github", "github.create_issue_comment"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports: %v", err)
+	}
+
+	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions unbound: %v", err)
+	}
+	if len(unbound) != 1 || len(unbound[0].Requires) != 1 {
+		t.Fatalf("unbound surfaces = %#v, want one GitHub managed credential requirement", unbound)
+	}
+	requirement := unbound[0].Requires[0]
+	if requirement.Kind != "managed_credential" || requirement.Name != "github_app" || requirement.Bound || requirement.Status != "UNBOUND" {
+		t.Fatalf("unbound requirement = %#v, want unbound github_app", requirement)
+	}
+	if requirement.GrantType != runtimemanagedcredentials.GrantGitHubAppInstallation ||
+		requirement.GrantModel != managedcredentialmodel.GrantModelInstallation ||
+		requirement.InstallationIDInput != "installation_id" {
+		t.Fatalf("unbound requirement shape = %#v, want github app installation grant", requirement)
+	}
+
+	matchingStore := runtimemanagedcredentials.NewMemoryStore(githubAppConnectedRecord())
+	bound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: matchingStore})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions bound: %v", err)
+	}
+	if len(bound) != 1 || len(bound[0].Requires) != 1 || !bound[0].Requires[0].Bound || bound[0].Requires[0].Status != "CONNECTED" {
+		t.Fatalf("bound requirement = %#v, want connected GitHub App credential", bound)
+	}
+
+	wrongGrant := githubAppConnectedRecord()
+	wrongGrant.GrantType = runtimemanagedcredentials.GrantClientCredentials
+	wrongGrantStore := runtimemanagedcredentials.NewMemoryStore(wrongGrant)
+	mismatch, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: wrongGrantStore})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions mismatch: %v", err)
+	}
+	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+		t.Fatalf("mismatch requirement = %#v, want fail-closed grant_type mismatch", mismatch)
 	}
 }
 
@@ -840,6 +957,22 @@ func microsoftGraphConnectedRecord() runtimemanagedcredentials.Record {
 		AccessToken:  "graph-access-secret",
 		Status:       runtimemanagedcredentials.StatusConnected,
 		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+}
+
+func githubAppConnectedRecord() runtimemanagedcredentials.Record {
+	return runtimemanagedcredentials.Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      runtimemanagedcredentials.GrantGitHubAppInstallation,
+		APIBaseURL:     "https://api.github.com",
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     "redacted-test-private-key",
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "github-install-secret",
+		Status:         runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:      time.Now().Add(time.Hour),
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -914,12 +914,14 @@ type HTTPToolSpec struct {
 	Retry          HTTPToolRetrySpec `yaml:"retry"`
 }
 type ManagedCredentialRef struct {
-	Key          string                                     `yaml:"key"`
-	Header       string                                     `yaml:"header"`
-	Prefix       string                                     `yaml:"prefix"`
-	Scopes       []string                                   `yaml:"scopes"`
-	GrantModel   string                                     `yaml:"grant_model"`
-	TokenRequest managedcredentialmodel.TokenRequestProfile `yaml:"token_request"`
+	Key                 string                                     `yaml:"key"`
+	Header              string                                     `yaml:"header"`
+	Prefix              string                                     `yaml:"prefix"`
+	GrantType           string                                     `yaml:"grant_type"`
+	Scopes              []string                                   `yaml:"scopes"`
+	GrantModel          string                                     `yaml:"grant_model"`
+	TokenRequest        managedcredentialmodel.TokenRequestProfile `yaml:"token_request"`
+	InstallationIDInput string                                     `yaml:"installation_id_input"`
 }
 type ToolInputSchema struct {
 	Type                 string                     `yaml:"type"`

--- a/internal/runtime/github_app_issue_comment_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_comment_supported_surface_test.go
@@ -1,0 +1,716 @@
+package runtime_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providerconnectors"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+
+		const (
+			runID        = "9a000000-0000-0000-0000-000000000001"
+			entityID     = "9a000000-0000-0000-0000-000000000002"
+			flowInstance = "github-app-issue-comment-pg"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		pg := &store.PostgresStore{DB: db}
+		workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
+
+		runGitHubAppIssueCommentSurface(t, slackManagedConnectorBackend{
+			name:          "postgres",
+			ctx:           ctx,
+			db:            db,
+			eventStore:    pg,
+			inboundStore:  pg,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        false,
+		})
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		const (
+			runID        = "9b000000-0000-0000-0000-000000000001"
+			entityID     = "9b000000-0000-0000-0000-000000000002"
+			flowInstance = "github-app-issue-comment-sqlite"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
+		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)
+
+		runGitHubAppIssueCommentSurface(t, slackManagedConnectorBackend{
+			name:          "sqlite",
+			ctx:           ctx,
+			db:            sqliteStore.DB,
+			eventStore:    sqliteStore,
+			inboundStore:  sqliteStore,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        true,
+		})
+	})
+}
+
+type githubAppIssueCommentCall struct {
+	auth string
+	body map[string]any
+	path string
+	raw  string
+}
+
+func runGitHubAppIssueCommentSurface(t *testing.T, backend slackManagedConnectorBackend) {
+	t.Helper()
+	privateKeyPEM, publicKey := githubAppIssueCommentPrivateKey(t)
+	fake := newFakeGitHubAppIssueCommentServer(t, publicKey)
+	defer fake.server.Close()
+
+	managedStore := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      runtimemanagedcredentials.GrantGitHubAppInstallation,
+		APIBaseURL:     fake.server.URL,
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     privateKeyPEM,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "expired-install-token",
+		Status:         runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:      time.Now().Add(-time.Hour),
+	})
+	source := githubAppIssueCommentSource(t, fake.server.URL)
+	bus, pc := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/github", backend.entityID)
+
+	publishGitHubIssueComment(t, backend, bus, gateway, webhookPath, "gh-delivery-1", "1001", "please respond")
+	firstCall := fake.requireSideEffectCall(t, backend.name, "issue comment reply")
+	if firstCall.path != "/repos/octo-org/octo-repo/issues/42/comments" {
+		t.Fatalf("%s GitHub comment path = %q, want issue comments endpoint", backend.name, firstCall.path)
+	}
+	if firstCall.auth != "Bearer github-install-token-1" {
+		t.Fatalf("%s GitHub comment auth = %q, want installation token", backend.name, firstCall.auth)
+	}
+	if got := slackManagedConnectorString(firstCall.body["body"]); got != "please respond" {
+		t.Fatalf("%s GitHub comment body = %#v, want inbound comment text", backend.name, firstCall.body["body"])
+	}
+	firstInboundEventID := loadGitHubAppIssueCommentInboundEventID(t, backend, "gh-delivery-1")
+	firstAttempt := waitForGitHubAppIssueCommentTerminalActivityAttempt(t, backend, firstInboundEventID)
+	if firstAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s first activity attempt status = %q, want succeeded", backend.name, firstAttempt.Status)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, firstAttempt.ResultEventID, firstAttempt.ResultEventType)
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s installation token requests = %d, want 1", backend.name, got)
+	}
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s GitHub issue comment requests = %d, want 1", backend.name, got)
+	}
+
+	publishGitHubIssueCommentExpectStatus(t, backend, bus, gateway, webhookPath, "gh-delivery-1", "1001", "please respond", http.StatusOK)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate webhook delivery")
+	if got := countGitHubAppIssueCommentActivityAttempts(t, backend); got != 1 {
+		t.Fatalf("%s activity attempts after duplicate webhook = %d, want 1", backend.name, got)
+	}
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s token requests after duplicate webhook = %d, want still 1", backend.name, got)
+	}
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s comment requests after duplicate webhook = %d, want still 1", backend.name, got)
+	}
+
+	requestEvent := loadSlackManagedConnectorActivityRequestEvent(t, backend, firstAttempt.RequestEventID)
+	if err := bus.EngineDispatcher().DispatchPostCommit(backend.ctx, []runtimeengine.EmitIntent{{Event: requestEvent}}); err != nil {
+		t.Fatalf("%s duplicate activity request dispatch: %v", backend.name, err)
+	}
+	waitForInboundBusQuiescence(t, bus)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate activity request")
+	if got := countGitHubAppIssueCommentActivityAttempts(t, backend); got != 1 {
+		t.Fatalf("%s activity attempts after duplicate activity request = %d, want 1", backend.name, got)
+	}
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s token requests after duplicate activity = %d, want still 1", backend.name, got)
+	}
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s comment requests after duplicate activity = %d, want still 1", backend.name, got)
+	}
+
+	assertGitHubAppIssueCommentManagedCredentialFailureBeforeDispatch(t, backend, fake, "missing credential", "gh-delivery-2", "1001", runtimemanagedcredentials.NewMemoryStore())
+	mismatched := managedStoreRecordWithInstallation(privateKeyPEM, fake.server.URL, "1001")
+	assertGitHubAppIssueCommentManagedCredentialFailureBeforeDispatch(t, backend, fake, "installation mismatch", "gh-delivery-3", "2002", runtimemanagedcredentials.NewMemoryStore(mismatched))
+	_ = pc
+	for _, secret := range []string{"expired-install-token", "github-install-token-1", "github-webhook-secret"} {
+		assertSlackManagedConnectorNoStoredSecret(t, backend, secret)
+	}
+}
+
+func newFakeGitHubAppIssueCommentServer(t *testing.T, publicKey *rsa.PublicKey) *fakeGitHubAppIssueCommentServer {
+	t.Helper()
+	fake := &fakeGitHubAppIssueCommentServer{
+		publicKey:   publicKey,
+		sideEffects: make(chan githubAppIssueCommentCall, 8),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations/1001/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			http.Error(w, "bad accept", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+			http.Error(w, "bad api version", http.StatusBadRequest)
+			return
+		}
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if jwt == "" || jwt == r.Header.Get("Authorization") {
+			http.Error(w, "missing app jwt", http.StatusUnauthorized)
+			return
+		}
+		verifyGitHubAppIssueCommentJWT(t, jwt, fake.publicKey, "github-app-client-id", time.Now().UTC())
+		call := fake.tokenCalls.Add(1)
+		if call != 1 {
+			http.Error(w, "unexpected token reacquisition", http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "github-install-token-1",
+			"expires_at": time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+		})
+	})
+	mux.HandleFunc("/repos/octo-org/octo-repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		fake.commentCalls.Add(1)
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer github-install-token-1" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "bad token"})
+			return
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			http.Error(w, "bad accept", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+			http.Error(w, "bad api version", http.StatusBadRequest)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		fake.sideEffects <- githubAppIssueCommentCall{
+			auth: r.Header.Get("Authorization"),
+			body: body,
+			path: r.URL.Path,
+			raw:  string(raw),
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   123,
+			"body": body["body"],
+		})
+	})
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+type fakeGitHubAppIssueCommentServer struct {
+	server       *httptest.Server
+	publicKey    *rsa.PublicKey
+	tokenCalls   atomic.Int64
+	commentCalls atomic.Int64
+	sideEffects  chan githubAppIssueCommentCall
+}
+
+func (f *fakeGitHubAppIssueCommentServer) requireSideEffectCall(t *testing.T, backend, context string) githubAppIssueCommentCall {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		return call
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s %s: timed out waiting for fake GitHub issue comment side effect", backend, context)
+		return githubAppIssueCommentCall{}
+	}
+}
+
+func (f *fakeGitHubAppIssueCommentServer) requireNoSideEffectCall(t *testing.T, backend, context string) {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		t.Fatalf("%s %s: unexpected fake GitHub issue comment side effect: auth=%s body=%s", backend, context, call.auth, call.raw)
+	default:
+	}
+}
+
+func (f *fakeGitHubAppIssueCommentServer) tokenRequestCount() int {
+	return int(f.tokenCalls.Load())
+}
+
+func (f *fakeGitHubAppIssueCommentServer) commentRequestCount() int {
+	return int(f.commentCalls.Load())
+}
+
+func publishGitHubIssueComment(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID, body string) {
+	t.Helper()
+	publishGitHubIssueCommentExpectStatus(t, backend, bus, gateway, webhookPath, deliveryID, installationID, body, http.StatusAccepted)
+}
+
+func publishGitHubIssueCommentExpectStatus(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID, body string, wantStatus int) {
+	t.Helper()
+	payload := []byte(fmt.Sprintf(`{"action":"created","installation":{"id":%s},"repository":{"name":"octo-repo","owner":{"login":"octo-org"}},"issue":{"number":42},"comment":{"id":9001,"body":%q}}`, installationID, body))
+	req := httptest.NewRequest(http.MethodPost, webhookPath, strings.NewReader(string(payload))).WithContext(backend.ctx)
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("github-webhook-secret", payload))
+	req.Header.Set("X-GitHub-Delivery", deliveryID)
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("%s gateway status for delivery %s = %d, want %d body=%s", backend.name, deliveryID, rec.Code, wantStatus, rec.Body.String())
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func githubAppIssueCommentSource(t *testing.T, baseURL string) semanticview.Source {
+	t.Helper()
+	handler := runtimecontracts.SystemNodeEventHandler{
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "github_create_issue_comment",
+			Tool: "github.create_issue_comment",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"installation_id": runtimecontracts.CELExpression("payload.payload.installation.id"),
+				"owner":           runtimecontracts.CELExpression("payload.payload.repository.owner.login"),
+				"repo":            runtimecontracts.CELExpression("payload.payload.repository.name"),
+				"issue_number":    runtimecontracts.CELExpression("payload.payload.issue.number"),
+				"body":            runtimecontracts.CELExpression("payload.payload.comment.body"),
+			},
+		},
+	}
+	const nodeID = "github-issue-comment-responder"
+	node := runtimecontracts.SystemNodeContract{
+		ID:            nodeID,
+		ExecutionType: runtimecontracts.SystemNodeExecutionType,
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"inbound.github.issue_comment": handler,
+		},
+	}
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"inbound.github.issue_comment"},
+				},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{nodeID: node},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "github_app_issue_comment_supported_surface",
+			Version: "1.0.0",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				nodeID: {
+					ID:                   nodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.github.issue_comment"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				nodeID: {"inbound.github.issue_comment": handler},
+			},
+			EventOwners: map[string][]string{
+				"inbound.github.issue_comment": {nodeID},
+			},
+		},
+	})
+	importSource := slackManagedConnectorPackImportSource{
+		Source: base,
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{{Provider: "github", Tool: "github.create_issue_comment"}},
+					},
+				},
+			},
+		},
+	}
+	source, err := providerconnectors.SourceWithConnectorPackImportsFromRegistry(importSource, githubAppIssueCommentPackRegistry(t, baseURL))
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImportsFromRegistry: %v", err)
+	}
+	return source
+}
+
+func githubAppIssueCommentPackRegistry(t *testing.T, baseURL string) *providerconnectors.PackRegistry {
+	t.Helper()
+	tool, ok := providerconnectors.BuiltinTool("github", "github.create_issue_comment")
+	if !ok {
+		t.Fatal("provider connector pack github.create_issue_comment not found")
+	}
+	if tool.HTTP == nil {
+		t.Fatal("provider connector pack github.create_issue_comment missing http block")
+	}
+	httpSpec := *tool.HTTP
+	tool.HTTP = &httpSpec
+	tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/comments"
+	registry, err := providerconnectors.NewPackRegistry(providerconnectors.LoadedPack{
+		Envelope: packs.Envelope{
+			ID: "provider.github.connector",
+			Provenance: packs.Provenance{
+				Source: packs.ProvenancePlatform,
+			},
+		},
+		Manifest: providerconnectors.ConnectorManifest{
+			Provider: "github",
+			Tools: map[string]runtimecontracts.ToolSchemaEntry{
+				"github.create_issue_comment": tool,
+			},
+		},
+		Source: "test:provider.github.connector",
+	})
+	if err != nil {
+		t.Fatalf("NewPackRegistry: %v", err)
+	}
+	return registry
+}
+
+func assertGitHubAppIssueCommentManagedCredentialFailureBeforeDispatch(t *testing.T, backend slackManagedConnectorBackend, fake *fakeGitHubAppIssueCommentServer, label, deliveryID, installationID string, managedStore runtimemanagedcredentials.Store) {
+	t.Helper()
+	beforeTokens := fake.tokenRequestCount()
+	beforeComments := fake.commentRequestCount()
+	source := githubAppIssueCommentSource(t, fake.server.URL)
+	bus, _ := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/github", backend.entityID)
+	publishGitHubIssueComment(t, backend, bus, gateway, webhookPath, deliveryID, installationID, label)
+	inboundEventID := loadGitHubAppIssueCommentInboundEventID(t, backend, deliveryID)
+	if got := countGitHubAppIssueCommentActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
+		t.Fatalf("%s %s activity attempts = %d, want 0", backend.name, label, got)
+	}
+	requireGitHubAppIssueCommentFailureEventEventually(t, backend, label, inboundEventID)
+	if got := fake.tokenRequestCount(); got != beforeTokens {
+		t.Fatalf("%s %s token requests = %d, want still %d", backend.name, label, got, beforeTokens)
+	}
+	if got := fake.commentRequestCount(); got != beforeComments {
+		t.Fatalf("%s %s comment requests = %d, want still %d", backend.name, label, got, beforeComments)
+	}
+	fake.requireNoSideEffectCall(t, backend.name, label)
+}
+
+func requireGitHubAppIssueCommentFailureEventEventually(t *testing.T, backend slackManagedConnectorBackend, label, sourceEventID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if got := countGitHubAppIssueCommentFailureEventsForSource(t, backend, sourceEventID); got == 1 {
+			return
+		} else if got > 1 {
+			t.Fatalf("%s %s failure events = %d, want 1", backend.name, label, got)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s failure event for source event %s was not created", backend.name, label, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func loadGitHubAppIssueCommentInboundEventID(t *testing.T, backend slackManagedConnectorBackend, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id
+			FROM events
+			WHERE run_id = ?
+			  AND entity_id = ?
+			  AND event_name = 'inbound.github.issue_comment'
+			  AND json_extract(payload, '$.provider_event_id') = ?
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, providerEventID).Scan(&eventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id::text
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND event_name = 'inbound.github.issue_comment'
+			  AND payload->>'provider_event_id' = $3
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, providerEventID).Scan(&eventID)
+	}
+	if err != nil {
+		t.Fatalf("%s load GitHub inbound event id for %s: %v", backend.name, providerEventID, err)
+	}
+	return eventID
+}
+
+func waitForGitHubAppIssueCommentTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last runtimepipeline.ActivityAttemptRecord
+	var saw bool
+	for {
+		rec, ok, err := tryLoadGitHubAppIssueCommentActivityAttempt(backend, sourceEventID)
+		if err != nil {
+			t.Fatalf("%s load activity attempt while waiting: %v", backend.name, err)
+		}
+		if ok {
+			last = rec
+			saw = true
+			if rec.Status != runtimepipeline.ActivityAttemptStatusStarted {
+				return rec
+			}
+		}
+		if time.Now().After(deadline) {
+			if saw {
+				t.Fatalf("%s activity attempt did not reach terminal status; last=%q", backend.name, last.Status)
+			}
+			t.Fatalf("%s activity attempt for source event %s was not created", backend.name, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func tryLoadGitHubAppIssueCommentActivityAttempt(backend slackManagedConnectorBackend, sourceEventID string) (runtimepipeline.ActivityAttemptRecord, bool, error) {
+	var requestEventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'github.create_issue_comment'
+			  AND source_event_id = ?
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id::text
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'github.create_issue_comment'
+			  AND source_event_id = $2::uuid
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, sourceEventID).Scan(&requestEventID)
+	}
+	if err == sql.ErrNoRows {
+		return runtimepipeline.ActivityAttemptRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	rec, ok, err := backend.workflowStore.LoadActivityAttempt(backend.ctx, requestEventID)
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	return rec, ok, nil
+}
+
+func countGitHubAppIssueCommentActivityAttempts(t *testing.T, backend slackManagedConnectorBackend) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'github.create_issue_comment'
+		`, backend.runID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'github.create_issue_comment'
+		`, backend.runID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count GitHub activity attempts: %v", backend.name, err)
+	}
+	return count
+}
+
+func countGitHubAppIssueCommentActivityAttemptsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = 'github.create_issue_comment'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = 'github.create_issue_comment'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count GitHub activity attempts for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func countGitHubAppIssueCommentFailureEventsForSource(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND event_name = 'github_create_issue_comment.failed'
+			  AND source_event_id = ?
+		`, backend.runID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name = 'github_create_issue_comment.failed'
+			  AND source_event_id = $2::uuid
+		`, backend.runID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count GitHub failure events for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func managedStoreRecordWithInstallation(privateKeyPEM, apiBaseURL, installationID string) runtimemanagedcredentials.Record {
+	return runtimemanagedcredentials.Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      runtimemanagedcredentials.GrantGitHubAppInstallation,
+		APIBaseURL:     apiBaseURL,
+		ClientID:       "github-app-client-id",
+		InstallationID: installationID,
+		PrivateKey:     privateKeyPEM,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "expired-install-token",
+		Status:         runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:      time.Now().Add(-time.Hour),
+	}
+}
+
+func githubAppIssueCommentPrivateKey(t *testing.T) (string, *rsa.PublicKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	raw := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: raw})
+	if len(pemBytes) == 0 {
+		t.Fatal("EncodeToMemory returned empty PEM")
+	}
+	return string(pemBytes), &key.PublicKey
+}
+
+func verifyGitHubAppIssueCommentJWT(t *testing.T, token string, publicKey *rsa.PublicKey, wantIss string, now time.Time) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("JWT parts = %d, want 3", len(parts))
+	}
+	decode := func(name, raw string, target any) {
+		t.Helper()
+		decoded, err := base64.RawURLEncoding.DecodeString(raw)
+		if err != nil {
+			t.Fatalf("decode JWT %s: %v", name, err)
+		}
+		if err := json.Unmarshal(decoded, target); err != nil {
+			t.Fatalf("unmarshal JWT %s: %v", name, err)
+		}
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	decode("header", parts[0], &header)
+	if header.Alg != "RS256" || header.Typ != "JWT" {
+		t.Fatalf("JWT header = %#v, want RS256 JWT", header)
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	decode("claims", parts[1], &claims)
+	if claims.Iss != wantIss {
+		t.Fatalf("JWT iss = %q, want %q", claims.Iss, wantIss)
+	}
+	nowUnix := now.Unix()
+	if claims.Iat > nowUnix || claims.Exp <= nowUnix || claims.Exp-claims.Iat > 11*60 {
+		t.Fatalf("JWT time claims = %#v, want active short-lived app JWT around %s", claims, now)
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode JWT signature: %v", err)
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, sum[:], signature); err != nil {
+		t.Fatalf("VerifyPKCS1v15: %v", err)
+	}
+}

--- a/internal/runtime/github_app_issue_comment_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_comment_supported_surface_test.go
@@ -174,6 +174,22 @@ func runGitHubAppIssueCommentSurface(t *testing.T, backend slackManagedConnector
 		t.Fatalf("%s comment requests after duplicate activity = %d, want still 1", backend.name, got)
 	}
 
+	publishGitHubIssueCommentFromSender(t, backend, bus, gateway, webhookPath, "gh-delivery-bot-1", "1001", "issue comment reply", "github-app[bot]", "Bot", http.StatusAccepted)
+	botInboundEventID := loadGitHubAppIssueCommentInboundEventID(t, backend, "gh-delivery-bot-1")
+	if got := countGitHubAppIssueCommentActivityAttemptsForSource(t, backend, botInboundEventID); got != 0 {
+		t.Fatalf("%s bot-authored inbound activity attempts = %d, want 0", backend.name, got)
+	}
+	fake.requireNoSideEffectCall(t, backend.name, "bot-authored issue_comment")
+	if got := countGitHubAppIssueCommentActivityAttempts(t, backend); got != 1 {
+		t.Fatalf("%s activity attempts after bot-authored issue_comment = %d, want still 1", backend.name, got)
+	}
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s token requests after bot-authored issue_comment = %d, want still 1", backend.name, got)
+	}
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s comment requests after bot-authored issue_comment = %d, want still 1", backend.name, got)
+	}
+
 	assertGitHubAppIssueCommentManagedCredentialFailureBeforeDispatch(t, backend, fake, "missing credential", "gh-delivery-2", "1001", runtimemanagedcredentials.NewMemoryStore())
 	mismatched := managedStoreRecordWithInstallation(privateKeyPEM, fake.server.URL, "1001")
 	assertGitHubAppIssueCommentManagedCredentialFailureBeforeDispatch(t, backend, fake, "installation mismatch", "gh-delivery-3", "2002", runtimemanagedcredentials.NewMemoryStore(mismatched))
@@ -307,7 +323,12 @@ func publishGitHubIssueComment(t *testing.T, backend slackManagedConnectorBacken
 
 func publishGitHubIssueCommentExpectStatus(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID, body string, wantStatus int) {
 	t.Helper()
-	payload := []byte(fmt.Sprintf(`{"action":"created","installation":{"id":%s},"repository":{"name":"octo-repo","owner":{"login":"octo-org"}},"issue":{"number":42},"comment":{"id":9001,"body":%q}}`, installationID, body))
+	publishGitHubIssueCommentFromSender(t, backend, bus, gateway, webhookPath, deliveryID, installationID, body, "octocat", "User", wantStatus)
+}
+
+func publishGitHubIssueCommentFromSender(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID, body, senderLogin, senderType string, wantStatus int) {
+	t.Helper()
+	payload := []byte(fmt.Sprintf(`{"action":"created","installation":{"id":%s},"repository":{"name":"octo-repo","owner":{"login":"octo-org"}},"issue":{"number":42},"comment":{"id":9001,"body":%q,"user":{"login":%q,"type":%q}},"sender":{"login":%q,"type":%q}}`, installationID, body, senderLogin, senderType, senderLogin, senderType))
 	req := httptest.NewRequest(http.MethodPost, webhookPath, strings.NewReader(string(payload))).WithContext(backend.ctx)
 	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("github-webhook-secret", payload))
 	req.Header.Set("X-GitHub-Delivery", deliveryID)
@@ -323,6 +344,10 @@ func publishGitHubIssueCommentExpectStatus(t *testing.T, backend slackManagedCon
 func githubAppIssueCommentSource(t *testing.T, baseURL string) semanticview.Source {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{
+			Check:  `payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
+			OnFail: "discard",
+		},
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "github_create_issue_comment",
 			Tool: "github.create_issue_comment",

--- a/internal/runtime/managedcredentials/model/model.go
+++ b/internal/runtime/managedcredentials/model/model.go
@@ -14,8 +14,9 @@ const (
 	TokenBodyForm = "form"
 	TokenBodyJSON = "json"
 
-	GrantModelScope     = "scope_grant"
-	GrantModelWorkspace = "workspace_grant"
+	GrantModelScope        = "scope_grant"
+	GrantModelWorkspace    = "workspace_grant"
+	GrantModelInstallation = "installation_grant"
 )
 
 type TokenRequestProfile struct {
@@ -141,10 +142,10 @@ func NormalizeGrantModel(raw string) string {
 func ValidateGrantModel(raw string) error {
 	normalized := NormalizeGrantModel(raw)
 	switch normalized {
-	case GrantModelScope, GrantModelWorkspace:
+	case GrantModelScope, GrantModelWorkspace, GrantModelInstallation:
 		return nil
 	default:
-		return fmt.Errorf("grant_model %q is not supported; want %s or %s", normalized, GrantModelScope, GrantModelWorkspace)
+		return fmt.Errorf("grant_model %q is not supported; want %s, %s, or %s", normalized, GrantModelScope, GrantModelWorkspace, GrantModelInstallation)
 	}
 }
 

--- a/internal/runtime/managedcredentials/requirements.go
+++ b/internal/runtime/managedcredentials/requirements.go
@@ -11,11 +11,13 @@ import (
 )
 
 type Requirement struct {
-	Kind         string
-	Name         string
-	Scopes       []string                                   `json:"scopes,omitempty"`
-	GrantModel   string                                     `json:"grant_model,omitempty"`
-	TokenRequest managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	Kind                string
+	Name                string
+	GrantType           string                                     `json:"grant_type,omitempty"`
+	Scopes              []string                                   `json:"scopes,omitempty"`
+	GrantModel          string                                     `json:"grant_model,omitempty"`
+	TokenRequest        managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	InstallationIDInput string                                     `json:"installation_id_input,omitempty"`
 }
 
 type RequirementDescriptor struct {
@@ -61,11 +63,13 @@ func appendToolRequirements(index map[string][]Requirement, source semanticview.
 			continue
 		}
 		index[storeKey] = append(index[storeKey], Requirement{
-			Kind:         "tool",
-			Name:         name,
-			Scopes:       append([]string{}, entry.ManagedCredential.Scopes...),
-			GrantModel:   entry.ManagedCredential.GrantModel,
-			TokenRequest: entry.ManagedCredential.TokenRequest,
+			Kind:                "tool",
+			Name:                name,
+			GrantType:           entry.ManagedCredential.GrantType,
+			Scopes:              append([]string{}, entry.ManagedCredential.Scopes...),
+			GrantModel:          entry.ManagedCredential.GrantModel,
+			TokenRequest:        entry.ManagedCredential.TokenRequest,
+			InstallationIDInput: entry.ManagedCredential.InstallationIDInput,
 		})
 	}
 }
@@ -126,6 +130,13 @@ func MissingOrUnusableRequired(ctx context.Context, store Store, source semantic
 			continue
 		}
 		for _, req := range desc.RequiredBy {
+			if err := GrantTypeCovers(desc.GrantType, req.GrantType); err != nil {
+				scoped := desc
+				scoped.Status = StatusScopeInsufficient
+				scoped.Failure = "grant-type-insufficient: " + err.Error()
+				out = append(out, scoped)
+				break
+			}
 			if err := managedcredentialmodel.GrantModelCovers(desc.GrantModel, req.GrantModel); err != nil {
 				scoped := desc
 				scoped.Status = StatusScopeInsufficient
@@ -179,13 +190,15 @@ func normalizeRequirements(items []Requirement) []Requirement {
 	for _, item := range items {
 		item.Kind = strings.TrimSpace(item.Kind)
 		item.Name = strings.TrimSpace(item.Name)
+		item.GrantType = NormalizeGrantType(item.GrantType)
 		item.Scopes = normalizeStrings(item.Scopes)
 		item.GrantModel = managedcredentialmodel.NormalizeGrantModel(item.GrantModel)
 		item.TokenRequest = managedcredentialmodel.NormalizeTokenRequestProfile(item.TokenRequest)
+		item.InstallationIDInput = strings.TrimSpace(item.InstallationIDInput)
 		if item.Kind == "" || item.Name == "" {
 			continue
 		}
-		key := item.Kind + "\x00" + item.Name + "\x00" + strings.Join(item.Scopes, "\x00") + "\x00" + item.GrantModel + "\x00" + managedcredentialmodel.TokenRequestProfileSummary(item.TokenRequest)
+		key := item.Kind + "\x00" + item.Name + "\x00" + item.GrantType + "\x00" + strings.Join(item.Scopes, "\x00") + "\x00" + item.GrantModel + "\x00" + managedcredentialmodel.TokenRequestProfileSummary(item.TokenRequest) + "\x00" + item.InstallationIDInput
 		if _, ok := seen[key]; ok {
 			continue
 		}

--- a/internal/runtime/managedcredentials/store.go
+++ b/internal/runtime/managedcredentials/store.go
@@ -3,10 +3,14 @@ package managedcredentials
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,6 +29,7 @@ const (
 	GrantAuthorizationCode     = "authorization_code"
 	GrantAuthorizationCodePKCE = "authorization_code_pkce"
 	GrantClientCredentials     = "client_credentials"
+	GrantGitHubAppInstallation = "github_app_installation"
 
 	StatusUnconnected       = "unconnected"
 	StatusPendingConsent    = "pending_consent"
@@ -53,8 +58,11 @@ type Record struct {
 	GrantType       string                                     `json:"grant_type"`
 	AuthURL         string                                     `json:"auth_url,omitempty"`
 	TokenURL        string                                     `json:"token_url"`
+	APIBaseURL      string                                     `json:"api_base_url,omitempty"`
 	ClientID        string                                     `json:"client_id"`
 	ClientSecret    string                                     `json:"client_secret,omitempty"`
+	InstallationID  string                                     `json:"installation_id,omitempty"`
+	PrivateKey      string                                     `json:"private_key,omitempty"`
 	RedirectURL     string                                     `json:"redirect_url,omitempty"`
 	Scopes          []string                                   `json:"scopes,omitempty"`
 	GrantModel      string                                     `json:"grant_model,omitempty"`
@@ -73,17 +81,19 @@ type Record struct {
 }
 
 type Descriptor struct {
-	Key          string                                     `json:"key"`
-	Provider     string                                     `json:"provider,omitempty"`
-	Account      string                                     `json:"account,omitempty"`
-	GrantType    string                                     `json:"grant_type,omitempty"`
-	Scopes       []string                                   `json:"scopes,omitempty"`
-	GrantModel   string                                     `json:"grant_model,omitempty"`
-	TokenRequest managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
-	Status       string                                     `json:"status"`
-	Failure      string                                     `json:"failure,omitempty"`
-	ExpiresAt    time.Time                                  `json:"expires_at,omitempty"`
-	UpdatedAt    time.Time                                  `json:"updated_at,omitempty"`
+	Key            string                                     `json:"key"`
+	Provider       string                                     `json:"provider,omitempty"`
+	Account        string                                     `json:"account,omitempty"`
+	GrantType      string                                     `json:"grant_type,omitempty"`
+	Scopes         []string                                   `json:"scopes,omitempty"`
+	GrantModel     string                                     `json:"grant_model,omitempty"`
+	TokenRequest   managedcredentialmodel.TokenRequestProfile `json:"token_request,omitempty"`
+	InstallationID string                                     `json:"installation_id,omitempty"`
+	APIBaseURL     string                                     `json:"api_base_url,omitempty"`
+	Status         string                                     `json:"status"`
+	Failure        string                                     `json:"failure,omitempty"`
+	ExpiresAt      time.Time                                  `json:"expires_at,omitempty"`
+	UpdatedAt      time.Time                                  `json:"updated_at,omitempty"`
 }
 
 type BeginAuthCodeRequest struct {
@@ -125,11 +135,23 @@ type ClientCredentialsRequest struct {
 	Account      string
 }
 
+type GitHubAppInstallationRequest struct {
+	Key            string
+	Provider       string
+	APIBaseURL     string
+	ClientID       string
+	InstallationID string
+	PrivateKey     string
+	Account        string
+}
+
 type AccessTokenRequest struct {
-	Key          string
-	Scopes       []string
-	GrantModel   string
-	TokenRequest managedcredentialmodel.TokenRequestProfile
+	Key            string
+	GrantType      string
+	Scopes         []string
+	GrantModel     string
+	TokenRequest   managedcredentialmodel.TokenRequestProfile
+	InstallationID string
 }
 
 type TokenSource struct {
@@ -348,6 +370,42 @@ func (s *TokenSource) ConnectClientCredentials(ctx context.Context, req ClientCr
 	return updated, nil
 }
 
+func (s *TokenSource) ConnectGitHubAppInstallation(ctx context.Context, req GitHubAppInstallationRequest) (Record, error) {
+	if s == nil || s.Store == nil {
+		return Record{}, fmt.Errorf("managed credential store is not configured")
+	}
+	record := Record{
+		Key:            strings.TrimSpace(req.Key),
+		Provider:       firstNonEmpty(strings.TrimSpace(req.Provider), "github"),
+		Account:        strings.TrimSpace(req.Account),
+		GrantType:      GrantGitHubAppInstallation,
+		APIBaseURL:     normalizeGitHubAPIBaseURL(req.APIBaseURL),
+		ClientID:       strings.TrimSpace(req.ClientID),
+		InstallationID: normalizeInstallationID(req.InstallationID),
+		PrivateKey:     strings.TrimSpace(req.PrivateKey),
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		Status:         StatusUnconnected,
+		UpdatedAt:      s.now(),
+	}
+	if record.Key == "" || record.ClientID == "" || record.InstallationID == "" || record.PrivateKey == "" {
+		return Record{}, fmt.Errorf("key, client_id, installation_id, and private_key are required for github_app_installation")
+	}
+	if _, err := parseRSAPrivateKey(record.PrivateKey); err != nil {
+		return Record{}, fmt.Errorf("managed credential %q private_key is invalid: %w", record.Key, err)
+	}
+	updated, err := s.exchangeGitHubAppInstallation(ctx, record, record.InstallationID)
+	if err != nil {
+		return s.markFailure(ctx, record, err)
+	}
+	updated.Status = StatusConnected
+	updated.Failure = ""
+	updated.UpdatedAt = s.now()
+	if err := s.Store.Put(ctx, updated); err != nil {
+		return Record{}, err
+	}
+	return updated, nil
+}
+
 func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (string, Record, error) {
 	record, ok, err := s.record(ctx, req.Key)
 	if err != nil {
@@ -355,6 +413,9 @@ func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (
 	}
 	if !ok {
 		return "", Record{}, fmt.Errorf("missing managed credential %q", strings.TrimSpace(req.Key))
+	}
+	if err := GrantTypeCovers(record.GrantType, req.GrantType); err != nil {
+		return "", Record{}, fmt.Errorf("managed credential %q grant-type-insufficient: %w", record.Key, err)
 	}
 	if err := managedcredentialmodel.GrantModelCovers(record.GrantModel, req.GrantModel); err != nil {
 		return "", Record{}, fmt.Errorf("managed credential %q grant-model-insufficient: %w", record.Key, err)
@@ -365,6 +426,9 @@ func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (
 	if err := ensureScopes(record.Scopes, req.Scopes); err != nil {
 		return "", Record{}, fmt.Errorf("managed credential %q scope-insufficient: %w", record.Key, err)
 	}
+	if err := ensureInstallationSelection(record, req.InstallationID); err != nil {
+		return "", Record{}, err
+	}
 	if strings.TrimSpace(record.Status) != StatusConnected {
 		return "", Record{}, fmt.Errorf("managed credential %q is %s", record.Key, statusOrUnconnected(record.Status))
 	}
@@ -372,6 +436,9 @@ func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (
 		record, err = s.refresh(ctx, record)
 		if err != nil {
 			return "", record, err
+		}
+		if err := GrantTypeCovers(record.GrantType, req.GrantType); err != nil {
+			return "", record, fmt.Errorf("managed credential %q grant-type-insufficient: %w", record.Key, err)
 		}
 		if err := ensureScopes(record.Scopes, req.Scopes); err != nil {
 			return "", record, fmt.Errorf("managed credential %q scope-insufficient: %w", record.Key, err)
@@ -381,6 +448,9 @@ func (s *TokenSource) AccessToken(ctx context.Context, req AccessTokenRequest) (
 		}
 		if err := managedcredentialmodel.TokenRequestProfileCovers(record.TokenRequest, req.TokenRequest); err != nil {
 			return "", record, fmt.Errorf("managed credential %q token-request-insufficient: %w", record.Key, err)
+		}
+		if err := ensureInstallationSelection(record, req.InstallationID); err != nil {
+			return "", record, err
 		}
 	}
 	return record.AccessToken, record, nil
@@ -416,6 +486,18 @@ func (s *TokenSource) refresh(ctx context.Context, record Record) (Record, error
 		if len(record.Scopes) > 0 {
 			values.Set("scope", strings.Join(record.Scopes, " "))
 		}
+	case GrantGitHubAppInstallation:
+		updated, err := s.exchangeGitHubAppInstallation(ctx, record, record.InstallationID)
+		if err != nil {
+			return s.markFailure(ctx, record, err)
+		}
+		updated.Status = StatusConnected
+		updated.Failure = ""
+		updated.UpdatedAt = s.now()
+		if err := s.Store.Put(ctx, updated); err != nil {
+			return Record{}, err
+		}
+		return updated, nil
 	default:
 		err := fmt.Errorf("managed credential %q has unsupported grant_type %q", record.Key, record.GrantType)
 		return s.markFailure(ctx, record, err)
@@ -515,6 +597,152 @@ func (s *TokenSource) exchange(ctx context.Context, record Record, values url.Va
 		updated.ExpiresAt = s.now().Add(time.Duration(body.ExpiresIn) * time.Second).UTC()
 	}
 	return updated, nil
+}
+
+func (s *TokenSource) exchangeGitHubAppInstallation(ctx context.Context, record Record, installationID string) (Record, error) {
+	installationID = normalizeInstallationID(installationID)
+	if installationID == "" {
+		return Record{}, fmt.Errorf("managed credential %q installation_id is required", record.Key)
+	}
+	if record.InstallationID != "" && normalizeInstallationID(record.InstallationID) != installationID {
+		return Record{}, fmt.Errorf("managed credential %q installation_id mismatch", record.Key)
+	}
+	if strings.TrimSpace(record.ClientID) == "" {
+		return Record{}, fmt.Errorf("managed credential %q client_id is required", record.Key)
+	}
+	if strings.TrimSpace(record.PrivateKey) == "" {
+		return Record{}, fmt.Errorf("managed credential %q private_key is required", record.Key)
+	}
+	jwt, err := s.githubAppJWT(record)
+	if err != nil {
+		return Record{}, err
+	}
+	tokenURL, err := githubInstallationAccessTokenURL(record, installationID)
+	if err != nil {
+		return Record{}, err
+	}
+	client := s.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return Record{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := client.Do(req)
+	if err != nil {
+		return Record{}, err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+		Error     string `json:"error"`
+		Message   string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Record{}, fmt.Errorf("decode github installation token response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(body.Error)
+		if msg == "" {
+			msg = strings.TrimSpace(body.Message)
+		}
+		if msg == "" {
+			msg = fmt.Sprintf("github installation token endpoint returned status %d", resp.StatusCode)
+		}
+		return Record{}, fmt.Errorf("%s", msg)
+	}
+	token := strings.TrimSpace(body.Token)
+	if token == "" {
+		return Record{}, fmt.Errorf("github installation token endpoint did not return token")
+	}
+	updated := record
+	updated.AccessToken = token
+	updated.TokenType = "Bearer"
+	updated.GrantType = GrantGitHubAppInstallation
+	updated.GrantModel = managedcredentialmodel.GrantModelInstallation
+	updated.InstallationID = installationID
+	if expires := strings.TrimSpace(body.ExpiresAt); expires != "" {
+		parsed, err := time.Parse(time.RFC3339, expires)
+		if err != nil {
+			return Record{}, fmt.Errorf("parse github installation token expires_at: %w", err)
+		}
+		updated.ExpiresAt = parsed.UTC()
+	}
+	return updated, nil
+}
+
+func (s *TokenSource) githubAppJWT(record Record) (string, error) {
+	key, err := parseRSAPrivateKey(record.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("managed credential %q private_key is invalid: %w", record.Key, err)
+	}
+	now := s.now()
+	header := struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}{Alg: "RS256", Typ: "JWT"}
+	claims := struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}{
+		Iss: strings.TrimSpace(record.ClientID),
+		Iat: now.Add(-60 * time.Second).Unix(),
+		Exp: now.Add(9 * time.Minute).Unix(),
+	}
+	if claims.Iss == "" {
+		return "", fmt.Errorf("managed credential %q client_id is required", record.Key)
+	}
+	headerRaw, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsRaw, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	encoder := base64.RawURLEncoding
+	signingInput := encoder.EncodeToString(headerRaw) + "." + encoder.EncodeToString(claimsRaw)
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", fmt.Errorf("sign github app jwt: %w", err)
+	}
+	return signingInput + "." + encoder.EncodeToString(sig), nil
+}
+
+func parseRSAPrivateKey(raw string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(raw)))
+	if block == nil {
+		return nil, fmt.Errorf("PEM block is required")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key must be RSA")
+	}
+	return key, nil
+}
+
+func githubInstallationAccessTokenURL(record Record, installationID string) (string, error) {
+	base := normalizeGitHubAPIBaseURL(record.APIBaseURL)
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("managed credential %q api_base_url is invalid", record.Key)
+	}
+	return strings.TrimRight(base, "/") + "/app/installations/" + url.PathEscape(installationID) + "/access_tokens", nil
 }
 
 func applyTokenRequestClientAuth(values url.Values, record Record, profile managedcredentialmodel.TokenRequestProfile) error {
@@ -645,23 +873,25 @@ func (s *TokenSource) refreshWindow() time.Duration {
 func (r Record) Descriptor() Descriptor {
 	status := statusOrUnconnected(r.Status)
 	return Descriptor{
-		Key:          strings.TrimSpace(r.Key),
-		Provider:     strings.TrimSpace(r.Provider),
-		Account:      strings.TrimSpace(r.Account),
-		GrantType:    strings.TrimSpace(r.GrantType),
-		Scopes:       append([]string{}, r.Scopes...),
-		GrantModel:   managedcredentialmodel.NormalizeGrantModel(r.GrantModel),
-		TokenRequest: managedcredentialmodel.NormalizeTokenRequestProfile(r.TokenRequest),
-		Status:       status,
-		Failure:      RedactString(strings.TrimSpace(r.Failure), r.SecretValues()...),
-		ExpiresAt:    r.ExpiresAt,
-		UpdatedAt:    r.UpdatedAt,
+		Key:            strings.TrimSpace(r.Key),
+		Provider:       strings.TrimSpace(r.Provider),
+		Account:        strings.TrimSpace(r.Account),
+		GrantType:      strings.TrimSpace(r.GrantType),
+		Scopes:         append([]string{}, r.Scopes...),
+		GrantModel:     managedcredentialmodel.NormalizeGrantModel(r.GrantModel),
+		TokenRequest:   managedcredentialmodel.NormalizeTokenRequestProfile(r.TokenRequest),
+		InstallationID: normalizeInstallationID(r.InstallationID),
+		APIBaseURL:     strings.TrimSpace(r.APIBaseURL),
+		Status:         status,
+		Failure:        RedactString(strings.TrimSpace(r.Failure), r.SecretValues()...),
+		ExpiresAt:      r.ExpiresAt,
+		UpdatedAt:      r.UpdatedAt,
 	}
 }
 
 func (r Record) SecretValues() []string {
 	var out []string
-	for _, value := range []string{r.AccessToken, r.RefreshToken, r.ClientSecret, r.PKCEVerifier, r.OAuthState} {
+	for _, value := range []string{r.AccessToken, r.RefreshToken, r.ClientSecret, r.PrivateKey, r.PKCEVerifier, r.OAuthState} {
 		value = strings.TrimSpace(value)
 		if value != "" {
 			out = append(out, value)
@@ -906,11 +1136,14 @@ func normalizeRecord(record Record) Record {
 	record.Key = strings.TrimSpace(record.Key)
 	record.Provider = strings.TrimSpace(record.Provider)
 	record.Account = strings.TrimSpace(record.Account)
-	record.GrantType = strings.TrimSpace(record.GrantType)
+	record.GrantType = NormalizeGrantType(record.GrantType)
 	record.AuthURL = strings.TrimSpace(record.AuthURL)
 	record.TokenURL = strings.TrimSpace(record.TokenURL)
+	record.APIBaseURL = strings.TrimSpace(record.APIBaseURL)
 	record.ClientID = strings.TrimSpace(record.ClientID)
 	record.ClientSecret = strings.TrimSpace(record.ClientSecret)
+	record.InstallationID = normalizeInstallationID(record.InstallationID)
+	record.PrivateKey = strings.TrimSpace(record.PrivateKey)
 	record.RedirectURL = strings.TrimSpace(record.RedirectURL)
 	record.Scopes = normalizeStrings(record.Scopes)
 	record.GrantModel = managedcredentialmodel.NormalizeGrantModel(record.GrantModel)
@@ -930,6 +1163,79 @@ func normalizeRecord(record Record) Record {
 		record.UpdatedAt = record.UpdatedAt.UTC()
 	}
 	return record
+}
+
+func NormalizeGrantType(raw string) string {
+	return strings.TrimSpace(strings.ToLower(raw))
+}
+
+func ValidateRequiredGrantType(raw string) error {
+	normalized := NormalizeGrantType(raw)
+	if normalized == "" {
+		return nil
+	}
+	switch normalized {
+	case GrantAuthorizationCode, GrantAuthorizationCodePKCE, GrantClientCredentials, GrantGitHubAppInstallation:
+		return nil
+	default:
+		return fmt.Errorf("grant_type %q is not supported", normalized)
+	}
+}
+
+func GrantTypeCovers(actual, required string) error {
+	required = NormalizeGrantType(required)
+	if required == "" {
+		return nil
+	}
+	actual = NormalizeGrantType(actual)
+	if actual != required {
+		return fmt.Errorf("record grant_type %s does not satisfy required grant_type %s", actual, required)
+	}
+	return nil
+}
+
+func ensureInstallationSelection(record Record, requested string) error {
+	if NormalizeGrantType(record.GrantType) != GrantGitHubAppInstallation {
+		return nil
+	}
+	requested = normalizeInstallationID(requested)
+	if requested == "" {
+		return fmt.Errorf("managed credential %q installation_id is required", record.Key)
+	}
+	recordInstallationID := normalizeInstallationID(record.InstallationID)
+	if recordInstallationID == "" {
+		return fmt.Errorf("managed credential %q installation_id is not configured", record.Key)
+	}
+	if requested != recordInstallationID {
+		return fmt.Errorf("managed credential %q installation_id mismatch", record.Key)
+	}
+	return nil
+}
+
+func normalizeInstallationID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if strings.HasSuffix(raw, ".0") {
+		raw = strings.TrimSuffix(raw, ".0")
+	}
+	return raw
+}
+
+func normalizeGitHubAPIBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "https://api.github.com"
+	}
+	return strings.TrimRight(raw, "/")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func statusOrUnconnected(status string) string {

--- a/internal/runtime/managedcredentials/store.go
+++ b/internal/runtime/managedcredentials/store.go
@@ -635,7 +635,7 @@ func (s *TokenSource) exchangeGitHubAppInstallation(ctx context.Context, record 
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	resp, err := client.Do(req)
 	if err != nil {
-		return Record{}, err
+		return Record{}, fmt.Errorf("%s", RedactString(err.Error(), jwt))
 	}
 	defer resp.Body.Close()
 	var body struct {

--- a/internal/runtime/managedcredentials/store.go
+++ b/internal/runtime/managedcredentials/store.go
@@ -655,7 +655,7 @@ func (s *TokenSource) exchangeGitHubAppInstallation(ctx context.Context, record 
 		if msg == "" {
 			msg = fmt.Sprintf("github installation token endpoint returned status %d", resp.StatusCode)
 		}
-		return Record{}, fmt.Errorf("%s", msg)
+		return Record{}, fmt.Errorf("%s", RedactString(msg, jwt))
 	}
 	token := strings.TrimSpace(body.Token)
 	if token == "" {

--- a/internal/runtime/managedcredentials/store_test.go
+++ b/internal/runtime/managedcredentials/store_test.go
@@ -2,7 +2,14 @@ package managedcredentials
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -430,6 +437,112 @@ func TestTokenSourceClientCredentialsUsesMicrosoftDefaultScopeAndNeverRefreshTok
 	}
 }
 
+func TestTokenSourceGitHubAppInstallationExchangesJWTAndRequiresInstallationSelection(t *testing.T) {
+	ctx := context.Background()
+	privateKeyPEM, publicKey := testGitHubAppPrivateKey(t)
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	var tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/app/installations/1001/access_tokens" {
+			t.Fatalf("path = %s, want installation token endpoint", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept = %q, want GitHub JSON media type", got)
+		}
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if strings.TrimSpace(jwt) == "" || jwt == r.Header.Get("Authorization") {
+			t.Fatalf("Authorization = %q, want Bearer JWT", r.Header.Get("Authorization"))
+		}
+		testVerifyGitHubAppJWT(t, jwt, publicKey, "github-app-client-id", now)
+		tokenRequests++
+		token := "github-install-token-1"
+		expires := now.Add(time.Second)
+		if tokenRequests > 1 {
+			token = "github-install-token-2"
+			expires = now.Add(time.Hour)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      token,
+			"expires_at": expires.Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	store := NewMemoryStore()
+	source := TokenSource{
+		Store: store,
+		Now: func() time.Time {
+			return now
+		},
+	}
+	record, err := source.ConnectGitHubAppInstallation(ctx, GitHubAppInstallationRequest{
+		Key:            "github_app",
+		Provider:       "github",
+		APIBaseURL:     server.URL,
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     privateKeyPEM,
+		Account:        "octo-org/octo-repo",
+	})
+	if err != nil {
+		t.Fatalf("ConnectGitHubAppInstallation: %v", err)
+	}
+	if record.Status != StatusConnected || record.AccessToken != "github-install-token-1" || record.GrantType != GrantGitHubAppInstallation {
+		t.Fatalf("connected record = %#v, want github app installation token", record)
+	}
+	if record.GrantModel != managedcredentialmodel.GrantModelInstallation || record.InstallationID != "1001" {
+		t.Fatalf("record grant/install = (%q, %q), want installation_grant/1001", record.GrantModel, record.InstallationID)
+	}
+
+	now = now.Add(2 * time.Second)
+	token, record, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:            "github_app",
+		GrantType:      GrantGitHubAppInstallation,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		InstallationID: "1001",
+	})
+	if err != nil {
+		t.Fatalf("AccessToken refresh-before-use: %v", err)
+	}
+	if token != "github-install-token-2" || record.AccessToken != "github-install-token-2" {
+		t.Fatalf("refreshed token = (%q, %q), want github-install-token-2", token, record.AccessToken)
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("installation token requests = %d, want 2", tokenRequests)
+	}
+
+	if _, _, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:            "github_app",
+		GrantType:      GrantGitHubAppInstallation,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		InstallationID: "2002",
+	}); err == nil || !strings.Contains(err.Error(), "installation_id mismatch") {
+		t.Fatalf("AccessToken wrong installation err = %v, want mismatch", err)
+	}
+	if _, _, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:            "github_app",
+		GrantType:      GrantClientCredentials,
+		InstallationID: "1001",
+	}); err == nil || !strings.Contains(err.Error(), "grant-type-insufficient") {
+		t.Fatalf("AccessToken wrong grant err = %v, want grant-type-insufficient", err)
+	}
+
+	desc := record.Descriptor()
+	raw, err := json.Marshal(desc)
+	if err != nil {
+		t.Fatalf("Marshal descriptor: %v", err)
+	}
+	if strings.Contains(string(raw), privateKeyPEM) || strings.Contains(string(raw), "github-install-token") {
+		t.Fatalf("descriptor leaked GitHub App secret material: %s", string(raw))
+	}
+	if desc.InstallationID != "1001" || desc.APIBaseURL != server.URL {
+		t.Fatalf("descriptor installation/api = (%q, %q), want 1001/%s", desc.InstallationID, desc.APIBaseURL, server.URL)
+	}
+}
+
 func TestTokenSourceRefreshUsesBasicJSONTokenRequestProfileAndRotatesRefreshToken(t *testing.T) {
 	ctx := context.Background()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -772,6 +885,66 @@ func TestTokenSourceRefreshFailurePropagatesFailureStatePersistenceError(t *test
 	}
 	if stored.Status != StatusConnected {
 		t.Fatalf("stale stored status = %q, want connected to prove write failure was not hidden", stored.Status)
+	}
+}
+
+func testGitHubAppPrivateKey(t *testing.T) (string, *rsa.PublicKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	raw := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: raw})
+	if len(pemBytes) == 0 {
+		t.Fatal("EncodeToMemory returned empty PEM")
+	}
+	return string(pemBytes), &key.PublicKey
+}
+
+func testVerifyGitHubAppJWT(t *testing.T, token string, publicKey *rsa.PublicKey, wantIss string, now time.Time) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("JWT parts = %d, want 3", len(parts))
+	}
+	decode := func(name, raw string, target any) {
+		t.Helper()
+		decoded, err := base64.RawURLEncoding.DecodeString(raw)
+		if err != nil {
+			t.Fatalf("decode JWT %s: %v", name, err)
+		}
+		if err := json.Unmarshal(decoded, target); err != nil {
+			t.Fatalf("unmarshal JWT %s: %v", name, err)
+		}
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	decode("header", parts[0], &header)
+	if header.Alg != "RS256" || header.Typ != "JWT" {
+		t.Fatalf("JWT header = %#v, want RS256 JWT", header)
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	decode("claims", parts[1], &claims)
+	if claims.Iss != wantIss {
+		t.Fatalf("JWT iss = %q, want %q", claims.Iss, wantIss)
+	}
+	if claims.Iat > now.Unix() || claims.Exp <= now.Unix() || claims.Exp-claims.Iat > 10*60+60 {
+		t.Fatalf("JWT time claims = %#v, want active short-lived app JWT around %s", claims, now)
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode JWT signature: %v", err)
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, sum[:], signature); err != nil {
+		t.Fatalf("VerifyPKCS1v15: %v", err)
 	}
 }
 

--- a/internal/runtime/managedcredentials/store_test.go
+++ b/internal/runtime/managedcredentials/store_test.go
@@ -543,6 +543,60 @@ func TestTokenSourceGitHubAppInstallationExchangesJWTAndRequiresInstallationSele
 	}
 }
 
+func TestTokenSourceGitHubAppInstallationExchangeErrorRedactsGeneratedJWT(t *testing.T) {
+	ctx := context.Background()
+	privateKeyPEM, _ := testGitHubAppPrivateKey(t)
+	var rawAuth string
+	store := NewMemoryStore(Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      GrantGitHubAppInstallation,
+		APIBaseURL:     "https://api.github.test",
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     privateKeyPEM,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "expired-install-token",
+		Status:         StatusConnected,
+		ExpiresAt:      time.Now().Add(-time.Hour),
+	})
+	source := TokenSource{
+		Store: store,
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			rawAuth = r.Header.Get("Authorization")
+			return nil, errors.New("proxy captured Authorization=" + rawAuth)
+		})},
+	}
+	_, _, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:            "github_app",
+		GrantType:      GrantGitHubAppInstallation,
+		InstallationID: "1001",
+	})
+	if err == nil {
+		t.Fatal("AccessToken error = nil, want transport failure")
+	}
+	jwt := strings.TrimPrefix(rawAuth, "Bearer ")
+	if jwt == "" || jwt == rawAuth {
+		t.Fatalf("captured auth header = %q, want bearer GitHub App JWT", rawAuth)
+	}
+	if strings.Contains(err.Error(), jwt) || strings.Contains(err.Error(), rawAuth) {
+		t.Fatalf("AccessToken error leaked generated JWT: %v", err)
+	}
+	stored, ok, getErr := store.Get(ctx, "github_app")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if strings.Contains(stored.Failure, jwt) || strings.Contains(stored.Failure, rawAuth) {
+		t.Fatalf("stored failure leaked generated JWT: %q", stored.Failure)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func TestTokenSourceRefreshUsesBasicJSONTokenRequestProfileAndRotatesRefreshToken(t *testing.T) {
 	ctx := context.Background()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/managedcredentials/store_test.go
+++ b/internal/runtime/managedcredentials/store_test.go
@@ -591,6 +591,57 @@ func TestTokenSourceGitHubAppInstallationExchangeErrorRedactsGeneratedJWT(t *tes
 	}
 }
 
+func TestTokenSourceGitHubAppInstallationHTTPErrorBodyRedactsGeneratedJWT(t *testing.T) {
+	ctx := context.Background()
+	privateKeyPEM, _ := testGitHubAppPrivateKey(t)
+	var rawAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "provider echoed Authorization=" + rawAuth,
+		})
+	}))
+	defer server.Close()
+
+	store := NewMemoryStore(Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      GrantGitHubAppInstallation,
+		APIBaseURL:     server.URL,
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     privateKeyPEM,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "expired-install-token",
+		Status:         StatusConnected,
+		ExpiresAt:      time.Now().Add(-time.Hour),
+	})
+	source := TokenSource{Store: store}
+	_, _, err := source.AccessToken(ctx, AccessTokenRequest{
+		Key:            "github_app",
+		GrantType:      GrantGitHubAppInstallation,
+		InstallationID: "1001",
+	})
+	if err == nil {
+		t.Fatal("AccessToken error = nil, want provider HTTP failure")
+	}
+	jwt := strings.TrimPrefix(rawAuth, "Bearer ")
+	if jwt == "" || jwt == rawAuth {
+		t.Fatalf("captured auth header = %q, want bearer GitHub App JWT", rawAuth)
+	}
+	if strings.Contains(err.Error(), jwt) || strings.Contains(err.Error(), rawAuth) {
+		t.Fatalf("AccessToken error leaked generated JWT: %v", err)
+	}
+	stored, ok, getErr := store.Get(ctx, "github_app")
+	if getErr != nil || !ok {
+		t.Fatalf("store.Get = (%#v, %v, %v)", stored, ok, getErr)
+	}
+	if strings.Contains(stored.Failure, jwt) || strings.Contains(stored.Failure, rawAuth) {
+		t.Fatalf("stored failure leaked generated JWT: %q", stored.Failure)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -843,10 +844,12 @@ func (d pipelineActivityDispatcher) resolveActivityManagedCredential(ctx context
 		HTTPClient: client,
 	}
 	token, record, err := tokenSource.AccessToken(ctx, runtimemanagedcredentials.AccessTokenRequest{
-		Key:          storeKey,
-		Scopes:       ref.Scopes,
-		GrantModel:   ref.GrantModel,
-		TokenRequest: ref.TokenRequest,
+		Key:            storeKey,
+		GrantType:      ref.GrantType,
+		Scopes:         ref.Scopes,
+		GrantModel:     ref.GrantModel,
+		TokenRequest:   ref.TokenRequest,
+		InstallationID: activityManagedCredentialInputValue(intent.Input, ref.InstallationIDInput),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s", runtimemanagedcredentials.RedactString(err.Error(), record.SecretValues()...))
@@ -867,6 +870,35 @@ func (d pipelineActivityDispatcher) resolveActivityManagedCredential(ctx context
 		Prefix:      prefix,
 		TokenSource: tokenSource,
 	}, nil
+}
+
+func activityManagedCredentialInputValue(input map[string]any, key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	value, ok := input[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		return strings.TrimSpace(strconv.FormatFloat(typed, 'f', -1, 64))
+	case float32:
+		return strings.TrimSpace(strconv.FormatFloat(float64(typed), 'f', -1, 32))
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case uint64:
+		return strconv.FormatUint(typed, 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
 }
 
 func applyActivityManagedCredentialHeader(headers http.Header, auth *activityManagedHTTPAuth, replace bool) error {

--- a/internal/runtime/tools/executor_http.go
+++ b/internal/runtime/tools/executor_http.go
@@ -194,8 +194,12 @@ func (e *Executor) resolveManagedCredentialForActor(ctx context.Context, actor m
 	if storeKey == "" {
 		return nil, fmt.Errorf("managed credential %q does not resolve to a deployment credential key", key)
 	}
+	if strings.TrimSpace(ref.InstallationIDInput) != "" {
+		return nil, fmt.Errorf("tool %s managed_credential.installation_id_input is supported only for activity input resolution", strings.TrimSpace(tool.Name))
+	}
 	token, record, err := e.managedTokenSource().AccessToken(ctx, runtimemanagedcredentials.AccessTokenRequest{
 		Key:          storeKey,
+		GrantType:    ref.GrantType,
 		Scopes:       ref.Scopes,
 		GrantModel:   ref.GrantModel,
 		TokenRequest: ref.TokenRequest,

--- a/internal/runtime/tools/managed_credentials_test.go
+++ b/internal/runtime/tools/managed_credentials_test.go
@@ -14,6 +14,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -110,6 +111,53 @@ func TestValidateToolImplementationsRejectsMalformedManagedCredentialReferences(
 	})
 	if _, err := ValidateToolImplementations(source); err == nil || !strings.Contains(err.Error(), "managed_credential is only supported") {
 		t.Fatalf("ValidateToolImplementations err = %v, want HTTP-only managed credential failure", err)
+	}
+}
+
+func TestExecutorHTTPToolRejectsInstallationIDInputOutsideActivityPath(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("HTTP server should not be called when installation_id_input is used outside activity execution")
+	}))
+	defer server.Close()
+
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"send_provider": {
+				HandlerType: "http",
+				InputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "POST",
+					URL:    server.URL,
+				},
+				ManagedCredential: &runtimecontracts.ManagedCredentialRef{
+					Key:                 "github_app",
+					GrantType:           runtimemanagedcredentials.GrantGitHubAppInstallation,
+					GrantModel:          managedcredentialmodel.GrantModelInstallation,
+					InstallationIDInput: "installation_id",
+				},
+			},
+		},
+	})
+	if _, err := ValidateToolImplementations(source); err != nil {
+		t.Fatalf("ValidateToolImplementations: %v", err)
+	}
+	exec := NewExecutorWithOptions(nil, nil, ExecutorOptions{
+		WorkflowSource: source,
+		ManagedCredentials: runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+			Key:            "github_app",
+			Provider:       "github",
+			GrantType:      runtimemanagedcredentials.GrantGitHubAppInstallation,
+			GrantModel:     managedcredentialmodel.GrantModelInstallation,
+			InstallationID: "1001",
+			AccessToken:    "github-install-token",
+			Status:         runtimemanagedcredentials.StatusConnected,
+			ExpiresAt:      time.Now().Add(time.Hour),
+		}),
+	})
+	_, err := exec.Execute(models.WithActor(ctx, managedCredentialActor()), "send_provider", map[string]any{"installation_id": "1001"})
+	if err == nil || !strings.Contains(err.Error(), "installation_id_input is supported only for activity input resolution") {
+		t.Fatalf("Execute err = %v, want activity-only installation_id_input failure", err)
 	}
 }
 

--- a/internal/runtime/tools/validation.go
+++ b/internal/runtime/tools/validation.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -56,6 +57,17 @@ func ValidateToolImplementations(source semanticview.Source) ([]error, error) {
 				return warnings, fmt.Errorf("tool %s managed_credential.header is required when prefix is set", name)
 			}
 			if entry.ManagedCredential != nil {
+				if err := runtimemanagedcredentials.ValidateRequiredGrantType(entry.ManagedCredential.GrantType); err != nil {
+					return warnings, fmt.Errorf("tool %s managed_credential.%s", name, err.Error())
+				}
+				grantType := runtimemanagedcredentials.NormalizeGrantType(entry.ManagedCredential.GrantType)
+				installationIDInput := strings.TrimSpace(entry.ManagedCredential.InstallationIDInput)
+				if grantType == runtimemanagedcredentials.GrantGitHubAppInstallation && installationIDInput == "" {
+					return warnings, fmt.Errorf("tool %s managed_credential.installation_id_input is required for grant_type %s", name, grantType)
+				}
+				if installationIDInput != "" && grantType != runtimemanagedcredentials.GrantGitHubAppInstallation {
+					return warnings, fmt.Errorf("tool %s managed_credential.installation_id_input requires grant_type %s", name, runtimemanagedcredentials.GrantGitHubAppInstallation)
+				}
 				if err := managedcredentialmodel.ValidateGrantModel(entry.ManagedCredential.GrantModel); err != nil {
 					return warnings, fmt.Errorf("tool %s managed_credential.%s", name, err.Error())
 				}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6339,12 +6339,17 @@ tool_model:
           same-name fallback is allowed. header optionally names the request header to receive the access token and defaults
           to `Authorization`. prefix optionally names the value prefix and defaults to `Bearer` only when header is omitted
           or `Authorization`; custom headers default to the raw access token. scopes optionally lists scopes required by this
-          tool call. grant_model defaults to `scope_grant` and may be `workspace_grant` for providers such as Notion that
-          return workspace/page grants rather than scope strings. token_request declares the required token endpoint profile:
-          client_auth `post` or `basic`, body `form` or `json`, and optional static non-secret token endpoint headers; static
-          token headers MUST NOT include Authorization or Content-Type, which are owned by client_auth/body. Boot/verify and
-          execution fail closed when the connected managed credential record does not cover every required scope, grant_model,
-          and token_request profile.
+          tool call. grant_type optionally declares the required managed credential grant family; supported values are
+          `authorization_code`, `authorization_code_pkce`, `client_credentials`, and `github_app_installation`. grant_model
+          defaults to `scope_grant` and may be `workspace_grant` for providers such as Notion that return workspace/page
+          grants rather than scope strings, or `installation_grant` for GitHub App installation-token credentials.
+          installation_id_input is required when grant_type is `github_app_installation` and names a top-level activity input
+          field that carries the GitHub installation id selected from verified inbound context; it is forbidden for other
+          grant types. token_request declares the required token endpoint profile: client_auth `post` or `basic`, body
+          `form` or `json`, and optional static non-secret token endpoint headers; static token headers MUST NOT include
+          Authorization or Content-Type, which are owned by client_auth/body. Boot/verify and execution fail closed when the
+          connected managed credential record does not cover every required grant_type, scope, grant_model, token_request
+          profile, and installation selection.
         rate_limit: string — optional external dispatch rate limit, format N/period.
         rate_limit_max_wait: string — required when rate_limit is present; maximum per-call admission wait before
           returning typed rate_limited.
@@ -6364,10 +6369,11 @@ tool_model:
         `managed_credential` is resolved after package/import credential binding and before request dispatch. The managed
         credential owner provides only in-flight authorization material. The runtime refreshes before use when the record is
         expired or near expiry, injects the token into the configured header, and on provider 401 refreshes once and retries
-        the request once. Missing, unconnected, refresh-failed, scope-insufficient, unsupported, or unbound managed
-        credentials fail closed before dispatch. The connected record's grant_model and token_request profile must match the
-        tool declaration before dispatch. A tool may not also configure the same header in `http.headers`; that would create
-        dual authorization ownership.
+        the request once. Missing, unconnected, refresh-failed, scope-insufficient, unsupported, grant-type-insufficient,
+        installation-id-mismatched, or unbound managed credentials fail closed before dispatch. The connected record's
+        grant_type, grant_model, token_request profile, scopes, and installation selection must match the tool declaration
+        before dispatch. A tool may not also configure the same header in `http.headers`; that would create dual
+        authorization ownership.
     external_provider_dispatch_rate_limit:
       description: >
         `rate_limit` on an HTTP tool declares process-local admission for outbound HTTP provider dispatch by that tool.
@@ -6425,7 +6431,7 @@ tool_model:
       - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
       - "direct runtime provider adapter code or bespoke connector dispatch."
     connector_pack_profile:
-      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, Notion Basic+JSON workspace-grant connector proof, and Microsoft Graph client_credentials `.default` connector proof"
+      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, Notion Basic+JSON workspace-grant connector proof, Microsoft Graph client_credentials `.default` connector proof, and GitHub App installation-token issue-comment connector proof"
       body_file: connector.yaml
       import_syntax: >
         package.yaml `connector_packs.imports[]` entries name `provider` and `tool`. The import is an explicit enablement
@@ -6446,7 +6452,8 @@ tool_model:
         non-idempotent writes, or exposing credential values. Requirement rows are typed: static secret requirements render
         BOUND/UNBOUND from the static credential store, while managed credential requirements render managed credential
         lifecycle status such as CONNECTED, UNCONNECTED, PENDING_CONSENT, REFRESH_FAILED, or SCOPE_INSUFFICIENT plus the
-        required scopes, grant_model, and token_request profile without exposing token values.
+        required grant_type, scopes, grant_model, token_request profile, and installation_id_input when present without
+        exposing token values.
       collision_policy: >
         No packed-vs-packed or packed-vs-flow-local connector shadowing is allowed in this slice. Any duplicate tool id
         fails closed before runtime construction and names both sources with remediation to remove one source or rename the
@@ -6546,8 +6553,10 @@ tool_model:
     - single-tenant/self-hosted/operator-connected deployment token records
     - authorization-code consent and callback, with or without PKCE depending on provider contract
     - client_credentials as the first non-consent grant variant
+    - GitHub App installation-token credentials as the first private-key/JWT app-installation grant variant
     - access token, refresh token when present, expiry, scopes, grant_model, token_request profile, provider/account identity,
-      grant type, status, refresh policy, and failure evidence
+      grant type, GitHub App private-key material and installation id when applicable, status, refresh policy, and failure
+      evidence
     - direct Executor.Execute, served /tools/{name}, MCP tools/call HTTP-tool entry points, and provider_connector activity
       execution on the `activity_attempts` path
     non_goals:
@@ -6571,16 +6580,21 @@ tool_model:
       key: Deployment-level managed credential key after import-boundary binding.
       provider: Provider label for operator status.
       account: Optional connected account identity/label.
-      grant_type: authorization_code | authorization_code_pkce | client_credentials.
+      grant_type: authorization_code | authorization_code_pkce | client_credentials | github_app_installation.
       auth_url: Authorization endpoint for authorization-code records.
       token_url: Token endpoint for grant and refresh requests.
+      api_base_url: Provider API base URL for app-installation token exchange when the grant does not use a normal OAuth
+        token_url; GitHub defaults to https://api.github.com.
       client_id: OAuth client ID.
       client_secret: Optional OAuth client secret.
+      installation_id: GitHub App installation id selected for a single-tenant/deployment credential record.
+      private_key: GitHub App RSA private key for RS256 app JWT signing; secret material, never returned by metadata/status
+        surfaces.
       redirect_url: Callback URL for authorization-code records.
       scopes: Granted/available scopes for scope_grant providers. Declared-empty scopes are valid for workspace_grant
         providers and MUST NOT be filled with fake scopes.
-      grant_model: scope_grant | workspace_grant. Readback must render workspace_grant as a workspace/page-level grant, not
-        as missing scopes.
+      grant_model: scope_grant | workspace_grant | installation_grant. Readback must render workspace_grant as a
+        workspace/page-level grant and installation_grant as an installation-scoped app grant, not as missing scopes.
       token_request: >
         Closed token endpoint profile used by auth-code exchange, refresh, and client_credentials. Fields are
         client_auth (`post` sends client_id/client_secret in the request body; `basic` sends HTTP Basic and omits
@@ -6597,8 +6611,11 @@ tool_model:
       HTTP tools name `managed_credential.key` as a package-local handle. Runtime consumers MUST map that handle through the
       same import-boundary `requires.credentials` / `bind.credentials` resolver used by static credentials, then read the
       managed credential record by the resulting deployment key. If the handle is undeclared, unbound, empty, missing from
-      the managed store, or does not match the tool's required grant_model/token_request/scopes, execution fails before
-      outbound dispatch. Same-name ambient fallback is forbidden for imported packages.
+      the managed store, or does not match the tool's required grant_type/grant_model/token_request/scopes, execution fails
+      before outbound dispatch. For `github_app_installation`, the tool declaration MUST provide installation_id_input and
+      runtime activity execution MUST resolve that top-level activity input before token acquisition; missing or mismatched
+      installation ids fail closed before token exchange and before provider dispatch. Same-name ambient fallback is
+      forbidden for imported packages.
     refresh_rule: >
       Before request dispatch, the resolver returns a valid access token or fails closed. It refreshes before use when the
       access token is absent or expires within the configured refresh window. For provider 401 responses, supported HTTP
@@ -6607,6 +6624,9 @@ tool_model:
       an existing row blocks refresh and provider redispatch. Refresh failure sets refresh_failed state with redacted failure
       evidence and returns a redacted runtime error. Auth-code exchange, refresh, and client_credentials all consume the same
       record token_request profile; provider-specific token endpoint behavior is data, not a provider branch in the engine.
+      GitHub App installation-token reacquisition signs a short-lived RS256 app JWT from the stored private key and POSTs to
+      `{api_base_url}/app/installations/{installation_id}/access_tokens`; it never uses OAuth client_credentials, OAuth App
+      user tokens, PAT/static bearer credentials, or connector-dispatch provider branches.
     client_credentials_resource_scope_policy: >
       Client-credentials connector packs may declare provider resource scopes such as
       `https://graph.microsoft.com/.default` under `managed_credential.scopes` with `grant_model: scope_grant`. Readback,
@@ -6615,27 +6635,40 @@ tool_model:
       provider-specific app-role, delegated-scope, or admin-consent readiness unless a separate source-authoritative owner
       for those permission claims is specified and implemented. Client-credentials refresh/re-acquisition repeats the
       `grant_type=client_credentials` token request and MUST NOT require or send a refresh token.
+    github_app_installation_policy: >
+      GitHub App connector packs that require app installation auth declare `managed_credential.grant_type:
+      github_app_installation`, `grant_model: installation_grant`, and `installation_id_input` naming the top-level
+      activity input populated from verified inbound GitHub event context. The deployment record stores the app/client id,
+      installation id, API base URL, and RSA private key, and caches the returned installation access token until expiry.
+      Runtime must fail closed when the inbound-selected installation id is absent or differs from the connected record.
+      Private keys, generated JWTs, installation tokens, webhook signing secrets, and provider errors containing those values
+      are secret material and MUST NOT appear in events, logs, activity attempts, status, or readback. This grant family is
+      not OAuth client_credentials, not a PAT/static bearer shortcut, and not a provider-specific connector dispatcher.
     operator_surface:
       command: swarm connections connect|callback|status|disconnect
       rule: >
         `swarm connections` is the supported local operator CLI for managed credential lifecycle. `connect` starts
-        authorization_code or authorization_code_pkce consent or completes a client_credentials grant; `callback` records the authorization-code
-        callback; `status` returns metadata and required_by information only; `disconnect` deletes the token record. The
-        command is intentionally separate from `swarm secrets`, which remains static key/value secret storage. Secret
-        values accepted by the CLI, including OAuth client secrets and authorization callback codes, MUST NOT be accepted
-        as argv flag values; supported local secret input uses stdin or an equivalent non-argv source. `connect` supports
-        closed token endpoint profile flags for grant_model, client_auth, body, and static non-secret token headers.
+        authorization_code or authorization_code_pkce consent, completes a client_credentials grant, or connects a
+        github_app_installation record by reading the RSA private key from a non-argv source and exchanging for an
+        installation token. `callback` records the authorization-code callback; `status` returns metadata and required_by
+        information only; `disconnect` deletes the token record. The command is intentionally separate from `swarm secrets`,
+        which remains static key/value secret storage. Secret values accepted by the CLI, including OAuth client secrets,
+        GitHub App private keys, and authorization callback codes, MUST NOT be accepted as argv flag values; supported local
+        secret input uses stdin or an equivalent non-argv source. `connect` supports closed token endpoint profile flags for
+        grant_model, client_auth, body, and static non-secret token headers, and supports GitHub App `--installation-id` and
+        optional `--api-base-url` metadata.
     boot_validation: >
       Boot/verify consumes managed_credential requirements and reports managed_credential_state for missing, pending,
-      refresh_failed, scope_insufficient, grant-model/token-profile mismatches, or otherwise unusable records. When boot
-      warnings are fatal, these findings block startup. Connector readback/doctor MUST compare declared tool scopes,
-      grant_model, and token_request profile against connected records and surface scope_insufficient rather than
-      connected/bound when the record does not cover every declared requirement. Execution still fails closed even when boot
-      warnings are non-fatal.
+      refresh_failed, scope_insufficient, grant-type/grant-model/token-profile mismatches, installation-input requirements,
+      or otherwise unusable records. When boot warnings are fatal, these findings block startup. Connector readback/doctor
+      MUST compare declared tool grant_type, scopes, grant_model, token_request profile, and installation_id_input against
+      connected records and surface scope_insufficient rather than connected/bound when the record does not cover every
+      declared requirement. Execution still fails closed even when boot warnings are non-fatal.
     redaction_guarantee: >
-      Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, and provider errors containing
-      those values MUST NOT be returned through logs, events, dead letters, tool results, metadata, or CLI/API/status
-      surfaces. Supported readback surfaces return only redacted metadata and failure evidence.
+      Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, GitHub App private keys,
+      generated JWTs, installation tokens, and provider errors containing those values MUST NOT be returned through logs,
+      events, dead letters, tool results, metadata, or CLI/API/status surfaces. Supported readback surfaces return only
+      redacted metadata and failure evidence.
   provider_trigger_adapters:
     description: >
       Source authority for first-class provider webhook triggers on top of the existing `inbound.webhook` gateway. The
@@ -16485,15 +16518,18 @@ cli_specification:
         JSON.
       subcommands:
         connect:
-          command: swarm connections connect <key> --grant authorization_code|authorization_code_pkce|client_credentials [...]
+          command: swarm connections connect <key> --grant authorization_code|authorization_code_pkce|client_credentials|github_app_installation [...]
           behavior: >
             For authorization_code and authorization_code_pkce, stores a pending consent record with provider config, optional
             PKCE challenge/state, grant_model, and token_request metadata, then prints only the authorization URL/state and
             redacted connection metadata. For client_credentials, exchanges with the token endpoint immediately and stores a
-            connected token record. OAuth client secrets, when required by the provider, are read through
-            `--client-secret-stdin`; an argv `--client-secret <value>` source is unsupported because it leaks through shell
-            history and process listings. Token endpoint profile flags are closed: token-client-auth post|basic, token-body
-            form|json, token-header Name=Value for non-secret headers, and grant-model scope_grant|workspace_grant.
+            connected token record. For github_app_installation, reads the GitHub App private key through
+            `--private-key-stdin`, requires `--installation-id`, optionally accepts `--api-base-url`, signs an app JWT, and
+            exchanges it for an installation token before storing connected metadata. OAuth client secrets and GitHub App
+            private keys, when required by the provider, are read through stdin flags; argv secret values such as
+            `--client-secret <value>` or `--private-key <value>` are unsupported because they leak through shell history and
+            process listings. Token endpoint profile flags are closed: token-client-auth post|basic, token-body form|json,
+            token-header Name=Value for non-secret headers, and grant-model scope_grant|workspace_grant|installation_grant.
         callback:
           command: swarm connections callback <key> --state <state> --code-stdin
           behavior: >
@@ -16505,8 +16541,9 @@ cli_specification:
           command: swarm connections status [<key>] [--json] [--contracts <path>]
           behavior: >
             Lists managed credential metadata only: key, provider, account, grant_type, scopes, grant_model, token_request,
-            status, redacted failure, expires_at, updated_at, present, and required_by where contract source context is
-            available. Values and token material are never returned.
+            installation_id, api_base_url, status, redacted failure, expires_at, updated_at, present, and required_by where
+            contract source context is available. Values, private keys, generated JWTs, and token material are never
+            returned.
         disconnect:
           command: swarm connections disconnect <key>
           behavior: Deletes the managed credential token record for the deployment key.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6641,6 +6641,10 @@ tool_model:
       activity input populated from verified inbound GitHub event context. The deployment record stores the app/client id,
       installation id, API base URL, and RSA private key, and caches the returned installation access token until expiry.
       Runtime must fail closed when the inbound-selected installation id is absent or differs from the connected record.
+      Issue-comment bot-loop flows that consume `inbound.github.issue_comment` and call a GitHub App issue-comment
+      connector MUST guard app/bot-authored comments before activity lowering, using an `on_fail: discard` handler guard
+      or equivalent no-side-effect filter. Delivery-id dedupe alone is not sufficient because an app-authored response is a
+      separate GitHub webhook delivery with a new delivery id.
       Private keys, generated JWTs, installation tokens, webhook signing secrets, and provider errors containing those values
       are secret material and MUST NOT appear in events, logs, activity attempts, status, or readback. This grant family is
       not OAuth client_credentials, not a PAT/static bearer shortcut, and not a provider-specific connector dispatcher.
@@ -6666,9 +6670,9 @@ tool_model:
       declared requirement. Execution still fails closed even when boot warnings are non-fatal.
     redaction_guarantee: >
       Access tokens, refresh tokens, client secrets, authorization codes, PKCE verifier/state, GitHub App private keys,
-      generated JWTs, installation tokens, and provider errors containing those values MUST NOT be returned through logs,
-      events, dead letters, tool results, metadata, or CLI/API/status surfaces. Supported readback surfaces return only
-      redacted metadata and failure evidence.
+      generated JWTs, installation tokens, provider errors containing those values, and transport/proxy errors that echo
+      generated Authorization headers MUST NOT be returned through logs, events, dead letters, tool results, metadata, or
+      CLI/API/status surfaces. Supported readback surfaces return only redacted metadata and failure evidence.
   provider_trigger_adapters:
     description: >
       Source authority for first-class provider webhook triggers on top of the existing `inbound.webhook` gateway. The


### PR DESCRIPTION
## Summary

- Adds `github_app_installation` managed credential semantics for GitHub App private-key JWT signing, installation-token exchange, cache/expiry, redaction, CLI connection, and requirement readback.
- Adds the `github.create_issue_comment` connector pack as data and wires `installation_id_input` through activity-managed credential resolution.
- Adds SQLite/Postgres supported-surface proof for GitHub `issue_comment` inbound -> flow/activity -> GitHub App installation token -> issue-comment REST write, including duplicate webhook and duplicate activity suppression.
- Updates `platform-spec.yaml` as the authoritative contract for the new grant family and connector requirement fields.

Closes #1898
Part of #1458
Part of #1862

## Governing Refs

- `platform-spec.yaml` provider connector tools: `tool_model.provider_connector_tools` around lines 6403-6468.
- `platform-spec.yaml` managed credential store: `tool_model.managed_credential_store` around lines 6547-6668.
- `platform-spec.yaml` provider trigger adapters / GitHub trigger: `tool_model.provider_trigger_adapters` around lines 6672-6855.
- `platform-spec.yaml` activity attempts: `runtime_state.activity_attempts` around lines 8947-8970.
- Binding issue/gate context: #1898 pre-audit and independent gate outcome.

## Semantic Migration

New canonical owner:

- `managed_credential_store` now owns the GitHub App installation-token grant family: private key storage/redaction, RS256 app JWT signing, installation-token exchange, cache/expiry, installation id selection, readback/status, and replay-safe activity consumption.

Old paths now invalid for this class:

- PAT/static bearer presented as GitHub App proof.
- OAuth App user token presented as installation-token proof.
- Fake `client_credentials` modeling of GitHub App auth.
- Provider-specific Go dispatcher for GitHub issue-comment writes.
- Ambient repository/issue/installation inference outside explicit inbound payload mapping.

Production paths checked for surviving old behavior:

- Connector packs import normal `ToolSchemaEntry` values and validate `grant_type` / `installation_id_input`.
- HTTP activity executor resolves installation id from activity input before token acquisition.
- Direct actor HTTP execution rejects `installation_id_input` because only activity input can carry the verified inbound context.
- CLI connection/status/readback handle GitHub App credentials without exposing private key/JWT/installation token values.
- Existing GitHub provider trigger ingress remains consumed, not replaced.

Migration completeness:

- Complete for #1898's approved GitHub App issue-comment reply-loop class.
- Broader GitHub App setup lifecycle, OAuth App/PAT auth modes, and other GitHub actions remain split parent tails.

## Validation

Focused proofs:

```sh
go test ./internal/runtime/tools -run TestExecutorHTTPToolRejectsInstallationIDInputOutsideActivityPath -count=1
go test ./internal/runtime/managedcredentials ./internal/providerconnectors
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal -count=1
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/runtime -run 'TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal|TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal|TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal|TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJournal' -count=1
```

Whole suite:

```sh
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test -p 1 ./...
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```

Note: an earlier unbounded full-suite attempt hit a local `internal/runtime/cataloge2e` context-deadline timeout while other Go/Postgres test runs were active on the machine. The failing subtest passed in isolation, the full package passed, the serialized full suite passed, and the final plain `go test ./...` passed.
