### PR TITLE
[agent-e][issue #1816] Improve run trace fidelity

### DIFF
--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -34,6 +34,7 @@ type diagnosticRunListOptions struct {
 type diagnosticTraceOptions struct {
 	apiOptions       rootCommandOptions
 	follow           bool
+	verbose          bool
 	noRetry          bool
 	deliveryDetail   bool
 	deliverySummary  bool
@@ -308,6 +309,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&traceOpts.follow, "follow", "f", false, "Follow live trace rows as they stream")
+	cmd.Flags().BoolVar(&traceOpts.verbose, "verbose", false, "Include internal trace rows such as platform.runtime_log")
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().BoolVar(&traceOpts.deliveryDetail, "delivery-detail", false, "Show snapshot delivery lifecycle fields from RunTraceRow")
 	cmd.Flags().BoolVar(&traceOpts.deliverySummary, "delivery-summary", false, "Summarize snapshot delivery lifecycle fields from all RunTraceRow pages")
@@ -547,7 +549,7 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	if err := validateDiagnosticRunTraceResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, diagnosticRunAPIErrorClassifier())
 	}
-	writeDiagnosticRunTrace(out, runID, result, opts.deliveryDetail)
+	writeDiagnosticRunTrace(out, runID, result, opts.deliveryDetail, opts.verbose)
 	return nil
 }
 
@@ -609,6 +611,9 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 	if len(filter) > 0 {
 		params["filter"] = filter
 	}
+	if o.verbose {
+		params["include_internal"] = true
+	}
 	return params, nil
 }
 
@@ -635,6 +640,9 @@ func (o diagnosticTraceOptions) followParams() (map[string]any, error) {
 	params := map[string]any{}
 	if len(filter) > 0 {
 		params["filter"] = filter
+	}
+	if o.verbose {
+		params["include_internal"] = true
 	}
 	return params, nil
 }
@@ -878,6 +886,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	}
 	retryAttempt := 0
 	var replaySince *time.Time
+	traceWriter := &runTraceRowLineWriter{}
 	for {
 		sub, err := subscribeRunTrace(ctx, wsEndpoint, client.token, runID, replaySince, params)
 		if err != nil {
@@ -897,7 +906,7 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 			}
 			continue
 		}
-		streamErr, interrupted := consumeDiagnosticTraceSubscription(ctx, out, sub, &replaySince)
+		streamErr, interrupted := consumeDiagnosticTraceSubscription(ctx, out, sub, &replaySince, traceWriter)
 		sub.close()
 		if interrupted {
 			return traceFollowDetached(errOut)
@@ -925,7 +934,10 @@ func followDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, cl
 	}
 }
 
