### PR TITLE
[agent-b][issue #1901] Standardize Postgres test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,25 +189,16 @@ jobs:
     timeout-minutes: 18
     env:
       SWARM_TEST_POSTGRES_DSN: host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable
+      SWARM_TEST_POSTGRES_ROLE_PROOF: "1"
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.ci-plan.outputs.shard_matrix) }}
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Start and verify disposable Postgres
+        run: ./internal/testutil/start-postgres-ci.sh
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -308,22 +299,12 @@ jobs:
     timeout-minutes: 12
     env:
       SWARM_TEST_POSTGRES_DSN: host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Start and verify disposable Postgres
+        run: ./internal/testutil/start-postgres-ci.sh
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -339,6 +320,16 @@ jobs:
           go test ./cmd/swarm \
             -run TestRunServeRuntimeConsumesCanonicalStoreSelectionBeforeStoreConstruction \
             -count=1 -json 2>&1 | tee test-results/semantic-smoke.json
+
+      - name: Prove owned Docker fallback
+        shell: bash
+        run: |
+          set -euo pipefail
+          env -u SWARM_TEST_POSTGRES_DSN \
+            SWARM_TEST_POSTGRES_ASSERT_OWNED_SETTINGS=1 \
+            go test ./internal/testutil \
+              -run '^TestOwnedPostgresSettings$' \
+              -count=1 -json 2>&1 | tee -a test-results/semantic-smoke.json
 
       - name: Prove catalog required smoke
         shell: bash
@@ -382,22 +373,12 @@ jobs:
     timeout-minutes: 35
     env:
       SWARM_TEST_POSTGRES_DSN: host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Start and verify disposable Postgres
+        run: ./internal/testutil/start-postgres-ci.sh
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -447,22 +428,12 @@ jobs:
     timeout-minutes: 25
     env:
       SWARM_TEST_POSTGRES_DSN: host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Start and verify disposable Postgres
+        run: ./internal/testutil/start-postgres-ci.sh
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,11 @@ for the full-truth push/manual/scheduled runs. Do not habitually force
 High-risk semantic/runtime migrations still require full local
 `go test ./... -count=1` when the issue gate or reviewer asks for it.
 
+Postgres-backed tests should use the supported host setup in
+[internal/testutil/POSTGRES.md](internal/testutil/POSTGRES.md). Keep the test
+DSN invocation-scoped; Docker remains a visible fallback, not the preferred
+local loop.
+
 If you change API/spec authority, update the authoritative root artifact in the
 same pull request as the implementation that makes it true.
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -52,6 +52,7 @@ import (
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"gopkg.in/yaml.v3"
 )
 
