### PR TITLE
[agent-c][issue #1847] Harden collection fan-out rows

### DIFF
--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -244,6 +244,36 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 					fmt.Fprintf(out, "      - %s\n", strings.Join(parts, " "))
 				}
 			}
+			if len(graph.FanOuts) > 0 {
+				fmt.Fprintln(out, "    fan_out:")
+				for _, fanOut := range graph.FanOuts {
+					from := strings.Join(fanOut.From, ",")
+					if from == "" {
+						from = "<none>"
+					}
+					parts := []string{
+						fmt.Sprintf("%s ->xN %s", from, strings.TrimSpace(fanOut.Emit)),
+						"items_from " + strings.TrimSpace(fanOut.ItemsFrom),
+					}
+					if strings.TrimSpace(fanOut.ItemAlias) != "" {
+						parts = append(parts, "as "+strings.TrimSpace(fanOut.ItemAlias))
+					}
+					if strings.TrimSpace(fanOut.Identity) != "" {
+						parts = append(parts, "identity "+strings.TrimSpace(fanOut.Identity))
+					}
+					detail := strings.TrimSpace(fanOut.Source)
+					if strings.TrimSpace(fanOut.NodeID) != "" {
+						detail += " " + strings.TrimSpace(fanOut.NodeID)
+					}
+					if strings.TrimSpace(fanOut.EventType) != "" {
+						detail += " on " + strings.TrimSpace(fanOut.EventType)
+					}
+					if detail != "" {
+						parts = append(parts, "("+strings.TrimSpace(detail)+")")
+					}
+					fmt.Fprintf(out, "      - %s\n", strings.Join(parts, " "))
+				}
+			}
 		}
 	}
 	if len(view.Diagnostics) > 0 {

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -248,6 +248,13 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	if len(graph.Timers) != 2 {
 		t.Fatalf("graph timers = %#v, want emit and advance stage timers", graph.Timers)
 	}
+	if len(graph.FanOuts) != 1 {
+		t.Fatalf("graph fan_outs = %#v, want ticket.opened collection fan-out", graph.FanOuts)
+	}
+	fanOut := graph.FanOuts[0]
+	if fanOut.Emit != "line_item.requested" || fanOut.ItemsFrom != "payload.line_items" || fanOut.ItemAlias != "line_item" || fanOut.Identity != "line_item" {
+		t.Fatalf("graph fan_out = %#v, want line_item multiplicity metadata", fanOut)
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -271,6 +278,7 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		"timer runtime on timer:support.active.timed_out after 72h timer support.active.timed_out",
 		"active after 48h emit ticket.sla_escalated (timer support.active.ticket.sla_escalated)",
 		"active after 72h advances_to timed_out (timer support.active.timed_out)",
+		"waiting ->xN line_item.requested items_from payload.line_items as line_item identity line_item (handler.fan_out support-node on ticket.opened)",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("describe --graph output missing %q:\n%s", want, text)
@@ -385,6 +393,7 @@ ticket.opened:
   swarm:
     source: external
   entity_id: string
+  line_items: "[text]"
 ticket.closed:
   swarm:
     source: external
@@ -393,6 +402,11 @@ ticket.sla_escalated:
   swarm:
     consumer: [operator]
   entity_id: string
+line_item.requested:
+  swarm:
+    consumer: [worker]
+  line_item_id: string
+  line_item_index: integer
 accumulate.timeout:
   swarm:
     source: platform
@@ -410,6 +424,15 @@ support-node:
   event_handlers:
     ticket.opened:
       create_entity: true
+      fan_out:
+        items_from: payload.line_items
+        as: line_item
+        identity: line_item
+        emit:
+          event: line_item.requested
+          fields:
+            line_item_id: line_item
+            line_item_index: fan_out.index
       advances_to: active
     ticket.closed:
       advances_to: done

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -75,11 +75,12 @@ type FlowSourceFiles struct {
 }
 
 type StageGraphView struct {
-	FlowID   string                `json:"flow_id"`
-	FlowPath string                `json:"flow_path,omitempty"`
-	Nodes    []StageGraphNodeView  `json:"nodes"`
-	Edges    []StageGraphEdgeView  `json:"edges"`
-	Timers   []StageGraphTimerView `json:"timers,omitempty"`
+	FlowID   string                 `json:"flow_id"`
+	FlowPath string                 `json:"flow_path,omitempty"`
+	Nodes    []StageGraphNodeView   `json:"nodes"`
+	Edges    []StageGraphEdgeView   `json:"edges"`
+	Timers   []StageGraphTimerView  `json:"timers,omitempty"`
+	FanOuts  []StageGraphFanOutView `json:"fan_outs,omitempty"`
 }
 
 type StageGraphNodeView struct {
@@ -106,6 +107,17 @@ type StageGraphTimerView struct {
 	After      string `json:"after"`
 	Emit       string `json:"emit,omitempty"`
 	AdvancesTo string `json:"advances_to,omitempty"`
+}
+
+type StageGraphFanOutView struct {
+	From      []string `json:"from,omitempty"`
+	Emit      string   `json:"emit"`
+	ItemsFrom string   `json:"items_from"`
+	ItemAlias string   `json:"as"`
+	Identity  string   `json:"identity"`
+	Source    string   `json:"source"`
+	NodeID    string   `json:"node_id,omitempty"`
+	EventType string   `json:"event_type,omitempty"`
 }
 
 type RequiredAgentsView struct {
@@ -402,7 +414,7 @@ func buildStageGraphs(source semanticview.Source, bundle *runtimecontracts.Workf
 		return nil
 	}
 	graphs := make([]StageGraphView, 0, len(bundle.FlowViews())+1)
-	if graph := buildStageGraphForFlow(source, "", "root", ""); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 {
+	if graph := buildStageGraphForFlow(source, "", "root", ""); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 || len(graph.FanOuts) > 0 {
 		graphs = append(graphs, graph)
 	}
 	for _, flow := range bundle.FlowViews() {
@@ -411,7 +423,7 @@ func buildStageGraphs(source semanticview.Source, bundle *runtimecontracts.Workf
 			continue
 		}
 		path := strings.Trim(strings.TrimSpace(flow.Path), "/")
-		if graph := buildStageGraphForFlow(source, flowID, flowID, path); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 {
+		if graph := buildStageGraphForFlow(source, flowID, flowID, path); len(graph.Nodes) > 0 || len(graph.Edges) > 0 || len(graph.Timers) > 0 || len(graph.FanOuts) > 0 {
 			graphs = append(graphs, graph)
 		}
 	}
@@ -443,6 +455,7 @@ func buildStageGraphForFlow(source semanticview.Source, flowID, label, path stri
 		Nodes:    nodes,
 		Edges:    buildStageGraphEdgesForFlow(source, flowID, initial, states, terminalSet),
 		Timers:   buildStageGraphTimersForFlow(source, flowID),
+		FanOuts:  buildStageGraphFanOutsForFlow(source, flowID, initial, states, terminalSet),
 	}
 }
 
@@ -507,8 +520,7 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial str
 		if nodeID == "" {
 			continue
 		}
-		sourceInfo, ok := source.NodeContractSource(nodeID)
-		if !ok || strings.TrimSpace(sourceInfo.FlowID) != strings.TrimSpace(flowID) {
+		if !authoringNodeBelongsToFlow(source, nodeID, flowID) {
 			continue
 		}
 		eventTypes := make([]string, 0, len(node.EventHandlers))
@@ -627,6 +639,133 @@ func buildStageGraphTimersForFlow(source semanticview.Source, flowID string) []S
 		return out[i].TimerID < out[j].TimerID
 	})
 	return out
+}
+
+func buildStageGraphFanOutsForFlow(source semanticview.Source, flowID, initial string, states []string, terminalSet map[string]struct{}) []StageGraphFanOutView {
+	if source == nil {
+		return nil
+	}
+	nonTerminal := make([]string, 0, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := terminalSet[state]; ok {
+			continue
+		}
+		nonTerminal = append(nonTerminal, state)
+	}
+	out := make([]StageGraphFanOutView, 0)
+	nodes := source.NodeEntries()
+	for _, nodeID := range sortedAuthoringNodeIDs(nodes) {
+		node := nodes[nodeID]
+		if !authoringNodeBelongsToFlow(source, nodeID, flowID) {
+			continue
+		}
+		eventTypes := make([]string, 0, len(node.EventHandlers))
+		for eventType := range node.EventHandlers {
+			if eventType = strings.TrimSpace(eventType); eventType != "" {
+				eventTypes = append(eventTypes, eventType)
+			}
+		}
+		sort.Strings(eventTypes)
+		for _, eventType := range eventTypes {
+			handler := node.EventHandlers[eventType]
+			from := append([]string{}, nonTerminal...)
+			if handler.CreateEntity {
+				from = nil
+				if strings.TrimSpace(initial) != "" {
+					from = []string{strings.TrimSpace(initial)}
+				}
+			}
+			out = append(out, fanOutViewsForHandler(from, strings.TrimSpace(nodeID), eventType, handler)...)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i]
+		right := out[j]
+		if strings.Join(left.From, "\x00") != strings.Join(right.From, "\x00") {
+			return strings.Join(left.From, "\x00") < strings.Join(right.From, "\x00")
+		}
+		if left.Emit != right.Emit {
+			return left.Emit < right.Emit
+		}
+		if left.Source != right.Source {
+			return left.Source < right.Source
+		}
+		if left.NodeID != right.NodeID {
+			return left.NodeID < right.NodeID
+		}
+		return left.EventType < right.EventType
+	})
+	return out
+}
+
+func authoringNodeBelongsToFlow(source semanticview.Source, nodeID, flowID string) bool {
+	sourceInfo, ok := source.NodeContractSource(nodeID)
+	if ok {
+		return strings.TrimSpace(sourceInfo.FlowID) == strings.TrimSpace(flowID)
+	}
+	return strings.TrimSpace(flowID) == ""
+}
+
+func fanOutViewsForHandler(from []string, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []StageGraphFanOutView {
+	out := make([]StageGraphFanOutView, 0, 5)
+	add := func(source string, spec *runtimecontracts.FanOutSpec) {
+		if spec == nil {
+			return
+		}
+		emit := strings.TrimSpace(spec.Emit.EventType())
+		if emit == "" {
+			return
+		}
+		out = append(out, StageGraphFanOutView{
+			From:      append([]string{}, from...),
+			Emit:      emit,
+			ItemsFrom: strings.TrimSpace(spec.ItemsFrom),
+			ItemAlias: strings.TrimSpace(spec.As),
+			Identity:  strings.TrimSpace(spec.Identity),
+			Source:    strings.TrimSpace(source),
+			NodeID:    strings.TrimSpace(nodeID),
+			EventType: strings.TrimSpace(eventType),
+		})
+	}
+	add("handler.fan_out", handler.FanOut)
+	for idx := range handler.Rules {
+		add(indexedHandlerGraphSource("handler.rules", idx, handler.Rules[idx].ID)+".fan_out", handler.Rules[idx].FanOut)
+	}
+	for idx := range handler.OnComplete {
+		add(indexedHandlerGraphSource("handler.on_complete", idx, handler.OnComplete[idx].ID)+".fan_out", handler.OnComplete[idx].FanOut)
+	}
+	if handler.Accumulate != nil {
+		for idx := range handler.Accumulate.OnComplete {
+			add(indexedHandlerGraphSource("handler.accumulate.on_complete", idx, handler.Accumulate.OnComplete[idx].ID)+".fan_out", handler.Accumulate.OnComplete[idx].FanOut)
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			add(indexedHandlerGraphSource("handler.accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID)+".fan_out", handler.Accumulate.OnTimeout.FanOut)
+		}
+	}
+	return out
+}
+
+func sortedAuthoringNodeIDs(nodes map[string]runtimecontracts.SystemNodeContract) []string {
+	nodeIDs := make([]string, 0, len(nodes))
+	for nodeID := range nodes {
+		if nodeID = strings.TrimSpace(nodeID); nodeID != "" {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+	}
+	sort.Strings(nodeIDs)
+	return nodeIDs
+}
+
+func indexedHandlerGraphSource(prefix string, idx int, id string) string {
+	id = strings.TrimSpace(id)
+	if id != "" {
+		return fmt.Sprintf("%s[%d:%s]", strings.TrimSpace(prefix), idx, id)
+	}
+	return fmt.Sprintf("%s[%d]", strings.TrimSpace(prefix), idx)
 }
 
 func authoringStringSet(values []string) map[string]struct{} {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -251,6 +251,61 @@ func TestBuildStageGraphShowsStageTimersAndTimedEdges(t *testing.T) {
 	}
 }
 
+func TestBuildStageGraphShowsFanOutMultiplicity(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			StageDeclarations: runtimecontracts.FlowStageDeclarations{
+				Declared: true,
+				Entries: []runtimecontracts.FlowStageDeclaration{
+					{ID: "waiting", Initial: true},
+					{ID: "awaiting_line_items"},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "waiting",
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"dispatcher": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"order.accepted": {
+						CreateEntity: true,
+						FanOut: &runtimecontracts.FanOutSpec{
+							ItemsFrom: "payload.line_items",
+							As:        "line_item",
+							Identity:  "line_item.id",
+							Emit:      runtimecontracts.EmitSpec{Event: "line_item.requested"},
+						},
+						AdvancesTo: "awaiting_line_items",
+					},
+				},
+			},
+		},
+	}
+
+	view, err := Build(context.Background(), semanticview.Wrap(bundle), BuildOptions{IncludeStageGraph: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(view.StageGraphs) != 1 {
+		t.Fatalf("StageGraphs = %#v, want one root graph", view.StageGraphs)
+	}
+	graph := view.StageGraphs[0]
+	if len(graph.FanOuts) != 1 {
+		t.Fatalf("graph fan_outs = %#v, want one fan-out edge", graph.FanOuts)
+	}
+	got := graph.FanOuts[0]
+	if got.Emit != "line_item.requested" || got.ItemsFrom != "payload.line_items" || got.ItemAlias != "line_item" || got.Identity != "line_item.id" {
+		t.Fatalf("fan-out view = %#v, want multiplicity metadata", got)
+	}
+	if len(got.From) != 1 || got.From[0] != "waiting" {
+		t.Fatalf("fan-out from = %#v, want initial stage", got.From)
+	}
+	if got.Source != "handler.fan_out" || got.NodeID != "dispatcher" || got.EventType != "order.accepted" {
+		t.Fatalf("fan-out source = %#v, want handler fan_out dispatcher/order.accepted", got)
+	}
+}
+
 func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
 	flow := runtimecontracts.FlowContractView{
 		Path: "analysis",

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -173,6 +173,9 @@ type checkerContext struct {
 	emitFieldExprLoaded   bool
 	emitFieldExprFindings []Finding
 
+	fanOutLoaded   bool
+	fanOutFindings []Finding
+
 	entityRefLoaded   bool
 	entityRefFindings []Finding
 
@@ -229,6 +232,7 @@ var bootCheckRegistry = []Check{
 	{ID: policySheetLookupCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetLookupValueRows},
 	{ID: policySheetValidationCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetValidationValueRows},
 	{ID: computeModuleCheckID, Severity: SeverityHardInvalidity, Run: checkComputeModuleValueRows},
+	{ID: fanOutValidationCheckID, Severity: SeverityHardInvalidity, Run: checkFanOutValidation},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
 	{ID: "required_mcp_tool_availability", Severity: SeverityHardInvalidity, Run: checkRequiredMCPToolAvailability},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 73 {
-		t.Fatalf("bootCheckRegistry count = %d, want 73", got)
+	if got := len(bootCheckRegistry); got != 74 {
+		t.Fatalf("bootCheckRegistry count = %d, want 74", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -58,6 +58,7 @@ var stableHardInvalidityRemediation = map[string]string{
 	"event_runtime_wiring_validation":         "Add the missing runtime handler/owner for the event or remove the event transition that requires runtime handling.",
 	"expression_field_reference_validation":   "Fix the expression field reference so it uses the supported namespace and declared field path.",
 	"event_metadata_authority":                "Move platform-owned event metadata out of authored business payload declarations.",
+	"fan_out_validation":                      "Fix fan_out so items_from names a declared collection, as names the item binding, identity uses that binding, and the emitted payload carries the identity.",
 	"flow_boundary_create_entity_validation":  "Fix the cross-flow create_entity declaration so it preserves the receiving flow boundary.",
 	"flow_data_access_validation":             "Use the supported flow data access form for the referenced field or remove the unsupported access.",
 	"flow_package_dependency_binding":         "Declare the required imported package binding or remove the unresolved dependency reference.",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -733,6 +733,9 @@ fanout-node:
   event_handlers:
     start:
       fan_out:
+        items_from: payload.items
+        as: ticket
+        identity: ticket.id
         emit: ticket.ready
 `,
 					},
@@ -787,6 +790,9 @@ accumulate-timeout-node:
         timeout_ms: 1000
         on_timeout:
           fan_out:
+            items_from: payload.items
+            as: ticket
+            identity: ticket.id
             emit: ticket.ready
 `,
 					},
@@ -3300,10 +3306,13 @@ func TestRun_RejectsRetiredFanOutTargetInFanOutEmitFieldExpressions(t *testing.T
 					"item.received": {
 						FanOut: &runtimecontracts.FanOutSpec{
 							ItemsFrom: "payload.items",
+							As:        "scored_item",
+							Identity:  "scored_item.id",
 							Emit: runtimecontracts.EmitSpec{
 								Event: "item.scored",
 								Fields: map[string]runtimecontracts.ExpressionValue{
 									"bad": runtimecontracts.CELExpression(`fan_out["target"]`),
+									"id":  runtimecontracts.CELExpression("scored_item.id"),
 								},
 							},
 						},
@@ -3375,16 +3384,18 @@ emit:
 	}
 }
 
-func TestRun_AcceptsYAMLScalarFanOutEmitItemExpressions(t *testing.T) {
+func TestRun_AcceptsYAMLScalarFanOutEmitAliasExpressions(t *testing.T) {
 	var handler runtimecontracts.SystemNodeEventHandler
 	if err := yaml.Unmarshal([]byte(`
 fan_out:
   items_from: payload.industries
+  as: industry
+  identity: industry
   emit:
     event: market_research.industry_assigned
     fields:
-      industry: item
-      taxonomy_categories: "[item]"
+      industry: industry
+      taxonomy_categories: "[industry]"
 `), &handler); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
@@ -3411,8 +3422,8 @@ fan_out:
 
 	report := Run(context.Background(), source, Options{})
 
-	if reportContains(report.Errors(), "emit_field_expression_validation", "item") {
-		t.Fatalf("unexpected item expression validation error, got %#v", report.Errors())
+	if reportContains(report.Errors(), "emit_field_expression_validation", "industry") {
+		t.Fatalf("unexpected fan_out alias expression validation error, got %#v", report.Errors())
 	}
 }
 
@@ -4149,10 +4160,13 @@ func TestRun_ErrorsForFanOutEmitSitePayloadDrift(t *testing.T) {
 	handler := node.EventHandlers["scan.corpus_dispatch"]
 	handler.Emit = runtimecontracts.EmitSpec{}
 	handler.FanOut = &runtimecontracts.FanOutSpec{
+		ItemsFrom: "payload.geography",
+		As:        "geography",
+		Identity:  "geography",
 		Emit: runtimecontracts.EmitSpec{
 			Event: "market_research.scan_assigned",
 			Fields: map[string]runtimecontracts.ExpressionValue{
-				"geography": runtimecontracts.RefExpression("payload.geography"),
+				"geography": runtimecontracts.CELExpression("geography"),
 			},
 		},
 	}
@@ -6333,8 +6347,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 73 {
-		t.Fatalf("bootCheckRegistry count = %d, want 73", got)
+	if got := len(bootCheckRegistry); got != 74 {
+		t.Fatalf("bootCheckRegistry count = %d, want 74", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -80,7 +80,7 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem}); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias}); err != nil {
 					c.dataAccumulationExprFindings = append(c.dataAccumulationExprFindings, Finding{
 						CheckID:  "data_accumulation_expression_validation",
 						Severity: "error",
@@ -109,7 +109,7 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 					expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem}); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias}); err != nil {
 					c.emitFieldExprFindings = append(c.emitFieldExprFindings, Finding{
 						CheckID:  "emit_field_expression_validation",
 						Severity: "error",
@@ -288,6 +288,7 @@ type expressionReference struct {
 	Phase           runtimepipeline.WorkflowEntityFieldLifecyclePhase
 	SelfTargetField string
 	AllowBareItem   bool
+	ItemAlias       string
 }
 
 type handlerCondition struct {
@@ -465,7 +466,7 @@ func handlerEntityExpressionsForSource(source semanticview.Source, flowID, nodeI
 
 func handlerEmitExpressionsForSource(source semanticview.Source, flowID, nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) []expressionReference {
 	out := make([]expressionReference, 0, 8)
-	appendSpec := func(kindPrefix, siteKey string, spec runtimecontracts.EmitSpec, phase runtimepipeline.WorkflowEntityFieldLifecyclePhase, allowBareItem bool) {
+	appendSpec := func(kindPrefix, siteKey string, spec runtimecontracts.EmitSpec, phase runtimepipeline.WorkflowEntityFieldLifecyclePhase, itemAlias string) {
 		if spec.Empty() {
 			return
 		}
@@ -490,21 +491,20 @@ func handlerEmitExpressionsForSource(source semanticview.Source, flowID, nodeID,
 				continue
 			}
 			out = append(out, expressionReference{
-				Kind:          kindPrefix + " emit field " + strings.TrimSpace(key),
-				Expression:    expr,
-				Phase:         phase,
-				AllowBareItem: allowBareItem,
+				Kind:       kindPrefix + " emit field " + strings.TrimSpace(key),
+				Expression: expr,
+				Phase:      phase,
+				ItemAlias:  strings.TrimSpace(itemAlias),
 			})
 		}
 	}
 	for _, site := range runtimecontracts.HandlerDeclarativeEmitSites(handler) {
-		allowBareItem := strings.Contains(site.Source, "fan_out.emit")
-		appendSpec(site.Source, site.SiteKey, site.Spec, runtimepipeline.WorkflowEntityFieldLifecycleEmitFields, allowBareItem)
+		appendSpec(site.Source, site.SiteKey, site.Spec, runtimepipeline.WorkflowEntityFieldLifecycleEmitFields, site.ItemAlias)
 	}
 	if handler.Guard != nil {
 		if failureSpec, err := handler.Guard.FailureSpec(); err == nil {
 			if parsed, err := runtimeengine.GuardFailureFromSpec(failureSpec); err == nil && parsed.Action == runtimeengine.GuardFailureEscalate {
-				appendSpec("guard escalation", "guard.on_fail.escalate", failureSpec.EscalationEmitSpec(), runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation, false)
+				appendSpec("guard escalation", "guard.on_fail.escalate", failureSpec.EscalationEmitSpec(), runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation, "")
 			}
 		}
 	}

--- a/internal/runtime/bootverify/workflow_fan_out_checks.go
+++ b/internal/runtime/bootverify/workflow_fan_out_checks.go
@@ -1,0 +1,221 @@
+package bootverify
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
+)
+
+const fanOutValidationCheckID = "fan_out_validation"
+
+func checkFanOutValidation(c *checkerContext) []Finding { return c.fanOutValidation() }
+
+func (c *checkerContext) fanOutValidation() []Finding {
+	if c.fanOutLoaded {
+		return c.fanOutFindings
+	}
+	c.fanOutLoaded = true
+	for _, nodeID := range sortedNodeIDs(c.source) {
+		node, ok := c.source.NodeEntries()[nodeID]
+		if !ok {
+			continue
+		}
+		flowID := nodeFlowID(c.source, nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			for _, site := range fanOutSites(handler) {
+				c.fanOutFindings = append(c.fanOutFindings, c.validateFanOutSite(flowID, nodeID, eventType, site)...)
+			}
+		}
+	}
+	return c.fanOutFindings
+}
+
+type fanOutValidationSite struct {
+	Source string
+	Spec   *runtimecontracts.FanOutSpec
+}
+
+func fanOutSites(handler runtimecontracts.SystemNodeEventHandler) []fanOutValidationSite {
+	out := make([]fanOutValidationSite, 0, 5)
+	add := func(source string, spec *runtimecontracts.FanOutSpec) {
+		if spec == nil {
+			return
+		}
+		out = append(out, fanOutValidationSite{Source: strings.TrimSpace(source), Spec: spec})
+	}
+	add("handler.fan_out", handler.FanOut)
+	for idx := range handler.Rules {
+		add(ruleScope("handler.rules", idx, handler.Rules[idx].ID)+".fan_out", handler.Rules[idx].FanOut)
+	}
+	for idx := range handler.OnComplete {
+		add(ruleScope("handler.on_complete", idx, handler.OnComplete[idx].ID)+".fan_out", handler.OnComplete[idx].FanOut)
+	}
+	if handler.Accumulate != nil {
+		for idx := range handler.Accumulate.OnComplete {
+			add(ruleScope("handler.accumulate.on_complete", idx, handler.Accumulate.OnComplete[idx].ID)+".fan_out", handler.Accumulate.OnComplete[idx].FanOut)
+		}
+		if handler.Accumulate.OnTimeout != nil {
+			add(ruleScope("handler.accumulate.on_timeout", 0, handler.Accumulate.OnTimeout.ID)+".fan_out", handler.Accumulate.OnTimeout.FanOut)
+		}
+	}
+	return out
+}
+
+func (c *checkerContext) validateFanOutSite(flowID, nodeID, eventType string, site fanOutValidationSite) []Finding {
+	spec := site.Spec
+	if spec == nil {
+		return nil
+	}
+	out := make([]Finding, 0, 4)
+	add := func(detail string) {
+		out = append(out, Finding{
+			CheckID:  fanOutValidationCheckID,
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("flow %s node %s handler %s %s: %s", defaultFlowLabel(flowID), nodeID, eventType, site.Source, detail),
+			Location: nodeID,
+		})
+	}
+	if err := runtimecontracts.ValidateFanOutAlias(spec.As); err != nil {
+		add("fan_out." + err.Error())
+	}
+	if strings.TrimSpace(spec.Identity) == "" {
+		add("fan_out.identity is required")
+	} else {
+		if err := workflowexpr.ValidateValueExpressionWithOptions(spec.Identity, workflowexpr.ValueExpressionOptions{ItemAlias: spec.As}); err != nil {
+			add(fmt.Sprintf("fan_out.identity %q is invalid: %v", spec.Identity, err))
+		}
+		if workflowexpr.ExpressionReferencesFanOutFieldForValidation(spec.Identity, "index") {
+			add("fan_out.identity must use the stable item alias, not fan_out.index")
+		}
+		if !expressionReferencesAlias(spec.Identity, spec.As) {
+			add(fmt.Sprintf("fan_out.identity %q must reference item alias %q", spec.Identity, strings.TrimSpace(spec.As)))
+		}
+		if !fanOutEmitCarriesIdentity(*spec) {
+			add(fmt.Sprintf("fan_out.emit.fields must carry identity expression %q", strings.TrimSpace(spec.Identity)))
+		}
+	}
+	if err := runtimecontracts.ValidateFanOutMaxItems(*spec); err != nil {
+		add(err.Error())
+	}
+	if err := c.validateFanOutItemsSource(flowID, eventType, *spec); err != nil {
+		add(err.Error())
+	}
+	return out
+}
+
+func (c *checkerContext) validateFanOutItemsSource(flowID, eventType string, spec runtimecontracts.FanOutSpec) error {
+	path, err := runtimecontracts.ValidateFanOutItemsSource(spec)
+	if err != nil {
+		return err
+	}
+	field := strings.TrimSpace(path.Segments[0])
+	switch path.Root {
+	case runtimepaths.RootPayload:
+		proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
+		if !proof.HasSchema {
+			return fmt.Errorf("fan_out.items_from %q references payload but event %s has no payload schema", strings.TrimSpace(spec.ItemsFrom), eventType)
+		}
+		fieldSpec, ok := proof.Entry.Payload.Properties[field]
+		if !ok {
+			return fmt.Errorf("fan_out.items_from %q references undeclared payload field %s", strings.TrimSpace(spec.ItemsFrom), field)
+		}
+		if !fanOutCollectionTypeRef(fieldSpec.Type) {
+			return fmt.Errorf("fan_out.items_from %q must reference a collection payload field; field %s has type %q", strings.TrimSpace(spec.ItemsFrom), field, strings.TrimSpace(fieldSpec.Type))
+		}
+	case runtimepaths.RootEntity:
+		view := wave1EntityContractForFlow(c.source, flowID)
+		if !view.Defined {
+			return fmt.Errorf("fan_out.items_from %q references entity but flow %s has no primary entity contract", strings.TrimSpace(spec.ItemsFrom), defaultFlowLabel(flowID))
+		}
+		fieldSpec, ok := view.Contract.Fields[field]
+		if !ok {
+			return fmt.Errorf("fan_out.items_from %q references undeclared entity field %s", strings.TrimSpace(spec.ItemsFrom), field)
+		}
+		if !fanOutCollectionTypeRef(fieldSpec.Type) {
+			return fmt.Errorf("fan_out.items_from %q must reference a collection entity field; field %s has type %q", strings.TrimSpace(spec.ItemsFrom), field, strings.TrimSpace(fieldSpec.Type))
+		}
+	}
+	return nil
+}
+
+func fanOutCollectionTypeRef(typeRef string) bool {
+	typeRef = strings.TrimSpace(typeRef)
+	lower := strings.ToLower(typeRef)
+	if typeRef == "" {
+		return false
+	}
+	switch {
+	case lower == "array":
+		return true
+	case strings.HasPrefix(lower, "array ") || strings.HasPrefix(lower, "array("):
+		return true
+	case strings.HasPrefix(lower, "array<") && strings.Contains(lower, ">"):
+		end := strings.Index(lower, ">")
+		return strings.TrimSpace(typeRef[len("array<"):end]) != ""
+	case strings.HasPrefix(lower, "list<") && strings.HasSuffix(lower, ">"):
+		return strings.TrimSpace(typeRef[len("list<"):len(typeRef)-1]) != ""
+	case strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]"):
+		return strings.TrimSpace(typeRef[1:len(typeRef)-1]) != ""
+	case strings.HasPrefix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[2:]) != ""
+	case strings.HasSuffix(typeRef, "[]"):
+		return strings.TrimSpace(typeRef[:len(typeRef)-2]) != ""
+	default:
+		return false
+	}
+}
+
+func fanOutEmitCarriesIdentity(spec runtimecontracts.FanOutSpec) bool {
+	want := strings.TrimSpace(spec.Identity)
+	if want == "" {
+		return false
+	}
+	for _, expr := range spec.Emit.Fields {
+		if strings.TrimSpace(fanOutExpressionText(expr)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func fanOutExpressionText(expr runtimecontracts.ExpressionValue) string {
+	switch expr.Kind {
+	case runtimecontracts.ExpressionKindRef:
+		return strings.TrimSpace(expr.Ref)
+	case runtimecontracts.ExpressionKindCEL:
+		return strings.TrimSpace(expr.CEL)
+	default:
+		return ""
+	}
+}
+
+func expressionReferencesAlias(expression, alias string) bool {
+	expression = workflowexpr.StripStringLiterals(strings.TrimSpace(expression))
+	alias = strings.TrimSpace(alias)
+	if expression == "" || alias == "" {
+		return false
+	}
+	for i := 0; i < len(expression); i++ {
+		if !strings.HasPrefix(expression[i:], alias) {
+			continue
+		}
+		if i > 0 && fanOutIdentifierPart(expression[i-1]) {
+			continue
+		}
+		end := i + len(alias)
+		if end < len(expression) && fanOutIdentifierPart(expression[end]) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func fanOutIdentifierPart(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}

--- a/internal/runtime/bootverify/workflow_fan_out_checks_test.go
+++ b/internal/runtime/bootverify/workflow_fan_out_checks_test.go
@@ -1,0 +1,181 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ValidatesFanOutCollectionContract(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*runtimecontracts.FanOutSpec, *runtimecontracts.WorkflowContractBundle)
+		wantError string
+	}{
+		{
+			name: "valid",
+		},
+		{
+			name: "items source accepts array schema type",
+			mutate: func(_ *runtimecontracts.FanOutSpec, bundle *runtimecontracts.WorkflowContractBundle) {
+				event := bundle.Events["order.accepted"]
+				event.Payload.Properties["line_items"] = runtimecontracts.EventFieldSpec{Type: "array"}
+				bundle.Events["order.accepted"] = event
+			},
+		},
+		{
+			name: "missing alias",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.As = ""
+			},
+			wantError: "fan_out.as is required",
+		},
+		{
+			name: "identity cannot use index",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.Identity = "fan_out.index"
+				spec.Emit.Fields["line_item_id"] = runtimecontracts.CELExpression("fan_out.index")
+			},
+			wantError: "fan_out.identity must use the stable item alias",
+		},
+		{
+			name: "identity must be carried",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.Emit.Fields["line_item_id"] = runtimecontracts.CELExpression("line_item.sku")
+			},
+			wantError: `fan_out.emit.fields must carry identity expression "line_item.id"`,
+		},
+		{
+			name: "max items only tightens ceiling",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.MaxItems = runtimecontracts.DefaultFanOutMaxItems + 1
+			},
+			wantError: "max_items may only tighten the ceiling",
+		},
+		{
+			name: "explicit zero max items fails closed",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.MaxItems = 0
+				spec.MaxItemsSet = true
+			},
+			wantError: "fan_out.max_items must be a positive integer when set",
+		},
+		{
+			name: "items source must be declared",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.ItemsFrom = "payload.undeclared_items"
+			},
+			wantError: "references undeclared payload field undeclared_items",
+		},
+		{
+			name: "items source must be a collection",
+			mutate: func(spec *runtimecontracts.FanOutSpec, bundle *runtimecontracts.WorkflowContractBundle) {
+				spec.ItemsFrom = "payload.customer_id"
+				event := bundle.Events["order.accepted"]
+				event.Payload.Properties["customer_id"] = runtimecontracts.EventFieldSpec{Type: "text"}
+				bundle.Events["order.accepted"] = event
+			},
+			wantError: `must reference a collection payload field; field customer_id has type "text"`,
+		},
+		{
+			name: "items source must not descend below declared collection field",
+			mutate: func(spec *runtimecontracts.FanOutSpec, _ *runtimecontracts.WorkflowContractBundle) {
+				spec.ItemsFrom = "payload.line_items.missing"
+				spec.ItemsPath = runtimecontracts.RefExpression(spec.ItemsFrom).RefPath
+			},
+			wantError: "must reference exactly one declared top-level collection field",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := runtimecontracts.FanOutSpec{
+				ItemsFrom: "payload.line_items",
+				As:        "line_item",
+				Identity:  "line_item.id",
+				Emit: runtimecontracts.EmitSpec{
+					Event: "line_item.requested",
+					Fields: map[string]runtimecontracts.ExpressionValue{
+						"line_item_id": runtimecontracts.CELExpression("line_item.id"),
+						"line_index":   runtimecontracts.CELExpression("fan_out.index"),
+					},
+				},
+			}
+			bundle := fanOutValidationBundle(spec)
+			if tc.mutate != nil {
+				handler := bundle.Nodes["dispatcher"].EventHandlers["order.accepted"]
+				tc.mutate(handler.FanOut, bundle)
+				bundle.Nodes["dispatcher"].EventHandlers["order.accepted"] = handler
+			}
+
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+			if tc.wantError == "" {
+				if reportContains(report.HardInvalidities(), fanOutValidationCheckID, "") {
+					t.Fatalf("unexpected fan_out_validation invalidity: %#v", report.HardInvalidities())
+				}
+				return
+			}
+			if !reportContains(report.HardInvalidities(), fanOutValidationCheckID, tc.wantError) {
+				t.Fatalf("expected fan_out_validation %q, got %#v", tc.wantError, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func TestFanOutCollectionTypeRef(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want bool
+	}{
+		{raw: "[text]", want: true},
+		{raw: "list<text>", want: true},
+		{raw: "text[]", want: true},
+		{raw: "[]text", want: true},
+		{raw: "array", want: true},
+		{raw: "array (required for batch modes)", want: true},
+		{raw: "array<text>", want: true},
+		{raw: "", want: false},
+		{raw: "text", want: false},
+		{raw: "[]", want: false},
+		{raw: "[ ]", want: false},
+		{raw: "list<>", want: false},
+		{raw: "array<>", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.raw, func(t *testing.T) {
+			if got := fanOutCollectionTypeRef(tc.raw); got != tc.want {
+				t.Fatalf("fanOutCollectionTypeRef(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func fanOutValidationBundle(spec runtimecontracts.FanOutSpec) *runtimecontracts.WorkflowContractBundle {
+	return &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"order.accepted": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"line_items": {Type: "[LineItem]"},
+				}},
+			},
+			"line_item.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+					"line_item_id": {Type: "text"},
+					"line_index":   {Type: "integer"},
+				}},
+			},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"dispatcher": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"order.accepted": {
+						FanOut: &spec,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
+++ b/internal/runtime/bootverify/workflow_policy_sheet_lookup_checks.go
@@ -301,6 +301,9 @@ func policySheetLookupFanOutConsumes(spec runtimecontracts.FanOutSpec, target st
 	if policySheetLookupExpressionConsumes(spec.ItemsFrom, target) {
 		return true
 	}
+	if policySheetLookupExpressionConsumes(spec.Identity, target) {
+		return true
+	}
 	for _, expr := range spec.Emit.Fields {
 		if policySheetLookupExpressionValueConsumes(expr, target) {
 			return true

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -12,6 +12,7 @@ type HandlerDeclarativeEmitSite struct {
 	RuleID    string
 	RuleIndex int
 	Spec      EmitSpec
+	ItemAlias string
 }
 
 func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
@@ -65,9 +66,13 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 
 func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclarativeEmitSite {
 	out := make([]HandlerDeclarativeEmitSite, 0, 8)
-	add := func(source, siteKey, ruleID string, ruleIndex int, spec EmitSpec) {
+	add := func(source, siteKey, ruleID string, ruleIndex int, spec EmitSpec, itemAlias ...string) {
 		if spec.Empty() {
 			return
+		}
+		alias := ""
+		if len(itemAlias) > 0 {
+			alias = strings.TrimSpace(itemAlias[0])
 		}
 		out = append(out, HandlerDeclarativeEmitSite{
 			Source:    strings.TrimSpace(source),
@@ -75,6 +80,7 @@ func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclar
 			RuleID:    strings.TrimSpace(ruleID),
 			RuleIndex: ruleIndex,
 			Spec:      cloneEmitSpec(spec),
+			ItemAlias: alias,
 		})
 	}
 	templateSites := HandlerRuleEmitTemplateSites(handler)
@@ -83,7 +89,7 @@ func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclar
 		for idx, rule := range handler.Rules {
 			add("handler.rules.emit", indexedHandlerEmitSiteKey("handler.rules", idx, "emit"), rule.ID, idx, rule.Emit)
 			if rule.FanOut != nil {
-				add("handler.rules.fan_out.emit", indexedHandlerEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+				add("handler.rules.fan_out.emit", indexedHandlerEmitSiteKey("handler.rules", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit, rule.FanOut.As)
 			}
 		}
 	} else {
@@ -93,25 +99,25 @@ func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclar
 	for idx, rule := range handler.OnComplete {
 		add("handler.on_complete.emit", indexedHandlerEmitSiteKey("handler.on_complete", idx, "emit"), rule.ID, idx, rule.Emit)
 		if rule.FanOut != nil {
-			add("handler.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+			add("handler.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit, rule.FanOut.As)
 		}
 	}
 	if handler.Accumulate != nil {
 		for idx, rule := range handler.Accumulate.OnComplete {
 			add("handler.accumulate.on_complete.emit", indexedHandlerEmitSiteKey("handler.accumulate.on_complete", idx, "emit"), rule.ID, idx, rule.Emit)
 			if rule.FanOut != nil {
-				add("handler.accumulate.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit)
+				add("handler.accumulate.on_complete.fan_out.emit", indexedHandlerEmitSiteKey("handler.accumulate.on_complete", idx, "fan_out.emit"), rule.ID, idx, rule.FanOut.Emit, rule.FanOut.As)
 			}
 		}
 		if handler.Accumulate.OnTimeout != nil {
 			add("handler.accumulate.on_timeout.emit", "handler.accumulate.on_timeout.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.Emit)
 			if handler.Accumulate.OnTimeout.FanOut != nil {
-				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.FanOut.Emit)
+				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.FanOut.Emit, handler.Accumulate.OnTimeout.FanOut.As)
 			}
 		}
 	}
 	if handler.FanOut != nil {
-		add("handler.fan_out.emit", "handler.fan_out.emit", "", -1, handler.FanOut.Emit)
+		add("handler.fan_out.emit", "handler.fan_out.emit", "", -1, handler.FanOut.Emit, handler.FanOut.As)
 	}
 	return out
 }

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -271,7 +271,7 @@ func TestWorkflowSemanticsDerivesEffectiveSystemNodeFacts(t *testing.T) {
 								Emit:      EmitSpec{Event: "task.rules.else"},
 							},
 						},
-						FanOut: &FanOutSpec{Emit: EmitSpec{Event: "task.child"}},
+						FanOut: &FanOutSpec{ItemsFrom: "payload.items", As: "task_item", Identity: "task_item", Emit: EmitSpec{Event: "task.child"}},
 					},
 				},
 			},

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -531,11 +531,97 @@ type ComputeKeyConfig struct {
 	ScoreKeys    []string `yaml:"score_keys"`
 	NumericKeys  []string `yaml:"numeric_keys"`
 }
+
+const (
+	DefaultFanOutMaxItems       = 1000
+	FanOutBoundExceededCode     = "platform.fan_out_bound_exceeded"
+	FanOutValidationCheckID     = "fan_out_validation"
+	FanOutPlatformIndexName     = "fan_out.index"
+	FanOutLegacyItemName        = "fan_out.item"
+	FanOutLegacyBareItemName    = "item"
+	FanOutUnsupportedIdentityNS = "fan_out.identity"
+)
+
 type FanOutSpec struct {
-	ItemsFrom string     `yaml:"items_from"`
-	ItemsPath paths.Path `yaml:"-"`
-	Emit      EmitSpec   `yaml:"emit"`
+	ItemsFrom   string     `yaml:"items_from"`
+	ItemsPath   paths.Path `yaml:"-"`
+	As          string     `yaml:"as"`
+	Identity    string     `yaml:"identity"`
+	MaxItems    int        `yaml:"max_items"`
+	MaxItemsSet bool       `yaml:"-"`
+	Emit        EmitSpec   `yaml:"emit"`
 }
+
+func EffectiveFanOutMaxItems(spec FanOutSpec) int {
+	if spec.MaxItems > 0 && spec.MaxItems < DefaultFanOutMaxItems {
+		return spec.MaxItems
+	}
+	return DefaultFanOutMaxItems
+}
+
+func ValidateFanOutItemsSource(spec FanOutSpec) (paths.Path, error) {
+	path := spec.ItemsPath
+	if path.IsZero() {
+		path = paths.Parse(spec.ItemsFrom)
+	}
+	raw := strings.TrimSpace(spec.ItemsFrom)
+	if raw == "" || path.IsZero() {
+		return paths.Path{}, fmt.Errorf("fan_out.items_from is required")
+	}
+	if !path.HasExplicitRoot() {
+		return paths.Path{}, fmt.Errorf("fan_out.items_from %q must use an explicit payload.* or entity.* root", raw)
+	}
+	if path.Root != paths.RootPayload && path.Root != paths.RootEntity {
+		return paths.Path{}, fmt.Errorf("fan_out.items_from %q must read a declared payload.* or entity.* collection", raw)
+	}
+	if len(path.Segments) != 1 || strings.TrimSpace(path.Segments[0]) == "" {
+		return paths.Path{}, fmt.Errorf("fan_out.items_from %q must reference exactly one declared top-level collection field", raw)
+	}
+	return path, nil
+}
+
+func ValidateFanOutMaxItems(spec FanOutSpec) error {
+	if spec.MaxItems < 0 || (spec.MaxItemsSet && spec.MaxItems == 0) {
+		return fmt.Errorf("fan_out.max_items must be a positive integer when set")
+	}
+	if spec.MaxItems > DefaultFanOutMaxItems {
+		return fmt.Errorf("fan_out.max_items %d exceeds platform ceiling %d; max_items may only tighten the ceiling", spec.MaxItems, DefaultFanOutMaxItems)
+	}
+	return nil
+}
+
+func ValidateFanOutAlias(alias string) error {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return fmt.Errorf("as is required")
+	}
+	if !simpleFanOutIdentifier(alias) {
+		return fmt.Errorf("as %q must be a simple identifier", alias)
+	}
+	switch alias {
+	case "payload", "entity", "_entity", "event", "policy", "computed", "fan_out", "accumulated", "query_entities", FanOutLegacyBareItemName:
+		return fmt.Errorf("as %q collides with a reserved expression root", alias)
+	}
+	return nil
+}
+
+func simpleFanOutIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 type HandlerOnSuccessSpec struct {
 	Emit EmitSpec `yaml:"emit"`
 }

--- a/internal/runtime/contracts/workflow_contract_yaml_rules.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_rules.go
@@ -229,17 +229,44 @@ func (f *FanOutSpec) UnmarshalYAML(node *yaml.Node) error {
 	}
 	var aux struct {
 		ItemsFrom string   `yaml:"items_from"`
+		As        string   `yaml:"as"`
+		Identity  string   `yaml:"identity"`
+		MaxItems  *int     `yaml:"max_items"`
 		Emit      EmitSpec `yaml:"emit"`
 	}
 	if err := node.Decode(&aux); err != nil {
 		return err
 	}
+	if err := ValidateFanOutAlias(aux.As); err != nil {
+		return fmt.Errorf("fan_out.%w", err)
+	}
+	if strings.TrimSpace(aux.Identity) == "" {
+		return fmt.Errorf("fan_out.identity is required")
+	}
+	maxItems := 0
+	maxItemsSet := hasYAMLMappingKey(node, "max_items")
+	if maxItemsSet && aux.MaxItems == nil {
+		return fmt.Errorf("fan_out.max_items must be a positive integer when set")
+	}
+	if aux.MaxItems != nil {
+		maxItems = *aux.MaxItems
+	}
 	*f = FanOutSpec{
-		ItemsFrom: strings.TrimSpace(aux.ItemsFrom),
-		Emit:      aux.Emit,
+		ItemsFrom:   strings.TrimSpace(aux.ItemsFrom),
+		As:          strings.TrimSpace(aux.As),
+		Identity:    strings.TrimSpace(aux.Identity),
+		MaxItems:    maxItems,
+		MaxItemsSet: maxItemsSet,
+		Emit:        aux.Emit,
 	}
 	f.ItemsFrom = strings.TrimSpace(f.ItemsFrom)
 	f.ItemsPath = paths.Parse(f.ItemsFrom)
+	if _, err := ValidateFanOutItemsSource(*f); err != nil {
+		return err
+	}
+	if err := ValidateFanOutMaxItems(*f); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -269,6 +296,9 @@ func validateFanOutFieldNodes(node *yaml.Node) error {
 
 var fanOutFieldOptions = map[string]struct{}{
 	"items_from": {},
+	"as":         {},
+	"identity":   {},
+	"max_items":  {},
 	"emit":       {},
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -2198,8 +2198,76 @@ emit:
 	if got := diagnostic.Problem; got != `fan_out field "foreach" is not supported.` {
 		t.Fatalf("diagnostic problem = %q, want unknown fan_out field problem", got)
 	}
-	if !reflect.DeepEqual(diagnostic.ValidOptions, []string{"emit", "items_from"}) {
-		t.Fatalf("diagnostic valid options = %#v, want emit/items_from", diagnostic.ValidOptions)
+	if !reflect.DeepEqual(diagnostic.ValidOptions, []string{"as", "emit", "identity", "items_from", "max_items"}) {
+		t.Fatalf("diagnostic valid options = %#v, want canonical fan_out options", diagnostic.ValidOptions)
+	}
+}
+
+func TestFanOutSpecDecode_RejectsExplicitZeroMaxItems(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+as: line_item
+identity: line_item.id
+max_items: 0
+emit:
+  event: routed.item
+  fields:
+    item_id: line_item.id
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), "fan_out.max_items must be a positive integer when set") {
+		t.Fatalf("yaml.Unmarshal error = %v, want explicit zero max_items rejection", err)
+	}
+}
+
+func TestFanOutSpecDecode_RejectsExplicitNullMaxItems(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+as: line_item
+identity: line_item.id
+max_items: null
+emit:
+  event: routed.item
+  fields:
+    item_id: line_item.id
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), "fan_out.max_items must be a positive integer when set") {
+		t.Fatalf("yaml.Unmarshal error = %v, want explicit null max_items rejection", err)
+	}
+}
+
+func TestFanOutSpecDecode_RejectsNestedItemsSource(t *testing.T) {
+	var spec FanOutSpec
+	err := yaml.Unmarshal([]byte(`
+items_from: payload.items.missing
+as: line_item
+identity: line_item.id
+emit:
+  event: routed.item
+  fields:
+    item_id: line_item.id
+`), &spec)
+	if err == nil || !strings.Contains(err.Error(), "must reference exactly one declared top-level collection field") {
+		t.Fatalf("yaml.Unmarshal error = %v, want nested items_from rejection", err)
+	}
+}
+
+func TestFanOutSpecDecode_DistinguishesOmittedMaxItems(t *testing.T) {
+	var spec FanOutSpec
+	if err := yaml.Unmarshal([]byte(`
+items_from: payload.items
+as: line_item
+identity: line_item.id
+emit:
+  event: routed.item
+  fields:
+    item_id: line_item.id
+`), &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if spec.MaxItemsSet || spec.MaxItems != 0 {
+		t.Fatalf("decoded max_items = %d set=%v, want omitted", spec.MaxItems, spec.MaxItemsSet)
 	}
 }
 
@@ -2830,6 +2898,12 @@ func TestHandlerRuleEntryDecode_PreservesRuleLevelFanOut(t *testing.T) {
 condition: "payload.mode == 'parallel'"
 fan_out:
   items_from: payload.items
+  as: line_item
+  identity: line_item.id
+  emit:
+    event: item.done
+    fields:
+      item_id: line_item.id
 data_accumulation:
   writes:
     - target_field: dispatch_count
@@ -3163,6 +3237,8 @@ rules:
     emit: rule.done
 fan_out:
   items_from: payload.items
+  as: line_item
+  identity: line_item.id
   emit: item.done
 `,
 			contains: "not supported with fan_out",
@@ -3177,6 +3253,8 @@ rules:
     condition: "else"
     fan_out:
       items_from: payload.items
+      as: line_item
+      identity: line_item.id
       emit: item.done
 `,
 			contains: "not supported with rules[0].fan_out",

--- a/internal/runtime/engine/errors.go
+++ b/internal/runtime/engine/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrEmitPayloadContractViolation = errors.New("engine: emit payload contract violation")
 	ErrInvalidConfig                = errors.New("engine: invalid config")
 	ErrNotImplemented               = errors.New("engine: not implemented")
+	ErrFanOutBoundExceeded          = errors.New("engine: fan_out bound exceeded")
 )

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
+	"github.com/division-sh/swarm/internal/runtime/rterrors"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 )
@@ -99,6 +100,7 @@ type executionFrame struct {
 	topLevelDataWritesApplied bool
 	ruleDataWritesApplied     bool
 	projectionApplied         bool
+	transitionApplied         bool
 }
 
 type handlerRuleSource string
@@ -1547,11 +1549,25 @@ func specialHandlerClearTarget(target string) bool {
 }
 
 func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
-	spec := e.selectedFanOut(frame)
-	if spec == nil {
+	active := e.selectedFanOut(frame)
+	if active.Spec == nil {
 		return false, nil
 	}
-	itemsValue, _ := resolveContractPath(frame.base, frame.state, spec.ItemsPath, spec.ItemsFrom)
+	spec := active.Spec
+	if err := runtimecontracts.ValidateFanOutAlias(spec.As); err != nil {
+		return false, fmt.Errorf("%w: fan_out.%v", ErrInvalidConfig, err)
+	}
+	if strings.TrimSpace(spec.Identity) == "" {
+		return false, fmt.Errorf("%w: fan_out.identity is required", ErrInvalidConfig)
+	}
+	itemsPath, err := runtimecontracts.ValidateFanOutItemsSource(*spec)
+	if err != nil {
+		return false, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+	if err := runtimecontracts.ValidateFanOutMaxItems(*spec); err != nil {
+		return false, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+	itemsValue, _ := resolveContractPath(frame.base, frame.state, itemsPath, spec.ItemsFrom)
 	items := sliceFromAny(itemsValue)
 	frame.result.FanOutCount = len(items)
 	frame.state.FanOut = map[string]any{}
@@ -1560,8 +1576,20 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	// entity write target.
 	frame.state.State.SetMetadata("fan_out_count", len(items))
 	frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
-	if len(items) == 0 {
-		return false, nil
+	limit := runtimecontracts.EffectiveFanOutMaxItems(*spec)
+	if len(items) > limit {
+		return false, rterrors.WrapRuntimeError(
+			runtimecontracts.FanOutBoundExceededCode,
+			"runtime.engine",
+			string(StepFanOut),
+			false,
+			ErrFanOutBoundExceeded,
+			"%s fan_out over %s resolved %d item(s), exceeding limit %d",
+			strings.TrimSpace(string(active.Source)),
+			strings.TrimSpace(spec.ItemsFrom),
+			len(items),
+			limit,
+		)
 	}
 	if err := e.stepDataWrites(frame); err != nil {
 		return false, err
@@ -1569,20 +1597,21 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 	if err := e.stepProjection(frame); err != nil {
 		return false, err
 	}
-	for _, item := range items {
+	for index, item := range items {
 		eventType := fanOutEventType(spec)
 		if eventType == "" {
 			continue
 		}
 		eventType = e.resolveDeclarativeEmitEventType(frame, eventType)
-		emitSpec, err := e.lowerEmitSpecForFrame(frame, "handler.fan_out.emit", spec.Emit)
+		emitSpec, err := e.lowerEmitSpecForFrame(frame, string(active.EmitSource()), spec.Emit)
 		if err != nil {
 			return false, err
 		}
 		emitSpec.Event = eventType
 		frame.state.SetFanOut("item", item)
+		frame.state.SetFanOut("index", index)
 		payload := map[string]any{}
-		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{AllowBareItem: true})
+		transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{ItemAlias: spec.As})
 		if err != nil {
 			return false, err
 		}
@@ -1598,7 +1627,11 @@ func (e *Executor) stepFanOut(frame *executionFrame) (bool, error) {
 		}
 	}
 	if len(frame.result.EmitIntents) == 0 && len(frame.result.DeadLetterIntents) == 0 {
-		return false, nil
+		if err := e.stepAdvancesTo(frame); err != nil {
+			return false, err
+		}
+		frame.result.Status = OutcomeFannedOut
+		return true, nil
 	}
 	if err := e.stepAdvancesTo(frame); err != nil {
 		return false, err
@@ -1712,6 +1745,9 @@ func (e *Executor) stepRules(frame *executionFrame) error {
 }
 
 func (e *Executor) stepAdvancesTo(frame *executionFrame) error {
+	if frame.transitionApplied {
+		return nil
+	}
 	next := strings.TrimSpace(frame.req.Handler.AdvancesTo)
 	if frame.rule != nil && strings.TrimSpace(frame.rule.AdvancesTo) != "" {
 		next = strings.TrimSpace(frame.rule.AdvancesTo)
@@ -1728,6 +1764,7 @@ func (e *Executor) stepAdvancesTo(frame *executionFrame) error {
 	frame.result.NextState = next
 	frame.state.State.CurrentState = next
 	frame.result.StateMutation.NextState = next
+	frame.transitionApplied = true
 	frame.result.ActionsExecuted = append(frame.result.ActionsExecuted,
 		identity.ActionRecordStateChange.String(),
 		identity.ActionUpdateState.String(),
@@ -2767,11 +2804,31 @@ func (e *Executor) selectedCompute(frame *executionFrame) *runtimecontracts.Comp
 	return frame.req.Handler.Compute
 }
 
-func (e *Executor) selectedFanOut(frame *executionFrame) *runtimecontracts.FanOutSpec {
-	if frame.rule != nil && frame.rule.FanOut != nil {
-		return frame.rule.FanOut
+type activeFanOutSpec struct {
+	Spec   *runtimecontracts.FanOutSpec
+	Source handlerRuleSource
+}
+
+func (a activeFanOutSpec) EmitSource() string {
+	switch a.Source {
+	case handlerRuleSourceRules:
+		return "handler.rules.fan_out.emit"
+	case handlerRuleSourceOnComplete:
+		return "handler.on_complete.fan_out.emit"
+	case handlerRuleSourceAccumulateOnComplete:
+		return "handler.accumulate.on_complete.fan_out.emit"
+	case handlerRuleSourceAccumulateOnTimeout:
+		return "handler.accumulate.on_timeout.fan_out.emit"
+	default:
+		return "handler.fan_out.emit"
 	}
-	return frame.req.Handler.FanOut
+}
+
+func (e *Executor) selectedFanOut(frame *executionFrame) activeFanOutSpec {
+	if frame.rule != nil && frame.rule.FanOut != nil {
+		return activeFanOutSpec{Spec: frame.rule.FanOut, Source: frame.ruleSource}
+	}
+	return activeFanOutSpec{Spec: frame.req.Handler.FanOut}
 }
 
 type activeDeclarativeEmitSpec struct {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -22,6 +22,7 @@ import (
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
+	"github.com/division-sh/swarm/internal/runtime/rterrors"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"gopkg.in/yaml.v3"
 )
@@ -421,6 +422,11 @@ type stubGuardRegistry struct {
 	entries map[identity.GuardKey]runtimeregistry.GuardInstruction
 }
 type stubPayloadShaper struct{}
+type recordingTransitionValidator struct {
+	calls   int
+	current string
+	next    string
+}
 type recordingPayloadShaper struct {
 	lastReq     ExecutionRequest
 	lastPayload map[string]any
@@ -519,6 +525,12 @@ func (stubPayloadShaper) ShapeEmitPayload(_ context.Context, _ ExecutionRequest,
 	out := cloneStringAnyMap(payload)
 	out["shaped_for"] = eventType
 	return out, nil
+}
+func (v *recordingTransitionValidator) ValidateTransition(currentState, nextState string) error {
+	v.calls++
+	v.current = currentState
+	v.next = nextState
+	return nil
 }
 func (s *recordingPayloadShaper) ShapeEmitPayload(ctx context.Context, req ExecutionRequest, eventType string, payload map[string]any) (map[string]any, error) {
 	s.lastReq = req
@@ -1503,12 +1515,14 @@ func TestExecutor_AccumulatorProjectionMaterializesBeforeTopLevelFanOutEmitField
 		},
 		FanOut: &runtimecontracts.FanOutSpec{
 			ItemsFrom: "payload.targets",
+			As:        "target_item",
+			Identity:  "target_item",
 			Emit: runtimecontracts.EmitSpec{
 				Event: "vertical.scored",
 				Fields: map[string]runtimecontracts.ExpressionValue{
 					"handler_marker": runtimecontracts.RefExpression("metadata.handler_marker"),
 					"scores":         runtimecontracts.RefExpression("entity.scores"),
-					"target":         runtimecontracts.RefExpression("fan_out.item"),
+					"target":         runtimecontracts.CELExpression("target_item"),
 				},
 			},
 		},
@@ -3714,6 +3728,8 @@ func TestExecutor_RejectsOnSuccessEmitWithRuleFanOut(t *testing.T) {
 				Condition: "else",
 				FanOut: &runtimecontracts.FanOutSpec{
 					ItemsFrom: "payload.items",
+					As:        "fan_item",
+					Identity:  "fan_item",
 					Emit:      runtimecontracts.EmitSpec{Event: "item.done"},
 				},
 			}},
@@ -3996,6 +4012,8 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
+				As:        "fan_item",
+				Identity:  "fan_item",
 				Emit:      runtimecontracts.EmitSpec{Event: "item.process"},
 			},
 			AdvancesTo: "processing",
@@ -4030,6 +4048,283 @@ func TestExecutor_FanOutCreatesShapedEmitIntentsAndStopsLoop(t *testing.T) {
 	}
 	if payload["shaped_for"] != "item.process" {
 		t.Fatalf("shaped payload missing marker: %#v", payload)
+	}
+}
+
+func TestExecutor_FanOutBoundExceededFailsClosedBeforeEmit(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:        stubSource(),
+		StateRepo:     stubStateRepo{},
+		TxRunner:      stubRunner{},
+		Locker:        stubLocker{},
+		Outbox:        stubOutbox{},
+		Dispatcher:    stubDispatcher{},
+		PayloadShaper: stubPayloadShaper{},
+		MaxChainDepth: 5,
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	_, err = exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1",
+		NodeID:   "node-1",
+		FlowID:   "flow-1",
+		Event:    eventtest.RootIngress("evt-1", "task.completed", "", "", json.RawMessage(`{"items":["a","b"]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			FanOut: &runtimecontracts.FanOutSpec{
+				ItemsFrom: "payload.items",
+				As:        "fan_item",
+				Identity:  "fan_item",
+				MaxItems:  1,
+				Emit: runtimecontracts.EmitSpec{
+					Event: "item.process",
+					Fields: map[string]runtimecontracts.ExpressionValue{
+						"item_id": runtimecontracts.CELExpression("fan_item"),
+					},
+				},
+			},
+		},
+		State: testStateSnapshot("pending", map[string]any{}, nil, map[string]map[string]any{}),
+	})
+	if err == nil {
+		t.Fatal("expected fan_out bound exceeded error")
+	}
+	if !errors.Is(err, ErrFanOutBoundExceeded) {
+		t.Fatalf("Execute error = %v, want ErrFanOutBoundExceeded", err)
+	}
+	runtimeErr, ok := rterrors.AsRuntimeError(err)
+	if !ok {
+		t.Fatalf("Execute error = %T %v, want RuntimeError", err, err)
+	}
+	if runtimeErr.Code != runtimecontracts.FanOutBoundExceededCode || runtimeErr.Retryable {
+		t.Fatalf("runtime error = %#v, want non-retryable %s", runtimeErr, runtimecontracts.FanOutBoundExceededCode)
+	}
+	if got := ClassifyFailure(err); got != FailureLogic {
+		t.Fatalf("ClassifyFailure = %v, want FailureLogic", got)
+	}
+}
+
+func TestExecutor_FanOutRuleContextsExecuteCanonicalCollectionContract(t *testing.T) {
+	type fanOutContextCase struct {
+		name            string
+		eventType       events.EventType
+		payload         json.RawMessage
+		handlerEventKey string
+		handler         func(*runtimecontracts.FanOutSpec) runtimecontracts.SystemNodeEventHandler
+	}
+	cases := []fanOutContextCase{
+		{
+			name:      "rules",
+			eventType: "batch.ready",
+			handler: func(spec *runtimecontracts.FanOutSpec) runtimecontracts.SystemNodeEventHandler {
+				return runtimecontracts.SystemNodeEventHandler{Rules: []runtimecontracts.HandlerRuleEntry{{
+					ID: "dispatch", Condition: "else", FanOut: spec, AdvancesTo: "dispatched",
+				}}}
+			},
+		},
+		{
+			name:      "on_complete",
+			eventType: "batch.ready",
+			handler: func(spec *runtimecontracts.FanOutSpec) runtimecontracts.SystemNodeEventHandler {
+				return runtimecontracts.SystemNodeEventHandler{OnComplete: []runtimecontracts.HandlerRuleEntry{{
+					ID: "dispatch", Condition: "else", FanOut: spec, AdvancesTo: "dispatched",
+				}}}
+			},
+		},
+		{
+			name:      "accumulate_on_complete",
+			eventType: "batch.ready",
+			handler: func(spec *runtimecontracts.FanOutSpec) runtimecontracts.SystemNodeEventHandler {
+				return runtimecontracts.SystemNodeEventHandler{Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnComplete: []runtimecontracts.HandlerRuleEntry{{
+						ID: "dispatch", Condition: "else", FanOut: spec, AdvancesTo: "dispatched",
+					}},
+				}}
+			},
+		},
+		{
+			name:            "accumulate_on_timeout",
+			eventType:       "accumulate.timeout",
+			handlerEventKey: "batch.ready",
+			payload: json.RawMessage(`{
+				"timer_handle": {
+					"kind": "accumulation_timeout",
+					"bucket": {"node_id": "node-1", "event_type": "batch.ready"}
+				}
+			}`),
+			handler: func(spec *runtimecontracts.FanOutSpec) runtimecontracts.SystemNodeEventHandler {
+				return runtimecontracts.SystemNodeEventHandler{Accumulate: &runtimecontracts.AccumulateSpec{
+					Completion: runtimecontracts.ParseAccumulateCompletion("all"),
+					OnTimeout: &runtimecontracts.HandlerRuleEntry{
+						ID: "dispatch", FanOut: spec, AdvancesTo: "dispatched",
+					},
+				}}
+			},
+		},
+	}
+
+	newSpec := func(maxItems int) *runtimecontracts.FanOutSpec {
+		return &runtimecontracts.FanOutSpec{
+			ItemsFrom:   "entity.items",
+			As:          "line_item",
+			Identity:    "line_item.id",
+			MaxItems:    maxItems,
+			MaxItemsSet: maxItems > 0,
+			Emit: runtimecontracts.EmitSpec{
+				Event: "item.process",
+				Fields: map[string]runtimecontracts.ExpressionValue{
+					"item_id":    runtimecontracts.CELExpression("line_item.id"),
+					"item_index": runtimecontracts.CELExpression("fan_out.index"),
+				},
+			},
+		}
+	}
+	state := func() StateSnapshot {
+		return testStateSnapshot("ready", map[string]any{
+			"items": []any{
+				map[string]any{"id": "item-a"},
+				map[string]any{"id": "item-b"},
+			},
+		}, nil, map[string]map[string]any{})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transition := &recordingTransitionValidator{}
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source:              stubSource(),
+				StateRepo:           stubStateRepo{},
+				TxRunner:            stubRunner{},
+				Locker:              stubLocker{},
+				Outbox:              stubOutbox{},
+				Dispatcher:          stubDispatcher{},
+				PayloadShaper:       stubPayloadShaper{},
+				TransitionValidator: transition,
+			}, nil)
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+			payload := tc.payload
+			if len(payload) == 0 {
+				payload = json.RawMessage(`{}`)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID:        "entity-1",
+				NodeID:          "node-1",
+				FlowID:          "flow-1",
+				Event:           eventtest.RootIngress("evt-1", tc.eventType, "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
+				HandlerEventKey: tc.handlerEventKey,
+				Handler:         tc.handler(newSpec(0)),
+				State:           state(),
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if result.FanOutCount != 2 || len(result.EmitIntents) != 2 {
+				t.Fatalf("fan_out result count=%d intents=%d, want 2/2", result.FanOutCount, len(result.EmitIntents))
+			}
+			for index, intent := range result.EmitIntents {
+				var emitted map[string]any
+				if err := json.Unmarshal(intent.Event.Payload(), &emitted); err != nil {
+					t.Fatalf("emit %d payload: %v", index, err)
+				}
+				if got, want := emitted["item_id"], []string{"item-a", "item-b"}[index]; got != want {
+					t.Fatalf("emit %d item_id = %#v, want %q", index, got, want)
+				}
+				if got := emitted["item_index"]; got != float64(index) {
+					t.Fatalf("emit %d item_index = %#v, want %d", index, got, index)
+				}
+			}
+			if got := result.NextState; got != "dispatched" {
+				t.Fatalf("NextState = %q, want dispatched", got)
+			}
+			if transition.calls != 1 || transition.current != "ready" || transition.next != "dispatched" {
+				t.Fatalf("transition = calls:%d %q->%q, want one ready->dispatched", transition.calls, transition.current, transition.next)
+			}
+
+			transition = &recordingTransitionValidator{}
+			exec.deps.TransitionValidator = transition
+			result, err = exec.Execute(context.Background(), ExecutionRequest{
+				EntityID:        "entity-1",
+				NodeID:          "node-1",
+				FlowID:          "flow-1",
+				Event:           eventtest.RootIngress("evt-bound", tc.eventType, "", "", payload, 0, "", "", events.EventEnvelope{}, time.Time{}),
+				HandlerEventKey: tc.handlerEventKey,
+				Handler:         tc.handler(newSpec(1)),
+				State:           state(),
+			})
+			if err == nil || !errors.Is(err, ErrFanOutBoundExceeded) {
+				t.Fatalf("bounded Execute result=%#v error=%v, want ErrFanOutBoundExceeded", result, err)
+			}
+			if transition.calls != 0 {
+				t.Fatalf("bounded transition calls = %d, want 0", transition.calls)
+			}
+		})
+	}
+}
+
+func TestExecutor_FanOutRejectsInvalidSourceAndExplicitZeroBound(t *testing.T) {
+	tests := []struct {
+		name string
+		spec runtimecontracts.FanOutSpec
+		want string
+	}{
+		{
+			name: "nested items source",
+			spec: runtimecontracts.FanOutSpec{ItemsFrom: "payload.items.missing", As: "line_item", Identity: "line_item.id", Emit: runtimecontracts.EmitSpec{Event: "item.process"}},
+			want: "must reference exactly one declared top-level collection field",
+		},
+		{
+			name: "explicit zero bound",
+			spec: runtimecontracts.FanOutSpec{ItemsFrom: "payload.items", As: "line_item", Identity: "line_item.id", MaxItemsSet: true, Emit: runtimecontracts.EmitSpec{Event: "item.process"}},
+			want: "fan_out.max_items must be a positive integer when set",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source: stubSource(), StateRepo: stubStateRepo{}, TxRunner: stubRunner{}, Locker: stubLocker{}, Outbox: stubOutbox{}, Dispatcher: stubDispatcher{},
+			}, nil)
+			if err != nil {
+				t.Fatalf("NewExecutor error: %v", err)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: "entity-1", NodeID: "node-1", FlowID: "flow-1",
+				Event:   eventtest.RootIngress("evt-1", "batch.ready", "", "", json.RawMessage(`{"items":[{"id":"item-a"}]}`), 0, "", "", events.EventEnvelope{}, time.Time{}),
+				Handler: runtimecontracts.SystemNodeEventHandler{FanOut: &tc.spec},
+				State:   testStateSnapshot("ready", map[string]any{}, nil, map[string]map[string]any{}),
+			})
+			if err == nil || !errors.Is(err, ErrInvalidConfig) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Execute result=%#v error=%v, want ErrInvalidConfig containing %q", result, err, tc.want)
+			}
+			if len(result.EmitIntents) != 0 || result.StateMutation.NextState != "" {
+				t.Fatalf("invalid fan_out produced effects: %#v", result)
+			}
+		})
+	}
+}
+
+func TestActiveFanOutSpecEmitSourceNamesOwningSite(t *testing.T) {
+	tests := []struct {
+		name   string
+		source handlerRuleSource
+		want   string
+	}{
+		{name: "handler", want: "handler.fan_out.emit"},
+		{name: "rules", source: handlerRuleSourceRules, want: "handler.rules.fan_out.emit"},
+		{name: "on_complete", source: handlerRuleSourceOnComplete, want: "handler.on_complete.fan_out.emit"},
+		{name: "accumulate_on_complete", source: handlerRuleSourceAccumulateOnComplete, want: "handler.accumulate.on_complete.fan_out.emit"},
+		{name: "accumulate_on_timeout", source: handlerRuleSourceAccumulateOnTimeout, want: "handler.accumulate.on_timeout.fan_out.emit"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (activeFanOutSpec{Source: tc.source}).EmitSource(); got != tc.want {
+				t.Fatalf("EmitSource = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -4390,6 +4685,8 @@ func TestExecutor_FanOutEmitUsesProducerSourceRouteNamespace(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
+				As:        "component_item",
+				Identity:  "component_item.id",
 				Emit: runtimecontracts.EmitSpec{
 					Event: "component-scaffold/component.scaffolded",
 				},
@@ -5069,6 +5366,8 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
+				As:        "fan_item",
+				Identity:  "fan_item",
 				Emit:      runtimecontracts.EmitSpec{Event: "item.process"},
 			},
 			AdvancesTo: "scanning",
@@ -5078,7 +5377,7 @@ func TestExecutor_FanOutEmptyPersistsCountAndContinues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
 	}
-	if result.Status != OutcomeCompleted {
+	if result.Status != OutcomeFannedOut {
 		t.Fatalf("Status = %q", result.Status)
 	}
 	if result.NextState != "scanning" {
@@ -5109,6 +5408,8 @@ func TestExecutor_FanOutInternalCountBypassesEntityContractValidation(t *testing
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
+				As:        "fan_item",
+				Identity:  "fan_item",
 				Emit:      runtimecontracts.EmitSpec{Event: "item.process"},
 			},
 			AdvancesTo: "scanning",
@@ -5146,6 +5447,8 @@ func TestExecutor_FanOutUsesExplicitEmitEvent(t *testing.T) {
 		Handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{
 				ItemsFrom: "payload.items",
+				As:        "routed_item",
+				Identity:  "routed_item.kind",
 				Emit:      runtimecontracts.EmitSpec{Event: "routed.item"},
 			},
 		},

--- a/internal/runtime/engine/transaction.go
+++ b/internal/runtime/engine/transaction.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 )
@@ -18,6 +19,11 @@ func ClassifyFailure(err error) FailureClass {
 		return FailureNone
 	case ErrChainDepthExceeded:
 		return FailureDeadLetter
+	}
+	if errors.Is(err, ErrFanOutBoundExceeded) {
+		return FailureLogic
+	}
+	switch err {
 	case ErrMissingSemanticSource,
 		ErrMissingStateRepo,
 		ErrMissingTransaction,

--- a/internal/runtime/engine/transaction_test.go
+++ b/internal/runtime/engine/transaction_test.go
@@ -106,6 +106,9 @@ func TestClassifyFailure(t *testing.T) {
 	if got := ClassifyFailure(ErrMissingStateRepo); got != FailureLogic {
 		t.Fatalf("missing-state-repo failure class = %v", got)
 	}
+	if got := ClassifyFailure(ErrFanOutBoundExceeded); got != FailureLogic {
+		t.Fatalf("fan-out-bound failure class = %v", got)
+	}
 	if got := ClassifyFailure(errors.New("temporary")); got != FailureTransient {
 		t.Fatalf("generic failure class = %v", got)
 	}

--- a/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
@@ -450,9 +450,7 @@ func assertNotionManagedConnectorMissingCredential(t *testing.T, backend slackMa
 	if got := countNotionManagedConnectorActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
 		t.Fatalf("%s missing managed credential activity attempts = %d, want 0", backend.name, got)
 	}
-	if got := countNotionManagedConnectorFailureEventsForSource(t, backend, inboundEventID); got != 1 {
-		t.Fatalf("%s missing managed credential failure events = %d, want 1", backend.name, got)
-	}
+	requireManagedConnectorFailureEventCountEventually(t, backend, "missing managed credential", inboundEventID, countNotionManagedConnectorFailureEventsForSource)
 }
 
 func waitForNotionManagedConnectorTerminalActivityAttempt(t *testing.T, backend slackManagedConnectorBackend, sourceEventID string) runtimepipeline.ActivityAttemptRecord {

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -3179,10 +3179,12 @@ func TestExecuteNodeContractHandler_RejectsUndeclaredBusinessPayloadAcrossSuppor
 			handler: runtimecontracts.SystemNodeEventHandler{
 				FanOut: &runtimecontracts.FanOutSpec{
 					ItemsFrom: "payload.items",
+					As:        "payload_item",
+					Identity:  "payload_item.label",
 					Emit: runtimecontracts.EmitSpec{
 						Event: "custom.emitted",
 						Fields: map[string]runtimecontracts.ExpressionValue{
-							"label": runtimecontracts.CELExpression(`"ok"`),
+							"label": runtimecontracts.CELExpression(`payload_item.label`),
 							"extra": runtimecontracts.CELExpression(`"bad"`),
 						},
 					},

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -195,10 +195,12 @@ func sqliteDynamicActivationBundle() *runtimecontracts.WorkflowContractBundle {
 					"component_scaffold.batch_requested": {
 						FanOut: &runtimecontracts.FanOutSpec{
 							ItemsFrom: "payload.components",
+							As:        "component",
+							Identity:  "component.component_id",
 							Emit: runtimecontracts.EmitSpec{
 								Event: "component_scaffold.spawn_requested",
 								Fields: map[string]runtimecontracts.ExpressionValue{
-									"component_id": runtimecontracts.CELExpression("fan_out.item.component_id"),
+									"component_id": runtimecontracts.CELExpression("component.component_id"),
 								},
 							},
 						},

--- a/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
@@ -520,9 +520,7 @@ func assertSlackManagedConnectorMissingCredential(t *testing.T, backend slackMan
 	if got := countSlackManagedConnectorActivityAttemptsForSource(t, backend, inboundEventID); got != 0 {
 		t.Fatalf("%s missing managed credential activity attempts = %d, want 0", backend.name, got)
 	}
-	if got := countSlackManagedConnectorFailureEventsForSource(t, backend, inboundEventID); got != 1 {
-		t.Fatalf("%s missing managed credential failure events = %d, want 1", backend.name, got)
-	}
+	requireManagedConnectorFailureEventCountEventually(t, backend, "missing managed credential", inboundEventID, countSlackManagedConnectorFailureEventsForSource)
 }
 
 func loadSlackManagedConnectorInboundEventID(t *testing.T, backend slackManagedConnectorBackend, providerEventID string) string {
@@ -710,6 +708,22 @@ func requireSlackManagedConnectorResultEventEventually(t *testing.T, backend sla
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("%s event row for %s/%s not found", backend.name, eventID, eventType)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func requireManagedConnectorFailureEventCountEventually(t *testing.T, backend slackManagedConnectorBackend, label, sourceEventID string, countFn func(*testing.T, slackManagedConnectorBackend, string) int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var got int
+	for {
+		got = countFn(t, backend, sourceEventID)
+		if got == 1 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s failure events = %d, want 1", backend.name, label, got)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -158,7 +158,7 @@ type catalogSystemNodeEventHandler struct {
 	Rules            catalogRuleList                           `yaml:"rules"`
 	Accumulate       *catalogAccumulateSpec                    `yaml:"accumulate"`
 	Compute          *catalogComputeSpec                       `yaml:"compute"`
-	FanOut           *catalogFanOutSpec                        `yaml:"fan_out"`
+	FanOut           *runtimecontracts.FanOutSpec              `yaml:"fan_out"`
 	Filter           *runtimecontracts.FilterSpec              `yaml:"filter"`
 	Reduce           *runtimecontracts.ReduceSpec              `yaml:"reduce"`
 	Count            *runtimecontracts.CountSpec               `yaml:"count"`
@@ -239,12 +239,6 @@ type catalogAccumulateSpec struct {
 type catalogComputeSpec struct {
 	StoreAs     string `yaml:"store_as"`
 	OutputField string `yaml:"output_field"`
-}
-
-type catalogFanOutSpec struct {
-	ItemsFrom string                    `yaml:"items_from"`
-	Target    string                    `yaml:"target"`
-	Emit      runtimecontracts.EmitSpec `yaml:"emit"`
 }
 
 type catalogActionParams struct {
@@ -2093,6 +2087,9 @@ func catalogCaseExecutableNowForDir(dir string, expected catalogExpectedDocument
 
 func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandler, step catalogTriggerStep, entity map[string]any, policy map[string]any, result catalogRunResult) catalogRunResult {
 	t.Helper()
+	if handler.FanOut != nil {
+		t.Fatalf("private catalog harness does not interpret fan_out; mark expected.runtime_only and use cataloge2e real-runtime proof")
+	}
 	payload := cloneStringAnyMapCatalog(step.Payload)
 	result.handlerOutcome = "success"
 	if !catalogGuardPasses(handler.Guard, payload, entity, policy, result.entityState) {
@@ -2159,7 +2156,6 @@ func executeCatalogHandlerStep(t testing.TB, handler catalogSystemNodeEventHandl
 	}
 	applyCatalogDataAccumulation(handler.DataAccumulation, payload, entity)
 	applyCatalogCompute(handler.Compute, entity)
-	applyCatalogFanOut(handler.FanOut, payload, entity, &result)
 	applyCatalogFilter(handler.Filter, payload, entity, policy, result.entityState)
 	applyCatalogReduce(handler.Reduce, payload, entity)
 	applyCatalogCount(handler.Count, payload, entity, policy, result.entityState)
@@ -2329,23 +2325,6 @@ func applyCatalogCompute(spec *catalogComputeSpec, entity map[string]any) {
 		return
 	}
 	catalogSetEntityPath(entity, field, "computed_value")
-}
-
-func applyCatalogFanOut(spec *catalogFanOutSpec, payload, entity map[string]any, result *catalogRunResult) {
-	if spec == nil || result == nil {
-		return
-	}
-	rawItems := resolveCatalogPath(paths.Parse(strings.TrimSpace(spec.ItemsFrom)), strings.TrimSpace(spec.ItemsFrom), entity, map[string]any{"payload": payload, "entity": entity})
-	items := catalogSlice(rawItems)
-	entity["fan_out_count"] = len(items)
-	if len(items) == 0 {
-		return
-	}
-	for range items {
-		if emit := strings.TrimSpace(spec.Emit.EventType()); emit != "" {
-			result.emittedEvents = append(result.emittedEvents, emit)
-		}
-	}
 }
 
 func applyCatalogClear(spec *runtimecontracts.ClearSpec, entity map[string]any) {

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/events.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/events.yaml
@@ -1,10 +1,13 @@
 item.created:
   emitter:
     - control-plane
+  item_id: string
+  items: "[IntakeItem]"
 item.processed:
   emitter:
     - worker-a
     - worker-b
+  item_id: string
 item.review_requested:
   emitter:
     - intake-router

--- a/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/flows/intake/nodes.yaml
@@ -17,9 +17,13 @@ intake-router:
         check: payload.item_id != ''
       fan_out:
         items_from: payload.items
+        as: intake_item
+        identity: intake_item.id
         emit:
           event: item.processed
           broadcast: true
+          fields:
+            item_id: intake_item.id
     item.processed:
       accumulate:
         expected_from: payload.expected_workers

--- a/internal/runtime/testdata/generic-swarm-bundle/types.yaml
+++ b/internal/runtime/testdata/generic-swarm-bundle/types.yaml
@@ -1,3 +1,5 @@
 types:
   GateState:
     open_gates: [text]
+  IntakeItem:
+    id: text

--- a/internal/runtime/testfixtures/fanoutpinroute/fixture.go
+++ b/internal/runtime/testfixtures/fanoutpinroute/fixture.go
@@ -140,10 +140,12 @@ classifier-coordinator:
             target_field: coordinator_id
       fan_out:
         items_from: payload.results
+        as: classified_account
+        identity: classified_account.account_id
         emit:
           event: account.classified
 `+producerRouteYAML(opts)+`          fields:
-            account_id: fan_out.item.account_id
+            account_id: classified_account.account_id
 `+emitCarryFieldsYAML(opts))
 }
 
@@ -164,7 +166,7 @@ func producerRouteYAML(opts Options) string {
 		return `          target:
             flow: account
             match:
-              account_id: fan_out.item.account_id
+              account_id: classified_account.account_id
 `
 	}
 	if opts.ProducerBroadcast {
@@ -177,8 +179,8 @@ func emitCarryFieldsYAML(opts Options) string {
 	if opts.MissingEmitCarry {
 		return ""
 	}
-	return `            bucket: fan_out.item.bucket
-            score: fan_out.item.score
+	return `            bucket: classified_account.bucket
+            score: classified_account.score
 `
 }
 

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -47,6 +47,7 @@ type ValueContext struct {
 
 type ValueExpressionOptions struct {
 	AllowBareItem bool
+	ItemAlias     string
 }
 
 func ValidateValueExpression(expression string) error {
@@ -62,8 +63,17 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	if expression == "" {
 		return fmt.Errorf("workflow data expression is empty")
 	}
-	if expressionReferencesRetiredFanOutTarget(expression) {
-		return fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
+	if expressionReferencesFanOutField(expression, "target") {
+		return fmt.Errorf("fan_out.target is retired; use the current fan_out emit item alias for per-item values or fan_out.count for fan-out count")
+	}
+	if expressionReferencesFanOutField(expression, "identity") {
+		return fmt.Errorf("fan_out.identity is not supported; use the declared fan_out identity expression directly through the item alias")
+	}
+	if expressionReferencesFanOutField(expression, "item") {
+		return fmt.Errorf("fan_out.item is retired from authored fan_out expressions; use the required fan_out item alias")
+	}
+	if strings.TrimSpace(opts.ItemAlias) == "" && expressionReferencesFanOutField(expression, "index") {
+		return fmt.Errorf("fan_out.index is only available inside fan_out.emit fields")
 	}
 	if err := ValidateEventReferences(expression); err != nil {
 		return err
@@ -88,8 +98,17 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	if normalized == "" {
 		return nil, fmt.Errorf("workflow data expression is empty")
 	}
-	if expressionReferencesRetiredFanOutTarget(normalized) {
-		return nil, fmt.Errorf("fan_out.target is retired; use fan_out.item for per-item values or fan_out.count for fan-out count")
+	if expressionReferencesFanOutField(normalized, "target") {
+		return nil, fmt.Errorf("fan_out.target is retired; use the current fan_out emit item alias for per-item values or fan_out.count for fan-out count")
+	}
+	if expressionReferencesFanOutField(normalized, "identity") {
+		return nil, fmt.Errorf("fan_out.identity is not supported; use the declared fan_out identity expression directly through the item alias")
+	}
+	if expressionReferencesFanOutField(normalized, "item") {
+		return nil, fmt.Errorf("fan_out.item is retired from authored fan_out expressions; use the required fan_out item alias")
+	}
+	if strings.TrimSpace(opts.ItemAlias) == "" && expressionReferencesFanOutField(normalized, "index") {
+		return nil, fmt.Errorf("fan_out.index is only available inside fan_out.emit fields")
 	}
 	if err := ValidateEventReferences(normalized); err != nil {
 		return nil, err
@@ -117,6 +136,9 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	if opts.AllowBareItem {
 		activation["item"] = NormalizeCELValue(ctx.FanOut["item"])
 	}
+	if alias := strings.TrimSpace(opts.ItemAlias); alias != "" {
+		activation[alias] = NormalizeCELValue(ctx.FanOut["item"])
+	}
 	out, _, err := program.Eval(activation)
 	if err != nil {
 		return nil, err
@@ -128,9 +150,14 @@ func ExpressionReferencesEntity(expression string) bool {
 	return len(EntityReferences(expression)) > 0
 }
 
-func expressionReferencesRetiredFanOutTarget(expression string) bool {
+func ExpressionReferencesFanOutFieldForValidation(expression, field string) bool {
+	return expressionReferencesFanOutField(expression, field)
+}
+
+func expressionReferencesFanOutField(expression, field string) bool {
 	expression = strings.TrimSpace(expression)
-	if expression == "" {
+	field = strings.TrimSpace(field)
+	if expression == "" || field == "" {
 		return false
 	}
 	for i := 0; i < len(expression); i++ {
@@ -159,8 +186,8 @@ func expressionReferencesRetiredFanOutTarget(expression string) bool {
 		switch expression[pos] {
 		case '.':
 			pos = skipExpressionWhitespace(expression, pos+1)
-			if strings.HasPrefix(expression[pos:], "target") {
-				end := pos + len("target")
+			if strings.HasPrefix(expression[pos:], field) {
+				end := pos + len(field)
 				if end >= len(expression) || !isIdentifierPart(expression[end]) {
 					return true
 				}
@@ -172,7 +199,7 @@ func expressionReferencesRetiredFanOutTarget(expression string) bool {
 				continue
 			}
 			next = skipExpressionWhitespace(expression, next)
-			if next < len(expression) && expression[next] == ']' && value == "target" {
+			if next < len(expression) && expression[next] == ']' && value == field {
 				return true
 			}
 		}
@@ -689,19 +716,22 @@ func NormalizeCELInputMap(source map[string]any) map[string]any {
 }
 
 func dataExpressionEnvForContext(opts ValueExpressionOptions) (*cel.Env, error) {
+	if strings.TrimSpace(opts.ItemAlias) != "" {
+		return newDataExpressionEnv(false, strings.TrimSpace(opts.ItemAlias))
+	}
 	if opts.AllowBareItem {
 		dataExpressionWithBareItemEnvOnce.Do(func() {
-			dataExpressionWithBareItemEnv, dataExpressionWithBareItemEnvErr = newDataExpressionEnv(true)
+			dataExpressionWithBareItemEnv, dataExpressionWithBareItemEnvErr = newDataExpressionEnv(true, "")
 		})
 		return dataExpressionWithBareItemEnv, dataExpressionWithBareItemEnvErr
 	}
 	dataExpressionEnvOnce.Do(func() {
-		dataExpressionEnv, dataExpressionEnvErr = newDataExpressionEnv(false)
+		dataExpressionEnv, dataExpressionEnvErr = newDataExpressionEnv(false, "")
 	})
 	return dataExpressionEnv, dataExpressionEnvErr
 }
 
-func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
+func newDataExpressionEnv(allowBareItem bool, itemAlias string) (*cel.Env, error) {
 	variables := []cel.EnvOption{
 		cel.Variable("entity", cel.DynType),
 		cel.Variable("_entity", cel.DynType),
@@ -713,6 +743,9 @@ func newDataExpressionEnv(allowBareItem bool) (*cel.Env, error) {
 	}
 	if allowBareItem {
 		variables = append(variables, cel.Variable("item", cel.DynType))
+	}
+	if itemAlias = strings.TrimSpace(itemAlias); itemAlias != "" {
+		variables = append(variables, cel.Variable(itemAlias, cel.DynType))
 	}
 	return cel.NewEnv(variables...)
 }

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -46,9 +46,9 @@ func TestEvalValueExpression_FailsClosedOnMissingEntityValueRead(t *testing.T) {
 }
 
 func TestEvalValueExpression_ExposesFanOutItemAlias(t *testing.T) {
-	value, err := EvalValueExpressionWithOptions(`[item]`, ValueContext{
+	value, err := EvalValueExpressionWithOptions(`[line_item]`, ValueContext{
 		FanOut: map[string]any{"item": "industry-a"},
-	}, ValueExpressionOptions{AllowBareItem: true})
+	}, ValueExpressionOptions{ItemAlias: "line_item"})
 	if err != nil {
 		t.Fatalf("EvalValueExpression error = %v", err)
 	}
@@ -291,17 +291,30 @@ func TestValidateValueExpression_AllowsSupportedEventContextRefs(t *testing.T) {
 	}
 }
 
-func TestValidateValueExpression_AllowsFanOutItemAndStringLiteralTargetText(t *testing.T) {
+func TestValidateValueExpression_AllowsFanOutAliasAndStringLiteralTargetText(t *testing.T) {
 	tests := []string{
-		`fan_out.item.target`,
-		`item.target`,
+		`line_item.target`,
 		`"fan_out.target"`,
 		`payload.note == "fan_out.target"`,
 	}
 	for _, expression := range tests {
 		t.Run(expression, func(t *testing.T) {
-			if err := ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{AllowBareItem: true}); err != nil {
+			if err := ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{ItemAlias: "line_item"}); err != nil {
 				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %v", expression, err)
+			}
+		})
+	}
+}
+
+func TestValidateValueExpression_RejectsRetiredFanOutItem(t *testing.T) {
+	for _, expression := range []string{`fan_out.item`, `fan_out.item.target`, `fan_out["item"]`} {
+		t.Run(expression, func(t *testing.T) {
+			err := ValidateValueExpressionWithOptions(expression, ValueExpressionOptions{ItemAlias: "line_item"})
+			if err == nil {
+				t.Fatalf("expected %q to reject retired fan_out.item", expression)
+			}
+			if got := err.Error(); got == "" || !containsAll(got, "fan_out.item", "retired") {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %q, want retired fan_out.item", expression, got)
 			}
 		})
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2729,10 +2729,32 @@ handler_specification:
     fan_out:
       field: fan_out
       type: object
-      purpose: For each item in a list, emit one ordinary event through the normal emit pipeline.
+      purpose: For each item in a bounded collection, emit one ordinary event through the normal emit pipeline.
       sub_fields:
-        items_from: string — source list (payload field or entity field)
-        emit: string or object — per-item event to emit, optionally with local fields payload construction
+        items_from: string — source collection at exactly one declared top-level payload.* or entity.* field.
+          Nested paths are unsupported in this slice and fail closed until the schema owner can prove the complete
+          terminal path is itself a collection.
+        as: string — required simple identifier that binds the current item for this row's emit.fields expressions.
+          `fan_out.item`, bare `item`, and `fan_out.identity` are not authoring namespaces.
+        identity: string — required expression over the item alias that declares the stable per-item key. It is
+          verification metadata, not a second expression namespace. Bootverify must prove `fan_out.emit.fields`
+          carries this exact expression so downstream join/dedup contracts can bind to the emitted payload.
+        max_items: optional positive integer tightening the platform ceiling. An authored zero is invalid; only omission
+          selects the platform ceiling. The platform ceiling is always enforced even when authors omit max_items.
+        emit: string or object — per-item event to emit, optionally with local fields payload construction. During
+          fan_out.emit.fields only, the item alias and platform-provided `fan_out.index` are available.
+      platform_ceiling:
+        max_items: 1000
+        overrun: >
+          Runtime evaluates items_from once per handler activation and checks the resulting count before any
+          per-item emit. If the count exceeds the effective limit, the handler fails closed with non-retryable
+          typed platform error `platform.fan_out_bound_exceeded`. The runtime must not silently truncate and
+          must not emit a partial prefix.
+      empty_collection: >
+        An empty collection emits zero events and still completes the fan_out row. Handler `advances_to` runs once
+        after fan_out completion, including the empty path, and `fan_out.count` is 0 for later data_accumulation.
+      transition_order: Handler `advances_to` fires once after per-item emission, not once per item.
+      graph_surface: describe --graph renders multiplicity-bearing fan-out edges such as `waiting ->xN line_item.requested`.
       route_authority: >
         `fan_out.emit` is a normal authored emit site. When it emits a
         pin-declared output event, routing is owned by the same output pin,
@@ -2754,11 +2776,13 @@ handler_specification:
         authored agent, that agent emits a batch-completed event, and the
         coordinator fans out result rows with target-less `fan_out.emit` to
         pin-declared outputs. Each row must construct the output pin key/carries
-        payload fields from the current `fan_out.item`, and parent connect
+        payload fields from the required item alias and declared `identity`
+        expression, and parent connect
         routes each emitted event to the intended flow instance by correlation
         key. No `batch_agent`, `map_agent`, inline runtime LLM invocation, or
         runtime-owned JSON result contract is part of this pattern.
-      side_effect: Writes fan_out.count to handler context (available for data_accumulation).
+      side_effect: Writes fan_out.count to handler context (available for data_accumulation). `fan_out.index`
+        is scoped to per-item emit field evaluation and is not a durable handler value.
     query:
       field: query
       type: object or list of objects
@@ -3103,7 +3127,8 @@ handler_specification:
           writing the entity field and are not addressable as `source.*`.
       fan_out:
         resolves_to: 'Handler context produced by the fan_out step. fan_out.count is the number of items
-          that were dispatched. Populated after fan_out executes, before data_accumulation.'
+          that were dispatched. Populated after fan_out executes, before data_accumulation. fan_out.index is
+          scoped to fan_out.emit.fields only.'
         available_in: 'data_accumulation.expression — the canonical way to write fan_out results to entity
           state. Example: expression: fan_out.count writes the dispatch count to an entity field for
           downstream accumulation tracking (expected_from: entity.search_expected_count).'
@@ -5492,7 +5517,8 @@ engine:
       payload: Current event payload fields
       event: Current runtime-owned event envelope/context fields
       policy: Policy values from flow policy.yaml merged with root policy.yaml
-      fan_out: Available after fan_out step (e.g., fan_out.count)
+      fan_out: Available after fan_out step for count metadata (fan_out.count). fan_out.index is available only
+        while evaluating fan_out.emit.fields for one item.
       accumulated: Available inside on_complete after accumulation (list of received items)
     ambient_time: >
       CEL guard/rule/filter/on_complete conditions must not call ambient time functions such as `now()` or

--- a/tests/tier3-list-processing/test-fan-out-basic/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/events.yaml
@@ -2,3 +2,4 @@ batch.submitted:
   items: array
 item.assigned:
   item: FanOutItem
+  item_id: text

--- a/tests/tier3-list-processing/test-fan-out-basic/expected.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/expected.yaml
@@ -7,7 +7,7 @@ trigger:
       - id: item-3
 
 expected:
-
+  runtime_only: true
   handler_outcome: success
   entity_state: scanning
   emitted_events:

--- a/tests/tier3-list-processing/test-fan-out-basic/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-basic/nodes.yaml
@@ -7,7 +7,12 @@ fan-out-node:
     batch.submitted:
       fan_out:
         items_from: payload.items
+        as: line_item
+        identity: line_item.id
         emit:
           event: item.assigned
           broadcast: true
+          fields:
+            item: line_item
+            item_id: line_item.id
       advances_to: scanning

--- a/tests/tier3-list-processing/test-fan-out-count/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/events.yaml
@@ -2,3 +2,4 @@ batch.received:
   items: array
 task.dispatched:
   item: FanOutItem
+  item_id: text

--- a/tests/tier3-list-processing/test-fan-out-count/expected.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/expected.yaml
@@ -7,7 +7,7 @@ trigger:
       - id: task-c
 
 expected:
-
+  runtime_only: true
   handler_outcome: success
   entity_state: processing
   emitted_events:

--- a/tests/tier3-list-processing/test-fan-out-count/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-count/nodes.yaml
@@ -7,7 +7,12 @@ fan-out-node:
     batch.received:
       fan_out:
         items_from: payload.items
+        as: task
+        identity: task.id
         emit:
           event: task.dispatched
           broadcast: true
+          fields:
+            item: task
+            item_id: task.id
       advances_to: processing

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/events.yaml
@@ -2,5 +2,7 @@ batch.submitted:
   items: array
 routed.a:
   item: FanOutItem
+  item_id: text
 routed.b:
   item: FanOutItem
+  item_id: text

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/expected.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/expected.yaml
@@ -8,7 +8,7 @@ trigger:
         id: item-2
 
 expected:
-
+  runtime_only: true
   handler_outcome: success
   entity_state: routing
   emitted_events:

--- a/tests/tier3-list-processing/test-fan-out-emit-mapping/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-emit-mapping/nodes.yaml
@@ -7,9 +7,12 @@ routing-node:
     batch.submitted:
       fan_out:
         items_from: payload.items
+        as: routed_item
+        identity: routed_item.id
         emit:
           event: routed.a
           broadcast: true
           fields:
-            item: item
+            item: routed_item
+            item_id: routed_item.id
       advances_to: routing

--- a/tests/tier3-list-processing/test-fan-out-empty/events.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/events.yaml
@@ -2,3 +2,4 @@ batch.submitted:
   items: array
 item.assigned:
   item: FanOutItem
+  item_id: text

--- a/tests/tier3-list-processing/test-fan-out-empty/expected.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/expected.yaml
@@ -4,7 +4,7 @@ trigger:
     items: []
 
 expected:
-
+  runtime_only: true
   handler_outcome: success
   entity_state: scanning
   emitted_events: []

--- a/tests/tier3-list-processing/test-fan-out-empty/nodes.yaml
+++ b/tests/tier3-list-processing/test-fan-out-empty/nodes.yaml
@@ -7,7 +7,12 @@ fan-out-node:
     batch.submitted:
       fan_out:
         items_from: payload.items
+        as: line_item
+        identity: line_item.id
         emit:
           event: item.assigned
           broadcast: true
+          fields:
+            item: line_item
+            item_id: line_item.id
       advances_to: scanning

--- a/tests/tier9-composition-patterns/test-compose-rules-fanout-data/nodes.yaml
+++ b/tests/tier9-composition-patterns/test-compose-rules-fanout-data/nodes.yaml
@@ -5,15 +5,12 @@ dispatcher:
   produces: [batch.dispatched]
   event_handlers:
     batch.requested:
+      count:
+        items_from: payload.items
+        store_as: entity.dispatch_count
       rules:
         - id: parallel
           condition: "payload.mode == 'parallel'"
-          fan_out:
-            items_from: payload.items
-          data_accumulation:
-            writes:
-              - target_field: dispatch_count
-                expression: fan_out.count
           advances_to: dispatched
           emit:
             event: batch.dispatched


### PR DESCRIPTION
Closes #1847

## Summary
- Promotes the public `fan_out` collection-row contract in `platform-spec.yaml`: required `as`, required `identity`, optional `max_items`, `fan_out.index`, empty-collection completion, and fail-closed bound handling.
- Adds the canonical `fan_out_validation` bootverify owner across all live `FanOutSpec` consumers: handler, rules, on_complete, accumulate on_complete, and accumulate on_timeout.
- Hardens runtime fan-out lowering: collection evaluated once, overrun fails before any partial emits with `platform.fan_out_bound_exceeded`, `advances_to` runs once after emission including empty collections, and source labels now preserve the owning fan-out site.
- Adds fan-out graph visibility in authoring view and `swarm describe --graph`, plus fixture/schema migrations for the supported fan-out surface.

## Governing refs / context
- Authoritative spec: `platform-spec.yaml` `fan_out` handler construct.
- Binding issue context: #1847 design-lock and approved pre-audit gate.
- Adjacent contract context: #1771 E6 declarative row ladder, #1786/#1835 delivery/route boundary, #1848 join/output assembly split, and #1869 platform error taxonomy.

## Semantic migration
- New canonical owner: `FanOutSpec` + bootverify `fan_out_validation` + runtime `stepFanOut`, with `platform-spec.yaml` as the merge artifact for the authoring contract.
- Old invalid authoring paths: `fan_out.item`, bare `item`, `fan_out.identity`, count-only `fan_out` as a collection row, and hard-coded `handler.fan_out.emit` source naming for all fan-out sites.
- Production paths checked: handler/rules/on_complete/accumulate fan-outs, expression validation/eval, payload completeness, pin-route proof, runtime lowering, generic/tier3/fanoutpinroute fixtures, authoring view, and `describe --graph`.
- Migration status: complete for the approved #1847 first slice; completion/join aggregation remains split to #1848 and delivery/instance fan-out remains outside this issue.

## Verification
Passed focused proof set:

```sh
go test ./internal/runtime/testcases ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/authoringview ./cmd/swarm ./internal/runtime/contracts ./internal/runtime/workflowexpr ./internal/runtime/pipeline -run 'FanOut|fan_out|ClassifyFailure|DynamicActivation|ExecuteNodeContractHandlerFailsClosedOnDeclarativeEmitPayloadContract|PayloadCompleteness|PinRoute|TestDescribeCommandGraphRendersStageGraph|TestGenericBundle_AccumulationFanoutPatterns' -count=1
```

Also passed:

```sh
go test ./internal/runtime/testcases
go test ./internal/runtime/engine -run 'FanOut|ActiveFanOutSpec|ClassifyFailure' -count=1
```

Attempted full suite:

```sh
go test ./...
```

It cannot complete in this local environment because Docker/Postgres is unavailable. The failing packages report `failed to connect to the docker API at unix:///var/run/docker.sock` while starting shared Postgres.