### PR TITLE
[agent-e][issue #1913] Rehome output registry split owners

### DIFF
--- a/cmd/swarm/cli_output_conformance_registry_test.go
+++ b/cmd/swarm/cli_output_conformance_registry_test.go
@@ -450,11 +450,16 @@ func TestCLIOutputConformanceMigratedDisplayWritersConsumeSharedRenderer(t *test
 	}
 }
 
-func TestCLIOutputConformanceNoStaleTableRendererSplitRows(t *testing.T) {
+func TestCLIOutputConformanceNoStaleActiveSplitOwners(t *testing.T) {
+	staleOwners := map[string]string{
+		"#1814": "display renderer migration is complete",
+		"#1816": "run trace fidelity migration is complete",
+		"#1821": "registry-ratchet parent must be closeable after active rows move to #1913",
+	}
 	rows := cliOutputConformanceRegistryRows(t)
 	for command, row := range rows {
-		if row.OwnerIssue == "#1814" {
-			t.Errorf("%s: command %q still points at #1814 after display renderer migration; split rows need a remaining non-stale owner", row.Key, command)
+		if reason, ok := staleOwners[row.OwnerIssue]; ok {
+			t.Errorf("%s: command %q still points at stale split owner %s (%s); split rows need a live active owner", row.Key, command, row.OwnerIssue, reason)
 		}
 	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -15211,8 +15211,8 @@ cli_specification:
             secrets_list:
               command: swarm secrets list
               classification: split
-              owner_issue: '#1821'
-              reason: secret list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: secret list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             secrets_check:
               command: swarm secrets check
               classification: split
@@ -15240,8 +15240,8 @@ cli_specification:
             connections_status:
               command: swarm connections status
               classification: split
-              owner_issue: '#1821'
-              reason: connection status table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: connection status table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             connections_disconnect:
               command: swarm connections disconnect
               classification: split
@@ -15294,8 +15294,8 @@ cli_specification:
             trace:
               command: swarm run trace
               classification: split
-              owner_issue: '#1816'
-              reason: trace tables consume the shared display renderer; trace fidelity/follow behavior remains on the dedicated trace owner before full shared-output classification.
+              owner_issue: '#1913'
+              reason: trace fidelity and display rendering have landed, but trace does not yet consume the full shared output-mode owner for successful output.
             run_fork:
               command: swarm run fork
               classification: shared_output
@@ -15370,8 +15370,8 @@ cli_specification:
             agents_list:
               command: swarm agent list
               classification: split
-              owner_issue: '#1821'
-              reason: agent list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: agent list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             agent_view:
               command: swarm agent view
               classification: split
@@ -15414,8 +15414,8 @@ cli_specification:
             events_list:
               command: swarm event list
               classification: split
-              owner_issue: '#1821'
-              reason: event list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: event list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             events_follow:
               command: swarm event follow
               classification: split
@@ -15424,8 +15424,8 @@ cli_specification:
             event_view:
               command: swarm event view
               classification: split
-              owner_issue: '#1821'
-              reason: event detail shell consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: event detail shell consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             event_replay:
               command: swarm event replay
               classification: split
@@ -15551,18 +15551,18 @@ cli_specification:
             entities_list:
               command: swarm entity list
               classification: split
-              owner_issue: '#1821'
-              reason: entity list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: entity list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             entity_view:
               command: swarm entity view
               classification: split
-              owner_issue: '#1821'
-              reason: entity detail shell consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: entity detail shell consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             entity_aggregate:
               command: swarm entity aggregate
               classification: split
-              owner_issue: '#1821'
-              reason: entity aggregate table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: entity aggregate table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             logs:
               command: swarm logs
               classification: split
@@ -15571,8 +15571,8 @@ cli_specification:
             incidents:
               command: swarm incidents
               classification: split
-              owner_issue: '#1821'
-              reason: incident table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: incident table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             context:
               command: swarm context
               classification: exception
@@ -15585,8 +15585,8 @@ cli_specification:
             context_list:
               command: swarm context list
               classification: split
-              owner_issue: '#1821'
-              reason: context list table/default text consumes the shared display renderer; full shared output-mode route-through remains pending.
+              owner_issue: '#1913'
+              reason: context list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
             context_prune:
               command: swarm context prune
               classification: split


### PR DESCRIPTION
## Summary

- Rehome the remaining active `output_conformance_registry` split rows from stale/close-target owners `#1821` and closed `#1816` to live owner `#1913`.
- Update the run trace registry reason so it no longer claims trace fidelity remains on closed #1816.
- Extend the CLI output conformance stale-owner guard from the completed #1814 table-renderer owner to all known stale active split owners for this class: #1814, #1816, and #1821.

Part of #1913
Part of #1821
Part of #1712

## Governing refs / context

- `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry`
- `cmd/swarm/cli_output_conformance_registry_test.go`
- #1913 Pre-Implementation Coverage Audit and independent gate outcome: approved as first slice
- #1821 lead ruling: registry-bound ratchet guard; split rows cite live owners; no output byte changes
- PR #1889: introduced the output conformance registry
- PR #1904 / #1814: completed shared display renderer and established stale-owner guard pattern
- PR #1909 / #1816: completed run trace fidelity; #1816 must not remain an active split owner

## Semantic migration accounting

- Canonical owner retained: `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry`.
- Active residual owner after this PR: #1913 for rows that remain `split` pending full shared output-mode route-through.
- Old active owner paths now invalid: `owner_issue: '#1821'` and `owner_issue: '#1816'` in active registry split rows.
- Production paths checked for surviving old behavior: no production command code changed; this is spec/test registry hygiene only.
- Migration completeness: complete for `cli.output_registry_stale_split_owner_refs`; #1913 intentionally remains open while active rows cite it. #1821 can be closed after this PR merges if no registry rows point at it.

## Verification

- `rg -n "owner_issue: '#(1821|1816)'" platform-spec.yaml` returned no matches
- `rg -n "owner_issue: '#1913'" platform-spec.yaml` returned the expected 11 active split rows
- `go test ./cmd/swarm -run 'TestCLIOutputConformance' -count=1`
- `go test ./internal/apispec -run 'TestCLIOutputConformanceRegistryPromotedAsCurrentStateOwner' -count=1`
- `go test ./cmd/swarm ./internal/apispec -run 'TestCLIOutputConformance|TestCLIOutputConformanceRegistryPromotedAsCurrentStateOwner' -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- `git diff --check`

## Notes

No user-visible output bytes should change in this PR. The changed files are only `platform-spec.yaml` and the registry conformance test.