@@ -10767,35 +10768,22 @@ func runForkReadinessFactHasDisposition(values []store.RunForkSelectedContractRe
 
 func setPostgresEnvFromDSN(t *testing.T, dsn string) {
 	t.Helper()
-	values := map[string]string{}
-	for _, part := range strings.Fields(dsn) {
-		key, value, ok := strings.Cut(part, "=")
-		if !ok {
-			continue
-		}
-		values[key] = value
+	parsed, err := pq.NewConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse canonical test Postgres DSN: %v", err)
 	}
-	for _, item := range []struct {
-		env string
-		key string
-	}{
-		{"PGPASSWORD", "password"},
-	} {
-		if value := strings.TrimSpace(values[item.key]); value != "" {
-			t.Setenv(item.env, value)
-		}
-	}
+	t.Setenv("PGPASSWORD", parsed.Password)
 	configPath := filepath.Join(t.TempDir(), "swarm.yaml")
 	t.Setenv("SWARM_CONFIG", configPath)
 	writeRuntimeConfigText(t, configPath, fmt.Sprintf(`store:
   backend: postgres
 database:
-  host: %s
-  port: %s
-  name: %s
-  user: %s
+  host: %q
+  port: %d
+  name: %q
+  user: %q
   password_env: PGPASSWORD
-  sslmode: %s
+  sslmode: %q
   pool_size: 5
 llm:
   backend: claude_cli
@@ -10807,7 +10795,7 @@ llm:
     command: true
     timeout: 2s
     output_format: json
-`, values["host"], values["port"], values["dbname"], values["user"], values["sslmode"]))
+`, parsed.Host, parsed.Port, parsed.Database, parsed.User, parsed.SSLMode))
 }
 
 func TestDefaultRuntimeConfig_RejectsUnsupportedRuntimeControlEnv(t *testing.T) {

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -275,6 +275,11 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "testutil owns local Postgres setup/teardown and is excluded from production selected-store authority",
 		},
+		"internal/testutil/postgres_dsn.go": {
+			Classification: rawSQLTestSupportBoundary,
+			Issue:          1901,
+			Reason:         "testutil owns the typed Postgres DSN and connector boundary used by local test setup/teardown",
+		},
 	}
 }
 

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -15,44 +15,6 @@ import (
 	"github.com/lib/pq"
 )
 
-func portFromDSN(t *testing.T, dsn string) int {
-	t.Helper()
-	for _, part := range strings.Fields(dsn) {
-		if strings.HasPrefix(part, "port=") {
-			var n int
-			fmtSscanf(strings.TrimPrefix(part, "port="), &n)
-			if n > 0 {
-				return n
-			}
-		}
-	}
-	t.Fatalf("port not found in dsn: %q", dsn)
-	return 0
-}
-
-func dbNameFromDSN(t *testing.T, dsn string) string {
-	t.Helper()
-	for _, part := range strings.Fields(dsn) {
-		if strings.HasPrefix(part, "dbname=") {
-			return strings.TrimPrefix(part, "dbname=")
-		}
-	}
-	t.Fatalf("dbname not found in dsn: %q", dsn)
-	return ""
-}
-
-// Small local helper to avoid importing fmt (keeps this file tiny in coverage terms).
-func fmtSscanf(s string, out *int) {
-	n := 0
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			break
-		}
-		n = n*10 + int(r-'0')
-	}
-	*out = n
-}
-
 func TestDSNFromConfigQuotesKeywordValues(t *testing.T) {
 	cfg := config.DatabaseConfig{
 		Host:    "127.0.0.1",
@@ -112,19 +74,21 @@ func TestDSNFromConfigPinsDefaultNonSecretKeywordsAgainstPGEnv(t *testing.T) {
 func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	defer cleanup()
-	port := portFromDSN(t, dsn)
-	dbName := dbNameFromDSN(t, dsn)
+	parsed, err := pq.NewConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse canonical test Postgres DSN: %v", err)
+	}
 
 	cfg := config.DatabaseConfig{
-		Host:     "127.0.0.1",
-		Port:     port,
-		Name:     dbName,
-		User:     "postgres",
-		SSLMode:  "disable",
+		Host:     parsed.Host,
+		Port:     int(parsed.Port),
+		Name:     parsed.Database,
+		User:     parsed.User,
+		SSLMode:  string(parsed.SSLMode),
 		PoolSize: 5,
 	}
-	gotDSN := DSNFromConfig(cfg, "postgres")
-	if !strings.Contains(gotDSN, "host='127.0.0.1'") || !strings.Contains(gotDSN, "dbname='"+dbName+"'") {
+	gotDSN := DSNFromConfig(cfg, parsed.Password)
+	if !strings.Contains(gotDSN, "host='"+parsed.Host+"'") || !strings.Contains(gotDSN, "dbname='"+parsed.Database+"'") {
 		t.Fatalf("unexpected dsn: %q", gotDSN)
 	}
 	pg, err := NewPostgresStore(gotDSN)

--- a/internal/testutil/POSTGRES.md
+++ b/internal/testutil/POSTGRES.md
@@ -1,0 +1,97 @@
+# Postgres Test Environment
+
+Swarm's Postgres-backed tests support PostgreSQL 16 as the parity target. The
+preferred local setup is a host Postgres instance selected explicitly with
+`SWARM_TEST_POSTGRES_DSN`; this avoids the Docker or Colima memory cost during
+normal test iteration.
+
+The test role must use password authentication and have `CREATEDB`. The harness
+creates isolated databases, initializes one canonical schema template, clones
+that template for each test, and removes the databases during cleanup. Custom
+`pqgo-*` TLS registrations, GSS authentication, passfiles, service files, and
+empty passwords are intentionally unsupported because cleanup runs in a separate
+process and must receive a self-contained connection value.
+
+## Existing Host Postgres
+
+For a local PostgreSQL 16 server whose current administrator can create roles:
+
+```bash
+psql postgres <<'SQL'
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'swarm_test') THEN
+    CREATE ROLE swarm_test LOGIN CREATEDB PASSWORD 'swarm-test';
+  ELSE
+    ALTER ROLE swarm_test LOGIN CREATEDB PASSWORD 'swarm-test';
+  END IF;
+END
+$$;
+SQL
+```
+
+Verify the client connection. `PGPASSWORD` is used only by this manual
+`pg_isready` command; the Go harness receives its password in the explicit DSN.
+
+```bash
+PGPASSWORD='swarm-test' pg_isready \
+  -h 127.0.0.1 -p 5432 -U swarm_test -d postgres
+```
+
+Run tests with an invocation-scoped DSN instead of a persistent shell export:
+
+```bash
+SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' \
+  go test ./...
+```
+
+URL DSNs are equally supported:
+
+```bash
+SWARM_TEST_POSTGRES_DSN='postgres://swarm_test:swarm-test@127.0.0.1:5432/postgres?sslmode=disable' \
+  go test ./internal/testutil -run '^TestStartPostgres' -count=1
+```
+
+A set but invalid DSN fails closed and never falls through to Docker.
+
+## Dedicated Fast Instance
+
+The durability settings below are safe only for a disposable test cluster. Do
+not apply them to a shared development or production server.
+
+On macOS with Homebrew PostgreSQL 16:
+
+```bash
+PG_BIN="$(brew --prefix postgresql@16)/bin"
+PG_DATA="$HOME/Library/Application Support/swarm/postgres-test"
+mkdir -p "$PG_DATA"
+printf '%s\n' 'swarm-test' > "$PG_DATA/.pwfile"
+"$PG_BIN/initdb" \
+  -D "$PG_DATA" \
+  -U swarm_test \
+  --auth-host=scram-sha-256 \
+  --pwfile="$PG_DATA/.pwfile"
+rm "$PG_DATA/.pwfile"
+"$PG_BIN/pg_ctl" \
+  -D "$PG_DATA" \
+  -l "$PG_DATA/postgres.log" \
+  -o "-p 55432 -c max_connections=300 -c fsync=off -c synchronous_commit=off -c full_page_writes=off" \
+  start
+```
+
+Use port `55432` in `SWARM_TEST_POSTGRES_DSN`. Stop the dedicated instance with:
+
+```bash
+"$(brew --prefix postgresql@16)/bin/pg_ctl" \
+  -D "$HOME/Library/Application Support/swarm/postgres-test" stop
+```
+
+## Docker Fallback
+
+When `SWARM_TEST_POSTGRES_DSN` is absent, the harness announces and uses a Docker
+fallback if a daemon is already running. It does not start Docker Desktop or
+Colima. The owned container uses tmpfs plus `fsync=off`,
+`synchronous_commit=off`, and `full_page_writes=off`.
+
+If Docker is missing or unavailable, the failure points back to this guide and
+retains the underlying executable, socket, startup, or readiness error.

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -259,7 +259,12 @@ func (s *sharedPostgresState) startDockerLocked() error {
 		return fmt.Errorf("empty host port from docker port: %q", portLine)
 	}
 
-	admin, err := parseTestPostgresDSN(fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=postgres dbname=postgres sslmode=disable", port))
+	portNumber, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || portNumber == 0 {
+		_ = exec.Command(dockerBin, "stop", name).Run()
+		return fmt.Errorf("invalid host port from docker port %q", portLine)
+	}
+	admin, err := newOwnedDockerPostgresDSN(uint16(portNumber))
 	if err != nil {
 		_ = exec.Command(dockerBin, "stop", name).Run()
 		return fmt.Errorf("build owned postgres DSN: %w", err)

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"github.com/division-sh/swarm/internal/store/platformschema"
-	_ "github.com/lib/pq"
-	"gopkg.in/yaml.v3"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,19 +16,31 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/store/platformschema"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	postgresTestSetupDoc      = "internal/testutil/POSTGRES.md"
+	dockerPostgresFallbackLog = "using Docker Postgres (set SWARM_TEST_POSTGRES_DSN for host Postgres - faster)"
 )
 
 type sharedPostgresState struct {
-	mu             sync.Mutex
-	lifecycle      sync.Mutex
-	started        bool
-	dockerBin      string
-	name           string
-	adminDSN       string
-	template       string
-	templated      bool
-	cleanupStarted bool
-	nextDBID       uint64
+	mu                sync.Mutex
+	lifecycle         sync.Mutex
+	started           bool
+	dockerBin         string
+	name              string
+	admin             testPostgresDSN
+	authenticatedRole string
+	template          string
+	templated         bool
+	cleanupStarted    bool
+	nextDBID          uint64
+	reportWriter      io.Writer
+	reportFallback    sync.Once
 }
 
 var sharedPostgres sharedPostgresState
@@ -70,11 +79,11 @@ func startPostgresDatabase(t *testing.T, useTemplate bool) (dsn string, db *sql.
 			t.Fatalf("start shared postgres: %v", err)
 		}
 	}
-	adminDSN := sharedPostgres.adminDSN
+	admin := sharedPostgres.admin
 	dbName := sharedPostgres.nextDatabaseName()
 	sharedPostgres.mu.Unlock()
 
-	adminDB, err := sql.Open("postgres", adminDSN)
+	adminDB, err := admin.open()
 	if err != nil {
 		t.Fatalf("open postgres admin: %v", err)
 	}
@@ -95,8 +104,19 @@ func startPostgresDatabase(t *testing.T, useTemplate bool) (dsn string, db *sql.
 		t.Fatalf("create empty postgres database %q: %v", dbName, err)
 	}
 
-	dsn = withDBName(adminDSN, dbName)
-	db, err = sql.Open("postgres", dsn)
+	projected, err := admin.withDatabase(dbName)
+	if err != nil {
+		_ = dropIsolatedDatabase(adminDB, dbName)
+		sharedPostgres.lifecycle.Unlock()
+		t.Fatalf("project postgres database %q: %v", dbName, err)
+	}
+	dsn, err = projected.string()
+	if err != nil {
+		_ = dropIsolatedDatabase(adminDB, dbName)
+		sharedPostgres.lifecycle.Unlock()
+		t.Fatalf("serialize postgres database %q: %v", dbName, err)
+	}
+	db, err = projected.open()
 	if err != nil {
 		_ = dropIsolatedDatabase(adminDB, dbName)
 		sharedPostgres.lifecycle.Unlock()
@@ -117,7 +137,7 @@ func startPostgresDatabase(t *testing.T, useTemplate bool) (dsn string, db *sql.
 		}
 		released = true
 		_ = db.Close()
-		adminCleanupDB, err := sql.Open("postgres", adminDSN)
+		adminCleanupDB, err := admin.open()
 		if err != nil {
 			t.Fatalf("reopen postgres admin for cleanup: %v", err)
 		}
@@ -158,19 +178,51 @@ func waitForTestDatabase(ctx context.Context, db *sql.DB, timeout time.Duration)
 }
 
 func (s *sharedPostgresState) startLocked() error {
-	if adminDSN := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_DSN")); adminDSN != "" {
-		db, err := sql.Open("postgres", adminDSN)
-		if err != nil {
-			return fmt.Errorf("open external postgres: %w", err)
+	return s.startLockedWithDSN(strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_DSN")))
+}
+
+func (s *sharedPostgresState) startLockedWithDSN(raw string) error {
+	if raw != "" {
+		if err := s.startExternalLocked(raw); err != nil {
+			return fmt.Errorf("SWARM_TEST_POSTGRES_DSN is set but unusable; Docker fallback is disabled; see %s: %w", postgresTestSetupDoc, err)
 		}
-		defer db.Close()
-		if err := waitForTestDatabase(context.Background(), db, 180*time.Second); err != nil {
-			return fmt.Errorf("external postgres not ready: %w", err)
-		}
-		s.started = true
-		s.adminDSN = adminDSN
 		return nil
 	}
+	s.reportDockerFallback()
+	if err := s.startDockerLocked(); err != nil {
+		return dockerPostgresSetupError(err)
+	}
+	return nil
+}
+
+func dockerPostgresSetupError(cause error) error {
+	return fmt.Errorf("SWARM_TEST_POSTGRES_DSN is not set and Docker fallback failed; configure host Postgres using %s: %w", postgresTestSetupDoc, cause)
+}
+
+func (s *sharedPostgresState) startExternalLocked(raw string) error {
+	admin, err := parseTestPostgresDSN(raw)
+	if err != nil {
+		return err
+	}
+	db, err := admin.open()
+	if err != nil {
+		return fmt.Errorf("open external postgres: %w", err)
+	}
+	defer db.Close()
+	if err := waitForTestDatabase(context.Background(), db, 180*time.Second); err != nil {
+		return fmt.Errorf("external postgres not ready: %w", err)
+	}
+	role, err := inspectTestPostgresSession(db)
+	if err != nil {
+		return err
+	}
+	s.started = true
+	s.admin = admin
+	s.authenticatedRole = role
+	return nil
+}
+
+func (s *sharedPostgresState) startDockerLocked() error {
 
 	dockerBin, err := exec.LookPath("docker")
 	if err != nil {
@@ -181,15 +233,7 @@ func (s *sharedPostgresState) startLocked() error {
 	}
 
 	name := fmt.Sprintf("swarm-test-pg-%d-%d", os.Getpid(), time.Now().UnixNano())
-	runArgs := []string{
-		"run", "-d", "--rm",
-		"--name", name,
-		"-e", "POSTGRES_PASSWORD=postgres",
-		"-e", "POSTGRES_DB=swarm",
-		"-p", "127.0.0.1::5432",
-		"postgres:16",
-		"-c", "max_connections=300",
-	}
+	runArgs := dockerPostgresRunArgs(name)
 	if out, err := exec.Command(dockerBin, runArgs...).CombinedOutput(); err != nil {
 		return fmt.Errorf("docker run postgres failed: %v output=%s", err, strings.TrimSpace(string(out)))
 	}
@@ -215,8 +259,12 @@ func (s *sharedPostgresState) startLocked() error {
 		return fmt.Errorf("empty host port from docker port: %q", portLine)
 	}
 
-	adminDSN := fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=postgres dbname=postgres sslmode=disable", port)
-	db, err := sql.Open("postgres", adminDSN)
+	admin, err := parseTestPostgresDSN(fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=postgres dbname=postgres sslmode=disable", port))
+	if err != nil {
+		_ = exec.Command(dockerBin, "stop", name).Run()
+		return fmt.Errorf("build owned postgres DSN: %w", err)
+	}
+	db, err := admin.open()
 	if err != nil {
 		_ = exec.Command(dockerBin, "stop", name).Run()
 		return fmt.Errorf("open postgres: %w", err)
@@ -237,6 +285,11 @@ func (s *sharedPostgresState) startLocked() error {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	role, err := inspectTestPostgresSession(db)
+	if err != nil {
+		_ = exec.Command(dockerBin, "stop", name).Run()
+		return err
+	}
 
 	if err := startContainerWatcher(dockerBin, name); err != nil {
 		_ = exec.Command(dockerBin, "stop", name).Run()
@@ -246,8 +299,61 @@ func (s *sharedPostgresState) startLocked() error {
 	s.started = true
 	s.dockerBin = dockerBin
 	s.name = name
-	s.adminDSN = adminDSN
+	s.admin = admin
+	s.authenticatedRole = role
 	return nil
+}
+
+func dockerPostgresRunArgs(name string) []string {
+	return []string{
+		"run", "-d", "--rm",
+		"--name", name,
+		"--tmpfs", "/var/lib/postgresql/data:rw",
+		"-e", "POSTGRES_PASSWORD=postgres",
+		"-e", "POSTGRES_DB=postgres",
+		"-p", "127.0.0.1::5432",
+		"postgres:16",
+		"-c", "max_connections=300",
+		"-c", "fsync=off",
+		"-c", "synchronous_commit=off",
+		"-c", "full_page_writes=off",
+	}
+}
+
+func (s *sharedPostgresState) reportDockerFallback() {
+	s.reportFallback.Do(func() {
+		writer := s.reportWriter
+		if writer == nil {
+			writer = os.Stderr
+		}
+		_, _ = fmt.Fprintln(writer, dockerPostgresFallbackLog)
+	})
+}
+
+func inspectTestPostgresSession(db *sql.DB) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var (
+		role             string
+		gssAuthenticated bool
+	)
+	if err := db.QueryRowContext(ctx, `
+		SELECT current_user,
+		       COALESCE((
+		           SELECT gss_authenticated
+		           FROM pg_catalog.pg_stat_gssapi
+		           WHERE pid = pg_backend_pid()
+		       ), false)
+	`).Scan(&role, &gssAuthenticated); err != nil {
+		return "", fmt.Errorf("verify postgres test authentication: %w", err)
+	}
+	if strings.TrimSpace(role) == "" {
+		return "", fmt.Errorf("verify postgres test authentication: current_user is empty")
+	}
+	if gssAuthenticated {
+		return "", fmt.Errorf("postgres test DSN used GSS authentication, which cannot be reproduced by the cleanup process; use password authentication")
+	}
+	return role, nil
 }
 
 func cleanupStaleTestContainers(dockerBin string) error {
@@ -300,13 +406,17 @@ func (s *sharedPostgresState) ensureTemplateDatabase(adminDB *sql.DB) error {
 	if err := createIsolatedDatabase(adminDB, templateName); err != nil {
 		return fmt.Errorf("create template database %q: %w", templateName, err)
 	}
-	templateDSN := withDBName(s.adminDSN, templateName)
-	templateDB, err := sql.Open("postgres", templateDSN)
+	templateDSN, err := s.admin.withDatabase(templateName)
+	if err != nil {
+		_ = dropIsolatedDatabase(adminDB, templateName)
+		return fmt.Errorf("project template database %q: %w", templateName, err)
+	}
+	templateDB, err := templateDSN.open()
 	if err != nil {
 		_ = dropIsolatedDatabase(adminDB, templateName)
 		return fmt.Errorf("open template database %q: %w", templateName, err)
 	}
-	if err := initializeDatabase(templateDB); err != nil {
+	if err := initializeDatabase(templateDB, s.authenticatedRole); err != nil {
 		_ = templateDB.Close()
 		_ = dropIsolatedDatabase(adminDB, templateName)
 		return fmt.Errorf("initialize template database %q: %w", templateName, err)
@@ -331,11 +441,15 @@ func (s *sharedPostgresState) startTemplateCleanupWatcher(templateName string) e
 	if err != nil {
 		return fmt.Errorf("resolve postgres template cleanup binary: %w", err)
 	}
+	adminDSN, err := s.admin.string()
+	if err != nil {
+		return fmt.Errorf("serialize postgres cleanup admin DSN: %w", err)
+	}
 	cmd := exec.Command(exe)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(withoutPostgresConnectionEnv(os.Environ()),
 		"SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP=1",
 		"SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID="+strconv.Itoa(os.Getpid()),
-		"SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN="+s.adminDSN,
+		"SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN="+adminDSN,
 		"SWARM_TEST_POSTGRES_TEMPLATE_NAME="+templateName,
 	)
 	if err := cmd.Start(); err != nil {
@@ -346,6 +460,18 @@ func (s *sharedPostgresState) startTemplateCleanupWatcher(templateName string) e
 	}
 	s.cleanupStarted = true
 	return nil
+}
+
+func withoutPostgresConnectionEnv(env []string) []string {
+	result := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "PG") || strings.HasPrefix(key, "SWARM_TEST_POSTGRES_TEMPLATE_") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
 }
 
 func runPostgresTemplateCleanupWatcherFromEnv() {
@@ -359,7 +485,11 @@ func runPostgresTemplateCleanupWatcherFromEnv() {
 		return
 	}
 	waitForProcessExit(parentPID)
-	db, err := sql.Open("postgres", adminDSN)
+	admin, err := parseTestPostgresDSN(adminDSN)
+	if err != nil {
+		return
+	}
+	db, err := admin.open()
 	if err != nil {
 		return
 	}
@@ -380,7 +510,7 @@ func waitForProcessExit(pid int) {
 	}
 }
 
-func initializeDatabase(db *sql.DB) error {
+func initializeDatabase(db *sql.DB, authenticatedRole string) error {
 	spec, err := loadPlatformSpec()
 	if err != nil {
 		return err
@@ -393,7 +523,7 @@ func initializeDatabase(db *sql.DB) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	if err := ensurePublicSchema(ctx, db); err != nil {
+	if err := ensurePublicSchema(ctx, db, authenticatedRole); err != nil {
 		return err
 	}
 	if err := platformschema.EnsurePostgresTables(ctx, db, plans, nil); err != nil {
@@ -427,10 +557,13 @@ func loadPlatformSpec() (runtimecontracts.PlatformSpecDocument, error) {
 	return spec, nil
 }
 
-func ensurePublicSchema(ctx context.Context, db *sql.DB) error {
+func ensurePublicSchema(ctx context.Context, db *sql.DB, authenticatedRole string) error {
+	if strings.TrimSpace(authenticatedRole) == "" {
+		return fmt.Errorf("authenticated postgres role is required")
+	}
 	for _, stmt := range []string{
 		`CREATE SCHEMA IF NOT EXISTS public`,
-		`GRANT ALL ON SCHEMA public TO postgres`,
+		`GRANT ALL ON SCHEMA public TO ` + quoteIdent(authenticatedRole),
 		`GRANT ALL ON SCHEMA public TO public`,
 	} {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
@@ -473,17 +606,6 @@ func dropIsolatedDatabase(adminDB *sql.DB, dbName string) error {
 		return fmt.Errorf("drop database %s: %w", dbName, err)
 	}
 	return nil
-}
-
-func withDBName(dsn, dbName string) string {
-	parts := strings.Fields(dsn)
-	for i, part := range parts {
-		if strings.HasPrefix(part, "dbname=") {
-			parts[i] = "dbname=" + dbName
-			return strings.Join(parts, " ")
-		}
-	}
-	return dsn + " dbname=" + dbName
 }
 
 func quoteIdent(v string) string {

--- a/internal/testutil/postgres_ci_test.go
+++ b/internal/testutil/postgres_ci_test.go
@@ -1,0 +1,175 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCIPostgresJobsShareOwnedLauncher(t *testing.T) {
+	root := testRepoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Env      map[string]string `yaml:"env"`
+			Services map[string]any    `yaml:"services"`
+			Steps    []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse ci.yml: %v", err)
+	}
+
+	wantJobs := []string{"full-conformance", "nightly-extras", "semantic-smoke", "test-shard"}
+	var gotJobs []string
+	for jobName, job := range workflow.Jobs {
+		if job.Env["SWARM_TEST_POSTGRES_DSN"] == "" {
+			continue
+		}
+		gotJobs = append(gotJobs, jobName)
+		if job.Env["SWARM_TEST_POSTGRES_DSN"] != "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable" {
+			t.Fatalf("job %s has non-canonical test DSN %q", jobName, job.Env["SWARM_TEST_POSTGRES_DSN"])
+		}
+		if _, hasLegacyService := job.Services["postgres"]; hasLegacyService {
+			t.Fatalf("job %s retains a Postgres service instead of the canonical launcher", jobName)
+		}
+		hasLauncher := false
+		for _, step := range job.Steps {
+			hasLauncher = hasLauncher || (step.Name == "Start and verify disposable Postgres" && strings.TrimSpace(step.Run) == "./internal/testutil/start-postgres-ci.sh")
+		}
+		if !hasLauncher {
+			t.Fatalf("job %s does not consume the canonical Postgres launcher", jobName)
+		}
+	}
+	sort.Strings(gotJobs)
+	if !reflect.DeepEqual(gotJobs, wantJobs) {
+		t.Fatalf("CI Postgres jobs = %v, want %v", gotJobs, wantJobs)
+	}
+	launcher, err := os.ReadFile(filepath.Join(root, "internal", "testutil", "start-postgres-ci.sh"))
+	if err != nil {
+		t.Fatalf("read canonical CI Postgres launcher: %v", err)
+	}
+	launcherText := string(launcher)
+	for _, want := range []string{
+		"docker run --detach --rm",
+		"--tmpfs /var/lib/postgresql/data:rw",
+		"--publish 127.0.0.1:5432:5432",
+		"postgres:16",
+		"-c max_connections=300",
+		"-c fsync=off",
+		"-c synchronous_commit=off",
+		"-c full_page_writes=off",
+		"pg_isready -U postgres -d postgres",
+		"for setting in max_connections fsync synchronous_commit full_page_writes",
+		`psql -U postgres -d postgres -tAc "SHOW $setting"`,
+	} {
+		if !strings.Contains(launcherText, want) {
+			t.Fatalf("canonical CI Postgres launcher missing %q", want)
+		}
+	}
+}
+
+func TestPostgresTestEnvironmentHasNoCompetingReaderOrProjector(t *testing.T) {
+	root := testRepoRoot(t)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		if strings.Contains(text, "withDB"+"Name(") {
+			t.Errorf("non-authoritative Postgres DSN projector survives in %s", rel)
+		}
+		manualParserFragments := []string{
+			"strings.Fields(" + "dsn)",
+			"strings.HasPrefix(part, " + `"port=")`,
+			"strings.HasPrefix(part, " + `"dbname=")`,
+		}
+		for _, fragment := range manualParserFragments {
+			if strings.Contains(text, fragment) {
+				t.Errorf("manual Postgres DSN interpreter %q survives in %s", fragment, rel)
+			}
+		}
+		if !strings.HasSuffix(path, "_test.go") && strings.Contains(text, `os.Getenv("SWARM_TEST_POSTGRES_DSN")`) && filepath.ToSlash(rel) != "internal/testutil/postgres.go" {
+			t.Errorf("competing SWARM_TEST_POSTGRES_DSN reader survives in %s", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan Postgres environment owners: %v", err)
+	}
+}
+
+func TestPostgresContributorGuideIsCanonicalAndQuarantined(t *testing.T) {
+	root := testRepoRoot(t)
+	guidePath := filepath.Join(root, "internal", "testutil", "POSTGRES.md")
+	guide, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("read POSTGRES.md: %v", err)
+	}
+	guideText := string(guide)
+	for _, want := range []string{
+		"SWARM_TEST_POSTGRES_DSN",
+		"PostgreSQL 16",
+		"CREATEDB",
+		"PGPASSWORD",
+		"fsync=off",
+		"synchronous_commit=off",
+		"full_page_writes=off",
+		"Docker Fallback",
+	} {
+		if !strings.Contains(guideText, want) {
+			t.Fatalf("POSTGRES.md missing %q", want)
+		}
+	}
+	contributing, err := os.ReadFile(filepath.Join(root, "CONTRIBUTING.md"))
+	if err != nil {
+		t.Fatalf("read CONTRIBUTING.md: %v", err)
+	}
+	if !strings.Contains(string(contributing), "internal/testutil/POSTGRES.md") {
+		t.Fatal("CONTRIBUTING.md does not link canonical Postgres test guide")
+	}
+
+	for _, rel := range []string{"README.md", ".env.example", "swarm.example.yaml"} {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if strings.Contains(string(data), "SWARM_TEST_POSTGRES_DSN") {
+			t.Fatalf("public onboarding surface %s advertises quarantined test env", rel)
+		}
+	}
+}
+
+func testRepoRoot(t *testing.T) string {
+	t.Helper()
+	specPath, err := platformSpecPath()
+	if err != nil {
+		t.Fatalf("platformSpecPath: %v", err)
+	}
+	return filepath.Dir(specPath)
+}

--- a/internal/testutil/postgres_dsn.go
+++ b/internal/testutil/postgres_dsn.go
@@ -30,10 +30,43 @@ func parseTestPostgresDSN(raw string) (testPostgresDSN, error) {
 }
 
 func newTestPostgresDSN(cfg pq.Config) (testPostgresDSN, error) {
+	if cfg.SSLNegotiation == "" {
+		cfg.SSLNegotiation = pq.SSLNegotiationPostgres
+	}
+	if cfg.TargetSessionAttrs == "" {
+		cfg.TargetSessionAttrs = pq.TargetSessionAttrsAny
+	}
+	if cfg.LoadBalanceHosts == "" {
+		cfg.LoadBalanceHosts = pq.LoadBalanceHostsDisable
+	}
+	if cfg.ClientEncoding == "" {
+		cfg.ClientEncoding = "UTF8"
+	}
+	if cfg.Datestyle == "" {
+		cfg.Datestyle = "ISO, MDY"
+	}
 	if err := validateTestPostgresConfig(cfg); err != nil {
 		return testPostgresDSN{}, err
 	}
 	return testPostgresDSN{config: cfg.Clone()}, nil
+}
+
+func newOwnedDockerPostgresDSN(port uint16) (testPostgresDSN, error) {
+	if port == 0 {
+		return testPostgresDSN{}, fmt.Errorf("owned Docker postgres port is required")
+	}
+	return newTestPostgresDSN(pq.Config{
+		Host:           "127.0.0.1",
+		Hostaddr:       netip.MustParseAddr("127.0.0.1"),
+		Port:           port,
+		Database:       "postgres",
+		User:           "postgres",
+		Password:       "postgres",
+		SSLMode:        pq.SSLModeDisable,
+		SSLSNI:         true,
+		ClientEncoding: "UTF8",
+		Datestyle:      "ISO, MDY",
+	})
 }
 
 func validateTestPostgresConfig(cfg pq.Config) error {
@@ -162,7 +195,19 @@ func serializeTestPostgresConfig(cfg pq.Config) (string, error) {
 func shouldSerializePostgresConfigField(value reflect.Value, key string) bool {
 	switch value.Kind() {
 	case reflect.String:
-		return key == "host" || value.String() != ""
+		if value.String() != "" {
+			return true
+		}
+		// lib/pq rejects empty enum and encoding values. Their effective
+		// defaults are materialized before serialization; every other empty
+		// string is emitted to preserve explicit-empty and env-shadowing
+		// semantics across the string transport boundary.
+		switch key {
+		case "sslmode", "sslnegotiation", "target_session_attrs", "load_balance_hosts", "client_encoding", "datestyle":
+			return false
+		default:
+			return true
+		}
 	case reflect.Struct:
 		if value.Type() == reflect.TypeOf(netip.Addr{}) {
 			return value.Interface().(netip.Addr).IsValid()

--- a/internal/testutil/postgres_dsn.go
+++ b/internal/testutil/postgres_dsn.go
@@ -55,7 +55,7 @@ func newOwnedDockerPostgresDSN(port uint16) (testPostgresDSN, error) {
 	if port == 0 {
 		return testPostgresDSN{}, fmt.Errorf("owned Docker postgres port is required")
 	}
-	return newTestPostgresDSN(pq.Config{
+	owned, err := newTestPostgresDSN(pq.Config{
 		Host:           "127.0.0.1",
 		Hostaddr:       netip.MustParseAddr("127.0.0.1"),
 		Port:           port,
@@ -67,6 +67,18 @@ func newOwnedDockerPostgresDSN(port uint16) (testPostgresDSN, error) {
 		ClientEncoding: "UTF8",
 		Datestyle:      "ISO, MDY",
 	})
+	if err != nil {
+		return testPostgresDSN{}, err
+	}
+	canonical, err := owned.string()
+	if err != nil {
+		return testPostgresDSN{}, err
+	}
+	// pq keeps password presence in private parser state and otherwise replaces
+	// a directly assigned password with pgpass lookup during connection. Reparse
+	// the fully explicit canonical form so pq records that state without giving
+	// any supported PG environment field authority over the owned source.
+	return parseTestPostgresDSN(canonical)
 }
 
 func validateTestPostgresConfig(cfg pq.Config) error {

--- a/internal/testutil/postgres_dsn.go
+++ b/internal/testutil/postgres_dsn.go
@@ -1,0 +1,237 @@
+package testutil
+
+import (
+	"database/sql"
+	"fmt"
+	"net/netip"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/lib/pq"
+)
+
+type testPostgresDSN struct {
+	config pq.Config
+}
+
+func parseTestPostgresDSN(raw string) (testPostgresDSN, error) {
+	cfg, err := pq.NewConfig(strings.TrimSpace(raw))
+	if err != nil {
+		return testPostgresDSN{}, fmt.Errorf("parse postgres test DSN: %w", err)
+	}
+	if cfg.SSLMode == "" {
+		cfg.SSLMode = pq.SSLModeRequire
+	}
+	return newTestPostgresDSN(cfg)
+}
+
+func newTestPostgresDSN(cfg pq.Config) (testPostgresDSN, error) {
+	if err := validateTestPostgresConfig(cfg); err != nil {
+		return testPostgresDSN{}, err
+	}
+	return testPostgresDSN{config: cfg.Clone()}, nil
+}
+
+func validateTestPostgresConfig(cfg pq.Config) error {
+	if cfg.Password == "" {
+		return fmt.Errorf("postgres test DSN requires a non-empty effective password; passfile, default .pgpass, peer, trust, and registry-backed authentication are unsupported")
+	}
+	if cfg.Passfile != "" {
+		return fmt.Errorf("postgres test DSN passfile is unsupported because cleanup runs in a separate process; provide password in SWARM_TEST_POSTGRES_DSN")
+	}
+	if strings.HasPrefix(string(cfg.SSLMode), "pqgo-") {
+		return fmt.Errorf("postgres test DSN sslmode %q is process-local and unsupported; use disable, require, verify-ca, or verify-full", cfg.SSLMode)
+	}
+	switch cfg.SSLMode {
+	case pq.SSLModeDisable, pq.SSLModeRequire, pq.SSLModeVerifyCA, pq.SSLModeVerifyFull:
+	default:
+		return fmt.Errorf("postgres test DSN sslmode %q is unsupported; use disable, require, verify-ca, or verify-full", cfg.SSLMode)
+	}
+	if cfg.KrbSrvname != "" || cfg.KrbSpn != "" {
+		return fmt.Errorf("postgres test DSN GSS options are process-local and unsupported; use password authentication")
+	}
+
+	typedKeys := postgresConfigTaggedKeys()
+	for key := range cfg.Runtime {
+		if key == "service" || key == "servicefile" {
+			return fmt.Errorf("postgres test DSN option %q is unsupported because cleanup runs in a separate process", key)
+		}
+		if _, collides := typedKeys[key]; collides {
+			return fmt.Errorf("postgres test DSN runtime option %q collides with a typed connection option", key)
+		}
+		if !validPostgresOptionKey(key) {
+			return fmt.Errorf("postgres test DSN runtime option key %q cannot be transported safely", key)
+		}
+	}
+	return nil
+}
+
+func (d testPostgresDSN) withDatabase(database string) (testPostgresDSN, error) {
+	if strings.TrimSpace(database) == "" {
+		return testPostgresDSN{}, fmt.Errorf("postgres test database name is required")
+	}
+	cfg := d.config.Clone()
+	cfg.Database = database
+	return newTestPostgresDSN(cfg)
+}
+
+func (d testPostgresDSN) open() (*sql.DB, error) {
+	connector, err := pq.NewConnectorConfig(d.config.Clone())
+	if err != nil {
+		return nil, err
+	}
+	return sql.OpenDB(connector), nil
+}
+
+func (d testPostgresDSN) string() (string, error) {
+	return serializeTestPostgresConfig(d.config)
+}
+
+func serializeTestPostgresConfig(cfg pq.Config) (string, error) {
+	if err := validateTestPostgresConfig(cfg); err != nil {
+		return "", err
+	}
+
+	values := make(map[string]string)
+	value := reflect.ValueOf(cfg)
+	typ := reflect.TypeOf(cfg)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		key, ok := field.Tag.Lookup("postgres")
+		if !ok || key == "" || key == "-" {
+			continue
+		}
+		if !shouldSerializePostgresConfigField(value.Field(i), key) {
+			continue
+		}
+		encoded, err := encodePostgresConfigField(value.Field(i), key)
+		if err != nil {
+			return "", fmt.Errorf("serialize pq.Config.%s: %w", field.Name, err)
+		}
+		values[key] = encoded
+	}
+
+	if len(cfg.Multi) > 0 {
+		hosts := []string{cfg.Host}
+		hostaddrs := []string{postgresAddrString(cfg.Hostaddr)}
+		ports := []string{strconv.Itoa(int(cfg.Port))}
+		hasHostaddr := cfg.Hostaddr.IsValid()
+		for _, alternate := range cfg.Multi {
+			hosts = append(hosts, alternate.Host)
+			hostaddrs = append(hostaddrs, postgresAddrString(alternate.Hostaddr))
+			ports = append(ports, strconv.Itoa(int(alternate.Port)))
+			hasHostaddr = hasHostaddr || alternate.Hostaddr.IsValid()
+		}
+		values["host"] = strings.Join(hosts, ",")
+		if hasHostaddr {
+			values["hostaddr"] = strings.Join(hostaddrs, ",")
+		}
+		values["port"] = strings.Join(ports, ",")
+	}
+
+	typedKeys := postgresConfigTaggedKeys()
+	for key, runtimeValue := range cfg.Runtime {
+		if _, collides := typedKeys[key]; collides {
+			return "", fmt.Errorf("runtime option %q collides with a typed connection option", key)
+		}
+		values[key] = runtimeValue
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var out strings.Builder
+	for i, key := range keys {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(key)
+		out.WriteByte('=')
+		out.WriteString(quotePostgresKeywordValue(values[key]))
+	}
+	return out.String(), nil
+}
+
+func shouldSerializePostgresConfigField(value reflect.Value, key string) bool {
+	switch value.Kind() {
+	case reflect.String:
+		return key == "host" || value.String() != ""
+	case reflect.Struct:
+		if value.Type() == reflect.TypeOf(netip.Addr{}) {
+			return value.Interface().(netip.Addr).IsValid()
+		}
+	}
+	return true
+}
+
+func encodePostgresConfigField(value reflect.Value, key string) (string, error) {
+	switch value.Kind() {
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Uint16:
+		return strconv.FormatUint(value.Uint(), 10), nil
+	case reflect.Int64:
+		if value.Type() != reflect.TypeOf(time.Duration(0)) || key != "connect_timeout" {
+			return "", fmt.Errorf("unsupported int64 field type %s", value.Type())
+		}
+		return strconv.FormatInt(int64(time.Duration(value.Int())/time.Second), 10), nil
+	case reflect.Bool:
+		if value.Bool() {
+			return "yes", nil
+		}
+		return "no", nil
+	case reflect.Struct:
+		if value.Type() != reflect.TypeOf(netip.Addr{}) {
+			return "", fmt.Errorf("unsupported struct field type %s", value.Type())
+		}
+		return postgresAddrString(value.Interface().(netip.Addr)), nil
+	default:
+		return "", fmt.Errorf("unsupported field type %s", value.Type())
+	}
+}
+
+func postgresConfigTaggedKeys() map[string]struct{} {
+	keys := make(map[string]struct{})
+	typ := reflect.TypeOf(pq.Config{})
+	for i := 0; i < typ.NumField(); i++ {
+		key, ok := typ.Field(i).Tag.Lookup("postgres")
+		if !ok || key == "" || key == "-" {
+			continue
+		}
+		keys[key] = struct{}{}
+	}
+	return keys
+}
+
+func postgresAddrString(addr netip.Addr) string {
+	if !addr.IsValid() {
+		return ""
+	}
+	return addr.String()
+}
+
+func quotePostgresKeywordValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `'`, `\'`)
+	return `'` + value + `'`
+}
+
+func validPostgresOptionKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		valid := r == '_' || r == '.' || unicode.IsLetter(r) || (i > 0 && unicode.IsDigit(r))
+		if !valid {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/testutil/postgres_dsn_test.go
+++ b/internal/testutil/postgres_dsn_test.go
@@ -112,6 +112,9 @@ func TestTestPostgresDSNRejectsNonTransportableSemantics(t *testing.T) {
 	}
 	pq.RegisterGSSProvider(func() (pq.GSS, error) { return nil, nil })
 	t.Cleanup(func() { pq.RegisterGSSProvider(nil) })
+	if _, err := parseTestPostgresDSN("host=127.0.0.1 user=tester password=secret sslmode=disable"); err != nil {
+		t.Fatalf("registered but unused GSS provider changed password-auth DSN acceptance: %v", err)
+	}
 
 	tests := []struct {
 		name     string

--- a/internal/testutil/postgres_dsn_test.go
+++ b/internal/testutil/postgres_dsn_test.go
@@ -103,6 +103,8 @@ func TestTestPostgresDSNPreservesExplicitEmptyApplicationName(t *testing.T) {
 }
 
 func TestOwnedDockerPostgresDSNIgnoresAmbientPGEnv(t *testing.T) {
+	pq.RegisterGSSProvider(func() (pq.GSS, error) { return nil, nil })
+	t.Cleanup(func() { pq.RegisterGSSProvider(nil) })
 	for key, value := range map[string]string{
 		"PGHOST":               "hostile.example",
 		"PGHOSTADDR":           "192.0.2.1",
@@ -119,6 +121,7 @@ func TestOwnedDockerPostgresDSNIgnoresAmbientPGEnv(t *testing.T) {
 		"PGSSLKEY":             "/tmp/hostile-key",
 		"PGSSLROOTCERT":        "/tmp/hostile-root",
 		"PGSSLSNI":             "0",
+		"PGKRBSRVNAME":         "hostile",
 		"PGCONNECT_TIMEOUT":    "19",
 		"PGCLIENTENCODING":     "LATIN1",
 		"PGDATESTYLE":          "SQL, DMY",

--- a/internal/testutil/postgres_dsn_test.go
+++ b/internal/testutil/postgres_dsn_test.go
@@ -1,0 +1,278 @@
+package testutil
+
+import (
+	"crypto/tls"
+	"net/netip"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+func TestTestPostgresDSNRoundTripsSupportedRepresentations(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "keyword explicit database",
+			raw:  "host=127.0.0.1 port=5432 user=tester password=secret dbname=postgres sslmode=disable application_name='swarm tests' search_path='public,extensions'",
+		},
+		{
+			name: "URL explicit database",
+			raw:  "postgres://tester:s%20ecret@127.0.0.1:5432/postgres?sslmode=disable&application_name=swarm%20tests&search_path=public%2Cextensions",
+		},
+		{
+			name: "keyword default database",
+			raw:  "host=127.0.0.1 port=5432 user=tester password=secret sslmode=disable",
+		},
+		{
+			name: "URL default database",
+			raw:  "postgres://tester:secret@127.0.0.1:5432?sslmode=disable",
+		},
+		{
+			name: "keyword escaping",
+			raw: "host=127.0.0.1 port=5432 user=tester password=" +
+				quotePostgresKeywordValue(`slash\ quote' space`) +
+				" dbname=postgres sslmode=disable application_name=" +
+				quotePostgresKeywordValue(`worker\ one's`),
+		},
+		{
+			name: "multihost and runtime",
+			raw:  "host=one.example,two.example hostaddr=127.0.0.1,127.0.0.2 port=5432,6543 user=tester password=secret dbname=postgres sslmode=require connect_timeout=9 target_session_attrs=read-write load_balance_hosts=random work_mem='16MB'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, err := parseTestPostgresDSN(tt.raw)
+			if err != nil {
+				t.Fatalf("parseTestPostgresDSN: %v", err)
+			}
+			projected, err := owner.withDatabase("projected_db")
+			if err != nil {
+				t.Fatalf("withDatabase: %v", err)
+			}
+
+			want := owner.config.Clone()
+			want.Database = "projected_db"
+			assertPostgresConfigEqual(t, projected.config, want)
+
+			canonical, err := projected.string()
+			if err != nil {
+				t.Fatalf("string: %v", err)
+			}
+			if strings.HasPrefix(canonical, "postgres://") || strings.HasPrefix(canonical, "postgresql://") {
+				t.Fatalf("canonical DSN remained URL-shaped: %q", canonical)
+			}
+
+			reparsed, err := parseTestPostgresDSN(canonical)
+			if err != nil {
+				t.Fatalf("reparse canonical DSN: %v\nDSN: %s", err, canonical)
+			}
+			assertPostgresConfigEqual(t, reparsed.config, projected.config)
+			if reparsed.config.Database != "projected_db" {
+				t.Fatalf("database = %q, want projected_db", reparsed.config.Database)
+			}
+		})
+	}
+}
+
+func TestTestPostgresDSNSerializerCoversPQConfigSchema(t *testing.T) {
+	typ := reflect.TypeOf(pq.Config{})
+	value := reflect.ValueOf(pq.Config{})
+	covered := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		key, ok := field.Tag.Lookup("postgres")
+		if !ok || key == "" || key == "-" {
+			continue
+		}
+		if covered[key] {
+			t.Fatalf("postgres config key %q appears more than once", key)
+		}
+		if _, err := encodePostgresConfigField(value.Field(i), key); err != nil {
+			t.Fatalf("pq.Config.%s (%s) has no serializer: %v", field.Name, key, err)
+		}
+		covered[key] = true
+	}
+
+	for key := range postgresConfigTaggedKeys() {
+		if !covered[key] {
+			t.Fatalf("postgres config key %q missing serializer coverage", key)
+		}
+	}
+}
+
+func TestTestPostgresDSNRejectsNonTransportableSemantics(t *testing.T) {
+	if err := pq.RegisterTLSConfig("swarm-test-process-local", &tls.Config{MinVersion: tls.VersionTLS12}); err != nil {
+		t.Fatalf("RegisterTLSConfig: %v", err)
+	}
+	pq.RegisterGSSProvider(func() (pq.GSS, error) { return nil, nil })
+	t.Cleanup(func() { pq.RegisterGSSProvider(nil) })
+
+	tests := []struct {
+		name     string
+		raw      string
+		contains string
+	}{
+		{name: "malformed", raw: "not-a-dsn", contains: "parse postgres test DSN"},
+		{name: "empty password", raw: "host=127.0.0.1 user=tester password='' sslmode=disable", contains: "non-empty effective password"},
+		{name: "passfile", raw: "host=127.0.0.1 user=tester password=secret passfile=/tmp/pgpass sslmode=disable", contains: "passfile is unsupported"},
+		{name: "service", raw: "host=127.0.0.1 user=tester password=secret service=cluster sslmode=disable", contains: "option \"service\" is unsupported"},
+		{name: "servicefile", raw: "host=127.0.0.1 user=tester password=secret servicefile=/tmp/service sslmode=disable", contains: "option \"servicefile\" is unsupported"},
+		{name: "custom TLS", raw: "host=127.0.0.1 user=tester password=secret sslmode=pqgo-swarm-test-process-local", contains: "process-local and unsupported"},
+		{name: "GSS service", raw: "host=127.0.0.1 user=tester password=secret sslmode=disable krbsrvname=postgres", contains: "GSS options are process-local"},
+		{name: "GSS SPN", raw: "host=127.0.0.1 user=tester password=secret sslmode=disable krbspn=postgres/host", contains: "GSS options are process-local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseTestPostgresDSN(tt.raw)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("error = %v, want substring %q", err, tt.contains)
+			}
+		})
+	}
+}
+
+func TestTestPostgresDSNRejectsRuntimeCollisionsAndUnsafeKeys(t *testing.T) {
+	base := pq.Config{
+		Host:     "127.0.0.1",
+		Port:     5432,
+		Database: "postgres",
+		User:     "tester",
+		Password: "secret",
+		SSLMode:  pq.SSLModeDisable,
+		SSLSNI:   true,
+		Runtime:  map[string]string{"host": "other"},
+	}
+	if _, err := newTestPostgresDSN(base); err == nil || !strings.Contains(err.Error(), "collides") {
+		t.Fatalf("collision error = %v", err)
+	}
+	base.Runtime = map[string]string{"bad key": "value"}
+	if _, err := newTestPostgresDSN(base); err == nil || !strings.Contains(err.Error(), "cannot be transported safely") {
+		t.Fatalf("unsafe key error = %v", err)
+	}
+}
+
+func TestTestPostgresDSNRejectsEnvironmentPassfile(t *testing.T) {
+	t.Setenv("PGPASSFILE", "/tmp/postgres test passfile")
+	_, err := parseTestPostgresDSN("host=127.0.0.1 user=tester password=secret sslmode=disable")
+	if err == nil || !strings.Contains(err.Error(), "passfile is unsupported") {
+		t.Fatalf("PGPASSFILE error = %v, want passfile rejection", err)
+	}
+}
+
+func TestTestPostgresDSNPreservesMaterializedConfigValues(t *testing.T) {
+	addr := netip.MustParseAddr("127.0.0.1")
+	cfg := pq.Config{
+		Host:                        "primary",
+		Hostaddr:                    addr,
+		Port:                        5432,
+		Database:                    "postgres",
+		User:                        "tester",
+		Password:                    `s\ e'cret`,
+		Options:                     "-c statement_timeout=5000",
+		ApplicationName:             "swarm tests",
+		FallbackApplicationName:     "fallback",
+		SSLMode:                     pq.SSLModeVerifyCA,
+		SSLNegotiation:              pq.SSLNegotiationPostgres,
+		SSLRootCert:                 "/tmp/root cert.pem",
+		SSLSNI:                      false,
+		ConnectTimeout:              7 * time.Second,
+		BinaryParameters:            true,
+		DisablePreparedBinaryResult: true,
+		ClientEncoding:              "UTF8",
+		Datestyle:                   "ISO, MDY",
+		TZ:                          "UTC",
+		Geqo:                        "off",
+		TargetSessionAttrs:          pq.TargetSessionAttrsReadWrite,
+		LoadBalanceHosts:            pq.LoadBalanceHostsDisable,
+		Runtime:                     map[string]string{"work_mem": "32MB"},
+		Multi: []pq.ConfigMultihost{{
+			Host:     "secondary",
+			Hostaddr: netip.MustParseAddr("127.0.0.2"),
+			Port:     6543,
+		}},
+	}
+	owner, err := newTestPostgresDSN(cfg)
+	if err != nil {
+		t.Fatalf("newTestPostgresDSN: %v", err)
+	}
+	canonical, err := owner.string()
+	if err != nil {
+		t.Fatalf("string: %v", err)
+	}
+	reparsed, err := parseTestPostgresDSN(canonical)
+	if err != nil {
+		t.Fatalf("reparse: %v\nDSN: %s", err, canonical)
+	}
+	assertPostgresConfigEqual(t, reparsed.config, cfg)
+}
+
+func TestTestPostgresDSNMaterializesEnvironmentDefaults(t *testing.T) {
+	t.Setenv("PGPASSWORD", "environment secret")
+	t.Setenv("PGAPPNAME", "environment app")
+	t.Setenv("PGCONNECT_TIMEOUT", "11")
+	t.Setenv("PGOPTIONS", "-c statement_timeout=1234")
+
+	owner, err := parseTestPostgresDSN("host=127.0.0.1 port=5432 user=tester dbname=postgres sslmode=disable")
+	if err != nil {
+		t.Fatalf("parse environment-backed DSN: %v", err)
+	}
+	if owner.config.Password != "environment secret" || owner.config.ApplicationName != "environment app" || owner.config.ConnectTimeout != 11*time.Second || owner.config.Options != "-c statement_timeout=1234" {
+		t.Fatalf("environment defaults were not materialized: %#v", exportedPostgresConfig(owner.config))
+	}
+	canonical, err := owner.string()
+	if err != nil {
+		t.Fatalf("serialize environment-backed DSN: %v", err)
+	}
+
+	t.Setenv("PGPASSWORD", "changed secret")
+	t.Setenv("PGAPPNAME", "changed app")
+	t.Setenv("PGCONNECT_TIMEOUT", "2")
+	t.Setenv("PGOPTIONS", "-c statement_timeout=99")
+	reparsed, err := parseTestPostgresDSN(canonical)
+	if err != nil {
+		t.Fatalf("reparse canonical DSN under changed environment: %v", err)
+	}
+	assertPostgresConfigEqual(t, reparsed.config, owner.config)
+}
+
+func TestWithoutPostgresConnectionEnv(t *testing.T) {
+	got := withoutPostgresConnectionEnv([]string{
+		"PATH=/bin",
+		"PGPASSWORD=secret",
+		"PGHOST=other",
+		"SWARM_TEST_POSTGRES_TEMPLATE_NAME=template",
+		"SWARM_CONFIG=/tmp/swarm.yaml",
+	})
+	want := []string{"PATH=/bin", "SWARM_CONFIG=/tmp/swarm.yaml"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("withoutPostgresConnectionEnv() = %v, want %v", got, want)
+	}
+}
+
+func assertPostgresConfigEqual(t *testing.T, got, want pq.Config) {
+	t.Helper()
+	if !reflect.DeepEqual(exportedPostgresConfig(got), exportedPostgresConfig(want)) {
+		t.Fatalf("postgres configs differ\ngot:  %#v\nwant: %#v", exportedPostgresConfig(got), exportedPostgresConfig(want))
+	}
+}
+
+func exportedPostgresConfig(cfg pq.Config) map[string]any {
+	result := make(map[string]any)
+	typ := reflect.TypeOf(cfg)
+	value := reflect.ValueOf(cfg)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		result[field.Name] = value.Field(i).Interface()
+	}
+	return result
+}