-func consumeDiagnosticTraceSubscription(ctx context.Context, out io.Writer, sub *runTraceSubscription, replaySince **time.Time) (error, bool) {
+func consumeDiagnosticTraceSubscription(ctx context.Context, out io.Writer, sub *runTraceSubscription, replaySince **time.Time, traceWriter *runTraceRowLineWriter) (error, bool) {
+	if traceWriter == nil {
+		traceWriter = &runTraceRowLineWriter{}
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -945,7 +957,7 @@ func consumeDiagnosticTraceSubscription(ctx context.Context, out io.Writer, sub 
 			if err != nil {
 				return fmt.Errorf("malformed run.subscribe_trace notification: event_created_at is not RFC3339: %w", err), false
 			}
-			writeRunCommandTraceRow(out, row)
+			traceWriter.Write(out, row)
 			nextReplaySince = nextReplaySince.UTC()
 			*replaySince = &nextReplaySince
 		case err := <-sub.errs:
@@ -1465,36 +1477,52 @@ func writeDiagnosticRunDiagnosis(out io.Writer, result diagnosticRunDiagnosisRes
 	}
 }
 
-func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTraceResult, deliveryDetail bool) {
+func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTraceResult, deliveryDetail, verbose bool) {
 	if out == nil {
 		return
 	}
-	fmt.Fprintf(out, "run trace: run_id=%s\n", runID)
+	startedAt, hasStart := traceRowsStart(result.Trace)
+	fmt.Fprintf(out, "run trace %s", runID)
+	if hasStart {
+		fmt.Fprintf(out, " started %s", formatTraceWallClock(startedAt))
+	}
+	fmt.Fprintf(out, " rows=%d\n", len(result.Trace))
 	if deliveryDetail {
 		writeDiagnosticRunTraceDeliveryDetail(out, result.Trace)
 	} else {
 		rows := make([][]string, 0, len(result.Trace))
+		includeSessionTurn := verbose || traceRowsHaveSessionOrTurn(result.Trace)
 		for _, row := range result.Trace {
-			rows = append(rows, []string{
-				row.EventCreatedAt,
+			tableRow := []string{
+				formatTraceRelativeFrom(startedAt, hasStart, row.EventCreatedAt),
 				row.EventName,
 				row.EventID,
 				emptyDash(row.DeliveryStatus),
-				emptyDash(row.SubscriberType) + "/" + emptyDash(row.SubscriberID),
-				emptyDash(row.SessionID),
-				emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
-			})
+				formatTraceSubscriber(row),
+			}
+			if includeSessionTurn {
+				tableRow = append(tableRow,
+					emptyDash(row.SessionID),
+					emptyDash(firstNonEmpty(row.TurnID, row.TurnTriggerEventType)),
+				)
+			}
+			rows = append(rows, tableRow)
+		}
+		columns := []cliTableColumn{
+			{Header: "TIME"},
+			{Header: "EVENT"},
+			{Header: "ID", KeyColumn: true},
+			{Header: "DELIVERY"},
+			{Header: "SUBSCRIBER"},
+		}
+		if includeSessionTurn {
+			columns = append(columns,
+				cliTableColumn{Header: "SESSION"},
+				cliTableColumn{Header: "TURN"},
+			)
 		}
 		writeCLITable(out, cliTable{
-			Columns: []cliTableColumn{
-				{Header: "EVENT AT"},
-				{Header: "EVENT"},
-				{Header: "EVENT ID", KeyColumn: true},
-				{Header: "DELIVERY"},
-				{Header: "SUBSCRIBER"},
-				{Header: "SESSION"},
-				{Header: "TURN"},
-			},
+			Columns:      columns,
 			Rows:         rows,
 			EmptyMessage: "No trace rows found for this run.",
 		})
@@ -1502,6 +1530,56 @@ func writeDiagnosticRunTrace(out io.Writer, runID string, result diagnosticRunTr
 	if result.NextCursor != "" {
 		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
 	}
+}
+
+func traceRowsStart(rows []diagnosticRunTraceRow) (time.Time, bool) {
+	if len(rows) == 0 {
+		return time.Time{}, false
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(rows[0].EventCreatedAt))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return startedAt.UTC(), true
+}
+
+func traceRowsHaveSessionOrTurn(rows []diagnosticRunTraceRow) bool {
+	for _, row := range rows {
+		if strings.TrimSpace(row.SessionID) != "" || strings.TrimSpace(row.TurnID) != "" || strings.TrimSpace(row.TurnTriggerEventType) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func formatTraceRelativeFrom(startedAt time.Time, hasStart bool, raw string) string {
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil || !hasStart {
+		return raw
+	}
+	return formatTraceOffset(at.UTC().Sub(startedAt))
+}
+
+func formatTraceOffset(duration time.Duration) string {
+	duration = duration.Round(time.Millisecond)
+	if duration == 0 {
+		return "+0ms"
+	}
+	sign := "+"
+	if duration < 0 {
+		sign = "-"
+		duration = -duration
+	}
+	return sign + duration.String()
+}
+
+func formatTraceWallClock(at time.Time) string {
+	return at.UTC().Format("15:04:05.000")
+}
+
+func formatTraceSubscriber(row diagnosticRunTraceRow) string {
+	subscriber := strings.Trim(strings.TrimSpace(row.SubscriberType)+"/"+strings.TrimSpace(row.SubscriberID), "/")
+	return emptyDash(subscriber)
 }
 
 func writeDiagnosticRunTraceDeliverySummary(out io.Writer, runID string, result diagnosticRunTraceSummaryResult) {

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -213,7 +213,7 @@ func TestStatusAndTraceResolveOmittedRunThroughActivePreference(t *testing.T) {
 			lists:      [][]any{{}, {}, {validDiagnosticRunHeaderWithStatus("terminal-run", "completed")}},
 			owner:      "run.trace",
 			selected:   "terminal-run",
-			wantOutput: "run trace: run_id=terminal-run",
+			wantOutput: "run trace terminal-run",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -347,11 +347,12 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 			t.Fatalf("method = %q, want run.trace", req.Method)
 		}
 		wantParams := map[string]any{
-			"run_id": "run-1",
-			"limit":  float64(2),
-			"cursor": "trace-cur",
-			"since":  "2026-05-13T10:00:00Z",
-			"until":  "2026-05-13T10:05:00Z",
+			"run_id":           "run-1",
+			"limit":            float64(2),
+			"cursor":           "trace-cur",
+			"since":            "2026-05-13T10:00:00Z",
+			"until":            "2026-05-13T10:05:00Z",
+			"include_internal": true,
 			"filter": map[string]any{
 				"event_name":      []any{"scan.requested", "scan.completed"},
 				"entity_id":       []any{"entity-1", "entity-2"},
@@ -382,6 +383,7 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
 		"run", "trace", "run-1",
+		"--verbose",
 		"--limit", "2",
 		"--cursor", "trace-cur",
 		"--since", "2026-05-13T10:00:00Z",
@@ -403,7 +405,12 @@ func TestTraceUsesRunTraceSnapshot(t *testing.T) {
 	if len(*requests) != 1 {
 		t.Fatalf("requests = %d, want 1", len(*requests))
 	}
-	for _, want := range []string{"run trace: run_id=run-1", "event-1", "scan.requested", "agent/agent-1", "next_cursor=trace-next"} {
+	for _, want := range []string{"run trace run-1", "event-1", "scan.requested", "agent/agent-1", "next_cursor=trace-next"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, want := range []string{"SESSION", "TURN", "+0ms"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -479,10 +486,11 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 			t.Fatalf("method[%d] = %q, want run.trace", callIndex, req.Method)
 		}
 		baseParams := map[string]any{
-			"run_id": "run-1",
-			"limit":  float64(1),
-			"since":  "2026-05-13T10:00:00Z",
-			"until":  "2026-05-13T10:05:00Z",
+			"run_id":           "run-1",
+			"limit":            float64(1),
+			"since":            "2026-05-13T10:00:00Z",
+			"until":            "2026-05-13T10:05:00Z",
+			"include_internal": true,
 			"filter": map[string]any{
 				"delivery_status": []any{"in_progress", "delivered", "failed"},
 				"subscriber_type": []any{"agent", "node"},
@@ -557,6 +565,7 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
 		"run", "trace", "run-1",
 		"--delivery-summary",
+		"--verbose",
 		"--limit", "1",
 		"--cursor", "start-cur",
 		"--since", "2026-05-13T10:00:00Z",
@@ -721,8 +730,13 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 	if len(*requests) != 2 {
 		t.Fatalf("requests = %d, want run.list then run.trace", len(*requests))
 	}
-	if !strings.Contains(stdout.String(), "run trace: run_id=active-run") {
+	if !strings.Contains(stdout.String(), "run trace active-run") {
 		t.Fatalf("stdout = %q, want resolved run trace header", stdout.String())
+	}
+	for _, unwanted := range []string{"SESSION", "TURN"} {
+		if strings.Contains(stdout.String(), unwanted) {
+			t.Fatalf("stdout contains %q for non-agent trace:\n%s", unwanted, stdout.String())
+		}
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -731,14 +745,16 @@ func TestTraceSnapshotFiltersUseOmittedRunResolver(t *testing.T) {
 
 func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
-		args       []string
-		wantFilter map[string]any
+		name                string
+		args                []string
+		wantFilter          map[string]any
+		wantIncludeInternal bool
 	}{
 		{
-			name:       "long follow",
-			args:       []string{"run", "trace", "run-follow", "--follow", "--no-retry", "--event-name", "scan.requested", "--event-name", "scan.completed", "--entity-id", "entity-1", "--entity-id", "entity-2", "--delivery-status", "delivered", "--delivery-status", "failed", "--subscriber-id", "agent-1", "--subscriber-id", "node-2", "--subscriber-type", "agent", "--subscriber-type", "node"},
-			wantFilter: wantFullTraceFilterParams(),
+			name:                "long follow verbose",
+			args:                []string{"run", "trace", "run-follow", "--follow", "--verbose", "--no-retry", "--event-name", "scan.requested", "--event-name", "scan.completed", "--entity-id", "entity-1", "--entity-id", "entity-2", "--delivery-status", "delivered", "--delivery-status", "failed", "--subscriber-id", "agent-1", "--subscriber-id", "node-2", "--subscriber-type", "agent", "--subscriber-type", "node"},
+			wantFilter:          wantFullTraceFilterParams(),
+			wantIncludeInternal: true,
 		},
 		{
 			name:       "shorthand follow",
@@ -761,7 +777,12 @@ func TestTraceFollowUsesRunSubscribeTrace(t *testing.T) {
 			}
 			assertRunCommandMethods(t, calls, nil)
 			assertRunCommandTraceSubscriptionWithFilter(t, wsRequests, "run-follow", false, tc.wantFilter)
-			if !strings.Contains(stdout.String(), "trace event_id=evt-follow") {
+			if got := (*wsRequests)[0].Params["include_internal"]; got != tc.wantIncludeInternal {
+				if tc.wantIncludeInternal || got != nil {
+					t.Fatalf("ws include_internal = %#v, want %t", got, tc.wantIncludeInternal)
+				}
+			}
+			if !strings.Contains(stdout.String(), "id=evt-follow") {
 				t.Fatalf("stdout = %q, want trace row", stdout.String())
 			}
 			if strings.TrimSpace(stderr.String()) != "" {
@@ -798,7 +819,7 @@ func TestTraceFollowOmittedRunReusesActivePreferenceResolver(t *testing.T) {
 		"event_name":    []any{"scan.requested"},
 		"subscriber_id": []any{"agent-1"},
 	})
-	if !strings.Contains(stdout.String(), "trace event_id=evt-active") {
+	if !strings.Contains(stdout.String(), "id=evt-active") {
 		t.Fatalf("stdout = %q, want trace row", stdout.String())
 	}
 }
@@ -824,6 +845,9 @@ func TestTraceHelpPromotesNoRetryWithoutReplaySince(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "--delivery-summary") {
 		t.Fatalf("help missing --delivery-summary:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--verbose") {
+		t.Fatalf("help missing --verbose:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "--replay-since") {
 		t.Fatalf("help exposed unpromoted --replay-since:\n%s", stdout.String())
@@ -945,7 +969,7 @@ func TestTraceFollowRecoversWithReplaySinceAfterClose(t *testing.T) {
 	if got := wsRequests[1].Params["replay_since"]; got != "2026-05-13T10:00:01Z" {
 		t.Fatalf("recovery replay_since = %#v, want first row timestamp", got)
 	}
-	for _, want := range []string{"trace event_id=evt-1", "trace event_id=evt-2"} {
+	for _, want := range []string{"id=evt-1", "id=evt-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -1043,7 +1067,7 @@ func TestTraceFollowRetriesRetryableReadFailure(t *testing.T) {
 			t.Fatalf("ws filter[%d] = %#v, want %#v", i, got, wantFilter)
 		}
 	}
-	if !strings.Contains(stdout.String(), "trace event_id=evt-recovered") {
+	if !strings.Contains(stdout.String(), "id=evt-recovered") {
 		t.Fatalf("stdout = %q, want recovered row", stdout.String())
 	}
 	if !strings.Contains(stderr.String(), "detached from run trace") {
@@ -1273,6 +1297,7 @@ func TestDiagnosticsRequireAPITokenBeforeRequest(t *testing.T) {
 	for _, args := range [][]string{
 		{"run", "list"},
 		{"run", "trace", "run-1"},
+		{"run", "trace", "run-1", "--verbose"},
 		{"run", "trace", "run-1", "--limit", "2", "--cursor", "cur", "--since", "2026-05-13T10:00:00Z", "--until", "2026-05-13T10:05:00Z"},
 		{"run", "trace", "run-1", "--delivery-detail"},
 		{"run", "trace", "run-1", "--delivery-summary"},

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -581,6 +581,7 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
+	traceWriter := &runTraceRowLineWriter{}
 	for {
 		select {
 		case <-ctx.Done():
@@ -602,7 +603,7 @@ func followRunCommand(ctx context.Context, out, errOut io.Writer, client *cliAPI
 				rows = nil
 				continue
 			}
-			writeRunCommandTraceRow(out, row)
+			traceWriter.Write(out, row)
 		case err := <-sub.errs:
 			if err != nil {
 				writeCLIAPIError(errOut, err)
@@ -832,28 +833,49 @@ func writeRunCommandReattached(out io.Writer, run diagnosticRunHeader) {
 }
 
 func writeRunCommandTraceRow(out io.Writer, row diagnosticRunTraceRow) {
+	writer := &runTraceRowLineWriter{}
+	writer.Write(out, row)
+}
+
+type runTraceRowLineWriter struct {
+	startedAt *time.Time
+}
+
+func (w *runTraceRowLineWriter) Write(out io.Writer, row diagnosticRunTraceRow) {
 	if out == nil {
 		return
 	}
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(row.EventCreatedAt))
+	if err == nil {
+		at = at.UTC()
+		if w.startedAt == nil {
+			startedAt := at
+			w.startedAt = &startedAt
+		}
+	}
+	relativeAt := strings.TrimSpace(row.EventCreatedAt)
+	if err == nil && w.startedAt != nil {
+		relativeAt = formatTraceOffset(at.Sub(*w.startedAt))
+	}
 	fields := []string{
-		"event_id=" + row.EventID,
-		"event_name=" + row.EventName,
-		"at=" + row.EventCreatedAt,
+		relativeAt,
+		row.EventName,
+		"id=" + row.EventID,
 	}
 	if row.EntityID != "" {
-		fields = append(fields, "entity_id="+row.EntityID)
+		fields = append(fields, "entity="+row.EntityID)
 	}
 	if row.DeliveryStatus != "" {
-		fields = append(fields, "delivery_status="+row.DeliveryStatus)
+		fields = append(fields, "delivery="+row.DeliveryStatus)
 	}
-	if row.SubscriberType != "" || row.SubscriberID != "" {
-		fields = append(fields, "subscriber="+strings.Trim(row.SubscriberType+"/"+row.SubscriberID, "/"))
+	if subscriber := formatTraceSubscriber(row); subscriber != "-" {
+		fields = append(fields, "subscriber="+subscriber)
 	}
 	if row.SessionID != "" {
-		fields = append(fields, "session_id="+row.SessionID)
+		fields = append(fields, "session="+row.SessionID)
 	}
-	if row.TurnID != "" {
-		fields = append(fields, "turn_id="+row.TurnID)
+	if turn := firstNonEmpty(row.TurnID, row.TurnTriggerEventType); turn != "" {
+		fields = append(fields, "turn="+turn)
 	}
 	fmt.Fprintf(out, "trace %s\n", strings.Join(fields, " "))
 }

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -82,7 +82,7 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 		return 0
 	}
 
-	stdout := &notifyingBuffer{needle: "trace event_id=evt-local", notify: tracePrinted}
+	stdout := &notifyingBuffer{needle: "id=evt-local", notify: tracePrinted}
 	var stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repo, []string{"run", "start", "--event", "scan.requested", "--payload", payloadPath, "--config", configPath, "--backend", "claude_cli", "--contracts", "contracts", "--data", "reference-data", "--platform-spec", "platform.yaml"}, stdout, &stderr, opts)
 	if code != 0 {
@@ -98,7 +98,7 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 	assertRunCommandMethods(t, calls, []string{"health.check", "health.check", "run.start", "run.get"})
 	assertRunCommandTraceSubscription(t, wsRequests, "run-local", true)
-	for _, want := range []string{"run started: run_id=run-local", "trace event_id=evt-local", "run terminal: run_id=run-local status=completed"} {
+	for _, want := range []string{"run started: run_id=run-local", "id=evt-local", "run terminal: run_id=run-local status=completed"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -472,7 +472,7 @@ func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *te
 	})
 	defer server.Close()
 
-	stdout := &notifyingBuffer{needle: "trace event_id=evt-foreground", notify: tracePrinted}
+	stdout := &notifyingBuffer{needle: "id=evt-foreground", notify: tracePrinted}
 	var stderr bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -490,7 +490,7 @@ func TestRunCommandConnectedForegroundFollowsTraceAndExitsOnTerminalRunGet(t *te
 		}
 	}
 	assertRunCommandTraceSubscription(t, wsRequests, "run-foreground", true)
-	for _, want := range []string{"trace event_id=evt-foreground", "run terminal: run_id=run-foreground status=completed"} {
+	for _, want := range []string{"id=evt-foreground", "run terminal: run_id=run-foreground status=completed"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/apiv1/operator_observability_test.go
+++ b/internal/apiv1/operator_observability_test.go
@@ -80,8 +80,18 @@ func TestOperatorObservabilityHandlersExposePersistedReadMethods(t *testing.T) {
 	if observability.lastTrace.Since == nil || observability.lastTrace.Until == nil || observability.lastTrace.Limit != 1 {
 		t.Fatalf("run.trace options = %#v", observability.lastTrace)
 	}
+	if !observability.lastTrace.ExcludeRuntimeLogs {
+		t.Fatalf("run.trace ExcludeRuntimeLogs = false, want default true")
+	}
 	if got := observability.lastTrace.Filter; len(got.EventNames) != 1 || got.EventNames[0] != "scan.requested" || len(got.EntityIDs) != 1 || got.EntityIDs[0] != "entity-1" || len(got.DeliveryStatuses) != 1 || got.DeliveryStatuses[0] != "delivered" || len(got.SubscriberIDs) != 1 || got.SubscriberIDs[0] != "agent-1" || len(got.SubscriberTypes) != 1 || got.SubscriberTypes[0] != "agent" {
 		t.Fatalf("run.trace filter = %#v", got)
+	}
+	traceVerbose := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-verbose","method":"run.trace","params":{"run_id":"run-1","include_internal":true}}`)
+	if traceVerbose.Error != nil {
+		t.Fatalf("run.trace include_internal error = %#v", traceVerbose.Error)
+	}
+	if observability.lastTrace.ExcludeRuntimeLogs {
+		t.Fatalf("run.trace include_internal ExcludeRuntimeLogs = true, want false")
 	}
 
 	invalidTraceSince := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"trace-since","method":"run.trace","params":{"run_id":"run-1","since":"not-a-time"}}`)
@@ -288,6 +298,9 @@ func (s *fakeObservabilityReadStore) LoadRunDebugTracePage(_ context.Context, ru
 	}
 	rows := []store.RunDebugTraceRow{}
 	for _, row := range s.traceRows[runID] {
+		if opts.ExcludeRuntimeLogs && row.EventName == "platform.runtime_log" {
+			continue
+		}
 		if opts.Since != nil && !row.EventCreatedAt.After(opts.Since.UTC()) {
 			continue
 		}

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -1207,7 +1207,18 @@ func OperatorObservabilityHandlers(opts OperatorReadOptions) map[string]MethodHa
 			if err != nil {
 				return nil, err
 			}
-			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{Limit: limit, Cursor: cursor, Since: since, Until: until, Filter: filter})
+			includeInternal, err := optionalBoolParam(req.Params, "include_internal", false)
+			if err != nil {
+				return nil, err
+			}
+			rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{
+				Limit:              limit,
+				Cursor:             cursor,
+				Since:              since,
+				Until:              until,
+				Filter:             filter,
+				ExcludeRuntimeLogs: !includeInternal,
+			})
 			if errors.Is(err, store.ErrRunNotFound) {
 				return nil, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 			}

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -49,6 +49,25 @@ func assertObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T, fixture obs
 	if rows, _ := asMap(t, trace.Result)["trace"].([]any); len(rows) != 1 || asMap(t, rows[0])["event_id"] != fixture.eventID {
 		t.Fatalf("run.trace rows = %#v, want event %s", asMap(t, trace.Result)["trace"], fixture.eventID)
 	}
+	defaultTrace := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"trace-default","method":"run.trace","params":{"run_id":%q,"limit":10}}`, fixture.runID))
+	if defaultTrace.Error != nil {
+		t.Fatalf("run.trace default error = %#v", defaultTrace.Error)
+	}
+	defaultRows, _ := asMap(t, defaultTrace.Result)["trace"].([]any)
+	if !traceRowsContainEvent(t, defaultRows, "trace.visible") {
+		t.Fatalf("run.trace default rows = %#v, want business event", defaultRows)
+	}
+	if traceRowsContainEvent(t, defaultRows, "platform.runtime_log") {
+		t.Fatalf("run.trace default rows = %#v, want runtime logs hidden", defaultRows)
+	}
+	verboseTrace := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"trace-verbose","method":"run.trace","params":{"run_id":%q,"include_internal":true,"limit":10}}`, fixture.runID))
+	if verboseTrace.Error != nil {
+		t.Fatalf("run.trace include_internal error = %#v", verboseTrace.Error)
+	}
+	verboseRows, _ := asMap(t, verboseTrace.Result)["trace"].([]any)
+	if !traceRowsContainEvent(t, verboseRows, "trace.visible") || !traceRowsContainEvent(t, verboseRows, "platform.runtime_log") {
+		t.Fatalf("run.trace include_internal rows = %#v, want business and runtime_log", verboseRows)
+	}
 
 	logs := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"logs","method":"runtime.logs","params":{"run_id":%q,"component":"scheduler","level":"warn","limit":10}}`, fixture.runID))
 	if logs.Error != nil {
@@ -96,6 +115,20 @@ func assertObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T, fixture obs
 		"filter":       map[string]any{"event_name": []any{"trace.visible"}},
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}, "event_id", fixture.eventID)
+	assertObservabilitySubscriptionNoNotification(t, server.URL, "run.subscribe_trace", map[string]any{
+		"run_id":       fixture.runID,
+		"filter":       map[string]any{"event_name": []any{"platform.runtime_log"}},
+		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	})
+	verboseTraceNotification := assertObservabilitySubscriptionNotification(t, server.URL, "run.subscribe_trace", map[string]any{
+		"run_id":           fixture.runID,
+		"filter":           map[string]any{"event_name": []any{"platform.runtime_log"}},
+		"include_internal": true,
+		"replay_since":     fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, "event_name", "platform.runtime_log")
+	if got := verboseTraceNotification["event_name"]; got != "platform.runtime_log" {
+		t.Fatalf("run.subscribe_trace include_internal notification = %#v", verboseTraceNotification)
+	}
 	logNotification := assertObservabilitySubscriptionNotification(t, server.URL, "runtime.subscribe_logs", map[string]any{
 		"run_id":       fixture.runID,
 		"component":    "scheduler",
@@ -113,6 +146,16 @@ func assertObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T, fixture obs
 		"source":       "agent-1",
 		"replay_since": fixture.now.Add(-time.Minute).Format(time.RFC3339Nano),
 	})
+}
+
+func traceRowsContainEvent(t *testing.T, rows []any, eventName string) bool {
+	t.Helper()
+	for _, row := range rows {
+		if asMap(t, row)["event_name"] == eventName {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSQLiteRunTraceAPISurfacePaginatesAndUsesMaterializationWindow(t *testing.T) {

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -182,8 +182,12 @@ func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSess
 	if err != nil {
 		return subscriptionPlan{}, err
 	}
+	includeInternal, err := optionalBoolParam(req.Params, "include_internal", false)
+	if err != nil {
+		return subscriptionPlan{}, err
+	}
 	baseSince := subscriptionBaseSince(replaySince, r.now())
-	if _, _, err := reads.LoadRunDebugTracePage(session.ctx, runID, store.RunDebugTraceQueryOptions{Limit: 1, Since: baseSince, Filter: filter}); errors.Is(err, store.ErrRunNotFound) {
+	if _, _, err := reads.LoadRunDebugTracePage(session.ctx, runID, store.RunDebugTraceQueryOptions{Limit: 1, Since: baseSince, Filter: filter, ExcludeRuntimeLogs: !includeInternal}); errors.Is(err, store.ErrRunNotFound) {
 		return subscriptionPlan{}, NewApplicationError(RunNotFoundCode, false, map[string]any{"run_id": runID})
 	} else if errors.Is(err, store.ErrInvalidObservabilityCursor) {
 		return subscriptionPlan{}, NewInvalidParamsError(map[string]any{"field": "replay_since", "reason": "invalid run trace replay watermark"})
@@ -194,7 +198,7 @@ func (r *SubscriptionRuntime) prepareRunTraceSubscription(session *webSocketSess
 	return subscriptionPlan{
 		Result: subscriptionIDResult{SubscriptionID: id},
 		Start: func() {
-			go r.runTraceSubscription(ctx, session, id, reads, runID, baseSince, filter)
+			go r.runTraceSubscription(ctx, session, id, reads, runID, baseSince, filter, includeInternal)
 		},
 		Cancel: cancel,
 	}, nil
@@ -353,9 +357,9 @@ func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, sessio
 	return false
 }
 
-func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter) {
+func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter, includeInternal bool) {
 	seen := map[string]string{}
-	if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, seen) {
+	if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, includeInternal, seen) {
 		return
 	}
 	ticker := time.NewTicker(r.pollInterval)
@@ -365,21 +369,22 @@ func (r *SubscriptionRuntime) runTraceSubscription(ctx context.Context, session 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, seen) {
+			if !r.emitTraceNotifications(ctx, session, subscriptionID, reads, runID, since, filter, includeInternal, seen) {
 				return
 			}
 		}
 	}
 }
 
-func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter, seen map[string]string) bool {
+func (r *SubscriptionRuntime) emitTraceNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, runID string, since *time.Time, filter store.RunDebugTraceFilter, includeInternal bool, seen map[string]string) bool {
 	cursor := ""
 	for page := 0; page < subscriptionMaxPages; page++ {
 		rows, nextCursor, err := reads.LoadRunDebugTracePage(ctx, runID, store.RunDebugTraceQueryOptions{
-			Limit:  subscriptionBatchLimit,
-			Cursor: cursor,
-			Since:  since,
-			Filter: filter,
+			Limit:              subscriptionBatchLimit,
+			Cursor:             cursor,
+			Since:              since,
+			Filter:             filter,
+			ExcludeRuntimeLogs: !includeInternal,
 		})
 		if err != nil {
 			session.close()

--- a/internal/apiv1/subscriptions_test.go
+++ b/internal/apiv1/subscriptions_test.go
@@ -393,8 +393,32 @@ func TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound(t *testi
 	if observability.lastTrace.Since == nil || !observability.lastTrace.Since.Equal(base) {
 		t.Fatalf("run.subscribe_trace since = %#v, want %s", observability.lastTrace.Since, base)
 	}
+	if !observability.lastTrace.ExcludeRuntimeLogs {
+		t.Fatalf("run.subscribe_trace ExcludeRuntimeLogs = false, want default true")
+	}
 	if got := observability.lastTrace.Filter; len(got.EventNames) != 1 || got.EventNames[0] != "scan.requested" || len(got.EntityIDs) != 1 || got.EntityIDs[0] != "entity-1" || len(got.DeliveryStatuses) != 1 || got.DeliveryStatuses[0] != "delivered" || len(got.SubscriberIDs) != 1 || got.SubscriberIDs[0] != "agent-1" || len(got.SubscriberTypes) != 1 || got.SubscriberTypes[0] != "agent" {
 		t.Fatalf("run.subscribe_trace filter = %#v", got)
+	}
+
+	verboseConn := dialTestWS(t, server.URL)
+	defer verboseConn.Close()
+	writeWSRequest(t, verboseConn, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-trace-verbose",
+		"method":  "run.subscribe_trace",
+		"params": map[string]any{
+			"run_id":           "run-1",
+			"include_internal": true,
+			"replay_since":     base.Format(time.RFC3339Nano),
+		},
+	})
+	verboseSubscribe := readWSResponse(t, verboseConn)
+	if verboseSubscribe.Error != nil {
+		t.Fatalf("run.subscribe_trace include_internal error = %#v", verboseSubscribe.Error)
+	}
+	_ = readWSNotification(t, verboseConn)
+	if observability.lastTrace.ExcludeRuntimeLogs {
+		t.Fatalf("run.subscribe_trace include_internal ExcludeRuntimeLogs = true, want false")
 	}
 }
 
@@ -415,6 +439,7 @@ func TestRunSubscribeTraceFilterValidation(t *testing.T) {
 	}{
 		{name: "unknown top-level limit", params: map[string]any{"run_id": "run-1", "limit": 1}, wantField: "limit"},
 		{name: "unknown top-level until", params: map[string]any{"run_id": "run-1", "until": "2026-05-13T10:05:00Z"}, wantField: "until"},
+		{name: "invalid include internal", params: map[string]any{"run_id": "run-1", "include_internal": "yes"}, wantField: "include_internal"},
 		{name: "unknown filter field", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"event_nmae": []any{"scan.requested"}}}, wantField: "filter.event_nmae"},
 		{name: "invalid delivery status", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"delivery_status": []any{"done"}}}, wantField: "filter.delivery_status"},
 		{name: "invalid subscriber type", params: map[string]any{"run_id": "run-1", "filter": map[string]any{"subscriber_type": []any{"system"}}}, wantField: "filter.subscriber_type"},

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -693,6 +693,43 @@ func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	}
 }
 
+func TestRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
+	ctx := context.Background()
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+
+	runID := uuid.NewString()
+	businessEvent := uuid.NewString()
+	runtimeLogEvent := uuid.NewString()
+	base := time.Unix(1700000600, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id, run_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			($1::uuid, $3::uuid, 'item.received', 'global', '{}'::jsonb, 'runtime', 'platform', $4),
+			($2::uuid, $3::uuid, 'platform.runtime_log', 'global', '{}'::jsonb, 'runtime', 'platform', $5)
+	`, businessEvent, runtimeLogEvent, runID, base, base.Add(time.Millisecond)); err != nil {
+		t.Fatalf("seed trace rows: %v", err)
+	}
+
+	allRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage all: %v", err)
+	}
+	if got := traceEventIDs(allRows); !sameStrings(got, []string{businessEvent, runtimeLogEvent}) {
+		t.Fatalf("all trace rows = %#v, want business and runtime_log", got)
+	}
+	filteredRows, _, err := pg.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, ExcludeRuntimeLogs: true})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage filtered: %v", err)
+	}
+	if got := traceEventIDs(filteredRows); !sameStrings(got, []string{businessEvent}) {
+		t.Fatalf("filtered trace rows = %#v, want business row only", got)
+	}
+}
+
 func TestRunDebugTracePageTypedFilters(t *testing.T) {
 	ctx := context.Background()
 	_, db, _ := testutil.StartPostgres(t)

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -158,11 +158,12 @@ type RunDebugReport struct {
 }
 
 type RunDebugTraceQueryOptions struct {
-	Limit  int
-	Cursor string
-	Since  *time.Time
-	Until  *time.Time
-	Filter RunDebugTraceFilter
+	Limit              int
+	Cursor             string
+	Since              *time.Time
+	Until              *time.Time
+	Filter             RunDebugTraceFilter
+	ExcludeRuntimeLogs bool
 }
 
 type RunDebugTraceFilter struct {
@@ -925,6 +926,10 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 	addTextArrayFilter(opts.Filter.DeliveryStatuses, "d.status")
 	addTextArrayFilter(opts.Filter.SubscriberIDs, "d.subscriber_id")
 	addTextArrayFilter(opts.Filter.SubscriberTypes, "d.subscriber_type")
+	if opts.ExcludeRuntimeLogs {
+		filterWhere += `
+			  AND e.event_name <> 'platform.runtime_log'`
+	}
 	args = append(args, opts.Limit+1)
 	limitArg := len(args)
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`

--- a/internal/store/sqlite_run_trace_parity_test.go
+++ b/internal/store/sqlite_run_trace_parity_test.go
@@ -128,6 +128,42 @@ func TestSQLiteRunDebugTracePageDeterministicDeliveryAndTurnTiePaging(t *testing
 	}
 }
 
+func TestSQLiteRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
+	ctx := context.Background()
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+
+	runID := "00000000-0000-0000-0000-000000001816"
+	businessEvent := "00000000-0000-0000-0000-000000001817"
+	runtimeLogEvent := "00000000-0000-0000-0000-000000001818"
+	base := time.Unix(1700000600, 0).UTC()
+	if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, base); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := sqliteStore.DB.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES
+			(?, ?, 'item.received', NULL, 'global', '{}', 'runtime', 'platform', ?),
+			(?, ?, 'platform.runtime_log', NULL, 'global', '{}', 'runtime', 'platform', ?)
+	`, runID, businessEvent, base, runID, runtimeLogEvent, base.Add(time.Millisecond)); err != nil {
+		t.Fatalf("seed trace rows: %v", err)
+	}
+
+	allRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage all: %v", err)
+	}
+	if got := traceEventIDs(allRows); !sameStrings(got, []string{businessEvent, runtimeLogEvent}) {
+		t.Fatalf("all trace rows = %#v, want business and runtime_log", got)
+	}
+	filteredRows, _, err := sqliteStore.LoadRunDebugTracePage(ctx, runID, RunDebugTraceQueryOptions{Limit: 10, ExcludeRuntimeLogs: true})
+	if err != nil {
+		t.Fatalf("LoadRunDebugTracePage filtered: %v", err)
+	}
+	if got := traceEventIDs(filteredRows); !sameStrings(got, []string{businessEvent}) {
+		t.Fatalf("filtered trace rows = %#v, want business row only", got)
+	}
+}
+
 func TestSQLiteRunDebugTracePageIncludesTaskAuditSessionsInWatermark(t *testing.T) {
 	ctx := context.Background()
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)

--- a/internal/store/sqlite_runtime_observability.go
+++ b/internal/store/sqlite_runtime_observability.go
@@ -85,6 +85,9 @@ func (s *SQLiteRuntimeStore) LoadRunDebugTracePage(ctx context.Context, runID st
 	appendIn("COALESCE(d.status, '')", opts.Filter.DeliveryStatuses)
 	appendIn("COALESCE(d.subscriber_id, '')", opts.Filter.SubscriberIDs)
 	appendIn("COALESCE(d.subscriber_type, '')", opts.Filter.SubscriberTypes)
+	if opts.ExcludeRuntimeLogs {
+		where = append(where, "e.event_name <> 'platform.runtime_log'")
+	}
 	args = append(args, opts.Limit+1)
 	rows, err := s.DB.QueryContext(ctx, `
 		WITH trace_sessions AS (

--- a/openrpc.json
+++ b/openrpc.json
@@ -6893,6 +6893,15 @@
           }
         },
         {
+          "name": "include_internal",
+          "required": false,
+          "description": "Optional trace visibility control. Defaults to false. When omitted or false, run.subscribe_trace excludes `platform.runtime_log` rows; when true, those internal runtime-log trace rows are included in notifications.",
+          "schema": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        {
           "name": "replay_since",
           "required": false,
           "description": "Optional catch-up window. If present, delivers trace rows from this time forward, then continues live. Subject to runtime trace retention.",
@@ -7002,6 +7011,15 @@
           "description": "Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.",
           "schema": {
             "$ref": "#/components/schemas/RunTraceFilter"
+          }
+        },
+        {
+          "name": "include_internal",
+          "required": false,
+          "description": "Optional trace visibility control. Defaults to false. When omitted or false, run.trace excludes `platform.runtime_log` rows; when true, those internal runtime-log trace rows are included.",
+          "schema": {
+            "default": false,
+            "type": "boolean"
           }
         }
       ],

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -14370,9 +14370,12 @@ cli_specification:
           `-f` shorthand is promoted in the trace command row as a CLI-only alias for `--follow`. Typed
           RunTraceFilter fields for event-name, subscriber identity, entity-id, and delivery-status are promoted on
           `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace` and consumed by `swarm run trace` snapshot and follow
-          modes. Snapshot `until` is promoted on `/v1/rpc run.trace` only as an inclusive upper bound. Review-artifact
-          `--include-payload`, shared `swarm run start` recovery, and multi-run `--all` remain explicitly unpromoted split
-          tails until later gated children promote their own canonical owners.
+          modes. Snapshot `until` is promoted on `/v1/rpc run.trace` only as an inclusive upper bound. `include_internal`
+          is promoted on both trace APIs by #1816 as the API-owned visibility control for `platform.runtime_log` trace
+          rows: omitted/false excludes those rows, true includes them. CLI `swarm run trace --verbose` is the user-facing
+          consumer of that API parameter. Review-artifact `--include-payload`, shared `swarm run start` recovery, and
+          multi-run `--all` remain explicitly unpromoted split tails until later gated children promote their own
+          canonical owners.
       mailbox_decision_sheet_and_result_ux:
         disposition: promoted_first_slice
         tracker: '#856'
@@ -17212,7 +17215,7 @@ cli_specification:
       defaulting: If run-id is omitted, resolve the target through run.list with active-run preference.
       behavior: Run-scoped operational status projection. This is the v2 replacement for `swarm investigate run`.
     trace:
-      command: swarm run trace [<run-id>] [--delivery-detail|--delivery-summary] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
+      command: swarm run trace [<run-id>] [--verbose] [--delivery-detail|--delivery-summary] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       group: run_operate
       tier: must_have
       implementation_status: implemented
@@ -17230,6 +17233,7 @@ cli_specification:
         - since
         - until
         - filter
+        - include_internal
         filter_schema: RunTraceFilter
         filter_fields:
           event_name: Repeatable event-name predicate. The CLI sends an array of non-empty names as `filter.event_name` and the server matches any value against RunTraceRow.event_name.
@@ -17254,6 +17258,9 @@ cli_specification:
           `/v1/rpc run.trace`. Follow `swarm run trace --follow` / `swarm run trace -f` consumes the same typed filter flags
           by sending `filter` to `/v1/ws run.subscribe_trace`; fixed-window snapshot controls `--since`, `--until`,
           `--limit`, and `--cursor` remain invalid with follow and must fail before any API or WebSocket request.
+          By default, both `run.trace` and `run.subscribe_trace` exclude `platform.runtime_log` trace rows. The CLI
+          `--verbose` flag sends `include_internal=true` to the selected trace API and reveals those rows. The CLI
+          MUST NOT hide or reveal runtime-log trace rows by client-side filtering.
           Snapshot `--delivery-detail` is a CLI-only rendering modifier over the same `/v1/rpc run.trace` response:
           it renders delivery identity, subscriber identity, delivery status/reason, delivery lifecycle timestamps, and
           queue/execution durations derived only from same-row RunTraceRow timestamps. `--delivery-detail` is invalid
@@ -17267,8 +17274,9 @@ cli_specification:
           is invalid with `--follow` and is mutually exclusive with `--delivery-detail`.
         proof_expectations:
         - exact /v1/rpc run.trace params for explicit run ids and omitted-run resolution through run.list
+        - default trace requests omit include_internal or send false and the API excludes platform.runtime_log; --verbose sends include_internal=true and reveals platform.runtime_log through the API owner
         - repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and compose with since/until/limit/cursor
-        - follow-mode repeatable filter flags serialize as RunTraceFilter arrays under the single `filter` param and are preserved across recovery requests
+        - follow-mode repeatable filter flags and include_internal serialize under the same run.subscribe_trace params and are preserved across recovery requests
         - invalid --since, invalid --until, since-after-until, out-of-range --limit, blank --cursor, blank/invalid typed filters, and fixed-window snapshot controls combined with --follow fail before API/WS calls
         - --delivery-detail renders only existing RunTraceRow delivery lifecycle facts and rejects --follow before API/WS calls
         - --delivery-summary exhausts /v1/rpc run.trace pagination across returned next_cursor values, captures and reuses a fixed until bound when the caller omits --until, treats --limit as page size rather than a total cap, rejects --follow and --delivery-detail before API/WS calls, fails closed on repeated/non-advancing cursors or malformed delivery rows, and renders only aggregate facts derived from existing RunTraceRow delivery fields
@@ -23566,6 +23574,12 @@ api_specification:
         description: Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
         schema:
           $ref: '#/components/schemas/RunTraceFilter'
+      - name: include_internal
+        required: false
+        description: Optional trace visibility control. Defaults to false. When omitted or false, run.trace excludes `platform.runtime_log` rows; when true, those internal runtime-log trace rows are included.
+        schema:
+          type: boolean
+          default: false
       result:
         name: result
         required: true
@@ -23627,6 +23641,12 @@ api_specification:
         description: Typed predicates over canonical RunTraceRow facts. Present fields are OR-lists within the field and AND-composed across fields.
         schema:
           $ref: '#/components/schemas/RunTraceFilter'
+      - name: include_internal
+        required: false
+        description: Optional trace visibility control. Defaults to false. When omitted or false, run.subscribe_trace excludes `platform.runtime_log` rows; when true, those internal runtime-log trace rows are included in notifications.
+        schema:
+          type: boolean
+          default: false
       - name: replay_since
         required: false
         description: Optional catch-up window. If present, delivers trace rows from this time forward, then continues live.


### PR DESCRIPTION
## Summary

- Promote `include_internal` on `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace`; default API behavior now excludes `platform.runtime_log`, and `include_internal=true` reveals those rows.
- Add `swarm run trace --verbose` and map it to the API-owned visibility flag for snapshot, follow, and delivery-summary pagination.
- Render default trace snapshots with relative row times, absolute start time, full IDs, and conditional session/turn columns; update shared follow row rendering used by `swarm run trace --follow` and foreground `swarm run start`.
- Regenerate `openrpc.json` from `platform-spec.yaml`.

Closes #1816
Part of #1712

## Governing Refs / Context

- `platform-spec.yaml#operator_observability_model.flight_recorder.joined_trace_surface`
- `platform-spec.yaml#cli_specification.command_catalog.trace`
- `platform-spec.yaml#api_specification.method_catalog.run.trace`
- `platform-spec.yaml#api_specification.method_catalog.run.subscribe_trace`
- `platform-spec.yaml#cli_specification.foundations.output_contract`
- #1816 lead ruling and approved Pre-Implementation Coverage Audit

## Semantic Migration

- New canonical owner for runtime-log trace visibility: `/v1/rpc run.trace` and `/v1/ws run.subscribe_trace` through `include_internal`.
- Store owner remains `store.RunDebugTraceRow` plus Postgres/SQLite `LoadRunDebugTracePage`; it gains `ExcludeRuntimeLogs` as an explicit option consumed by the API owners.
- Old invalid path: CLI-side runtime-log filtering as the semantic owner. The CLI now only sends `include_internal=true` for `--verbose` and renders the API-owned result.
- Production paths checked for surviving old behavior: RPC snapshot, WS subscription/follow, CLI snapshot, CLI follow, delivery-summary pagination, and shared `swarm run start` foreground trace row writer. Dashboard/builder direct-store seams were not moved and are different/split contexts under the approved gate.
- Migration completeness: complete for the chosen `run_trace_api_owned_fidelity` class; broader #1712/#1821/#1815/#1564/#1819 tails remain open.

## Tests

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/store -run 'TestRunDebugTracePageExcludeRuntimeLogs|TestSQLiteRunDebugTracePageExcludeRuntimeLogs|TestRunDebugTracePageCursorAndRunNotFound|TestSQLiteRunDebugTracePagePaginationWindowAndFilterParity' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/apiv1 -run 'TestOperatorObservabilityHandlersExposePersistedReadMethods|TestHandlerWebSocketRunSubscribeTraceUsesOwnerReplayAndRunNotFound|TestRunSubscribeTraceFilterValidation|Test(SQLite|Postgres)ObservabilityOwnerBacksSupportedAPISurfaces|TestOpenRPC' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run 'TestTrace|TestRunStart(Foreground|StartsLocalServe)|TestDiagnosticsRequireAPITokenBeforeRequest|TestRunServeRuntimeEventPublishRunIDFollowUpServedPath(DefaultSQLite|Postgres)' -count=1`
- `go test ./internal/apispec -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`