### PR TITLE
[agent-a][issue #1924] Make reply resolution runnable

### DIFF
--- a/.github/test-shards/go-test-shards.json
+++ b/.github/test-shards/go-test-shards.json
@@ -46,6 +46,7 @@
         "github.com/division-sh/swarm/internal/runtime/startupownership",
         "github.com/division-sh/swarm/internal/runtime/testfixtures/sealedpackage",
         "github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin",
+        "github.com/division-sh/swarm/internal/runtime/testfixtures/templatereply",
         "github.com/division-sh/swarm/internal/runtime/testfixtures/templateselectorcreate",
         "github.com/division-sh/swarm/internal/store/backendselection",
         "github.com/division-sh/swarm/internal/testtiming"
@@ -142,6 +143,7 @@
         "github.com/division-sh/swarm/internal/runtime/managedcredentials/model",
         "github.com/division-sh/swarm/internal/runtime/pythonmodule",
         "github.com/division-sh/swarm/internal/runtime/replayclaim",
+        "github.com/division-sh/swarm/internal/runtime/replycontext",
         "github.com/division-sh/swarm/internal/runtime/runquiescence",
         "github.com/division-sh/swarm/internal/runtime/semanticview",
         "github.com/division-sh/swarm/internal/runtime/sharedjson",

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -169,6 +169,9 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 		fmt.Fprintln(out, "connect route plans:")
 		for _, plan := range view.ConnectRoutePlans {
 			fmt.Fprintf(out, "  - %s.%s -> %s.%s resolution=%s delivery=%s\n", plan.Source.FlowID, plan.Source.Pin, plan.Receiver.FlowID, plan.Receiver.Pin, plan.ResolutionKind, plan.Delivery)
+			if plan.Reply != nil {
+				fmt.Fprintf(out, "    reply: role=%s request=%s.%s reply=%s.%s provider=%s.%s->%s\n", plan.Reply.Role, plan.Reply.RequesterFlowID, plan.Reply.RequestOutputPin, plan.Reply.RequesterFlowID, plan.Reply.ReplyInputPin, plan.Reply.ProviderFlowID, plan.Reply.ProviderInputPin, plan.Reply.ProviderOutputPin)
+			}
 		}
 	}
 	if len(view.StageGraphs) > 0 {

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -158,6 +158,7 @@ type diagnosticRunTraceRow struct {
 	DeliveryID            string `json:"delivery_id,omitempty"`
 	DeliveryStatus        string `json:"delivery_status,omitempty"`
 	DeliveryReasonCode    string `json:"delivery_reason_code,omitempty"`
+	ReplyContextID        string `json:"reply_context_id,omitempty"`
 	DeliveryLastError     string `json:"delivery_last_error,omitempty"`
 	DeliveryRetryCount    int    `json:"delivery_retry_count,omitempty"`
 	DeliveryRetryEligible bool   `json:"delivery_retry_eligible,omitempty"`
@@ -1645,6 +1646,7 @@ func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTr
 			emptyDash(row.SubscriberType) + "/" + emptyDash(row.SubscriberID),
 			emptyDash(row.DeliveryStatus),
 			emptyDash(row.DeliveryReasonCode),
+			emptyDash(row.ReplyContextID),
 			emptyDash(row.DeliveryCreatedAt),
 			emptyDash(row.DeliveryStartedAt),
 			emptyDash(row.DeliveryDeliveredAt),
@@ -1663,6 +1665,7 @@ func writeDiagnosticRunTraceDeliveryDetail(out io.Writer, rows []diagnosticRunTr
 			{Header: "SUBSCRIBER", IdentifierFamily: cliIdentifierFamilySubscriber},
 			{Header: "STATUS"},
 			{Header: "REASON"},
+			{Header: "REPLY CONTEXT", KeyColumn: true},
 			{Header: "DELIVERY CREATED"},
 			{Header: "DELIVERY STARTED"},
 			{Header: "DELIVERY DELIVERED"},

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"time"
@@ -45,24 +46,91 @@ type RouteIdentity struct {
 	FlowID       string `json:"flow_id,omitempty"`
 }
 
+// ReplyContextRef is an opaque reference to platform-owned reply routing
+// state. The full mutable record is never carried through event payloads or
+// envelopes.
+type ReplyContextRef struct {
+	ID string `json:"id"`
+}
+
+func (r ReplyContextRef) Normalized() ReplyContextRef {
+	return ReplyContextRef{ID: strings.TrimSpace(r.ID)}
+}
+
+func (r ReplyContextRef) Empty() bool {
+	return r.Normalized().ID == ""
+}
+
+// DeliveryContext contains route-scoped platform metadata. It is persisted
+// with one delivery route and installed only while that route executes.
+type DeliveryContext struct {
+	Reply *ReplyContextRef `json:"reply,omitempty"`
+}
+
+func (c DeliveryContext) Normalized() DeliveryContext {
+	if c.Reply == nil {
+		return DeliveryContext{}
+	}
+	reply := c.Reply.Normalized()
+	if reply.Empty() {
+		return DeliveryContext{}
+	}
+	return DeliveryContext{Reply: &reply}
+}
+
+func (c DeliveryContext) Empty() bool {
+	return c.Normalized().Reply == nil
+}
+
+func (c DeliveryContext) ReplyContextID() string {
+	c = c.Normalized()
+	if c.Reply == nil {
+		return ""
+	}
+	return c.Reply.ID
+}
+
 type DeliveryRoute struct {
-	SubscriberType string        `json:"subscriber_type"`
-	SubscriberID   string        `json:"subscriber_id"`
-	Target         RouteIdentity `json:"delivery_target_route,omitempty"`
+	SubscriberType string          `json:"subscriber_type"`
+	SubscriberID   string          `json:"subscriber_id"`
+	Target         RouteIdentity   `json:"delivery_target_route,omitempty"`
+	Context        DeliveryContext `json:"delivery_context,omitempty"`
 }
 
 type Event struct {
-	admissionClass EventAdmissionClass
-	id             string
-	eventType      EventType
-	sourceAgent    string
-	taskID         string
-	payload        json.RawMessage
-	chainDepth     int
-	runID          string
-	parentEventID  string
-	envelope       EventEnvelope
-	createdAt      time.Time
+	admissionClass  EventAdmissionClass
+	id              string
+	eventType       EventType
+	sourceAgent     string
+	taskID          string
+	payload         json.RawMessage
+	chainDepth      int
+	runID           string
+	parentEventID   string
+	envelope        EventEnvelope
+	deliveryContext DeliveryContext
+	createdAt       time.Time
+}
+
+type deliveryContextKey struct{}
+
+func WithDeliveryContext(ctx context.Context, deliveryContext DeliveryContext) context.Context {
+	deliveryContext = deliveryContext.Normalized()
+	if deliveryContext.Empty() {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, deliveryContextKey{}, deliveryContext)
+}
+
+func DeliveryContextFromContext(ctx context.Context) DeliveryContext {
+	if ctx == nil {
+		return DeliveryContext{}
+	}
+	deliveryContext, _ := ctx.Value(deliveryContextKey{}).(DeliveryContext)
+	return deliveryContext.Normalized()
 }
 
 type eventJSON struct {
@@ -291,6 +359,17 @@ func (e Event) WithLineage(lineage EventLineage) Event {
 func (e Event) WithEnvelope(envelope EventEnvelope) Event {
 	e.envelope = envelope.Normalized()
 	return e
+}
+
+// WithDeliveryContext creates a route-scoped event projection. The context is
+// intentionally omitted from Event JSON and EventEnvelope.
+func (e Event) WithDeliveryContext(deliveryContext DeliveryContext) Event {
+	e.deliveryContext = deliveryContext.Normalized()
+	return e
+}
+
+func (e Event) DeliveryContext() DeliveryContext {
+	return e.deliveryContext.Normalized()
 }
 
 func (e Event) WithEntityID(entityID string) Event {
@@ -523,6 +602,7 @@ func (r DeliveryRoute) Normalized() DeliveryRoute {
 		SubscriberType: strings.TrimSpace(r.SubscriberType),
 		SubscriberID:   strings.TrimSpace(r.SubscriberID),
 		Target:         r.Target.Normalized(),
+		Context:        r.Context.Normalized(),
 	}
 }
 
@@ -544,6 +624,7 @@ func NormalizeDeliveryRoutes(in []DeliveryRoute) []DeliveryRoute {
 			target.FlowID,
 			target.FlowInstance,
 			target.EntityID,
+			route.Context.ReplyContextID(),
 		}, "\x00")
 		if _, ok := seen[key]; ok {
 			continue

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -205,6 +205,7 @@ type ConnectRoutePlanView struct {
 	ResolutionKind            string                  `json:"resolution_kind"`
 	Address                   *ConnectAddressView     `json:"address,omitempty"`
 	InstanceKey               *ConnectInstanceKeyView `json:"instance_key,omitempty"`
+	Reply                     *ConnectReplyView       `json:"reply,omitempty"`
 	Map                       []ConnectMapEntryView   `json:"map,omitempty"`
 	RequiresRuntimeResolution bool                    `json:"requires_runtime_resolution"`
 	SourceFile                string                  `json:"source_file,omitempty"`
@@ -235,6 +236,17 @@ type ConnectInstanceKeyView struct {
 	Mappings   []ConnectInstanceKeyMappingView `json:"mappings,omitempty"`
 	OnMissing  string                          `json:"on_missing,omitempty"`
 	OnConflict string                          `json:"on_conflict,omitempty"`
+}
+
+type ConnectReplyView struct {
+	Role              string `json:"role"`
+	RequesterFlowID   string `json:"requester_flow_id"`
+	RequestOutputPin  string `json:"request_output_pin"`
+	ReplyInputPin     string `json:"reply_input_pin"`
+	ProviderFlowID    string `json:"provider_flow_id"`
+	ProviderInputPin  string `json:"provider_input_pin"`
+	ProviderOutputPin string `json:"provider_output_pin"`
+	CorrelationKey    string `json:"correlation_key,omitempty"`
 }
 
 type ConnectInstanceKeyMappingView struct {
@@ -981,6 +993,18 @@ func buildConnectRoutePlans(bundle *runtimecontracts.WorkflowContractBundle, pla
 		}
 		if plan.InstanceKey != nil {
 			item.InstanceKey = connectInstanceKeyView(plan.InstanceKey)
+		}
+		if plan.ReplyResolution != nil {
+			item.Reply = &ConnectReplyView{
+				Role:              strings.TrimSpace(plan.ReplyResolution.Role),
+				RequesterFlowID:   strings.TrimSpace(plan.ReplyResolution.RequesterFlowID),
+				RequestOutputPin:  strings.TrimSpace(plan.ReplyResolution.RequestOutputPin),
+				ReplyInputPin:     strings.TrimSpace(plan.ReplyResolution.ReplyInputPin),
+				ProviderFlowID:    strings.TrimSpace(plan.ReplyResolution.ProviderFlowID),
+				ProviderInputPin:  strings.TrimSpace(plan.ReplyResolution.ProviderInputPin),
+				ProviderOutputPin: strings.TrimSpace(plan.ReplyResolution.ProviderOutputPin),
+				CorrelationKey:    strings.TrimSpace(plan.ReplyResolution.CorrelationKey),
+			}
 		}
 		out = append(out, item)
 	}

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -14,7 +14,30 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatereply"
 )
+
+func TestBuildShowsReplyPairedTopology(t *testing.T) {
+	source := templatereply.LoadSource(t, templatereply.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	view := mustBuild(t, source, &report)
+	if len(view.ConnectRoutePlans) != 2 {
+		t.Fatalf("reply connect route plans = %#v, want request and response", view.ConnectRoutePlans)
+	}
+	roles := map[string]*ConnectReplyView{}
+	for _, plan := range view.ConnectRoutePlans {
+		if plan.Reply == nil {
+			t.Fatalf("reply topology missing from plan %#v", plan)
+		}
+		roles[plan.Reply.Role] = plan.Reply
+	}
+	for _, role := range []string{"request", "response"} {
+		reply := roles[role]
+		if reply == nil || reply.RequestOutputPin != templatereply.RequesterRequestPin || reply.ReplyInputPin != templatereply.RequesterReplyPin || reply.ProviderInputPin != templatereply.ProviderRequestPin || reply.ProviderOutputPin != templatereply.ProviderReplyPin {
+			t.Fatalf("reply role %s = %#v", role, reply)
+		}
+	}
+}
 
 func TestBuildShowsTemplateInstanceRouteKeysAndCarries(t *testing.T) {
 	source := templateflowpilot.LoadSource(t, templateflowpilot.Options{})

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -317,8 +317,9 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 		return validateCarriedKeyInputPinResolution(source, flowID, pin, resolution.Mode)
 	case runtimecontracts.FlowInputResolutionModeFanIn:
 		return validateFanInInputPinResolution(source, flowID, pin)
-	case runtimecontracts.FlowInputResolutionModeFanOut,
-		runtimecontracts.FlowInputResolutionModeReply:
+	case runtimecontracts.FlowInputResolutionModeReply:
+		return validateReplyInputPinResolution(source, flowID, pin)
+	case runtimecontracts.FlowInputResolutionModeFanOut:
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_unimplemented", fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode), location))
 	case "":
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution.mode is required", location))
@@ -326,6 +327,53 @@ func validateInputPinResolution(source semanticview.Source, flowID string, pin r
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", fmt.Sprintf("resolution mode %q is not supported", resolution.Mode), location))
 	}
 	return findings
+}
+
+func validateReplyInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	resolution := pin.Resolution
+	location := flowID
+	var findings []Finding
+	if !resolution.InstanceKey.Empty() || resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "instance_resolution_invalid", "resolution mode reply may only declare replies_to and correlation_key", location))
+	}
+	requestPinName := strings.TrimSpace(resolution.RepliesTo)
+	if requestPinName == "" {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", "resolution mode reply requires replies_to", location))
+	}
+	requestPin, ok := source.FlowOutputEventPin(flowID, requestPinName)
+	if !ok {
+		return append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply replies_to %q must name a same-flow output pin", requestPinName), location))
+	}
+	correlationKey := strings.TrimSpace(resolution.CorrelationKey)
+	if correlationKey != "" && !containsTrimmedString(requestPin.Carries, correlationKey) {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply correlation_key %q must name a carry declared by output pin %s", correlationKey, requestPinName), location))
+	}
+	requestConnects := source.CompositionConnectsFrom(flowID, requestPinName)
+	if len(requestConnects) != 1 {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply request pin %s.%s must have exactly one connected counterpart, got %d", flowID, requestPinName, len(requestConnects)), location))
+		return findings
+	}
+	replyConnects := source.CompositionConnectsTo(flowID, pin.PinName())
+	if len(replyConnects) != 1 {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply input pin %s.%s must have exactly one connected provider output, got %d", flowID, pin.PinName(), len(replyConnects)), location))
+		return findings
+	}
+	requestTarget, requestErr := requestConnects[0].ToRef()
+	replySource, replyErr := replyConnects[0].FromRef()
+	if requestErr != nil || replyErr != nil || requestTarget.Root || replySource.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(replySource.FlowID) {
+		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", "resolution mode reply request and reply edges must connect the same provider flow", location))
+	}
+	return findings
+}
+
+func containsTrimmedString(values []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func validateFanInInputPinResolution(source semanticview.Source, flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -3,8 +3,10 @@ package bus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -12,6 +14,7 @@ import (
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -24,20 +27,26 @@ type connectRoutePlanResolver struct {
 	issues          []runtimepinrouting.ConnectRoutePlanIssue
 	loadDescriptors connectRoutePlanDescriptorLoader
 	lifecycle       templateInstanceLifecycleOwner
+	replyStore      runtimereplycontext.Store
 }
 
 type connectRoutePlanDispatch struct {
-	Matched          bool
-	Failure          runtimepinrouting.TargetFailure
-	LiveRecipients   []RoutePlanLiveRecipient
-	DeliveryIntents  []RoutePlanDeliveryIntent
-	RoutedRecipients []Subscriber
-	ExtraDetail      map[string]any
+	Matched              bool
+	Failure              runtimepinrouting.TargetFailure
+	LiveRecipients       []RoutePlanLiveRecipient
+	DeliveryIntents      []RoutePlanDeliveryIntent
+	RoutedRecipients     []Subscriber
+	ExtraDetail          map[string]any
+	ReplyContextConsumed bool
 }
 
-func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader, activator runtimepipeline.FlowInstanceActivator) connectRoutePlanResolver {
+func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTable, loadDescriptors connectRoutePlanDescriptorLoader, activator runtimepipeline.FlowInstanceActivator, stores ...any) connectRoutePlanResolver {
+	var replyStore runtimereplycontext.Store
+	if len(stores) > 0 {
+		replyStore, _ = stores[0].(runtimereplycontext.Store)
+	}
 	if source == nil {
-		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors}
+		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors, replyStore: replyStore}
 	}
 	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
 	return connectRoutePlanResolver{
@@ -47,6 +56,7 @@ func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTa
 		issues:          append([]runtimepinrouting.ConnectRoutePlanIssue(nil), issues...),
 		loadDescriptors: loadDescriptors,
 		lifecycle:       newTemplateInstanceLifecycleOwner(source, routeTable, loadDescriptors, activator),
+		replyStore:      replyStore,
 	}
 }
 
@@ -84,6 +94,24 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		},
 	}
 	for _, plan := range matched {
+		if plan.ReplyResolution != nil && plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleResponse {
+			routes, subscribers, failure, detail, err := r.materializeReplyResponse(ctx, evt, plan)
+			if err != nil {
+				return connectRoutePlanDispatch{}, err
+			}
+			if failure != "" {
+				out.Failure = failure
+				for key, value := range detail {
+					out.ExtraDetail[key] = value
+				}
+				return out, nil
+			}
+			out.ReplyContextConsumed = true
+			out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConnectRoutePlan)...)
+			out.LiveRecipients = append(out.LiveRecipients, connectRoutePlanLiveRecipients(routes)...)
+			out.RoutedRecipients = append(out.RoutedRecipients, subscribers...)
+			continue
+		}
 		materialized, decision, err := r.materializeConnectRoutePlan(ctx, evt, plan, values, descriptors)
 		if err != nil {
 			return connectRoutePlanDispatch{}, err
@@ -106,6 +134,12 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			return connectRoutePlanDispatch{}, err
 		}
 		routes, subscribers := r.deliveryRoutesForMaterialization(plan, materialized)
+		if plan.ReplyResolution != nil && plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleRequest {
+			routes, err = r.materializeReplyRequest(ctx, evt, plan, routes, values)
+			if err != nil {
+				return connectRoutePlanDispatch{}, err
+			}
+		}
 		if cleanupPreview != nil {
 			cleanupPreview()
 		}
@@ -134,6 +168,136 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	out.DeliveryIntents = normalizeRoutePlanDeliveryIntents(out.DeliveryIntents)
 	out.RoutedRecipients = dedupeSubscribers(out.RoutedRecipients)
 	return out, nil
