### PR TITLE
[agent-f][issue #1912] GitHub App issue workflow breadth

### DIFF
--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -4502,6 +4502,7 @@ func runServedMailboxApproveDecisionLifecycleProof(t *testing.T, rt servedContro
 	requireServedMailboxRawTerminalState(t, rt.DB, rt.Backend, fixture.ApproveID, "approved")
 	requireServedMailboxDetailState(t, rt.Endpoint, fixture.ApproveID, "decided", "approved", "approved")
 	requireServedMailboxTerminalEvent(t, rt.DB, rt.Backend, fixture, approved.DownstreamEventID, fixture.ApproveID, "approved", "", map[string]any{"approved": true})
+	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, approved.DownstreamEventID, "platform", "pipeline", "success", 1)
 	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.approve", approveKey, 1)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.ApproveID, 1)
 	approveReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.approve", map[string]any{
@@ -4536,6 +4537,7 @@ func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControl
 	requireServedMailboxRawTerminalState(t, rt.DB, rt.Backend, fixture.RejectID, "rejected")
 	requireServedMailboxDetailState(t, rt.Endpoint, fixture.RejectID, "decided", "rejected", "rejected")
 	requireServedMailboxTerminalEvent(t, rt.DB, rt.Backend, fixture, rejected.DownstreamEventID, fixture.RejectID, "rejected", "not enough evidence", nil)
+	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, rejected.DownstreamEventID, "platform", "pipeline", "success", 1)
 	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.reject", rejectKey, 1)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
 	rejectReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.reject", map[string]any{
@@ -4563,6 +4565,7 @@ func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlP
 	requireServedMailboxRawDeferredState(t, rt.DB, rt.Backend, fixture)
 	requireServedMailboxDetailState(t, rt.Endpoint, fixture.DeferID, "deferred", "", "deferred")
 	requireServedMailboxDeferredEvent(t, rt.DB, rt.Backend, fixture, deferred.DownstreamEventID)
+	waitServedEventPublishReceiptOutcomeCount(t, rt.DB, rt.Backend, deferred.DownstreamEventID, "platform", "pipeline", "success", 1)
 	requireServedControlAPIIdempotencyRows(t, rt.DB, rt.Backend, "mailbox.defer", deferKey, 1)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
 	deferReplay := requireServedMailboxDecisionResult(t, rt.Endpoint, "mailbox.defer", map[string]any{

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -39,6 +39,7 @@ import (
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -4519,7 +4520,9 @@ func runServedMailboxApproveDecisionLifecycleProof(t *testing.T, rt servedContro
 	if already.Data["code"] != apiv1.MailboxAlreadyDecidedCode {
 		t.Fatalf("%s mailbox.reject already-decided data = %#v, want %s", rt.Backend, already.Data, apiv1.MailboxAlreadyDecidedCode)
 	}
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle))
+	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxApproveDecisionLifecycle), func() string {
+		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
+	})
 }
 
 func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4547,7 +4550,9 @@ func runServedMailboxRejectDecisionLifecycleProof(t *testing.T, rt servedControl
 	})
 	requireServedMailboxReplay(t, rejectReplay, rejected)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_decided", fixture.RejectID, 1)
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle))
+	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle), func() string {
+		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
+	})
 }
 
 func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4575,7 +4580,9 @@ func runServedMailboxDeferDecisionLifecycleProof(t *testing.T, rt servedControlP
 	})
 	requireServedMailboxReplay(t, deferReplay, deferred)
 	requireServedMailboxEventCount(t, rt.DB, rt.Backend, "mailbox.item_deferred", fixture.DeferID, 1)
-	requireServedParitySettlementPostconditions(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle))
+	requireServedParitySettlementPostconditionsWithDebug(t, rt.Endpoint, fixture.RunID, servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle), func() string {
+		return servedEventPublishDebugSummary(t, rt.DB, rt.Backend, fixture.RunID)
+	})
 }
 
 func runServedTestSetupEntitiesLifecycleProof(t *testing.T, rt servedControlProofRuntime) {
@@ -4768,19 +4775,9 @@ func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) 
 		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, fixture.RunID, now); err != nil {
 			t.Fatalf("seed postgres mailbox proof run: %v", err)
 		}
-		if _, err := db.ExecContext(ctx, `
-			INSERT INTO events (
-				event_id, run_id, event_name, entity_id, flow_instance, scope,
-				payload, produced_by, produced_by_type, created_at
-			) VALUES (
-				$1::uuid, $2::uuid, 'review.requested', $3::uuid, $4, 'entity',
-				'{"request":true}'::jsonb, 'operator', 'external', $5
-			)
-		`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
+		pgStore := &store.PostgresStore{DB: db}
+		if err := seedServedMailboxDecisionSourceEvent(ctx, pgStore, fixture, now); err != nil {
 			t.Fatalf("seed postgres mailbox proof source event: %v", err)
-		}
-		if err := (&store.PostgresStore{DB: db}).UpsertPipelineReceipt(ctx, fixture.SourceEventID, "processed", ""); err != nil {
-			t.Fatalf("seed postgres mailbox proof source event pipeline receipt: %v", err)
 		}
 		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
@@ -4789,20 +4786,9 @@ func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) 
 		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, fixture.RunID, now); err != nil {
 			t.Fatalf("seed sqlite mailbox proof run: %v", err)
 		}
-		if _, err := db.ExecContext(ctx, `
-			INSERT INTO events (
-				event_id, run_id, event_name, entity_id, flow_instance, scope,
-				payload, produced_by, produced_by_type, created_at
-			) VALUES (
-				?, ?, 'review.requested', ?, ?, 'entity',
-				'{"request":true}', 'operator', 'external', ?
-			)
-		`, fixture.SourceEventID, fixture.RunID, fixture.EntityID, fixture.SourceFlow, now); err != nil {
-			t.Fatalf("seed sqlite mailbox proof source event: %v", err)
-		}
 		sqliteStore := &store.SQLiteRuntimeStore{SQLiteSchemaStore: &store.SQLiteSchemaStore{DB: db}}
-		if err := sqliteStore.UpsertPipelineReceipt(ctx, fixture.SourceEventID, "processed", ""); err != nil {
-			t.Fatalf("seed sqlite mailbox proof source event pipeline receipt: %v", err)
+		if err := seedServedMailboxDecisionSourceEvent(ctx, sqliteStore, fixture, now); err != nil {
+			t.Fatalf("seed sqlite mailbox proof source event: %v", err)
 		}
 		seedServedMailboxDecisionItem(t, db, backend, fixture.ApproveID, fixture, "review_request", "approve item", `{"title":"approve item"}`, nil)
 		seedServedMailboxDecisionItem(t, db, backend, fixture.RejectID, fixture, "approval", "reject item", `{"title":"reject item"}`, nil)
@@ -4811,6 +4797,31 @@ func seedServedMailboxDecisionFixture(t *testing.T, db *sql.DB, backend string) 
 		t.Fatalf("unknown mailbox proof backend %q", backend)
 	}
 	return fixture