--- a/internal/testutil/postgres_dsn_test.go
+++ b/internal/testutil/postgres_dsn_test.go
@@ -80,6 +80,88 @@ func TestTestPostgresDSNRoundTripsSupportedRepresentations(t *testing.T) {
 	}
 }
 
+func TestTestPostgresDSNPreservesExplicitEmptyApplicationName(t *testing.T) {
+	owner, err := parseTestPostgresDSN("host=127.0.0.1 port=5432 user=tester password=secret dbname=postgres sslmode=disable application_name='' fallback_application_name='fallback'")
+	if err != nil {
+		t.Fatalf("parse explicit-empty application name: %v", err)
+	}
+	if owner.config.ApplicationName != "" || owner.config.FallbackApplicationName != "fallback" {
+		t.Fatalf("source application names = (%q, %q), want empty and fallback", owner.config.ApplicationName, owner.config.FallbackApplicationName)
+	}
+	canonical, err := owner.string()
+	if err != nil {
+		t.Fatalf("serialize explicit-empty application name: %v", err)
+	}
+	if !strings.Contains(canonical, "application_name=''") {
+		t.Fatalf("canonical DSN omitted explicit empty application_name: %q", canonical)
+	}
+	reparsed, err := parseTestPostgresDSN(canonical)
+	if err != nil {
+		t.Fatalf("reparse explicit-empty application name: %v", err)
+	}
+	assertPostgresConfigEqual(t, reparsed.config, owner.config)
+}
+
+func TestOwnedDockerPostgresDSNIgnoresAmbientPGEnv(t *testing.T) {
+	for key, value := range map[string]string{
+		"PGHOST":               "hostile.example",
+		"PGHOSTADDR":           "192.0.2.1",
+		"PGPORT":               "6543",
+		"PGDATABASE":           "hostile",
+		"PGUSER":               "hostile",
+		"PGPASSWORD":           "hostile",
+		"PGPASSFILE":           "/tmp/hostile-passfile",
+		"PGOPTIONS":            "-c search_path=hostile",
+		"PGAPPNAME":            "hostile",
+		"PGSSLMODE":            "verify-full",
+		"PGSSLNEGOTIATION":     "direct",
+		"PGSSLCERT":            "/tmp/hostile-cert",
+		"PGSSLKEY":             "/tmp/hostile-key",
+		"PGSSLROOTCERT":        "/tmp/hostile-root",
+		"PGSSLSNI":             "0",
+		"PGCONNECT_TIMEOUT":    "19",
+		"PGCLIENTENCODING":     "LATIN1",
+		"PGDATESTYLE":          "SQL, DMY",
+		"PGTZ":                 "Pacific/Honolulu",
+		"PGGEQO":               "on",
+		"PGTARGETSESSIONATTRS": "read-only",
+		"PGLOADBALANCEHOSTS":   "random",
+	} {
+		t.Setenv(key, value)
+	}
+
+	owner, err := newOwnedDockerPostgresDSN(55432)
+	if err != nil {
+		t.Fatalf("newOwnedDockerPostgresDSN: %v", err)
+	}
+	want, err := newTestPostgresDSN(pq.Config{
+		Host:           "127.0.0.1",
+		Hostaddr:       netip.MustParseAddr("127.0.0.1"),
+		Port:           55432,
+		Database:       "postgres",
+		User:           "postgres",
+		Password:       "postgres",
+		SSLMode:        pq.SSLModeDisable,
+		SSLSNI:         true,
+		ClientEncoding: "UTF8",
+		Datestyle:      "ISO, MDY",
+	})
+	if err != nil {
+		t.Fatalf("build expected Docker config: %v", err)
+	}
+	assertPostgresConfigEqual(t, owner.config, want.config)
+
+	canonical, err := owner.string()
+	if err != nil {
+		t.Fatalf("serialize owned Docker config: %v", err)
+	}
+	reparsed, err := parseTestPostgresDSN(canonical)
+	if err != nil {
+		t.Fatalf("reparse owned Docker config under hostile PG env: %v", err)
+	}
+	assertPostgresConfigEqual(t, reparsed.config, owner.config)
+}
+
 func TestTestPostgresDSNSerializerCoversPQConfigSchema(t *testing.T) {
 	typ := reflect.TypeOf(pq.Config{})
 	value := reflect.ValueOf(pq.Config{})

--- a/internal/testutil/postgres_environment_test.go
+++ b/internal/testutil/postgres_environment_test.go
@@ -1,0 +1,138 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestSharedPostgresStateRejectsBadDSNWithoutDockerFallback(t *testing.T) {
+	state := &sharedPostgresState{}
+	err := state.startLockedWithDSN("not-a-dsn")
+	if err == nil {
+		t.Fatal("expected invalid DSN failure")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"SWARM_TEST_POSTGRES_DSN is set but unusable",
+		"Docker fallback is disabled",
+		postgresTestSetupDoc,
+		"parse postgres test DSN",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q missing %q", message, want)
+		}
+	}
+	if strings.Contains(message, "docker not found") || strings.Contains(message, "docker run") {
+		t.Fatalf("invalid DSN reached Docker fallback: %q", message)
+	}
+}
+
+func TestSharedPostgresStateReportsDockerFallbackOnce(t *testing.T) {
+	var output bytes.Buffer
+	state := &sharedPostgresState{reportWriter: &output}
+	state.reportDockerFallback()
+	state.reportDockerFallback()
+	if got, want := output.String(), dockerPostgresFallbackLog+"\n"; got != want {
+		t.Fatalf("fallback output = %q, want %q", got, want)
+	}
+}
+
+func TestDockerPostgresRunArgsOwnDisposableSettings(t *testing.T) {
+	args := dockerPostgresRunArgs("swarm-test")
+	for _, pair := range [][]string{
+		{"--tmpfs", "/var/lib/postgresql/data:rw"},
+		{"-e", "POSTGRES_DB=postgres"},
+		{"-c", "max_connections=300"},
+		{"-c", "fsync=off"},
+		{"-c", "synchronous_commit=off"},
+		{"-c", "full_page_writes=off"},
+	} {
+		if !containsAdjacentStrings(args, pair[0], pair[1]) {
+			t.Fatalf("docker args %q missing adjacent %q", args, pair)
+		}
+	}
+}
+
+func TestInspectTestPostgresSessionRejectsGSSBeforeLifecycleMutation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mock.ExpectQuery(`(?s)SELECT current_user,.*pg_catalog\.pg_stat_gssapi`).
+		WillReturnRows(sqlmock.NewRows([]string{"current_user", "gss_authenticated"}).AddRow("tester", true))
+
+	_, err = inspectTestPostgresSession(db)
+	if err == nil || !strings.Contains(err.Error(), "used GSS authentication") {
+		t.Fatalf("GSS error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestInspectTestPostgresSessionReturnsServerRole(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mock.ExpectQuery(`(?s)SELECT current_user,.*pg_catalog\.pg_stat_gssapi`).
+		WillReturnRows(sqlmock.NewRows([]string{"current_user", "gss_authenticated"}).AddRow("swarm_test", false))
+
+	role, err := inspectTestPostgresSession(db)
+	if err != nil {
+		t.Fatalf("inspectTestPostgresSession: %v", err)
+	}
+	if role != "swarm_test" {
+		t.Fatalf("role = %q, want swarm_test", role)
+	}
+}
+
+func TestEnsurePublicSchemaGrantsAuthenticatedRole(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, statement := range []string{
+		`CREATE SCHEMA IF NOT EXISTS public`,
+		`GRANT ALL ON SCHEMA public TO "role-with-dash"`,
+		`GRANT ALL ON SCHEMA public TO public`,
+	} {
+		mock.ExpectExec(regexp.QuoteMeta(statement)).WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+	if err := ensurePublicSchema(context.Background(), db, "role-with-dash"); err != nil {
+		t.Fatalf("ensurePublicSchema: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDockerSetupDiagnosticPreservesCause(t *testing.T) {
+	cause := errors.New("dial unix /var/run/docker.sock: no such file")
+	err := dockerPostgresSetupError(cause)
+	if !strings.Contains(err.Error(), postgresTestSetupDoc) {
+		t.Fatalf("Docker failure missing setup doc: %v", err)
+	}
+	if !errors.Is(err, cause) || !strings.Contains(err.Error(), cause.Error()) {
+		t.Fatalf("Docker failure lost technical cause: %v", err)
+	}
+}
+
+func containsAdjacentStrings(values []string, first, second string) bool {
+	for i := 0; i+1 < len(values); i++ {
+		if slices.Equal(values[i:i+2], []string{first, second}) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testutil/postgres_environment_test.go
+++ b/internal/testutil/postgres_environment_test.go
@@ -34,6 +34,28 @@ func TestSharedPostgresStateRejectsBadDSNWithoutDockerFallback(t *testing.T) {
 	}
 }
 
+func TestSharedPostgresStateRejectsUnreachableDSNWithoutDockerFallback(t *testing.T) {
+	var output bytes.Buffer
+	state := &sharedPostgresState{reportWriter: &output}
+	err := state.startLockedWithDSN("host=127.0.0.1 port=1 user=tester password=secret dbname=postgres sslmode=disable connect_timeout=1")
+	if err == nil {
+		t.Fatal("expected unreachable DSN failure")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"SWARM_TEST_POSTGRES_DSN is set but unusable",
+		"Docker fallback is disabled",
+		"external postgres not ready",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q missing %q", message, want)
+		}
+	}
+	if output.Len() != 0 {
+		t.Fatalf("unreachable explicit DSN announced Docker fallback: %q", output.String())
+	}
+}
+
 func TestSharedPostgresStateReportsDockerFallbackOnce(t *testing.T) {
 	var output bytes.Buffer
 	state := &sharedPostgresState{reportWriter: &output}

--- a/internal/testutil/postgres_integration_test.go
+++ b/internal/testutil/postgres_integration_test.go
@@ -1,0 +1,353 @@
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+func TestPostgresDSNIntegrationMatrix(t *testing.T) {
+	raw := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_DSN"))
+	if raw == "" {
+		t.Skip("SWARM_TEST_POSTGRES_DSN is required for external DSN integration matrix")
+	}
+	base, err := parseTestPostgresDSN(raw)
+	if err != nil {
+		t.Fatalf("parse base DSN: %v", err)
+	}
+	ensureDefaultUserDatabase(t, base)
+
+	for name, form := range externalPostgresDSNForms(t, base.config) {
+		t.Run(name, func(t *testing.T) {
+			exercisePostgresDSN(t, form)
+		})
+	}
+}
+
+func TestPostgresDSNNonPostgresRole(t *testing.T) {
+	if os.Getenv("SWARM_TEST_POSTGRES_ROLE_PROOF") != "1" {
+		t.Skip("set SWARM_TEST_POSTGRES_ROLE_PROOF=1 with a role-admin DSN to run role proof")
+	}
+	raw := strings.TrimSpace(os.Getenv("SWARM_TEST_POSTGRES_DSN"))
+	if raw == "" {
+		t.Fatal("SWARM_TEST_POSTGRES_DSN is required for role proof")
+	}
+	base, err := parseTestPostgresDSN(raw)
+	if err != nil {
+		t.Fatalf("parse base DSN: %v", err)
+	}
+	adminDB, err := base.open()
+	if err != nil {
+		t.Fatalf("open admin: %v", err)
+	}
+	defer adminDB.Close()
+	if err := waitForTestDatabase(context.Background(), adminDB, 10*time.Second); err != nil {
+		t.Fatalf("admin readiness: %v", err)
+	}
+
+	role := fmt.Sprintf("swarm_test_role_%d_%d", os.Getpid(), time.Now().UnixNano())
+	password := fmt.Sprintf("swarm-role-%d", time.Now().UnixNano())
+	if _, err := adminDB.Exec("CREATE ROLE " + quoteIdent(role) + " LOGIN CREATEDB PASSWORD " + quoteLiteral(password)); err != nil {
+		t.Fatalf("create proof role: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupDB, openErr := base.open()
+		if openErr != nil {
+			return
+		}
+		defer cleanupDB.Close()
+		_, _ = cleanupDB.Exec("DROP ROLE IF EXISTS " + quoteIdent(role))
+	})
+
+	roleConfig := base.config.Clone()
+	roleConfig.User = role
+	roleConfig.Password = password
+	if roleConfig.Database == "" {
+		roleConfig.Database = "postgres"
+	}
+	roleOwner, err := newTestPostgresDSN(roleConfig)
+	if err != nil {
+		t.Fatalf("role DSN: %v", err)
+	}
+	roleDSN, err := roleOwner.string()
+	if err != nil {
+		t.Fatalf("serialize role DSN: %v", err)
+	}
+	exercisePostgresDSN(t, roleDSN)
+}
+
+func TestOwnedPostgresSettings(t *testing.T) {
+	if os.Getenv("SWARM_TEST_POSTGRES_ASSERT_OWNED_SETTINGS") != "1" {
+		t.Skip("owned Postgres settings proof is opt-in")
+	}
+	_, db, cleanup := StartPostgres(t)
+	defer cleanup()
+	for setting, want := range map[string]string{
+		"fsync":              "off",
+		"synchronous_commit": "off",
+		"full_page_writes":   "off",
+	} {
+		var got string
+		if err := db.QueryRow("SHOW " + setting).Scan(&got); err != nil {
+			t.Fatalf("SHOW %s: %v", setting, err)
+		}
+		if got != want {
+			t.Fatalf("%s = %q, want %q", setting, got, want)
+		}
+	}
+}
+
+func exercisePostgresDSN(t *testing.T, raw string) {
+	t.Helper()
+	admin, err := parseTestPostgresDSN(raw)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	adminDB, err := admin.open()
+	if err != nil {
+		t.Fatalf("open admin: %v", err)
+	}
+	defer adminDB.Close()
+	if err := waitForTestDatabase(context.Background(), adminDB, 10*time.Second); err != nil {
+		t.Fatalf("admin readiness: %v", err)
+	}
+	role, err := inspectTestPostgresSession(adminDB)
+	if err != nil {
+		t.Fatalf("inspect session: %v", err)
+	}
+
+	suffix := fmt.Sprintf("%d_%d", os.Getpid(), time.Now().UnixNano())
+	templateName := "mas_matrix_template_" + suffix
+	cloneName := "mas_matrix_clone_" + suffix
+	emptyName := "mas_matrix_empty_" + suffix
+	childCleanupName := "mas_matrix_child_" + suffix
+	for _, name := range []string{cloneName, emptyName, childCleanupName, templateName} {
+		name := name
+		t.Cleanup(func() {
+			cleanupDB, openErr := admin.open()
+			if openErr != nil {
+				return
+			}
+			defer cleanupDB.Close()
+			_ = dropIsolatedDatabase(cleanupDB, name)
+		})
+	}
+
+	if err := createIsolatedDatabase(adminDB, templateName); err != nil {
+		t.Fatalf("create template: %v", err)
+	}
+	templateDSN, err := admin.withDatabase(templateName)
+	if err != nil {
+		t.Fatalf("project template: %v", err)
+	}
+	templateDB, err := templateDSN.open()
+	if err != nil {
+		t.Fatalf("open template: %v", err)
+	}
+	if err := initializeDatabase(templateDB, role); err != nil {
+		_ = templateDB.Close()
+		t.Fatalf("initialize template: %v", err)
+	}
+	if err := templateDB.Close(); err != nil {
+		t.Fatalf("close template: %v", err)
+	}
+
+	if err := createIsolatedDatabaseFromTemplate(adminDB, cloneName, templateName); err != nil {
+		t.Fatalf("clone template: %v", err)
+	}
+	cloneDSN, err := admin.withDatabase(cloneName)
+	if err != nil {
+		t.Fatalf("project clone: %v", err)
+	}
+	serializedClone, err := cloneDSN.string()
+	if err != nil {
+		t.Fatalf("serialize clone: %v", err)
+	}
+	cloneDB, err := sql.Open("postgres", serializedClone)
+	if err != nil {
+		t.Fatalf("open returned clone DSN: %v", err)
+	}
+	assertStartPostgresSchema(t, cloneDB, mustPlatformVersion(t))
+	if err := cloneDB.Close(); err != nil {
+		t.Fatalf("close clone: %v", err)
+	}
+
+	if err := createIsolatedDatabase(adminDB, emptyName); err != nil {
+		t.Fatalf("create empty database: %v", err)
+	}
+	emptyDSN, err := admin.withDatabase(emptyName)
+	if err != nil {
+		t.Fatalf("project empty database: %v", err)
+	}
+	serializedEmpty, err := emptyDSN.string()
+	if err != nil {
+		t.Fatalf("serialize empty database: %v", err)
+	}
+	emptyDB, err := sql.Open("postgres", serializedEmpty)
+	if err != nil {
+		t.Fatalf("open returned empty DSN: %v", err)
+	}
+	var hasSchemaVersion bool
+	if err := emptyDB.QueryRow(`SELECT to_regclass('public.schema_version') IS NOT NULL`).Scan(&hasSchemaVersion); err != nil {
+		_ = emptyDB.Close()
+		t.Fatalf("inspect empty database: %v", err)
+	}
+	if err := emptyDB.Close(); err != nil {
+		t.Fatalf("close empty database: %v", err)
+	}
+	if hasSchemaVersion {
+		t.Fatal("StartEmptyPostgres projection unexpectedly contained canonical schema")
+	}
+
+	if err := createIsolatedDatabase(adminDB, childCleanupName); err != nil {
+		t.Fatalf("create child-cleanup database: %v", err)
+	}
+	proveCleanupChildTransport(t, admin, childCleanupName)
+	assertDatabaseAbsent(t, adminDB, childCleanupName)
+
+	for _, name := range []string{cloneName, emptyName, templateName} {
+		if err := dropIsolatedDatabase(adminDB, name); err != nil {
+			t.Fatalf("drop %s: %v", name, err)
+		}
+		assertDatabaseAbsent(t, adminDB, name)
+	}
+}
+
+func externalPostgresDSNForms(t *testing.T, cfg pq.Config) map[string]string {
+	t.Helper()
+	if len(cfg.Multi) > 0 {
+		t.Fatal("integration representation matrix requires a single-host base DSN")
+	}
+	host := cfg.Host
+	if host == "" && cfg.Hostaddr.IsValid() {
+		host = cfg.Hostaddr.String()
+	}
+	if host == "" || strings.HasPrefix(host, "/") || strings.HasPrefix(host, "@") {
+		t.Fatal("integration representation matrix requires a TCP host")
+	}
+	database := cfg.Database
+	if database == "" {
+		database = cfg.User
+	}
+	keyword := func(includeDatabase bool) string {
+		parts := []string{
+			"host=" + quotePostgresKeywordValue(host),
+			"port=" + quotePostgresKeywordValue(strconv.Itoa(int(cfg.Port))),
+			"user=" + quotePostgresKeywordValue(cfg.User),
+			"password=" + quotePostgresKeywordValue(cfg.Password),
+			"sslmode=" + quotePostgresKeywordValue(string(cfg.SSLMode)),
+		}
+		if includeDatabase {
+			parts = append(parts, "dbname="+quotePostgresKeywordValue(database))
+		}
+		return strings.Join(parts, " ")
+	}
+	postgresURL := func(includeDatabase bool) string {
+		u := &url.URL{
+			Scheme: "postgres",
+			User:   url.UserPassword(cfg.User, cfg.Password),
+			Host:   net.JoinHostPort(host, strconv.Itoa(int(cfg.Port))),
+		}
+		if includeDatabase {
+			u.Path = "/" + database
+		}
+		query := u.Query()
+		query.Set("sslmode", string(cfg.SSLMode))
+		u.RawQuery = query.Encode()
+		return u.String()
+	}
+	return map[string]string{
+		"keyword explicit database": keyword(true),
+		"URL explicit database":     postgresURL(true),
+		"keyword default database":  keyword(false),
+		"URL default database":      postgresURL(false),
+	}
+}
+
+func ensureDefaultUserDatabase(t *testing.T, admin testPostgresDSN) {
+	t.Helper()
+	if admin.config.User == "" {
+		t.Fatal("base Postgres user is required")
+	}
+	db, err := admin.open()
+	if err != nil {
+		t.Fatalf("open admin for default database: %v", err)
+	}
+	defer db.Close()
+	var exists bool
+	if err := db.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)`, admin.config.User).Scan(&exists); err != nil {
+		t.Fatalf("check default database: %v", err)
+	}
+	if exists {
+		return
+	}
+	if err := createIsolatedDatabase(db, admin.config.User); err != nil {
+		t.Fatalf("create default user database %q: %v", admin.config.User, err)
+	}
+	t.Cleanup(func() {
+		cleanupDB, openErr := admin.open()
+		if openErr != nil {
+			return
+		}
+		defer cleanupDB.Close()
+		_ = dropIsolatedDatabase(cleanupDB, admin.config.User)
+	})
+}
+
+func proveCleanupChildTransport(t *testing.T, admin testPostgresDSN, database string) {
+	t.Helper()
+	adminDSN, err := admin.string()
+	if err != nil {
+		t.Fatalf("serialize cleanup admin: %v", err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe, "-test.run=^$")
+	cmd.Env = append(withoutPostgresConnectionEnv(os.Environ()),
+		"SWARM_TEST_POSTGRES_TEMPLATE_CLEANUP=1",
+		"SWARM_TEST_POSTGRES_TEMPLATE_PARENT_PID="+strconv.Itoa(int(^uint32(0)>>1)),
+		"SWARM_TEST_POSTGRES_TEMPLATE_ADMIN_DSN="+adminDSN,
+		"SWARM_TEST_POSTGRES_TEMPLATE_NAME="+database,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cleanup child: %v output=%s", err, strings.TrimSpace(string(output)))
+	}
+}
+
+func assertDatabaseAbsent(t *testing.T, adminDB *sql.DB, database string) {
+	t.Helper()
+	var exists bool
+	if err := adminDB.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)`, database).Scan(&exists); err != nil {
+		t.Fatalf("check database %q: %v", database, err)
+	}
+	if exists {
+		t.Fatalf("database %q still exists", database)
+	}
+}
+
+func mustPlatformVersion(t *testing.T) string {
+	t.Helper()
+	spec, err := loadPlatformSpec()
+	if err != nil {
+		t.Fatalf("load platform spec: %v", err)
+	}
+	return spec.Platform.Version
+}
+
+func quoteLiteral(value string) string {
+	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
+}

--- a/internal/testutil/start-postgres-ci.sh
+++ b/internal/testutil/start-postgres-ci.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly container_name="swarm-ci-postgres"
+
+docker rm --force "$container_name" >/dev/null 2>&1 || true
+docker run --detach --rm \
+  --name "$container_name" \
+  --tmpfs /var/lib/postgresql/data:rw \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB=postgres \
+  --publish 127.0.0.1:5432:5432 \
+  postgres:16 \
+  -c max_connections=300 \
+  -c fsync=off \
+  -c synchronous_commit=off \
+  -c full_page_writes=off \
+  >/dev/null
+
+ready=false
+for _ in $(seq 1 60); do
+  if docker exec "$container_name" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$ready" != "true" ]]; then
+  docker logs "$container_name"
+  echo "disposable Postgres did not become ready" >&2
+  exit 1
+fi
+
+declare -A expected=(
+  [max_connections]=300
+  [fsync]=off
+  [synchronous_commit]=off
+  [full_page_writes]=off
+)
+for setting in max_connections fsync synchronous_commit full_page_writes; do
+  value="$(docker exec "$container_name" psql -U postgres -d postgres -tAc "SHOW $setting")"
+  if [[ "$value" != "${expected[$setting]}" ]]; then
+    echo "$setting=$value, want ${expected[$setting]}" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary

- make one typed `testPostgresDSN` owner use `pq.NewConfig`, cloned `pq.Config` values, typed connectors, and deterministic canonical serialization at the returned-DSN and cleanup-process boundaries
- fail closed on malformed, ambiguous, or process-local connection semantics; derive the authenticated role from PostgreSQL and remove token parsers, `withDBName`, and hardcoded role assumptions
- document the supported host PostgreSQL 16 setup and give Docker fallback an actionable, cause-preserving diagnostic
- launch all four CI PostgreSQL instances through one explicit tmpfs/disposable-settings script and verify actual server settings

## Governing Context

No exact governing platform-spec section defines the test-harness DSN lifecycle. The binding context is issue #1901 plus its approved audit chain:

- [Pre-Implementation Coverage Audit](https://github.com/division-sh/swarm/issues/1901#issuecomment-4929928009)
- [repaired owner/consumer audit](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930023900)
- [serialization/transport repair](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930066102)
- [process-global-state repair](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930096786)
- [Gate B approval](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930117488)
- [implementation-time consumer repair](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930267053) and [approval](https://github.com/division-sh/swarm/issues/1901#issuecomment-4930283367)

Adjacent authority is the `platform-spec.yaml` Environment Variable Contract classification of `SWARM_TEST_POSTGRES_DSN` as test-quarantined. This PR changes test infrastructure, not platform architecture or production runtime semantics, so no authoritative platform-spec semantic update is required.

## Semantic Migration

- **New canonical owner:** `internal/testutil.testPostgresDSN`, backed by lib/pq's typed config/parser/connector contract.
- **Old invalid paths:** raw keyword token scanning in `withDBName`, `internal/store` test helpers, and the `cmd/swarm` run-fork config bridge; hardcoded `postgres` role grants; duplicated/invalid GitHub service-container command declarations.
- **Production paths checked:** returned DSNs through representative store and pipeline consumers, all affected package families, cleanup-child transport with `PG*` connection env removed, template/clone/empty lifecycle, four CI jobs, and the repository-wide full suite.
- **Migration status:** complete for `postgres_test_environment_contract_gap`. #1196 remains open for the broader test-health parent.

## Proof

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=55432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' SWARM_TEST_POSTGRES_ROLE_PROOF=1 go test ./...`
- keyword/URL, explicit/default database, escaping, multihost/runtime, changed-PG-environment, cleanup-child, non-`postgres` role, template clone, empty database, and returned-DSN integration proofs
- `actionlint .github/workflows/ci.yml` and `bash -n internal/testutil/start-postgres-ci.sh`
- SQLite default proof with `SWARM_TEST_POSTGRES_DSN` absent
- Docker-unavailable fallback proof retains the raw daemon cause and points to `internal/testutil/POSTGRES.md`; CI runs the actual owned Docker fallback and settings proof

Closes #1901
Part of #1196