+}
+
+func (r connectRoutePlanResolver) materializeReplyRequest(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, routes []events.DeliveryRoute, values map[string]string) ([]events.DeliveryRoute, error) {
+	reply := plan.ReplyResolution
+	if reply == nil || reply.Role != runtimepinrouting.ConnectReplyRoleRequest {
+		return routes, nil
+	}
+	origin := evt.SourceRoute().Normalized()
+	if origin.Empty() {
+		origin = events.RouteIdentity{
+			FlowID:       strings.TrimSpace(reply.RequesterFlowID),
+			FlowInstance: strings.Trim(evt.FlowInstance(), "/"),
+			EntityID:     strings.TrimSpace(evt.EntityID()),
+		}.Normalized()
+	}
+	if origin.Empty() {
+		return nil, fmt.Errorf("reply request %s.%s has no concrete origin route", reply.RequesterFlowID, reply.RequestOutputPin)
+	}
+	correlation := strings.TrimSpace(evt.ID())
+	if key := strings.TrimSpace(reply.CorrelationKey); key != "" {
+		correlation = strings.TrimSpace(values["payload."+key])
+		if correlation == "" {
+			return nil, fmt.Errorf("reply request %s.%s is missing declared carried correlation key %s", reply.RequesterFlowID, reply.RequestOutputPin, key)
+		}
+	}
+	now := evt.CreatedAt()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	record := runtimereplycontext.Record{
+		RunID:                evt.RunID(),
+		RequestEventID:       evt.ID(),
+		RequesterFlowID:      reply.RequesterFlowID,
+		RequestOutputPin:     reply.RequestOutputPin,
+		ReplyInputPin:        reply.ReplyInputPin,
+		ProviderFlowID:       reply.ProviderFlowID,
+		ProviderInputPin:     reply.ProviderInputPin,
+		ProviderOutputPin:    reply.ProviderOutputPin,
+		Origin:               origin,
+		RequestCorrelationID: correlation,
+		CorrelationKey:       reply.CorrelationKey,
+		State:                runtimereplycontext.StateOpen,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	record.ID = runtimereplycontext.DeterministicID(record.RequestEventID, record.RequesterFlowID, record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID, record.Origin)
+	if r.replyStore == nil {
+		return nil, fmt.Errorf("ReplyContextStore is required for resolution mode reply")
+	}
+	if !templateInstanceLifecyclePreview(ctx) {
+		if err := r.replyStore.CreateReplyContext(ctx, record); err != nil {
+			return nil, err
+		}
+	}
+	deliveryContext := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: record.ID}}
+	for i := range routes {
+		routes[i].Context = deliveryContext
+	}
+	return events.NormalizeDeliveryRoutes(routes), nil
+}
+
+func (r connectRoutePlanResolver) materializeReplyResponse(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan) ([]events.DeliveryRoute, []Subscriber, runtimepinrouting.TargetFailure, map[string]any, error) {
+	reply := plan.ReplyResolution
+	contextID := events.DeliveryContextFromContext(ctx).ReplyContextID()
+	detail := map[string]any{
+		"connect_route_plan_resolution_mode": "reply",
+		"connect_route_plan_request_pin":     reply.RequesterFlowID + "." + reply.RequestOutputPin,
+		"connect_route_plan_reply_pin":       reply.RequesterFlowID + "." + reply.ReplyInputPin,
+	}
+	if contextID == "" || r.replyStore == nil {
+		detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
+		return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+	}
+	record, err := r.replyStore.LoadReplyContext(ctx, contextID)
+	if err != nil {
+		if errors.Is(err, runtimereplycontext.ErrNotFound) {
+			detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
+			return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+		}
+		return nil, nil, "", nil, err
+	}
+	if record.RequesterFlowID != reply.RequesterFlowID || record.RequestOutputPin != reply.RequestOutputPin || record.ReplyInputPin != reply.ReplyInputPin || record.ProviderFlowID != reply.ProviderFlowID || record.ProviderInputPin != reply.ProviderInputPin || record.ProviderOutputPin != reply.ProviderOutputPin {
+		detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
+		return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+	}
+	target := record.Origin.Normalized()
+	subscribers := r.resolveSelectedReceiverCarriers(plan, target)
+	if target.Empty() || len(subscribers) == 0 {
+		detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
+		detail["reply_origin"] = target
+		return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+	}
+	claimed := record
+	outcome := runtimereplycontext.ClaimAccepted
+	if templateInstanceLifecyclePreview(ctx) {
+		if record.State == runtimereplycontext.StateTerminal {
+			if record.AcceptedReplyEventID == evt.ID() {
+				outcome = runtimereplycontext.ClaimIdempotent
+			} else {
+				outcome = runtimereplycontext.ClaimTerminal
+			}
+		}
+	} else {
+		claimed, outcome, err = r.replyStore.ClaimReplyContext(ctx, contextID, evt.ID())
+		if err != nil {
+			return nil, nil, "", nil, err
+		}
+	}
+	if outcome == runtimereplycontext.ClaimTerminal {
+		detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureReplyAlreadyTerminal)
+		detail["accepted_reply_event_id"] = claimed.AcceptedReplyEventID
+		return nil, nil, runtimepinrouting.FailureReplyAlreadyTerminal, detail, nil
+	}
+	routes := make([]events.DeliveryRoute, 0, len(subscribers))
+	for _, subscriber := range subscribers {
+		subscriberType := strings.TrimSpace(subscriber.Type)
+		if subscriberType == "" {
+			subscriberType = "node"
+		}
+		routes = append(routes, events.DeliveryRoute{
+			SubscriberType: subscriberType,
+			SubscriberID:   strings.TrimSpace(subscriber.ID),
+			Target:         target,
+		})
+	}
+	detail["reply_context_id"] = contextID
+	detail["request_event_id"] = record.RequestEventID
+	detail["request_correlation_id"] = record.RequestCorrelationID
+	detail["reply_claim_outcome"] = outcome
+	return events.NormalizeDeliveryRoutes(routes), dedupeSubscribers(subscribers), "", detail, nil
 }
 
 func (r connectRoutePlanResolver) materializeConnectRoutePlan(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string, descriptors []runtimepinrouting.Descriptor) (runtimepinrouting.ConnectRoutePlanMaterialization, TemplateInstanceLifecycleDecision, error) {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -95,7 +95,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	}
 	for _, plan := range matched {
 		if plan.ReplyResolution != nil && plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleResponse {
-			routes, subscribers, failure, detail, err := r.materializeReplyResponse(ctx, evt, plan)
+			routes, subscribers, failure, detail, err := r.materializeReplyResponse(ctx, evt, plan, values)
 			if err != nil {
 				return connectRoutePlanDispatch{}, err
 			}
@@ -229,7 +229,7 @@ func (r connectRoutePlanResolver) materializeReplyRequest(ctx context.Context, e
 	return events.NormalizeDeliveryRoutes(routes), nil
 }
 
-func (r connectRoutePlanResolver) materializeReplyResponse(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan) ([]events.DeliveryRoute, []Subscriber, runtimepinrouting.TargetFailure, map[string]any, error) {
+func (r connectRoutePlanResolver) materializeReplyResponse(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string) ([]events.DeliveryRoute, []Subscriber, runtimepinrouting.TargetFailure, map[string]any, error) {
 	reply := plan.ReplyResolution
 	contextID := events.DeliveryContextFromContext(ctx).ReplyContextID()
 	detail := map[string]any{
@@ -249,9 +249,22 @@ func (r connectRoutePlanResolver) materializeReplyResponse(ctx context.Context, 
 		}
 		return nil, nil, "", nil, err
 	}
-	if record.RequesterFlowID != reply.RequesterFlowID || record.RequestOutputPin != reply.RequestOutputPin || record.ReplyInputPin != reply.ReplyInputPin || record.ProviderFlowID != reply.ProviderFlowID || record.ProviderInputPin != reply.ProviderInputPin || record.ProviderOutputPin != reply.ProviderOutputPin {
+	if record.RequesterFlowID != reply.RequesterFlowID || record.RequestOutputPin != reply.RequestOutputPin || record.ReplyInputPin != reply.ReplyInputPin || record.ProviderFlowID != reply.ProviderFlowID || record.ProviderInputPin != reply.ProviderInputPin || record.ProviderOutputPin != reply.ProviderOutputPin || record.CorrelationKey != strings.TrimSpace(reply.CorrelationKey) {
 		detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
 		return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+	}
+	if key := record.CorrelationKey; key != "" {
+		actual := strings.TrimSpace(values["payload."+key])
+		if actual == "" || actual != record.RequestCorrelationID {
+			detail["connect_route_plan_failure"] = string(runtimepinrouting.FailureStaleArrival)
+			detail["reply_context_id"] = contextID
+			detail["reply_correlation_key"] = key
+			detail["request_correlation_id"] = record.RequestCorrelationID
+			if actual != "" {
+				detail["reply_correlation_id"] = actual
+			}
+			return nil, nil, runtimepinrouting.FailureStaleArrival, detail, nil
+		}
 	}
 	target := record.Origin.Normalized()
 	subscribers := r.resolveSelectedReceiverCarriers(plan, target)

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -164,6 +164,7 @@ func routePlanFromConnectRouteDispatch(evt events.Event, connectPlan connectRout
 	}
 	routePlan.RoutedRecipients = dedupeSubscribers(connectPlan.RoutedRecipients)
 	routePlan.ExtraDetail = cloneAnyMap(connectPlan.ExtraDetail)
+	routePlan.ReplyContextConsumed = connectPlan.ReplyContextConsumed
 	return routePlan.Normalized()
 }
 
@@ -319,7 +320,7 @@ func targetedConcreteEventKeysForPlan(evt events.Event) []string {
 		if flowInstance == "" {
 			continue
 		}
-		staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)
+		staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
 		if staticScope == "" {
 			continue
 		}
@@ -339,7 +340,7 @@ func concreteFlowInstanceEventKey(evt events.Event) string {
 	if eventType == "" || flowInstance == "" {
 		return ""
 	}
-	staticScope := runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance)
+	staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
 	if staticScope == "" {
 		return ""
 	}

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -1271,3 +1271,29 @@ func TestDeliveryPlanner_FailsClosedOnPolicyError(t *testing.T) {
 		t.Fatalf("Plan err = %v, want descriptor store unavailable", err)
 	}
 }
+
+func TestRoutedEventKeysForPlan_LocalizesStaticAndMaterializedFlowInstances(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		flowInstance string
+		want         string
+	}{
+		{name: "static", flowInstance: "provider", want: "provider/mailbox.item_decided"},
+		{name: "materialized template", flowInstance: "requester/account-a", want: "requester/account-a/mailbox.item_decided"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", "mailbox.item_decided", "", "", nil, 0, "", "", events.EnvelopeForFlowInstance(events.EventEnvelope{}, tc.flowInstance), time.Time{})
+			keys := routedEventKeysForPlan(evt)
+			found := false
+			for _, key := range keys {
+				if key == tc.want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("routed keys = %#v, want %q", keys, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -178,7 +178,7 @@ func (eb *EventBus) rebuildRoutePlanners() {
 	if eb == nil {
 		return
 	}
-	eb.connectRoutePlanner = newConnectRoutePlanResolver(eb.semanticSource, eb.routeTable, eb.PinRoutingDescriptors, eb.templateInstanceActivator)
+	eb.connectRoutePlanner = newConnectRoutePlanResolver(eb.semanticSource, eb.routeTable, eb.PinRoutingDescriptors, eb.templateInstanceActivator, eb.store)
 	eb.deliveryPlanner = eb.newEventBusDeliveryPlanner()
 }
 

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -427,6 +427,7 @@ func (eb *EventBus) dispatchCommittedPublishAsync(ctx context.Context, evt event
 }
 
 func (eb *EventBus) completeCommittedPublishDispatch(ctx context.Context, evt events.Event, inboundPlan RoutePlan) {
+	ctx = WithoutEventMutationContext(ctx)
 	eb.notifyTestPostCommitDispatchStarted(ctx, evt)
 	defer eb.notifyTestPostCommitDispatchCompleted(ctx, evt)
 
@@ -965,76 +966,18 @@ func publishSelectedForkLineageOwner(ctx context.Context) string {
 }
 
 func (eb *EventBus) publishDeferred(ctx context.Context, evt events.Event) (err error) {
-	ctx = WithCurrentRuntimeEpoch(ctx)
-	if err := ensurePublishEpoch(ctx); err != nil {
-		return err
-	}
-	receiptOverride := &runtimepipeline.PipelineReceiptOverride{}
-	ctx = runtimepipeline.WithPipelineReceiptOverride(ctx, receiptOverride)
-	eb.inFlightPublishes.Add(1)
-	defer eb.inFlightPublishes.Add(-1)
 	if evt.Type() == "" {
 		return errors.New("deferred event type is required")
 	}
 	if !isValidEventTypeName(string(evt.Type())) {
 		return fmt.Errorf("invalid deferred event type: %s", strings.TrimSpace(string(evt.Type())))
 	}
+	ctx = WithoutEventMutationContext(runtimepipeline.WithoutPipelineSQLTxContext(ctx))
 	ctx, evt, err = admitEventForPublish(ctx, evt, time.Now(), "runtime")
 	if err != nil {
 		return err
 	}
-	persisted := false
-	queued := false
-	defer func() {
-		if queued {
-			return
-		}
-		if !shouldPersistPipelineReceipt(persisted, err) {
-			return
-		}
-		status, errText := pipelineReceiptStatus(ctx, err)
-		eb.markPipelineReceipt(ctx, evt.ID(), status, errText)
-	}()
-	plan, err := eb.planSubscribedPublish(ctx, evt)
-	if err != nil {
-		return err
-	}
-	if err := eb.persistSubscribedPublishPlan(ctx, evt, plan); err != nil {
-		return err
-	}
-	persisted = true
-	if plan.TargetFailure != "" {
-		applyTargetDeliveryFailureReceipt(receiptOverride, plan.TargetFailure)
-		eb.recordTargetDeliveryFailure(ctx, evt, plan)
-		eb.logPublished(ctx, evt, 0)
-		return nil
-	}
-	if reason, err := eb.dispatchQueueReason(ctx, evt); err != nil {
-		return err
-	} else if reason != "" {
-		queued = true
-		eb.logDispatchQueued(ctx, reason, evt, len(plan.RecipientIDs()), false, false)
-		eb.logPublished(ctx, evt, 0)
-		return nil
-	}
-	passthrough, deferred, err := eb.runInterceptorsForDeliveryRoutes(ctx, evt, plan.DeliveryRoutes())
-	if err != nil {
-		return err
-	}
-	if passthrough {
-		var deliverQueued bool
-		if deliverQueued, err = eb.deliverSubscribedPublishPlan(ctx, evt, plan); err != nil {
-			return err
-		}
-		queued = deliverQueued
-	}
-	eb.logPublished(ctx, evt, 0)
-	for _, d := range deferred {
-		if err := eb.publishDeferred(ctx, d); err != nil {
-			return err
-		}
-	}
-	return nil
+	return eb.Publish(ctx, evt)
 }
 
 func (eb *EventBus) logPublished(ctx context.Context, evt events.Event, durationUS int) {
@@ -1076,6 +1019,7 @@ func (eb *EventBus) planSubscribedRoutePlan(ctx context.Context, evt events.Even
 		return RoutePlan{}, err
 	}
 	routePlan := plan.Normalized()
+	routePlan = routePlan.WithDefaultDeliveryContext(events.DeliveryContextFromContext(ctx))
 	if recordDiagnostic {
 		eb.recordPublishDiagnostic(ctx, evt, routePlan)
 	}

--- a/internal/runtime/bus/eventbus_routing.go
+++ b/internal/runtime/bus/eventbus_routing.go
@@ -249,7 +249,7 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 	for _, recipient := range expected {
 		expectedSet[recipient] = struct{}{}
 	}
-	targetsByRecipient := deliveryRouteTargetsBySubscriber(deliveryRoutes)
+	routesByRecipient := deliveryRoutesBySubscriber(deliveryRoutes)
 	recipients := eb.snapshotRecipientChans(dispatchRecipients)
 	delivered := make([]string, 0, len(recipients))
 	seen := make(map[string]struct{}, len(recipients))
@@ -264,15 +264,21 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 	}
 	timedOut := make([]string, 0, len(recipients))
 	for _, recipient := range recipients {
-		targets := targetsByRecipient[recipient.deliveryRouteTargetKey()]
-		if len(targets) == 0 && recipient.isWorkflowRuntimeInternalCarrier() {
-			targets = workflowRuntimeInternalCarrierTargets(deliveryRoutes)
+		routes := routesByRecipient[recipient.deliveryRouteTargetKey()]
+		if recipient.isWorkflowRuntimeInternalCarrier() {
+			// The workflow-runtime subscription is an in-memory carrier for the
+			// concrete node delivery routes. Its placeholder route must never
+			// hide the target or route-scoped context owned by those routes.
+			if nodeRoutes := workflowRuntimeInternalCarrierRoutes(deliveryRoutes); len(nodeRoutes) > 0 {
+				routes = nodeRoutes
+			}
 		}
-		if len(targets) == 0 {
-			targets = []events.RouteIdentity{{}}
+		if len(routes) == 0 {
+			routes = []events.DeliveryRoute{{}}
 		}
-		for _, target := range targets {
-			deliverEvent := evt
+		for _, route := range routes {
+			target := route.Target.Normalized()
+			deliverEvent := evt.WithDeliveryContext(route.Context)
 			if !target.Empty() {
 				deliverEvent = events.NewProjectionEvent(
 					evt.ID(),
@@ -285,7 +291,7 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 					evt.ParentEventID(),
 					events.EnvelopeForTargetRoute(evt.NormalizedEnvelope(), target),
 					evt.CreatedAt(),
-				)
+				).WithDeliveryContext(route.Context)
 			}
 			select {
 			case recipient.ch <- deliverEvent:
@@ -324,6 +330,23 @@ func (eb *EventBus) deliverToRecipientsWithRoutes(ctx context.Context, evt event
 		return eb.logAuthoritativeDeliveryIncomplete(ctx, evt, expected, delivered, missing, timedOut, nil)
 	}
 	return nil
+}
+
+func deliveryRoutesBySubscriber(deliveryRoutes []events.DeliveryRoute) map[deliveryRouteTargetKey][]events.DeliveryRoute {
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) == 0 {
+		return nil
+	}
+	out := make(map[deliveryRouteTargetKey][]events.DeliveryRoute, len(deliveryRoutes))
+	for _, route := range deliveryRoutes {
+		route = route.Normalized()
+		if route.SubscriberType == "" || route.SubscriberID == "" {
+			continue
+		}
+		key := deliveryRouteTargetKey{subscriberType: route.SubscriberType, subscriberID: route.SubscriberID}
+		out[key] = append(out[key], route)
+	}
+	return out
 }
 
 func agentChannelDeliveryRecipients(recipientIDs []string, deliveryRoutes []events.DeliveryRoute) []string {
@@ -428,6 +451,24 @@ func workflowRuntimeInternalCarrierTargets(deliveryRoutes []events.DeliveryRoute
 		out = append(out, target)
 	}
 	return out
+}
+
+func workflowRuntimeInternalCarrierRoutes(deliveryRoutes []events.DeliveryRoute) []events.DeliveryRoute {
+	deliveryRoutes = events.NormalizeDeliveryRoutes(deliveryRoutes)
+	if len(deliveryRoutes) == 0 {
+		return nil
+	}
+	out := make([]events.DeliveryRoute, 0, len(deliveryRoutes))
+	for _, route := range deliveryRoutes {
+		if strings.TrimSpace(route.SubscriberType) != "node" {
+			continue
+		}
+		if strings.TrimSpace(route.SubscriberID) == workflowRuntimeInternalCarrierID {
+			continue
+		}
+		out = append(out, route)
+	}
+	return events.NormalizeDeliveryRoutes(out)
 }
 
 func (eb *EventBus) snapshotRecipientChans(agentIDs []string) []agentRecipient {

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -374,6 +374,45 @@ func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
 	}
 }
 
+func TestEventBusWorkflowRuntimeCarrierPrefersConcreteNodeRouteOverPlaceholder(t *testing.T) {
+	eb, err := NewEventBus(newTargetRouteMemoryStore())
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	ch := eb.SubscribeInternal(workflowRuntimeInternalCarrierID, events.EventType("review/task.started"))
+	defer eb.Unsubscribe(workflowRuntimeInternalCarrierID)
+
+	contextRef := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:route-carrier"}}
+	evt := eventtest.RootIngress(uuid.NewString(), events.EventType("review/task.started"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	routes := []events.DeliveryRoute{
+		{
+			SubscriberType: "node",
+			SubscriberID:   "review-node",
+			Target:         events.RouteIdentity{FlowID: "review", FlowInstance: "review/inst-1", EntityID: "entity-1"},
+			Context:        contextRef,
+		},
+		{
+			SubscriberType: "node",
+			SubscriberID:   workflowRuntimeInternalCarrierID,
+		},
+	}
+	if err := eb.deliverToRecipientsWithRoutes(context.Background(), evt, []string{workflowRuntimeInternalCarrierID}, routes); err != nil {
+		t.Fatalf("deliverToRecipientsWithRoutes: %v", err)
+	}
+	got := requireBusEvent(t, ch, "workflow runtime concrete route delivery")
+	if got.TargetRoute().Normalized() != routes[0].Target.Normalized() {
+		t.Fatalf("workflow runtime target = %#v, want %#v", got.TargetRoute(), routes[0].Target)
+	}
+	if got.DeliveryContext().ReplyContextID() != contextRef.ReplyContextID() {
+		t.Fatalf("workflow runtime delivery context = %#v, want %#v", got.DeliveryContext(), contextRef)
+	}
+	select {
+	case extra := <-ch:
+		t.Fatalf("workflow runtime received placeholder delivery %#v", extra.TargetRoute())
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
 func deliveryRoutesContain(routes []events.DeliveryRoute, want events.DeliveryRoute) bool {
 	want = want.Normalized()
 	for _, got := range events.NormalizeDeliveryRoutes(routes) {

--- a/internal/runtime/bus/outbox.go
+++ b/internal/runtime/bus/outbox.go
@@ -50,17 +50,18 @@ func (o engineOutbox) WriteOutbox(ctx context.Context, intents []runtimeengine.E
 		if strings.TrimSpace(string(intent.Event.Type())) == "" {
 			continue
 		}
+		intentCtx := events.WithDeliveryContext(ctx, intent.Context)
 		var err error
-		intent.Event, err = normalizeOutboxEvent(ctx, intent.Event)
-		if err != nil {
-			return err
-		}
-		plan, err := o.deliveryPlanForIntent(ctx, *intent)
+		intent.Event, err = normalizeOutboxEvent(intentCtx, intent.Event)
 		if err != nil {
 			return err
 		}
 		if err := mutation.AppendEvent(ctx, intent.Event); err != nil {
 			return fmt.Errorf("persist event: %w", err)
+		}
+		plan, err := o.deliveryPlanForIntent(intentCtx, *intent)
+		if err != nil {
+			return err
 		}
 		if err := o.bus.insertEventDeliveriesMutation(ctx, mutation, intent.Event.ID(), plan.PersistedRecipientIDs(), plan.DeliveryTargets(), plan.DeliveryRoutes()); err != nil {
 			return fmt.Errorf("persist event deliveries: %w", err)
@@ -185,6 +186,7 @@ func clonePostCommitEvent(evt events.Event) events.Event {
 }
 
 func (d engineDispatcher) dispatchIntent(ctx context.Context, intent runtimeengine.EmitIntent) (bool, error) {
+	ctx = events.WithDeliveryContext(ctx, intent.Context)
 	if reason, err := d.bus.dispatchQueueReason(ctx, intent.Event); err != nil {
 		return false, err
 	} else if reason != "" {
@@ -265,6 +267,7 @@ func (eb *EventBus) deliveryRoutesForPostCommitIntent(ctx context.Context, event
 }
 
 func (d engineDispatcher) dispatchExplicitDirectIntent(ctx context.Context, intent runtimeengine.EmitIntent) error {
+	ctx = events.WithDeliveryContext(ctx, intent.Context)
 	plan, err := d.bus.planDirectRoutePlan(ctx, intent.Event, intent.Recipients)
 	if err != nil {
 		return err

--- a/internal/runtime/bus/route_plan.go
+++ b/internal/runtime/bus/route_plan.go
@@ -158,6 +158,7 @@ type RoutePlan struct {
 	ContradictionReason  string
 	BlockedByCycle       bool
 	CycleEscalation      *events.Event
+	ReplyContextConsumed bool
 }
 
 type RoutePlanLiveRecipient struct {
@@ -171,6 +172,7 @@ type RoutePlanDeliveryIntent struct {
 	SubscriberType string
 	SubscriberID   string
 	Target         events.RouteIdentity
+	Context        events.DeliveryContext
 	Producer       routeIntentProducer
 	Persist        bool
 }
@@ -272,6 +274,20 @@ func (p *RoutePlan) AddDeliveryIntents(intents ...RoutePlanDeliveryIntent) {
 	p.DeliveryIntents = normalizeRoutePlanDeliveryIntents(append(p.DeliveryIntents, intents...))
 }
 
+func (p RoutePlan) WithDefaultDeliveryContext(deliveryContext events.DeliveryContext) RoutePlan {
+	p = p.Normalized()
+	deliveryContext = deliveryContext.Normalized()
+	if deliveryContext.Empty() || p.ReplyContextConsumed {
+		return p
+	}
+	for i := range p.DeliveryIntents {
+		if p.DeliveryIntents[i].Context.Empty() {
+			p.DeliveryIntents[i].Context = deliveryContext
+		}
+	}
+	return p.Normalized()
+}
+
 func (p RoutePlan) RecipientIDs() []string {
 	p = p.Normalized()
 	out := make([]string, 0, len(p.LiveRecipients))
@@ -322,6 +338,7 @@ func (p RoutePlan) DeliveryRoutes() []events.DeliveryRoute {
 			SubscriberType: intent.SubscriberType,
 			SubscriberID:   intent.SubscriberID,
 			Target:         intent.Target,
+			Context:        intent.Context,
 		})
 	}
 	return events.NormalizeDeliveryRoutes(out)
@@ -402,6 +419,7 @@ func routePlanDeliveryIntentsFromRoutes(routes []events.DeliveryRoute, producer 
 			SubscriberType: route.SubscriberType,
 			SubscriberID:   route.SubscriberID,
 			Target:         route.Target,
+			Context:        route.Context,
 			Producer:       producer,
 			Persist:        true,
 		})
@@ -481,11 +499,12 @@ func normalizeRoutePlanDeliveryIntents(in []RoutePlanDeliveryIntent) []RoutePlan
 		intent.SubscriberType = strings.TrimSpace(intent.SubscriberType)
 		intent.SubscriberID = strings.TrimSpace(intent.SubscriberID)
 		intent.Target = intent.Target.Normalized()
+		intent.Context = intent.Context.Normalized()
 		intent.Producer = intent.Producer.Normalized()
 		if intent.SubscriberType == "" || intent.SubscriberID == "" {
 			continue
 		}
-		key := strings.Join([]string{intent.SubscriberType, intent.SubscriberID, intent.Target.FlowID, intent.Target.FlowInstance, intent.Target.EntityID}, "\x00")
+		key := strings.Join([]string{intent.SubscriberType, intent.SubscriberID, intent.Target.FlowID, intent.Target.FlowInstance, intent.Target.EntityID, intent.Context.ReplyContextID()}, "\x00")
 		if idx, ok := indexByKey[key]; ok {
 			out[idx].Persist = out[idx].Persist || intent.Persist
 			if out[idx].Producer.Empty() {

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -265,6 +265,16 @@ func EventMutationFromContext(ctx context.Context) (EventMutation, bool) {
 	return mutation, ok && mutation != nil
 }
 
+// WithoutEventMutationContext crosses the commit boundary without retaining a
+// mutation whose transaction is no longer usable. Post-commit consumers must
+// acquire a fresh mutation from their own active transaction.
+func WithoutEventMutationContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, eventMutationContextKey{}, nil)
+}
+
 type TransactionalEventReplayScopePersistence interface {
 	UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
 }

--- a/internal/runtime/conformance/reply_resolution_conformance_test.go
+++ b/internal/runtime/conformance/reply_resolution_conformance_test.go
@@ -1,0 +1,1022 @@
+package conformance
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	"github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatereply"
+	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestReplyResolutionConformance_BootAndLoweringExposePairedLoop(t *testing.T) {
+	source := templatereply.LoadSource(t, templatereply.Options{})
+	report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("template reply hard invalidities = %#v, want none", got)
+	}
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 || len(plans) != 2 {
+		t.Fatalf("reply lowering plans=%#v issues=%#v, want two paired plans", plans, issues)
+	}
+	roles := map[string]runtimepinrouting.ConnectRoutePlanReplyResolution{}
+	for _, plan := range plans {
+		if plan.ReplyResolution == nil {
+			t.Fatalf("reply plan = %#v, want typed reply resolution", plan)
+		}
+		if plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleResponse && plan.ResolutionKind != runtimepinrouting.ConnectResolutionReply {
+			t.Fatalf("reply response plan resolution = %q, want reply", plan.ResolutionKind)
+		}
+		roles[plan.ReplyResolution.Role] = *plan.ReplyResolution
+	}
+	for _, role := range []string{runtimepinrouting.ConnectReplyRoleRequest, runtimepinrouting.ConnectReplyRoleResponse} {
+		got, ok := roles[role]
+		if !ok {
+			t.Fatalf("reply role %q missing from %#v", role, roles)
+		}
+		if got.RequestOutputPin != templatereply.RequesterRequestPin || got.ReplyInputPin != templatereply.RequesterReplyPin || got.ProviderFlowID != templatereply.ProviderFlowID || got.CorrelationKey != templatereply.CorrelationKey {
+			t.Fatalf("reply role %q pairing = %#v", role, got)
+		}
+	}
+}
+
+func TestReplyResolutionConformance_DefaultCorrelationUsesStableRequestEventID(t *testing.T) {
+	ctx := context.Background()
+	source := templatereply.LoadSource(t, templatereply.Options{DefaultEventIDCorrelation: true})
+	report := runtimebootverify.Run(ctx, source, runtimebootverify.Options{})
+	if got := report.HardInvalidities(); len(got) != 0 {
+		t.Fatalf("default-correlation hard invalidities = %#v", got)
+	}
+	store := newReplyConformanceStore()
+	eb, err := bus.NewEventBusWithOptions(store, bus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if err := eb.AddFlowInstanceRouteContext(ctx, bus.FlowInstanceRouteMaterializationRequest{
+		Identity:            runtimeflowidentity.StoredRoute(templatereply.RequesterFlowID, "account-a", templatereply.RequesterFlowID+"/account-a"),
+		ActivationVariables: map[string]string{"account_id": "account-a"},
+	}); err != nil {
+		t.Fatalf("materialize requester route: %v", err)
+	}
+	request := replyConformanceEvent(source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent), uuid.NewString(), templatereply.RequesterFlowID, templatereply.RequesterFlowID+"/account-a", map[string]any{
+		"provider_request_id": "ignored-for-default",
+		"account_id":          "account-a",
+	})
+	if err := eb.Publish(ctx, request); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	routes := store.routesFor(request.ID())
+	if len(routes) != 1 {
+		t.Fatalf("request routes = %#v", routes)
+	}
+	record, err := store.LoadReplyContext(ctx, routes[0].Context.ReplyContextID())
+	if err != nil || record.RequestCorrelationID != request.ID() || record.CorrelationKey != "" {
+		t.Fatalf("default correlation record = %#v err=%v", record, err)
+	}
+}
+
+func TestReplyResolutionConformance_VerifierFailsClosedForInvalidPairedTopology(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts templatereply.Options
+		want string
+	}{
+		{name: "missing replies_to", opts: templatereply.Options{MissingRepliesTo: true}, want: "requires replies_to"},
+		{name: "correlation key not carried", opts: templatereply.Options{MissingCorrelationCarry: true}, want: "must name a carry"},
+		{name: "ambiguous request counterpart", opts: templatereply.Options{AmbiguousRequestEdge: true}, want: "exactly one connected counterpart"},
+		{name: "different provider counterpart", opts: templatereply.Options{MismatchedProvider: true}, want: "same provider flow"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := templatereply.LoadSource(t, tc.opts)
+			report := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
+			found := false
+			for _, finding := range report.HardInvalidities() {
+				if strings.Contains(finding.Message, tc.want) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("hard invalidities = %#v, want message containing %q", report.HardInvalidities(), tc.want)
+			}
+		})
+	}
+}
+
+func TestReplyResolutionConformance_RoutesConcurrentSameOriginAndCrossOriginByPersistedContext(t *testing.T) {
+	ctx := context.Background()
+	source := templatereply.LoadSource(t, templatereply.Options{})
+	store := newReplyConformanceStore()
+	eb, err := bus.NewEventBusWithOptions(store, bus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, accountID := range []string{"account-a", "account-b"} {
+		if err := eb.AddFlowInstanceRouteContext(ctx, bus.FlowInstanceRouteMaterializationRequest{
+			Identity:            runtimeflowidentity.StoredRoute(templatereply.RequesterFlowID, accountID, templatereply.RequesterFlowID+"/"+accountID),
+			ActivationVariables: map[string]string{"account_id": accountID},
+		}); err != nil {
+			t.Fatalf("materialize requester route %s: %v", accountID, err)
+		}
+	}
+
+	type requestCase struct {
+		name       string
+		accountID  string
+		requestID  string
+		requestKey string
+	}
+	cases := []requestCase{
+		{name: "same-origin-first", accountID: "account-a", requestID: uuid.NewString(), requestKey: "account-a-request-1"},
+		{name: "same-origin-second", accountID: "account-a", requestID: uuid.NewString(), requestKey: "account-a-request-2"},
+		{name: "cross-origin", accountID: "account-b", requestID: uuid.NewString(), requestKey: "account-a-request-1"},
+	}
+	contexts := map[string]events.DeliveryContext{}
+	for _, tc := range cases {
+		request := replyConformanceEvent(source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent), tc.requestID, templatereply.RequesterFlowID, templatereply.RequesterFlowID+"/"+tc.accountID, map[string]any{
+			"provider_request_id": tc.requestKey,
+			"account_id":          tc.accountID,
+		})
+		before := store.createCalls
+		preflight, err := eb.CheckPublishRecipientPlan(ctx, request)
+		if err != nil {
+			t.Fatalf("preflight %s: %v", tc.name, err)
+		}
+		if store.createCalls != before {
+			t.Fatalf("preflight %s persisted reply context", tc.name)
+		}
+		if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 1 || preflight.DeliveryRoutes[0].Context.Empty() {
+			t.Fatalf("preflight %s = %#v", tc.name, preflight)
+		}
+		if err := eb.Publish(ctx, request); err != nil {
+			t.Fatalf("publish request %s: %v", tc.name, err)
+		}
+		routes := store.routesFor(request.ID())
+		if len(routes) != 1 || routes[0].Context.Empty() {
+			t.Fatalf("request %s persisted routes = %#v", tc.name, routes)
+		}
+		contexts[tc.name] = routes[0].Context
+	}
+	if contexts["same-origin-first"].ReplyContextID() == contexts["same-origin-second"].ReplyContextID() || contexts["same-origin-first"].ReplyContextID() == contexts["cross-origin"].ReplyContextID() {
+		t.Fatalf("concurrent request contexts crossed: %#v", contexts)
+	}
+
+	for _, tc := range []requestCase{cases[2], cases[1], cases[0]} {
+		replyID := uuid.NewString()
+		reply := replyConformanceEvent(source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent), replyID, templatereply.ProviderFlowID, templatereply.ProviderFlowID, map[string]any{
+			"provider_request_id": tc.requestKey,
+			"account_id":          tc.accountID,
+			"result":              tc.name,
+		})
+		replyCtx := events.WithDeliveryContext(ctx, contexts[tc.name])
+		beforeClaims := store.claimCalls
+		preflight, err := eb.CheckPublishRecipientPlan(replyCtx, reply)
+		if err != nil {
+			t.Fatalf("reply preflight %s: %v", tc.name, err)
+		}
+		if store.claimCalls != beforeClaims {
+			t.Fatalf("reply preflight %s claimed terminal context", tc.name)
+		}
+		if preflight.TargetFailure != "" {
+			t.Fatalf("reply preflight %s failure = %q", tc.name, preflight.TargetFailure)
+		}
+		if err := eb.Publish(replyCtx, reply); err != nil {
+			t.Fatalf("publish reply %s: %v", tc.name, err)
+		}
+		routes := store.routesFor(reply.ID())
+		if len(routes) != 1 || routes[0].Target.FlowInstance != templatereply.RequesterFlowID+"/"+tc.accountID {
+			t.Fatalf("reply %s routes = %#v", tc.name, routes)
+		}
+		if !routes[0].Context.Empty() {
+			t.Fatalf("terminal reply %s leaked consumed context: %#v", tc.name, routes[0].Context)
+		}
+	}
+	firstContext := contexts["same-origin-first"]
+	lateReply := replyConformanceEvent(source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent), uuid.NewString(), templatereply.ProviderFlowID, templatereply.ProviderFlowID, map[string]any{
+		"provider_request_id": cases[0].requestKey,
+		"account_id":          "account-a",
+		"result":              "too-late",
+	})
+	lateCtx := events.WithDeliveryContext(ctx, firstContext)
+	beforeClaims := store.claimCalls
+	latePlan, err := eb.CheckPublishRecipientPlan(lateCtx, lateReply)
+	if err != nil {
+		t.Fatalf("late reply preflight: %v", err)
+	}
+	if store.claimCalls != beforeClaims || latePlan.TargetFailure != string(runtimepinrouting.FailureReplyAlreadyTerminal) {
+		t.Fatalf("late reply preflight = %#v claims=%d/%d", latePlan, store.claimCalls, beforeClaims)
+	}
+	if err := eb.Publish(lateCtx, lateReply); err != nil {
+		t.Fatalf("publish late reply: %v", err)
+	}
+	if routes := store.routesFor(lateReply.ID()); len(routes) != 0 {
+		t.Fatalf("late reply persisted routes = %#v, want none", routes)
+	}
+
+	staleReply := replyConformanceEvent(source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent), uuid.NewString(), templatereply.ProviderFlowID, templatereply.ProviderFlowID, map[string]any{
+		"provider_request_id": "missing",
+		"account_id":          "account-a",
+		"result":              "stale",
+	})
+	staleCtx := events.WithDeliveryContext(ctx, events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:missing"}})
+	stalePlan, err := eb.CheckPublishRecipientPlan(staleCtx, staleReply)
+	if err != nil {
+		t.Fatalf("stale reply preflight: %v", err)
+	}
+	if stalePlan.TargetFailure != string(runtimepinrouting.FailureStaleArrival) {
+		t.Fatalf("stale reply failure = %q, want %q", stalePlan.TargetFailure, runtimepinrouting.FailureStaleArrival)
+	}
+}
+
+func TestReplyResolutionConformance_DurableRestartRoutesOverlappingRequestsOnBothBackends(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T) durableReplyConformanceStore
+	}{
+		{
+			name: "postgres",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return &store.PostgresStore{DB: db}
+			},
+		},
+		{
+			name: "sqlite",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				return storetest.StartSQLiteRuntimeStore(t)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			source := templatereply.LoadSource(t, templatereply.Options{})
+			backend := tc.setup(t)
+			runID := uuid.NewString()
+			seedDurableReplyConformanceRun(t, ctx, backend, runID)
+
+			requestBus := newDurableReplyConformanceBus(t, ctx, backend, source)
+			type requestCase struct {
+				name       string
+				accountID  string
+				eventID    string
+				requestKey string
+			}
+			requests := []requestCase{
+				{name: "same-origin-first", accountID: "account-a", eventID: uuid.NewString(), requestKey: "account-a-request-1"},
+				{name: "same-origin-second", accountID: "account-a", eventID: uuid.NewString(), requestKey: "account-a-request-2"},
+				{name: "cross-origin", accountID: "account-b", eventID: uuid.NewString(), requestKey: "account-a-request-1"},
+			}
+			contexts := make(map[string]events.DeliveryContext, len(requests))
+			for _, req := range requests {
+				evt := replyConformanceEventForRun(
+					source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent),
+					req.eventID,
+					runID,
+					templatereply.RequesterFlowID,
+					templatereply.RequesterFlowID+"/"+req.accountID,
+					map[string]any{
+						"provider_request_id": req.requestKey,
+						"account_id":          req.accountID,
+					},
+				)
+				if err := requestBus.Publish(ctx, evt); err != nil {
+					t.Fatalf("publish request %s: %v", req.name, err)
+				}
+				routes, err := backend.ListEventDeliveryRoutes(ctx, req.eventID)
+				if err != nil || len(routes) != 1 || routes[0].Context.Empty() {
+					t.Fatalf("persisted request routes %s = %#v err=%v", req.name, routes, err)
+				}
+				contexts[req.name] = routes[0].Context
+			}
+			if contexts[requests[0].name].ReplyContextID() == contexts[requests[1].name].ReplyContextID() {
+				t.Fatalf("overlapping same-origin requests share reply context: %#v", contexts)
+			}
+
+			// Reconstructing the bus forces reply routing to consume persisted route
+			// context and durable reply state rather than process-local request state.
+			restartedBus := newDurableReplyConformanceBus(t, ctx, backend, source)
+			for _, req := range []requestCase{requests[2], requests[1], requests[0]} {
+				replyID := uuid.NewString()
+				reply := replyConformanceEventForRun(
+					source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent),
+					replyID,
+					runID,
+					templatereply.ProviderFlowID,
+					templatereply.ProviderFlowID,
+					map[string]any{
+						"provider_request_id": req.requestKey,
+						"account_id":          req.accountID,
+						"result":              req.name,
+					},
+				)
+				publishCtx := events.WithDeliveryContext(ctx, contexts[req.name])
+				if err := restartedBus.Publish(publishCtx, reply); err != nil {
+					t.Fatalf("publish reply %s after restart: %v", req.name, err)
+				}
+				routes, err := backend.ListEventDeliveryRoutes(ctx, replyID)
+				if err != nil || len(routes) != 1 {
+					t.Fatalf("persisted reply routes %s = %#v err=%v", req.name, routes, err)
+				}
+				wantInstance := templatereply.RequesterFlowID + "/" + req.accountID
+				if routes[0].Target.FlowInstance != wantInstance || !routes[0].Context.Empty() {
+					t.Fatalf("persisted reply route %s = %#v, want instance %q with consumed context", req.name, routes[0], wantInstance)
+				}
+				record, err := backend.LoadReplyContext(ctx, contexts[req.name].ReplyContextID())
+				if err != nil || record.State != runtimereplycontext.StateTerminal || record.AcceptedReplyEventID != replyID {
+					t.Fatalf("terminal reply context %s = %#v err=%v", req.name, record, err)
+				}
+			}
+		})
+	}
+}
+
+func TestReplyResolutionConformance_DurableMailboxAndHumanTaskResumeToTerminalReply(t *testing.T) {
+	for _, backendCase := range []struct {
+		name  string
+		setup func(*testing.T) durableReplyConformanceStore
+	}{
+		{
+			name: "postgres",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return &store.PostgresStore{DB: db}
+			},
+		},
+		{
+			name: "sqlite",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				return storetest.StartSQLiteRuntimeStore(t)
+			},
+		},
+	} {
+		for _, continuationKind := range []string{templatereply.ContinuationMailbox, templatereply.ContinuationHuman} {
+			t.Run(backendCase.name+"/"+continuationKind, func(t *testing.T) {
+				ctx := context.Background()
+				requestKey := continuationKind + "-request"
+				source := templatereply.LoadSource(t, templatereply.Options{
+					ProviderContinuation:   continuationKind,
+					ContinuationRequestKey: requestKey,
+					ContinuationAccountID:  "account-a",
+				})
+				if findings := runtimebootverify.Run(ctx, source, runtimebootverify.Options{}).HardInvalidities(); len(findings) != 0 {
+					t.Fatalf("continuation fixture hard invalidities = %#v", findings)
+				}
+				backend := backendCase.setup(t)
+				continuations, ok := backend.(replyContinuationConformanceStore)
+				if !ok {
+					t.Fatalf("%T lacks reply continuation conformance surface", backend)
+				}
+				runID := uuid.NewString()
+				seedDurableReplyConformanceRun(t, ctx, backend, runID)
+				requestBus := newDurableReplyContinuationRuntime(t, ctx, backend, source)
+				requestID := uuid.NewString()
+				request := replyConformanceEventForRun(
+					source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent),
+					requestID,
+					runID,
+					templatereply.RequesterFlowID,
+					templatereply.RequesterFlowID+"/account-a",
+					map[string]any{"provider_request_id": requestKey, "account_id": "account-a"},
+				)
+				if err := requestBus.Publish(ctx, request); err != nil {
+					t.Fatalf("publish continuation request: %v", err)
+				}
+				requestRoutes, err := backend.ListEventDeliveryRoutes(ctx, requestID)
+				if err != nil || len(requestRoutes) != 1 || requestRoutes[0].Context.Empty() {
+					t.Fatalf("continuation request routes = %#v err=%v", requestRoutes, err)
+				}
+				deliveryContext := requestRoutes[0].Context
+
+				rowID := ""
+				switch continuationKind {
+				case templatereply.ContinuationMailbox:
+					rowID = loadReplyContinuationRowID(t, ctx, backend, requestID, "approval")
+				case templatereply.ContinuationHuman:
+					rowID, err = continuations.CreateHumanTask(events.WithDeliveryContext(ctx, deliveryContext), runtimetools.HumanTaskCreateRecord{
+						ActorID:       "provider-agent",
+						FlowInstance:  templatereply.ProviderFlowID,
+						Category:      "approval",
+						Description:   "Approve provider reply",
+						ExpectedValue: "approved",
+						Priority:      "normal",
+						Deadline:      time.Now().UTC().Add(time.Hour),
+						SourceEventID: requestID,
+						Context:       deliveryContext,
+					})
+					if err != nil {
+						t.Fatalf("CreateHumanTask: %v", err)
+					}
+				}
+				item, err := continuations.GetMailboxItem(ctx, rowID)
+				if err != nil || item.ReplyContextID != deliveryContext.ReplyContextID() {
+					t.Fatalf("continuation row = %#v err=%v", item, err)
+				}
+
+				// Rebuild both EventBus and Pipeline before the row outcome. The
+				// outcome must restore authority from the row, not process memory.
+				resumedBus := newDurableReplyContinuationRuntime(t, ctx, backend, source)
+				if continuationKind == templatereply.ContinuationHuman {
+					for _, eventType := range []string{"human_task.deferred", "human_task.approved"} {
+						if routes := resumedBus.RouteTable().Resolve(eventType); len(routes) == 0 {
+							t.Fatalf("human-task outcome route %s is missing", eventType)
+						}
+					}
+				}
+				deferAt := time.Now().UTC()
+				switch continuationKind {
+				case templatereply.ContinuationMailbox:
+					if _, err := continuations.DecideV1MailboxItem(ctx, store.MailboxV1DecisionRequest{
+						MailboxID:            rowID,
+						Action:               "deferred",
+						ActorTokenID:         "operator",
+						DeferUntil:           deferAt.Add(10 * time.Minute),
+						Now:                  deferAt,
+						DecisionEventType:    "mailbox.item_deferred",
+						DecisionEventPublish: resumedBus.PublishInMutation,
+					}); err != nil {
+						t.Fatalf("defer mailbox continuation: %v", err)
+					}
+				case templatereply.ContinuationHuman:
+					if err := continuations.DecideHumanTask(ctx, runtimetools.HumanTaskDecisionRecord{
+						TaskID:               rowID,
+						Status:               "deferred",
+						ActorID:              "operator",
+						Reason:               "review later",
+						RequeueDate:          deferAt.Add(10 * time.Minute).Format(time.RFC3339),
+						DecidedAt:            deferAt,
+						DecisionEventPublish: resumedBus.PublishInMutation,
+					}); err != nil {
+						t.Fatalf("defer human continuation: %v", err)
+					}
+				}
+				waitReplyConformanceBus(t, resumedBus)
+				assertReplyContextState(t, ctx, backend, deliveryContext.ReplyContextID(), runtimereplycontext.StateOpen, "")
+				if got := countReplyConformanceEvents(t, ctx, backend, source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent)); got != 0 {
+					t.Fatalf("terminal replies after defer = %d, want 0", got)
+				}
+
+				finalAt := deferAt.Add(time.Second)
+				switch continuationKind {
+				case templatereply.ContinuationMailbox:
+					if _, err := continuations.DecideV1MailboxItem(ctx, store.MailboxV1DecisionRequest{
+						MailboxID:            rowID,
+						Action:               "approved",
+						ActorTokenID:         "operator",
+						Now:                  finalAt,
+						DecisionEventType:    "mailbox.item_decided",
+						DecisionEventPublish: resumedBus.PublishInMutation,
+					}); err != nil {
+						t.Fatalf("approve mailbox continuation: %v", err)
+					}
+				case templatereply.ContinuationHuman:
+					if err := continuations.DecideHumanTask(ctx, runtimetools.HumanTaskDecisionRecord{
+						TaskID:               rowID,
+						Status:               "approved",
+						ActorID:              "operator",
+						Reason:               "approved",
+						DecidedAt:            finalAt,
+						DecisionEventPublish: resumedBus.PublishInMutation,
+					}); err != nil {
+						t.Fatalf("approve human continuation: %v", err)
+					}
+				}
+				waitReplyConformanceBus(t, resumedBus)
+				replyType := source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent)
+				replyID := loadLatestReplyConformanceEventID(t, ctx, backend, replyType)
+				routes, err := backend.ListEventDeliveryRoutes(ctx, replyID)
+				if err != nil || len(routes) != 1 || routes[0].Target.FlowInstance != templatereply.RequesterFlowID+"/account-a" {
+					t.Fatalf("terminal continuation reply routes = %#v err=%v", routes, err)
+				}
+				assertReplyContextState(t, ctx, backend, deliveryContext.ReplyContextID(), runtimereplycontext.StateTerminal, replyID)
+				proveReplyContinuationStaleOrigin(t, ctx, backend, source, continuationKind, requestKey)
+			})
+		}
+	}
+}
+
+func proveReplyContinuationStaleOrigin(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, source semanticview.Source, continuationKind, requestKey string) {
+	t.Helper()
+	requestBus := newDurableReplyContinuationRuntime(t, ctx, backend, source)
+	requestID := uuid.NewString()
+	request := replyConformanceEventForRun(
+		source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent),
+		requestID,
+		loadReplyConformanceRunID(t, ctx, backend),
+		templatereply.RequesterFlowID,
+		templatereply.RequesterFlowID+"/account-a",
+		map[string]any{"provider_request_id": requestKey + "-stale", "account_id": "account-a"},
+	)
+	if err := requestBus.Publish(ctx, request); err != nil {
+		t.Fatalf("publish stale-origin continuation request: %v", err)
+	}
+	routes, err := backend.ListEventDeliveryRoutes(ctx, requestID)
+	if err != nil || len(routes) != 1 || routes[0].Context.Empty() {
+		t.Fatalf("stale-origin request routes = %#v err=%v", routes, err)
+	}
+	deliveryContext := routes[0].Context
+	continuations := backend.(replyContinuationConformanceStore)
+	rowID := ""
+	switch continuationKind {
+	case templatereply.ContinuationMailbox:
+		rowID = loadReplyContinuationRowID(t, ctx, backend, requestID, "approval")
+	case templatereply.ContinuationHuman:
+		rowID, err = continuations.CreateHumanTask(events.WithDeliveryContext(ctx, deliveryContext), runtimetools.HumanTaskCreateRecord{
+			ActorID:       "provider-agent",
+			FlowInstance:  templatereply.ProviderFlowID,
+			Category:      "approval",
+			Description:   "Approve stale-origin provider reply",
+			ExpectedValue: "approved",
+			Priority:      "normal",
+			Deadline:      time.Now().UTC().Add(time.Hour),
+			SourceEventID: requestID,
+			Context:       deliveryContext,
+		})
+		if err != nil {
+			t.Fatalf("CreateHumanTask for stale origin: %v", err)
+		}
+	}
+
+	staleBus := newDurableReplyContinuationRuntimeWithRequesterRoutes(t, ctx, backend, source, false)
+	replyType := source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent)
+	repliesBefore := countReplyConformanceEvents(t, ctx, backend, replyType)
+	now := time.Now().UTC()
+	switch continuationKind {
+	case templatereply.ContinuationMailbox:
+		if _, err := continuations.DecideV1MailboxItem(ctx, store.MailboxV1DecisionRequest{
+			MailboxID:            rowID,
+			Action:               "approved",
+			ActorTokenID:         "operator",
+			Now:                  now,
+			DecisionEventType:    "mailbox.item_decided",
+			DecisionEventPublish: staleBus.PublishInMutation,
+		}); err != nil {
+			t.Fatalf("approve stale-origin mailbox continuation: %v", err)
+		}
+	case templatereply.ContinuationHuman:
+		if err := continuations.DecideHumanTask(ctx, runtimetools.HumanTaskDecisionRecord{
+			TaskID:               rowID,
+			Status:               "approved",
+			ActorID:              "operator",
+			Reason:               "approved",
+			DecidedAt:            now,
+			DecisionEventPublish: staleBus.PublishInMutation,
+		}); err != nil {
+			t.Fatalf("approve stale-origin human continuation: %v", err)
+		}
+	}
+	waitReplyConformanceBus(t, staleBus)
+	if got := countReplyConformanceEvents(t, ctx, backend, replyType); got != repliesBefore+1 {
+		t.Fatalf("stale-origin terminal reply events = %d, want %d", got, repliesBefore+1)
+	}
+	replyID := loadLatestReplyConformanceEventID(t, ctx, backend, replyType)
+	if routes, err := backend.ListEventDeliveryRoutes(ctx, replyID); err != nil || len(routes) != 0 {
+		t.Fatalf("stale-origin reply routes = %#v err=%v, want none", routes, err)
+	}
+	if got := loadReplyConformanceTargetFailure(t, ctx, backend, replyID); got != string(runtimepinrouting.FailureStaleArrival) {
+		t.Fatalf("stale-origin target failure = %q, want %q", got, runtimepinrouting.FailureStaleArrival)
+	}
+	assertReplyContextState(t, ctx, backend, deliveryContext.ReplyContextID(), runtimereplycontext.StateOpen, "")
+}
+
+type durableReplyConformanceStore interface {
+	bus.EventStore
+	runtimereplycontext.Store
+	ListEventDeliveryRoutes(context.Context, string) ([]events.DeliveryRoute, error)
+}
+
+type replyContinuationConformanceStore interface {
+	durableReplyConformanceStore
+	runtimepipeline.MailboxWriteMaterializationStore
+	runtimetools.HumanTaskPersistence
+	GetMailboxItem(context.Context, string) (runtimetools.MailboxItem, error)
+	DecideV1MailboxItem(context.Context, store.MailboxV1DecisionRequest) (store.MailboxV1DecisionOutcome, error)
+}
+
+func newDurableReplyConformanceBus(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, source semanticview.Source) *bus.EventBus {
+	t.Helper()
+	if source == nil {
+		t.Fatal("reply conformance semantic source is required")
+	}
+	eb, err := bus.NewEventBusWithOptions(backend, bus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	for _, accountID := range []string{"account-a", "account-b"} {
+		if err := eb.AddFlowInstanceRouteContext(ctx, bus.FlowInstanceRouteMaterializationRequest{
+			Identity:            runtimeflowidentity.StoredRoute(templatereply.RequesterFlowID, accountID, templatereply.RequesterFlowID+"/"+accountID),
+			ActivationVariables: map[string]string{"account_id": accountID},
+		}); err != nil {
+			t.Fatalf("materialize requester route %s: %v", accountID, err)
+		}
+	}
+	return eb
+}
+
+func newDurableReplyContinuationRuntime(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, source semanticview.Source) *bus.EventBus {
+	return newDurableReplyContinuationRuntimeWithRequesterRoutes(t, ctx, backend, source, true)
+}
+
+func newDurableReplyContinuationRuntimeWithRequesterRoutes(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, source semanticview.Source, addRequesterRoutes bool) *bus.EventBus {
+	t.Helper()
+	continuations, ok := backend.(replyContinuationConformanceStore)
+	if !ok {
+		t.Fatalf("%T lacks reply continuation runtime surface", backend)
+	}
+	var coordinator *runtimepipeline.PipelineCoordinator
+	eb, err := bus.NewEventBusWithOptions(backend, bus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []bus.EventInterceptor {
+			if coordinator == nil {
+				return nil
+			}
+			return []bus.EventInterceptor{coordinator}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	db := replyConformanceDB(t, backend)
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	if sqliteStore, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		workflowStore = runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, sqliteStore)
+	}
+	workflow, err := runtimepipeline.LoadWorkflowDefinition(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowDefinition: %v", err)
+	}
+	nodes, err := runtimepipeline.LoadWorkflowNodes(source)
+	if err != nil {
+		t.Fatalf("LoadWorkflowNodes: %v", err)
+	}
+	module := conformanceLoadedWorkflowModule{
+		source:   source,
+		workflow: workflow,
+		nodes:    nodes,
+		guards:   runtimepipeline.NewContractGuardRegistry(source),
+		actions:  runtimepipeline.NewContractActionRegistry(source),
+	}
+	coordinator = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:                  module,
+		WorkflowStore:           workflowStore,
+		MailboxMaterializer:     continuations,
+		EventReceiptsCapability: func(context.Context) (bool, error) { return true, nil },
+	})
+	if addRequesterRoutes {
+		for _, accountID := range []string{"account-a", "account-b"} {
+			if err := eb.AddFlowInstanceRouteContext(ctx, bus.FlowInstanceRouteMaterializationRequest{
+				Identity:            runtimeflowidentity.StoredRoute(templatereply.RequesterFlowID, accountID, templatereply.RequesterFlowID+"/"+accountID),
+				ActivationVariables: map[string]string{"account_id": accountID},
+			}); err != nil {
+				t.Fatalf("materialize requester route %s: %v", accountID, err)
+			}
+		}
+	}
+	return eb
+}
+
+func replyConformanceDB(t *testing.T, backend durableReplyConformanceStore) *sql.DB {
+	t.Helper()
+	switch typed := backend.(type) {
+	case *store.PostgresStore:
+		return typed.DB
+	case *store.SQLiteRuntimeStore:
+		return typed.DB
+	default:
+		t.Fatalf("unsupported reply conformance backend %T", backend)
+		return nil
+	}
+}
+
+func loadReplyContinuationRowID(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, sourceEventID, itemType string) string {
+	t.Helper()
+	db := replyConformanceDB(t, backend)
+	query := `SELECT item_id::text FROM mailbox WHERE source_event_id = $1::uuid AND item_type = $2`
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		query = `SELECT item_id FROM mailbox WHERE source_event_id = ? AND item_type = ?`
+	}
+	var id string
+	if err := db.QueryRowContext(ctx, query, sourceEventID, itemType).Scan(&id); err != nil {
+		t.Fatalf("load reply continuation row: %v", err)
+	}
+	return id
+}
+
+func loadReplyConformanceRunID(t *testing.T, ctx context.Context, backend durableReplyConformanceStore) string {
+	t.Helper()
+	db := replyConformanceDB(t, backend)
+	query := `SELECT run_id::text FROM runs ORDER BY started_at DESC, run_id DESC LIMIT 1`
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		query = `SELECT run_id FROM runs ORDER BY started_at DESC, run_id DESC LIMIT 1`
+	}
+	var runID string
+	if err := db.QueryRowContext(ctx, query).Scan(&runID); err != nil {
+		t.Fatalf("load reply conformance run: %v", err)
+	}
+	return runID
+}
+
+func loadReplyConformanceTargetFailure(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, eventID string) string {
+	t.Helper()
+	db := replyConformanceDB(t, backend)
+	query := `SELECT COALESCE(target_failure_reason, '') FROM dead_letters WHERE original_event_id = $1::uuid ORDER BY created_at DESC LIMIT 1`
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		query = `SELECT COALESCE(target_failure_reason, '') FROM dead_letters WHERE original_event_id = ? ORDER BY created_at DESC LIMIT 1`
+	}
+	var reason string
+	if err := db.QueryRowContext(ctx, query, eventID).Scan(&reason); err != nil {
+		t.Fatalf("load reply conformance target failure: %v", err)
+	}
+	return reason
+}
+
+func countReplyConformanceEvents(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, eventType string) int {
+	t.Helper()
+	db := replyConformanceDB(t, backend)
+	query := `SELECT COUNT(*) FROM events WHERE event_name = $1`
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		query = `SELECT COUNT(*) FROM events WHERE event_name = ?`
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, query, eventType).Scan(&count); err != nil {
+		t.Fatalf("count reply conformance events: %v", err)
+	}
+	return count
+}
+
+func loadLatestReplyConformanceEventID(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, eventType string) string {
+	t.Helper()
+	db := replyConformanceDB(t, backend)
+	query := `SELECT event_id::text FROM events WHERE event_name = $1 ORDER BY created_at DESC, event_id DESC LIMIT 1`
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		query = `SELECT event_id FROM events WHERE event_name = ? ORDER BY created_at DESC, event_id DESC LIMIT 1`
+	}
+	var id string
+	if err := db.QueryRowContext(ctx, query, eventType).Scan(&id); err != nil {
+		t.Fatalf("load terminal reply event: %v\npersisted runtime rows:\n%s", err, replyConformanceDebugRows(ctx, db, backend))
+	}
+	return id
+}
+
+func replyConformanceDebugRows(ctx context.Context, db *sql.DB, backend durableReplyConformanceStore) string {
+	eventID := "event_id::text"
+	sourceID := "COALESCE(source_event_id::text, '')"
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		eventID = "event_id"
+		sourceID = "COALESCE(source_event_id, '')"
+	}
+	rows, err := db.QueryContext(ctx, `SELECT `+eventID+`, event_name, `+sourceID+` FROM events ORDER BY created_at, event_id`)
+	if err != nil {
+		return "events query: " + err.Error()
+	}
+	defer rows.Close()
+	var out strings.Builder
+	for rows.Next() {
+		var id, name, source string
+		if err := rows.Scan(&id, &name, &source); err != nil {
+			return "events scan: " + err.Error()
+		}
+		fmt.Fprintf(&out, "event %s %s source=%s\n", id, name, source)
+	}
+	deliveryEventID := "event_id::text"
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		deliveryEventID = "event_id"
+	}
+	deliveries, err := db.QueryContext(ctx, `SELECT `+deliveryEventID+`, subscriber_type, subscriber_id, status, COALESCE(reason_code, ''), COALESCE(last_error, '') FROM event_deliveries ORDER BY created_at, delivery_id`)
+	if err != nil {
+		fmt.Fprintf(&out, "deliveries query: %v\n", err)
+		return out.String()
+	}
+	defer deliveries.Close()
+	for deliveries.Next() {
+		var id, subscriberType, subscriberID, status, reason, lastError string
+		if err := deliveries.Scan(&id, &subscriberType, &subscriberID, &status, &reason, &lastError); err != nil {
+			fmt.Fprintf(&out, "deliveries scan: %v\n", err)
+			break
+		}
+		fmt.Fprintf(&out, "delivery %s %s/%s status=%s reason=%s error=%s\n", id, subscriberType, subscriberID, status, reason, lastError)
+	}
+	receiptEventID := "event_id::text"
+	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
+		receiptEventID = "event_id"
+	}
+	receipts, err := db.QueryContext(ctx, `SELECT `+receiptEventID+`, subscriber_type, subscriber_id, outcome, COALESCE(reason_code, ''), COALESCE(side_effects, '{}') FROM event_receipts ORDER BY event_id, subscriber_type, subscriber_id`)
+	if err != nil {
+		fmt.Fprintf(&out, "receipts query: %v\n", err)
+		return out.String()
+	}
+	defer receipts.Close()
+	for receipts.Next() {
+		var id, subscriberType, subscriberID, outcome, reason string
+		var sideEffects any
+		if err := receipts.Scan(&id, &subscriberType, &subscriberID, &outcome, &reason, &sideEffects); err != nil {
+			fmt.Fprintf(&out, "receipts scan: %v\n", err)
+			break
+		}
+		if raw, ok := sideEffects.([]byte); ok {
+			sideEffects = string(raw)
+		}
+		fmt.Fprintf(&out, "receipt %s %s/%s outcome=%s reason=%s effects=%v\n", id, subscriberType, subscriberID, outcome, reason, sideEffects)
+	}
+	return out.String()
+}
+
+func assertReplyContextState(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, contextID string, state runtimereplycontext.State, acceptedEventID string) {
+	t.Helper()
+	record, err := backend.LoadReplyContext(ctx, contextID)
+	if err != nil || record.State != state || record.AcceptedReplyEventID != acceptedEventID {
+		t.Fatalf("reply context state = %#v err=%v, want state=%q accepted=%q", record, err, state, acceptedEventID)
+	}
+}
+
+func waitReplyConformanceBus(t *testing.T, eb *bus.EventBus) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := eb.WaitForQuiescence(ctx); err != nil {
+		t.Fatalf("wait for reply conformance bus: %v", err)
+	}
+}
+
+func seedDurableReplyConformanceRun(t *testing.T, ctx context.Context, backend durableReplyConformanceStore, runID string) {
+	t.Helper()
+	switch typed := backend.(type) {
+	case *store.PostgresStore:
+		if _, err := typed.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+			t.Fatalf("seed postgres reply conformance run: %v", err)
+		}
+	case *store.SQLiteRuntimeStore:
+		if _, err := typed.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, runID); err != nil {
+			t.Fatalf("seed sqlite reply conformance run: %v", err)
+		}
+	default:
+		t.Fatalf("unsupported reply conformance backend %T", backend)
+	}
+}
+
+func replyConformanceEvent(eventType, id, flowID, flowInstance string, payload map[string]any) events.Event {
+	return replyConformanceEventForRun(eventType, id, uuid.NewString(), flowID, flowInstance, payload)
+}
+
+func replyConformanceEventForRun(eventType, id, runID, flowID, flowInstance string, payload map[string]any) events.Event {
+	raw, _ := json.Marshal(payload)
+	return eventtest.RootIngress(
+		id,
+		events.EventType(eventType),
+		"",
+		"",
+		raw,
+		0,
+		runID,
+		"",
+		events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{
+			FlowID:       flowID,
+			FlowInstance: flowInstance,
+			EntityID:     runtimeflowidentity.EntityID(flowInstance),
+		}),
+		time.Now().UTC(),
+	)
+}
+
+type replyConformanceStore struct {
+	bus.InMemoryEventStore
+	mu          sync.Mutex
+	events      map[string]events.Event
+	routes      map[string][]events.DeliveryRoute
+	scopes      map[string]runtimereplayclaim.CommittedReplayScope
+	contexts    map[string]runtimereplycontext.Record
+	createCalls int
+	claimCalls  int
+}
+
+func newReplyConformanceStore() *replyConformanceStore {
+	return &replyConformanceStore{
+		events:   map[string]events.Event{},
+		routes:   map[string][]events.DeliveryRoute{},
+		scopes:   map[string]runtimereplayclaim.CommittedReplayScope{},
+		contexts: map[string]runtimereplycontext.Record{},
+	}
+}
+
+func (s *replyConformanceStore) SupportsPersistedReplay() bool { return true }
+
+func (s *replyConformanceStore) PersistEventWithDeliveryRouteSetAndScope(_ context.Context, evt events.Event, routes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events[evt.ID()] = evt
+	s.routes[evt.ID()] = events.NormalizeDeliveryRoutes(routes)
+	s.scopes[evt.ID()] = scope
+	return nil
+}
+
+func (s *replyConformanceStore) InsertEventDeliveryRoutes(_ context.Context, eventID string, routes []events.DeliveryRoute) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routes[eventID] = events.NormalizeDeliveryRoutes(routes)
+	return nil
+}
+
+func (s *replyConformanceStore) ListEventDeliveryRoutes(_ context.Context, eventID string) ([]events.DeliveryRoute, error) {
+	return s.routesFor(eventID), nil
+}
+
+func (s *replyConformanceStore) UpsertCommittedReplayScope(_ context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scopes[eventID] = scope
+	return nil
+}
+
+func (s *replyConformanceStore) LoadCommittedReplayScope(_ context.Context, eventID string) (runtimereplayclaim.CommittedReplayScope, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	scope := s.scopes[eventID]
+	if scope == "" {
+		return "", runtimereplayclaim.ErrMissingCommittedReplayScope
+	}
+	return scope, nil
+}
+
+func (s *replyConformanceStore) ListEventDeliveryRecipients(_ context.Context, eventID string) ([]string, error) {
+	routes := s.routesFor(eventID)
+	out := make([]string, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, route.SubscriberID)
+	}
+	return out, nil
+}
+
+func (s *replyConformanceStore) CreateReplyContext(_ context.Context, record runtimereplycontext.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.createCalls++
+	record = record.Normalized()
+	if existing, ok := s.contexts[record.ID]; ok {
+		if existing.RequestEventID != record.RequestEventID || existing.Origin != record.Origin {
+			return errors.New("reply context identity collision")
+		}
+		return nil
+	}
+	s.contexts[record.ID] = record
+	return nil
+}
+
+func (s *replyConformanceStore) LoadReplyContext(_ context.Context, id string) (runtimereplycontext.Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.contexts[id]
+	if !ok {
+		return runtimereplycontext.Record{}, runtimereplycontext.ErrNotFound
+	}
+	return record, nil
+}
+
+func (s *replyConformanceStore) ClaimReplyContext(_ context.Context, id, replyEventID string) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.claimCalls++
+	record, ok := s.contexts[id]
+	if !ok {
+		return runtimereplycontext.Record{}, "", runtimereplycontext.ErrNotFound
+	}
+	if record.State == runtimereplycontext.StateTerminal {
+		if record.AcceptedReplyEventID == replyEventID {
+			return record, runtimereplycontext.ClaimIdempotent, nil
+		}
+		return record, runtimereplycontext.ClaimTerminal, nil
+	}
+	now := time.Now().UTC()
+	record.State = runtimereplycontext.StateTerminal
+	record.AcceptedReplyEventID = replyEventID
+	record.TerminalAt = &now
+	record.UpdatedAt = now
+	s.contexts[id] = record
+	return record, runtimereplycontext.ClaimAccepted, nil
+}
+
+func (s *replyConformanceStore) routesFor(eventID string) []events.DeliveryRoute {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]events.DeliveryRoute(nil), s.routes[eventID]...)
+}