+}
+
+func seedServedMailboxDecisionSourceEvent(ctx context.Context, store runtimebus.EventMutationRunner, fixture servedMailboxDecisionFixture, createdAt time.Time) error {
+	envelope := events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, fixture.EntityID), fixture.SourceFlow)
+	evt := eventtest.PersistedProjection(
+		fixture.SourceEventID,
+		events.EventType("review.requested"),
+		"operator",
+		"",
+		json.RawMessage(`{"request":true}`),
+		0,
+		fixture.RunID,
+		"",
+		envelope,
+		createdAt,
+	)
+	return store.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		if err := mutation.AppendEvent(ctx, evt); err != nil {
+			return err
+		}
+		if err := mutation.UpsertCommittedReplayScope(ctx, fixture.SourceEventID, runtimereplayclaim.CommittedReplayScopeSubscribed); err != nil {
+			return err
+		}
+		return mutation.UpsertPipelineReceipt(ctx, fixture.SourceEventID, "processed", "")
+	})
 }
 
 func seedServedMailboxDecisionItem(t *testing.T, db *sql.DB, backend, mailboxID string, fixture servedMailboxDecisionFixture, itemType, summary, payload string, expiresAt *time.Time) {
@@ -5379,6 +5390,11 @@ func runServedDynamicAutoEmitProof(t *testing.T, endpoint string, db *sql.DB, ba
 
 func requireServedParitySettlementPostconditions(t *testing.T, endpoint, runID string, scenario servedparity.Scenario) {
 	t.Helper()
+	requireServedParitySettlementPostconditionsWithDebug(t, endpoint, runID, scenario, nil)
+}
+
+func requireServedParitySettlementPostconditionsWithDebug(t *testing.T, endpoint, runID string, scenario servedparity.Scenario, debug func() string) {
+	t.Helper()
 	var last diagnosticRunDiagnosisResult
 	deadline := time.Now().Add(servedProofPollDeadline)
 	for time.Now().Before(deadline) {
@@ -5399,7 +5415,11 @@ func requireServedParitySettlementPostconditions(t *testing.T, endpoint, runID s
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("served parity scenario %s settlement did not quiesce for run %s: ready=%v active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d",
+	extra := ""
+	if debug != nil {
+		extra = "\n" + debug()
+	}
+	t.Fatalf("served parity scenario %s settlement did not quiesce for run %s: ready=%v active_deliveries=%d unsettled_pipeline_events=%d due_timers=%d active_session_leases=%d%s",
 		scenario.ID,
 		runID,
 		boolPointerValue(last.TestQuiescence.Ready),
@@ -5407,6 +5427,7 @@ func requireServedParitySettlementPostconditions(t *testing.T, endpoint, runID s
 		intPointerValue(last.TestQuiescence.UnsettledPipelineEvents),
 		intPointerValue(last.TestQuiescence.DueTimers),
 		intPointerValue(last.TestQuiescence.ActiveSessionLeases),
+		extra,
 	)
 }
 

--- a/internal/packs/envelope.go
+++ b/internal/packs/envelope.go
@@ -57,7 +57,7 @@ type CanCapabilities struct {
 	VerifySecret            string   `yaml:"verify_secret,omitempty" json:"verify_secret,omitempty"`
 	EmitEvents              []string `yaml:"emit_events,omitempty" json:"emit_events,omitempty"`
 	PersistDedupeMarkers    bool     `yaml:"persist_dedupe_markers,omitempty" json:"persist_dedupe_markers,omitempty"`
-	CallProviderAction      string   `yaml:"call_provider_action,omitempty" json:"call_provider_action,omitempty"`
+	CallProviderActions     []string `yaml:"call_provider_actions,omitempty" json:"call_provider_actions,omitempty"`
 	LowerThroughActivity    bool     `yaml:"lower_through_activity,omitempty" json:"lower_through_activity,omitempty"`
 	JournalActivityAttempts bool     `yaml:"journal_activity_attempts,omitempty" json:"journal_activity_attempts,omitempty"`
 }
@@ -221,7 +221,7 @@ func (c Capabilities) validateTrigger(packID string) error {
 	if strings.TrimSpace(c.Can.ReceiveHTTPSRoute) == "" {
 		return fmt.Errorf("pack %q capabilities.can.receive_https_route is required", packID)
 	}
-	if strings.TrimSpace(c.Can.CallProviderAction) != "" || c.Can.LowerThroughActivity || c.Can.JournalActivityAttempts {
+	if len(c.Can.CallProviderActions) > 0 || c.Can.LowerThroughActivity || c.Can.JournalActivityAttempts {
 		return fmt.Errorf("pack %q trigger capabilities must not declare connector capability fields", packID)
 	}
 	if len(c.Can.EmitEvents) == 0 {
@@ -247,8 +247,19 @@ func (c Capabilities) validateTrigger(packID string) error {
 }
 
 func (c Capabilities) validateConnector(packID string) error {
-	if strings.TrimSpace(c.Can.CallProviderAction) == "" {
-		return fmt.Errorf("pack %q capabilities.can.call_provider_action is required", packID)
+	if len(c.Can.CallProviderActions) == 0 {
+		return fmt.Errorf("pack %q capabilities.can.call_provider_actions is required", packID)
+	}
+	seenActions := map[string]struct{}{}
+	for _, action := range c.Can.CallProviderActions {
+		action = strings.TrimSpace(action)
+		if action == "" {
+			return fmt.Errorf("pack %q capabilities.can.call_provider_actions must not contain empty entries", packID)
+		}
+		if _, exists := seenActions[action]; exists {
+			return fmt.Errorf("pack %q capabilities.can.call_provider_actions contains duplicate %q", packID, action)
+		}
+		seenActions[action] = struct{}{}
 	}
 	if strings.TrimSpace(c.Can.ReceiveHTTPSRoute) != "" || strings.TrimSpace(c.Can.VerifySecret) != "" || len(c.Can.EmitEvents) > 0 || c.Can.PersistDedupeMarkers {
 		return fmt.Errorf("pack %q connector capabilities must not declare trigger capability fields", packID)
@@ -312,7 +323,11 @@ func (e Envelope) SurfaceWithRequirements(boundSecrets, boundManagedCredentials 
 	can := []string{}
 	switch strings.TrimSpace(e.Type) {
 	case TypeConnector:
-		can = append(can, "call provider action "+strings.TrimSpace(e.Capabilities.Can.CallProviderAction))
+		actions := append([]string(nil), e.Capabilities.Can.CallProviderActions...)
+		sort.Strings(actions)
+		for _, action := range actions {
+			can = append(can, "call provider action "+strings.TrimSpace(action))
+		}
 		if e.Capabilities.Can.LowerThroughActivity {
 			can = append(can, "lower through platform.activity_requested")
 		}

--- a/internal/providerconnectors/packs.go
+++ b/internal/providerconnectors/packs.go
@@ -177,9 +177,6 @@ func (m ConnectorManifest) Validate() error {
 	if len(names) == 0 {
 		return fmt.Errorf("connector manifest tools are required")
 	}
-	if len(names) > 1 {
-		return fmt.Errorf("connector manifest provider %q declares %d tools; this first slice supports one connector action per pack", provider, len(names))
-	}
 	for _, toolID := range names {
 		tool := m.Tools[toolID]
 		if !isProviderConnector(tool) {
@@ -201,13 +198,9 @@ func (m ConnectorManifest) Validate() error {
 
 func DerivedCapabilities(manifest ConnectorManifest) packs.Capabilities {
 	names := manifestToolNames(manifest)
-	toolID := ""
-	if len(names) > 0 {
-		toolID = names[0]
-	}
 	return packs.Capabilities{
 		Can: packs.CanCapabilities{
-			CallProviderAction:      strings.TrimSpace(toolID),
+			CallProviderActions:     names,
 			LowerThroughActivity:    true,
 			JournalActivityAttempts: true,
 		},

--- a/internal/providerconnectors/packs/github/connector.yaml
+++ b/internal/providerconnectors/packs/github/connector.yaml
@@ -1,5 +1,86 @@
 provider: github
 tools:
+  github.add_labels_to_issue:
+    category: provider_connector
+    description: add labels to GitHub issues
+    handler_type: http
+    effect_class: non_idempotent_write
+    managed_credential:
+      key: github_app
+      grant_type: github_app_installation
+      grant_model: installation_grant
+      installation_id_input: installation_id
+    input_schema:
+      type: object
+      properties:
+        installation_id:
+          type: string
+        owner:
+          type: string
+        repo:
+          type: string
+        issue_number:
+          type: integer
+        labels:
+          type: array
+          items:
+            type: string
+      required:
+        - installation_id
+        - owner
+        - repo
+        - issue_number
+        - labels
+    output_schema:
+      type: object
+    http:
+      method: POST
+      url: https://api.github.com/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/labels
+      headers:
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: "2022-11-28"
+      body:
+        labels: "{{input.labels}}"
+  github.create_issue:
+    category: provider_connector
+    description: create GitHub issues
+    handler_type: http
+    effect_class: non_idempotent_write
+    managed_credential:
+      key: github_app
+      grant_type: github_app_installation
+      grant_model: installation_grant
+      installation_id_input: installation_id
+    input_schema:
+      type: object
+      properties:
+        installation_id:
+          type: string
+        owner:
+          type: string
+        repo:
+          type: string
+        title:
+          type: string
+        body:
+          type: string
+      required:
+        - installation_id
+        - owner
+        - repo
+        - title
+        - body
+    output_schema:
+      type: object
+    http:
+      method: POST
+      url: https://api.github.com/repos/{{input.owner}}/{{input.repo}}/issues
+      headers:
+        Accept: application/vnd.github+json
+        X-GitHub-Api-Version: "2022-11-28"
+      body:
+        title: "{{input.title}}"
+        body: "{{input.body}}"
   github.create_issue_comment:
     category: provider_connector
     description: create GitHub issue comments

--- a/internal/providerconnectors/packs/github/pack.yaml
+++ b/internal/providerconnectors/packs/github/pack.yaml
@@ -2,12 +2,15 @@ id: provider.github.connector
 version: 0.1.0
 platform_version: ">=0.7.0 <0.8.0"
 type: connector
-manifest_hash: sha256:dca6952b20e5521326b7cb83ef85fbf3390d0c29f9b68bee65ba66ce2445b25d
+manifest_hash: sha256:5b6be20a1d75567d4c60d621ae4cbec555e406ec7ebf22d03b0c4204498804dd
 provenance:
   source: platform
 capabilities:
   can:
-    call_provider_action: github.create_issue_comment
+    call_provider_actions:
+      - github.add_labels_to_issue
+      - github.create_issue
+      - github.create_issue_comment
     lower_through_activity: true
     journal_activity_attempts: true
   cannot:
@@ -19,4 +22,4 @@ requires:
     - github_app
 tests:
   - providerconnectors/github_pack
-  - runtime/github_app_issue_comment_supported_surface
+  - runtime/github_app_issue_workflow_supported_surface

--- a/internal/providerconnectors/packs/microsoft_graph/pack.yaml
+++ b/internal/providerconnectors/packs/microsoft_graph/pack.yaml
@@ -7,7 +7,8 @@ provenance:
   source: platform
 capabilities:
   can:
-    call_provider_action: microsoft_graph.send_mail
+    call_provider_actions:
+      - microsoft_graph.send_mail
     lower_through_activity: true
     journal_activity_attempts: true
   cannot:

--- a/internal/providerconnectors/packs/notion/pack.yaml
+++ b/internal/providerconnectors/packs/notion/pack.yaml
@@ -7,7 +7,8 @@ provenance:
   source: platform
 capabilities:
   can:
-    call_provider_action: notion.append_block_children
+    call_provider_actions:
+      - notion.append_block_children
     lower_through_activity: true
     journal_activity_attempts: true
   cannot:

--- a/internal/providerconnectors/packs/slack/pack.yaml
+++ b/internal/providerconnectors/packs/slack/pack.yaml
@@ -7,7 +7,8 @@ provenance:
   source: platform
 capabilities:
   can:
-    call_provider_action: slack.post_message
+    call_provider_actions:
+      - slack.post_message
     lower_through_activity: true
     journal_activity_attempts: true
   cannot:

--- a/internal/providerconnectors/packs/telegram/pack.yaml
+++ b/internal/providerconnectors/packs/telegram/pack.yaml
@@ -7,7 +7,8 @@ provenance:
   source: platform
 capabilities:
   can:
-    call_provider_action: telegram.send_message
+    call_provider_actions:
+      - telegram.send_message
     lower_through_activity: true
     journal_activity_attempts: true
   cannot:

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -754,6 +754,13 @@ func TestProviderConnectorPackVerificationFailsClosed(t *testing.T) {
 			want: "field unexpected not found",
 		},
 		{
+			name: "retired scalar action capability",
+			mutate: func(t *testing.T, files fstest.MapFS) {
+				replaceConnectorPackFile(t, files, "pack.yaml", "call_provider_actions:\n      - telegram.send_message", "call_provider_action: telegram.send_message")
+			},
+			want: "field call_provider_action not found",
+		},
+		{
 			name: "missing tests metadata",
 			mutate: func(t *testing.T, files fstest.MapFS) {
 				replaceConnectorPackFile(t, files, "pack.yaml", "tests:\n  - providerconnectors/telegram_pack\n  - runtime/telegram_connector_supported_surface\n", "tests: []\n")

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -478,6 +478,35 @@ func TestDefaultPackRegistryLoadsGitHubAppInstallationPack(t *testing.T) {
 	if strings.Contains(tool.HTTP.URL, "secret") || strings.Contains(tool.HTTP.URL, "token") {
 		t.Fatal("builtin GitHub tool leaked a concrete credential value")
 	}
+
+	createIssue, ok := BuiltinTool("github", "github.create_issue")
+	if !ok {
+		t.Fatal("BuiltinTool github.create_issue not found")
+	}
+	if !isProviderConnector(createIssue) || createIssue.ManagedCredential == nil || createIssue.ManagedCredential.GrantType != runtimemanagedcredentials.GrantGitHubAppInstallation {
+		t.Fatalf("builtin GitHub create issue tool = %#v, want provider connector with github_app_installation", createIssue)
+	}
+	if createIssue.HTTP == nil || createIssue.HTTP.Method != "POST" || !strings.Contains(createIssue.HTTP.URL, "/repos/{{input.owner}}/{{input.repo}}/issues") {
+		t.Fatalf("builtin GitHub create issue http = %#v, want create issue endpoint", createIssue.HTTP)
+	}
+
+	addLabels, ok := BuiltinTool("github", "github.add_labels_to_issue")
+	if !ok {
+		t.Fatal("BuiltinTool github.add_labels_to_issue not found")
+	}
+	if !isProviderConnector(addLabels) || addLabels.ManagedCredential == nil || addLabels.ManagedCredential.GrantType != runtimemanagedcredentials.GrantGitHubAppInstallation {
+		t.Fatalf("builtin GitHub add labels tool = %#v, want provider connector with github_app_installation", addLabels)
+	}
+	if addLabels.HTTP == nil || addLabels.HTTP.Method != "POST" || !strings.Contains(addLabels.HTTP.URL, "/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/labels") {
+		t.Fatalf("builtin GitHub add labels http = %#v, want issue labels endpoint", addLabels.HTTP)
+	}
+	bodyMap, ok := addLabels.HTTP.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("builtin GitHub add labels body = %#v, want object body", addLabels.HTTP.Body)
+	}
+	if body, ok := bodyMap["labels"].(string); !ok || body != "{{input.labels}}" {
+		t.Fatalf("builtin GitHub add labels body = %#v, want whole-field labels template", addLabels.HTTP.Body)
+	}
 }
 
 func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *testing.T) {
@@ -578,6 +607,59 @@ func TestGitHubConnectorPackReportsInstallationGrantRequirement(t *testing.T) {
 	}
 }
 
+func TestGitHubConnectorPackImportsMultipleActionsExplicitly(t *testing.T) {
+	ctx := context.Background()
+	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{
+							{Provider: "github", Tool: "github.add_labels_to_issue"},
+							{Provider: "github", Tool: "github.create_issue"},
+							{Provider: "github", Tool: "github.create_issue_comment"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImports: %v", err)
+	}
+	tools := source.ToolEntries()
+	for _, toolID := range []string{"github.add_labels_to_issue", "github.create_issue", "github.create_issue_comment"} {
+		tool, ok := tools[toolID]
+		if !ok {
+			t.Fatalf("imported tool %s missing", toolID)
+		}
+		if !isProviderConnector(tool) || tool.ManagedCredential == nil || tool.ManagedCredential.Key != "github_app" {
+			t.Fatalf("imported GitHub tool %s = %#v, want github_app provider connector", toolID, tool)
+		}
+	}
+	surfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	if err != nil {
+		t.Fatalf("SurfacesWithOptions: %v", err)
+	}
+	if len(surfaces) != 3 {
+		t.Fatalf("surfaces = %#v, want three GitHub action surfaces", surfaces)
+	}
+	seen := map[string]bool{}
+	for _, surface := range surfaces {
+		seen[surface.ToolID] = true
+		if len(surface.Requires) != 1 || surface.Requires[0].Kind != "managed_credential" || surface.Requires[0].Name != "github_app" || surface.Requires[0].Bound {
+			t.Fatalf("surface %s requirements = %#v, want unbound github_app managed credential", surface.ToolID, surface.Requires)
+		}
+	}
+	for _, toolID := range []string{"github.add_labels_to_issue", "github.create_issue", "github.create_issue_comment"} {
+		if !seen[toolID] {
+			t.Fatalf("surface for %s missing in %#v", toolID, surfaces)
+		}
+	}
+}
+
 func TestMicrosoftGraphConnectorPackReportsDefaultScopeManagedCredentialRequirement(t *testing.T) {
 	ctx := context.Background()
 	source, err := SourceWithConnectorPackImports(providerConnectorScopedSource{
@@ -653,7 +735,7 @@ func TestProviderConnectorPackVerificationFailsClosed(t *testing.T) {
 		{
 			name: "capability declaration drift",
 			mutate: func(t *testing.T, files fstest.MapFS) {
-				replaceConnectorPackFile(t, files, "pack.yaml", "call_provider_action: telegram.send_message", "call_provider_action: telegram.other")
+				replaceConnectorPackFile(t, files, "pack.yaml", "- telegram.send_message", "- telegram.other")
 			},
 			want: "capabilities do not match",
 		},

--- a/internal/runtime/github_app_issue_workflow_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_workflow_supported_surface_test.go
@@ -1,0 +1,863 @@
+package runtime_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providerconnectors"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+
+		const (
+			runID        = "9c000000-0000-0000-0000-000000000001"
+			entityID     = "9c000000-0000-0000-0000-000000000002"
+			flowInstance = "github-app-issue-workflow-pg"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		pg := &store.PostgresStore{DB: db}
+		workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
+
+		runGitHubAppIssueWorkflowSurface(t, slackManagedConnectorBackend{
+			name:          "postgres",
+			ctx:           ctx,
+			db:            db,
+			eventStore:    pg,
+			inboundStore:  pg,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        false,
+		})
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		const (
+			runID        = "9d000000-0000-0000-0000-000000000001"
+			entityID     = "9d000000-0000-0000-0000-000000000002"
+			flowInstance = "github-app-issue-workflow-sqlite"
+		)
+		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
+		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
+		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)
+
+		runGitHubAppIssueWorkflowSurface(t, slackManagedConnectorBackend{
+			name:          "sqlite",
+			ctx:           ctx,
+			db:            sqliteStore.DB,
+			eventStore:    sqliteStore,
+			inboundStore:  sqliteStore,
+			workflowStore: workflowStore,
+			runID:         runID,
+			entityID:      entityID,
+			sqlite:        true,
+		})
+	})
+}
+
+type githubAppIssueWorkflowCall struct {
+	action string
+	auth   string
+	body   map[string]any
+	path   string
+	raw    string
+}
+
+func runGitHubAppIssueWorkflowSurface(t *testing.T, backend slackManagedConnectorBackend) {
+	t.Helper()
+	privateKeyPEM, publicKey := githubAppIssueCommentPrivateKey(t)
+	fake := newFakeGitHubAppIssueWorkflowServer(t, publicKey)
+	defer fake.server.Close()
+
+	managedStore := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
+		Key:            "github_app",
+		Provider:       "github",
+		GrantType:      runtimemanagedcredentials.GrantGitHubAppInstallation,
+		APIBaseURL:     fake.server.URL,
+		ClientID:       "github-app-client-id",
+		InstallationID: "1001",
+		PrivateKey:     privateKeyPEM,
+		GrantModel:     managedcredentialmodel.GrantModelInstallation,
+		AccessToken:    "expired-install-token",
+		Status:         runtimemanagedcredentials.StatusConnected,
+		ExpiresAt:      time.Now().Add(-time.Hour),
+	})
+	source := githubAppIssueWorkflowSource(t, fake.server.URL)
+	bus, pc := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/github", backend.entityID)
+
+	publishGitHubIssueOpenedWithSignature(t, backend, bus, gateway, webhookPath, "gh-issue-bad-signature", "1001", 42, "Bad signature issue", "sha256=bad", http.StatusUnauthorized)
+	fake.requireNoSideEffectCall(t, backend.name, "invalid issues signature")
+	if got := fake.tokenRequestCount(); got != 0 {
+		t.Fatalf("%s token requests after invalid signature = %d, want 0", backend.name, got)
+	}
+
+	publishGitHubIssueComment(t, backend, bus, gateway, webhookPath, "gh-comment-1", "1001", "please respond")
+	commentCall := fake.requireSideEffectCall(t, backend.name, "issue_comment reply")
+	if commentCall.action != "create_issue_comment" || commentCall.path != "/repos/octo-org/octo-repo/issues/42/comments" {
+		t.Fatalf("%s GitHub comment call = %#v, want issue comment endpoint", backend.name, commentCall)
+	}
+	if got := slackManagedConnectorString(commentCall.body["body"]); got != "please respond" {
+		t.Fatalf("%s GitHub comment body = %#v, want inbound comment text", backend.name, commentCall.body["body"])
+	}
+	commentEventID := loadGitHubInboundEventID(t, backend, "inbound.github.issue_comment", "gh-comment-1")
+	commentAttempt := waitForGitHubTerminalActivityAttempt(t, backend, "github.create_issue_comment", commentEventID)
+	if commentAttempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+		t.Fatalf("%s comment activity status = %q, want succeeded", backend.name, commentAttempt.Status)
+	}
+	requireSlackManagedConnectorResultEventEventually(t, backend, commentAttempt.ResultEventID, commentAttempt.ResultEventType)
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s installation token requests after comment = %d, want 1", backend.name, got)
+	}
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s GitHub issue comment requests = %d, want 1", backend.name, got)
+	}
+
+	publishGitHubIssueOpened(t, backend, bus, gateway, webhookPath, "gh-issue-1", "1001", 42, "Incoming support issue")
+	issueCalls := fake.requireSideEffectCalls(t, backend.name, "issues opened actions", 2)
+	issueCreateCall := requireGitHubWorkflowCall(t, backend.name, issueCalls, "create_issue")
+	if issueCreateCall.auth != "Bearer github-install-token-1" || issueCreateCall.path != "/repos/octo-org/octo-repo/issues" {
+		t.Fatalf("%s GitHub create issue call = %#v, want create issue endpoint with installation token", backend.name, issueCreateCall)
+	}
+	if got := slackManagedConnectorString(issueCreateCall.body["title"]); got != "Incoming support issue" {
+		t.Fatalf("%s GitHub create issue title = %#v, want inbound issue title", backend.name, issueCreateCall.body["title"])
+	}
+	if got := slackManagedConnectorString(issueCreateCall.body["body"]); got != "Created by Swarm follow-up" {
+		t.Fatalf("%s GitHub create issue body = %#v, want literal follow-up body", backend.name, issueCreateCall.body["body"])
+	}
+	labelCall := requireGitHubWorkflowCall(t, backend.name, issueCalls, "add_labels_to_issue")
+	if labelCall.auth != "Bearer github-install-token-1" || labelCall.path != "/repos/octo-org/octo-repo/issues/42/labels" {
+		t.Fatalf("%s GitHub label call = %#v, want issue labels endpoint with installation token", backend.name, labelCall)
+	}
+	requireGitHubLabelsBody(t, backend.name, labelCall.body["labels"], []string{"triage", "swarm"})
+	issueEventID := loadGitHubInboundEventID(t, backend, "inbound.github.issues", "gh-issue-1")
+	createIssueAttempt := waitForGitHubTerminalActivityAttempt(t, backend, "github.create_issue", issueEventID)
+	addLabelsAttempt := waitForGitHubTerminalActivityAttempt(t, backend, "github.add_labels_to_issue", issueEventID)
+	for _, attempt := range []runtimepipeline.ActivityAttemptRecord{createIssueAttempt, addLabelsAttempt} {
+		if attempt.Status != runtimepipeline.ActivityAttemptStatusSucceeded {
+			t.Fatalf("%s issues activity %s status = %q, want succeeded", backend.name, attempt.Tool, attempt.Status)
+		}
+		requireSlackManagedConnectorResultEventEventually(t, backend, attempt.ResultEventID, attempt.ResultEventType)
+	}
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s installation token requests after issues actions = %d, want still 1", backend.name, got)
+	}
+	if got := fake.issueRequestCount(); got != 1 {
+		t.Fatalf("%s GitHub create issue requests = %d, want 1", backend.name, got)
+	}
+	if got := fake.labelRequestCount(); got != 1 {
+		t.Fatalf("%s GitHub add labels requests = %d, want 1", backend.name, got)
+	}
+
+	publishGitHubIssueOpenedExpectStatus(t, backend, bus, gateway, webhookPath, "gh-issue-1", "1001", 42, "Incoming support issue", http.StatusOK)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate issues webhook delivery")
+	for _, toolID := range []string{"github.create_issue", "github.add_labels_to_issue"} {
+		if got := countGitHubActivityAttemptsForSource(t, backend, toolID, issueEventID); got != 1 {
+			t.Fatalf("%s %s attempts after duplicate webhook = %d, want 1", backend.name, toolID, got)
+		}
+	}
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s token requests after duplicate issues webhook = %d, want still 1", backend.name, got)
+	}
+
+	duplicateRequests := []runtimeengine.EmitIntent{
+		{Event: loadSlackManagedConnectorActivityRequestEvent(t, backend, createIssueAttempt.RequestEventID)},
+		{Event: loadSlackManagedConnectorActivityRequestEvent(t, backend, addLabelsAttempt.RequestEventID)},
+	}
+	if err := bus.EngineDispatcher().DispatchPostCommit(backend.ctx, duplicateRequests); err != nil {
+		t.Fatalf("%s duplicate issue activity request dispatch: %v", backend.name, err)
+	}
+	waitForInboundBusQuiescence(t, bus)
+	fake.requireNoSideEffectCall(t, backend.name, "duplicate issues activity requests")
+	if got := fake.tokenRequestCount(); got != 1 {
+		t.Fatalf("%s token requests after duplicate issues activities = %d, want still 1", backend.name, got)
+	}
+	if got := fake.issueRequestCount(); got != 1 {
+		t.Fatalf("%s create issue requests after duplicate activities = %d, want still 1", backend.name, got)
+	}
+	if got := fake.labelRequestCount(); got != 1 {
+		t.Fatalf("%s add labels requests after duplicate activities = %d, want still 1", backend.name, got)
+	}
+
+	publishGitHubIssueCommentFromSender(t, backend, bus, gateway, webhookPath, "gh-comment-bot-1", "1001", "bot echo", "github-app[bot]", "Bot", http.StatusAccepted)
+	botCommentEventID := loadGitHubInboundEventID(t, backend, "inbound.github.issue_comment", "gh-comment-bot-1")
+	if got := countGitHubActivityAttemptsForSource(t, backend, "github.create_issue_comment", botCommentEventID); got != 0 {
+		t.Fatalf("%s bot-authored comment attempts = %d, want 0", backend.name, got)
+	}
+	fake.requireNoSideEffectCall(t, backend.name, "bot-authored issue_comment")
+	if got := fake.commentRequestCount(); got != 1 {
+		t.Fatalf("%s comment requests after bot-authored comment = %d, want still 1", backend.name, got)
+	}
+
+	assertGitHubAppIssueWorkflowManagedCredentialFailureBeforeDispatch(t, backend, fake, "missing credential", "gh-comment-missing-credential", "1001", runtimemanagedcredentials.NewMemoryStore())
+	mismatched := managedStoreRecordWithInstallation(privateKeyPEM, fake.server.URL, "1001")
+	assertGitHubAppIssueWorkflowManagedCredentialFailureBeforeDispatch(t, backend, fake, "installation mismatch", "gh-comment-installation-mismatch", "2002", runtimemanagedcredentials.NewMemoryStore(mismatched))
+	_ = pc
+	for _, secret := range []string{"expired-install-token", "github-install-token-1", "github-webhook-secret"} {
+		assertSlackManagedConnectorNoStoredSecret(t, backend, secret)
+	}
+}
+
+func newFakeGitHubAppIssueWorkflowServer(t *testing.T, publicKey *rsa.PublicKey) *fakeGitHubAppIssueWorkflowServer {
+	t.Helper()
+	fake := &fakeGitHubAppIssueWorkflowServer{
+		publicKey:   publicKey,
+		sideEffects: make(chan githubAppIssueWorkflowCall, 8),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app/installations/1001/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			http.Error(w, "bad accept", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+			http.Error(w, "bad api version", http.StatusBadRequest)
+			return
+		}
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if jwt == "" || jwt == r.Header.Get("Authorization") {
+			http.Error(w, "missing app jwt", http.StatusUnauthorized)
+			return
+		}
+		verifyGitHubAppIssueCommentJWT(t, jwt, fake.publicKey, "github-app-client-id", time.Now().UTC())
+		call := fake.tokenCalls.Add(1)
+		if call != 1 {
+			http.Error(w, "unexpected token reacquisition", http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "github-install-token-1",
+			"expires_at": time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+		})
+	})
+	mux.HandleFunc("/repos/octo-org/octo-repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fake.acceptSideEffectRequest(t, w, r, "create_issue")
+		if !ok {
+			return
+		}
+		fake.issueCalls.Add(1)
+		fake.sideEffects <- githubAppIssueWorkflowCall{
+			action: "create_issue",
+			auth:   r.Header.Get("Authorization"),
+			body:   body,
+			path:   r.URL.Path,
+			raw:    mustMarshalGitHubWorkflowBody(t, body),
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     456,
+			"number": 101,
+			"title":  body["title"],
+			"body":   body["body"],
+		})
+	})
+	mux.HandleFunc("/repos/octo-org/octo-repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fake.acceptSideEffectRequest(t, w, r, "create_issue_comment")
+		if !ok {
+			return
+		}
+		fake.commentCalls.Add(1)
+		fake.sideEffects <- githubAppIssueWorkflowCall{
+			action: "create_issue_comment",
+			auth:   r.Header.Get("Authorization"),
+			body:   body,
+			path:   r.URL.Path,
+			raw:    mustMarshalGitHubWorkflowBody(t, body),
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   123,
+			"body": body["body"],
+		})
+	})
+	mux.HandleFunc("/repos/octo-org/octo-repo/issues/42/labels", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fake.acceptSideEffectRequest(t, w, r, "add_labels_to_issue")
+		if !ok {
+			return
+		}
+		fake.labelCalls.Add(1)
+		fake.sideEffects <- githubAppIssueWorkflowCall{
+			action: "add_labels_to_issue",
+			auth:   r.Header.Get("Authorization"),
+			body:   body,
+			path:   r.URL.Path,
+			raw:    mustMarshalGitHubWorkflowBody(t, body),
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "triage"},
+			{"name": "swarm"},
+		})
+	})
+	fake.server = httptest.NewServer(mux)
+	return fake
+}
+
+type fakeGitHubAppIssueWorkflowServer struct {
+	server       *httptest.Server
+	publicKey    *rsa.PublicKey
+	tokenCalls   atomic.Int64
+	commentCalls atomic.Int64
+	issueCalls   atomic.Int64
+	labelCalls   atomic.Int64
+	sideEffects  chan githubAppIssueWorkflowCall
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) acceptSideEffectRequest(t *testing.T, w http.ResponseWriter, r *http.Request, action string) (map[string]any, bool) {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return nil, false
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "bad method", http.StatusMethodNotAllowed)
+		return nil, false
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer github-install-token-1" {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "bad token"})
+		return nil, false
+	}
+	if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+		http.Error(w, "bad accept", http.StatusBadRequest)
+		return nil, false
+	}
+	if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+		http.Error(w, "bad api version", http.StatusBadRequest)
+		return nil, false
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		http.Error(w, action+": "+err.Error(), http.StatusBadRequest)
+		return nil, false
+	}
+	return body, true
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) requireSideEffectCall(t *testing.T, backend, context string) githubAppIssueWorkflowCall {
+	t.Helper()
+	calls := f.requireSideEffectCalls(t, backend, context, 1)
+	return calls[0]
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) requireSideEffectCalls(t *testing.T, backend, context string, want int) []githubAppIssueWorkflowCall {
+	t.Helper()
+	calls := make([]githubAppIssueWorkflowCall, 0, want)
+	deadline := time.After(5 * time.Second)
+	for len(calls) < want {
+		select {
+		case call := <-f.sideEffects:
+			calls = append(calls, call)
+		case <-deadline:
+			t.Fatalf("%s %s: timed out waiting for %d fake GitHub side effects; got %d", backend, context, want, len(calls))
+		}
+	}
+	return calls
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) requireNoSideEffectCall(t *testing.T, backend, context string) {
+	t.Helper()
+	select {
+	case call := <-f.sideEffects:
+		t.Fatalf("%s %s: unexpected fake GitHub side effect: action=%s auth=%s body=%s", backend, context, call.action, call.auth, call.raw)
+	default:
+	}
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) tokenRequestCount() int {
+	return int(f.tokenCalls.Load())
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) commentRequestCount() int {
+	return int(f.commentCalls.Load())
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) issueRequestCount() int {
+	return int(f.issueCalls.Load())
+}
+
+func (f *fakeGitHubAppIssueWorkflowServer) labelRequestCount() int {
+	return int(f.labelCalls.Load())
+}
+
+func publishGitHubIssueOpened(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID string, issueNumber int, title string) {
+	t.Helper()
+	publishGitHubIssueOpenedExpectStatus(t, backend, bus, gateway, webhookPath, deliveryID, installationID, issueNumber, title, http.StatusAccepted)
+}
+
+func publishGitHubIssueOpenedExpectStatus(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID string, issueNumber int, title string, wantStatus int) {
+	t.Helper()
+	payload := githubIssueOpenedPayload(installationID, issueNumber, title)
+	publishGitHubIssueOpenedWithSignature(t, backend, bus, gateway, webhookPath, deliveryID, installationID, issueNumber, title, githubWebhookSignature("github-webhook-secret", payload), wantStatus)
+}
+
+func publishGitHubIssueOpenedWithSignature(t *testing.T, backend slackManagedConnectorBackend, bus *runtimebus.EventBus, gateway *runtimepkg.InboundGateway, webhookPath, deliveryID, installationID string, issueNumber int, title, signature string, wantStatus int) {
+	t.Helper()
+	payload := githubIssueOpenedPayload(installationID, issueNumber, title)
+	req := httptest.NewRequest(http.MethodPost, webhookPath, strings.NewReader(string(payload))).WithContext(backend.ctx)
+	if strings.TrimSpace(signature) != "" {
+		req.Header.Set("X-Hub-Signature-256", signature)
+	}
+	req.Header.Set("X-GitHub-Delivery", deliveryID)
+	req.Header.Set("X-GitHub-Event", "issues")
+	rec := httptest.NewRecorder()
+	gateway.Handler().ServeHTTP(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("%s gateway status for issues delivery %s = %d, want %d body=%s", backend.name, deliveryID, rec.Code, wantStatus, rec.Body.String())
+	}
+	waitForInboundBusQuiescence(t, bus)
+}
+
+func githubIssueOpenedPayload(installationID string, issueNumber int, title string) []byte {
+	return []byte(fmt.Sprintf(`{"action":"opened","installation":{"id":%s},"repository":{"name":"octo-repo","owner":{"login":"octo-org"}},"issue":{"number":%d,"title":%q},"sender":{"login":"octocat","type":"User"}}`, installationID, issueNumber, title))
+}
+
+func githubAppIssueWorkflowSource(t *testing.T, baseURL string) semanticview.Source {
+	t.Helper()
+	commentHandler := runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{
+			Check:  `payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
+			OnFail: "discard",
+		},
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "github_create_issue_comment",
+			Tool: "github.create_issue_comment",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"installation_id": runtimecontracts.CELExpression("payload.payload.installation.id"),
+				"owner":           runtimecontracts.CELExpression("payload.payload.repository.owner.login"),
+				"repo":            runtimecontracts.CELExpression("payload.payload.repository.name"),
+				"issue_number":    runtimecontracts.CELExpression("payload.payload.issue.number"),
+				"body":            runtimecontracts.CELExpression("payload.payload.comment.body"),
+			},
+		},
+	}
+	createIssueHandler := runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{
+			Check:  `payload.payload.action == "opened"`,
+			OnFail: "discard",
+		},
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "github_create_issue",
+			Tool: "github.create_issue",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"installation_id": runtimecontracts.CELExpression("payload.payload.installation.id"),
+				"owner":           runtimecontracts.CELExpression("payload.payload.repository.owner.login"),
+				"repo":            runtimecontracts.CELExpression("payload.payload.repository.name"),
+				"title":           runtimecontracts.CELExpression("payload.payload.issue.title"),
+				"body":            runtimecontracts.LiteralExpression("Created by Swarm follow-up"),
+			},
+		},
+	}
+	addLabelsHandler := runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{
+			Check:  `payload.payload.action == "opened"`,
+			OnFail: "discard",
+		},
+		Activity: runtimecontracts.ActivitySpec{
+			ID:   "github_add_labels_to_issue",
+			Tool: "github.add_labels_to_issue",
+			Input: map[string]runtimecontracts.ExpressionValue{
+				"installation_id": runtimecontracts.CELExpression("payload.payload.installation.id"),
+				"owner":           runtimecontracts.CELExpression("payload.payload.repository.owner.login"),
+				"repo":            runtimecontracts.CELExpression("payload.payload.repository.name"),
+				"issue_number":    runtimecontracts.CELExpression("payload.payload.issue.number"),
+				"labels":          runtimecontracts.LiteralExpression([]any{"triage", "swarm"}),
+			},
+		},
+	}
+	const (
+		commentNodeID = "github-issue-comment-responder"
+		createNodeID  = "github-issue-creator"
+		labelNodeID   = "github-issue-labeler"
+	)
+	nodes := map[string]runtimecontracts.SystemNodeContract{
+		commentNodeID: {
+			ID:            commentNodeID,
+			ExecutionType: runtimecontracts.SystemNodeExecutionType,
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"inbound.github.issue_comment": commentHandler},
+		},
+		createNodeID: {
+			ID:            createNodeID,
+			ExecutionType: runtimecontracts.SystemNodeExecutionType,
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"inbound.github.issues": createIssueHandler},
+		},
+		labelNodeID: {
+			ID:            labelNodeID,
+			ExecutionType: runtimecontracts.SystemNodeExecutionType,
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"inbound.github.issues": addLabelsHandler},
+		},
+	}
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"inbound.github.issue_comment", "inbound.github.issues"},
+				},
+			},
+		},
+		Nodes: nodes,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "github_app_issue_workflow_supported_surface",
+			Version: "1.0.0",
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				commentNodeID: {
+					ID:                   commentNodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.github.issue_comment"},
+				},
+				createNodeID: {
+					ID:                   createNodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.github.issues"},
+				},
+				labelNodeID: {
+					ID:                   labelNodeID,
+					ExecutionType:        runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"inbound.github.issues"},
+				},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				commentNodeID: {"inbound.github.issue_comment": commentHandler},
+				createNodeID:  {"inbound.github.issues": createIssueHandler},
+				labelNodeID:   {"inbound.github.issues": addLabelsHandler},
+			},
+			EventOwners: map[string][]string{
+				"inbound.github.issue_comment": {commentNodeID},
+				"inbound.github.issues":        {createNodeID, labelNodeID},
+			},
+		},
+	})
+	importSource := slackManagedConnectorPackImportSource{
+		Source: base,
+		projectScopes: []semanticview.ProjectScope{
+			{
+				Key: ".",
+				Manifest: runtimecontracts.ProjectPackageDocument{
+					ConnectorPacks: runtimecontracts.ConnectorPackImports{
+						Imports: []runtimecontracts.ConnectorPackImport{
+							{Provider: "github", Tool: "github.add_labels_to_issue"},
+							{Provider: "github", Tool: "github.create_issue"},
+							{Provider: "github", Tool: "github.create_issue_comment"},
+						},
+					},
+				},
+			},
+		},
+	}
+	source, err := providerconnectors.SourceWithConnectorPackImportsFromRegistry(importSource, githubAppIssueWorkflowPackRegistry(t, baseURL))
+	if err != nil {
+		t.Fatalf("SourceWithConnectorPackImportsFromRegistry: %v", err)
+	}
+	return source
+}
+
+func githubAppIssueWorkflowPackRegistry(t *testing.T, baseURL string) *providerconnectors.PackRegistry {
+	t.Helper()
+	tools := map[string]runtimecontracts.ToolSchemaEntry{}
+	for _, toolID := range []string{"github.add_labels_to_issue", "github.create_issue", "github.create_issue_comment"} {
+		tool, ok := providerconnectors.BuiltinTool("github", toolID)
+		if !ok {
+			t.Fatalf("provider connector pack %s not found", toolID)
+		}
+		if tool.HTTP == nil {
+			t.Fatalf("provider connector pack %s missing http block", toolID)
+		}
+		httpSpec := *tool.HTTP
+		tool.HTTP = &httpSpec
+		switch toolID {
+		case "github.add_labels_to_issue":
+			tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/labels"
+		case "github.create_issue":
+			tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/repos/{{input.owner}}/{{input.repo}}/issues"
+		case "github.create_issue_comment":
+			tool.HTTP.URL = strings.TrimRight(baseURL, "/") + "/repos/{{input.owner}}/{{input.repo}}/issues/{{input.issue_number}}/comments"
+		}
+		tools[toolID] = tool
+	}
+	registry, err := providerconnectors.NewPackRegistry(providerconnectors.LoadedPack{
+		Envelope: packs.Envelope{
+			ID: "provider.github.connector",
+			Provenance: packs.Provenance{
+				Source: packs.ProvenancePlatform,
+			},
+		},
+		Manifest: providerconnectors.ConnectorManifest{
+			Provider: "github",
+			Tools:    tools,
+		},
+		Source: "test:provider.github.connector",
+	})
+	if err != nil {
+		t.Fatalf("NewPackRegistry: %v", err)
+	}
+	return registry
+}
+
+func assertGitHubAppIssueWorkflowManagedCredentialFailureBeforeDispatch(t *testing.T, backend slackManagedConnectorBackend, fake *fakeGitHubAppIssueWorkflowServer, label, deliveryID, installationID string, managedStore runtimemanagedcredentials.Store) {
+	t.Helper()
+	beforeTokens := fake.tokenRequestCount()
+	beforeComments := fake.commentRequestCount()
+	beforeIssues := fake.issueRequestCount()
+	beforeLabels := fake.labelRequestCount()
+	source := githubAppIssueWorkflowSource(t, fake.server.URL)
+	bus, _ := startSlackManagedConnectorBusAndCoordinator(t, backend, source, managedStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, backend.inboundStore)
+	webhookPath := fmt.Sprintf("/webhooks/%s/github", backend.entityID)
+	publishGitHubIssueComment(t, backend, bus, gateway, webhookPath, deliveryID, installationID, label)
+	inboundEventID := loadGitHubInboundEventID(t, backend, "inbound.github.issue_comment", deliveryID)
+	if got := countGitHubActivityAttemptsForSource(t, backend, "github.create_issue_comment", inboundEventID); got != 0 {
+		t.Fatalf("%s %s activity attempts = %d, want 0", backend.name, label, got)
+	}
+	requireGitHubFailureEventEventually(t, backend, label, "github_create_issue_comment.failed", inboundEventID)
+	if got := fake.tokenRequestCount(); got != beforeTokens {
+		t.Fatalf("%s %s token requests = %d, want still %d", backend.name, label, got, beforeTokens)
+	}
+	if got := fake.commentRequestCount(); got != beforeComments {
+		t.Fatalf("%s %s comment requests = %d, want still %d", backend.name, label, got, beforeComments)
+	}
+	if got := fake.issueRequestCount(); got != beforeIssues {
+		t.Fatalf("%s %s issue requests = %d, want still %d", backend.name, label, got, beforeIssues)
+	}
+	if got := fake.labelRequestCount(); got != beforeLabels {
+		t.Fatalf("%s %s label requests = %d, want still %d", backend.name, label, got, beforeLabels)
+	}
+	fake.requireNoSideEffectCall(t, backend.name, label)
+}
+
+func loadGitHubInboundEventID(t *testing.T, backend slackManagedConnectorBackend, eventName, providerEventID string) string {
+	t.Helper()
+	var eventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id
+			FROM events
+			WHERE run_id = ?
+			  AND entity_id = ?
+			  AND event_name = ?
+			  AND json_extract(payload, '$.provider_event_id') = ?
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, eventName, providerEventID).Scan(&eventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT event_id::text
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND entity_id = $2::uuid
+			  AND event_name = $3
+			  AND payload->>'provider_event_id' = $4
+			ORDER BY created_at DESC
+			LIMIT 1
+		`, backend.runID, backend.entityID, eventName, providerEventID).Scan(&eventID)
+	}
+	if err != nil {
+		t.Fatalf("%s load GitHub inbound event id for %s/%s: %v", backend.name, eventName, providerEventID, err)
+	}
+	return eventID
+}
+
+func waitForGitHubTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, toolID, sourceEventID string) runtimepipeline.ActivityAttemptRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last runtimepipeline.ActivityAttemptRecord
+	var saw bool
+	for {
+		rec, ok, err := tryLoadGitHubActivityAttempt(backend, toolID, sourceEventID)
+		if err != nil {
+			t.Fatalf("%s load %s activity attempt while waiting: %v", backend.name, toolID, err)
+		}
+		if ok {
+			last = rec
+			saw = true
+			if rec.Status != runtimepipeline.ActivityAttemptStatusStarted {
+				return rec
+			}
+		}
+		if time.Now().After(deadline) {
+			if saw {
+				t.Fatalf("%s %s activity attempt did not reach terminal status; last=%q", backend.name, toolID, last.Status)
+			}
+			t.Fatalf("%s %s activity attempt for source event %s was not created", backend.name, toolID, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func tryLoadGitHubActivityAttempt(backend slackManagedConnectorBackend, toolID, sourceEventID string) (runtimepipeline.ActivityAttemptRecord, bool, error) {
+	var requestEventID string
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = ?
+			  AND source_event_id = ?
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, toolID, sourceEventID).Scan(&requestEventID)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT request_event_id::text
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = $2
+			  AND source_event_id = $3::uuid
+			ORDER BY started_at ASC
+			LIMIT 1
+		`, backend.runID, toolID, sourceEventID).Scan(&requestEventID)
+	}
+	if err == sql.ErrNoRows {
+		return runtimepipeline.ActivityAttemptRecord{}, false, nil
+	}
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	rec, ok, err := backend.workflowStore.LoadActivityAttempt(backend.ctx, requestEventID)
+	if err != nil {
+		return runtimepipeline.ActivityAttemptRecord{}, false, err
+	}
+	return rec, ok, nil
+}
+
+func countGitHubActivityAttemptsForSource(t *testing.T, backend slackManagedConnectorBackend, toolID, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = ?
+			  AND tool = ?
+			  AND source_event_id = ?
+		`, backend.runID, toolID, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM activity_attempts
+			WHERE run_id = $1::uuid
+			  AND tool = $2
+			  AND source_event_id = $3::uuid
+		`, backend.runID, toolID, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count %s activity attempts for source event %s: %v", backend.name, toolID, sourceEventID, err)
+	}
+	return count
+}
+
+func requireGitHubFailureEventEventually(t *testing.T, backend slackManagedConnectorBackend, label, eventName, sourceEventID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if got := countGitHubFailureEventsForSource(t, backend, eventName, sourceEventID); got == 1 {
+			return
+		} else if got > 1 {
+			t.Fatalf("%s %s failure events = %d, want 1", backend.name, label, got)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s failure event %s for source event %s was not created", backend.name, label, eventName, sourceEventID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func countGitHubFailureEventsForSource(t *testing.T, backend slackManagedConnectorBackend, eventName, sourceEventID string) int {
+	t.Helper()
+	var count int
+	var err error
+	if backend.sqlite {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = ?
+			  AND event_name = ?
+			  AND source_event_id = ?
+		`, backend.runID, eventName, sourceEventID).Scan(&count)
+	} else {
+		err = backend.db.QueryRowContext(backend.ctx, `
+			SELECT COUNT(*)
+			FROM events
+			WHERE run_id = $1::uuid
+			  AND event_name = $2
+			  AND source_event_id = $3::uuid
+		`, backend.runID, eventName, sourceEventID).Scan(&count)
+	}
+	if err != nil {
+		t.Fatalf("%s count failure events for source event %s: %v", backend.name, sourceEventID, err)
+	}
+	return count
+}
+
+func requireGitHubWorkflowCall(t *testing.T, backend string, calls []githubAppIssueWorkflowCall, action string) githubAppIssueWorkflowCall {
+	t.Helper()
+	for _, call := range calls {
+		if call.action == action {
+			return call
+		}
+	}
+	t.Fatalf("%s GitHub side effects = %#v, want action %s", backend, calls, action)
+	return githubAppIssueWorkflowCall{}
+}
+
+func requireGitHubLabelsBody(t *testing.T, backend string, raw any, want []string) {
+	t.Helper()
+	values, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("%s labels body = %#v, want JSON array", backend, raw)
+	}
+	if len(values) != len(want) {
+		t.Fatalf("%s labels body = %#v, want %#v", backend, raw, want)
+	}
+	for i, value := range values {
+		if got := slackManagedConnectorString(value); got != want[i] {
+			t.Fatalf("%s labels[%d] = %#v, want %q", backend, i, value, want[i])
+		}
+	}
+}
+
+func mustMarshalGitHubWorkflowBody(t *testing.T, body map[string]any) string {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal GitHub workflow body: %v", err)
+	}
+	return string(raw)
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6541,7 +6541,7 @@ tool_model:
       - "`rate_limit` and `rate_limit_max_wait`; connector admission/rate limiting is split until specified."
       - "direct runtime provider adapter code or bespoke connector dispatch."
     connector_pack_profile:
-      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, Notion Basic+JSON workspace-grant connector proof, Microsoft Graph client_credentials `.default` connector proof, and GitHub App installation-token issue-comment connector proof"
+      status: "first slices: Telegram static connector pack proof, Slack managed-credential connector pack proof, Notion Basic+JSON workspace-grant connector proof, Microsoft Graph client_credentials `.default` connector proof, and GitHub App installation-token issue/comment multi-action connector proof"
       body_file: connector.yaml
       import_syntax: >
         package.yaml `connector_packs.imports[]` entries name `provider` and `tool`. The import is an explicit enablement
@@ -6553,11 +6553,13 @@ tool_model:
       verification_rule: >
         The envelope hash is over the exact connector.yaml bytes. The loader parses the envelope with strict known fields,
         verifies the exact byte hash, parses connector.yaml through the normal tool schema owner, validates the
-        provider_connector profile, derives connector capabilities/requires mechanically from the tool declaration, and
-        rejects any declared capability or requirement drift.
+        provider_connector profile, derives connector capabilities/requires mechanically from every tool declaration in
+        deterministic tool-id order, and rejects any declared capability or requirement drift. Connector envelopes declare
+        action capability truth as `capabilities.can.call_provider_actions`, a non-empty list of the exact packed tool ids;
+        the former scalar action form is non-authoritative.
       capability_surface: >
         Connector pack CAN/CANNOT/readback is kind-specific. Connector CAN rows include calling the declared provider
-        action, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
+        action or actions, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
         `activity_attempts`. Connector CANNOT rows include bypassing `activity_attempts`, automatically retrying
         non-idempotent writes, or exposing credential values. Requirement rows are typed: static secret requirements render
         BOUND/UNBOUND from the static credential store, while managed credential requirements render managed credential

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6556,7 +6556,10 @@ tool_model:
         provider_connector profile, derives connector capabilities/requires mechanically from every tool declaration in
         deterministic tool-id order, and rejects any declared capability or requirement drift. Connector envelopes declare
         action capability truth as `capabilities.can.call_provider_actions`, a non-empty list of the exact packed tool ids;
-        the former scalar action form is non-authoritative.
+        the former scalar `capabilities.can.call_provider_action` form is retired and MUST fail closed under strict
+        envelope parsing rather than being accepted as a compatibility alias. External connector-pack directories remain a
+        later gated surface, so first-party connector packs are migrated aggressively before any external connector-pack
+        compatibility promise exists.
       capability_surface: >
         Connector pack CAN/CANNOT/readback is kind-specific. Connector CAN rows include calling the declared provider
         action or actions, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in


### PR DESCRIPTION
## Summary

- Broaden the GitHub App connector pack from comment-only to issue/comment workflow breadth: `github.create_issue_comment`, `github.create_issue`, and `github.add_labels_to_issue`.
- Promote connector pack capability ownership from scalar `capabilities.can.call_provider_action` to canonical plural `capabilities.can.call_provider_actions`, derived from the packed ToolSchemaEntry set.
- Add a supported-surface runtime proof for GitHub `issues` and `issue_comment` events through the GitHub App installation credential and `activity_attempts` journal.
- Stabilize the existing served mailbox parity proof by waiting for the exact downstream pipeline receipt before broad run-quiescence assertion.