--- a/internal/runtime/conformance/reply_resolution_conformance_test.go
+++ b/internal/runtime/conformance/reply_resolution_conformance_test.go
@@ -351,6 +351,100 @@ func TestReplyResolutionConformance_DurableRestartRoutesOverlappingRequestsOnBot
 	}
 }
 
+func TestReplyResolutionConformance_DurableExplicitCorrelationFailsClosedOnBothBackends(t *testing.T) {
+	for _, backendCase := range []struct {
+		name  string
+		setup func(*testing.T) durableReplyConformanceStore
+	}{
+		{
+			name: "postgres",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return &store.PostgresStore{DB: db}
+			},
+		},
+		{
+			name: "sqlite",
+			setup: func(t *testing.T) durableReplyConformanceStore {
+				return storetest.StartSQLiteRuntimeStore(t)
+			},
+		},
+	} {
+		t.Run(backendCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			source := templatereply.LoadSource(t, templatereply.Options{OptionalReplyCorrelation: true})
+			backend := backendCase.setup(t)
+			runID := uuid.NewString()
+			seedDurableReplyConformanceRun(t, ctx, backend, runID)
+			eb := newDurableReplyConformanceBus(t, ctx, backend, source)
+
+			for _, invalid := range []struct {
+				name    string
+				value   string
+				include bool
+			}{
+				{name: "absent_value"},
+				{name: "inconsistent_value", value: "different-request", include: true},
+			} {
+				t.Run(invalid.name, func(t *testing.T) {
+					requestID := uuid.NewString()
+					requestKey := "request-" + uuid.NewString()
+					request := replyConformanceEventForRun(
+						source.ResolveFlowEventReference(templatereply.RequesterFlowID, templatereply.RequestEvent),
+						requestID,
+						runID,
+						templatereply.RequesterFlowID,
+						templatereply.RequesterFlowID+"/account-a",
+						map[string]any{"provider_request_id": requestKey, "account_id": "account-a"},
+					)
+					if err := eb.Publish(ctx, request); err != nil {
+						t.Fatalf("publish request: %v", err)
+					}
+					requestRoutes, err := backend.ListEventDeliveryRoutes(ctx, requestID)
+					if err != nil || len(requestRoutes) != 1 || requestRoutes[0].Context.Empty() {
+						t.Fatalf("request routes = %#v err=%v, want one carried reply context", requestRoutes, err)
+					}
+					deliveryContext := requestRoutes[0].Context
+					replyID := uuid.NewString()
+					replyPayload := map[string]any{"account_id": "account-a", "result": "invalid"}
+					if invalid.include {
+						replyPayload["provider_request_id"] = invalid.value
+					}
+					reply := replyConformanceEventForRun(
+						source.ResolveFlowEventReference(templatereply.ProviderFlowID, templatereply.ReplyEvent),
+						replyID,
+						runID,
+						templatereply.ProviderFlowID,
+						templatereply.ProviderFlowID,
+						replyPayload,
+					)
+					publishCtx := events.WithDeliveryContext(ctx, deliveryContext)
+					preflight, err := eb.CheckPublishRecipientPlan(publishCtx, reply)
+					if err != nil {
+						t.Fatalf("reply preflight: %v", err)
+					}
+					if preflight.TargetFailure != string(runtimepinrouting.FailureStaleArrival) || len(preflight.DeliveryRoutes) != 0 {
+						t.Fatalf("reply preflight = %#v, want stale arrival with zero routes", preflight)
+					}
+					assertReplyContextState(t, ctx, backend, deliveryContext.ReplyContextID(), runtimereplycontext.StateOpen, "")
+
+					if err := eb.Publish(publishCtx, reply); err != nil {
+						t.Fatalf("publish invalid reply: %v", err)
+					}
+					if routes, err := backend.ListEventDeliveryRoutes(ctx, replyID); err != nil || len(routes) != 0 {
+						t.Fatalf("invalid reply routes = %#v err=%v, want none", routes, err)
+					}
+					if got := loadReplyConformanceTargetFailure(t, ctx, backend, replyID); got != string(runtimepinrouting.FailureStaleArrival) {
+						t.Fatalf("invalid reply target failure = %q, want %q", got, runtimepinrouting.FailureStaleArrival)
+					}
+					assertReplyContextState(t, ctx, backend, deliveryContext.ReplyContextID(), runtimereplycontext.StateOpen, "")
+				})
+			}
+		})
+	}
+}
+
 func TestReplyResolutionConformance_DurableMailboxAndHumanTaskResumeToTerminalReply(t *testing.T) {
 	for _, backendCase := range []struct {
 		name  string

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -685,6 +685,7 @@ seam_families:
       - internal/runtime/bus/sealed_flow_package_fixture_test.go
       - internal/runtime/conformance/sealed_flow_package_conformance_test.go
       - internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
+      - internal/runtime/conformance/reply_resolution_conformance_test.go
       - internal/runtime/conformance/singleton_coordinator_pilot_conformance_test.go
       - internal/runtime/conformance/template_flow_pilot_conformance_test.go
       - internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -701,7 +702,9 @@ seam_families:
       package-boundary proof consumer for the existing route-authority owners.
       #1553 adds the singleton coordinator pilot conformance fixture as a
       consumer that proves contained map/list state does not produce lowered
-      connect route authority.
+      connect route authority. #1924 adds the reply-resolution conformance
+      fixture as a consumer of lowered connect plans and typed route authority;
+      it does not introduce an alternate routing owner.
   - id: route_authority_conformance_artifacts
     layer: conformance_guardrails
     classification: canonical_owner

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -161,6 +161,40 @@ func TestPlatformEventCatalogSchemasValidateCurrentProducerPayloadShapes(t *test
 				"timestamp":         "2026-06-02T03:00:00Z",
 			},
 		},
+		{
+			eventType: "human_task.approved",
+			payload: map[string]any{
+				"task_id":          "00000000-0000-0000-0000-000000000130",
+				"requesting_agent": "provider-agent",
+				"status":           "approved",
+				"decided_by":       "operator",
+				"decided_at":       "2026-07-09T12:00:00Z",
+				"category":         "approval",
+				"description":      "Approve provider reply",
+				"expected_value":   "approved",
+				"priority":         "normal",
+				"requeue_count":    0,
+				"talking_points":   []any{"confirm account"},
+				"reason":           "approved",
+			},
+		},
+		{
+			eventType: "human_task.deferred",
+			payload: map[string]any{
+				"task_id":          "00000000-0000-0000-0000-000000000131",
+				"requesting_agent": "provider-agent",
+				"status":           "deferred",
+				"decided_by":       "operator",
+				"decided_at":       "2026-07-09T12:00:00Z",
+				"category":         "approval",
+				"description":      "Approve provider reply",
+				"expected_value":   "approved",
+				"priority":         "normal",
+				"requeue_count":    1,
+				"reason":           "review later",
+				"requeue_date":     "2026-07-09T13:00:00Z",
+			},
+		},
 	} {
 		t.Run(tc.eventType, func(t *testing.T) {
 			schema, ok := registry[tc.eventType]

--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -238,6 +238,20 @@ func SemanticScope(instancePath string) string {
 	return instancePath
 }
 
+func SemanticScopeFromFlowInstanceRef(flowInstance string) string {
+	flowInstance = normalizeRef(flowInstance)
+	if flowInstance == "" {
+		return ""
+	}
+	if scopeKey := SemanticScopeFromInstancePath(flowInstance); scopeKey != "" {
+		return scopeKey
+	}
+	if _, err := uuid.Parse(flowInstance); err == nil {
+		return ""
+	}
+	return flowInstance
+}
+
 func Stored(
 	source semanticview.Source,
 	workflowName,

--- a/internal/runtime/core/flowidentity/flowidentity_test.go
+++ b/internal/runtime/core/flowidentity/flowidentity_test.go
@@ -79,6 +79,24 @@ func TestSemanticScope_DistinguishesStaticAndInstancedPaths(t *testing.T) {
 	}
 }
 
+func TestSemanticScopeFromFlowInstanceRef_DistinguishesStaticScopeFromRootID(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{ref: "", want: ""},
+		{ref: "provider", want: "provider"},
+		{ref: "provider/inst-1", want: "provider"},
+		{ref: "parent/provider/inst-1", want: "parent/provider"},
+		{ref: "11111111-1111-4111-8111-111111111111", want: ""},
+	}
+	for _, tc := range cases {
+		if got := SemanticScopeFromFlowInstanceRef(tc.ref); got != tc.want {
+			t.Fatalf("SemanticScopeFromFlowInstanceRef(%q) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
 func TestStoredCoordinates_SeparateScopeFromConcretePath(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -39,6 +39,7 @@ const (
 	ConnectResolutionAddress     ConnectRoutePlanResolutionKind = "address"
 	ConnectResolutionInstanceKey ConnectRoutePlanResolutionKind = "instance_key"
 	ConnectResolutionBroadcast   ConnectRoutePlanResolutionKind = "broadcast"
+	ConnectResolutionReply       ConnectRoutePlanResolutionKind = "reply"
 )
 
 type ConnectRoutePlanFailure string
@@ -113,6 +114,22 @@ type ConnectRoutePlanFanIn struct {
 	Singleton   string
 }
 
+type ConnectRoutePlanReplyResolution struct {
+	Role              string
+	RequesterFlowID   string
+	RequestOutputPin  string
+	ReplyInputPin     string
+	ProviderFlowID    string
+	ProviderInputPin  string
+	ProviderOutputPin string
+	CorrelationKey    string
+}
+
+const (
+	ConnectReplyRoleRequest  = "request"
+	ConnectReplyRoleResponse = "response"
+)
+
 type ConnectRoutePlan struct {
 	PackageKey                string
 	Source                    ConnectRoutePlanEndpoint
@@ -124,6 +141,7 @@ type ConnectRoutePlan struct {
 	Address                   *ConnectRoutePlanAddress
 	InstanceKey               *ConnectRoutePlanInstanceKey
 	FanIn                     *ConnectRoutePlanFanIn
+	ReplyResolution           *ConnectRoutePlanReplyResolution
 	Map                       []ConnectRoutePlanMapEntry
 	Reply                     map[string]string
 	Target                    events.RouteIdentity
@@ -223,7 +241,11 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	if fanInIssue.Failure != "" {
 		return ConnectRoutePlan{}, fanInIssue
 	}
-	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast {
+	replyResolution, replyIssue := connectReplyResolution(source, connect, sourceEndpoint, to, inputPin)
+	if replyIssue.Failure != "" {
+		return ConnectRoutePlan{}, replyIssue
+	}
+	if receiverRequiresRuntimeResolution(receiverScope) && address == nil && instanceKey == nil && delivery != ConnectDeliveryBroadcast && (replyResolution == nil || replyResolution.Role != ConnectReplyRoleResponse) {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: to.FlowID}
 	}
 	targetKind := connectTargetKind(delivery)
@@ -247,11 +269,17 @@ func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 			address,
 			instanceKey,
 		),
-		Address:     address,
-		InstanceKey: instanceKey,
-		FanIn:       fanIn,
-		Map:         connectMapEntries(connect.Map),
-		Reply:       cloneStringMap(connect.Reply),
+		Address:         address,
+		InstanceKey:     instanceKey,
+		FanIn:           fanIn,
+		ReplyResolution: replyResolution,
+		Map:             connectMapEntries(connect.Map),
+		Reply:           cloneStringMap(connect.Reply),
+	}
+	if replyResolution != nil && replyResolution.Role == ConnectReplyRoleResponse {
+		plan.ResolutionKind = ConnectResolutionReply
+		plan.RequiresRuntimeResolution = true
+		return plan, ConnectRoutePlanIssue{}
 	}
 	if !receiverRequiresRuntimeResolution(receiverScope) {
 		route := staticConnectRoute(source, to.FlowID)
@@ -663,9 +691,80 @@ func connectResolutionInstanceKey(source semanticview.Source, connect runtimecon
 		return connectCarriedKeyResolutionInstanceKey(source, connect, inputPin, resolution, delivery, receiverFlowID)
 	case runtimecontracts.FlowInputResolutionModeFanIn:
 		return nil, ConnectRoutePlanIssue{}
+	case runtimecontracts.FlowInputResolutionModeReply:
+		return nil, ConnectRoutePlanIssue{}
 	default:
 		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: fmt.Sprintf("resolution mode %q is design-locked but not runnable in this slice", resolution.Mode)}
 	}
+}
+
+func connectReplyResolution(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, sourceEndpoint ConnectRoutePlanEndpoint, receiverRef runtimecontracts.FlowPackagePinRef, inputPin runtimecontracts.FlowInputEventPin) (*ConnectRoutePlanReplyResolution, ConnectRoutePlanIssue) {
+	if inputPin.Resolution.Mode == runtimecontracts.FlowInputResolutionModeReply {
+		resolution := inputPin.Resolution
+		if inputPin.Address != nil || !resolution.InstanceKey.Empty() || resolution.Aggregation != "" || resolution.Window != "" || len(resolution.DedupBy) > 0 || resolution.Singleton != "" {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureInstanceResolutionInvalid, Detail: "resolution mode reply may only declare replies_to and correlation_key"}
+		}
+		requestOutputPin := strings.TrimSpace(resolution.RepliesTo)
+		if requestOutputPin == "" {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: "resolution mode reply requires replies_to"}
+		}
+		requestOutput, ok := source.FlowOutputEventPin(receiverRef.FlowID, requestOutputPin)
+		if !ok {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("resolution mode reply replies_to %q must name a same-flow output pin", requestOutputPin)}
+		}
+		correlationKey := strings.TrimSpace(resolution.CorrelationKey)
+		if correlationKey != "" && !stringListContains(normalizedPinCarries(requestOutput.Carries), correlationKey) {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("resolution mode reply correlation_key %q must name a carry declared by output pin %s", correlationKey, requestOutputPin)}
+		}
+		requestConnects := source.CompositionConnectsFrom(receiverRef.FlowID, requestOutputPin)
+		if len(requestConnects) != 1 {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("resolution mode reply request pin %s.%s must have exactly one connected counterpart, got %d", receiverRef.FlowID, requestOutputPin, len(requestConnects))}
+		}
+		requestTarget, err := requestConnects[0].ToRef()
+		if err != nil || requestTarget.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(sourceEndpoint.FlowID) {
+			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: "resolution mode reply request and reply edges must connect the same provider flow"}
+		}
+		return &ConnectRoutePlanReplyResolution{
+			Role:              ConnectReplyRoleResponse,
+			RequesterFlowID:   strings.TrimSpace(receiverRef.FlowID),
+			RequestOutputPin:  requestOutputPin,
+			ReplyInputPin:     strings.TrimSpace(receiverRef.Pin),
+			ProviderFlowID:    strings.TrimSpace(sourceEndpoint.FlowID),
+			ProviderInputPin:  strings.TrimSpace(requestTarget.Pin),
+			ProviderOutputPin: strings.TrimSpace(sourceEndpoint.Pin),
+			CorrelationKey:    correlationKey,
+		}, ConnectRoutePlanIssue{}
+	}
+
+	var matches []ConnectRoutePlanReplyResolution
+	for _, replyInput := range source.FlowInputEventPins(sourceEndpoint.FlowID) {
+		if replyInput.Resolution.Mode != runtimecontracts.FlowInputResolutionModeReply || strings.TrimSpace(replyInput.Resolution.RepliesTo) != strings.TrimSpace(sourceEndpoint.Pin) {
+			continue
+		}
+		for _, replyConnect := range source.CompositionConnectsTo(sourceEndpoint.FlowID, replyInput.PinName()) {
+			from, err := replyConnect.FromRef()
+			if err != nil || from.Root || strings.TrimSpace(from.FlowID) != strings.TrimSpace(receiverRef.FlowID) {
+				continue
+			}
+			matches = append(matches, ConnectRoutePlanReplyResolution{
+				Role:              ConnectReplyRoleRequest,
+				RequesterFlowID:   strings.TrimSpace(sourceEndpoint.FlowID),
+				RequestOutputPin:  strings.TrimSpace(sourceEndpoint.Pin),
+				ReplyInputPin:     strings.TrimSpace(replyInput.PinName()),
+				ProviderFlowID:    strings.TrimSpace(receiverRef.FlowID),
+				ProviderInputPin:  strings.TrimSpace(receiverRef.Pin),
+				ProviderOutputPin: strings.TrimSpace(from.Pin),
+				CorrelationKey:    strings.TrimSpace(replyInput.Resolution.CorrelationKey),
+			})
+		}
+	}
+	if len(matches) > 1 {
+		return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("request pin %s.%s participates in multiple reply loops", sourceEndpoint.FlowID, sourceEndpoint.Pin)}
+	}
+	if len(matches) == 1 {
+		return &matches[0], ConnectRoutePlanIssue{}
+	}
+	return nil, ConnectRoutePlanIssue{}
 }
 
 func connectFanIn(source semanticview.Source, connect runtimecontracts.FlowPackageConnect, inputPin runtimecontracts.FlowInputEventPin, delivery ConnectRoutePlanDelivery, receiverFlowID string) (*ConnectRoutePlanFanIn, ConnectRoutePlanIssue) {

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -28,6 +28,8 @@ const (
 	FailureTargetSenderEmptySourceRuntime TargetFailure = "target_sender_empty_source_runtime"
 	FailureProducerTargetCommonPath       TargetFailure = "producer_target_common_path_forbidden"
 	FailureProducerBroadcastCommonPath    TargetFailure = "producer_broadcast_common_path_forbidden"
+	FailureReplyAlreadyTerminal           TargetFailure = "platform.reply_already_terminal"
+	FailureStaleArrival                   TargetFailure = "platform.stale_arrival"
 )
 
 type AuthoredTarget struct {

--- a/internal/runtime/core/state/mailbox.go
+++ b/internal/runtime/core/state/mailbox.go
@@ -8,21 +8,23 @@ import (
 
 // MailboxItem is a platform-owned durable human-task/escalation record.
 type MailboxItem struct {
-	ID            string          `json:"id"`
-	EventID       string          `json:"event_id,omitempty"`
-	EntityID      string          `json:"entity_id,omitempty"`
-	FromAgent     string          `json:"from_agent,omitempty"`
-	Type          string          `json:"type"`
-	Priority      string          `json:"priority"`
-	Status        string          `json:"status"`
-	Notified      bool            `json:"notified,omitempty"`
-	Summary       string          `json:"summary,omitempty"`
-	Context       json.RawMessage `json:"context,omitempty"`
-	TimeoutAt     time.Time       `json:"timeout_at,omitempty"`
-	Decision      string          `json:"decision,omitempty"`
-	DecisionNotes string          `json:"decision_notes,omitempty"`
-	CreatedAt     time.Time       `json:"created_at"`
-	UpdatedAt     time.Time       `json:"updated_at"`
+	ID             string          `json:"id"`
+	EventID        string          `json:"event_id,omitempty"`
+	EntityID       string          `json:"entity_id,omitempty"`
+	FlowInstance   string          `json:"flow_instance,omitempty"`
+	FromAgent      string          `json:"from_agent,omitempty"`
+	Type           string          `json:"type"`
+	Priority       string          `json:"priority"`
+	Status         string          `json:"status"`
+	Notified       bool            `json:"notified,omitempty"`
+	Summary        string          `json:"summary,omitempty"`
+	Context        json.RawMessage `json:"context,omitempty"`
+	TimeoutAt      time.Time       `json:"timeout_at,omitempty"`
+	Decision       string          `json:"decision,omitempty"`
+	DecisionNotes  string          `json:"decision_notes,omitempty"`
+	ReplyContextID string          `json:"-"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
 }
 
 func (m MailboxItem) EffectiveEntityID() string {

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -39,8 +39,9 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "entity_state", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "entity_state.run_id", DeleteOrderGroup: 3},
 		{Table: "timers", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteMixedRowPolicy, PredicateOwner: "timers.run_id|forked_from_run_id|forked_from_event_id -> events.run_id", DeleteOrderGroup: 3},
 		{Table: "run_control_state", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_control_state.run_id", DeleteOrderGroup: 3},
-		{Table: "events", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "events.run_id", DeleteOrderGroup: 4},
-		{Table: "runs", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteAll, PredicateOwner: "runs.run_id cleanup set", DeleteOrderGroup: 5},
+		{Table: "reply_contexts", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "reply_contexts.run_id", DeleteOrderGroup: 4},
+		{Table: "events", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "events.run_id", DeleteOrderGroup: 5},
+		{Table: "runs", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteAll, PredicateOwner: "runs.run_id cleanup set", DeleteOrderGroup: 6},
 		{Table: "schema_version", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "schema/migration state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "api_idempotency", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "API idempotency/auth-like state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "runtime_ingress_state", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "singleton runtime ingress owner", PreservationProof: "must survive destructive runtime cleanup"},
@@ -104,7 +105,7 @@ func CleanupEntryForPolicy(entry CleanupCatalogEntry, policy CleanupPolicy) Clea
 	if policy.IncludeBundles {
 		entry.Classification = CleanupDeleteAll
 		entry.PredicateOwner = "runtime.nuke include_bundles=true server-wide bundle catalog deletion"
-		entry.DeleteOrderGroup = 6
+		entry.DeleteOrderGroup = 7
 		entry.PreservationProof = ""
 		return entry
 	}

--- a/internal/runtime/engine/delivery_context_test.go
+++ b/internal/runtime/engine/delivery_context_test.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/core/identity"
+)
+
+type deliveryContextTimerApplier struct {
+	intents []TimerIntent
+}
+
+func (r *deliveryContextTimerApplier) ApplyTimerIntents(_ context.Context, _ identity.EntityID, intents []TimerIntent) error {
+	r.intents = append([]TimerIntent(nil), intents...)
+	return nil
+}
+
+type deliveryContextActivityWriter struct {
+	intents []ActivityIntent
+}
+
+func (r *deliveryContextActivityWriter) WriteActivityIntents(_ context.Context, intents []ActivityIntent) error {
+	r.intents = append([]ActivityIntent(nil), intents...)
+	return nil
+}
+
+func TestExecutorPersistPropagatesDeliveryContextToEveryContinuationIntent(t *testing.T) {
+	outbox := &recordingEmitOutbox{}
+	timers := &deliveryContextTimerApplier{}
+	activities := &deliveryContextActivityWriter{}
+	exec := &Executor{deps: RuntimeDependencies{
+		StateRepo:       stubStateRepo{},
+		Outbox:          outbox,
+		TimerApplier:    timers,
+		ActivityIntents: activities,
+	}}
+	deliveryContext := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:intent-propagation"}}
+	ctx := events.WithDeliveryContext(context.Background(), deliveryContext)
+	frame := executionFrame{
+		req: ExecutionRequest{EntityID: identity.EntityID("entity-a")},
+		result: ExecutionResult{
+			EmitIntents:     []EmitIntent{{}},
+			TimerIntents:    []TimerIntent{{TimerID: "provider-timeout"}},
+			ActivityIntents: []ActivityIntent{{ActivityID: "provider-call"}},
+		},
+	}
+	if err := exec.persist(ctx, frame); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if len(outbox.intents) != 1 || outbox.intents[0].Context.ReplyContextID() != deliveryContext.ReplyContextID() {
+		t.Fatalf("emit context = %#v", outbox.intents)
+	}
+	if len(timers.intents) != 1 || timers.intents[0].Context.ReplyContextID() != deliveryContext.ReplyContextID() {
+		t.Fatalf("timer context = %#v", timers.intents)
+	}
+	if len(activities.intents) != 1 || activities.intents[0].Context.ReplyContextID() != deliveryContext.ReplyContextID() {
+		t.Fatalf("activity context = %#v", activities.intents)
+	}
+}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -2342,6 +2342,24 @@ func (e *Executor) buildTimerIntents(frame *executionFrame) []TimerIntent {
 }
 
 func (e *Executor) persist(ctx context.Context, frame executionFrame) error {
+	deliveryContext := events.DeliveryContextFromContext(ctx)
+	if !deliveryContext.Empty() {
+		for i := range frame.result.EmitIntents {
+			if frame.result.EmitIntents[i].Context.Empty() {
+				frame.result.EmitIntents[i].Context = deliveryContext
+			}
+		}
+		for i := range frame.result.TimerIntents {
+			if frame.result.TimerIntents[i].Context.Empty() {
+				frame.result.TimerIntents[i].Context = deliveryContext
+			}
+		}
+		for i := range frame.result.ActivityIntents {
+			if frame.result.ActivityIntents[i].Context.Empty() {
+				frame.result.ActivityIntents[i].Context = deliveryContext
+			}
+		}
+	}
 	if frame.result.StateMutation.StateCarrier.Metadata == nil {
 		frame.result.StateMutation.StateCarrier.Metadata = cloneStringAnyMap(frame.state.State.StateCarrier.Metadata)
 	}

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -284,6 +284,7 @@ func (s *ExecutionState) SetFanOut(key string, value any) {
 
 type EmitIntent struct {
 	Event          events.Event
+	Context        events.DeliveryContext
 	Recipients     []string
 	ChainDepth     int
 	ParentEventID  string
@@ -291,6 +292,7 @@ type EmitIntent struct {
 }
 
 type TimerIntent struct {
+	Context      events.DeliveryContext
 	Operation    TimerOperation
 	TimerID      string
 	Owner        identity.NodeID
@@ -303,6 +305,7 @@ type TimerIntent struct {
 }
 
 type ActivityIntent struct {
+	Context          events.DeliveryContext
 	ActivityID       string
 	Tool             string
 	Input            map[string]any
@@ -325,6 +328,7 @@ type ActivityIntent struct {
 }
 
 func (i ActivityIntent) Normalized() ActivityIntent {
+	i.Context = i.Context.Normalized()
 	i.ActivityID = strings.TrimSpace(i.ActivityID)
 	i.Tool = strings.TrimSpace(i.Tool)
 	i.SuccessEvent = strings.TrimSpace(i.SuccessEvent)

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -55,6 +55,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	if am == nil {
 		return fmt.Errorf("agent manager is required")
 	}
+	if req.Context.Empty() {
+		req.Context = events.DeliveryContextFromContext(ctx)
+	}
+	ctx = events.WithDeliveryContext(ctx, req.Context)
 	if req.ContractBundle == nil {
 		return fmt.Errorf("contract bundle is required")
 	}
@@ -157,9 +161,10 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 		return fmt.Errorf("event bus does not support derived flow-instance routing for %s", flowPath)
 	}
 	if strings.TrimSpace(autoEmitName) != "" {
+		autoEmitCtx := events.WithDeliveryContext(context.Background(), req.Context)
 		publishAutoEmit := func() {
-			if err := am.bus.Publish(context.Background(), autoEmitEvent); err != nil {
-				am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{
+			if err := am.bus.Publish(autoEmitCtx, autoEmitEvent); err != nil {
+				am.bus.LogRuntime(autoEmitCtx, runtimepipeline.RuntimeLogEntry{
 					Level:     "warn",
 					Message:   "Auto-emitting the flow activation event failed",
 					Component: "flow_activation",

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -34,6 +34,7 @@ type flowActivationTestBus struct {
 	addedRouteRequests []runtimebus.FlowInstanceRouteMaterializationRequest
 	removedPairs       []string
 	published          []events.Event
+	publishedContexts  []events.DeliveryContext
 	runtimeLogs        []runtimepipeline.RuntimeLogEntry
 	unsubscribed       []string
 	removeErr          error
@@ -156,8 +157,9 @@ func (*flowActivationTestStore) ListPendingSubscribedEvents(context.Context, str
 	return nil, nil
 }
 
-func (b *flowActivationTestBus) Publish(_ context.Context, evt events.Event) error {
+func (b *flowActivationTestBus) Publish(ctx context.Context, evt events.Event) error {
 	b.published = append(b.published, evt)
+	b.publishedContexts = append(b.publishedContexts, events.DeliveryContextFromContext(ctx))
 	return nil
 }
 
@@ -564,6 +566,23 @@ func TestActivateFlowInstancePublishesAutoEmitEvent(t *testing.T) {
 	}
 	if got, _ := autoEmit.ContextMap("")["source_event_id"].(string); got != triggerEventID {
 		t.Fatalf("event context source_event_id = %q, want trigger event %q", got, triggerEventID)
+	}
+}
+
+func TestActivateFlowInstancePreservesReplyContextIntoAutoEmit(t *testing.T) {
+	bundle := testFlowBundle("review.created")
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	req := testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")
+	req.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:child-activation"}}
+	if err := am.ActivateFlowInstance(context.Background(), req); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(bus.publishedContexts) != 1 || bus.publishedContexts[0].ReplyContextID() != req.Context.ReplyContextID() {
+		t.Fatalf("child auto-emit contexts = %#v, want %q", bus.publishedContexts, req.Context.ReplyContextID())
+	}
+	if !bus.published[0].DeliveryContext().Empty() {
+		t.Fatalf("child auto-emit exposed reply context on business event: %#v", bus.published[0].DeliveryContext())
 	}
 }
 

--- a/internal/runtime/manager/receipts.go
+++ b/internal/runtime/manager/receipts.go
@@ -75,6 +75,7 @@ func (am *AgentManager) processEventDetailed(ctx context.Context, agent Agent, e
 	}
 	ctx = runtimecorrelation.WithInboundEvent(ctx, evt)
 	ctx = runtimecorrelation.WithRunID(ctx, strings.TrimSpace(evt.RunID()))
+	ctx = events.WithDeliveryContext(ctx, evt.DeliveryContext())
 	if writer, ok := am.store.(deliveryProgressWriter); ok && writer != nil {
 		if err := writer.MarkEventDeliveryInProgress(ctx, evt.ID(), agent.ID(), ""); err != nil {
 			if am.bus != nil {

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -136,7 +136,10 @@ func TestWriteReceiptConvergesNormalRunCompletionAfterReceiptRetryPersists(t *te
 	}
 }
 
-type traceRecordingAgent struct{ parent string }
+type traceRecordingAgent struct {
+	parent         string
+	replyContextID string
+}
 
 func (a *traceRecordingAgent) ID() string                        { return "trace-agent" }
 func (a *traceRecordingAgent) Type() string                      { return "llm" }
@@ -145,6 +148,7 @@ func (a *traceRecordingAgent) OnEvent(ctx context.Context, evt events.Event) ([]
 	if inbound, ok := runtimebus.InboundEventFromContext(ctx); ok {
 		a.parent = inbound.ID()
 	}
+	a.replyContextID = events.DeliveryContextFromContext(ctx).ReplyContextID()
 	return nil, nil
 }
 
@@ -436,12 +440,16 @@ func TestProcessEvent_PropagatesInboundParentWithoutTraceSeeding(t *testing.T) {
 	am := NewAgentManager(nil, nil)
 	evt := eventtest.RootIngress("evt-123",
 		events.EventType("discovery/market_research.scan_assigned"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	evt = evt.WithDeliveryContext(events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:agent-delivery"}})
 
 	if err := am.processEvent(context.Background(), agent, evt); err != nil {
 		t.Fatalf("processEvent: %v", err)
 	}
 	if agent.parent != "evt-123" {
 		t.Fatalf("parent event = %q, want evt-123", agent.parent)
+	}
+	if agent.replyContextID != "reply-v1:agent-delivery" {
+		t.Fatalf("agent reply context = %q", agent.replyContextID)
 	}
 }
 

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -380,7 +380,7 @@ func activityRequestEmitIntent(intent runtimeengine.ActivityIntent) (runtimeengi
 		},
 		time.Now().UTC(),
 	)
-	return runtimeengine.EmitIntent{Event: evt}, nil
+	return runtimeengine.EmitIntent{Event: evt, Context: intent.Context}, nil
 }
 
 func activityRequestEventID(intent runtimeengine.ActivityIntent) string {
@@ -494,6 +494,7 @@ func activityIntentFromRequestEvent(evt events.Event) (runtimeengine.ActivityInt
 		return runtimeengine.ActivityIntent{}, fmt.Errorf("decode activity request %s: %w", evt.ID(), err)
 	}
 	intent := runtimeengine.ActivityIntent{
+		Context:          evt.DeliveryContext(),
 		ActivityID:       payload.ActivityID,
 		Tool:             payload.Tool,
 		Input:            cloneStringAnyMap(payload.Input),
@@ -1209,6 +1210,7 @@ func (d pipelineActivityDispatcher) publishActivityResult(ctx context.Context, i
 }
 
 func (d pipelineActivityDispatcher) publishActivityResultWithID(ctx context.Context, intent runtimeengine.ActivityIntent, eventID, eventType string, payload map[string]any) error {
+	ctx = events.WithDeliveryContext(ctx, intent.Context)
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -1274,6 +1276,9 @@ func (d pipelineActivityDispatcher) publishJournaledActivityResult(ctx context.C
 		return fmt.Errorf("activity attempt %s has no terminal journal result", rec.RequestEventID)
 	}
 	intent.Attempt = rec.Attempt
+	if id := strings.TrimSpace(rec.ReplyContextID); id != "" {
+		intent.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: id}}
+	}
 	return d.publishActivityResultWithID(ctx, intent, rec.ResultEventID, rec.ResultEventType, rec.ResultPayload)
 }
 
@@ -1296,6 +1301,7 @@ func activityAttemptStartRecord(intent runtimeengine.ActivityIntent, inputHash s
 		SuccessEvent:    intent.SuccessEvent,
 		FailureEvent:    intent.FailureEvent,
 		InputHash:       inputHash,
+		ReplyContextID:  intent.Context.ReplyContextID(),
 	}
 }
 

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -122,11 +122,12 @@ func TestPipelineActivityRequestEventExecutesHTTPToolAndPublishesGeneratedSucces
 		Module: staticSemanticWorkflowModule{source: source},
 	})
 	intent := testActivityIntent(inputURL)
+	intent.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: "reply-v1:activity-round-trip"}}
 	request, err := activityRequestEmitIntent(intent)
 	if err != nil {
 		t.Fatalf("activityRequestEmitIntent: %v", err)
 	}
-	handled, err := pc.handleEventResult(context.Background(), request.Event)
+	handled, err := pc.handleEventResult(context.Background(), request.Event.WithDeliveryContext(intent.Context))
 	if err != nil {
 		t.Fatalf("handleEventResult: %v", err)
 	}
@@ -138,6 +139,9 @@ func TestPipelineActivityRequestEventExecutesHTTPToolAndPublishesGeneratedSucces
 	}
 	if len(bus.publishes) != 1 {
 		t.Fatalf("published events = %d, want 1", len(bus.publishes))
+	}
+	if len(bus.publishContexts) != 1 || bus.publishContexts[0].ReplyContextID() != intent.Context.ReplyContextID() {
+		t.Fatalf("published activity result contexts = %#v, want %q", bus.publishContexts, intent.Context.ReplyContextID())
 	}
 	evt := bus.publishes[0]
 	if got := evt.Type(); got != events.EventType("research.scanner_source_scrape.succeeded") {
@@ -1091,6 +1095,7 @@ func createActivityJournalSQLiteSchema(t *testing.T, ctx context.Context, db *sq
 			result_payload TEXT,
 			error TEXT,
 			input_hash TEXT NOT NULL,
+			reply_context_id TEXT,
 			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			completed_at TEXT,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/internal/runtime/pipeline/activity_journal.go
+++ b/internal/runtime/pipeline/activity_journal.go
@@ -39,6 +39,7 @@ type ActivityAttemptRecord struct {
 	ResultPayload   map[string]any
 	Error           string
 	InputHash       string
+	ReplyContextID  string
 	StartedAt       time.Time
 	CompletedAt     *time.Time
 	UpdatedAt       time.Time
@@ -57,9 +58,9 @@ func (s *WorkflowInstanceStore) StartActivityAttempt(ctx context.Context, rec Ac
 			INSERT INTO activity_attempts (
 				request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
 				node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
-				success_event, failure_event, input_hash
+				success_event, failure_event, input_hash, reply_context_id
 			) VALUES (
-				?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+				?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, '')
 			)
 			ON CONFLICT (request_event_id) DO NOTHING
 		`
@@ -68,17 +69,17 @@ func (s *WorkflowInstanceStore) StartActivityAttempt(ctx context.Context, rec Ac
 				INSERT INTO activity_attempts (
 					request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
 					node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
-					success_event, failure_event, input_hash
+					success_event, failure_event, input_hash, reply_context_id
 				) VALUES (
 					$1::uuid, $2::uuid, NULLIF($3, '')::uuid, NULLIF($4, '')::uuid, NULLIF($5, '')::uuid, NULLIF($6, ''),
-					$7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+					$7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')
 				)
 				ON CONFLICT (request_event_id) DO NOTHING
 			`
 		}
 		res, err := dbExecContext(txctx, s.db, query, rec.RequestEventID, rec.RunID, nullableUUID(rec.SourceEventID), nullableUUID(rec.ParentEventID), nullableUUID(rec.EntityID), nullableString(rec.FlowInstance),
 			rec.NodeID, rec.HandlerEventKey, rec.ActivityID, rec.Tool, rec.EffectClass, rec.Attempt, rec.Status,
-			rec.SuccessEvent, rec.FailureEvent, rec.InputHash)
+			rec.SuccessEvent, rec.FailureEvent, rec.InputHash, rec.ReplyContextID)
 		if err != nil {
 			return fmt.Errorf("start activity attempt %s: %w", rec.RequestEventID, err)
 		}
@@ -230,7 +231,7 @@ func (s *WorkflowInstanceStore) LoadActivityAttempt(ctx context.Context, request
 		SELECT request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
 		       node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
 		       success_event, failure_event, result_event_id, result_event_type, result_payload,
-		       error, input_hash, started_at, completed_at, updated_at
+		       error, input_hash, reply_context_id, started_at, completed_at, updated_at
 		FROM activity_attempts
 		WHERE request_event_id = ?
 	`
@@ -239,7 +240,7 @@ func (s *WorkflowInstanceStore) LoadActivityAttempt(ctx context.Context, request
 			SELECT request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
 			       node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
 			       success_event, failure_event, result_event_id, result_event_type, result_payload,
-			       error, input_hash, started_at, completed_at, updated_at
+			       error, input_hash, reply_context_id, started_at, completed_at, updated_at
 			FROM activity_attempts
 			WHERE request_event_id = $1::uuid
 		`
@@ -258,14 +259,14 @@ func (s *WorkflowInstanceStore) LoadActivityAttempt(ctx context.Context, request
 func scanActivityAttempt(row *sql.Row) (ActivityAttemptRecord, error) {
 	var rec ActivityAttemptRecord
 	var sourceEventID, parentEventID, entityID, flowInstance sql.NullString
-	var resultEventID, resultEventType, errorText sql.NullString
+	var resultEventID, resultEventType, errorText, replyContextID sql.NullString
 	var rawPayload any
 	var startedAtRaw, completedAtRaw, updatedAtRaw any
 	if err := row.Scan(
 		&rec.RequestEventID, &rec.RunID, &sourceEventID, &parentEventID, &entityID, &flowInstance,
 		&rec.NodeID, &rec.HandlerEventKey, &rec.ActivityID, &rec.Tool, &rec.EffectClass, &rec.Attempt, &rec.Status,
 		&rec.SuccessEvent, &rec.FailureEvent, &resultEventID, &resultEventType, &rawPayload,
-		&errorText, &rec.InputHash, &startedAtRaw, &completedAtRaw, &updatedAtRaw,
+		&errorText, &rec.InputHash, &replyContextID, &startedAtRaw, &completedAtRaw, &updatedAtRaw,
 	); err != nil {
 		return ActivityAttemptRecord{}, err
 	}
@@ -297,6 +298,7 @@ func scanActivityAttempt(row *sql.Row) (ActivityAttemptRecord, error) {
 	rec.ResultEventID = resultEventID.String
 	rec.ResultEventType = resultEventType.String
 	rec.Error = errorText.String
+	rec.ReplyContextID = replyContextID.String
 	if rawPayload != nil {
 		decoded, err := decodeActivityAttemptPayload(rawPayload)
 		if err != nil {
@@ -386,6 +388,7 @@ func (rec ActivityAttemptRecord) normalized() ActivityAttemptRecord {
 	rec.ResultEventType = strings.TrimSpace(rec.ResultEventType)
 	rec.Error = strings.TrimSpace(rec.Error)
 	rec.InputHash = strings.TrimSpace(rec.InputHash)
+	rec.ReplyContextID = strings.TrimSpace(rec.ReplyContextID)
 	if rec.Attempt <= 0 {
 		rec.Attempt = 1
 	}

--- a/internal/runtime/pipeline/activity_journal_test.go
+++ b/internal/runtime/pipeline/activity_journal_test.go
@@ -76,3 +76,75 @@ func TestActivityAttemptJournalSQLiteAndPostgres(t *testing.T) {
 		})
 	}
 }
+
+func TestActivityAttemptJournalPreservesReplyContextAcrossRestart(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		store func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool)
+	}{
+		{
+			name: "sqlite",
+			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				db, journal := newSQLiteActivityJournalStore(t, ctx)
+				return db, journal, true
+			},
+		},
+		{
+			name: "postgres",
+			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return db, NewWorkflowInstanceStore(db), false
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, journal, sqlite := tc.store(t, ctx)
+			runID := uuid.NewString()
+			seedActivityRun(t, db, sqlite, runID)
+			requestEventID := uuid.NewString()
+			replyContextID := "reply-v1:activity-" + uuid.NewString()
+			seedActivityReplyContext(t, db, sqlite, runID, requestEventID, replyContextID)
+			intent := testNonIdempotentActivityIntent(runID, uuid.NewString(), uuid.NewString())
+			start := activityAttemptStartRecord(intent, activityInputHash(intent.Input))
+			start.ReplyContextID = replyContextID
+			if _, inserted, err := journal.StartActivityAttempt(ctx, start); err != nil || !inserted {
+				t.Fatalf("StartActivityAttempt inserted=%v err=%v", inserted, err)
+			}
+			restarted := NewWorkflowInstanceStore(db)
+			if sqlite {
+				restarted = NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, &recordingRuntimeMutationRunner{db: db})
+			}
+			loaded, ok, err := restarted.LoadActivityAttempt(ctx, start.RequestEventID)
+			if err != nil || !ok || loaded.ReplyContextID != replyContextID {
+				t.Fatalf("restarted activity attempt = %#v ok=%v err=%v", loaded, ok, err)
+			}
+		})
+	}
+}
+
+func seedActivityReplyContext(t *testing.T, db *sql.DB, sqlite bool, runID, requestEventID, replyContextID string) {
+	t.Helper()
+	if sqlite {
+		return
+	}
+	if _, err := db.Exec(`
+		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'provider.requested', 'global', '{}'::jsonb, 'test', 'platform', now())
+	`, runID, requestEventID); err != nil {
+		t.Fatalf("seed postgres reply request event: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO reply_contexts (
+			reply_context_id, run_id, request_event_id, requester_flow_id, request_output_pin,
+			reply_input_pin, provider_flow_id, provider_input_pin, provider_output_pin,
+			origin_route, request_correlation_id, state, created_at, updated_at
+		)
+		VALUES ($1, $2::uuid, $3::uuid, 'requester', 'provider_requested', 'provider_replied', 'provider',
+			'provider_requested', 'provider_replied', '{"flow_id":"requester","flow_instance":"requester/a","entity_id":"entity-a"}'::jsonb, $3, 'open', now(), now())
+	`, replyContextID, runID, requestEventID); err != nil {
+		t.Fatalf("seed postgres reply context: %v", err)
+	}
+}

--- a/internal/runtime/pipeline/delivery_context_test.go
+++ b/internal/runtime/pipeline/delivery_context_test.go
@@ -1,0 +1,22 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+func TestWorkflowNodeDeliveryRouteInstallsReplyContext(t *testing.T) {
+	route := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "provider-node",
+		Context: events.DeliveryContext{
+			Reply: &events.ReplyContextRef{ID: "reply-v1:node-delivery"},
+		},
+	}
+	ctx := withWorkflowNodeDeliveryRoute(context.Background(), route)
+	if got := events.DeliveryContextFromContext(ctx).ReplyContextID(); got != route.Context.ReplyContextID() {
+		t.Fatalf("node delivery reply context = %q, want %q", got, route.Context.ReplyContextID())
+	}
+}

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -28,13 +28,14 @@ import (
 )
 
 type recordingPipelineBus struct {
-	mu            sync.Mutex
-	publishes     []events.Event
-	runtimeLogs   []RuntimeLogEntry
-	outboxIntents []runtimeengine.EmitIntent
-	publishErr    error
-	outboxErr     error
-	runtimeLogErr error
+	mu              sync.Mutex
+	publishes       []events.Event
+	publishContexts []events.DeliveryContext
+	runtimeLogs     []RuntimeLogEntry
+	outboxIntents   []runtimeengine.EmitIntent
+	publishErr      error
+	outboxErr       error
+	runtimeLogErr   error
 }
 
 type recordingPipelineDispatcher struct {
@@ -45,13 +46,14 @@ type recordingPipelineOutbox struct {
 	bus *recordingPipelineBus
 }
 
-func (b *recordingPipelineBus) Publish(_ context.Context, evt events.Event) error {
+func (b *recordingPipelineBus) Publish(ctx context.Context, evt events.Event) error {
 	if b.publishErr != nil {
 		return b.publishErr
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.publishes = append(b.publishes, evt)
+	b.publishContexts = append(b.publishContexts, events.DeliveryContextFromContext(ctx))
 	return nil
 }
 

--- a/internal/runtime/pipeline/mailbox_materialization.go
+++ b/internal/runtime/pipeline/mailbox_materialization.go
@@ -16,16 +16,17 @@ import (
 )
 
 type MailboxWriteMaterialization struct {
-	ItemID        string
-	EntityID      string
-	FlowInstance  string
-	Scope         string
-	ItemType      string
-	SourceEventID string
-	FromAgent     string
-	Severity      string
-	Summary       string
-	Payload       json.RawMessage
+	ItemID         string
+	EntityID       string
+	FlowInstance   string
+	Scope          string
+	ItemType       string
+	SourceEventID  string
+	FromAgent      string
+	Severity       string
+	Summary        string
+	Payload        json.RawMessage
+	ReplyContextID string
 }
 
 type MailboxWriteMaterializationStore interface {
@@ -109,16 +110,17 @@ func (pc *PipelineCoordinator) materializeMailboxItem(ctx context.Context, actio
 	}
 	itemID := deterministicMailboxItemID(sourceEventID, nodeID)
 	record := MailboxWriteMaterialization{
-		ItemID:        itemID,
-		EntityID:      strings.TrimSpace(entityID),
-		FlowInstance:  flowInstance,
-		Scope:         scope,
-		ItemType:      normalizedType,
-		SourceEventID: sourceEventID,
-		FromAgent:     "system_node:" + nodeID,
-		Severity:      severity,
-		Summary:       summary,
-		Payload:       json.RawMessage(payloadJSON),
+		ItemID:         itemID,
+		EntityID:       strings.TrimSpace(entityID),
+		FlowInstance:   flowInstance,
+		Scope:          scope,
+		ItemType:       normalizedType,
+		SourceEventID:  sourceEventID,
+		FromAgent:      "system_node:" + nodeID,
+		Severity:       severity,
+		Summary:        summary,
+		Payload:        json.RawMessage(payloadJSON),
+		ReplyContextID: events.DeliveryContextFromContext(ctx).ReplyContextID(),
 	}
 	if err := pc.mailboxMaterializer.MaterializeMailboxWrite(ctx, record); err != nil {
 		return fmt.Errorf("mailbox_write materialize: %w", err)

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -58,6 +58,7 @@ func withWorkflowNodeDeliveryRoute(ctx context.Context, route events.DeliveryRou
 		return nil
 	}
 	route = route.Normalized()
+	ctx = events.WithDeliveryContext(ctx, route.Context)
 	return context.WithValue(ctx, workflowNodeDeliveryRouteKey{}, route)
 }
 

--- a/internal/runtime/pipeline/scheduler.go
+++ b/internal/runtime/pipeline/scheduler.go
@@ -7,10 +7,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	"github.com/robfig/cron/v3"
 )
 
 type Schedule struct {
+	Context      events.DeliveryContext
 	RunID        string
 	AgentID      string
 	EventType    string
@@ -32,6 +34,13 @@ func (s *Schedule) NormalizeRunID() {
 		return
 	}
 	s.RunID = s.EffectiveRunID()
+}
+
+func (s *Schedule) NormalizeDeliveryContext() {
+	if s == nil {
+		return
+	}
+	s.Context = s.Context.Normalized()
 }
 
 func (s Schedule) EffectiveEntityID() string {
@@ -89,6 +98,7 @@ func (s *Scheduler) Register(sc Schedule) error {
 		return errors.New("agent_id and event_type are required")
 	}
 	sc.NormalizeRunID()
+	sc.NormalizeDeliveryContext()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
 	if sc.Mode == "" {

--- a/internal/runtime/pipeline/scheduler_run_identity_test.go
+++ b/internal/runtime/pipeline/scheduler_run_identity_test.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"testing"
 	"time"
+
+	"github.com/division-sh/swarm/internal/events"
 )
 
 func TestSchedulerKeysSchedulesByRunID(t *testing.T) {
@@ -46,4 +48,31 @@ func TestSchedulerKeysSchedulesByRunID(t *testing.T) {
 		t.Fatalf("run B schedule was cancelled by run A exact cancel")
 	}
 	s.Stop()
+}
+
+func TestSchedulerOneShotPreservesReplyContextToFire(t *testing.T) {
+	fired := make(chan Schedule, 1)
+	scheduler := NewScheduler(func(schedule Schedule) {
+		fired <- schedule
+	})
+	t.Cleanup(scheduler.Stop)
+	want := "reply-v1:one-shot-fire"
+	if err := scheduler.Register(Schedule{
+		Context:   events.DeliveryContext{Reply: &events.ReplyContextRef{ID: want}},
+		AgentID:   "provider-agent",
+		EventType: "provider.resume",
+		Mode:      "once",
+		At:        time.Now().Add(10 * time.Millisecond),
+		TaskID:    "reply-resume",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	select {
+	case got := <-fired:
+		if got.Context.ReplyContextID() != want {
+			t.Fatalf("fired reply context = %q, want %q", got.Context.ReplyContextID(), want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("one-shot schedule did not fire")
+	}
 }

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -14,6 +14,7 @@ import (
 )
 
 type FlowInstanceActivationRequest struct {
+	Context        events.DeliveryContext
 	ContractBundle semanticview.Source
 	Instance       runtimeflowidentity.Instance
 	InitialState   string
@@ -77,6 +78,7 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 		EntityID:     sourceEntityID,
 	}
 	req := FlowInstanceActivationRequest{
+		Context:        events.DeliveryContextFromContext(ctx),
 		ContractBundle: pc.SemanticSource(),
 		Instance:       instance,
 		InitialState:   strings.TrimSpace(plan.AdvancesTo),

--- a/internal/runtime/replycontext/model.go
+++ b/internal/runtime/replycontext/model.go
@@ -1,0 +1,144 @@
+package replycontext
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+type State string
+
+const (
+	StateOpen     State = "open"
+	StateTerminal State = "terminal"
+)
+
+type Record struct {
+	ID                   string
+	RunID                string
+	RequestEventID       string
+	RequesterFlowID      string
+	RequestOutputPin     string
+	ReplyInputPin        string
+	ProviderFlowID       string
+	ProviderInputPin     string
+	ProviderOutputPin    string
+	Origin               events.RouteIdentity
+	RequestCorrelationID string
+	CorrelationKey       string
+	State                State
+	AcceptedReplyEventID string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	TerminalAt           *time.Time
+}
+
+func (r Record) Normalized() Record {
+	r.ID = strings.TrimSpace(r.ID)
+	r.RunID = strings.TrimSpace(r.RunID)
+	r.RequestEventID = strings.TrimSpace(r.RequestEventID)
+	r.RequesterFlowID = strings.TrimSpace(r.RequesterFlowID)
+	r.RequestOutputPin = strings.TrimSpace(r.RequestOutputPin)
+	r.ReplyInputPin = strings.TrimSpace(r.ReplyInputPin)
+	r.ProviderFlowID = strings.TrimSpace(r.ProviderFlowID)
+	r.ProviderInputPin = strings.TrimSpace(r.ProviderInputPin)
+	r.ProviderOutputPin = strings.TrimSpace(r.ProviderOutputPin)
+	r.Origin = r.Origin.Normalized()
+	r.RequestCorrelationID = strings.TrimSpace(r.RequestCorrelationID)
+	r.CorrelationKey = strings.TrimSpace(r.CorrelationKey)
+	r.AcceptedReplyEventID = strings.TrimSpace(r.AcceptedReplyEventID)
+	if r.State == "" {
+		r.State = StateOpen
+	}
+	if !r.CreatedAt.IsZero() {
+		r.CreatedAt = r.CreatedAt.UTC()
+	}
+	if !r.UpdatedAt.IsZero() {
+		r.UpdatedAt = r.UpdatedAt.UTC()
+	}
+	if r.TerminalAt != nil {
+		terminalAt := r.TerminalAt.UTC()
+		r.TerminalAt = &terminalAt
+	}
+	return r
+}
+
+func (r Record) Validate() error {
+	r = r.Normalized()
+	if r.ID == "" || r.RequestEventID == "" || r.RequesterFlowID == "" || r.RequestOutputPin == "" || r.ReplyInputPin == "" || r.ProviderFlowID == "" || r.ProviderInputPin == "" || r.ProviderOutputPin == "" || r.RequestCorrelationID == "" {
+		return fmt.Errorf("reply context requires stable id, request identity, paired topology, and correlation")
+	}
+	if r.Origin.Empty() {
+		return fmt.Errorf("reply context origin route is required")
+	}
+	switch r.State {
+	case StateOpen:
+		if r.AcceptedReplyEventID != "" || r.TerminalAt != nil {
+			return fmt.Errorf("open reply context cannot have terminal reply state")
+		}
+	case StateTerminal:
+		if r.AcceptedReplyEventID == "" || r.TerminalAt == nil {
+			return fmt.Errorf("terminal reply context requires accepted reply event and terminal time")
+		}
+	default:
+		return fmt.Errorf("unsupported reply context state %q", r.State)
+	}
+	return nil
+}
+
+// SameIdentity reports whether two records describe the same immutable
+// request/reply authority. Lifecycle fields and timestamps may change after
+// creation and therefore are intentionally excluded.
+func (r Record) SameIdentity(other Record) bool {
+	r = r.Normalized()
+	other = other.Normalized()
+	return r.ID == other.ID &&
+		r.RunID == other.RunID &&
+		r.RequestEventID == other.RequestEventID &&
+		r.RequesterFlowID == other.RequesterFlowID &&
+		r.RequestOutputPin == other.RequestOutputPin &&
+		r.ReplyInputPin == other.ReplyInputPin &&
+		r.ProviderFlowID == other.ProviderFlowID &&
+		r.ProviderInputPin == other.ProviderInputPin &&
+		r.ProviderOutputPin == other.ProviderOutputPin &&
+		r.Origin == other.Origin &&
+		r.RequestCorrelationID == other.RequestCorrelationID &&
+		r.CorrelationKey == other.CorrelationKey
+}
+
+func DeterministicID(requestEventID, requesterFlowID, requestOutputPin, replyInputPin, providerFlowID string, origin events.RouteIdentity) string {
+	origin = origin.Normalized()
+	material := strings.Join([]string{
+		strings.TrimSpace(requestEventID),
+		strings.TrimSpace(requesterFlowID),
+		strings.TrimSpace(requestOutputPin),
+		strings.TrimSpace(replyInputPin),
+		strings.TrimSpace(providerFlowID),
+		origin.FlowID,
+		origin.FlowInstance,
+		origin.EntityID,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(material))
+	return "reply-v1:" + hex.EncodeToString(sum[:])
+}
+
+type ClaimOutcome string
+
+const (
+	ClaimAccepted   ClaimOutcome = "accepted"
+	ClaimIdempotent ClaimOutcome = "idempotent"
+	ClaimTerminal   ClaimOutcome = "already_terminal"
+)
+
+type Store interface {
+	CreateReplyContext(context.Context, Record) error
+	LoadReplyContext(context.Context, string) (Record, error)
+	ClaimReplyContext(context.Context, string, string) (Record, ClaimOutcome, error)
+}
+
+var ErrNotFound = fmt.Errorf("reply context not found")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -474,6 +474,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	rt.Scheduler = runtimepipeline.NewScheduler(func(sc runtimepipeline.Schedule) {
 		callbackCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
+		callbackCtx = events.WithDeliveryContext(callbackCtx, sc.Context)
 		if err := rt.Bus.Publish(callbackCtx, scheduledEvent(sc)); err != nil {
 			if rt.Logger != nil {
 				handleRuntimeLogPersistenceError("scheduler", "publish_failed", rt.Logger.Error(callbackCtx, "scheduler", "publish_failed", map[string]any{

--- a/internal/runtime/testfixtures/templatereply/fixture.go
+++ b/internal/runtime/testfixtures/templatereply/fixture.go
@@ -32,6 +32,7 @@ type Options struct {
 	AmbiguousRequestEdge      bool
 	MismatchedProvider        bool
 	DefaultEventIDCorrelation bool
+	OptionalReplyCorrelation  bool
 	ProviderContinuation      string
 	ContinuationRequestKey    string
 	ContinuationAccountID     string
@@ -144,7 +145,7 @@ requester_state:
     type: text
     _unused_reason: template reply origin identity fixture field
 `)
-	writeFile(t, filepath.Join(root, "flows", "requester", "events.yaml"), eventContractsYAML())
+	writeFile(t, filepath.Join(root, "flows", "requester", "events.yaml"), eventContractsYAML(opts.OptionalReplyCorrelation))
 	writeFile(t, filepath.Join(root, "flows", "requester", "nodes.yaml"), `
 requester-node:
   id: requester-node
@@ -174,7 +175,7 @@ pins:
 `)
 	writeFlowSupportFiles(t, root, flowID)
 	writeFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), "{}\n")
-	writeFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), eventContractsYAML())
+	writeFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), eventContractsYAML(opts.OptionalReplyCorrelation))
 	writeFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), providerNodesYAML(opts))
 }
 
@@ -271,7 +272,11 @@ provider-node:
 	}
 }
 
-func eventContractsYAML() string {
+func eventContractsYAML(optionalReplyCorrelation bool) string {
+	replyRequired := "[provider_request_id, account_id, result]"
+	if optionalReplyCorrelation {
+		replyRequired = "[account_id, result]"
+	}
 	return `
 provider.requested:
   provider_request_id: text
@@ -281,7 +286,7 @@ provider.replied:
   provider_request_id: text
   account_id: text
   result: text
-  required: [provider_request_id, account_id, result]
+  required: ` + replyRequired + `
 `
 }
 

--- a/internal/runtime/testfixtures/templatereply/fixture.go
+++ b/internal/runtime/testfixtures/templatereply/fixture.go
@@ -1,0 +1,311 @@
+package templatereply
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	RequesterFlowID     = "requester"
+	RequesterRequestPin = "provider_requested"
+	RequesterReplyPin   = "provider_replied"
+	RequesterNodeID     = "requester-node"
+	ProviderFlowID      = "provider"
+	ProviderRequestPin  = "provider_requested"
+	ProviderReplyPin    = "provider_replied"
+	ProviderNodeID      = "provider-node"
+	RequestEvent        = "provider.requested"
+	ReplyEvent          = "provider.replied"
+	CorrelationKey      = "provider_request_id"
+	ContinuationMailbox = "mailbox"
+	ContinuationHuman   = "human_task"
+)
+
+type Options struct {
+	MissingRepliesTo          bool
+	MissingCorrelationCarry   bool
+	AmbiguousRequestEdge      bool
+	MismatchedProvider        bool
+	DefaultEventIDCorrelation bool
+	ProviderContinuation      string
+	ContinuationRequestKey    string
+	ContinuationAccountID     string
+}
+
+func LoadBundle(t testing.TB, opts Options) *runtimecontracts.WorkflowContractBundle {
+	t.Helper()
+	bundle, err := LoadBundleResult(t, opts)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return bundle
+}
+
+func LoadBundleResult(t testing.TB, opts Options) (*runtimecontracts.WorkflowContractBundle, error) {
+	t.Helper()
+	root := Write(t, opts)
+	return runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRoot(t)))
+}
+
+func LoadSource(t testing.TB, opts Options) semanticview.Source {
+	t.Helper()
+	return semanticview.Wrap(LoadBundle(t, opts))
+}
+
+func Write(t testing.TB, opts Options) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.yaml"), packageYAML(opts))
+	writeFile(t, filepath.Join(root, "schema.yaml"), "name: template-reply\n")
+	for _, name := range []string{"policy.yaml", "tools.yaml", "agents.yaml", "events.yaml", "nodes.yaml"} {
+		writeFile(t, filepath.Join(root, name), "{}\n")
+	}
+	writeRequester(t, root, opts)
+	writeProvider(t, root, "provider", opts)
+	if opts.MismatchedProvider {
+		writeProvider(t, root, "other-provider", Options{})
+	}
+	return root
+}
+
+func packageYAML(opts Options) string {
+	extraFlow := ""
+	replyFrom := "provider.provider_replied"
+	if opts.MismatchedProvider {
+		extraFlow = "  - id: other-provider\n    flow: other-provider\n    mode: static\n"
+		replyFrom = "other-provider.provider_replied"
+	}
+	extraRequest := ""
+	if opts.AmbiguousRequestEdge {
+		extraRequest = "  - from: requester.provider_requested\n    to: provider.provider_requested\n"
+	}
+	return `name: template-reply
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: requester
+    flow: requester
+    mode: template
+  - id: provider
+    flow: provider
+    mode: static
+` + extraFlow + `connect:
+  - from: requester.provider_requested
+    to: provider.provider_requested
+` + extraRequest + `  - from: ` + replyFrom + `
+    to: requester.provider_replied
+`
+}
+
+func writeRequester(t testing.TB, root string, opts Options) {
+	repliesTo := "          replies_to: provider_requested\n"
+	if opts.MissingRepliesTo {
+		repliesTo = ""
+	}
+	carries := "        carries: [provider_request_id]\n"
+	if opts.MissingCorrelationCarry {
+		carries = ""
+	}
+	correlation := "          correlation_key: provider_request_id\n"
+	if opts.DefaultEventIDCorrelation {
+		correlation = ""
+	}
+	writeFile(t, filepath.Join(root, "flows", "requester", "schema.yaml"), `
+name: requester
+mode: template
+instance:
+  by: account_id
+  on_missing: reject
+  on_conflict: reject
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: provider_replied
+        event: provider.replied
+        resolution:
+          mode: reply
+`+repliesTo+correlation+`  outputs:
+    events:
+      - name: provider_requested
+        event: provider.requested
+        key: provider_request_id
+`+carries)
+	writeFlowSupportFiles(t, root, "requester")
+	writeFile(t, filepath.Join(root, "flows", "requester", "entities.yaml"), `
+requester_state:
+  account_id:
+    type: text
+    _unused_reason: template reply origin identity fixture field
+`)
+	writeFile(t, filepath.Join(root, "flows", "requester", "events.yaml"), eventContractsYAML())
+	writeFile(t, filepath.Join(root, "flows", "requester", "nodes.yaml"), `
+requester-node:
+  id: requester-node
+  execution_type: system_node
+  subscribes_to: [provider.replied]
+  event_handlers:
+    provider.replied:
+      advances_to: active
+`)
+}
+
+func writeProvider(t testing.TB, root, flowID string, opts Options) {
+	writeFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+pins:
+  inputs:
+    events:
+      - name: provider_requested
+        event: provider.requested
+`+providerContinuationInputsYAML(opts)+`  outputs:
+    events:
+      - name: provider_replied
+        event: provider.replied
+        key: provider_request_id
+        carries: [provider_request_id]
+`)
+	writeFlowSupportFiles(t, root, flowID)
+	writeFile(t, filepath.Join(root, "flows", flowID, "entities.yaml"), "{}\n")
+	writeFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), eventContractsYAML())
+	writeFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), providerNodesYAML(opts))
+}
+
+func providerContinuationInputsYAML(opts Options) string {
+	switch opts.ProviderContinuation {
+	case ContinuationMailbox:
+		return `      - name: mailbox_deferred
+        event: mailbox.item_deferred
+      - name: mailbox_decided
+        event: mailbox.item_decided
+`
+	case ContinuationHuman:
+		return `      - name: human_task_deferred
+        event: human_task.deferred
+      - name: human_task_approved
+        event: human_task.approved
+`
+	default:
+		return ""
+	}
+}
+
+func providerNodesYAML(opts Options) string {
+	switch opts.ProviderContinuation {
+	case ContinuationMailbox:
+		return `
+provider-node:
+  id: provider-node
+  execution_type: system_node
+  subscribes_to: [provider.requested, mailbox.item_deferred, mailbox.item_decided]
+  produces: [provider.replied]
+  event_handlers:
+    provider.requested:
+      action:
+        id: mailbox_write
+        mailbox:
+          item_type:
+            literal: approval
+          summary:
+            literal: Review provider response
+          payload:
+            provider_request_id:
+              ref: payload.provider_request_id
+            account_id:
+              ref: payload.account_id
+    mailbox.item_deferred: {}
+    mailbox.item_decided:
+      emit:
+        event: provider.replied
+        fields:
+          provider_request_id: payload.mailbox_payload.provider_request_id
+          account_id: payload.mailbox_payload.account_id
+          result:
+            literal: approved
+`
+	case ContinuationHuman:
+		requestKey := opts.ContinuationRequestKey
+		if requestKey == "" {
+			requestKey = "human-request"
+		}
+		accountID := opts.ContinuationAccountID
+		if accountID == "" {
+			accountID = "account-a"
+		}
+		return `
+provider-node:
+  id: provider-node
+  execution_type: system_node
+  subscribes_to: [provider.requested, human_task.deferred, human_task.approved]
+  produces: [provider.replied]
+  event_handlers:
+    provider.requested: {}
+    human_task.deferred: {}
+    human_task.approved:
+      emit:
+        event: provider.replied
+        fields:
+          provider_request_id:
+            literal: ` + requestKey + `
+          account_id:
+            literal: ` + accountID + `
+          result:
+            literal: approved
+`
+	default:
+		return `
+provider-node:
+  id: provider-node
+  execution_type: system_node
+  subscribes_to: [provider.requested]
+  event_handlers:
+    provider.requested: {}
+`
+	}
+}
+
+func eventContractsYAML() string {
+	return `
+provider.requested:
+  provider_request_id: text
+  account_id: text
+  required: [provider_request_id, account_id]
+provider.replied:
+  provider_request_id: text
+  account_id: text
+  result: text
+  required: [provider_request_id, account_id, result]
+`
+}
+
+func writeFlowSupportFiles(t testing.TB, root, flowID string) {
+	for _, name := range []string{"policy.yaml", "tools.yaml", "agents.yaml"} {
+		writeFile(t, filepath.Join(root, "flows", flowID, name), "{}\n")
+	}
+}
+
+func writeFile(t testing.TB, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve template reply fixture path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}

--- a/internal/runtime/tools/deps.go
+++ b/internal/runtime/tools/deps.go
@@ -30,6 +30,10 @@ type EventPublisher interface {
 	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
 }
 
+type MutationEventPublisher interface {
+	PublishInMutation(ctx context.Context, evt events.Event) error
+}
+
 type Scheduler interface {
 	Register(runtimepipeline.Schedule) error
 	Stop()

--- a/internal/runtime/tools/executor.go
+++ b/internal/runtime/tools/executor.go
@@ -760,6 +760,10 @@ func (e *Executor) ExecMailboxSendDirect(actor models.AgentConfig, input any) (a
 	return e.execMailboxSend(context.Background(), actor, input)
 }
 
+func (e *Executor) ExecMailboxSendDirectContext(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
+	return e.execMailboxSend(ctx, actor, input)
+}
+
 func (e *Executor) ExecHumanTaskRequestDirect(ctx context.Context, actor models.AgentConfig, input any) (any, error) {
 	return e.execHumanTaskRequest(ctx, actor, input)
 }

--- a/internal/runtime/tools/executor_human_tasks.go
+++ b/internal/runtime/tools/executor_human_tasks.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
 
@@ -84,15 +86,28 @@ func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentC
 		}
 	}
 
+	flowInstance := actor.CanonicalFlowPath()
+	var sourceEventID string
+	if inbound, ok := runtimebus.InboundEventFromContext(ctx); ok {
+		sourceEventID = inbound.ID()
+		if target := inbound.TargetRoute().Normalized(); target.FlowInstance != "" {
+			flowInstance = target.FlowInstance
+		} else if inbound.FlowInstance() != "" {
+			flowInstance = inbound.FlowInstance()
+		}
+	}
 	taskID, err := store.CreateHumanTask(ctx, HumanTaskCreateRecord{
 		ActorID:       actor.ID,
 		EntityID:      in.EntityID,
+		FlowInstance:  flowInstance,
 		Category:      in.Category,
 		Description:   in.Description,
 		TalkingPoints: talkingJSON,
 		ExpectedValue: in.ExpectedValue,
 		Priority:      in.Priority,
 		Deadline:      deadline,
+		SourceEventID: sourceEventID,
+		Context:       events.DeliveryContextFromContext(ctx),
 	})
 	if err != nil {
 		return nil, err
@@ -174,15 +189,20 @@ func (e *Executor) execHumanTaskDecide(ctx context.Context, actor models.AgentCo
 		}
 	}
 skipBudget:
+	var decisionEventPublish func(context.Context, events.Event) error
+	if publisher, ok := e.bus.(MutationEventPublisher); ok && publisher != nil {
+		decisionEventPublish = publisher.PublishInMutation
+	}
 
 	if err := store.DecideHumanTask(ctx, HumanTaskDecisionRecord{
-		TaskID:       in.TaskID,
-		Status:       newStatus,
-		ActorID:      actor.ID,
-		Reason:       in.Reason,
-		PriorityRank: in.PriorityRank,
-		RequeueDate:  in.RequeueDate,
-		DecidedAt:    time.Now().UTC(),
+		TaskID:               in.TaskID,
+		Status:               newStatus,
+		ActorID:              actor.ID,
+		Reason:               in.Reason,
+		PriorityRank:         in.PriorityRank,
+		RequeueDate:          in.RequeueDate,
+		DecidedAt:            time.Now().UTC(),
+		DecisionEventPublish: decisionEventPublish,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/runtime/tools/executor_mailbox.go
+++ b/internal/runtime/tools/executor_mailbox.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
 
@@ -69,15 +70,16 @@ func (e *Executor) execMailboxSend(ctx context.Context, actor models.AgentConfig
 	}
 
 	id, err := store.InsertMailboxItem(ctx, MailboxItem{
-		EventID:   in.EventID,
-		EntityID:  in.EntityID,
-		FromAgent: actor.ID,
-		Type:      in.Type,
-		Priority:  in.Priority,
-		Status:    "pending",
-		Context:   ctxJSON,
-		Summary:   in.Summary,
-		TimeoutAt: timeout,
+		EventID:        in.EventID,
+		EntityID:       in.EntityID,
+		FromAgent:      actor.ID,
+		Type:           in.Type,
+		Priority:       in.Priority,
+		Status:         "pending",
+		Context:        ctxJSON,
+		Summary:        in.Summary,
+		TimeoutAt:      timeout,
+		ReplyContextID: events.DeliveryContextFromContext(ctx).ReplyContextID(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -17,6 +17,7 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/store"
@@ -28,6 +29,7 @@ import (
 type humanTaskToolStore interface {
 	runtimetools.HumanTaskPersistence
 	runtimetools.MailboxPersistence
+	runtimereplycontext.Store
 	GetV1MailboxItem(ctx context.Context, id string) (store.MailboxV1ItemDetail, error)
 }
 
@@ -256,11 +258,50 @@ func TestHumanTaskTools_BackendNeutralPersistence(t *testing.T) {
 			}}
 			exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
 				Config:            cfg,
+				MailboxStore:      tc.store,
 				HumanTaskStore:    tc.store,
 				AuthorityProvider: allowHumanTaskAuthority{},
 			})
-			requester := models.AgentConfig{ID: "requester", Role: "worker", EntityID: uuid.NewString()}
+			requester := models.AgentConfig{
+				ID:          "requester",
+				Role:        "worker",
+				FlowPath:    "provider",
+				EntityID:    uuid.NewString(),
+				Tools:       []string{"human_task_request", "mailbox_send"},
+				Permissions: []string{"human_task_request"},
+			}
 			decider := models.AgentConfig{ID: "decider", Role: "operator"}
+
+			replyCtx, replyContextID, requestEventID := seedReplyToolContext(t, tc.store)
+			replyTaskOut, err := exec.ExecHumanTaskRequestDirect(replyCtx, requester, map[string]any{
+				"category":       "review",
+				"description":    "Needs reply-scoped human review",
+				"expected_value": "approval",
+				"priority":       "high",
+			})
+			if err != nil {
+				t.Fatalf("reply-scoped human_task_request: %v", err)
+			}
+			replyTaskID := strings.TrimSpace(asString(replyTaskOut.(map[string]any)["task_id"]))
+			replyTask, err := tc.store.GetMailboxItem(context.Background(), replyTaskID)
+			if err != nil || replyTask.ReplyContextID != replyContextID || replyTask.FlowInstance != "provider" {
+				t.Fatalf("reply-scoped human task = %#v err=%v", replyTask, err)
+			}
+			mailboxOut, err := exec.ExecMailboxSendDirectContext(replyCtx, requester, map[string]any{
+				"event_id": requestEventID,
+				"type":     "approval",
+				"priority": "normal",
+				"summary":  "Needs reply-scoped mailbox review",
+				"context":  map[string]any{"kind": "reply"},
+			})
+			if err != nil {
+				t.Fatalf("reply-scoped mailbox_send: %v", err)
+			}
+			mailboxID := strings.TrimSpace(asString(mailboxOut.(map[string]any)["mailbox_id"]))
+			mailboxItem, err := tc.store.GetMailboxItem(context.Background(), mailboxID)
+			if err != nil || mailboxItem.ReplyContextID != replyContextID {
+				t.Fatalf("reply-scoped mailbox item = %#v err=%v", mailboxItem, err)
+			}
 
 			firstID := createHumanTaskWithExecutor(t, exec, requester)
 			firstItem, err := tc.store.GetMailboxItem(context.Background(), firstID)
@@ -331,6 +372,71 @@ func TestHumanTaskTools_BackendNeutralPersistence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func seedReplyToolContext(t *testing.T, persistence humanTaskToolStore) (context.Context, string, string) {
+	t.Helper()
+	runID := uuid.NewString()
+	requestEventID := uuid.NewString()
+	now := time.Now().UTC()
+	switch typed := persistence.(type) {
+	case *store.PostgresStore:
+		if _, err := typed.DB.ExecContext(context.Background(), `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, now); err != nil {
+			t.Fatalf("seed postgres reply tool run: %v", err)
+		}
+		if _, err := typed.DB.ExecContext(context.Background(), `
+			INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES ($1::uuid, $2::uuid, 'provider.requested', 'global', '{}'::jsonb, 'requester', 'node', $3)
+		`, runID, requestEventID, now); err != nil {
+			t.Fatalf("seed postgres reply tool event: %v", err)
+		}
+	case *store.SQLiteRuntimeStore:
+		if _, err := typed.DB.ExecContext(context.Background(), `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, now); err != nil {
+			t.Fatalf("seed sqlite reply tool run: %v", err)
+		}
+		if _, err := typed.DB.ExecContext(context.Background(), `
+			INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+			VALUES (?, ?, 'provider.requested', 'global', '{}', 'requester', 'node', ?)
+		`, runID, requestEventID, now); err != nil {
+			t.Fatalf("seed sqlite reply tool event: %v", err)
+		}
+	default:
+		t.Fatalf("unsupported reply tool store %T", persistence)
+	}
+	record := runtimereplycontext.Record{
+		RunID:                runID,
+		RequestEventID:       requestEventID,
+		RequesterFlowID:      "requester",
+		RequestOutputPin:     "provider_requested",
+		ReplyInputPin:        "provider_replied",
+		ProviderFlowID:       "provider",
+		ProviderInputPin:     "provider_requested",
+		ProviderOutputPin:    "provider_replied",
+		Origin:               events.RouteIdentity{FlowID: "requester", FlowInstance: "requester/account-a", EntityID: uuid.NewString()},
+		RequestCorrelationID: requestEventID,
+		State:                runtimereplycontext.StateOpen,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	record.ID = runtimereplycontext.DeterministicID(record.RequestEventID, record.RequesterFlowID, record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID, record.Origin)
+	if err := persistence.CreateReplyContext(context.Background(), record); err != nil {
+		t.Fatalf("seed reply tool context: %v", err)
+	}
+	inbound := eventtest.RootIngress(
+		requestEventID,
+		events.EventType("provider.requested"),
+		"",
+		"",
+		nil,
+		0,
+		runID,
+		"",
+		events.EnvelopeForSourceRoute(events.EventEnvelope{}, events.RouteIdentity{FlowID: "provider", FlowInstance: "provider"}),
+		now,
+	)
+	ctx := runtimebus.WithInboundEvent(runtimecorrelation.WithRunID(context.Background(), runID), inbound)
+	ctx = events.WithDeliveryContext(ctx, events.DeliveryContext{Reply: &events.ReplyContextRef{ID: record.ID}})
+	return ctx, record.ID, requestEventID
 }
 
 func assertHumanTaskDeferredProjection(t *testing.T, store humanTaskToolStore, taskID string) {

--- a/internal/runtime/tools/persistence.go
+++ b/internal/runtime/tools/persistence.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	corestate "github.com/division-sh/swarm/internal/runtime/core/state"
 )
 
@@ -94,20 +95,24 @@ type HumanTaskPersistence interface {
 type HumanTaskCreateRecord struct {
 	ActorID       string
 	EntityID      string
+	FlowInstance  string
 	Category      string
 	Description   string
 	TalkingPoints json.RawMessage
 	ExpectedValue string
 	Priority      string
 	Deadline      time.Time
+	SourceEventID string
+	Context       events.DeliveryContext
 }
 
 type HumanTaskDecisionRecord struct {
-	TaskID       string
-	Status       string
-	ActorID      string
-	Reason       string
-	PriorityRank int
-	RequeueDate  string
-	DecidedAt    time.Time
+	TaskID               string
+	Status               string
+	ActorID              string
+	Reason               string
+	PriorityRank         int
+	RequeueDate          string
+	DecidedAt            time.Time
+	DecisionEventPublish func(context.Context, events.Event) error
 }

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -317,6 +317,20 @@ func destructiveResetCleanupSeverPreservedReferences(ctx context.Context, exec d
 				  )
 			`,
 		},
+		{
+			name: "mailbox.reply_context_id",
+			query: `
+				UPDATE mailbox preserved
+				SET reply_context_id = NULL
+				WHERE preserved.reply_context_id IS NOT NULL
+				  AND EXISTS (
+					SELECT 1
+					FROM reply_contexts cleanup
+					WHERE cleanup.reply_context_id = preserved.reply_context_id
+					  AND cleanup.run_id = ANY($1::uuid[])
+				  )
+			`,
+		},
 	}
 	for _, stmt := range statements {
 		if _, err := exec.ExecContext(ctx, stmt.query, pq.Array(runIDs)); err != nil {
@@ -428,7 +442,7 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBu
 			return `SELECT COUNT(*) FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
 		}
 		return `DELETE FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
-	case "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "entity_mutations", "entity_state", "run_control_state", "events", "runs":
+	case "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
 		if mode == "count" {
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -434,6 +434,8 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 	predecessorSessionID := uuid.NewString()
 	cleanupTimerID := uuid.NewString()
 	preservedTimerID := uuid.NewString()
+	replyContextID := "reply-v1:cleanup-" + uuid.NewString()
+	mailboxID := uuid.NewString()
 	crossRunDeliveryID := uuid.NewString()
 	entityID := uuid.NewString()
 	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO agents (agent_id, role, model, conversation_mode) VALUES ('agent-a', 'operator', 'default', 'session')`); err != nil {
@@ -492,6 +494,26 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 		VALUES ($1::uuid, 'preserved source timer', $2::uuid, 'timer.global', now(), 'global_recurring')
 	`, preservedTimerID, cleanupTimerID); err != nil {
 		t.Fatalf("seed preserved source timer: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO reply_contexts (
+			reply_context_id, run_id, request_event_id, requester_flow_id, request_output_pin,
+			reply_input_pin, provider_flow_id, provider_input_pin, provider_output_pin,
+			origin_route, request_correlation_id, state
+		)
+		VALUES (
+			$1, $2::uuid, $3::uuid, 'requester', 'provider_requested', 'provider_replied',
+			'provider', 'provider_requested', 'provider_replied',
+			'{"flow_id":"requester","flow_instance":"requester/a"}'::jsonb, $3::text, 'open'
+		)
+	`, replyContextID, runID, eventID); err != nil {
+		t.Fatalf("seed cleanup reply context: %v", err)
+	}
+	if _, err := pg.DB.ExecContext(ctx, `
+		INSERT INTO mailbox (item_id, item_type, source_event_id, from_agent, summary, reply_context_id)
+		VALUES ($1::uuid, 'human_task', $2::uuid, 'agent-a', 'preserved reply mailbox', $3)
+	`, mailboxID, eventID, replyContextID); err != nil {
+		t.Fatalf("seed preserved reply mailbox: %v", err)
 	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO runtime_ingress_state (status, controlled_by, transition_event_id)
@@ -583,6 +605,16 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 	}
 	if sourceTimer.Valid {
 		t.Fatalf("preserved timer source_timer_id = %q, want NULL", sourceTimer.String)
+	}
+	if got := countRowsWhere(t, ctx, pg, "reply_contexts", `reply_context_id = $1`, replyContextID); got != 0 {
+		t.Fatalf("cleanup reply context rows = %d, want deleted", got)
+	}
+	var mailboxReplyContext sql.NullString
+	if err := pg.DB.QueryRowContext(ctx, `SELECT reply_context_id FROM mailbox WHERE item_id = $1::uuid`, mailboxID).Scan(&mailboxReplyContext); err != nil {
+		t.Fatalf("read preserved mailbox reply context: %v", err)
+	}
+	if mailboxReplyContext.Valid {
+		t.Fatalf("preserved mailbox reply_context_id = %q, want NULL", mailboxReplyContext.String)
 	}
 }
 

--- a/internal/store/event_mutation.go
+++ b/internal/store/event_mutation.go
@@ -48,9 +48,22 @@ func (m *sqlEventMutation) operationContext(ctx context.Context) context.Context
 	return ctx
 }
 
+func (m *sqlEventMutation) validatePipelineTransaction(ctx context.Context) error {
+	if m == nil || m.tx == nil {
+		return fmt.Errorf("event mutation transaction is required")
+	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != m.tx {
+		return fmt.Errorf("event mutation belongs to a different pipeline transaction")
+	}
+	return nil
+}
+
 func (m *sqlEventMutation) AppendEvent(ctx context.Context, evt events.Event) error {
 	if m == nil || m.txStore == nil {
 		return fmt.Errorf("event mutation store is required")
+	}
+	if err := m.validatePipelineTransaction(ctx); err != nil {
+		return err
 	}
 	return m.txStore.AppendEventTx(m.operationContext(ctx), m.tx, evt)
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -600,13 +600,17 @@ func (s *PostgresStore) ListEventDeliveryRoutes(ctx context.Context, eventID str
 	if caps.Events.DeliveryTargetRoute {
 		routeSelect = `COALESCE(delivery_target_route, '{}'::jsonb)`
 	}
+	contextSelect := `'{}'::jsonb`
+	if caps.Events.DeliveryContext {
+		contextSelect = `COALESCE(delivery_context, '{}'::jsonb)`
+	}
 	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
-		SELECT subscriber_type, subscriber_id, %s
+		SELECT subscriber_type, subscriber_id, %s, %s
 		FROM event_deliveries
 		WHERE event_id = $1::uuid
 		  AND NOT (subscriber_type = $2 AND subscriber_id = $3)
 		ORDER BY created_at ASC, delivery_id ASC
-	`, routeSelect), eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	`, routeSelect, contextSelect), eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
 	if err != nil {
 		return nil, fmt.Errorf("list event delivery routes: %w", err)
 	}
@@ -614,14 +618,15 @@ func (s *PostgresStore) ListEventDeliveryRoutes(ctx context.Context, eventID str
 	out := make([]events.DeliveryRoute, 0, 8)
 	for rows.Next() {
 		var subscriberType, subscriberID string
-		var raw json.RawMessage
-		if err := rows.Scan(&subscriberType, &subscriberID, &raw); err != nil {
+		var raw, contextRaw json.RawMessage
+		if err := rows.Scan(&subscriberType, &subscriberID, &raw, &contextRaw); err != nil {
 			return nil, fmt.Errorf("scan event delivery route: %w", err)
 		}
 		out = append(out, events.DeliveryRoute{
 			SubscriberType: subscriberType,
 			SubscriberID:   subscriberID,
 			Target:         decodeRouteIdentityJSON(raw),
+			Context:        decodeDeliveryContextJSON(contextRaw),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -967,6 +972,7 @@ func (s *PostgresStore) insertEventDeliveryRoutesSpec(ctx context.Context, caps 
 		execFn = tx.ExecContext
 	}
 	withTarget := caps.Events.DeliveryTargetRoute
+	withContext := caps.Events.DeliveryContext
 	q := `
 		INSERT INTO event_deliveries (event_id, subscriber_type, subscriber_id, reason_code, created_at)
 		VALUES ($1::uuid, $2, $3, $4, now())
@@ -997,6 +1003,25 @@ func (s *PostgresStore) insertEventDeliveryRoutesSpec(ctx context.Context, caps 
 			`
 		}
 	}
+	if withContext {
+		if !withTarget {
+			return fmt.Errorf("event_deliveries.delivery_target_route required with delivery_context")
+		}
+		q = `
+			INSERT INTO event_deliveries (event_id, subscriber_type, subscriber_id, reason_code, delivery_target_route, delivery_context, created_at)
+			VALUES ($1::uuid, $2, $3, $4, $5::jsonb, $6::jsonb, now())
+			ON CONFLICT DO NOTHING
+		`
+		if caps.Events.DeliveryRunID {
+			q = `
+				INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, reason_code, delivery_target_route, delivery_context, created_at)
+				SELECT e.run_id, e.event_id, $2, $3, $4, $5::jsonb, $6::jsonb, now()
+				FROM events e
+				WHERE e.event_id = $1::uuid
+				ON CONFLICT DO NOTHING
+			`
+		}
+	}
 	for _, route := range deliveryRoutes {
 		route = route.Normalized()
 		if route.SubscriberType == "" || route.SubscriberID == "" {
@@ -1008,11 +1033,39 @@ func (s *PostgresStore) insertEventDeliveryRoutesSpec(ctx context.Context, caps 
 		} else if !route.Target.Empty() {
 			return fmt.Errorf("event_deliveries.delivery_target_route required for target-routed delivery")
 		}
+		if withContext {
+			args = append(args, string(deliveryContextJSON(route.Context)))
+		} else if !route.Context.Empty() {
+			return fmt.Errorf("event_deliveries.delivery_context required for route-scoped reply context")
+		}
 		if _, err := execFn(ctx, q, args...); err != nil {
 			return fmt.Errorf("insert event delivery (%s=%s): %w", route.SubscriberType, route.SubscriberID, err)
 		}
 	}
 	return nil
+}
+
+func deliveryContextJSON(deliveryContext events.DeliveryContext) json.RawMessage {
+	deliveryContext = deliveryContext.Normalized()
+	if deliveryContext.Empty() {
+		return json.RawMessage(`{}`)
+	}
+	raw, err := json.Marshal(deliveryContext)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return raw
+}
+
+func decodeDeliveryContextJSON(raw []byte) events.DeliveryContext {
+	if len(raw) == 0 {
+		return events.DeliveryContext{}
+	}
+	var deliveryContext events.DeliveryContext
+	if err := json.Unmarshal(raw, &deliveryContext); err != nil {
+		return events.DeliveryContext{}
+	}
+	return deliveryContext.Normalized()
 }
 
 func deliveryRouteReasonCode(route events.DeliveryRoute) string {

--- a/internal/store/mailbox.go
+++ b/internal/store/mailbox.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/google/uuid"
 )
@@ -38,6 +39,9 @@ func (s *PostgresStore) InsertMailboxItem(ctx context.Context, item runtimetools
 	}
 	if len(item.Context) == 0 {
 		item.Context = []byte("{}")
+	}
+	if strings.TrimSpace(item.ReplyContextID) == "" {
+		item.ReplyContextID = events.DeliveryContextFromContext(ctx).ReplyContextID()
 	}
 	if caps.Mailbox == SchemaFlavorCanonical {
 		if err := s.insertMailboxItemSpec(ctx, item); err != nil {
@@ -207,14 +211,14 @@ func (s *PostgresStore) insertMailboxItemSpec(ctx context.Context, item runtimet
 		INSERT INTO mailbox (
 			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
 			from_agent, severity, summary, payload, status, decision, decision_notes,
-			notified, expires_at, created_at
+			notified, expires_at, reply_context_id, created_at
 		)
 		VALUES (
-			$1::uuid, NULLIF($2,'')::uuid, NULL, $3, $4, NULLIF($5,'')::uuid,
-			NULLIF($6,''), $7, NULLIF($8,''), $9::jsonb, $10, NULLIF($11,''),
-			NULLIF($12,''), $13, $14, now()
+			$1::uuid, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5, NULLIF($6,'')::uuid,
+			NULLIF($7,''), $8, NULLIF($9,''), $10::jsonb, $11, NULLIF($12,''),
+			NULLIF($13,''), $14, $15, NULLIF($16,''), now()
 		)
-	`, item.ID, coalesceMailboxEntityID(item), scope, item.Type, item.EventID, item.FromAgent, normalizeMailboxSeverity(item.Priority), item.Summary, string(item.Context), status, decision, item.DecisionNotes, item.Notified, expiresAt)
+	`, item.ID, coalesceMailboxEntityID(item), strings.Trim(strings.TrimSpace(item.FlowInstance), "/"), scope, item.Type, item.EventID, item.FromAgent, normalizeMailboxSeverity(item.Priority), item.Summary, string(item.Context), status, decision, item.DecisionNotes, item.Notified, expiresAt, strings.TrimSpace(item.ReplyContextID))
 	if err != nil {
 		return fmt.Errorf("insert mailbox item: %w", err)
 	}
@@ -228,6 +232,7 @@ func (s *PostgresStore) listMailboxItemsSpec(ctx context.Context, status string,
 			item_id::text,
 			COALESCE(source_event_id::text, ''),
 			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
 			COALESCE(from_agent, ''),
 			item_type,
 			COALESCE(severity, 'normal'),
@@ -237,7 +242,8 @@ func (s *PostgresStore) listMailboxItemsSpec(ctx context.Context, status string,
 			COALESCE(summary, ''),
 			expires_at,
 			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
+			COALESCE(decision_notes, ''),
+			COALESCE(reply_context_id, '')
 		FROM mailbox
 		WHERE `+where+`
 		ORDER BY created_at ASC
@@ -264,6 +270,7 @@ func (s *PostgresStore) getMailboxItemSpec(ctx context.Context, id string) (runt
 			item_id::text,
 			COALESCE(source_event_id::text, ''),
 			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
 			COALESCE(from_agent, ''),
 			item_type,
 			COALESCE(severity, 'normal'),
@@ -273,7 +280,8 @@ func (s *PostgresStore) getMailboxItemSpec(ctx context.Context, id string) (runt
 			COALESCE(summary, ''),
 			expires_at,
 			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
+			COALESCE(decision_notes, ''),
+			COALESCE(reply_context_id, '')
 		FROM mailbox
 		WHERE item_id = $1::uuid
 	`, id)
@@ -333,6 +341,7 @@ func (s *PostgresStore) expireMailboxItemsSpec(ctx context.Context, limit int) (
 			m.item_id::text,
 			COALESCE(m.source_event_id::text, ''),
 			COALESCE(m.entity_id::text, ''),
+			COALESCE(m.flow_instance, ''),
 			COALESCE(m.from_agent, ''),
 			m.item_type,
 			COALESCE(m.severity, 'normal'),
@@ -342,7 +351,8 @@ func (s *PostgresStore) expireMailboxItemsSpec(ctx context.Context, limit int) (
 			COALESCE(m.summary, ''),
 			m.expires_at,
 			COALESCE(m.decision, ''),
-			COALESCE(m.decision_notes, '')
+			COALESCE(m.decision_notes, ''),
+			COALESCE(m.reply_context_id, '')
 	`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("expire mailbox items: %w", err)
@@ -357,6 +367,7 @@ func (s *PostgresStore) listUnnotifiedCriticalMailboxItemsSpec(ctx context.Conte
 			item_id::text,
 			COALESCE(source_event_id::text, ''),
 			COALESCE(entity_id::text, ''),
+			COALESCE(flow_instance, ''),
 			COALESCE(from_agent, ''),
 			item_type,
 			COALESCE(severity, 'normal'),
@@ -366,7 +377,8 @@ func (s *PostgresStore) listUnnotifiedCriticalMailboxItemsSpec(ctx context.Conte
 			COALESCE(summary, ''),
 			expires_at,
 			COALESCE(decision, ''),
-			COALESCE(decision_notes, '')
+			COALESCE(decision_notes, ''),
+			COALESCE(reply_context_id, '')
 		FROM mailbox
 		WHERE status = 'pending'
 		  AND severity = 'critical'
@@ -402,6 +414,7 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 			&it.ID,
 			&it.EventID,
 			&it.EntityID,
+			&it.FlowInstance,
 			&it.FromAgent,
 			&it.Type,
 			&it.Priority,
@@ -412,6 +425,7 @@ func scanSpecMailboxItems(rows *sql.Rows) ([]runtimetools.MailboxItem, error) {
 			&timeoutRaw,
 			&it.Decision,
 			&it.DecisionNotes,
+			&it.ReplyContextID,
 		); err != nil {
 			return nil, fmt.Errorf("scan mailbox item: %w", err)
 		}

--- a/internal/store/mailbox_materialization.go
+++ b/internal/store/mailbox_materialization.go
@@ -35,14 +35,14 @@ func (s *PostgresStore) MaterializeMailboxWrite(ctx context.Context, item runtim
 	_, err = exec.ExecContext(ctx, `
 		INSERT INTO mailbox (
 			item_id, entity_id, flow_instance, scope, item_type, source_event_id,
-			from_agent, severity, summary, payload, status, notified, created_at
+			from_agent, severity, summary, payload, status, notified, reply_context_id, created_at
 		)
 		VALUES (
 			$1::uuid, NULLIF($2,'')::uuid, NULLIF($3,''), $4, $5, $6::uuid,
-			$7, $8, NULLIF($9,''), $10::jsonb, 'pending', false, now()
+			$7, $8, NULLIF($9,''), $10::jsonb, 'pending', false, NULLIF($11,''), now()
 		)
 		ON CONFLICT (item_id) DO NOTHING
-	`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload))
+	`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), item.ReplyContextID)
 	if err != nil {
 		return fmt.Errorf("materialize postgres mailbox_write: %w", err)
 	}
@@ -69,11 +69,11 @@ func (s *SQLiteRuntimeStore) MaterializeMailboxWrite(ctx context.Context, item r
 		_, err := tx.ExecContext(txctx, `
 			INSERT INTO mailbox (
 				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
-				from_agent, severity, summary, payload, status, notified, created_at
+				from_agent, severity, summary, payload, status, notified, reply_context_id, created_at
 			)
-			VALUES (?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'pending', 0, ?)
+			VALUES (?, NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'pending', 0, NULLIF(?, ''), ?)
 			ON CONFLICT(item_id) DO NOTHING
-		`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), now)
+		`, item.ItemID, item.EntityID, item.FlowInstance, item.Scope, item.ItemType, item.SourceEventID, item.FromAgent, item.Severity, item.Summary, string(item.Payload), item.ReplyContextID, now)
 		if err != nil {
 			return fmt.Errorf("materialize sqlite mailbox_write: %w", err)
 		}
@@ -98,6 +98,7 @@ func normalizeMailboxWriteMaterialization(item runtimepipeline.MailboxWriteMater
 	item.FromAgent = strings.TrimSpace(item.FromAgent)
 	item.Severity = normalizeMailboxSeverity(item.Severity)
 	item.Summary = strings.TrimSpace(item.Summary)
+	item.ReplyContextID = strings.TrimSpace(item.ReplyContextID)
 	if item.ItemID == "" {
 		return item, fmt.Errorf("mailbox_write item_id is required")
 	}

--- a/internal/store/mailbox_v1.go
+++ b/internal/store/mailbox_v1.go
@@ -188,7 +188,8 @@ func (s *PostgresStore) ListV1MailboxItems(ctx context.Context, opts MailboxV1Li
 			COALESCE(m.decided_by, ''),
 			COALESCE(m.decision_notes, ''),
 			COALESCE(m.from_agent, ''),
-			COALESCE(e.run_id::text, '')
+			COALESCE(e.run_id::text, ''),
+			COALESCE(m.reply_context_id, '')
 		FROM mailbox m
 		LEFT JOIN events e ON e.event_id = m.source_event_id
 		`+where+`
@@ -381,6 +382,10 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	outcome.Result.DownstreamEventName = strings.TrimSpace(input.DecisionEventType)
 	outcome.Result.DownstreamSubscribers = &subscribers
 	outcome.Result.DownstreamSubscriberSource = subscriberSource
+	deliveryContext := replyDeliveryContext(row.ReplyContextID)
+	if !deliveryContext.Empty() {
+		evt = evt.WithDeliveryContext(deliveryContext)
+	}
 	outcome.DecisionEvent = &evt
 
 	var res sql.Result
@@ -424,13 +429,17 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 		}
 	}
 	if outcome.DecisionEvent != nil {
+		publishCtx := txctx
+		if !deliveryContext.Empty() {
+			publishCtx = events.WithDeliveryContext(txctx, deliveryContext)
+		}
 		publish := input.DecisionEventPublish
 		if publish == nil {
 			publish = func(ctx context.Context, evt events.Event) error {
 				return s.appendMailboxV1DecisionEventTx(ctx, tx, evt)
 			}
 		}
-		if err := publish(txctx, *outcome.DecisionEvent); err != nil {
+		if err := publish(publishCtx, *outcome.DecisionEvent); err != nil {
 			return MailboxV1DecisionOutcome{}, fmt.Errorf("publish v1 mailbox decision event: %w", err)
 		}
 	}
@@ -452,6 +461,14 @@ func (s *PostgresStore) DecideV1MailboxItem(ctx context.Context, input MailboxV1
 	committed = true
 	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	return outcome, nil
+}
+
+func replyDeliveryContext(replyContextID string) events.DeliveryContext {
+	replyContextID = strings.TrimSpace(replyContextID)
+	if replyContextID == "" {
+		return events.DeliveryContext{}
+	}
+	return events.DeliveryContext{Reply: &events.ReplyContextRef{ID: replyContextID}}.Normalized()
 }
 
 func prepareMailboxV1IdempotencyRequest(input MailboxV1DecisionRequest) (APIIdempotencyRequest, bool, error) {
@@ -606,24 +623,25 @@ func mailboxV1ListWhere(opts MailboxV1ListOptions, cursor mailboxV1Cursor) (stri
 }
 
 type mailboxV1Row struct {
-	ID            string
-	Type          string
-	Status        string
-	Decision      string
-	Priority      string
-	SourceEventID string
-	FlowInstance  string
-	EntityID      string
-	Payload       map[string]any
-	RawPayload    json.RawMessage
-	ExpiresAt     sql.NullTime
-	DeferredUntil sql.NullTime
-	CreatedAtTime time.Time
-	DecidedAt     sql.NullTime
-	DecidedBy     string
-	DecisionNotes string
-	FromAgent     string
-	RunID         string
+	ID             string
+	Type           string
+	Status         string
+	Decision       string
+	Priority       string
+	SourceEventID  string
+	FlowInstance   string
+	EntityID       string
+	Payload        map[string]any
+	RawPayload     json.RawMessage
+	ExpiresAt      sql.NullTime
+	DeferredUntil  sql.NullTime
+	CreatedAtTime  time.Time
+	DecidedAt      sql.NullTime
+	DecidedBy      string
+	DecisionNotes  string
+	FromAgent      string
+	RunID          string
+	ReplyContextID string
 }
 
 type mailboxV1RowQueryer interface {
@@ -661,7 +679,8 @@ func (s *PostgresStore) loadMailboxV1RowTx(ctx context.Context, tx *sql.Tx, id s
 			COALESCE(m.decided_by, ''),
 			COALESCE(m.decision_notes, ''),
 			COALESCE(m.from_agent, ''),
-			COALESCE(e.run_id::text, '')
+			COALESCE(e.run_id::text, ''),
+			COALESCE(m.reply_context_id, '')
 		FROM mailbox m
 		LEFT JOIN events e ON e.event_id = m.source_event_id
 		WHERE m.item_id = $1::uuid
@@ -703,6 +722,7 @@ func scanMailboxV1Rows(rows *sql.Rows) ([]mailboxV1Row, error) {
 			&row.DecisionNotes,
 			&row.FromAgent,
 			&row.RunID,
+			&row.ReplyContextID,
 		); err != nil {
 			return nil, fmt.Errorf("scan v1 mailbox item: %w", err)
 		}

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -166,8 +166,10 @@ func platformTableOrder(name string) int {
 		return 5
 	case "events":
 		return 10
-	case "activity_attempts":
+	case "reply_contexts":
 		return 11
+	case "activity_attempts":
+		return 12
 	case "run_fork_selected_contract_bindings":
 		return 15
 	case "run_fork_selected_contract_executions":

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -230,6 +230,28 @@ func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) er
 			return fmt.Errorf("ensure event_deliveries.delivery_target_route column: %w", err)
 		}
 	}
+	if catalog.hasTable("event_deliveries") && !catalog.hasColumns("event_deliveries", "delivery_context") {
+		if _, err := s.DB.ExecContext(ctx, `ALTER TABLE event_deliveries ADD COLUMN IF NOT EXISTS delivery_context JSONB NOT NULL DEFAULT '{}'::jsonb`); err != nil {
+			return fmt.Errorf("ensure event_deliveries.delivery_context column: %w", err)
+		}
+	}
+	if catalog.hasTable("reply_contexts") {
+		for _, column := range []struct {
+			table string
+			name  string
+		}{
+			{table: "activity_attempts", name: "reply_context_id"},
+			{table: "timers", name: "reply_context_id"},
+			{table: "mailbox", name: "reply_context_id"},
+		} {
+			if !catalog.hasTable(column.table) || catalog.hasColumns(column.table, column.name) {
+				continue
+			}
+			if _, err := s.DB.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s TEXT REFERENCES reply_contexts(reply_context_id)`, column.table, column.name)); err != nil {
+				return fmt.Errorf("ensure %s.%s column: %w", column.table, column.name, err)
+			}
+		}
+	}
 	if catalog.hasTable("event_receipts") && catalog.hasColumns("event_receipts", "event_id", "subscriber_type", "subscriber_id") {
 		if err := s.ensureEventReceiptsTypedSubscriberIdentity(ctx); err != nil {
 			return err

--- a/internal/store/reply_context_store.go
+++ b/internal/store/reply_context_store.go
@@ -1,0 +1,324 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
+)
+
+type replyContextSQL interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+var _ runtimereplycontext.Store = (*PostgresStore)(nil)
+var _ runtimereplycontext.Store = (*SQLiteRuntimeStore)(nil)
+
+func (s *PostgresStore) CreateReplyContext(ctx context.Context, record runtimereplycontext.Record) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return createPostgresReplyContext(ctx, tx, record)
+	}
+	return createPostgresReplyContext(ctx, s.DB, record)
+}
+
+func createPostgresReplyContext(ctx context.Context, db replyContextSQL, record runtimereplycontext.Record) error {
+	record = record.Normalized()
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	origin, err := json.Marshal(record.Origin)
+	if err != nil {
+		return fmt.Errorf("encode reply context origin: %w", err)
+	}
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO reply_contexts (
+			reply_context_id, run_id, request_event_id, requester_flow_id,
+			request_output_pin, reply_input_pin, provider_flow_id,
+			provider_input_pin, provider_output_pin, origin_route,
+			request_correlation_id, correlation_key, state,
+			accepted_reply_event_id, created_at, updated_at, terminal_at
+		)
+		VALUES (
+			$1, NULLIF($2, '')::uuid, $3::uuid, $4,
+			$5, $6, $7, $8, $9, $10::jsonb,
+			$11, NULLIF($12, ''), $13,
+			NULLIF($14, '')::uuid, $15, $16, $17
+		)
+		ON CONFLICT DO NOTHING
+	`, record.ID, record.RunID, record.RequestEventID, record.RequesterFlowID,
+		record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID,
+		record.ProviderInputPin, record.ProviderOutputPin, string(origin),
+		record.RequestCorrelationID, record.CorrelationKey, string(record.State),
+		record.AcceptedReplyEventID, record.CreatedAt, record.UpdatedAt, record.TerminalAt)
+	if err != nil {
+		return fmt.Errorf("create reply context: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("create reply context rows: %w", err)
+	}
+	if rows == 1 {
+		return nil
+	}
+	existing, loadErr := loadPostgresReplyContext(ctx, db, record.ID, false)
+	return resolveReplyContextCreateConflict(record, existing, loadErr)
+}
+
+func (s *SQLiteRuntimeStore) CreateReplyContext(ctx context.Context, record runtimereplycontext.Record) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return createSQLiteReplyContextTx(ctx, tx, record)
+	}
+	return s.runRuntimeMutation(ctx, "sqlite reply context create", func(txctx context.Context, tx *sql.Tx) error {
+		return createSQLiteReplyContextTx(txctx, tx, record)
+	})
+}
+
+func createSQLiteReplyContextTx(ctx context.Context, db replyContextSQL, record runtimereplycontext.Record) error {
+	record = record.Normalized()
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	origin, err := json.Marshal(record.Origin)
+	if err != nil {
+		return fmt.Errorf("encode reply context origin: %w", err)
+	}
+	result, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO reply_contexts (
+			reply_context_id, run_id, request_event_id, requester_flow_id,
+			request_output_pin, reply_input_pin, provider_flow_id,
+			provider_input_pin, provider_output_pin, origin_route,
+			request_correlation_id, correlation_key, state,
+			accepted_reply_event_id, created_at, updated_at, terminal_at
+		)
+		VALUES (?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, NULLIF(?, ''), ?, ?, ?)
+	`, record.ID, record.RunID, record.RequestEventID, record.RequesterFlowID,
+		record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID,
+		record.ProviderInputPin, record.ProviderOutputPin, string(origin),
+		record.RequestCorrelationID, record.CorrelationKey, string(record.State),
+		record.AcceptedReplyEventID, record.CreatedAt, record.UpdatedAt, record.TerminalAt)
+	if err != nil {
+		return fmt.Errorf("create sqlite reply context: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("create sqlite reply context rows: %w", err)
+	}
+	if rows == 1 {
+		return nil
+	}
+	existing, loadErr := loadSQLiteReplyContext(ctx, db, record.ID)
+	return resolveReplyContextCreateConflict(record, existing, loadErr)
+}
+
+func resolveReplyContextCreateConflict(record, existing runtimereplycontext.Record, loadErr error) error {
+	if loadErr == nil && existing.SameIdentity(record) {
+		return nil
+	}
+	if loadErr != nil && !errors.Is(loadErr, runtimereplycontext.ErrNotFound) {
+		return fmt.Errorf("load conflicting reply context: %w", loadErr)
+	}
+	record = record.Normalized()
+	return fmt.Errorf(
+		"reply context correlation collision for flow %q origin %q and correlation %q; use a unique carried correlation value for each in-flight request",
+		record.RequesterFlowID,
+		record.Origin.FlowInstance,
+		record.RequestCorrelationID,
+	)
+}
+
+func (s *PostgresStore) LoadReplyContext(ctx context.Context, id string) (runtimereplycontext.Record, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return loadPostgresReplyContext(ctx, tx, id, false)
+	}
+	return loadPostgresReplyContext(ctx, s.DB, id, false)
+}
+
+func loadPostgresReplyContext(ctx context.Context, db replyContextSQL, id string, forUpdate bool) (runtimereplycontext.Record, error) {
+	query := postgresReplyContextSelect + ` WHERE reply_context_id = $1`
+	if forUpdate {
+		query += ` FOR UPDATE`
+	}
+	return scanReplyContext(db.QueryRowContext(ctx, query, strings.TrimSpace(id)))
+}
+
+func (s *SQLiteRuntimeStore) LoadReplyContext(ctx context.Context, id string) (runtimereplycontext.Record, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return loadSQLiteReplyContext(ctx, tx, id)
+	}
+	return loadSQLiteReplyContext(ctx, s.DB, id)
+}
+
+func loadSQLiteReplyContext(ctx context.Context, db replyContextSQL, id string) (runtimereplycontext.Record, error) {
+	return scanReplyContext(db.QueryRowContext(ctx, sqliteReplyContextSelect+` WHERE reply_context_id = ?`, strings.TrimSpace(id)))
+}
+
+func (s *PostgresStore) ClaimReplyContext(ctx context.Context, id, replyEventID string) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return claimPostgresReplyContext(ctx, tx, id, replyEventID)
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimereplycontext.Record{}, "", err
+	}
+	defer func() { _ = tx.Rollback() }()
+	record, outcome, err := claimPostgresReplyContext(ctx, tx, id, replyEventID)
+	if err != nil {
+		return runtimereplycontext.Record{}, "", err
+	}
+	if err := tx.Commit(); err != nil {
+		return runtimereplycontext.Record{}, "", err
+	}
+	return record, outcome, nil
+}
+
+func claimPostgresReplyContext(ctx context.Context, tx *sql.Tx, id, replyEventID string) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	record, err := loadPostgresReplyContext(ctx, tx, id, true)
+	if err != nil {
+		return runtimereplycontext.Record{}, "", err
+	}
+	return claimLoadedReplyContextTx(ctx, tx, record, replyEventID, true)
+}
+
+func (s *SQLiteRuntimeStore) ClaimReplyContext(ctx context.Context, id, replyEventID string) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		record, err := loadSQLiteReplyContext(ctx, tx, id)
+		if err != nil {
+			return runtimereplycontext.Record{}, "", err
+		}
+		return claimLoadedReplyContextTx(ctx, tx, record, replyEventID, false)
+	}
+	var record runtimereplycontext.Record
+	var outcome runtimereplycontext.ClaimOutcome
+	err := s.runRuntimeMutation(ctx, "sqlite reply context claim", func(txctx context.Context, tx *sql.Tx) error {
+		loaded, err := loadSQLiteReplyContext(txctx, tx, id)
+		if err != nil {
+			return err
+		}
+		record, outcome, err = claimLoadedReplyContextTx(txctx, tx, loaded, replyEventID, false)
+		return err
+	})
+	return record, outcome, err
+}
+
+func claimLoadedReplyContextTx(ctx context.Context, db replyContextSQL, record runtimereplycontext.Record, replyEventID string, postgres bool) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	replyEventID = strings.TrimSpace(replyEventID)
+	if replyEventID == "" {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("reply event id is required")
+	}
+	if record.State == runtimereplycontext.StateTerminal {
+		if record.AcceptedReplyEventID == replyEventID {
+			return record, runtimereplycontext.ClaimIdempotent, nil
+		}
+		return record, runtimereplycontext.ClaimTerminal, nil
+	}
+	existsQuery := `SELECT EXISTS (SELECT 1 FROM events WHERE event_id = ?)`
+	if postgres {
+		existsQuery = `SELECT EXISTS (SELECT 1 FROM events WHERE event_id = $1::uuid)`
+	}
+	var replyEventPersisted bool
+	if err := db.QueryRowContext(ctx, existsQuery, replyEventID).Scan(&replyEventPersisted); err != nil {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("verify reply event %s persistence before claim: %w", replyEventID, err)
+	}
+	if !replyEventPersisted {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("reply event %s must be persisted in the reply-context mutation before terminal claim", replyEventID)
+	}
+	now := time.Now().UTC()
+	query := `UPDATE reply_contexts SET state = ?, accepted_reply_event_id = ?, terminal_at = ?, updated_at = ? WHERE reply_context_id = ? AND state = 'open'`
+	args := []any{string(runtimereplycontext.StateTerminal), replyEventID, now, now, record.ID}
+	if postgres {
+		query = `UPDATE reply_contexts SET state = $1, accepted_reply_event_id = $2::uuid, terminal_at = $3, updated_at = $4 WHERE reply_context_id = $5 AND state = 'open'`
+	}
+	result, err := db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("claim reply context %s for reply event %s: %w", record.ID, replyEventID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("claim reply context rows: %w", err)
+	}
+	if rows != 1 {
+		return runtimereplycontext.Record{}, "", fmt.Errorf("reply context claim lost atomic update")
+	}
+	record.State = runtimereplycontext.StateTerminal
+	record.AcceptedReplyEventID = replyEventID
+	record.TerminalAt = &now
+	record.UpdatedAt = now
+	return record.Normalized(), runtimereplycontext.ClaimAccepted, nil
+}
+
+const postgresReplyContextSelect = `
+	SELECT reply_context_id, COALESCE(run_id::text, ''), request_event_id::text,
+	       requester_flow_id, request_output_pin, reply_input_pin,
+	       provider_flow_id, provider_input_pin, provider_output_pin,
+	       origin_route, request_correlation_id, COALESCE(correlation_key, ''),
+	       state, COALESCE(accepted_reply_event_id::text, ''),
+	       created_at, updated_at, terminal_at
+	FROM reply_contexts`
+
+const sqliteReplyContextSelect = `
+	SELECT reply_context_id, COALESCE(run_id, ''), request_event_id,
+	       requester_flow_id, request_output_pin, reply_input_pin,
+	       provider_flow_id, provider_input_pin, provider_output_pin,
+	       origin_route, request_correlation_id, COALESCE(correlation_key, ''),
+	       state, COALESCE(accepted_reply_event_id, ''),
+	       created_at, updated_at, terminal_at
+	FROM reply_contexts`
+
+type replyContextRowScanner interface {
+	Scan(...any) error
+}
+
+func scanReplyContext(row replyContextRowScanner) (runtimereplycontext.Record, error) {
+	var record runtimereplycontext.Record
+	var originJSON []byte
+	var createdAtRaw, updatedAtRaw, terminalAtRaw any
+	if err := row.Scan(
+		&record.ID, &record.RunID, &record.RequestEventID,
+		&record.RequesterFlowID, &record.RequestOutputPin, &record.ReplyInputPin,
+		&record.ProviderFlowID, &record.ProviderInputPin, &record.ProviderOutputPin,
+		&originJSON, &record.RequestCorrelationID, &record.CorrelationKey,
+		&record.State, &record.AcceptedReplyEventID,
+		&createdAtRaw, &updatedAtRaw, &terminalAtRaw,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return runtimereplycontext.Record{}, runtimereplycontext.ErrNotFound
+		}
+		return runtimereplycontext.Record{}, fmt.Errorf("load reply context: %w", err)
+	}
+	if err := json.Unmarshal(originJSON, &record.Origin); err != nil {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context origin: %w", err)
+	}
+	createdAt, ok, err := sqliteTimeValue(createdAtRaw)
+	if err != nil {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context created_at: %w", err)
+	}
+	if !ok {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context created_at: value is required")
+	}
+	updatedAt, ok, err := sqliteTimeValue(updatedAtRaw)
+	if err != nil {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context updated_at: %w", err)
+	}
+	if !ok {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context updated_at: value is required")
+	}
+	record.CreatedAt = createdAt
+	record.UpdatedAt = updatedAt
+	if terminalAt, ok, err := sqliteTimeValue(terminalAtRaw); err != nil {
+		return runtimereplycontext.Record{}, fmt.Errorf("decode reply context terminal_at: %w", err)
+	} else if ok {
+		record.TerminalAt = &terminalAt
+	}
+	record = record.Normalized()
+	if err := record.Validate(); err != nil {
+		return runtimereplycontext.Record{}, fmt.Errorf("invalid persisted reply context: %w", err)
+	}
+	return record, nil
+}

--- a/internal/store/reply_context_store_test.go
+++ b/internal/store/reply_context_store_test.go
@@ -1,0 +1,400 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
+	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+type replyContextStoreTestSurface interface {
+	runtimereplycontext.Store
+	InsertEventDeliveryRoutes(context.Context, string, []events.DeliveryRoute) error
+	ListEventDeliveryRoutes(context.Context, string) ([]events.DeliveryRoute, error)
+}
+
+type replyContinuationStoreTestSurface interface {
+	replyContextStoreTestSurface
+	runtimetools.MailboxPersistence
+	runtimetools.HumanTaskPersistence
+	MaterializeMailboxWrite(context.Context, runtimepipeline.MailboxWriteMaterialization) error
+	DecideV1MailboxItem(context.Context, MailboxV1DecisionRequest) (MailboxV1DecisionOutcome, error)
+	UpsertSchedule(context.Context, runtimepipeline.Schedule) error
+	LoadActiveSchedules(context.Context) ([]runtimepipeline.Schedule, error)
+}
+
+func TestReplyContinuationRows_BackendParityMailboxAndHumanTaskRestoreContext(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error)
+	}{
+		{name: "postgres", setup: setupPostgresReplyContextStoreTest},
+		{name: "sqlite", setup: setupSQLiteReplyContextStoreTest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base, seed := tc.setup(t)
+			store, ok := base.(replyContinuationStoreTestSurface)
+			if !ok {
+				t.Fatalf("%s store lacks reply continuation surface", tc.name)
+			}
+			ctx := context.Background()
+			runID := uuid.NewString()
+			requestEventID := uuid.NewString()
+			if err := seed(ctx, runID, requestEventID); err != nil {
+				t.Fatalf("seed continuation source: %v", err)
+			}
+			now := time.Now().UTC()
+			record := runtimereplycontext.Record{
+				RunID:                runID,
+				RequestEventID:       requestEventID,
+				RequesterFlowID:      "requester",
+				RequestOutputPin:     "provider_requested",
+				ReplyInputPin:        "provider_replied",
+				ProviderFlowID:       "provider",
+				ProviderInputPin:     "provider_requested",
+				ProviderOutputPin:    "provider_replied",
+				Origin:               events.RouteIdentity{FlowID: "requester", FlowInstance: "requester/account-a", EntityID: uuid.NewString()},
+				RequestCorrelationID: requestEventID,
+				State:                runtimereplycontext.StateOpen,
+				CreatedAt:            now,
+				UpdatedAt:            now,
+			}
+			record.ID = runtimereplycontext.DeterministicID(record.RequestEventID, record.RequesterFlowID, record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID, record.Origin)
+			if err := store.CreateReplyContext(ctx, record); err != nil {
+				t.Fatalf("CreateReplyContext: %v", err)
+			}
+			deliveryContext := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: record.ID}}
+
+			systemMailboxID := uuid.NewString()
+			if err := store.MaterializeMailboxWrite(ctx, runtimepipeline.MailboxWriteMaterialization{
+				ItemID:         systemMailboxID,
+				Scope:          "global",
+				ItemType:       "approval",
+				SourceEventID:  requestEventID,
+				FromAgent:      "system_node:provider-node",
+				Severity:       "normal",
+				Summary:        "approve provider result",
+				Payload:        []byte(`{"kind":"system"}`),
+				ReplyContextID: record.ID,
+			}); err != nil {
+				t.Fatalf("MaterializeMailboxWrite: %v", err)
+			}
+			item, err := store.GetMailboxItem(ctx, systemMailboxID)
+			if err != nil || item.ReplyContextID != record.ID {
+				t.Fatalf("system mailbox readback = %#v err=%v", item, err)
+			}
+
+			agentMailboxID, err := store.InsertMailboxItem(events.WithDeliveryContext(ctx, deliveryContext), runtimetools.MailboxItem{
+				EventID:   requestEventID,
+				FromAgent: "provider-agent",
+				Type:      "approval",
+				Priority:  "normal",
+				Status:    "pending",
+				Summary:   "agent approval",
+				Context:   []byte(`{"kind":"agent"}`),
+			})
+			if err != nil {
+				t.Fatalf("InsertMailboxItem: %v", err)
+			}
+			item, err = store.GetMailboxItem(ctx, agentMailboxID)
+			if err != nil || item.ReplyContextID != record.ID {
+				t.Fatalf("agent mailbox readback = %#v err=%v", item, err)
+			}
+
+			schedule := runtimepipeline.Schedule{
+				Context:   deliveryContext,
+				RunID:     runID,
+				AgentID:   "provider-agent",
+				EventType: "provider.resume",
+				Mode:      "once",
+				At:        now.Add(10 * time.Minute),
+				TaskID:    "reply-resume",
+				Payload:   []byte(`{"resume":true}`),
+			}
+			if err := store.UpsertSchedule(ctx, schedule); err != nil {
+				t.Fatalf("UpsertSchedule: %v", err)
+			}
+			schedules, err := store.LoadActiveSchedules(ctx)
+			if err != nil {
+				t.Fatalf("LoadActiveSchedules: %v", err)
+			}
+			foundSchedule := false
+			for _, loaded := range schedules {
+				if loaded.TaskID == schedule.TaskID {
+					foundSchedule = loaded.Context.ReplyContextID() == record.ID
+				}
+			}
+			if !foundSchedule {
+				t.Fatalf("one-shot schedule did not restore reply context: %#v", schedules)
+			}
+			recurring := schedule
+			recurring.TaskID = "reply-recurring"
+			recurring.Mode = "cron"
+			recurring.Cron = "@every 1h"
+			if err := store.UpsertSchedule(ctx, recurring); err == nil {
+				t.Fatal("recurring schedule with open reply context unexpectedly accepted")
+			}
+
+			var mailboxEvents []events.Event
+			mailboxPublisher := func(publishCtx context.Context, evt events.Event) error {
+				if _, ok := runtimepipeline.PipelineSQLTxFromContext(publishCtx); !ok {
+					t.Fatal("mailbox decision publish escaped row transaction")
+				}
+				if got := events.DeliveryContextFromContext(publishCtx).ReplyContextID(); got != record.ID {
+					t.Fatalf("mailbox decision context = %q, want %q", got, record.ID)
+				}
+				mailboxEvents = append(mailboxEvents, evt)
+				return nil
+			}
+			deferUntil := now.Add(time.Hour)
+			deferred, err := store.DecideV1MailboxItem(ctx, MailboxV1DecisionRequest{
+				MailboxID:            agentMailboxID,
+				Action:               "deferred",
+				ActorTokenID:         "operator",
+				DeferUntil:           deferUntil,
+				Now:                  now,
+				DecisionEventType:    "mailbox.item_deferred",
+				DecisionEventPublish: mailboxPublisher,
+			})
+			if err != nil || deferred.Result.Status != "deferred" || len(mailboxEvents) != 1 || mailboxEvents[0].DeliveryContext().ReplyContextID() != record.ID {
+				t.Fatalf("mailbox defer outcome=%#v events=%#v err=%v", deferred, mailboxEvents, err)
+			}
+			item, err = store.GetMailboxItem(ctx, agentMailboxID)
+			if err != nil || item.Status != "pending" || item.ReplyContextID != record.ID {
+				t.Fatalf("deferred mailbox row = %#v err=%v", item, err)
+			}
+
+			humanTaskID, err := store.CreateHumanTask(ctx, runtimetools.HumanTaskCreateRecord{
+				ActorID:       "provider-agent",
+				FlowInstance:  "provider",
+				Category:      "approval",
+				Description:   "approve provider response",
+				ExpectedValue: "approved",
+				Priority:      "normal",
+				Deadline:      now.Add(2 * time.Hour),
+				SourceEventID: requestEventID,
+				Context:       deliveryContext,
+			})
+			if err != nil {
+				t.Fatalf("CreateHumanTask: %v", err)
+			}
+			item, err = store.GetMailboxItem(ctx, humanTaskID)
+			if err != nil || item.ReplyContextID != record.ID || item.FlowInstance != "provider" {
+				t.Fatalf("human task readback = %#v err=%v", item, err)
+			}
+			var humanEvents []events.Event
+			humanPublisher := func(publishCtx context.Context, evt events.Event) error {
+				if _, ok := runtimepipeline.PipelineSQLTxFromContext(publishCtx); !ok {
+					t.Fatal("human outcome publish escaped row transaction")
+				}
+				if got := events.DeliveryContextFromContext(publishCtx).ReplyContextID(); got != record.ID {
+					t.Fatalf("human outcome context = %q, want %q", got, record.ID)
+				}
+				humanEvents = append(humanEvents, evt)
+				return nil
+			}
+			if err := store.DecideHumanTask(ctx, runtimetools.HumanTaskDecisionRecord{
+				TaskID:               humanTaskID,
+				Status:               "deferred",
+				ActorID:              "operator",
+				Reason:               "later",
+				RequeueDate:          now.Add(30 * time.Minute).Format(time.RFC3339),
+				DecidedAt:            now,
+				DecisionEventPublish: humanPublisher,
+			}); err != nil {
+				t.Fatalf("defer human task: %v", err)
+			}
+			item, err = store.GetMailboxItem(ctx, humanTaskID)
+			if err != nil || item.Status != "pending" || item.ReplyContextID != record.ID || len(humanEvents) != 1 || humanEvents[0].Type() != "human_task.deferred" {
+				t.Fatalf("deferred human task row=%#v events=%#v err=%v", item, humanEvents, err)
+			}
+			if err := store.DecideHumanTask(ctx, runtimetools.HumanTaskDecisionRecord{
+				TaskID:               humanTaskID,
+				Status:               "approved",
+				ActorID:              "operator",
+				Reason:               "approved",
+				DecidedAt:            now.Add(time.Minute),
+				DecisionEventPublish: humanPublisher,
+			}); err != nil {
+				t.Fatalf("approve human task: %v", err)
+			}
+			item, err = store.GetMailboxItem(ctx, humanTaskID)
+			if err != nil || item.Status != "decided" || item.ReplyContextID != record.ID || len(humanEvents) != 2 || humanEvents[1].Type() != "human_task.approved" {
+				t.Fatalf("approved human task row=%#v events=%#v err=%v", item, humanEvents, err)
+			}
+			loaded, err := store.LoadReplyContext(ctx, record.ID)
+			if err != nil || loaded.State != runtimereplycontext.StateOpen {
+				t.Fatalf("mailbox/human decisions consumed terminal claim: %#v err=%v", loaded, err)
+			}
+		})
+	}
+}
+
+func TestReplyContextStore_BackendParityAtomicClaimAndDeliveryReadback(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error)
+	}{
+		{name: "postgres", setup: setupPostgresReplyContextStoreTest},
+		{name: "sqlite", setup: setupSQLiteReplyContextStoreTest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, seed := tc.setup(t)
+			ctx := context.Background()
+			runID := uuid.NewString()
+			requestEventID := uuid.NewString()
+			collisionEventID := uuid.NewString()
+			replyIDs := []string{uuid.NewString(), uuid.NewString()}
+			if err := seed(ctx, runID, append([]string{requestEventID, collisionEventID}, replyIDs...)...); err != nil {
+				t.Fatalf("seed reply context source: %v", err)
+			}
+			now := time.Now().UTC()
+			record := runtimereplycontext.Record{
+				RunID:                runID,
+				RequestEventID:       requestEventID,
+				RequesterFlowID:      "requester",
+				RequestOutputPin:     "provider_requested",
+				ReplyInputPin:        "provider_replied",
+				ProviderFlowID:       "provider",
+				ProviderInputPin:     "provider_requested",
+				ProviderOutputPin:    "provider_replied",
+				Origin:               events.RouteIdentity{FlowID: "requester", FlowInstance: "requester/account-a", EntityID: uuid.NewString()},
+				RequestCorrelationID: "same-authored-key",
+				CorrelationKey:       "provider_request_id",
+				State:                runtimereplycontext.StateOpen,
+				CreatedAt:            now,
+				UpdatedAt:            now,
+			}
+			record.ID = runtimereplycontext.DeterministicID(record.RequestEventID, record.RequesterFlowID, record.RequestOutputPin, record.ReplyInputPin, record.ProviderFlowID, record.Origin)
+			if err := store.CreateReplyContext(ctx, record); err != nil {
+				t.Fatalf("CreateReplyContext: %v", err)
+			}
+			if err := store.CreateReplyContext(ctx, record); err != nil {
+				t.Fatalf("idempotent CreateReplyContext: %v", err)
+			}
+			collision := record
+			collision.RequestEventID = collisionEventID
+			collision.ID = runtimereplycontext.DeterministicID(collision.RequestEventID, collision.RequesterFlowID, collision.RequestOutputPin, collision.ReplyInputPin, collision.ProviderFlowID, collision.Origin)
+			if err := store.CreateReplyContext(ctx, collision); err == nil {
+				t.Fatal("same-origin in-flight correlation collision unexpectedly accepted")
+			}
+			loaded, err := store.LoadReplyContext(ctx, record.ID)
+			if err != nil {
+				t.Fatalf("LoadReplyContext: %v", err)
+			}
+			if loaded.ID != record.ID || loaded.Origin != record.Origin.Normalized() || loaded.RequestCorrelationID != record.RequestCorrelationID {
+				t.Fatalf("loaded reply context = %#v, want %#v", loaded, record)
+			}
+
+			type result struct {
+				eventID string
+				outcome runtimereplycontext.ClaimOutcome
+				err     error
+			}
+			results := make(chan result, len(replyIDs))
+			var wg sync.WaitGroup
+			for _, replyID := range replyIDs {
+				wg.Add(1)
+				go func(eventID string) {
+					defer wg.Done()
+					_, outcome, err := store.ClaimReplyContext(ctx, record.ID, eventID)
+					results <- result{eventID: eventID, outcome: outcome, err: err}
+				}(replyID)
+			}
+			wg.Wait()
+			close(results)
+			acceptedID := ""
+			outcomes := map[runtimereplycontext.ClaimOutcome]int{}
+			for got := range results {
+				if got.err != nil {
+					t.Fatalf("ClaimReplyContext(%s): %v", got.eventID, got.err)
+				}
+				outcomes[got.outcome]++
+				if got.outcome == runtimereplycontext.ClaimAccepted {
+					acceptedID = got.eventID
+				}
+			}
+			if outcomes[runtimereplycontext.ClaimAccepted] != 1 || outcomes[runtimereplycontext.ClaimTerminal] != 1 {
+				t.Fatalf("claim outcomes = %#v, want one accepted and one terminal", outcomes)
+			}
+			claimed, outcome, err := store.ClaimReplyContext(ctx, record.ID, acceptedID)
+			if err != nil || outcome != runtimereplycontext.ClaimIdempotent || claimed.AcceptedReplyEventID != acceptedID {
+				t.Fatalf("accepted replay = record:%#v outcome:%q err:%v", claimed, outcome, err)
+			}
+
+			deliveryContext := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: record.ID}}
+			routes := []events.DeliveryRoute{{
+				SubscriberType: "node",
+				SubscriberID:   "provider-node",
+				Target:         events.RouteIdentity{FlowID: "provider", FlowInstance: "provider", EntityID: uuid.NewString()},
+				Context:        deliveryContext,
+			}}
+			if err := store.InsertEventDeliveryRoutes(ctx, requestEventID, routes); err != nil {
+				t.Fatalf("InsertEventDeliveryRoutes: %v", err)
+			}
+			gotRoutes, err := store.ListEventDeliveryRoutes(ctx, requestEventID)
+			if err != nil {
+				t.Fatalf("ListEventDeliveryRoutes: %v", err)
+			}
+			if len(gotRoutes) != 1 || gotRoutes[0].Context.ReplyContextID() != record.ID {
+				t.Fatalf("delivery context readback = %#v", gotRoutes)
+			}
+		})
+	}
+}
+
+func setupPostgresReplyContextStoreTest(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	return store, func(ctx context.Context, runID string, eventIDs ...string) error {
+		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', now())`, runID); err != nil {
+			return err
+		}
+		for i, eventID := range eventIDs {
+			eventName := "provider.replied"
+			if i == 0 {
+				eventName = "provider.requested"
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+				VALUES ($1::uuid, $2::uuid, $3, 'global', '{}'::jsonb, 'test', 'platform', now())
+			`, runID, eventID, eventName); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func setupSQLiteReplyContextStoreTest(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+	t.Helper()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	return store, func(ctx context.Context, runID string, eventIDs ...string) error {
+		if _, err := store.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, time.Now().UTC()); err != nil {
+			return err
+		}
+		for i, eventID := range eventIDs {
+			eventName := "provider.replied"
+			if i == 0 {
+				eventName = "provider.requested"
+			}
+			if _, err := store.DB.ExecContext(ctx, `
+				INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+				VALUES (?, ?, ?, 'global', '{}', 'test', 'platform', ?)
+			`, runID, eventID, eventName, time.Now().UTC()); err != nil {
+				return fmt.Errorf("insert sqlite event: %w", err)
+			}
+		}
+		return nil
+	}
+}

--- a/internal/store/run_debug_read_surface.go
+++ b/internal/store/run_debug_read_surface.go
@@ -187,6 +187,7 @@ type RunDebugTraceRow struct {
 	SubscriberID          string     `json:"subscriber_id,omitempty"`
 	DeliveryStatus        string     `json:"delivery_status,omitempty"`
 	DeliveryReasonCode    string     `json:"delivery_reason_code,omitempty"`
+	ReplyContextID        string     `json:"reply_context_id,omitempty"`
 	DeliveryLastError     string     `json:"delivery_last_error,omitempty"`
 	DeliveryRetryCount    int        `json:"delivery_retry_count,omitempty"`
 	DeliveryRetryEligible bool       `json:"delivery_retry_eligible,omitempty"`
@@ -871,6 +872,10 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 		return nil, "", err
 	}
 	sessionSources := runDebugTraceSessionSources(caps)
+	replyContextSelect := "''"
+	if caps.Events.DeliveryContext {
+		replyContextSelect = "COALESCE(d.delivery_context->'reply'->>'id', '')"
+	}
 	args := []any{runID}
 	cursorWhere := ""
 	if opts.Cursor != "" {
@@ -949,6 +954,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 				COALESCE(d.subscriber_id, ''),
 				COALESCE(d.status, ''),
 				COALESCE(d.reason_code, ''),
+				%s,
 				COALESCE(d.last_error, ''),
 				COALESCE(d.retry_count, 0),
 				COALESCE(d.active_session_id::text, ''),
@@ -1004,7 +1010,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			t.created_at ASC NULLS FIRST,
 			t.turn_id ASC NULLS FIRST
 		LIMIT $%d
-		`, sessionSources, cursorWhere, sinceWhere, untilWhere, filterWhere, limitArg), args...)
+		`, sessionSources, replyContextSelect, cursorWhere, sinceWhere, untilWhere, filterWhere, limitArg), args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("load run debug trace: %w", err)
 	}
@@ -1033,6 +1039,7 @@ func (s *PostgresStore) LoadRunDebugTracePage(ctx context.Context, runID string,
 			&item.SubscriberID,
 			&item.DeliveryStatus,
 			&item.DeliveryReasonCode,
+			&item.ReplyContextID,
 			&item.DeliveryLastError,
 			&item.DeliveryRetryCount,
 			&item.ActiveSessionID,

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -407,6 +407,7 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	sessionID := uuid.NewString()
 	turnID := uuid.NewString()
 	entityID := uuid.NewString()
+	replyContextID := "reply-v1:trace-context"
 	now := time.Unix(1700000400, 0).UTC()
 
 	if _, err := db.ExecContext(ctx, `
@@ -441,13 +442,13 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status,
-			retry_count, reason_code, last_error, active_session_id, started_at, created_at
+			retry_count, reason_code, last_error, active_session_id, delivery_context, started_at, created_at
 		)
 		VALUES (
 			$1::uuid, $2::uuid, $3::uuid, 'agent', 'agent-source', 'failed',
-			2, 'handler_error', 'trace boom', $4::uuid, $5, $6
+			2, 'handler_error', 'trace boom', $4::uuid, jsonb_build_object('reply', jsonb_build_object('id', $7::text)), $5, $6
 		)
-	`, deliveryID, runID, eventID, sessionID, now.Add(1*time.Second), now.Add(500*time.Millisecond)); err != nil {
+	`, deliveryID, runID, eventID, sessionID, now.Add(1*time.Second), now.Add(500*time.Millisecond), replyContextID); err != nil {
 		t.Fatalf("seed delivery: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
@@ -483,6 +484,9 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 	}
 	if got.DeliveryReasonCode != "handler_error" || got.DeliveryLastError != "trace boom" || got.DeliveryRetryCount != 2 || !got.DeliveryRetryEligible || got.DeliveryTerminal {
 		t.Fatalf("delivery failure trace evidence = %#v", got)
+	}
+	if got.ReplyContextID != replyContextID {
+		t.Fatalf("delivery reply context = %q, want %q", got.ReplyContextID, replyContextID)
 	}
 	if got.SessionID != sessionID || got.SessionKind != "live_session" || got.SessionRuntimeMode != "session" {
 		t.Fatalf("session trace = %#v", got)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -109,6 +109,7 @@ type runForkAdmissionEvidence struct {
 	ActiveSession           bool
 	ActiveConversationAudit bool
 	ActiveTurn              bool
+	OpenReplyContext        bool
 }
 
 type runForkSourceFacts struct {
@@ -139,6 +140,7 @@ func RequireCanonicalRunForkPlannerCapabilities(caps StoreSchemaCapabilities, ca
 		"event_receipts":   {"event_id", "subscriber_type", "subscriber_id", "outcome", "reason_code", "processed_at"},
 		"dead_letters":     {"original_event_id", "handler_node", "created_at"},
 		"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "new_value", "caused_by_event", "created_at"},
+		"reply_contexts":   {"reply_context_id", "run_id", "request_event_id", "state"},
 	}
 	for tableName, columns := range required {
 		if catalog.hasColumns(tableName, columns...) {
@@ -632,6 +634,10 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 			return runForkAdmissionEvidence{}, err
 		}
 	}
+	openReplyContext, err := s.hasRunForkOpenReplyContext(ctx, runID, cursor)
+	if err != nil {
+		return runForkAdmissionEvidence{}, err
+	}
 	return runForkAdmissionEvidence{
 		Pending:                 pending,
 		RelevantTimer:           relevantTimer,
@@ -639,7 +645,25 @@ func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalo
 		ActiveSession:           activeSession,
 		ActiveConversationAudit: activeConversationAudit,
 		ActiveTurn:              activeTurn,
+		OpenReplyContext:        openReplyContext,
 	}, nil
+}
+
+func (s *PostgresStore) hasRunForkOpenReplyContext(ctx context.Context, runID string, cursor runForkEventCursor) (bool, error) {
+	var exists bool
+	if err := s.DB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM reply_contexts rc
+			JOIN events request_event ON request_event.event_id = rc.request_event_id
+			WHERE rc.run_id = $1::uuid
+			  AND rc.state = 'open'
+			  AND (request_event.created_at, request_event.event_id) <= ($2::timestamptz, $3::uuid)
+		)
+	`, runID, cursor.CreatedAt, cursor.EventID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check fork open reply contexts: %w", err)
+	}
+	return exists, nil
 }
 
 func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string, cursor runForkEventCursor, entities []RunForkEntityState) (runForkSourceFacts, error) {

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -59,6 +59,52 @@ func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
 	}
 }
 
+func TestRunForkPlanner_FailsClosedForOpenReplyContextAtForkPoint(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	runID := uuid.NewString()
+	requestEventID := uuid.NewString()
+	at := time.Unix(1700000050, 0).UTC()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+		VALUES ($1::uuid, $2::uuid, 'provider.requested', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, requestEventID, at); err != nil {
+		t.Fatalf("seed request event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO reply_contexts (
+			reply_context_id, run_id, request_event_id, requester_flow_id,
+			request_output_pin, reply_input_pin, provider_flow_id, provider_input_pin,
+			provider_output_pin, origin_route, request_correlation_id, state
+		)
+		VALUES (
+			'reply-v1:test-open', $1::uuid, $2::uuid, 'requester',
+			'provider_requested', 'provider_replied', 'provider', 'requested',
+			'replied', '{"flow_instance":"requester"}'::jsonb, $2, 'open'
+		)
+	`, runID, requestEventID); err != nil {
+		t.Fatalf("seed reply context: %v", err)
+	}
+
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: at.Format(time.RFC3339Nano)})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if plan.ExecutionReady {
+		t.Fatalf("open reply context plan unexpectedly execution-ready: %#v", plan)
+	}
+	if !runForkTestHasPlanBlocker(plan, RunForkBlockerOpenReplyContextUnsupported) {
+		t.Fatalf("open reply context blocker missing: %#v", plan.UnsupportedBlockers)
+	}
+}
+
 func TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -34,6 +34,7 @@ const (
 	RunForkReplayResumeFactForkReplayState           = "fork_replay_state"
 	RunForkReplayResumeFactContractSwap              = "contract_swap"
 	RunForkReplayResumeFactHistoricalReplayExecution = "historical_replay_execution"
+	RunForkReplayResumeFactOpenReplyContext          = "open_reply_context"
 )
 
 const (
@@ -46,6 +47,7 @@ const (
 	RunForkBlockerConversationAuditUnproven             = "conversation_audit_history_unproven"
 	RunForkBlockerActiveTurnHistoryUnproven             = "active_turn_history_unproven"
 	RunForkBlockerEntitySnapshotMetadataUnproven        = "entity_snapshot_metadata_unproven"
+	RunForkBlockerOpenReplyContextUnsupported           = "open_reply_context_unsupported"
 )
 
 type RunForkReplayResumeAdmission struct {
@@ -163,6 +165,17 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		blockers = appendRunForkBlocker(blockers, blocker)
 		dispositions = append(dispositions, RunForkReplayResumeDisposition{
 			Fact:        RunForkReplayResumeFactActiveTurnHistory,
+			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
+			BlockerCode: blocker.Code,
+			Message:     blocker.Message,
+		})
+		hasHistoricalReplayRequirement = true
+	}
+	if evidence.OpenReplyContext {
+		blocker := runForkReplayResumeBlocker(RunForkBlockerOpenReplyContextUnsupported)
+		blockers = appendRunForkBlocker(blockers, blocker)
+		dispositions = append(dispositions, RunForkReplayResumeDisposition{
+			Fact:        RunForkReplayResumeFactOpenReplyContext,
 			Disposition: RunForkReplayResumeDispositionFailClosedBlocker,
 			BlockerCode: blocker.Code,
 			Message:     blocker.Message,
@@ -401,6 +414,11 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerEntitySnapshotMetadataUnproven,
 			Message: "fork materialization requires owner-authorized source-at-T entity snapshot metadata for every reconstructed entity",
+		}
+	case RunForkBlockerOpenReplyContextUnsupported:
+		return RunForkUnsupportedBlocker{
+			Code:    RunForkBlockerOpenReplyContextUnsupported,
+			Message: "timestamp fork is blocked because the source run has an open reply context at the fork point; complete or cancel the request before forking",
 		}
 	default:
 		code = strings.TrimSpace(code)

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 )
@@ -23,6 +24,13 @@ func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.S
 		sc.Mode = "once"
 	}
 	sc = scheduleWithContextRunID(ctx, sc)
+	if sc.Context.Empty() {
+		sc.Context = events.DeliveryContextFromContext(ctx)
+	}
+	sc.NormalizeDeliveryContext()
+	if !sc.Context.Empty() && strings.EqualFold(strings.TrimSpace(sc.Mode), "cron") {
+		return fmt.Errorf("recurring schedules cannot carry an open reply context")
+	}
 	entityID := sc.EffectiveEntityID()
 	sc.EntityID = entityID
 	sc.NormalizeRunID()
@@ -202,14 +210,14 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 		INSERT INTO timers (
 			run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
 			fire_at, recurring, recurrence_cron, recurrence_interval,
-			owner_node, owner_agent, task_type, status
+			owner_node, owner_agent, reply_context_id, task_type, status
 		)
 		VALUES (
 			NULLIF($1,'')::uuid, $2, NULLIF($3,'')::uuid, NULLIF($4,''), $5, $6::jsonb,
 			$7, $8, NULLIF($9,''), NULL,
-			NULL, $10, $11, 'active'
+			NULL, $10, NULLIF($11, ''), $12, 'active'
 		)
-	`, sc.RunID, timerName, sc.EntityID, sc.FlowInstance, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, taskType)
+	`, sc.RunID, timerName, sc.EntityID, sc.FlowInstance, sc.EventType, string(payload), fireAt, recurring, sc.Cron, sc.AgentID, sc.Context.ReplyContextID(), taskType)
 	if err != nil {
 		return fmt.Errorf("insert timer: %w", err)
 	}
@@ -263,7 +271,8 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			fire_at,
 			COALESCE(entity_id::text, ''),
 			COALESCE(flow_instance, ''),
-			fire_payload
+			fire_payload,
+			COALESCE(reply_context_id, '')
 		FROM timers
 		WHERE status = 'active'
 		  AND owner_agent IS NOT NULL
@@ -277,9 +286,10 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 	out := make([]runtimepipeline.Schedule, 0)
 	for rows.Next() {
 		var (
-			sc      runtimepipeline.Schedule
-			fireAt  time.Time
-			payload []byte
+			sc             runtimepipeline.Schedule
+			fireAt         time.Time
+			payload        []byte
+			replyContextID string
 		)
 		if err := rows.Scan(
 			&sc.RunID,
@@ -291,11 +301,15 @@ func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimep
 			&sc.EntityID,
 			&sc.FlowInstance,
 			&payload,
+			&replyContextID,
 		); err != nil {
 			return nil, fmt.Errorf("scan active timer: %w", err)
 		}
 		sc.At = fireAt
 		sc.TaskID, sc.Payload = extractPersistedScheduleTaskID(payload)
+		if replyContextID != "" {
+			sc.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: replyContextID}}
+		}
 		out = append(out, sc)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/schema_capabilities.go
+++ b/internal/store/schema_capabilities.go
@@ -33,6 +33,7 @@ type EventSchemaCapabilities struct {
 	LogIdempotencyKey    bool
 	LogRouteIdentity     bool
 	DeliveryTargetRoute  bool
+	DeliveryContext      bool
 	ReceiptTypedIdentity bool
 }
 
@@ -232,6 +233,7 @@ func detectStoreSchemaCapabilities(catalog schemaColumnCatalog) StoreSchemaCapab
 		LogIdempotencyKey:    catalog.hasColumns("events", "idempotency_key"),
 		LogRouteIdentity:     catalog.hasColumns("events", "source_route", "target_route", "target_set"),
 		DeliveryTargetRoute:  catalog.hasColumns("event_deliveries", "delivery_target_route"),
+		DeliveryContext:      catalog.hasColumns("event_deliveries", "delivery_context"),
 	}
 
 	caps.Conversations = ConversationSchemaCapabilities{

--- a/internal/store/sqlite_mailbox_v1.go
+++ b/internal/store/sqlite_mailbox_v1.go
@@ -57,7 +57,8 @@ func (s *SQLiteRuntimeStore) ListV1MailboxItems(ctx context.Context, opts Mailbo
 			COALESCE(m.decided_by, ''),
 			COALESCE(m.decision_notes, ''),
 			COALESCE(m.from_agent, ''),
-			COALESCE(e.run_id, '')
+			COALESCE(e.run_id, ''),
+			COALESCE(m.reply_context_id, '')
 		FROM mailbox m
 		LEFT JOIN events e ON e.event_id = m.source_event_id
 		`+where+`
@@ -231,6 +232,10 @@ func (s *SQLiteRuntimeStore) DecideV1MailboxItem(ctx context.Context, input Mail
 		outcome.Result.DownstreamEventName = strings.TrimSpace(input.DecisionEventType)
 		outcome.Result.DownstreamSubscribers = &subscribers
 		outcome.Result.DownstreamSubscriberSource = subscriberSource
+		deliveryContext := replyDeliveryContext(row.ReplyContextID)
+		if !deliveryContext.Empty() {
+			evt = evt.WithDeliveryContext(deliveryContext)
+		}
 		outcome.DecisionEvent = &evt
 
 		var res sql.Result
@@ -274,13 +279,17 @@ func (s *SQLiteRuntimeStore) DecideV1MailboxItem(ctx context.Context, input Mail
 			}
 		}
 		if outcome.DecisionEvent != nil {
+			publishCtx := txctx
+			if !deliveryContext.Empty() {
+				publishCtx = events.WithDeliveryContext(txctx, deliveryContext)
+			}
 			publish := input.DecisionEventPublish
 			if publish == nil {
 				publish = func(ctx context.Context, evt events.Event) error {
 					return s.appendSQLiteMailboxV1DecisionEventTx(ctx, tx, evt)
 				}
 			}
-			if err := publish(txctx, *outcome.DecisionEvent); err != nil {
+			if err := publish(publishCtx, *outcome.DecisionEvent); err != nil {
 				return fmt.Errorf("publish sqlite v1 mailbox decision event: %w", err)
 			}
 		}
@@ -369,7 +378,8 @@ func (s *SQLiteRuntimeStore) loadSQLiteMailboxV1RowTx(ctx context.Context, tx *s
 			COALESCE(m.decided_by, ''),
 			COALESCE(m.decision_notes, ''),
 			COALESCE(m.from_agent, ''),
-			COALESCE(e.run_id, '')
+			COALESCE(e.run_id, ''),
+			COALESCE(m.reply_context_id, '')
 		FROM mailbox m
 		LEFT JOIN events e ON e.event_id = m.source_event_id
 		WHERE m.item_id = ?
@@ -415,6 +425,7 @@ func scanSQLiteMailboxV1Rows(rows *sql.Rows) ([]mailboxV1Row, error) {
 			&row.DecisionNotes,
 			&row.FromAgent,
 			&row.RunID,
+			&row.ReplyContextID,
 		); err != nil {
 			return nil, fmt.Errorf("scan sqlite v1 mailbox item: %w", err)
 		}

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -127,19 +127,39 @@ func (s *SQLiteRuntimeStore) InsertEventDeliveryRoutesTx(ctx context.Context, tx
 			return s.InsertEventDeliveryRoutesTx(txctx, tx, eventID, deliveryRoutes)
 		})
 	}
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return err
+	}
 	for _, route := range deliveryRoutes {
 		route = route.Normalized()
 		if route.SubscriberType == "" || route.SubscriberID == "" {
 			continue
 		}
+		if !caps.Events.DeliveryContext {
+			if !route.Context.Empty() {
+				return fmt.Errorf("event_deliveries.delivery_context required for route-scoped reply context")
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT OR IGNORE INTO event_deliveries (
+					delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route,
+					status, reason_code, created_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+			`, uuid.NewString(), sqliteNullString(runID.String), eventID, route.SubscriberType, route.SubscriberID,
+				string(routeIdentityJSON(route.Target)), deliveryRouteReasonCode(route), s.now()); err != nil {
+				return fmt.Errorf("insert sqlite event delivery route (%s=%s): %w", route.SubscriberType, route.SubscriberID, err)
+			}
+			continue
+		}
 		if _, err := tx.ExecContext(ctx, `
 			INSERT OR IGNORE INTO event_deliveries (
-				delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route,
+				delivery_id, run_id, event_id, subscriber_type, subscriber_id, delivery_target_route, delivery_context,
 				status, reason_code, created_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
 		`, uuid.NewString(), sqliteNullString(runID.String), eventID, route.SubscriberType, route.SubscriberID,
-			string(routeIdentityJSON(route.Target)), deliveryRouteReasonCode(route), s.now()); err != nil {
+			string(routeIdentityJSON(route.Target)), string(deliveryContextJSON(route.Context)), deliveryRouteReasonCode(route), s.now()); err != nil {
 			return fmt.Errorf("insert sqlite event delivery route (%s=%s): %w", route.SubscriberType, route.SubscriberID, err)
 		}
 	}
@@ -285,13 +305,21 @@ func (s *SQLiteRuntimeStore) ListEventDeliveryRoutes(ctx context.Context, eventI
 	if eventID == "" {
 		return nil, nil
 	}
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT subscriber_type, subscriber_id, COALESCE(delivery_target_route, '{}')
+	caps, err := s.schemaCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	contextSelect := `'{}'`
+	if caps.Events.DeliveryContext {
+		contextSelect = `COALESCE(delivery_context, '{}')`
+	}
+	rows, err := s.DB.QueryContext(ctx, fmt.Sprintf(`
+		SELECT subscriber_type, subscriber_id, COALESCE(delivery_target_route, '{}'), %s
 		FROM event_deliveries
 		WHERE event_id = ?
 		  AND NOT (subscriber_type = ? AND subscriber_id = ?)
 		ORDER BY created_at ASC, delivery_id ASC
-	`, eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
+	`, contextSelect), eventID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID)
 	if err != nil {
 		return nil, fmt.Errorf("list sqlite event delivery routes: %w", err)
 	}
@@ -299,11 +327,14 @@ func (s *SQLiteRuntimeStore) ListEventDeliveryRoutes(ctx context.Context, eventI
 	out := make([]events.DeliveryRoute, 0, 8)
 	for rows.Next() {
 		var route events.DeliveryRoute
-		var raw json.RawMessage
-		if err := rows.Scan(&route.SubscriberType, &route.SubscriberID, &raw); err != nil {
+		var rawValue, contextValue any
+		if err := rows.Scan(&route.SubscriberType, &route.SubscriberID, &rawValue, &contextValue); err != nil {
 			return nil, fmt.Errorf("scan sqlite event delivery route: %w", err)
 		}
+		raw := jsonRawMessageValue(rawValue)
+		contextRaw := jsonRawMessageValue(contextValue)
 		route.Target = decodeRouteIdentityJSON(raw)
+		route.Context = decodeDeliveryContextJSON(contextRaw)
 		out = append(out, route)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
@@ -37,6 +38,9 @@ func (s *SQLiteRuntimeStore) InsertMailboxItem(ctx context.Context, item runtime
 	if len(item.Context) == 0 {
 		item.Context = []byte("{}")
 	}
+	if strings.TrimSpace(item.ReplyContextID) == "" {
+		item.ReplyContextID = events.DeliveryContextFromContext(ctx).ReplyContextID()
+	}
 	scope := "global"
 	if entityID := coalesceMailboxEntityID(item); entityID != "" {
 		scope = "entity"
@@ -47,12 +51,12 @@ func (s *SQLiteRuntimeStore) InsertMailboxItem(ctx context.Context, item runtime
 			INSERT INTO mailbox (
 				item_id, entity_id, flow_instance, scope, item_type, source_event_id,
 				from_agent, severity, summary, payload, status, decision, decision_notes,
-				notified, expires_at, created_at
+				notified, expires_at, reply_context_id, created_at
 			)
-			VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, item.ID, sqliteNullUUID(coalesceMailboxEntityID(item)), scope, item.Type, sqliteNullUUID(item.EventID),
+			VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?)
+		`, item.ID, sqliteNullUUID(coalesceMailboxEntityID(item)), strings.Trim(strings.TrimSpace(item.FlowInstance), "/"), scope, item.Type, sqliteNullUUID(item.EventID),
 			sqliteNullString(item.FromAgent), normalizeMailboxSeverity(item.Priority), sqliteNullString(item.Summary), string(item.Context),
-			status, sqliteNullString(decision), sqliteNullString(item.DecisionNotes), item.Notified, sqliteNullTime(item.TimeoutAt), time.Now().UTC())
+			status, sqliteNullString(decision), sqliteNullString(item.DecisionNotes), item.Notified, sqliteNullTime(item.TimeoutAt), strings.TrimSpace(item.ReplyContextID), time.Now().UTC())
 		return err
 	}); err != nil {
 		return "", fmt.Errorf("insert sqlite mailbox item: %w", err)
@@ -215,10 +219,10 @@ func (s *SQLiteRuntimeStore) MarkMailboxItemNotified(ctx context.Context, id str
 
 func sqliteMailboxSelectSQL(where string) string {
 	return `
-		SELECT item_id, COALESCE(source_event_id, ''), COALESCE(entity_id, ''), COALESCE(from_agent, ''),
+		SELECT item_id, COALESCE(source_event_id, ''), COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(from_agent, ''),
 		       item_type, COALESCE(severity, 'normal'), status, COALESCE(notified, false),
 		       COALESCE(payload, '{}'), COALESCE(summary, ''), expires_at,
-		       COALESCE(decision, ''), COALESCE(decision_notes, '')
+		       COALESCE(decision, ''), COALESCE(decision_notes, ''), COALESCE(reply_context_id, '')
 		FROM mailbox
 		WHERE ` + where
 }
@@ -231,6 +235,13 @@ func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipel
 		sc.Mode = "once"
 	}
 	sc = scheduleWithContextRunID(ctx, sc)
+	if sc.Context.Empty() {
+		sc.Context = events.DeliveryContextFromContext(ctx)
+	}
+	sc.NormalizeDeliveryContext()
+	if !sc.Context.Empty() && strings.EqualFold(strings.TrimSpace(sc.Mode), "cron") {
+		return fmt.Errorf("recurring schedules cannot carry an open reply context")
+	}
 	sc.NormalizeRunID()
 	sc.NormalizeEntityID()
 	sc.NormalizeFlowInstance()
@@ -257,11 +268,11 @@ func (s *SQLiteRuntimeStore) UpsertSchedule(ctx context.Context, sc runtimepipel
 		_, err := tx.ExecContext(txctx, `
 			INSERT INTO timers (
 				timer_id, run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload,
-				fire_at, recurring, recurrence_cron, owner_agent, task_type, status, created_at
+				fire_at, recurring, recurrence_cron, owner_agent, reply_context_id, task_type, status, created_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, 'active', ?)
 		`, uuid.NewString(), sqliteNullUUID(sc.RunID), timerName, sqliteNullUUID(sc.EntityID), sqliteNullString(sc.FlowInstance),
-			sc.EventType, string(persistedSchedulePayload(sc)), fireAt.UTC(), recurring, sqliteNullString(sc.Cron), sc.AgentID, taskType, time.Now().UTC())
+			sc.EventType, string(persistedSchedulePayload(sc)), fireAt.UTC(), recurring, sqliteNullString(sc.Cron), sc.AgentID, sc.Context.ReplyContextID(), taskType, time.Now().UTC())
 		return err
 	}); err != nil {
 		return fmt.Errorf("insert sqlite timer: %w", err)
@@ -301,7 +312,7 @@ func (s *SQLiteRuntimeStore) LoadActiveSchedules(ctx context.Context) ([]runtime
 	exec := sqliteScheduleDBExecutor(ctx, s.DB)
 	rows, err := exec.QueryContext(ctx, `
 		SELECT COALESCE(run_id, ''), COALESCE(owner_agent, ''), fire_event, COALESCE(recurrence_cron, ''),
-		       fire_at, COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(fire_payload, '{}')
+		       fire_at, COALESCE(entity_id, ''), COALESCE(flow_instance, ''), COALESCE(fire_payload, '{}'), COALESCE(reply_context_id, '')
 		FROM timers
 		WHERE status = 'active'
 		ORDER BY fire_at ASC
@@ -315,7 +326,8 @@ func (s *SQLiteRuntimeStore) LoadActiveSchedules(ctx context.Context) ([]runtime
 		var sc runtimepipeline.Schedule
 		var fireAt any
 		var payload any
-		if err := rows.Scan(&sc.RunID, &sc.AgentID, &sc.EventType, &sc.Cron, &fireAt, &sc.EntityID, &sc.FlowInstance, &payload); err != nil {
+		var replyContextID string
+		if err := rows.Scan(&sc.RunID, &sc.AgentID, &sc.EventType, &sc.Cron, &fireAt, &sc.EntityID, &sc.FlowInstance, &payload, &replyContextID); err != nil {
 			return nil, fmt.Errorf("scan sqlite schedule: %w", err)
 		}
 		if at, ok, err := sqliteTimeValue(fireAt); err != nil {
@@ -330,6 +342,9 @@ func (s *SQLiteRuntimeStore) LoadActiveSchedules(ctx context.Context) ([]runtime
 			sc.Mode = "once"
 		}
 		sc.TaskID = scheduleTaskIDFromPayload(sc.Payload)
+		if replyContextID != "" {
+			sc.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: replyContextID}}
+		}
 		out = append(out, sc)
 	}
 	return out, rows.Err()

--- a/internal/store/sqlite_schema.go
+++ b/internal/store/sqlite_schema.go
@@ -163,8 +163,46 @@ func (s *SQLiteSchemaStore) EnsureSchemaTables(ctx context.Context, plans []Sche
 	if err := s.ensureSQLiteMailboxDeferredUntil(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureSQLiteReplyContextColumns(ctx); err != nil {
+		return err
+	}
 	_, err = s.BindSchemaCapabilities(ctx)
 	return err
+}
+
+func (s *SQLiteSchemaStore) ensureSQLiteReplyContextColumns(ctx context.Context) error {
+	columns := []struct {
+		table      string
+		name       string
+		definition string
+	}{
+		{table: "event_deliveries", name: "delivery_context", definition: "TEXT NOT NULL DEFAULT '{}'"},
+		{table: "activity_attempts", name: "reply_context_id", definition: "TEXT REFERENCES reply_contexts(reply_context_id)"},
+		{table: "timers", name: "reply_context_id", definition: "TEXT REFERENCES reply_contexts(reply_context_id)"},
+		{table: "mailbox", name: "reply_context_id", definition: "TEXT REFERENCES reply_contexts(reply_context_id)"},
+	}
+	for _, column := range columns {
+		existing, err := sqliteTableColumnList(ctx, s.DB, column.table)
+		if err != nil {
+			return err
+		}
+		if len(existing) == 0 || stringSliceContainsFold(existing, column.name) {
+			continue
+		}
+		if _, err := s.DB.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, column.table, column.name, column.definition)); err != nil {
+			return fmt.Errorf("add sqlite %s.%s: %w", column.table, column.name, err)
+		}
+	}
+	return nil
+}
+
+func stringSliceContainsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(want)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SQLiteSchemaStore) ensureSQLiteMailboxDeferredUntil(ctx context.Context) error {

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -22,8 +22,8 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	if len(platformPlans) != 30 {
-		t.Fatalf("platform table plan count = %d, want 30", len(platformPlans))
+	if len(platformPlans) != 31 {
+		t.Fatalf("platform table plan count = %d, want 31", len(platformPlans))
 	}
 	entityPlans, err := GenerateEntityTableDDLs(runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemutationlog "github.com/division-sh/swarm/internal/runtime/mutationlog"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -396,31 +399,31 @@ func (s *PostgresStore) DecideHumanTask(ctx context.Context, rec runtimetools.Hu
 	if err != nil {
 		return fmt.Errorf("begin postgres human task decision: %w", err)
 	}
+	postCommitActions := make([]func(), 0, 4)
+	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
+	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommitActions)
 	committed := false
 	defer func() {
 		if !committed {
 			_ = tx.Rollback()
 		}
 	}()
-	var expiresAt sql.NullTime
-	if err := tx.QueryRowContext(ctx, `
-		SELECT expires_at
-		FROM mailbox
-		WHERE item_id = $1::uuid
-		  AND item_type = 'human_task'
-		FOR UPDATE
-	`, rec.TaskID).Scan(&expiresAt); err != nil {
-		if err == sql.ErrNoRows {
+	row, err := s.loadMailboxV1RowTx(txctx, tx, rec.TaskID, true)
+	if err != nil {
+		if errors.Is(err, ErrMailboxV1NotFound) {
 			return fmt.Errorf("human task not found: %s", rec.TaskID)
 		}
 		return fmt.Errorf("load postgres human task: %w", err)
 	}
-	if err := validateHumanTaskDeferUntil(rec, deferUntil, expiresAt); err != nil {
+	if row.Type != "human_task" {
+		return fmt.Errorf("human task not found: %s", rec.TaskID)
+	}
+	if err := validateHumanTaskDeferUntil(rec, deferUntil, row.ExpiresAt); err != nil {
 		return err
 	}
 	var res sql.Result
 	if rec.Status == "deferred" {
-		res, err = tx.ExecContext(ctx, `
+		res, err = tx.ExecContext(txctx, `
 			UPDATE mailbox
 			SET status = 'pending',
 			    decision = NULL,
@@ -438,7 +441,7 @@ func (s *PostgresStore) DecideHumanTask(ctx context.Context, rec runtimetools.Hu
 			  AND item_type = 'human_task'
 		`, rec.TaskID, rec.Reason, rec.ActorID, rec.DecidedAt, deferUntil)
 	} else {
-		res, err = tx.ExecContext(ctx, `
+		res, err = tx.ExecContext(txctx, `
 			UPDATE mailbox
 			SET status = CASE WHEN $2 = 'timed_out' THEN 'expired' ELSE 'decided' END,
 			    decision = $2,
@@ -456,10 +459,14 @@ func (s *PostgresStore) DecideHumanTask(ctx context.Context, rec runtimetools.Hu
 	if affected, err := res.RowsAffected(); err == nil && affected == 0 {
 		return fmt.Errorf("human task not found: %s", rec.TaskID)
 	}
+	if err := publishHumanTaskOutcome(txctx, row, rec); err != nil {
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit postgres human task decision: %w", err)
 	}
 	committed = true
+	runtimepipeline.FlushPipelinePostCommitActions(postCommitActions)
 	return nil
 }
 
@@ -473,25 +480,17 @@ func (s *SQLiteRuntimeStore) DecideHumanTask(ctx context.Context, rec runtimetoo
 		return err
 	}
 	return s.runRuntimeMutation(ctx, "sqlite human task decision", func(txctx context.Context, tx *sql.Tx) error {
-		var payloadRaw any
-		var expiresAtRaw any
-		if err := tx.QueryRowContext(txctx, `
-			SELECT COALESCE(payload, '{}'), expires_at
-			FROM mailbox
-			WHERE item_id = ? AND item_type = 'human_task'
-		`, rec.TaskID).Scan(&payloadRaw, &expiresAtRaw); err != nil {
-			return fmt.Errorf("load sqlite human task payload: %w", err)
+		row, err := s.loadSQLiteMailboxV1RowTx(txctx, tx, rec.TaskID)
+		if err != nil {
+			return fmt.Errorf("load sqlite human task: %w", err)
 		}
-		expiresAt := sql.NullTime{}
-		if parsed, ok, err := sqliteTimeValue(expiresAtRaw); err != nil {
-			return fmt.Errorf("decode sqlite human task expiry: %w", err)
-		} else if ok {
-			expiresAt = sql.NullTime{Time: parsed, Valid: true}
+		if row.Type != "human_task" {
+			return fmt.Errorf("human task not found: %s", rec.TaskID)
 		}
-		if err := validateHumanTaskDeferUntil(rec, deferUntil, expiresAt); err != nil {
+		if err := validateHumanTaskDeferUntil(rec, deferUntil, row.ExpiresAt); err != nil {
 			return err
 		}
-		payload, err := toolDecodeJSONMap(payloadRaw)
+		payload, err := toolDecodeJSONMap(row.RawPayload)
 		if err != nil {
 			return fmt.Errorf("decode sqlite human task payload: %w", err)
 		}
@@ -538,6 +537,9 @@ func (s *SQLiteRuntimeStore) DecideHumanTask(ctx context.Context, rec runtimetoo
 		if affected, err := res.RowsAffected(); err == nil && affected == 0 {
 			return fmt.Errorf("human task not found: %s", rec.TaskID)
 		}
+		if err := publishHumanTaskOutcome(txctx, row, rec); err != nil {
+			return err
+		}
 		return nil
 	})
 }
@@ -551,12 +553,15 @@ func createHumanTask(ctx context.Context, store mailboxPersistence, rec runtimet
 		return "", fmt.Errorf("human-task persistence store is required")
 	}
 	rec = normalizeHumanTaskCreateRecord(rec)
+	taskID := uuid.NewString()
 	payload := map[string]any{
-		"category":       rec.Category,
-		"description":    rec.Description,
-		"expected_value": rec.ExpectedValue,
-		"priority":       rec.Priority,
-		"requeue_count":  0,
+		"category":         rec.Category,
+		"description":      rec.Description,
+		"expected_value":   rec.ExpectedValue,
+		"priority":         rec.Priority,
+		"requeue_count":    0,
+		"requesting_agent": rec.ActorID,
+		"task_id":          taskID,
 	}
 	if len(rec.TalkingPoints) > 0 && strings.TrimSpace(string(rec.TalkingPoints)) != "null" {
 		var talking any
@@ -569,15 +574,84 @@ func createHumanTask(ctx context.Context, store mailboxPersistence, rec runtimet
 		return "", fmt.Errorf("create human task: marshal payload: %w", err)
 	}
 	return store.InsertMailboxItem(ctx, runtimetools.MailboxItem{
-		EntityID:  rec.EntityID,
-		FromAgent: rec.ActorID,
-		Type:      "human_task",
-		Priority:  rec.Priority,
-		Status:    "pending",
-		Summary:   rec.Description,
-		Context:   json.RawMessage(payloadJSON),
-		TimeoutAt: rec.Deadline,
+		ID:             taskID,
+		EventID:        rec.SourceEventID,
+		EntityID:       rec.EntityID,
+		FlowInstance:   rec.FlowInstance,
+		FromAgent:      rec.ActorID,
+		Type:           "human_task",
+		Priority:       rec.Priority,
+		Status:         "pending",
+		Summary:        rec.Description,
+		Context:        json.RawMessage(payloadJSON),
+		TimeoutAt:      rec.Deadline,
+		ReplyContextID: rec.Context.ReplyContextID(),
 	})
+}
+
+func publishHumanTaskOutcome(ctx context.Context, row mailboxV1Row, rec runtimetools.HumanTaskDecisionRecord) error {
+	deliveryContext := replyDeliveryContext(row.ReplyContextID)
+	if rec.DecisionEventPublish == nil {
+		if !deliveryContext.Empty() {
+			return fmt.Errorf("human task %s has reply context but no transactional outcome publisher", row.ID)
+		}
+		return nil
+	}
+	eventType := ""
+	switch rec.Status {
+	case "approved":
+		eventType = "human_task.approved"
+	case "rejected":
+		eventType = "human_task.rejected"
+	case "deferred":
+		eventType = "human_task.deferred"
+	case "timed_out":
+		eventType = "human_task.expired"
+	default:
+		return fmt.Errorf("human task %s has unsupported outcome %q", row.ID, rec.Status)
+	}
+	payload := cloneMailboxV1Payload(row.Payload)
+	payload["task_id"] = row.ID
+	payload["requesting_agent"] = strings.TrimSpace(row.FromAgent)
+	payload["status"] = rec.Status
+	payload["decided_by"] = rec.ActorID
+	payload["decided_at"] = rec.DecidedAt.UTC().Format(time.RFC3339Nano)
+	if rec.Reason != "" {
+		payload["reason"] = rec.Reason
+	}
+	if rec.Status == "rejected" {
+		payload["rejection_reason"] = rec.Reason
+	}
+	if rec.Status == "deferred" {
+		payload["requeue_date"] = rec.RequeueDate
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal human task outcome: %w", err)
+	}
+	evt := events.NewRuntimeControlEvent(
+		uuid.NewString(),
+		events.EventType(eventType),
+		"runtime",
+		"",
+		raw,
+		0,
+		strings.TrimSpace(row.RunID),
+		strings.TrimSpace(row.SourceEventID),
+		events.EventEnvelope{
+			EntityID:     strings.TrimSpace(row.EntityID),
+			FlowInstance: strings.TrimSpace(row.FlowInstance),
+		},
+		rec.DecidedAt.UTC(),
+	)
+	if !deliveryContext.Empty() {
+		evt = evt.WithDeliveryContext(deliveryContext)
+		ctx = events.WithDeliveryContext(ctx, deliveryContext)
+	}
+	if err := rec.DecisionEventPublish(ctx, evt); err != nil {
+		return fmt.Errorf("publish human task outcome: %w", err)
+	}
+	return nil
 }
 
 func toolEntitySelectSQL(where string) string {
@@ -1039,10 +1113,13 @@ func toolJSONSQLArg(value any) (any, error) {
 func normalizeHumanTaskCreateRecord(rec runtimetools.HumanTaskCreateRecord) runtimetools.HumanTaskCreateRecord {
 	rec.ActorID = strings.TrimSpace(rec.ActorID)
 	rec.EntityID = strings.TrimSpace(rec.EntityID)
+	rec.FlowInstance = strings.Trim(strings.TrimSpace(rec.FlowInstance), "/")
 	rec.Category = strings.TrimSpace(rec.Category)
 	rec.Description = strings.TrimSpace(rec.Description)
 	rec.ExpectedValue = strings.TrimSpace(rec.ExpectedValue)
 	rec.Priority = strings.TrimSpace(rec.Priority)
+	rec.SourceEventID = strings.TrimSpace(rec.SourceEventID)
+	rec.Context = rec.Context.Normalized()
 	if rec.Priority == "" {
 		rec.Priority = "medium"
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3471,6 +3471,10 @@ engine:
         durable_refs: [event_deliveries.delivery_context, activity_attempts.reply_context_id, timers.reply_context_id, mailbox.reply_context_id]
         rule: Durable consumers store only the opaque reply_context_id.
       terminal_claim:
+        explicit_correlation_validation: When correlation_key is declared, the provider reply MUST carry the same non-empty
+          scalar value persisted from the paired request. A missing or unequal response value fails closed as
+          platform.stale_arrival before origin resolution or terminal claim, persists no requester delivery, and leaves the
+          reply context open.
         first_reply: Atomically changes open to terminal and records accepted_reply_event_id.
         accepted_replay: The same reply event id is idempotent and reuses its persisted delivery.
         distinct_second_reply: Fails closed as platform.reply_already_terminal and names the accepted/rejected event ids.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3423,6 +3423,67 @@ engine:
         key/carries plus receiver instance.by for normal same-name instance-key routing, explicit addressed input-pin
         descriptor routing for approved addressed surfaces, or an explicit dynamic target escape hatch at emit/publish
         time. Structural ParentRoute binding is only a child-to-parent fallback when no lowered connect target applies.
+    reply_resolution:
+      status: runnable_v1
+      description: Receiver-declared request/reply routing returns one terminal provider result to the exact route that
+        emitted the paired request. The runtime carries this authority as opaque route-scoped delivery context; business
+        payload, event envelope, source lineage, flow-instance metadata, requesting_agent, and task_id are never routing owners.
+      authoring:
+        request_output:
+          shape: 'pins.outputs.events[] {name: provider_requested, event: provider.requested, carries: [provider_request_id]}'
+          correlation: The optional correlation_key must name one declared scalar carried key on this output pin.
+        reply_input:
+          shape: 'pins.inputs.events[] {name: provider_replied, event: provider.replied, resolution: {mode: reply, replies_to: provider_requested, correlation_key: provider_request_id}}'
+          replies_to: Required. Names exactly one output pin on the same requester flow.
+        topology: Parent connect must contain exactly one request edge from the paired requester output to one provider
+          counterpart and exactly one response edge from that same counterpart to the reply input.
+        default_correlation: Stable request event id when correlation_key is absent.
+      lowering:
+        owner: runtime/core/pinrouting.ConnectRoutePlan.ReplyResolution
+        result: One typed request role and one typed response role share requester pins, provider pins, and optional correlation key.
+        ambiguity: Missing pins, undeclared carried keys, multiple request counterparts, multiple response counterparts,
+          or different provider counterparts are hard boot invalidities.
+      delivery_context:
+        type: 'events.DeliveryContext{Reply: *ReplyContextRef{ID string}}'
+        scope: One delivery route. It is installed independently for each node/agent route and is omitted from EventEnvelope JSON.
+        creation: Request publication creates the full reply_contexts row in the same typed event mutation after the request
+          event exists and before provider delivery commits. Recipient preflight computes the deterministic id but performs no write.
+        identity: Deterministic from request event, paired topology, and normalized origin route. Logical resolution identity
+          is (origin_instance_id, request_correlation_id) within the paired topology.
+        consumption: Only publication through the declared provider reply output consumes the ref and terminally claims it.
+      continuation_carriers:
+        ordinary_emit: EmitIntent.Context and route-aware EventBus publish preserve the ref.
+        activity: ActivityIntent.Context and activity_attempts.reply_context_id preserve the ref across request, provider call,
+          journal readback, and result publication.
+        timer: TimerIntent.Context and timers.reply_context_id preserve the ref for one-shot schedules; recurring schedules
+          carrying an open reply context fail closed.
+        child: FlowInstanceActivationRequest.Context preserves the ref through activation, child input/auto-emit, and completion;
+          no instance-global metadata copy is permitted.
+        mailbox: mailbox.reply_context_id is populated by system mailbox_write and agent mailbox_send. Defer and terminal
+          decision updates restore it into the transactional decision-event publication context and do not claim the reply.
+        human_task: human_task_request stores source_event_id, flow_instance, and mailbox.reply_context_id. Defer and final decision outcomes
+          are produced from the locked durable row in the same mutation, restore the ref independently of requesting_agent/task_id,
+          and do not claim the reply.
+      persistence:
+        owner: store.ReplyContextStore
+        backends: [postgres, sqlite]
+        full_record: reply_contexts owns request/topology/origin/correlation/lifecycle/accepted-event facts.
+        durable_refs: [event_deliveries.delivery_context, activity_attempts.reply_context_id, timers.reply_context_id, mailbox.reply_context_id]
+        rule: Durable consumers store only the opaque reply_context_id.
+      terminal_claim:
+        first_reply: Atomically changes open to terminal and records accepted_reply_event_id.
+        accepted_replay: The same reply event id is idempotent and reuses its persisted delivery.
+        distinct_second_reply: Fails closed as platform.reply_already_terminal and names the accepted/rejected event ids.
+        missing_or_closed_origin: Fails closed as platform.stale_arrival; no create, broadcast, source, or payload fallback is allowed.
+        mailbox_and_human_decisions: Non-terminal provider continuation events; they preserve but never consume the claim.
+      replay_and_fork:
+        restart: Event deliveries and continuation rows restore refs only from their typed columns.
+        same_run_replay: Uses the persisted delivery route context; it does not reconstruct reply identity.
+        timestamp_fork: A source run with an open reply context at the selected frontier fails closed with
+          open_reply_context_unsupported. The context is never copied or reopened in the fork.
+      observability:
+        graph: Generated connect route plans expose both request and response roles and name the paired request/reply/provider pins.
+        trace: run.trace exposes reply_context_id from event_deliveries.delivery_context for platform debugging; business payload remains unchanged.
     target_resolution:
       precedence:
       - lowered parent connect route plan
@@ -3536,6 +3597,10 @@ engine:
         parent_route_incomplete: Structural child-to-parent routing needs ParentRoute but instance metadata only has incomplete legacy parent data.
         target_ambiguous: flow/match resolution finds more than one target without allow_fanout:true.
         target_not_subscribed: Target instance exists but does not subscribe to the emitted event type.
+        platform.reply_already_terminal: A distinct reply event attempted to consume a context already terminally claimed by
+          another reply. Diagnostics name reply_context_id, request event, accepted reply event, and rejected reply event.
+        platform.stale_arrival: Reply context is missing, malformed, topology-mismatched, or resolves to no live origin carrier.
+          Diagnostics name the paired request/reply pins and available context identity; no fallback delivery is attempted.
       emit_time_tool_error:
         target_sender_no_inbound_runtime: target:sender reached a mixed path with no inbound event source.
         target_sender_empty_source_runtime: target:sender reached an inbound event whose source is empty.
@@ -9068,7 +9133,7 @@ platform_tables:
       - No production cleanup owner may use all-table truncate, cascading bulk truncation, table name heuristics, entity_id-only predicates, or flow_instance-only predicates.
       - Every platform_tables.tables entry must have exactly one destructive-reset cleanup classification in the typed cleanup catalog.
       - Apply and dry-run must consume the plan cleanup_runs snapshot only; runs created after the plan/quiescence envelope are out of scope for that cleanup call.
-      - Before deleting planned run-scoped rows, apply must sever nullable preserved/out-of-scope references into the cleanup set; current severed references are agent_sessions.successor_session_id, runs.forked_from_run_id/forked_from_event_id, runtime_ingress_state.transition_event_id, entity_mutations.caused_by_event, and timers.source_timer_id.
+      - Before deleting planned run-scoped rows, apply must sever nullable preserved/out-of-scope references into the cleanup set; current severed references are agent_sessions.successor_session_id, runs.forked_from_run_id/forked_from_event_id, runtime_ingress_state.transition_event_id, entity_mutations.caused_by_event, timers.source_timer_id, and mailbox.reply_context_id.
       - Fork-lineage cleanup must delete fork replay and selected-contract rows by fork/source run_id and by linked cleanup-owned event/delivery references before deleting event_deliveries or events; preserved fork/source run IDs are not sufficient proof that the row is out of scope.
       - Runtime-owned persisted facts that describe running or historical execution must carry an exact run_id, event lineage, or fork/source run lineage before destructive reset may delete them.
       - Generated node-state tables and legacy/future product optimization tables remain split-preserved until a separate
@@ -9088,6 +9153,7 @@ platform_tables:
         - run_fork_selected_contract_bindings
       delete_by_run_id:
         - activity_attempts
+        - reply_contexts
         - agent_turns
         - agent_sessions
         - entity_mutations
@@ -9144,6 +9210,39 @@ platform_tables:
         \ idx_events_flow (flow_instance, event_name) WHERE flow_instance IS NOT NULL,\n    INDEX idx_events_source_route ((source_route->>'flow_instance'), (source_route->>'entity_id')) WHERE source_route <> '{}'::jsonb,\n    INDEX idx_events_target_route ((target_route->>'flow_instance'), (target_route->>'entity_id')) WHERE target_route <> '{}'::jsonb,\n    INDEX idx_events_global (event_name,\
         \ created_at) WHERE scope = 'global',\n    INDEX idx_events_idempotency (idempotency_key) WHERE idempotency_key\
         \ IS NOT NULL,\n    INDEX idx_events_source (source_event_id) WHERE source_event_id IS NOT NULL\n);"
+    reply_contexts:
+      description: >-
+        Canonical mutable owner for one request/reply loop. A request delivery route carries only
+        reply_context_id in its typed delivery_context; business payloads, EventEnvelope, lineage,
+        and generic flow metadata never own or reconstruct reply routing. The record binds the
+        request event, paired request/reply topology, concrete origin route, and request correlation.
+        Terminal claim is atomic: the first reply event wins, replay of that same event is idempotent,
+        and a distinct later reply fails closed as platform.reply_already_terminal.
+      ddl: |
+        CREATE TABLE reply_contexts (
+            reply_context_id        TEXT PRIMARY KEY,
+            run_id                  UUID REFERENCES runs(run_id),
+            request_event_id        UUID NOT NULL REFERENCES events(event_id),
+            requester_flow_id       TEXT NOT NULL,
+            request_output_pin      TEXT NOT NULL,
+            reply_input_pin         TEXT NOT NULL,
+            provider_flow_id        TEXT NOT NULL,
+            provider_input_pin      TEXT NOT NULL,
+            provider_output_pin     TEXT NOT NULL,
+            origin_route            JSONB NOT NULL,
+            request_correlation_id  TEXT NOT NULL,
+            correlation_key         TEXT,
+            state                   TEXT NOT NULL DEFAULT 'open' CHECK (state IN ('open', 'terminal')),
+            accepted_reply_event_id UUID REFERENCES events(event_id),
+            created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            terminal_at             TIMESTAMPTZ,
+            CHECK ((state = 'open' AND accepted_reply_event_id IS NULL AND terminal_at IS NULL) OR (state = 'terminal' AND accepted_reply_event_id IS NOT NULL AND terminal_at IS NOT NULL)),
+            UNIQUE (requester_flow_id, request_output_pin, reply_input_pin, provider_flow_id, request_correlation_id, origin_route),
+            INDEX idx_reply_contexts_run_state (run_id, state),
+            INDEX idx_reply_contexts_request (request_event_id),
+            INDEX idx_reply_contexts_correlation (request_correlation_id, state)
+        );
     activity_attempts:
       description: 'Durable attempt/result journal for executable non-idempotent activity calls. A platform.activity_requested
         event is the request owner; this table is the provider-attempt truth owner after the request is admitted. The
@@ -9157,7 +9256,7 @@ platform_tables:
         request events, the existing row is consumed before static or managed credential resolution, token refresh, or outbound
         preparation. response_mapping, rate_limit, MCP/platform/native/generated tools, idempotent_write, and long_running remain
         split/fail-closed.'
-      ddl: "CREATE TABLE activity_attempts (\n    request_event_id UUID PRIMARY KEY,\n    run_id            UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id   UUID,\n    parent_event_id   UUID,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    node_id           TEXT NOT NULL,\n    handler_event_key TEXT NOT NULL,\n    activity_id       TEXT NOT NULL,\n    tool              TEXT NOT NULL,\n    effect_class      TEXT NOT NULL CHECK (effect_class = 'non_idempotent_write'),\n    attempt           INTEGER NOT NULL DEFAULT 1 CHECK (attempt = 1),\n    status            TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed', 'uncertain')),\n    success_event     TEXT NOT NULL,\n    failure_event     TEXT NOT NULL,\n    result_event_id   UUID,\n    result_event_type TEXT,\n    result_payload    JSONB,\n    error             TEXT,\n    input_hash        TEXT NOT NULL,\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    completed_at      TIMESTAMPTZ,\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((status = 'started' AND result_event_id IS NULL AND result_event_type IS NULL AND result_payload IS NULL AND error IS NULL AND completed_at IS NULL) OR (status IN ('succeeded', 'failed', 'uncertain') AND result_event_id IS NOT NULL AND result_event_type IS NOT NULL AND result_payload IS NOT NULL AND completed_at IS NOT NULL)),\n    INDEX idx_activity_attempts_run (run_id, started_at),\n    INDEX idx_activity_attempts_activity (run_id, activity_id, tool),\n    INDEX idx_activity_attempts_result_event (result_event_id) WHERE result_event_id IS NOT NULL\n);"
+      ddl: "CREATE TABLE activity_attempts (\n    request_event_id UUID PRIMARY KEY,\n    run_id            UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id   UUID,\n    parent_event_id   UUID,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    node_id           TEXT NOT NULL,\n    handler_event_key TEXT NOT NULL,\n    activity_id       TEXT NOT NULL,\n    tool              TEXT NOT NULL,\n    effect_class      TEXT NOT NULL CHECK (effect_class = 'non_idempotent_write'),\n    attempt           INTEGER NOT NULL DEFAULT 1 CHECK (attempt = 1),\n    status            TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed', 'uncertain')),\n    success_event     TEXT NOT NULL,\n    failure_event     TEXT NOT NULL,\n    result_event_id   UUID,\n    result_event_type TEXT,\n    result_payload    JSONB,\n    error             TEXT,\n    input_hash        TEXT NOT NULL,\n    reply_context_id  TEXT REFERENCES reply_contexts(reply_context_id),\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    completed_at      TIMESTAMPTZ,\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((status = 'started' AND result_event_id IS NULL AND result_event_type IS NULL AND result_payload IS NULL AND error IS NULL AND completed_at IS NULL) OR (status IN ('succeeded', 'failed', 'uncertain') AND result_event_id IS NOT NULL AND result_event_type IS NOT NULL AND result_payload IS NOT NULL AND completed_at IS NOT NULL)),\n    INDEX idx_activity_attempts_run (run_id, started_at),\n    INDEX idx_activity_attempts_activity (run_id, activity_id, tool),\n    INDEX idx_activity_attempts_result_event (result_event_id) WHERE result_event_id IS NOT NULL\n);"
     run_fork_selected_contract_bindings:
       description: Durable selected-contract source binding for timestamp forks. One row binds a fork run to the selected
         contract source identity that was admitted before materialization. This is prerequisite fork-run state for future
@@ -9193,7 +9292,8 @@ platform_tables:
       description: >-
         Tracks delivery of events to subscribers (nodes and agents). One row per event x subscriber. run_id inherited
         from the parent event for run-scoped queries. delivery_target_route stores the concrete target_set member assigned
-        to this subscriber when fan-out routing materializes multiple target identities. status is the canonical lifecycle
+        to this subscriber when fan-out routing materializes multiple target identities. delivery_context stores opaque
+        platform-only route-scoped continuation references and is never part of the business event envelope. status is the canonical lifecycle
         owner for both agent and node deliveries: pending means queued/not started; in_progress means the delivery has been
         claimed or handler execution has started; delivered means successfully settled; failed means a retry-visible
         handler/dispatch failure; dead_letter means terminal failure. Agent and system-node execution paths must mark
@@ -9202,7 +9302,7 @@ platform_tables:
       ddl: "CREATE TABLE event_deliveries (\n    delivery_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    run_id\
         \            UUID REFERENCES runs(run_id),\n    event_id          UUID NOT NULL REFERENCES events(event_id),\n\
         \    subscriber_type   TEXT NOT NULL CHECK (subscriber_type IN ('node', 'agent')),\n    subscriber_id     TEXT NOT\
-        \ NULL,\n    delivery_target_route JSONB NOT NULL DEFAULT '{}',\n    status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'in_progress', 'delivered',\
+        \ NULL,\n    delivery_target_route JSONB NOT NULL DEFAULT '{}',\n    delivery_context JSONB NOT NULL DEFAULT '{}',\n    status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'in_progress', 'delivered',\
         \ 'failed', 'dead_letter')),\n    retry_count       INTEGER NOT NULL DEFAULT 0,\n    reason_code       TEXT,\n\
         \    last_error        TEXT,\n    active_session_id UUID,\n    started_at        TIMESTAMPTZ,\n    delivered_at\
         \      TIMESTAMPTZ,\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_deliveries_run (run_id,\
@@ -9400,7 +9500,8 @@ platform_tables:
         distinguishes task kinds: human_task, review_request, approval, alert, operational_decision. human_tasks are represented
         as mailbox items with item_type = "human_task". from_agent identifies the requesting agent. summary provides a human-readable
         description. decision_notes captures the human rationale. notified tracks whether the human was alerted. source_event_id
-        links back to the triggering event for traceability.'
+        links back to the triggering event for traceability. reply_context_id is platform-only route-scoped continuation
+        authority and must never be copied into payload.'
       ddl: "CREATE TABLE mailbox (\n    item_id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    entity_id     \
         \    UUID,\n    flow_instance     TEXT,\n    scope             TEXT NOT NULL DEFAULT 'entity' CHECK (scope IN ('entity',\
         \ 'flow', 'global')),\n    item_type         TEXT NOT NULL,\n    source_event_id   UUID,\n    from_agent        TEXT,\n\
@@ -9408,7 +9509,7 @@ platform_tables:
         \           TEXT,\n    payload           JSONB NOT NULL DEFAULT '{}',\n    status            TEXT NOT NULL DEFAULT\
         \ 'pending' CHECK (status IN ('pending', 'decided', 'expired', 'cancelled')),\n    decision          TEXT,\n    decision_notes\
         \    TEXT,\n    decided_by        TEXT,\n    decided_at        TIMESTAMPTZ,\n    notified          BOOLEAN NOT NULL\
-        \ DEFAULT FALSE,\n    expires_at        TIMESTAMPTZ,\n    deferred_until    TIMESTAMPTZ,\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n\
+        \ DEFAULT FALSE,\n    expires_at        TIMESTAMPTZ,\n    deferred_until    TIMESTAMPTZ,\n    reply_context_id  TEXT REFERENCES reply_contexts(reply_context_id),\n    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n\
         \    INDEX idx_mailbox_status (status, severity, created_at),\n    INDEX idx_mailbox_entity (entity_id) WHERE entity_id\
         \ IS NOT NULL,\n    INDEX idx_mailbox_type (item_type, status),\n    INDEX idx_mailbox_global (scope, status) WHERE\
         \ scope = 'global'\n);"
@@ -9523,7 +9624,8 @@ platform_tables:
         flow_instance set, tied to a specific entity lifecycle inside run_id. Global timers: entity_id, flow_instance,
         and run_id NULL, used for boot-start workflow timers and platform-level work (periodic scans, health checks,
         digest compilation).
-        fire_payload carries context when the timer fires. owner_node OR owner_agent identifies who declared the timer
+        fire_payload carries business input when the timer fires; reply_context_id separately carries opaque route-scoped
+        continuation authority for one-shot timers. owner_node OR owner_agent identifies who declared the timer
         (mutually exclusive). source_timer_id, forked_from_run_id, forked_from_event_id, and reconstruction_owner are
         lineage-only fields for fork-local reconstructed timers and must not make the source timer executable fork truth.
         recurrence_cron supports cron expressions for global recurring schedules. recurrence_interval supports duration
@@ -9536,7 +9638,7 @@ platform_tables:
         \    reconstruction_owner TEXT,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    fire_event        TEXT NOT NULL,\n\
         \    fire_payload      JSONB NOT NULL DEFAULT '{}',\n    fire_at           TIMESTAMPTZ NOT NULL,\n    recurring  \
         \       BOOLEAN NOT NULL DEFAULT FALSE,\n    recurrence_cron   TEXT,\n    recurrence_interval TEXT,\n    owner_node\
-        \        TEXT,\n    owner_agent       TEXT,\n    task_type         TEXT NOT NULL DEFAULT 'timer' CHECK (task_type\
+        \        TEXT,\n    owner_agent       TEXT,\n    reply_context_id  TEXT REFERENCES reply_contexts(reply_context_id),\n    task_type         TEXT NOT NULL DEFAULT 'timer' CHECK (task_type\
         \ IN ('timer', 'scheduled_task', 'deadline', 'global_recurring')),\n    status            TEXT NOT NULL DEFAULT 'active'\
         \ CHECK (status IN ('active', 'fired', 'cancelled', 'expired')),\n    fired_at          TIMESTAMPTZ,\n    created_at\
         \        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    INDEX idx_timers_run (run_id, status, fire_at) WHERE run_id IS NOT NULL,\n\
@@ -11886,13 +11988,162 @@ platform_events:
       forbidden_fields:
       - payload
       produced_by_type: platform
+    human_task.approved:
+      description: Product-facing platform event emitted after an operator approves a persisted human task.
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["human_task.approved"].payload'
+      producer_evidence:
+        produced_by_type: platform
+        locations:
+        - internal/store/tool_persistence.go#publishHumanTaskOutcome
+      routing_class: event_loop_routable
+      scope: entity or flow
+      payload:
+        task_id: uuid
+        requesting_agent: text
+        status: text
+        decided_by: text
+        decided_at: timestamp
+        category: text
+        description: text
+        expected_value: text
+        priority: text
+        requeue_count: integer
+        talking_points: array
+        reason: text
+        rejection_reason: text
+        expiry_reason: text
+        requeue_date: timestamp
+      required:
+      - task_id
+      - requesting_agent
+      - status
+      - decided_by
+      - decided_at
+      - category
+      - description
+      - expected_value
+      - priority
+      - requeue_count
+      produced_by_type: platform
+    human_task.rejected:
+      description: Product-facing platform event emitted after an operator rejects a persisted human task.
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["human_task.rejected"].payload'
+      producer_evidence:
+        produced_by_type: platform
+        locations:
+        - internal/store/tool_persistence.go#publishHumanTaskOutcome
+      routing_class: event_loop_routable
+      scope: entity or flow
+      payload:
+        task_id: uuid
+        requesting_agent: text
+        status: text
+        decided_by: text
+        decided_at: timestamp
+        category: text
+        description: text
+        expected_value: text
+        priority: text
+        requeue_count: integer
+        talking_points: array
+        reason: text
+        rejection_reason: text
+        expiry_reason: text
+        requeue_date: timestamp
+      required:
+      - task_id
+      - requesting_agent
+      - status
+      - decided_by
+      - decided_at
+      - category
+      - description
+      - expected_value
+      - priority
+      - requeue_count
+      produced_by_type: platform
+    human_task.deferred:
+      description: Product-facing platform event emitted when a persisted human task is deferred without terminally deciding it.
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["human_task.deferred"].payload'
+      producer_evidence:
+        produced_by_type: platform
+        locations:
+        - internal/store/tool_persistence.go#publishHumanTaskOutcome
+      routing_class: event_loop_routable
+      scope: entity or flow
+      payload:
+        task_id: uuid
+        requesting_agent: text
+        status: text
+        decided_by: text
+        decided_at: timestamp
+        category: text
+        description: text
+        expected_value: text
+        priority: text
+        requeue_count: integer
+        talking_points: array
+        reason: text
+        rejection_reason: text
+        expiry_reason: text
+        requeue_date: timestamp
+      required:
+      - task_id
+      - requesting_agent
+      - status
+      - decided_by
+      - decided_at
+      - category
+      - description
+      - expected_value
+      - priority
+      - requeue_count
+      produced_by_type: platform
+    human_task.expired:
+      description: Product-facing platform event emitted when a persisted human task reaches its terminal timeout decision.
+      schema_authority: 'platform-spec.yaml#platform_events.catalog["human_task.expired"].payload'
+      producer_evidence:
+        produced_by_type: platform
+        locations:
+        - internal/store/tool_persistence.go#publishHumanTaskOutcome
+      routing_class: event_loop_routable
+      scope: entity or flow
+      payload:
+        task_id: uuid
+        requesting_agent: text
+        status: text
+        decided_by: text
+        decided_at: timestamp
+        category: text
+        description: text
+        expected_value: text
+        priority: text
+        requeue_count: integer
+        talking_points: array
+        reason: text
+        rejection_reason: text
+        expiry_reason: text
+        requeue_date: timestamp
+      required:
+      - task_id
+      - requesting_agent
+      - status
+      - decided_by
+      - decided_at
+      - category
+      - description
+      - expected_value
+      - priority
+      - requeue_count
+      produced_by_type: platform
   routing_rules:
     description: Most platform events enter the normal event loop. Products can subscribe agents to them. System nodes can handle
       them. They follow standard routing, delivery, and persistence rules.
     routable_events: 'Platform events that enter the normal event loop: platform.dead_letter, platform.agent_failed,
       platform.agent_panic, platform.event_quarantined, platform.dead_letter_escalation, platform.run_stalled, platform.reset, platform.auth_required,
       platform.paused, platform.resumed, platform.boot, platform.recovery_failed, platform.agent_started, platform.budget_threshold_crossed,
-      mailbox.item_decided, mailbox.item_deferred. Products can subscribe to these.'
+      mailbox.item_decided, mailbox.item_deferred, human_task.approved, human_task.rejected, human_task.deferred,
+      human_task.expired. Products can subscribe to these.'
     internal_routable_events: 'platform.activity_requested enters the normal event loop as a platform-internal durable activity
       request and is consumed by workflow-runtime; products MUST NOT author, emit, or claim ownership of it.'
     diagnostic_events: 'Platform events that bypass the event loop and are persisted directly to the events table:


### PR DESCRIPTION
## Summary

- make `resolution.mode: reply` runnable for paired request/reply connect loops
- introduce route-scoped `events.DeliveryContext` with an opaque reply-context ref and one backend-neutral `ReplyContextStore`
- preserve the ref through node, agent, activity, one-shot timer, child activation, mailbox, human-task, replay/restart, trace, and both Postgres/SQLite persistence paths
- fail closed for terminal races, stale origins, recurring schedules with open reply contexts, and timestamp forks
- add the canonical `template-reply` fixture and production-path conformance
- update destructive-reset ownership for the new run-scoped table and preserved mailbox references

Closes #1924

Parent #1835 remains open for barrier, fan-out, and Empire counterpart proof.

## Governing context

Before this PR, no exact authoritative spec section made reply resolution runnable. The binding context was the repaired #1924 issue/audit and independent gate, the #1835 resolution-mode design lock, and the adjacent existing composition-routing, typed delivery-route, persistence, replay/fork, and diagnostic contracts.

This PR promotes the accepted semantics into authoritative `platform-spec.yaml` at:

- `engine.composition_routing.reply_resolution`
- `engine.error_taxonomy.target_resolution_failures`
- `platform_tables.destructive_reset_cleanup_policy`
- `platform_tables.tables.reply_contexts`
- the updated `event_deliveries`, `activity_attempts`, `timers`, and `mailbox` DDL/capability contracts

The platform remains on the shared `0.7.0` train.

Gate records:

- second amended audit: https://github.com/division-sh/swarm/issues/1924#issuecomment-4929844793
- independent approval: https://github.com/division-sh/swarm/issues/1924#issuecomment-4929886624
- approval after master advance: https://github.com/division-sh/swarm/issues/1924#issuecomment-4929907106

## Semantic migration

New canonical owners:

- `events.DeliveryContext` owns the route-scoped opaque carrier
- `replycontext.Store` owns the full mutable request/topology/origin/correlation/terminal record
- typed continuation rows own only `reply_context_id`

Invalid/non-authoritative paths:

- business payload, `EventEnvelope`, source/parent lineage, flow metadata, `requesting_agent`, and `task_id` are not reply-routing owners
- direct mailbox/human outcome injection is not conformance proof
- live subscriptions and route reconstruction do not replace persisted route context

The old `connect.reply` metadata spelling remains isolated and non-authoritative as explicitly required by the gate; its retirement belongs to E1a (#1738/#1827). The migration is complete for the chosen runnable reply-mode class.

Production paths checked include ordinary node/agent emit, HTTP activity request/journal/result, one-shot schedule persistence/fire, child activation/auto-emit, system and agent mailbox creation/decision, human-task request/defer/final outcome, committed delivery readback, run trace, timestamp-fork admission, stale origin, and destructive reset.

## Verification

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- reply conformance repeated with `-count=5`
- reply store atomicity/backend parity repeated with `-count=5`
- activity, timer, and agent mailbox/human-task paths repeated with `-count=5`