Closes #1912
Part of #1458
Part of #1862
Related to #1915

## Governing Refs / Context

Exact governing spec refs:

- `platform-spec.yaml:2979` and nearby `activity_requested` / `activity_attempts` requirements for provider connector activity execution.
- `platform-spec.yaml:6453-6456` managed credential fields for `github_app_installation` and `installation_id_input`.
- `platform-spec.yaml:6513-6577` `provider_connector_tools`, connector pack import, pack verification, capability surface, and activity journal ownership.
- `platform-spec.yaml:6673-6768` managed credential store and GitHub App installation policy.
- `platform-spec.yaml:6818-6855` GitHub provider trigger event semantics.
- `platform-spec.yaml:9006-9076` `activity_attempts` authoritative journal schema.

## Semantic Migration

New canonical owner:

- `internal/packs.Envelope.Capabilities.Can.CallProviderActions` owns connector-pack declared action capability truth.
- `internal/providerconnectors.DerivedCapabilities` derives that plural action set deterministically from the imported connector manifest tool IDs.

Old path now invalid:

- Scalar `capabilities.can.call_provider_action` is removed and non-authoritative.
- The previous one-tool connector pack assumption is removed; connector packs may declare multiple ToolSchemaEntry actions, with explicit imports still required per action.

Production paths checked for surviving old behavior:

- All first-party connector pack envelopes were migrated to `call_provider_actions`.
- GitHub pack load/readback/import tests cover the multi-action pack.
- `rg call_provider_action|CallProviderAction` shows no remaining scalar owner.

Migration complete for first-party connector packs in this PR.

## Verification

- `GOTMPDIR=/Users/youmew/dev/swarm-test-tmp/agent-f-gotmp SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./internal/providerconnectors ./internal/runtime -run 'TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal|TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal|TestDefaultPackRegistryLoadsGitHubAppInstallationPack|TestGitHubConnectorPackImportsMultipleActionsExplicitly|TestProviderConnectorPackVerificationFailsClosed' -count=1`
- `GOTMPDIR=/Users/youmew/dev/swarm-test-tmp/agent-f-gotmp SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -run '^TestServedParityHarnessMailboxDecisionLifecycle$' -count=1 -v`
- `GOTMPDIR=/Users/youmew/dev/swarm-test-tmp/agent-f-gotmp SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./cmd/swarm -count=1`
- `GOTMPDIR=/Users/youmew/dev/swarm-test-tmp/agent-f-gotmp SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
