### PR TITLE
[agent-f][issue #1929] Unify provider capability surfaces

### DIFF
--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -62,6 +62,8 @@ func cliHumanCodePhrasesFromSpec(t *testing.T, projection *yaml.Node) map[cliHum
 	knownSpecFamilies := map[string]bool{
 		"run_status": true, "operational_state": true, "agent_status": true,
 		"conversation_mode": true, "session_scope": true, "delivery_status": true,
+		"provider_subject_kind": true, "provider_subject_status": true, "provider_capability": true,
+		"provider_guarantee": true, "provider_requirement_status": true,
 		"run_blocking_tuples": true, "agent_lifecycle_tuples": true, "watchdog_tuples": true,
 	}
 	forEachYAMLMappingNode(t, families, func(name string, _ *yaml.Node) {
@@ -71,12 +73,17 @@ func cliHumanCodePhrasesFromSpec(t *testing.T, projection *yaml.Node) map[cliHum
 	})
 
 	for specName, family := range map[string]cliHumanCodeFamily{
-		"run_status":        cliHumanCodeRunStatus,
-		"operational_state": cliHumanCodeOperationalState,
-		"agent_status":      cliHumanCodeAgentStatus,
-		"conversation_mode": cliHumanCodeConversationMode,
-		"session_scope":     cliHumanCodeSessionScope,
-		"delivery_status":   cliHumanCodeDeliveryStatus,
+		"run_status":                  cliHumanCodeRunStatus,
+		"operational_state":           cliHumanCodeOperationalState,
+		"agent_status":                cliHumanCodeAgentStatus,
+		"conversation_mode":           cliHumanCodeConversationMode,
+		"session_scope":               cliHumanCodeSessionScope,
+		"delivery_status":             cliHumanCodeDeliveryStatus,
+		"provider_subject_kind":       cliHumanCodeProviderSubjectKind,
+		"provider_subject_status":     cliHumanCodeProviderSubjectStatus,
+		"provider_capability":         cliHumanCodeProviderCapability,
+		"provider_guarantee":          cliHumanCodeProviderGuarantee,
+		"provider_requirement_status": cliHumanCodeProviderRequirementStatus,
 	} {
 		phrases := driftMappingValue(driftMappingValue(families, specName), "phrases")
 		forEachYAMLMapping(t, phrases, func(code, phrase string) {
@@ -214,6 +221,11 @@ func TestCLIHumanCodePublicConsumersUseSharedProjector(t *testing.T) {
 		"cliHumanCodeWatchdogBlockingLayer":       string(cliHumanCodeWatchdogBlockingLayer),
 		"cliHumanCodeWatchdogAction":              string(cliHumanCodeWatchdogAction),
 		"cliHumanCodeWatchdogOutcome":             string(cliHumanCodeWatchdogOutcome),
+		"cliHumanCodeProviderSubjectKind":         string(cliHumanCodeProviderSubjectKind),
+		"cliHumanCodeProviderSubjectStatus":       string(cliHumanCodeProviderSubjectStatus),
+		"cliHumanCodeProviderCapability":          string(cliHumanCodeProviderCapability),
+		"cliHumanCodeProviderGuarantee":           string(cliHumanCodeProviderGuarantee),
+		"cliHumanCodeProviderRequirementStatus":   string(cliHumanCodeProviderRequirementStatus),
 	}
 	actual := map[string][]string{}
 	rawOutput := map[string][]string{}

--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/userfacing"
 	"gopkg.in/yaml.v3"
 )
@@ -37,6 +38,72 @@ func TestCLIHumanCodePhraseParityRejectsSpecOnlyDrift(t *testing.T) {
 	if got := cliHumanCodePhrasesFromSpec(t, projection); reflect.DeepEqual(cliHumanCodePhrases, got) {
 		t.Fatal("spec-only phrase drift did not break implementation parity")
 	}
+}
+
+func TestProviderHumanCodePhrasesMatchMachineOwnersAndCapabilitySpec(t *testing.T) {
+	machineValues := packs.ProviderHumanCodeValues()
+	for family, want := range machineValues {
+		got := make([]string, 0, len(cliHumanCodePhrases[family]))
+		for code := range cliHumanCodePhrases[family] {
+			got = append(got, code)
+		}
+		sort.Strings(got)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("provider human-code family %s differs from machine owner:\ngot:  %v\nwant: %v", family, got, want)
+		}
+	}
+	capabilityValues := machineValues[userfacing.HumanCodeProviderCapability]
+	if specValues := providerKnownCapabilityCodesFromSpec(t, loadPlatformSpecRootForHumanProjection(t)); !reflect.DeepEqual(specValues, capabilityValues) {
+		t.Fatalf("known provider capability spec differs from machine owner:\ngot:  %v\nwant: %v", specValues, capabilityValues)
+	}
+}
+
+func TestProviderHumanCodeParityRejectsKnownCapabilitySpecDrift(t *testing.T) {
+	root := loadPlatformSpecRootForHumanProjection(t)
+	toolModel := driftMappingValue(root, "tool_model")
+	surface := driftMappingValue(toolModel, "provider_capability_surface")
+	facts := driftMappingValue(surface, "facts")
+	known := driftMappingValue(facts, "known_capability_codes")
+	known.Content = append(known.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: "adversarial_current_capability"})
+
+	got := providerKnownCapabilityCodesFromSpec(t, root)
+	want := packs.ProviderHumanCodeValues()[userfacing.HumanCodeProviderCapability]
+	if reflect.DeepEqual(got, want) {
+		t.Fatal("known capability spec drift did not break machine-owner parity")
+	}
+}
+
+func loadPlatformSpecRootForHumanProjection(t *testing.T) *yaml.Node {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(driftTestRepoRoot(t), "platform-spec.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Content) != 1 {
+		t.Fatalf("platform spec document content = %d, want 1", len(doc.Content))
+	}
+	return doc.Content[0]
+}
+
+func providerKnownCapabilityCodesFromSpec(t *testing.T, root *yaml.Node) []string {
+	t.Helper()
+	toolModel := driftMappingValue(root, "tool_model")
+	surface := driftMappingValue(toolModel, "provider_capability_surface")
+	facts := driftMappingValue(surface, "facts")
+	known := driftMappingValue(facts, "known_capability_codes")
+	if known == nil || known.Kind != yaml.SequenceNode {
+		t.Fatal("provider_capability_surface.facts.known_capability_codes must be a sequence")
+	}
+	out := make([]string, 0, len(known.Content))
+	for _, node := range known.Content {
+		out = append(out, strings.TrimSpace(node.Value))
+	}
+	sort.Strings(out)
+	return out
 }
 
 func loadCLIHumanCodeProjectionSpec(t *testing.T) *yaml.Node {

--- a/cmd/swarm/cli_output.go
+++ b/cmd/swarm/cli_output.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/division-sh/swarm/internal/userfacing"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -78,88 +79,34 @@ type cliDetailField struct {
 	Value string
 }
 
-type cliHumanCodeFamily string
+type cliHumanCodeFamily = userfacing.HumanCodeFamily
 
 const (
-	cliHumanCodeRunStatus                   cliHumanCodeFamily = "run_status"
-	cliHumanCodeOperationalState            cliHumanCodeFamily = "operational_state"
-	cliHumanCodeRunBlockingLayer            cliHumanCodeFamily = "run_blocking_layer"
-	cliHumanCodeRunBlockingReason           cliHumanCodeFamily = "run_blocking_reason"
-	cliHumanCodeAgentStatus                 cliHumanCodeFamily = "agent_status"
-	cliHumanCodeConversationMode            cliHumanCodeFamily = "conversation_mode"
-	cliHumanCodeSessionScope                cliHumanCodeFamily = "session_scope"
-	cliHumanCodeDeliveryStatus              cliHumanCodeFamily = "delivery_status"
-	cliHumanCodeAgentLifecycleState         cliHumanCodeFamily = "agent_lifecycle_state"
-	cliHumanCodeAgentLifecycleBlockingLayer cliHumanCodeFamily = "agent_lifecycle_blocking_layer"
-	cliHumanCodeWatchdogState               cliHumanCodeFamily = "watchdog_state"
-	cliHumanCodeWatchdogBlockingLayer       cliHumanCodeFamily = "watchdog_blocking_layer"
-	cliHumanCodeWatchdogAction              cliHumanCodeFamily = "watchdog_action"
-	cliHumanCodeWatchdogOutcome             cliHumanCodeFamily = "watchdog_outcome"
+	cliHumanCodeRunStatus                   = userfacing.HumanCodeRunStatus
+	cliHumanCodeOperationalState            = userfacing.HumanCodeOperationalState
+	cliHumanCodeRunBlockingLayer            = userfacing.HumanCodeRunBlockingLayer
+	cliHumanCodeRunBlockingReason           = userfacing.HumanCodeRunBlockingReason
+	cliHumanCodeAgentStatus                 = userfacing.HumanCodeAgentStatus
+	cliHumanCodeConversationMode            = userfacing.HumanCodeConversationMode
+	cliHumanCodeSessionScope                = userfacing.HumanCodeSessionScope
+	cliHumanCodeDeliveryStatus              = userfacing.HumanCodeDeliveryStatus
+	cliHumanCodeAgentLifecycleState         = userfacing.HumanCodeAgentLifecycleState
+	cliHumanCodeAgentLifecycleBlockingLayer = userfacing.HumanCodeAgentLifecycleBlockingLayer
+	cliHumanCodeWatchdogState               = userfacing.HumanCodeWatchdogState
+	cliHumanCodeWatchdogBlockingLayer       = userfacing.HumanCodeWatchdogBlockingLayer
+	cliHumanCodeWatchdogAction              = userfacing.HumanCodeWatchdogAction
+	cliHumanCodeWatchdogOutcome             = userfacing.HumanCodeWatchdogOutcome
+	cliHumanCodeProviderSubjectKind         = userfacing.HumanCodeProviderSubjectKind
+	cliHumanCodeProviderSubjectStatus       = userfacing.HumanCodeProviderSubjectStatus
+	cliHumanCodeProviderCapability          = userfacing.HumanCodeProviderCapability
+	cliHumanCodeProviderGuarantee           = userfacing.HumanCodeProviderGuarantee
+	cliHumanCodeProviderRequirementStatus   = userfacing.HumanCodeProviderRequirementStatus
 )
 
-var cliHumanCodePhrases = map[cliHumanCodeFamily]map[string]string{
-	cliHumanCodeRunStatus: {
-		"running": "running", "paused": "paused", "completed": "completed",
-		"failed": "failed", "cancelled": "cancelled", "forked": "forked",
-	},
-	cliHumanCodeOperationalState: {
-		"running": "running", "stalled": "stalled", "paused": "paused",
-		"completed": "completed", "failed": "failed", "cancelled": "cancelled", "forked": "forked",
-	},
-	cliHumanCodeRunBlockingLayer: {
-		"scoring_terminal_outcome": "scoring outcome",
-		"delivery_lifecycle":       "delivery lifecycle",
-	},
-	cliHumanCodeRunBlockingReason: {
-		"terminal_scoring_outcome_missing": "waiting for a terminal scoring outcome",
-		"no_active_deliveries":             "no active deliveries",
-	},
-	cliHumanCodeAgentStatus: {
-		"idle": "idle", "running": "running", "paused": "paused",
-		"failed": "failed", "terminated": "terminated",
-	},
-	cliHumanCodeConversationMode: {
-		"task": "task", "session": "session", "session_per_entity": "session per entity",
-	},
-	cliHumanCodeSessionScope: {
-		"global": "global", "flow": "flow", "entity": "entity",
-	},
-	cliHumanCodeDeliveryStatus: {
-		"pending": "pending", "in_progress": "in progress", "delivered": "delivered",
-		"failed": "failed", "dead_letter": "dead letter",
-	},
-	cliHumanCodeAgentLifecycleState: {
-		"queued": "queued", "launching": "launching", "active": "active",
-		"retrying": "retrying", "exhausted": "exhausted",
-	},
-	cliHumanCodeAgentLifecycleBlockingLayer: {
-		"delivery_queue":    "delivery queue",
-		"session_launch":    "session launch",
-		"session_execution": "session execution",
-		"delivery_retry":    "delivery retry",
-		"delivery_terminal": "delivery terminal",
-	},
-	cliHumanCodeWatchdogState: {
-		"healthy_long_running": "healthy, long-running",
-		"no_output":            "no output",
-	},
-	cliHumanCodeWatchdogBlockingLayer: {
-		"session_execution": "session execution",
-	},
-	cliHumanCodeWatchdogAction: {
-		"turn_long_running": "turn running for a long time",
-		"session_no_output": "session produced no output",
-	},
-	cliHumanCodeWatchdogOutcome: {
-		"observed": "observed", "warning_emitted": "warning emitted",
-	},
-}
+var cliHumanCodePhrases = userfacing.HumanCodePhrases()
 
 func formatCLIHumanCode(family cliHumanCodeFamily, raw string) string {
-	if phrase, ok := cliHumanCodePhrases[family][strings.TrimSpace(raw)]; ok {
-		return phrase
-	}
-	return raw
+	return userfacing.ProjectHumanCode(family, raw)
 }
 
 func formatCLIHumanCount(count int, singular, plural string) string {

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -12,7 +12,9 @@ import (
 func TestContextListCommandUsesSwarmDirRegistry(t *testing.T) {
 	swarmDir := t.TempDir()
 	registry := newLocalContextRegistry(swarmDir)
-	if err := registry.WriteDescriptor(testLocalContextDescriptor("local", "runtime-a")); err != nil {
+	desc := testLocalContextDescriptor("local", "runtime-a")
+	desc.APIServer = "http://127.0.0.1:0/local"
+	if err := registry.WriteDescriptor(desc); err != nil {
 		t.Fatal(err)
 	}
 	var out, errOut bytes.Buffer

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -195,8 +195,8 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		CheckGatewayEnv:        true,
 		CheckContractSecrets:   cmd.Flags().Changed("contracts"),
 		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets("doctor"),
+		ProviderTriggerPacks:   providerPackLoad.Loaded,
 	})
-	appendProviderTriggerPackSurfaceFindings(&report, providerPackLoad.Loaded)
 	addUnifiedConfigDiagnosticsToReport(&report, cfgResult.Diagnostics)
 	addSwarmEnvFindingsToLocalPreflightReport(&report, envFindings)
 	return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/division-sh/swarm/internal/packs"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
@@ -134,6 +135,30 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 	if !report.OK || report.Owner != localPreflightOwner || report.Mode != "doctor" || report.Backend != "claude_cli" {
 		t.Fatalf("report = %#v", report)
 	}
+	if len(report.CapabilitySubjects) != 15 {
+		t.Fatalf("capability subjects = %#v, want eight triggers plus seven connector actions", report.CapabilitySubjects)
+	}
+	for _, subject := range report.CapabilitySubjects {
+		code := "provider_connector_" + findingCode(subject.ID)
+		if subject.Kind != packs.SubjectProviderTrigger {
+			if finding, ok := localPreflightReportFinding(report, code); !ok || finding.Message != packs.RenderSubject(subject, false) {
+				t.Fatalf("connector subject/finding projection drift for %s: subject=%#v finding=%#v", subject.ID, subject, finding)
+			}
+			continue
+		}
+		code = "provider_trigger_pack_" + findingCode(subject.Provider)
+		if finding, ok := localPreflightReportFinding(report, code); !ok || finding.Message != packs.RenderSubject(subject, false) {
+			t.Fatalf("trigger subject/finding projection drift for %s: subject=%#v finding=%#v", subject.ID, subject, finding)
+		}
+		if subject.Status != packs.StatusAvailable {
+			t.Fatalf("trigger subject %s status = %s, want AVAILABLE", subject.ID, subject.Status)
+		}
+		for _, requirement := range subject.Requirements {
+			if requirement.Scope != packs.RequirementScopeTarget || requirement.Satisfied != nil || requirement.Status != "" || requirement.Remediation != "" {
+				t.Fatalf("trigger subject %s requirement = %#v, want target-scoped unevaluated", subject.ID, requirement)
+			}
+		}
+	}
 	for _, want := range []string{"backend_credential_present", "docker_available", "workspace_image_available", "workspace_claude_cli_available"} {
 		if !localPreflightReportHasCode(report, want) {
 			t.Fatalf("report missing finding %q: %#v", want, report.Findings)
@@ -159,18 +184,18 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 		}
 	}
 	if !localPreflightReportFindingContains(report, "provider_trigger_pack_github", "CAN receive HTTPS route /webhooks/{entity}/github") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_github", "CANNOT emit_undeclared_events") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_github", "requires webhook_signing.github=UNBOUND") {
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_github", "guarantee: cannot emit undeclared events") ||
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_github", "requires webhook_signing.github (target-scoped)") {
 		t.Fatalf("github provider pack surface missing CAN/CANNOT/requires readback: %#v", report.Findings)
 	}
 	if !localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "CAN receive HTTPS route /webhooks/{entity}/stripe") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "CANNOT emit_undeclared_events") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "requires webhook_signing.stripe=UNBOUND") {
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "guarantee: cannot emit undeclared events") ||
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_stripe", "requires webhook_signing.stripe (target-scoped)") {
 		t.Fatalf("stripe provider pack surface missing CAN/CANNOT/requires readback: %#v", report.Findings)
 	}
 	if !localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "CAN receive HTTPS route /webhooks/{entity}/telegram") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "CANNOT emit_undeclared_events") ||
-		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "requires webhook_signing.telegram=UNBOUND") {
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "guarantee: cannot emit undeclared events") ||
+		!localPreflightReportFindingContains(report, "provider_trigger_pack_telegram", "requires webhook_signing.telegram (target-scoped)") {
 		t.Fatalf("telegram provider pack surface missing CAN/CANNOT/requires readback: %#v", report.Findings)
 	}
 }
@@ -238,10 +263,10 @@ func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.
 		t.Fatalf("report missing telegram connector finding: %#v", report.Findings)
 	}
 	for _, want := range []string{
-		"CAN send Telegram messages via api.telegram.org",
+		"CAN call provider action send Telegram messages via api.telegram.org",
 		"CAN lower through platform.activity_requested",
 		"CAN journal non-idempotent attempts in activity_attempts",
-		"CANNOT expose credential values",
+		"guarantee: cannot expose credential values",
 		"requires telegram_bot_token=BOUND",
 	} {
 		if !localPreflightReportFindingContains(report, "provider_connector_telegram_send_message", want) {
@@ -293,10 +318,10 @@ func TestDoctorClaudeCLIPreflightReportsSlackManagedConnectorPackSurface(t *test
 		t.Fatalf("report missing slack connector finding: %#v", report.Findings)
 	}
 	for _, want := range []string{
-		"CAN post Slack messages via slack.com",
+		"CAN call provider action post Slack messages via slack.com",
 		"CAN lower through platform.activity_requested",
 		"CAN journal non-idempotent attempts in activity_attempts",
-		"CANNOT expose credential values",
+		"guarantee: cannot expose credential values",
 		"requires managed_credential:slack_oauth=CONNECTED",
 	} {
 		if !localPreflightReportFindingContains(report, "provider_connector_slack_post_message", want) {
@@ -1346,6 +1371,15 @@ func localPreflightReportFindingContains(report localPreflightReport, code, want
 		}
 	}
 	return false
+}
+
+func localPreflightReportFinding(report localPreflightReport, code string) (localPreflightFinding, bool) {
+	for _, finding := range report.Findings {
+		if finding.Code == code {
+			return finding, true
+		}
+	}
+	return localPreflightFinding{}, false
 }
 
 func stringSliceContainsPrefix(values []string, prefix string) bool {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -278,6 +278,39 @@ func TestDoctorClaudeCLIPreflightReportsTelegramConnectorToolSurface(t *testing.
 	}
 }
 
+func TestDoctorProviderCapabilityReadbackFailureIsTypedBlocker(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	credentialPath := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(credentialPath, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SWARM_CREDENTIALS_FILE", credentialPath)
+
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), true)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = writeDoctorTelegramConnectorContractsFixture(t)
+			break
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	finding, ok := localPreflightReportFinding(report, "provider_connector_surface_failed")
+	if !ok || finding.Severity != localPreflightSeverityBlocker || finding.Status != localPreflightStatusFailed || finding.Remediation == "" {
+		t.Fatalf("readback failure finding = %#v", finding)
+	}
+}
+
 func TestDoctorClaudeCLIPreflightReportsSlackManagedConnectorPackSurface(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -200,6 +200,44 @@ func TestDoctorClaudeCLIPreflightJSONReportsOKWithoutDB(t *testing.T) {
 	}
 }
 
+func TestDoctorContractSourceFailurePreservesProviderTriggerSubjects(t *testing.T) {
+	setDoctorEmptyProviderSecrets(t)
+	args := doctorClaudeArgs(t, writeDoctorClaudeConfig(t, ""), true)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--contracts" {
+			args[i+1] = t.TempDir()
+			break
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	if report.OK || !localPreflightReportHasCode(report, "contract_source_load_failed") {
+		t.Fatalf("report = %#v, want blocking contract source failure", report)
+	}
+	if len(report.CapabilitySubjects) != 8 {
+		t.Fatalf("capability subjects = %#v, want eight admitted provider triggers", report.CapabilitySubjects)
+	}
+	for _, subject := range report.CapabilitySubjects {
+		if subject.Kind != packs.SubjectProviderTrigger || subject.Status != packs.StatusAvailable {
+			t.Fatalf("subject = %#v, want AVAILABLE provider trigger", subject)
+		}
+		if !localPreflightReportHasCode(report, "provider_trigger_pack_"+findingCode(subject.Provider)) {
+			t.Fatalf("report missing finding for trigger subject %#v: %#v", subject, report.Findings)
+		}
+	}
+}
+
 func TestDoctorClaudeCLIPreflightSkipsCredentialForAgentFreeContracts(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -182,6 +182,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 }
 
 func loadLocalPreflightCapabilitySource(ctx context.Context, req localPreflightRequest, report *localPreflightReport) (semanticview.Source, string, bool) {
+	appendProviderTriggerCapabilitySubjects(report, req.ProviderTriggerPacks)
 	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
 	if err != nil {
 		message := err.Error()
@@ -196,7 +197,6 @@ func loadLocalPreflightCapabilitySource(ctx context.Context, req localPreflightR
 		return nil, "", false
 	}
 	appendProviderConnectorCapabilitySubjects(ctx, report, source)
-	appendProviderTriggerCapabilitySubjects(report, req.ProviderTriggerPacks)
 	return source, contractsRoot, true
 }
 

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
@@ -63,11 +65,12 @@ type localPreflightFinding struct {
 }
 
 type localPreflightReport struct {
-	OK       bool                    `json:"ok"`
-	Owner    string                  `json:"owner"`
-	Mode     string                  `json:"mode"`
-	Backend  string                  `json:"backend"`
-	Findings []localPreflightFinding `json:"findings"`
+	OK                 bool                    `json:"ok"`
+	Owner              string                  `json:"owner"`
+	Mode               string                  `json:"mode"`
+	Backend            string                  `json:"backend"`
+	CapabilitySubjects []packs.Subject         `json:"capability_subjects,omitempty"`
+	Findings           []localPreflightFinding `json:"findings"`
 }
 
 type localPreflightRequest struct {
@@ -84,6 +87,7 @@ type localPreflightRequest struct {
 	CheckGatewayEnv        bool
 	CheckContractSecrets   bool
 	ContractSecretSeverity localPreflightSeverity
+	ProviderTriggerPacks   []providertriggers.LoadedPack
 }
 
 func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) localPreflightReport {
@@ -106,10 +110,12 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 	}
 	report.Backend = strings.TrimSpace(profile.ID)
 	if profile.ID != llmselection.BackendClaudeCLI && report.Mode != "doctor" {
+		if _, _, ok := loadLocalPreflightCapabilitySource(ctx, req, &report); !ok {
+			return report.finalize()
+		}
 		report.add(localPreflightBackendPrerequisite, "backend_not_claude_cli", localPreflightSeverityInfo, localPreflightStatusSkipped, fmt.Sprintf("backend %q does not require claude_cli local proof prerequisites", profile.ID), "")
 		return report.finalize()
 	}
-
 	if req.CheckListeners {
 		report.checkListener("api_listener", "api", req.APIListenAddr)
 		report.checkListener("mcp_listener", "mcp", req.MCPListenAddr)
@@ -118,20 +124,10 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 		report.checkGatewayEnv()
 	}
 
-	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
-	if err != nil {
-		message := err.Error()
-		remediation := "fix the selected --contracts and --platform-spec paths"
-		if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
-			message = diagnostic.Problem
-			if strings.TrimSpace(diagnostic.Remediation) != "" {
-				remediation = diagnostic.Remediation
-			}
-		}
-		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
+	source, contractsRoot, ok := loadLocalPreflightCapabilitySource(ctx, req, &report)
+	if !ok {
 		return report.finalize()
 	}
-	appendProviderConnectorToolSurfaceFindings(ctx, &report, source)
 	workspaceBackend, err := decideWorkspaceBackend(req.WorkspaceBackend, req.Config, source)
 	if err != nil {
 		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities")
@@ -185,6 +181,25 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 	return report.finalize()
 }
 
+func loadLocalPreflightCapabilitySource(ctx context.Context, req localPreflightRequest, report *localPreflightReport) (semanticview.Source, string, bool) {
+	source, contractsRoot, err := loadLocalPreflightSource(req.RepoRoot, req.ResolvedPaths)
+	if err != nil {
+		message := err.Error()
+		remediation := "fix the selected --contracts and --platform-spec paths"
+		if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
+			message = diagnostic.Problem
+			if strings.TrimSpace(diagnostic.Remediation) != "" {
+				remediation = diagnostic.Remediation
+			}
+		}
+		report.add(localPreflightWorkspacePrerequisite, "contract_source_load_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
+		return nil, "", false
+	}
+	appendProviderConnectorCapabilitySubjects(ctx, report, source)
+	appendProviderTriggerCapabilitySubjects(report, req.ProviderTriggerPacks)
+	return source, contractsRoot, true
+}
+
 func (r *localPreflightReport) add(category localPreflightCategory, code string, severity localPreflightSeverity, status localPreflightFindingStatus, message, remediation string) {
 	r.addWithOwner(category, code, severity, status, message, remediation, localPreflightOwner)
 }
@@ -214,6 +229,41 @@ func (r *localPreflightReport) addWithOwner(category localPreflightCategory, cod
 		Remediation: strings.TrimSpace(remediation),
 		Owner:       owner,
 	})
+}
+
+func (r *localPreflightReport) addCapabilitySubjects(subjects []packs.Subject) {
+	if r == nil || len(subjects) == 0 {
+		return
+	}
+	combined := append(append([]packs.Subject(nil), r.CapabilitySubjects...), subjects...)
+	normalized, err := packs.NormalizeSubjects(combined)
+	if err != nil {
+		r.add(localPreflightProviderPackPrerequisite, "provider_capability_model_invalid", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider pack or connector capability declarations")
+		return
+	}
+	r.CapabilitySubjects = normalized
+	for _, subject := range subjects {
+		prefix := "provider_connector_"
+		identity := subject.ID
+		if subject.Kind == packs.SubjectProviderTrigger {
+			prefix = "provider_trigger_pack_"
+			identity = subject.Provider
+		}
+		remediation := ""
+		for _, requirement := range subject.Requirements {
+			if requirement.Satisfied != nil && !*requirement.Satisfied && requirement.Remediation != "" {
+				remediation = requirement.Remediation
+				break
+			}
+		}
+		r.add(localPreflightProviderPackPrerequisite, prefix+findingCode(identity), localPreflightSeverityInfo, localPreflightStatusOK, packs.RenderSubject(subject, false), remediation)
+	}
+}
+
+func findingCode(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.NewReplacer(".", "_", "-", "_", " ", "_").Replace(value)
+	return strings.Trim(value, "_")
 }
 
 func (r localPreflightReport) finalize() localPreflightReport {
@@ -468,7 +518,7 @@ func serveLocalPreflightMode(opts serveOptions) string {
 	return "serve"
 }
 
-func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serveOptions, cfg *config.Config, resolvedPaths cliContractPlatformSpecPaths, workspaceBackend workspaceBackendSelection, mountSources workspaceMountSources) localPreflightReport {
+func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serveOptions, cfg *config.Config, resolvedPaths cliContractPlatformSpecPaths, workspaceBackend workspaceBackendSelection, mountSources workspaceMountSources, providerTriggerPacks []providertriggers.LoadedPack) localPreflightReport {
 	mode := serveLocalPreflightMode(opts)
 	return runLocalClaudeCLIPreflight(ctx, localPreflightRequest{
 		Mode:                   mode,
@@ -484,5 +534,6 @@ func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serv
 		CheckGatewayEnv:        true,
 		CheckContractSecrets:   true,
 		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets(mode),
+		ProviderTriggerPacks:   providerTriggerPacks,
 	})
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -943,7 +943,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	logWorkspaceBackendDecision(opts.Output, primaryWorkspaceBackend)
 	if shouldRunServeLocalClaudeCLIPreflight(opts) {
-		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources)
+		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources, providerPackLoad.Loaded)
 		if preflight.HasBlockers() {
 			detail := preflight.BlockerSummary()
 			reporter.emit(5, "local_preflight", "FAILED", detail)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -14221,7 +14221,11 @@ func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wa
 	if err != nil {
 		t.Fatalf("resolve workspace backend for preflight proof: %v", err)
 	}
-	report := runServeLocalClaudeCLIPreflight(context.Background(), repoRoot(), opts, cfgResult.Config, resolvedPaths, workspaceBackend, workspaceMountSources{DataSource: t.TempDir(), DataSourceSource: "test"})
+	providerPacks, err := loadConfiguredProviderTriggerPacks(repoRoot(), cfgResult)
+	if err != nil {
+		t.Fatalf("load provider packs for preflight proof: %v", err)
+	}
+	report := runServeLocalClaudeCLIPreflight(context.Background(), repoRoot(), opts, cfgResult.Config, resolvedPaths, workspaceBackend, workspaceMountSources{DataSource: t.TempDir(), DataSourceSource: "test"}, providerPacks.Loaded)
 	if report.Mode != wantMode {
 		t.Fatalf("preflight mode = %q, want %q", report.Mode, wantMode)
 	}
@@ -14232,6 +14236,9 @@ func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wa
 	}
 	if report.HasBlockers() {
 		t.Fatalf("stale local gateway URL env produced blockers, want warnings only:\n%#v", report)
+	}
+	if len(report.CapabilitySubjects) != 15 {
+		t.Fatalf("%s capability subjects = %#v, want eight triggers plus seven connector actions", wantMode, report.CapabilitySubjects)
 	}
 }
 

--- a/cmd/swarm/provider_connector_tools.go
+++ b/cmd/swarm/provider_connector_tools.go
@@ -2,16 +2,12 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/division-sh/swarm/internal/providerconnectors"
-	managedcredentialmodel "github.com/division-sh/swarm/internal/runtime/managedcredentials/model"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
-func appendProviderConnectorToolSurfaceFindings(ctx context.Context, report *localPreflightReport, source semanticview.Source) {
+func appendProviderConnectorCapabilitySubjects(ctx context.Context, report *localPreflightReport, source semanticview.Source) {
 	if report == nil || source == nil {
 		return
 	}
@@ -21,131 +17,27 @@ func appendProviderConnectorToolSurfaceFindings(ctx context.Context, report *loc
 		report.add(localPreflightProviderPackPrerequisite, "provider_connector_pack_import_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector pack imports")
 		return
 	}
-	discovered, err := providerconnectors.Surfaces(ctx, source, nil)
+	opts := providerconnectors.CapabilityOptions{Registry: providerconnectors.DefaultPackRegistry(), IncludeInstalled: true}
+	if providerconnectors.HasEffectiveConnectors(source) {
+		opts.StaticCredentials, err = buildProviderCredentialStore()
+		if err != nil {
+			report.add(localPreflightProviderPackPrerequisite, "provider_connector_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
+			return
+		}
+		opts.ManagedCredentials, err = buildManagedCredentialStore()
+		if err != nil {
+			report.add(localPreflightProviderPackPrerequisite, "provider_connector_managed_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local managed credential store used by swarm connections")
+			return
+		}
+	}
+	subjects, err := providerconnectors.CapabilitySubjects(ctx, source, opts)
 	if err != nil {
-		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")
+		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations or credential readback")
 		return
 	}
-	if len(discovered) == 0 {
-		return
-	}
-	store, err := buildProviderCredentialStore()
-	if err != nil {
-		report.add(localPreflightProviderPackPrerequisite, "provider_connector_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local credential store used by swarm secrets")
-		return
-	}
-	managedStore, err := buildManagedCredentialStore()
-	if err != nil {
-		report.add(localPreflightProviderPackPrerequisite, "provider_connector_managed_credential_store_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the local managed credential store used by swarm connections")
-		return
-	}
-	surfaces, err := providerconnectors.SurfacesWithOptions(ctx, source, providerconnectors.SurfaceOptions{
-		StaticCredentials:  store,
-		ManagedCredentials: managedStore,
-	})
-	if err != nil {
-		report.add(localPreflightProviderPackPrerequisite, "provider_connector_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider connector tool declarations")
-		return
-	}
-	sort.SliceStable(surfaces, func(i, j int) bool {
-		return strings.TrimSpace(surfaces[i].ToolID) < strings.TrimSpace(surfaces[j].ToolID)
-	})
-	for _, surface := range surfaces {
-		report.add(localPreflightProviderPackPrerequisite, "provider_connector_"+connectorFindingCode(surface.ToolID), localPreflightSeverityInfo, localPreflightStatusOK, providerConnectorSurfaceMessage(surface), "")
-	}
-}
-
-func providerConnectorSurfaceMessage(surface providerconnectors.Surface) string {
-	message := fmt.Sprintf("provider connector tool %s %s %s requires %s",
-		strings.TrimSpace(surface.ToolID),
-		formatProviderConnectorSurfaceVerbs("CAN", surface.Can),
-		formatProviderConnectorSurfaceVerbs("CANNOT", surface.Cannot),
-		formatProviderConnectorRequirements(surface.Requires),
-	)
-	if surface.Generation != nil {
-		message += fmt.Sprintf(" generated operation=%s permissions=%s source=%s source_hash=%s profile=%s profile_hash=%s manifest_hash=%s fixture=%s:%s review=%s generator=%s",
-			strings.TrimSpace(surface.Generation.OperationID),
-			formatProviderConnectorGenerationPermissions(surface.Generation.Permissions),
-			strings.TrimSpace(surface.Generation.SourcePath),
-			strings.TrimSpace(surface.Generation.SourceSHA256),
-			strings.TrimSpace(surface.Generation.ProfilePath),
-			strings.TrimSpace(surface.Generation.ProfileSHA256),
-			strings.TrimSpace(surface.Generation.ManifestSHA256),
-			strings.TrimSpace(surface.Generation.FixtureID),
-			strings.TrimSpace(surface.Generation.FixtureStatus),
-			strings.TrimSpace(surface.Generation.ReviewStatus),
-			strings.TrimSpace(surface.Generation.GeneratorVersion),
-		)
-	}
-	return message
-}
-
-func formatProviderConnectorGenerationPermissions(permissions []providerconnectors.GenerationPermission) string {
-	if len(permissions) == 0 {
-		return "none"
-	}
-	items := make([]string, 0, len(permissions))
-	for _, permission := range permissions {
-		items = append(items, strings.TrimSpace(permission.ID)+":"+strings.TrimSpace(permission.Note))
-	}
-	return "[" + strings.Join(items, "; ") + "]"
-}
-
-func formatProviderConnectorSurfaceVerbs(verb string, items []string) string {
-	if len(items) == 0 {
-		return strings.TrimSpace(verb) + " none"
-	}
-	parts := make([]string, 0, len(items))
-	for _, item := range items {
-		item = strings.TrimSpace(item)
-		if item == "" {
-			continue
-		}
-		parts = append(parts, strings.TrimSpace(verb)+" "+item)
-	}
-	if len(parts) == 0 {
-		return strings.TrimSpace(verb) + " none"
-	}
-	return strings.Join(parts, "; ")
-}
-
-func formatProviderConnectorRequirements(requirements []providerconnectors.RequirementStatus) string {
-	if len(requirements) == 0 {
-		return "none"
-	}
-	parts := make([]string, 0, len(requirements))
-	for _, requirement := range requirements {
-		status := "UNBOUND"
-		if strings.TrimSpace(requirement.Status) != "" {
-			status = strings.TrimSpace(requirement.Status)
-		} else if requirement.Bound {
-			status = "BOUND"
-		}
-		name := strings.TrimSpace(requirement.Name)
-		if strings.TrimSpace(requirement.Kind) == "managed_credential" {
-			name = "managed_credential:" + name
-		}
-		details := make([]string, 0, 3)
-		if len(requirement.Scopes) > 0 {
-			details = append(details, "scopes="+strings.Join(requirement.Scopes, ","))
-		}
-		if grantModel := strings.TrimSpace(requirement.GrantModel); grantModel != "" {
-			details = append(details, "grant_model="+grantModel)
-		}
-		if summary := managedcredentialmodel.TokenRequestProfileSummary(requirement.TokenRequest); summary != managedcredentialmodel.TokenRequestProfileSummary(managedcredentialmodel.DefaultTokenRequestProfile()) {
-			details = append(details, "token_request="+summary)
-		}
-		if len(details) > 0 {
-			parts = append(parts, name+"="+status+"("+strings.Join(details, ";")+")")
-			continue
-		}
-		parts = append(parts, name+"="+status)
-	}
-	return strings.Join(parts, "; ")
+	report.addCapabilitySubjects(subjects)
 }
 
 func connectorFindingCode(toolID string) string {
-	toolID = strings.TrimSpace(strings.ToLower(toolID))
-	toolID = strings.NewReplacer(".", "_", "-", "_", " ", "_").Replace(toolID)
-	return strings.Trim(toolID, "_")
+	return findingCode(toolID)
 }

--- a/cmd/swarm/provider_connector_tools_test.go
+++ b/cmd/swarm/provider_connector_tools_test.go
@@ -113,7 +113,10 @@ func TestProviderGuaranteeRegistryMatchesSpecAndNamesLiveProofs(t *testing.T) {
 		if len(proof) != 2 {
 			t.Fatalf("guarantee %s execution_proof = %q, want '<package> <test>'", code, row.ExecutionProof)
 		}
-		assertGoTestFunctionExists(t, proof[0], strings.Split(proof[1], "/")[0])
+		if strings.Contains(proof[1], "/") {
+			t.Fatalf("guarantee %s execution_proof = %q, want a dedicated top-level Go test", code, row.ExecutionProof)
+		}
+		assertGoTestFunctionExists(t, proof[0], proof[1])
 	}
 	if got := packs.GuaranteeEnforcementOwners(); !reflect.DeepEqual(got, owners) {
 		t.Fatalf("guarantee registry differs from authoritative platform spec:\ngot:  %#v\nwant: %#v", got, owners)

--- a/cmd/swarm/provider_connector_tools_test.go
+++ b/cmd/swarm/provider_connector_tools_test.go
@@ -1,37 +1,34 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/division-sh/swarm/internal/providerconnectors"
+	"github.com/division-sh/swarm/internal/packs"
 )
 
 func TestProviderConnectorSurfaceMessageIncludesGeneratedReviewEvidence(t *testing.T) {
-	message := providerConnectorSurfaceMessage(providerconnectors.Surface{
-		ToolID:   "github.create_issue",
-		Can:      []string{"create GitHub issues"},
-		Cannot:   []string{"bypass activity_attempts"},
-		Requires: nil,
-		Generation: &providerconnectors.GenerationSurface{
-			GeneratorVersion: "swarm-openapi-gen/v1",
-			SourcePath:       "catalog/sources/github.json.gz",
-			SourceSHA256:     "sha256:source",
-			ProfilePath:      "catalog/generator-profiles/github.yaml",
-			ProfileSHA256:    "sha256:profile",
-			ManifestSHA256:   "sha256:manifest",
-			OperationID:      "issues/create",
-			Permissions: []providerconnectors.GenerationPermission{
-				{ID: "issues:write", Note: "GitHub App Issues permission at write level"},
-			},
-			FixtureID:     "github/issues-create",
-			FixtureStatus: "passing",
-			ReviewStatus:  "approved",
-		},
-	})
+	guarantee, err := packs.NewGuarantee(packs.GuaranteeActivityJournal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := packs.RenderSubject(packs.Subject{
+		ID: "github.create_issue", Kind: packs.SubjectProviderConnector, Provider: "github", Action: "create_issue",
+		Source: "connector_pack_import", Applicability: "effective", Status: packs.StatusReady,
+		Capabilities: []packs.Capability{{Code: packs.CapabilityCallProviderAction, Target: "create GitHub issues"}},
+		Guarantees:   []packs.Guarantee{guarantee},
+		Evidence: []packs.Evidence{{Kind: "generation", Fields: map[string]string{
+			"generator": "swarm-openapi-gen/v1", "source": "catalog/sources/github.json.gz", "source_hash": "sha256:source",
+			"profile": "catalog/generator-profiles/github.yaml", "profile_hash": "sha256:profile", "manifest_hash": "sha256:manifest",
+			"operation": "issues/create", "permissions": "issues:write:GitHub App Issues permission at write level",
+			"fixture": "github/issues-create:passing", "review": "approved",
+		}}},
+	}, true)
 	for _, want := range []string{
 		"operation=issues/create",
-		"permissions=[issues:write:GitHub App Issues permission at write level]",
+		"permissions=issues:write:GitHub App Issues permission at write level",
 		"source_hash=sha256:source",
 		"profile_hash=sha256:profile",
 		"manifest_hash=sha256:manifest",
@@ -40,6 +37,38 @@ func TestProviderConnectorSurfaceMessageIncludesGeneratedReviewEvidence(t *testi
 	} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("message = %q, want %q", message, want)
+		}
+	}
+}
+
+func TestProviderCapabilitySurfaceRetiresDuplicateOwnersAndTargetBindingGuess(t *testing.T) {
+	files := map[string][]string{
+		"internal/packs/envelope.go": {
+			"func (e Envelope) Surface", "type CapabilitySurface", "type RequirementStatus",
+		},
+		"internal/providerconnectors/providerconnectors.go": {
+			"type Surface struct", "SurfacesWithOptions", "type RequirementStatus", "ResolveInboundTarget", "SQLiteRuntimeStore", "PostgresRuntimeStore",
+		},
+		"internal/providertriggers/providertriggers.go": {
+			"CapabilitySurface(", "ResolveInboundTarget", "SQLiteRuntimeStore", "PostgresRuntimeStore",
+		},
+		"cmd/swarm/provider_connector_tools.go": {
+			"providerConnectorSurfaceMessage", "formatProviderConnectorSurfaceVerbs", "formatProviderConnectorRequirements",
+		},
+		"cmd/swarm/provider_trigger_packs.go": {
+			"providerTriggerPackSurfaceMessage", "formatProviderTriggerPackRequirements", "ResolveInboundTarget",
+		},
+		"cmd/swarm/doctor.go": {"appendProviderTriggerPackSurfaceFindings"},
+	}
+	for name, forbidden := range files {
+		body, err := os.ReadFile(filepath.Join(repoRoot(), name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, token := range forbidden {
+			if strings.Contains(string(body), token) {
+				t.Fatalf("%s retains forbidden provider capability owner or target-binding seam %q", name, token)
+			}
 		}
 	}
 }

--- a/cmd/swarm/provider_connector_tools_test.go
+++ b/cmd/swarm/provider_connector_tools_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/packs"
+	"gopkg.in/yaml.v3"
 )
 
 func TestProviderConnectorSurfaceMessageIncludesGeneratedReviewEvidence(t *testing.T) {
@@ -46,6 +48,9 @@ func TestProviderCapabilitySurfaceRetiresDuplicateOwnersAndTargetBindingGuess(t 
 		"internal/packs/envelope.go": {
 			"func (e Envelope) Surface", "type CapabilitySurface", "type RequirementStatus",
 		},
+		"internal/packs/capability_surface.go": {
+			"var capabilityPhrases", "func humanSubjectKind", "func humanSubjectStatus", "phrase string\n\tenforcedBy",
+		},
 		"internal/providerconnectors/providerconnectors.go": {
 			"type Surface struct", "SurfacesWithOptions", "type RequirementStatus", "ResolveInboundTarget", "SQLiteRuntimeStore", "PostgresRuntimeStore",
 		},
@@ -58,7 +63,8 @@ func TestProviderCapabilitySurfaceRetiresDuplicateOwnersAndTargetBindingGuess(t 
 		"cmd/swarm/provider_trigger_packs.go": {
 			"providerTriggerPackSurfaceMessage", "formatProviderTriggerPackRequirements", "ResolveInboundTarget",
 		},
-		"cmd/swarm/doctor.go": {"appendProviderTriggerPackSurfaceFindings"},
+		"cmd/swarm/doctor.go":     {"appendProviderTriggerPackSurfaceFindings"},
+		"cmd/swarm/cli_output.go": {"map[cliHumanCodeFamily]map[string]string{"},
 	}
 	for name, forbidden := range files {
 		body, err := os.ReadFile(filepath.Join(repoRoot(), name))
@@ -70,5 +76,92 @@ func TestProviderCapabilitySurfaceRetiresDuplicateOwnersAndTargetBindingGuess(t 
 				t.Fatalf("%s retains forbidden provider capability owner or target-binding seam %q", name, token)
 			}
 		}
+	}
+	capabilityBody, err := os.ReadFile(filepath.Join(repoRoot(), "internal/packs/capability_surface.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(capabilityBody), "userfacing.ProjectHumanCode") < 5 {
+		t.Fatal("provider capability rendering does not route every kind/status/capability/guarantee/requirement phrase family through the shared human-code owner")
+	}
+}
+
+func TestProviderGuaranteeRegistryMatchesSpecAndNamesLiveProofs(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRoot(), "platform-spec.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spec struct {
+		ToolModel struct {
+			ProviderCapabilitySurface struct {
+				Guarantees struct {
+					Claims map[string]struct {
+						EnforcedBy     string `yaml:"enforced_by"`
+						ExecutionProof string `yaml:"execution_proof"`
+					} `yaml:"claims"`
+				} `yaml:"guarantee_enforcement_registry"`
+			} `yaml:"provider_capability_surface"`
+		} `yaml:"tool_model"`
+	}
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatal(err)
+	}
+	owners := map[string]string{}
+	for code, row := range spec.ToolModel.ProviderCapabilitySurface.Guarantees.Claims {
+		owners[code] = strings.TrimSpace(row.EnforcedBy)
+		proof := strings.Fields(strings.TrimSpace(row.ExecutionProof))
+		if len(proof) != 2 {
+			t.Fatalf("guarantee %s execution_proof = %q, want '<package> <test>'", code, row.ExecutionProof)
+		}
+		assertGoTestFunctionExists(t, proof[0], strings.Split(proof[1], "/")[0])
+	}
+	if got := packs.GuaranteeEnforcementOwners(); !reflect.DeepEqual(got, owners) {
+		t.Fatalf("guarantee registry differs from authoritative platform spec:\ngot:  %#v\nwant: %#v", got, owners)
+	}
+	ownerFiles := map[string]string{
+		"internal/providertriggers.Manifest.resolveEventName":                                     "internal/providertriggers/providertriggers.go",
+		"internal/providertriggers.Manifest.Accept":                                               "internal/providertriggers/providertriggers.go",
+		"internal/runtime.InboundGateway.handleWebhook":                                           "internal/runtime/inbound.go",
+		"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent": "internal/runtime/pipeline/activity_engine.go",
+		"internal/runtime/pipeline.executePreparedActivityHTTPTool":                               "internal/runtime/pipeline/activity_engine.go",
+	}
+	for _, owner := range owners {
+		path, ok := ownerFiles[owner]
+		if !ok {
+			t.Fatalf("guarantee enforcement owner %q has no executable-owner liveness classification", owner)
+		}
+		body, err := os.ReadFile(filepath.Join(repoRoot(), path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		symbol := owner[strings.LastIndex(owner, ".")+1:]
+		if !strings.Contains(string(body), symbol) {
+			t.Fatalf("guarantee enforcement owner %q is not live in %s", owner, path)
+		}
+	}
+}
+
+func assertGoTestFunctionExists(t *testing.T, packagePath, testName string) {
+	t.Helper()
+	root := filepath.Join(repoRoot(), filepath.FromSlash(packagePath))
+	found := false
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			return err
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(body), "func "+testName+"(") {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatalf("execution proof %s %s does not name a live Go test", packagePath, testName)
 	}
 }

--- a/cmd/swarm/provider_trigger_packs.go
+++ b/cmd/swarm/provider_trigger_packs.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/packs"
@@ -80,45 +79,18 @@ func resolveProviderTriggerPackDirs(repo, configPath string, dirs []string) []st
 	return out
 }
 
-func appendProviderTriggerPackSurfaceFindings(report *localPreflightReport, loaded []providertriggers.LoadedPack) {
+func appendProviderTriggerCapabilitySubjects(report *localPreflightReport, loaded []providertriggers.LoadedPack) {
 	if report == nil || len(loaded) == 0 {
 		return
 	}
-	sort.SliceStable(loaded, func(i, j int) bool {
-		return strings.TrimSpace(loaded[i].Manifest.Provider) < strings.TrimSpace(loaded[j].Manifest.Provider)
-	})
+	subjects := make([]packs.Subject, 0, len(loaded))
 	for _, pack := range loaded {
-		provider := providertriggers.NormalizeProviderName(pack.Manifest.Provider)
-		if provider == "" {
-			provider = strings.TrimSpace(pack.Envelope.ID)
+		subject, err := pack.CapabilitySubject()
+		if err != nil {
+			report.add(localPreflightProviderPackPrerequisite, "provider_trigger_surface_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix provider trigger pack capability declarations")
+			return
 		}
-		report.add(localPreflightProviderPackPrerequisite, "provider_trigger_pack_"+provider, localPreflightSeverityInfo, localPreflightStatusOK, providerTriggerPackSurfaceMessage(pack), "")
+		subjects = append(subjects, subject)
 	}
-}
-
-func providerTriggerPackSurfaceMessage(pack providertriggers.LoadedPack) string {
-	surface := pack.CapabilitySurface(nil)
-	return fmt.Sprintf("provider trigger pack %s source_path=%s provenance=%s CAN %s CANNOT %s requires %s",
-		strings.TrimSpace(pack.Envelope.ID),
-		strings.TrimSpace(pack.SourcePath),
-		strings.TrimSpace(pack.Envelope.Provenance.Source),
-		strings.Join(surface.Can, "; "),
-		strings.Join(surface.Cannot, "; "),
-		formatProviderTriggerPackRequirements(surface.Requires),
-	)
-}
-
-func formatProviderTriggerPackRequirements(requirements []packs.RequirementStatus) string {
-	if len(requirements) == 0 {
-		return "none"
-	}
-	parts := make([]string, 0, len(requirements))
-	for _, requirement := range requirements {
-		status := "UNBOUND"
-		if requirement.Bound {
-			status = "BOUND"
-		}
-		parts = append(parts, strings.TrimSpace(requirement.Name)+"="+status)
-	}
-	return strings.Join(parts, "; ")
+	report.addCapabilitySubjects(subjects)
 }

--- a/internal/apispec/cli_topology_spec_test.go
+++ b/internal/apispec/cli_topology_spec_test.go
@@ -154,6 +154,20 @@ func TestCLIHumanCodeProjectionOwnsCurrentProducerTuples(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, projection, "unknown_value_rule"), "exact original machine shape")
 
 	families := mustMappingValue(t, projection, "families")
+	providerFamilies := map[string]string{
+		"provider_subject_kind":       "internal/packs",
+		"provider_subject_status":     "internal/packs",
+		"provider_capability":         "internal/packs",
+		"provider_guarantee":          "tool_model.provider_capability_surface",
+		"provider_requirement_status": "internal/packs",
+	}
+	for family, owner := range providerFamilies {
+		row := mustMappingValue(t, families, family)
+		assertScalarContains(t, mustMappingValue(t, row, "machine_owner"), owner)
+		if phrases := mustMappingValue(t, row, "phrases"); len(phrases.Content) == 0 {
+			t.Fatalf("human_code_projection family %s has no reviewed phrases", family)
+		}
+	}
 	lifecycle := mustMappingValue(t, families, "agent_lifecycle_tuples")
 	assertScalarContains(t, mustMappingValue(t, lifecycle, "machine_owner"), "agentLifecycleBlockingLayer")
 	assertScalarContains(t, mustMappingValue(t, lifecycle, "machine_owner"), "StateFromDelivery")

--- a/internal/packs/capability_surface.go
+++ b/internal/packs/capability_surface.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/division-sh/swarm/internal/userfacing"
 )
 
 type SubjectKind string
@@ -99,26 +101,23 @@ type Evidence struct {
 	Fields map[string]string `json:"fields"`
 }
 
-var capabilityPhrases = map[string]string{
-	CapabilityReceiveHTTPSRoute:    "receive HTTPS route",
-	CapabilityVerifySecret:         "verify named secret",
-	CapabilityEmitEvent:            "emit named event",
-	CapabilityPersistDedupeMarkers: "persist dedupe markers",
-	CapabilityCallProviderAction:   "call provider action",
-	CapabilityLowerThroughActivity: "lower through platform.activity_requested",
-	CapabilityJournalAttempts:      "journal non-idempotent attempts in activity_attempts",
-}
-
 var guaranteeRegistry = map[string]struct {
-	phrase     string
 	enforcedBy string
 }{
-	GuaranteeEmitDeclaredEventsOnly: {"emit undeclared events", "provider_trigger_event_name_policy"},
-	GuaranteeAdmissionBeforeCode:    {"run code before admission", "provider_trigger_admission_sequence"},
-	GuaranteeBoundResourcesOnly:     {"touch unbound resources", "provider_trigger_resource_binding_gate"},
-	GuaranteeActivityJournal:        {"bypass activity_attempts", "activity_attempts"},
-	GuaranteeNoAutomaticWriteRetry:  {"retry non_idempotent_write automatically", "activity_effect_retry_policy"},
-	GuaranteeCredentialRedaction:    {"expose credential values", "credential_redaction_boundary"},
+	GuaranteeEmitDeclaredEventsOnly: {"internal/providertriggers.Manifest.resolveEventName"},
+	GuaranteeAdmissionBeforeCode:    {"internal/providertriggers.Manifest.Accept"},
+	GuaranteeBoundResourcesOnly:     {"internal/runtime.InboundGateway.handleWebhook"},
+	GuaranteeActivityJournal:        {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
+	GuaranteeNoAutomaticWriteRetry:  {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
+	GuaranteeCredentialRedaction:    {"internal/runtime/pipeline.executePreparedActivityHTTPTool"},
+}
+
+func GuaranteeEnforcementOwners() map[string]string {
+	out := make(map[string]string, len(guaranteeRegistry))
+	for code, entry := range guaranteeRegistry {
+		out[code] = entry.enforcedBy
+	}
+	return out
 }
 
 func NewGuarantee(code string) (Guarantee, error) {
@@ -215,28 +214,71 @@ func normalizeSubject(subject *Subject) error {
 	if subject.ID == "" || subject.Provider == "" || subject.Source == "" || subject.Applicability == "" {
 		return fmt.Errorf("capability subject id, provider, source, and applicability are required")
 	}
+	providedStatus := subject.Status
+	for i := range subject.Requirements {
+		requirement := &subject.Requirements[i]
+		requirement.Kind = strings.TrimSpace(requirement.Kind)
+		requirement.Name = strings.TrimSpace(requirement.Name)
+		requirement.Scope = strings.TrimSpace(requirement.Scope)
+		requirement.Status = strings.ToUpper(strings.TrimSpace(requirement.Status))
+		requirement.Remediation = strings.TrimSpace(requirement.Remediation)
+		requirement.Source = strings.TrimSpace(requirement.Source)
+		if requirement.Kind == "" || requirement.Name == "" || requirement.Scope == "" {
+			return fmt.Errorf("capability subject %q requirement kind, name, and scope are required", subject.ID)
+		}
+	}
+	var derivedStatus SubjectStatus
 	switch subject.Kind {
 	case SubjectProviderTrigger:
-		if subject.Status != StatusAvailable {
-			return fmt.Errorf("provider trigger subject %q must be AVAILABLE without a selected target", subject.ID)
+		if subject.Source != "trigger_pack" || subject.Applicability != "installed" {
+			return fmt.Errorf("provider trigger subject %q must use trigger_pack/installed applicability", subject.ID)
 		}
+		derivedStatus = StatusAvailable
 		for _, requirement := range subject.Requirements {
 			if requirement.Scope != RequirementScopeTarget || requirement.Satisfied != nil || requirement.Status != "" || requirement.Remediation != "" {
 				return fmt.Errorf("provider trigger subject %q requirement %q must remain target-scoped and unevaluated", subject.ID, requirement.Name)
 			}
 		}
 	case SubjectProviderConnector:
-		if subject.Status != StatusReady && subject.Status != StatusNotReady && subject.Status != StatusAvailable {
-			return fmt.Errorf("provider connector subject %q has invalid status %q", subject.ID, subject.Status)
+		switch subject.Applicability {
+		case "installed":
+			if subject.Source != "connector_pack" {
+				return fmt.Errorf("installed provider connector subject %q must use connector_pack source", subject.ID)
+			}
+			derivedStatus = StatusAvailable
+		case "effective":
+			if subject.Source != "flow_local" && subject.Source != "connector_pack_import" {
+				return fmt.Errorf("effective provider connector subject %q has invalid source %q", subject.ID, subject.Source)
+			}
+			derivedStatus = StatusReady
+		default:
+			return fmt.Errorf("provider connector subject %q has invalid applicability %q", subject.ID, subject.Applicability)
+		}
+		hasImport := false
+		for _, requirement := range subject.Requirements {
+			if err := validateConnectorRequirement(subject.ID, requirement); err != nil {
+				return err
+			}
+			if requirement.Kind == RequirementImport {
+				hasImport = true
+				if subject.Applicability != "installed" {
+					return fmt.Errorf("effective provider connector subject %q must not carry import requirement %q", subject.ID, requirement.Name)
+				}
+			}
+			if subject.Applicability == "effective" && requirement.Satisfied != nil && !*requirement.Satisfied {
+				derivedStatus = StatusNotReady
+			}
+		}
+		if subject.Applicability == "installed" && !hasImport {
+			return fmt.Errorf("installed provider connector subject %q must carry an import requirement", subject.ID)
 		}
 	default:
 		return fmt.Errorf("capability subject %q has unsupported kind %q", subject.ID, subject.Kind)
 	}
-	for _, requirement := range subject.Requirements {
-		if requirement.Satisfied != nil && !*requirement.Satisfied && strings.TrimSpace(requirement.Remediation) == "" {
-			return fmt.Errorf("capability subject %q unsatisfied requirement %q has no registered remediation", subject.ID, requirement.Name)
-		}
+	if providedStatus != "" && providedStatus != derivedStatus {
+		return fmt.Errorf("capability subject %q status %q contradicts derived status %q", subject.ID, providedStatus, derivedStatus)
 	}
+	subject.Status = derivedStatus
 	for i := range subject.Capabilities {
 		subject.Capabilities[i].Code = strings.TrimSpace(subject.Capabilities[i].Code)
 		subject.Capabilities[i].Target = strings.TrimSpace(subject.Capabilities[i].Target)
@@ -272,13 +314,47 @@ func normalizeSubject(subject *Subject) error {
 	return nil
 }
 
+func validateConnectorRequirement(subjectID string, requirement Requirement) error {
+	if requirement.Satisfied == nil || requirement.Status == "" {
+		return fmt.Errorf("provider connector subject %q requirement %q must be evaluated", subjectID, requirement.Name)
+	}
+	allowed := false
+	switch requirement.Kind {
+	case RequirementSecret:
+		allowed = requirement.Status == "BOUND" || requirement.Status == "UNBOUND"
+	case RequirementManagedCredential:
+		switch requirement.Status {
+		case "CONNECTED", "UNCONNECTED", "PENDING_CONSENT", "REFRESH_FAILED", "SCOPE_INSUFFICIENT":
+			allowed = true
+		}
+	case RequirementImport:
+		allowed = requirement.Status == "NOT_IMPORTED"
+	}
+	if !allowed {
+		return fmt.Errorf("provider connector subject %q requirement %q has invalid %s status %q", subjectID, requirement.Name, requirement.Kind, requirement.Status)
+	}
+	wantSatisfied := requirementSatisfied(requirement.Kind, requirement.Status)
+	if *requirement.Satisfied != wantSatisfied {
+		return fmt.Errorf("provider connector subject %q requirement %q status %q contradicts satisfied=%t", subjectID, requirement.Name, requirement.Status, *requirement.Satisfied)
+	}
+	wantRemediation := requirementRemediation(requirement.Kind, requirement.Name, requirement.Status)
+	if requirement.Remediation != wantRemediation {
+		return fmt.Errorf("provider connector subject %q requirement %q remediation does not match canonical %s/%s remediation", subjectID, requirement.Name, requirement.Kind, requirement.Status)
+	}
+	return nil
+}
+
 func RenderSubject(subject Subject, verbose bool) string {
 	normalized, err := NormalizeSubjects([]Subject{subject})
 	if err != nil {
 		return "invalid capability subject: " + err.Error()
 	}
 	subject = normalized[0]
-	parts := []string{fmt.Sprintf("%s %s %s", humanSubjectKind(subject.Kind), subject.ID, humanSubjectStatus(subject.Status))}
+	parts := []string{fmt.Sprintf("%s %s %s",
+		userfacing.ProjectHumanCode(userfacing.HumanCodeProviderSubjectKind, string(subject.Kind)),
+		subject.ID,
+		userfacing.ProjectHumanCode(userfacing.HumanCodeProviderSubjectStatus, string(subject.Status)),
+	)}
 	if subject.Provenance != "" {
 		parts = append(parts, "provenance="+subject.Provenance)
 	}
@@ -289,20 +365,14 @@ func RenderSubject(subject Subject, verbose bool) string {
 		parts = append(parts, renderRequirement(requirement))
 	}
 	for _, capability := range subject.Capabilities {
-		phrase := capabilityPhrases[capability.Code]
-		if phrase == "" {
-			phrase = capability.Code
-		}
+		phrase := userfacing.ProjectHumanCode(userfacing.HumanCodeProviderCapability, capability.Code)
 		if capability.Target != "" {
 			phrase += " " + capability.Target
 		}
 		parts = append(parts, "CAN "+phrase)
 	}
 	for _, guarantee := range subject.Guarantees {
-		phrase := guarantee.Code
-		if entry, ok := guaranteeRegistry[guarantee.Code]; ok {
-			phrase = entry.phrase
-		}
+		phrase := userfacing.ProjectHumanCode(userfacing.HumanCodeProviderGuarantee, guarantee.Code)
 		parts = append(parts, "guarantee: cannot "+phrase+" - enforced by "+guarantee.EnforcedBy)
 	}
 	if verbose {
@@ -322,24 +392,6 @@ func RenderSubject(subject Subject, verbose bool) string {
 	return strings.Join(parts, "; ")
 }
 
-func humanSubjectKind(kind SubjectKind) string {
-	switch kind {
-	case SubjectProviderTrigger:
-		return "provider trigger pack"
-	case SubjectProviderConnector:
-		return "provider connector"
-	default:
-		return string(kind)
-	}
-}
-
-func humanSubjectStatus(status SubjectStatus) string {
-	if status == StatusNotReady {
-		return "NOT READY"
-	}
-	return string(status)
-}
-
 func renderRequirement(requirement Requirement) string {
 	name := requirement.Name
 	if requirement.Kind == RequirementManagedCredential {
@@ -352,6 +404,7 @@ func renderRequirement(requirement Requirement) string {
 	if status == "" {
 		status = "UNKNOWN"
 	}
+	status = userfacing.ProjectHumanCode(userfacing.HumanCodeProviderRequirementStatus, status)
 	text := "requires " + name + "=" + status
 	if requirement.Remediation != "" && requirement.Satisfied != nil && !*requirement.Satisfied {
 		text += " (fix: " + requirement.Remediation + ")"

--- a/internal/packs/capability_surface.go
+++ b/internal/packs/capability_surface.go
@@ -1,0 +1,360 @@
+package packs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type SubjectKind string
+
+const (
+	SubjectProviderTrigger   SubjectKind = "provider_trigger"
+	SubjectProviderConnector SubjectKind = "provider_connector"
+)
+
+type SubjectStatus string
+
+const (
+	StatusReady     SubjectStatus = "READY"
+	StatusNotReady  SubjectStatus = "NOT_READY"
+	StatusAvailable SubjectStatus = "AVAILABLE"
+)
+
+const (
+	RequirementSecret            = "secret"
+	RequirementManagedCredential = "managed_credential"
+	RequirementImport            = "import"
+	RequirementScopeTarget       = "target"
+)
+
+const (
+	CapabilityReceiveHTTPSRoute    = "receive_https_route"
+	CapabilityVerifySecret         = "verify_secret"
+	CapabilityEmitEvent            = "emit_event"
+	CapabilityPersistDedupeMarkers = "persist_dedupe_markers"
+	CapabilityCallProviderAction   = "call_provider_action"
+	CapabilityLowerThroughActivity = "lower_through_activity"
+	CapabilityJournalAttempts      = "journal_activity_attempts"
+)
+
+const (
+	GuaranteeEmitDeclaredEventsOnly = "emit_undeclared_events"
+	GuaranteeAdmissionBeforeCode    = "run_code_before_admission"
+	GuaranteeBoundResourcesOnly     = "touch_unbound_resources"
+	GuaranteeActivityJournal        = "bypass_activity_attempts"
+	GuaranteeNoAutomaticWriteRetry  = "retry_non_idempotent_write_automatically"
+	GuaranteeCredentialRedaction    = "expose_credential_values"
+)
+
+type Subject struct {
+	ID            string        `json:"id"`
+	Kind          SubjectKind   `json:"kind"`
+	Provider      string        `json:"provider"`
+	Action        string        `json:"action,omitempty"`
+	Source        string        `json:"source"`
+	Provenance    string        `json:"provenance,omitempty"`
+	SourcePath    string        `json:"source_path,omitempty"`
+	Applicability string        `json:"applicability"`
+	Status        SubjectStatus `json:"status"`
+	Capabilities  []Capability  `json:"capabilities,omitempty"`
+	Guarantees    []Guarantee   `json:"guarantees,omitempty"`
+	Requirements  []Requirement `json:"requirements,omitempty"`
+	Evidence      []Evidence    `json:"evidence,omitempty"`
+}
+
+type Capability struct {
+	Code   string `json:"code"`
+	Target string `json:"target,omitempty"`
+}
+
+type Guarantee struct {
+	Code       string `json:"code"`
+	EnforcedBy string `json:"enforced_by"`
+}
+
+type Requirement struct {
+	Kind                string               `json:"kind"`
+	Name                string               `json:"name"`
+	Scope               string               `json:"scope"`
+	Status              string               `json:"status,omitempty"`
+	Satisfied           *bool                `json:"satisfied,omitempty"`
+	Remediation         string               `json:"remediation,omitempty"`
+	Source              string               `json:"source,omitempty"`
+	GrantType           string               `json:"grant_type,omitempty"`
+	Scopes              []string             `json:"scopes,omitempty"`
+	GrantModel          string               `json:"grant_model,omitempty"`
+	TokenRequest        *TokenRequestProfile `json:"token_request,omitempty"`
+	InstallationIDInput string               `json:"installation_id_input,omitempty"`
+}
+
+type TokenRequestProfile struct {
+	ClientAuth    string            `json:"client_auth,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	StaticHeaders map[string]string `json:"static_headers,omitempty"`
+}
+
+type Evidence struct {
+	Kind   string            `json:"kind"`
+	Fields map[string]string `json:"fields"`
+}
+
+var capabilityPhrases = map[string]string{
+	CapabilityReceiveHTTPSRoute:    "receive HTTPS route",
+	CapabilityVerifySecret:         "verify named secret",
+	CapabilityEmitEvent:            "emit named event",
+	CapabilityPersistDedupeMarkers: "persist dedupe markers",
+	CapabilityCallProviderAction:   "call provider action",
+	CapabilityLowerThroughActivity: "lower through platform.activity_requested",
+	CapabilityJournalAttempts:      "journal non-idempotent attempts in activity_attempts",
+}
+
+var guaranteeRegistry = map[string]struct {
+	phrase     string
+	enforcedBy string
+}{
+	GuaranteeEmitDeclaredEventsOnly: {"emit undeclared events", "provider_trigger_event_name_policy"},
+	GuaranteeAdmissionBeforeCode:    {"run code before admission", "provider_trigger_admission_sequence"},
+	GuaranteeBoundResourcesOnly:     {"touch unbound resources", "provider_trigger_resource_binding_gate"},
+	GuaranteeActivityJournal:        {"bypass activity_attempts", "activity_attempts"},
+	GuaranteeNoAutomaticWriteRetry:  {"retry non_idempotent_write automatically", "activity_effect_retry_policy"},
+	GuaranteeCredentialRedaction:    {"expose credential values", "credential_redaction_boundary"},
+}
+
+func NewGuarantee(code string) (Guarantee, error) {
+	code = strings.TrimSpace(code)
+	entry, ok := guaranteeRegistry[code]
+	if !ok {
+		return Guarantee{}, fmt.Errorf("capability guarantee %q has no registered enforcement owner", code)
+	}
+	return Guarantee{Code: code, EnforcedBy: entry.enforcedBy}, nil
+}
+
+func RequirementWithStatus(kind, name, scope, status, source string) Requirement {
+	kind = strings.TrimSpace(kind)
+	name = strings.TrimSpace(name)
+	status = strings.ToUpper(strings.TrimSpace(status))
+	satisfied := requirementSatisfied(kind, status)
+	return Requirement{
+		Kind:        kind,
+		Name:        name,
+		Scope:       strings.TrimSpace(scope),
+		Status:      status,
+		Satisfied:   &satisfied,
+		Remediation: requirementRemediation(kind, name, status),
+		Source:      strings.TrimSpace(source),
+	}
+}
+
+func TargetScopedRequirement(kind, name string) Requirement {
+	return Requirement{Kind: strings.TrimSpace(kind), Name: strings.TrimSpace(name), Scope: RequirementScopeTarget}
+}
+
+func requirementSatisfied(kind, status string) bool {
+	switch strings.TrimSpace(kind) {
+	case RequirementSecret:
+		return status == "BOUND"
+	case RequirementManagedCredential:
+		return status == "CONNECTED"
+	default:
+		return false
+	}
+}
+
+func requirementRemediation(kind, name, status string) string {
+	name = strings.TrimSpace(name)
+	switch strings.TrimSpace(kind) {
+	case RequirementSecret:
+		if status != "BOUND" {
+			return "swarm secrets set " + name
+		}
+	case RequirementManagedCredential:
+		switch status {
+		case "CONNECTED":
+			return ""
+		case "REFRESH_FAILED":
+			return "swarm connections disconnect " + name + " && swarm connections connect " + name
+		default:
+			return "swarm connections connect " + name
+		}
+	case RequirementImport:
+		return "add connector_packs.imports entry for " + name
+	}
+	return ""
+}
+
+func NormalizeSubjects(subjects []Subject) ([]Subject, error) {
+	out := append([]Subject(nil), subjects...)
+	for i := range out {
+		if err := normalizeSubject(&out[i]); err != nil {
+			return nil, err
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].ID < out[j].ID
+	})
+	for i := 1; i < len(out); i++ {
+		if out[i-1].Kind == out[i].Kind && out[i-1].ID == out[i].ID {
+			return nil, fmt.Errorf("duplicate capability subject %s/%s", out[i].Kind, out[i].ID)
+		}
+	}
+	return out, nil
+}
+
+func normalizeSubject(subject *Subject) error {
+	subject.ID = strings.TrimSpace(subject.ID)
+	subject.Provider = strings.TrimSpace(subject.Provider)
+	subject.Action = strings.TrimSpace(subject.Action)
+	subject.Source = strings.TrimSpace(subject.Source)
+	subject.Provenance = strings.TrimSpace(subject.Provenance)
+	subject.SourcePath = strings.TrimSpace(subject.SourcePath)
+	subject.Applicability = strings.TrimSpace(subject.Applicability)
+	if subject.ID == "" || subject.Provider == "" || subject.Source == "" || subject.Applicability == "" {
+		return fmt.Errorf("capability subject id, provider, source, and applicability are required")
+	}
+	switch subject.Kind {
+	case SubjectProviderTrigger:
+		if subject.Status != StatusAvailable {
+			return fmt.Errorf("provider trigger subject %q must be AVAILABLE without a selected target", subject.ID)
+		}
+		for _, requirement := range subject.Requirements {
+			if requirement.Scope != RequirementScopeTarget || requirement.Satisfied != nil || requirement.Status != "" || requirement.Remediation != "" {
+				return fmt.Errorf("provider trigger subject %q requirement %q must remain target-scoped and unevaluated", subject.ID, requirement.Name)
+			}
+		}
+	case SubjectProviderConnector:
+		if subject.Status != StatusReady && subject.Status != StatusNotReady && subject.Status != StatusAvailable {
+			return fmt.Errorf("provider connector subject %q has invalid status %q", subject.ID, subject.Status)
+		}
+	default:
+		return fmt.Errorf("capability subject %q has unsupported kind %q", subject.ID, subject.Kind)
+	}
+	for _, requirement := range subject.Requirements {
+		if requirement.Satisfied != nil && !*requirement.Satisfied && strings.TrimSpace(requirement.Remediation) == "" {
+			return fmt.Errorf("capability subject %q unsatisfied requirement %q has no registered remediation", subject.ID, requirement.Name)
+		}
+	}
+	for i := range subject.Capabilities {
+		subject.Capabilities[i].Code = strings.TrimSpace(subject.Capabilities[i].Code)
+		subject.Capabilities[i].Target = strings.TrimSpace(subject.Capabilities[i].Target)
+	}
+	for i := range subject.Guarantees {
+		guarantee, err := NewGuarantee(subject.Guarantees[i].Code)
+		if err != nil {
+			return err
+		}
+		if current := strings.TrimSpace(subject.Guarantees[i].EnforcedBy); current != "" && current != guarantee.EnforcedBy {
+			return fmt.Errorf("capability guarantee %q enforcement owner %q does not match registry owner %q", guarantee.Code, current, guarantee.EnforcedBy)
+		}
+		subject.Guarantees[i] = guarantee
+	}
+	sort.SliceStable(subject.Capabilities, func(i, j int) bool {
+		if subject.Capabilities[i].Code != subject.Capabilities[j].Code {
+			return subject.Capabilities[i].Code < subject.Capabilities[j].Code
+		}
+		return subject.Capabilities[i].Target < subject.Capabilities[j].Target
+	})
+	sort.SliceStable(subject.Guarantees, func(i, j int) bool { return subject.Guarantees[i].Code < subject.Guarantees[j].Code })
+	sort.SliceStable(subject.Requirements, func(i, j int) bool {
+		leftUnsatisfied := subject.Requirements[i].Satisfied != nil && !*subject.Requirements[i].Satisfied
+		rightUnsatisfied := subject.Requirements[j].Satisfied != nil && !*subject.Requirements[j].Satisfied
+		if leftUnsatisfied != rightUnsatisfied {
+			return leftUnsatisfied
+		}
+		if subject.Requirements[i].Kind != subject.Requirements[j].Kind {
+			return subject.Requirements[i].Kind < subject.Requirements[j].Kind
+		}
+		return subject.Requirements[i].Name < subject.Requirements[j].Name
+	})
+	return nil
+}
+
+func RenderSubject(subject Subject, verbose bool) string {
+	normalized, err := NormalizeSubjects([]Subject{subject})
+	if err != nil {
+		return "invalid capability subject: " + err.Error()
+	}
+	subject = normalized[0]
+	parts := []string{fmt.Sprintf("%s %s %s", humanSubjectKind(subject.Kind), subject.ID, humanSubjectStatus(subject.Status))}
+	if subject.Provenance != "" {
+		parts = append(parts, "provenance="+subject.Provenance)
+	}
+	if subject.SourcePath != "" {
+		parts = append(parts, "source_path="+subject.SourcePath)
+	}
+	for _, requirement := range subject.Requirements {
+		parts = append(parts, renderRequirement(requirement))
+	}
+	for _, capability := range subject.Capabilities {
+		phrase := capabilityPhrases[capability.Code]
+		if phrase == "" {
+			phrase = capability.Code
+		}
+		if capability.Target != "" {
+			phrase += " " + capability.Target
+		}
+		parts = append(parts, "CAN "+phrase)
+	}
+	for _, guarantee := range subject.Guarantees {
+		phrase := guarantee.Code
+		if entry, ok := guaranteeRegistry[guarantee.Code]; ok {
+			phrase = entry.phrase
+		}
+		parts = append(parts, "guarantee: cannot "+phrase+" - enforced by "+guarantee.EnforcedBy)
+	}
+	if verbose {
+		for _, evidence := range subject.Evidence {
+			keys := make([]string, 0, len(evidence.Fields))
+			for key := range evidence.Fields {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			values := make([]string, 0, len(keys))
+			for _, key := range keys {
+				values = append(values, key+"="+evidence.Fields[key])
+			}
+			parts = append(parts, "evidence "+evidence.Kind+": "+strings.Join(values, " "))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func humanSubjectKind(kind SubjectKind) string {
+	switch kind {
+	case SubjectProviderTrigger:
+		return "provider trigger pack"
+	case SubjectProviderConnector:
+		return "provider connector"
+	default:
+		return string(kind)
+	}
+}
+
+func humanSubjectStatus(status SubjectStatus) string {
+	if status == StatusNotReady {
+		return "NOT READY"
+	}
+	return string(status)
+}
+
+func renderRequirement(requirement Requirement) string {
+	name := requirement.Name
+	if requirement.Kind == RequirementManagedCredential {
+		name = "managed_credential:" + name
+	}
+	if requirement.Scope == RequirementScopeTarget && requirement.Satisfied == nil {
+		return "requires " + name + " (target-scoped)"
+	}
+	status := requirement.Status
+	if status == "" {
+		status = "UNKNOWN"
+	}
+	text := "requires " + name + "=" + status
+	if requirement.Remediation != "" && requirement.Satisfied != nil && !*requirement.Satisfied {
+		text += " (fix: " + requirement.Remediation + ")"
+	}
+	return text
+}

--- a/internal/packs/capability_surface.go
+++ b/internal/packs/capability_surface.go
@@ -31,6 +31,17 @@ const (
 )
 
 const (
+	RequirementStatusBound             = "BOUND"
+	RequirementStatusUnbound           = "UNBOUND"
+	RequirementStatusConnected         = "CONNECTED"
+	RequirementStatusUnconnected       = "UNCONNECTED"
+	RequirementStatusPendingConsent    = "PENDING_CONSENT"
+	RequirementStatusRefreshFailed     = "REFRESH_FAILED"
+	RequirementStatusScopeInsufficient = "SCOPE_INSUFFICIENT"
+	RequirementStatusNotImported       = "NOT_IMPORTED"
+)
+
+const (
 	CapabilityReceiveHTTPSRoute    = "receive_https_route"
 	CapabilityVerifySecret         = "verify_secret"
 	CapabilityEmitEvent            = "emit_event"
@@ -110,6 +121,49 @@ var guaranteeRegistry = map[string]struct {
 	GuaranteeActivityJournal:        {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
 	GuaranteeNoAutomaticWriteRetry:  {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
 	GuaranteeCredentialRedaction:    {"internal/runtime/pipeline.executePreparedActivityHTTPTool"},
+}
+
+var connectorRequirementStatuses = map[string]map[string]bool{
+	RequirementSecret: {
+		RequirementStatusBound: true, RequirementStatusUnbound: true,
+	},
+	RequirementManagedCredential: {
+		RequirementStatusConnected: true, RequirementStatusUnconnected: true,
+		RequirementStatusPendingConsent: true, RequirementStatusRefreshFailed: true,
+		RequirementStatusScopeInsufficient: true,
+	},
+	RequirementImport: {
+		RequirementStatusNotImported: true,
+	},
+}
+
+func ProviderHumanCodeValues() map[userfacing.HumanCodeFamily][]string {
+	out := map[userfacing.HumanCodeFamily][]string{
+		userfacing.HumanCodeProviderSubjectKind: {
+			string(SubjectProviderTrigger), string(SubjectProviderConnector),
+		},
+		userfacing.HumanCodeProviderSubjectStatus: {
+			string(StatusReady), string(StatusNotReady), string(StatusAvailable),
+		},
+		userfacing.HumanCodeProviderCapability: {
+			CapabilityReceiveHTTPSRoute, CapabilityVerifySecret, CapabilityEmitEvent,
+			CapabilityPersistDedupeMarkers, CapabilityCallProviderAction,
+			CapabilityLowerThroughActivity, CapabilityJournalAttempts,
+		},
+	}
+	for code := range guaranteeRegistry {
+		out[userfacing.HumanCodeProviderGuarantee] = append(out[userfacing.HumanCodeProviderGuarantee], code)
+	}
+	for _, statuses := range connectorRequirementStatuses {
+		for status := range statuses {
+			out[userfacing.HumanCodeProviderRequirementStatus] = append(out[userfacing.HumanCodeProviderRequirementStatus], status)
+		}
+	}
+	out[userfacing.HumanCodeProviderRequirementStatus] = append(out[userfacing.HumanCodeProviderRequirementStatus], "UNKNOWN")
+	for family := range out {
+		sort.Strings(out[family])
+	}
+	return out
 }
 
 func GuaranteeEnforcementOwners() map[string]string {
@@ -319,16 +373,8 @@ func validateConnectorRequirement(subjectID string, requirement Requirement) err
 		return fmt.Errorf("provider connector subject %q requirement %q must be evaluated", subjectID, requirement.Name)
 	}
 	allowed := false
-	switch requirement.Kind {
-	case RequirementSecret:
-		allowed = requirement.Status == "BOUND" || requirement.Status == "UNBOUND"
-	case RequirementManagedCredential:
-		switch requirement.Status {
-		case "CONNECTED", "UNCONNECTED", "PENDING_CONSENT", "REFRESH_FAILED", "SCOPE_INSUFFICIENT":
-			allowed = true
-		}
-	case RequirementImport:
-		allowed = requirement.Status == "NOT_IMPORTED"
+	if statuses, ok := connectorRequirementStatuses[requirement.Kind]; ok {
+		allowed = statuses[requirement.Status]
 	}
 	if !allowed {
 		return fmt.Errorf("provider connector subject %q requirement %q has invalid %s status %q", subjectID, requirement.Name, requirement.Kind, requirement.Status)

--- a/internal/packs/capability_surface_test.go
+++ b/internal/packs/capability_surface_test.go
@@ -10,7 +10,7 @@ func TestNormalizeSubjectsRejectsGlobalTriggerReadiness(t *testing.T) {
 		ID: "provider.stripe", Kind: SubjectProviderTrigger, Provider: "stripe",
 		Source: "trigger_pack", Applicability: "installed", Status: StatusReady,
 	}
-	if _, err := NormalizeSubjects([]Subject{subject}); err == nil || !strings.Contains(err.Error(), "must be AVAILABLE") {
+	if _, err := NormalizeSubjects([]Subject{subject}); err == nil || !strings.Contains(err.Error(), "contradicts derived status \"AVAILABLE\"") {
 		t.Fatalf("NormalizeSubjects error = %v, want global trigger readiness rejection", err)
 	}
 
@@ -20,6 +20,61 @@ func TestNormalizeSubjectsRejectsGlobalTriggerReadiness(t *testing.T) {
 		t.Fatalf("NormalizeSubjects error = %v, want evaluated trigger requirement rejection", err)
 	}
 }
+
+func TestNormalizeSubjectsOwnsConnectorReadinessRollup(t *testing.T) {
+	unbound := RequirementWithStatus(RequirementSecret, "acme_key", "deployment", "UNBOUND", "credential_store")
+	connected := RequirementWithStatus(RequirementManagedCredential, "acme_oauth", "deployment", "CONNECTED", "managed_credential_store")
+
+	for _, tc := range []struct {
+		name    string
+		subject Subject
+		want    string
+	}{
+		{
+			name: "ready contradicts unsatisfied requirement",
+			subject: Subject{ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Source: "flow_local", Applicability: "effective", Status: StatusReady,
+				Requirements: []Requirement{unbound}},
+			want: "contradicts derived status \"NOT_READY\"",
+		},
+		{
+			name: "not ready contradicts satisfied requirements",
+			subject: Subject{ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Source: "flow_local", Applicability: "effective", Status: StatusNotReady,
+				Requirements: []Requirement{connected}},
+			want: "contradicts derived status \"READY\"",
+		},
+		{
+			name: "installed cannot claim ready",
+			subject: Subject{ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Source: "connector_pack", Applicability: "installed", Status: StatusReady,
+				Requirements: []Requirement{RequirementWithStatus(RequirementImport, "acme.write", "package", "NOT_IMPORTED", "connector_pack_registry")}},
+			want: "contradicts derived status \"AVAILABLE\"",
+		},
+		{
+			name: "satisfied flag must match status",
+			subject: Subject{ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Source: "flow_local", Applicability: "effective",
+				Requirements: []Requirement{{Kind: RequirementSecret, Name: "acme_key", Scope: "deployment", Status: "UNBOUND", Satisfied: boolPointer(true), Remediation: "swarm secrets set acme_key"}}},
+			want: "contradicts satisfied=true",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NormalizeSubjects([]Subject{tc.subject}); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NormalizeSubjects error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	derived, err := NormalizeSubjects([]Subject{{
+		ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Source: "flow_local", Applicability: "effective",
+		Requirements: []Requirement{unbound, connected},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derived) != 1 || derived[0].Status != StatusNotReady {
+		t.Fatalf("derived subjects = %#v, want NOT_READY", derived)
+	}
+}
+
+func boolPointer(value bool) *bool { return &value }
 
 func TestRenderSubjectUsesRegistriesAndPreservesUnknownCapabilityCode(t *testing.T) {
 	guarantee, err := NewGuarantee(GuaranteeActivityJournal)
@@ -44,7 +99,7 @@ func TestRenderSubjectUsesRegistriesAndPreservesUnknownCapabilityCode(t *testing
 		"requires acme_key=UNBOUND (fix: swarm secrets set acme_key)",
 		"CAN call provider action write Acme records",
 		"CAN unknown_capability_code target",
-		"guarantee: cannot bypass activity_attempts - enforced by activity_attempts",
+		"guarantee: cannot bypass activity_attempts - enforced by internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("RenderSubject = %q, want %q", rendered, want)

--- a/internal/packs/capability_surface_test.go
+++ b/internal/packs/capability_surface_test.go
@@ -1,0 +1,84 @@
+package packs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSubjectsRejectsGlobalTriggerReadiness(t *testing.T) {
+	subject := Subject{
+		ID: "provider.stripe", Kind: SubjectProviderTrigger, Provider: "stripe",
+		Source: "trigger_pack", Applicability: "installed", Status: StatusReady,
+	}
+	if _, err := NormalizeSubjects([]Subject{subject}); err == nil || !strings.Contains(err.Error(), "must be AVAILABLE") {
+		t.Fatalf("NormalizeSubjects error = %v, want global trigger readiness rejection", err)
+	}
+
+	subject.Status = StatusAvailable
+	subject.Requirements = []Requirement{RequirementWithStatus(RequirementSecret, "webhook_signing.stripe", RequirementScopeTarget, "BOUND", "credential_store")}
+	if _, err := NormalizeSubjects([]Subject{subject}); err == nil || !strings.Contains(err.Error(), "target-scoped and unevaluated") {
+		t.Fatalf("NormalizeSubjects error = %v, want evaluated trigger requirement rejection", err)
+	}
+}
+
+func TestRenderSubjectUsesRegistriesAndPreservesUnknownCapabilityCode(t *testing.T) {
+	guarantee, err := NewGuarantee(GuaranteeActivityJournal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := Subject{
+		ID: "acme.write", Kind: SubjectProviderConnector, Provider: "acme", Action: "write",
+		Source: "flow_local", Applicability: "effective", Status: StatusNotReady,
+		Capabilities: []Capability{
+			{Code: "unknown_capability_code", Target: "target"},
+			{Code: CapabilityCallProviderAction, Target: "write Acme records"},
+		},
+		Guarantees: []Guarantee{guarantee},
+		Requirements: []Requirement{
+			RequirementWithStatus(RequirementSecret, "acme_key", "deployment", "UNBOUND", "file"),
+		},
+	}
+	rendered := RenderSubject(subject, false)
+	for _, want := range []string{
+		"provider connector acme.write NOT READY",
+		"requires acme_key=UNBOUND (fix: swarm secrets set acme_key)",
+		"CAN call provider action write Acme records",
+		"CAN unknown_capability_code target",
+		"guarantee: cannot bypass activity_attempts - enforced by activity_attempts",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("RenderSubject = %q, want %q", rendered, want)
+		}
+	}
+	if strings.Index(rendered, "requires ") > strings.Index(rendered, "CAN ") {
+		t.Fatalf("RenderSubject = %q, want unsatisfied requirement before capabilities", rendered)
+	}
+}
+
+func TestGuaranteeAndRemediationRegistriesFailClosed(t *testing.T) {
+	if _, err := NewGuarantee("provider_specific_guess"); err == nil {
+		t.Fatal("NewGuarantee accepted an unregistered enforcement claim")
+	}
+	refresh := RequirementWithStatus(RequirementManagedCredential, "slack_oauth", "deployment", "REFRESH_FAILED", "managed_credential_store")
+	if refresh.Satisfied == nil || *refresh.Satisfied || refresh.Remediation != "swarm connections disconnect slack_oauth && swarm connections connect slack_oauth" {
+		t.Fatalf("refresh remediation = %#v", refresh)
+	}
+}
+
+func TestNormalizeSubjectsOrdersDeterministicallyAndRejectsDuplicates(t *testing.T) {
+	items := []Subject{
+		{ID: "z.write", Kind: SubjectProviderConnector, Provider: "z", Source: "flow_local", Applicability: "effective", Status: StatusReady},
+		{ID: "provider.a", Kind: SubjectProviderTrigger, Provider: "a", Source: "trigger_pack", Applicability: "installed", Status: StatusAvailable},
+		{ID: "a.write", Kind: SubjectProviderConnector, Provider: "a", Source: "flow_local", Applicability: "effective", Status: StatusReady},
+	}
+	normalized, err := NormalizeSubjects(items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := normalized[0].ID + "," + normalized[1].ID + "," + normalized[2].ID; got != "a.write,z.write,provider.a" {
+		t.Fatalf("normalized order = %s", got)
+	}
+	if _, err := NormalizeSubjects(append(items, items[0])); err == nil || !strings.Contains(err.Error(), "duplicate capability subject") {
+		t.Fatalf("duplicate error = %v", err)
+	}
+}

--- a/internal/packs/envelope.go
+++ b/internal/packs/envelope.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -71,19 +70,6 @@ type Loaded struct {
 	Envelope     Envelope
 	ManifestBody []byte
 	Directory    string
-}
-
-type RequirementStatus struct {
-	Kind   string
-	Name   string
-	Status string
-	Bound  bool
-}
-
-type CapabilitySurface struct {
-	Can      []string
-	Cannot   []string
-	Requires []RequirementStatus
 }
 
 func Load(fsys fs.FS, dir, runningPlatformVersion string) (Loaded, error) {
@@ -329,67 +315,6 @@ func CapabilitiesEqual(a, b Capabilities) bool {
 
 func RequiresEqual(a, b Requires) bool {
 	return canonicalJSON(a) == canonicalJSON(b)
-}
-
-func (e Envelope) Surface(boundSecrets map[string]bool) CapabilitySurface {
-	return e.SurfaceWithRequirements(boundSecrets, nil)
-}
-
-func (e Envelope) SurfaceWithRequirements(boundSecrets, boundManagedCredentials map[string]bool) CapabilitySurface {
-	can := []string{}
-	switch strings.TrimSpace(e.Type) {
-	case TypeConnector:
-		actions := append([]string(nil), e.Capabilities.Can.CallProviderActions...)
-		sort.Strings(actions)
-		for _, action := range actions {
-			can = append(can, "call provider action "+strings.TrimSpace(action))
-		}
-		if e.Capabilities.Can.LowerThroughActivity {
-			can = append(can, "lower through platform.activity_requested")
-		}
-		if e.Capabilities.Can.JournalActivityAttempts {
-			can = append(can, "journal non-idempotent attempts in activity_attempts")
-		}
-	default:
-		can = append(can, "receive HTTPS route "+strings.TrimSpace(e.Capabilities.Can.ReceiveHTTPSRoute))
-		if secret := strings.TrimSpace(e.Capabilities.Can.VerifySecret); secret != "" {
-			can = append(can, "verify named secret "+secret)
-		}
-		for _, event := range e.Capabilities.Can.EmitEvents {
-			can = append(can, "emit named event "+strings.TrimSpace(event))
-		}
-		if e.Capabilities.Can.PersistDedupeMarkers {
-			can = append(can, "persist dedupe markers")
-		}
-	}
-	cannot := append([]string(nil), e.Capabilities.Cannot...)
-	sort.Strings(cannot)
-	requirements := make([]RequirementStatus, 0, len(e.Requires.Secrets)+len(e.Requires.ManagedCredentials))
-	for _, secret := range e.Requires.Secrets {
-		secret = strings.TrimSpace(secret)
-		bound := boundSecrets[secret]
-		status := "UNBOUND"
-		if bound {
-			status = "BOUND"
-		}
-		requirements = append(requirements, RequirementStatus{Kind: "secret", Name: secret, Status: status, Bound: bound})
-	}
-	for _, credential := range e.Requires.ManagedCredentials {
-		credential = strings.TrimSpace(credential)
-		bound := boundManagedCredentials[credential]
-		status := "UNBOUND"
-		if bound {
-			status = "CONNECTED"
-		}
-		requirements = append(requirements, RequirementStatus{Kind: "managed_credential", Name: credential, Status: status, Bound: bound})
-	}
-	sort.Slice(requirements, func(i, j int) bool {
-		if requirements[i].Kind != requirements[j].Kind {
-			return requirements[i].Kind < requirements[j].Kind
-		}
-		return requirements[i].Name < requirements[j].Name
-	})
-	return CapabilitySurface{Can: can, Cannot: cannot, Requires: requirements}
 }
 
 func canonicalJSON(v any) string {

--- a/internal/providerconnectors/packs.go
+++ b/internal/providerconnectors/packs.go
@@ -38,6 +38,13 @@ type PackRegistry struct {
 	byProvider map[string]map[string]LoadedPack
 }
 
+type InstalledTool struct {
+	Provider string
+	ToolID   string
+	Tool     runtimecontracts.ToolSchemaEntry
+	Pack     LoadedPack
+}
+
 var (
 	defaultPackRegistryOnce sync.Once
 	defaultPackRegistry     *PackRegistry
@@ -158,6 +165,58 @@ func (r *PackRegistry) Lookup(provider, toolID string) (LoadedPack, bool) {
 	}
 	pack, ok := byTool[toolID]
 	return pack, ok
+}
+
+func (r *PackRegistry) Inventory() []InstalledTool {
+	if r == nil {
+		return nil
+	}
+	providers := make([]string, 0, len(r.byProvider))
+	for provider := range r.byProvider {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	var out []InstalledTool
+	for _, provider := range providers {
+		toolIDs := make([]string, 0, len(r.byProvider[provider]))
+		for toolID := range r.byProvider[provider] {
+			toolIDs = append(toolIDs, toolID)
+		}
+		sort.Strings(toolIDs)
+		for _, toolID := range toolIDs {
+			pack := r.byProvider[provider][toolID]
+			out = append(out, InstalledTool{
+				Provider: provider,
+				ToolID:   toolID,
+				Tool:     pack.Manifest.Tools[toolID],
+				Pack:     pack,
+			})
+		}
+	}
+	return out
+}
+
+func GenerationSurfaceForPackTool(pack LoadedPack, toolID string) (GenerationSurface, bool) {
+	if pack.Manifest.Generation == nil {
+		return GenerationSurface{}, false
+	}
+	operation, ok := pack.Manifest.Generation.OperationForTool(strings.TrimSpace(toolID))
+	if !ok {
+		return GenerationSurface{}, false
+	}
+	return GenerationSurface{
+		GeneratorVersion: pack.Manifest.Generation.GeneratorVersion,
+		SourcePath:       pack.Manifest.Generation.Source.Path,
+		SourceSHA256:     pack.Manifest.Generation.Source.SHA256,
+		ProfilePath:      pack.Manifest.Generation.Profile.Path,
+		ProfileSHA256:    pack.Manifest.Generation.Profile.SHA256,
+		ManifestSHA256:   pack.Envelope.ManifestHash,
+		OperationID:      operation.OperationID,
+		Permissions:      append([]GenerationPermission(nil), operation.Permissions...),
+		FixtureID:        operation.FixtureID,
+		FixtureStatus:    operation.FixtureStatus,
+		ReviewStatus:     operation.ReviewStatus,
+	}, true
 }
 
 func LoadPackFS(fsys fs.FS, dir, runningPlatformVersion string) (LoadedPack, error) {
@@ -334,22 +393,8 @@ func SourceWithConnectorPackImportsFromRegistry(source semanticview.Source, regi
 		}
 		tool := pack.Manifest.Tools[item.toolID]
 		importedTools[item.toolID] = tool
-		if pack.Manifest.Generation != nil {
-			if operation, exists := pack.Manifest.Generation.OperationForTool(item.toolID); exists {
-				importedGeneration[item.toolID] = GenerationSurface{
-					GeneratorVersion: pack.Manifest.Generation.GeneratorVersion,
-					SourcePath:       pack.Manifest.Generation.Source.Path,
-					SourceSHA256:     pack.Manifest.Generation.Source.SHA256,
-					ProfilePath:      pack.Manifest.Generation.Profile.Path,
-					ProfileSHA256:    pack.Manifest.Generation.Profile.SHA256,
-					ManifestSHA256:   pack.Envelope.ManifestHash,
-					OperationID:      operation.OperationID,
-					Permissions:      append([]GenerationPermission(nil), operation.Permissions...),
-					FixtureID:        operation.FixtureID,
-					FixtureStatus:    operation.FixtureStatus,
-					ReviewStatus:     operation.ReviewStatus,
-				}
-			}
+		if generation, exists := GenerationSurfaceForPackTool(pack, item.toolID); exists {
+			importedGeneration[item.toolID] = generation
 		}
 		importSources[item.toolID] = item.source
 		if importedByProjectScope[item.projectScopeKey] == nil {
@@ -361,6 +406,7 @@ func SourceWithConnectorPackImportsFromRegistry(source semanticview.Source, regi
 		Source:                 source,
 		importedTools:          importedTools,
 		importedGeneration:     importedGeneration,
+		importSources:          importSources,
 		importedByProjectScope: importedByProjectScope,
 	}, nil
 }
@@ -398,6 +444,7 @@ type connectorPackSource struct {
 	semanticview.Source
 	importedTools          map[string]runtimecontracts.ToolSchemaEntry
 	importedGeneration     map[string]GenerationSurface
+	importSources          map[string]string
 	importedByProjectScope map[string]map[string]runtimecontracts.ToolSchemaEntry
 }
 
@@ -412,6 +459,11 @@ func (s connectorPackSource) ConnectorPackImportsApplied() bool {
 func (s connectorPackSource) ConnectorGenerationSurface(toolID string) (GenerationSurface, bool) {
 	evidence, ok := s.importedGeneration[strings.TrimSpace(toolID)]
 	return evidence, ok
+}
+
+func (s connectorPackSource) ConnectorPackImportSource(toolID string) (string, bool) {
+	source, ok := s.importSources[strings.TrimSpace(toolID)]
+	return source, ok
 }
 
 func (s connectorPackSource) ToolEntries() map[string]runtimecontracts.ToolSchemaEntry {

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/packs"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/runtime/httpresponsesuccess"
@@ -17,30 +18,6 @@ import (
 )
 
 const Category = "provider_connector"
-
-type RequirementStatus struct {
-	Kind                string
-	Name                string
-	Status              string
-	Bound               bool
-	GrantType           string
-	Scopes              []string
-	GrantModel          string
-	TokenRequest        managedcredentialmodel.TokenRequestProfile
-	InstallationIDInput string
-}
-
-type Surface struct {
-	ToolID       string
-	Provider     string
-	Action       string
-	EndpointHost string
-	EffectClass  string
-	Generation   *GenerationSurface
-	Can          []string
-	Cannot       []string
-	Requires     []RequirementStatus
-}
 
 type GenerationSurface struct {
 	GeneratorVersion string
@@ -56,9 +33,11 @@ type GenerationSurface struct {
 	ReviewStatus     string
 }
 
-type SurfaceOptions struct {
+type CapabilityOptions struct {
 	StaticCredentials  runtimecredentials.Store
 	ManagedCredentials runtimemanagedcredentials.Store
+	Registry           *PackRegistry
+	IncludeInstalled   bool
 }
 
 func ValidateSource(source semanticview.Source) []error {
@@ -83,13 +62,24 @@ func ValidateSource(source semanticview.Source) []error {
 	return errs
 }
 
-func Surfaces(ctx context.Context, source semanticview.Source, store runtimecredentials.Store) ([]Surface, error) {
-	return SurfacesWithOptions(ctx, source, SurfaceOptions{StaticCredentials: store})
+func HasEffectiveConnectors(source semanticview.Source) bool {
+	if source == nil {
+		return false
+	}
+	for _, tool := range source.ToolEntries() {
+		if isProviderConnector(tool) {
+			return true
+		}
+	}
+	return false
 }
 
-func SurfacesWithOptions(ctx context.Context, source semanticview.Source, opts SurfaceOptions) ([]Surface, error) {
+func CapabilitySubjects(ctx context.Context, source semanticview.Source, opts CapabilityOptions) ([]packs.Subject, error) {
 	if source == nil {
 		return nil, nil
+	}
+	if opts.Registry == nil {
+		opts.Registry = DefaultPackRegistry()
 	}
 	tools := source.ToolEntries()
 	names := make([]string, 0, len(tools))
@@ -97,19 +87,33 @@ func SurfacesWithOptions(ctx context.Context, source semanticview.Source, opts S
 		names = append(names, strings.TrimSpace(name))
 	}
 	sort.Strings(names)
-	out := make([]Surface, 0)
+	out := make([]packs.Subject, 0)
+	effective := map[string]struct{}{}
 	for _, name := range names {
 		tool := tools[name]
 		if !isProviderConnector(tool) {
 			continue
 		}
-		surface, err := surfaceForTool(ctx, source, name, tool, opts)
+		surface, err := capabilitySubjectForTool(ctx, source, name, tool, opts)
 		if err != nil {
 			return nil, err
 		}
+		effective[name] = struct{}{}
 		out = append(out, surface)
 	}
-	return out, nil
+	if opts.IncludeInstalled {
+		for _, installed := range opts.Registry.Inventory() {
+			if _, exists := effective[installed.ToolID]; exists {
+				continue
+			}
+			subject, err := availableCapabilitySubject(installed)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, subject)
+		}
+	}
+	return packs.NormalizeSubjects(out)
 }
 
 func isProviderConnector(tool runtimecontracts.ToolSchemaEntry) bool {
@@ -216,7 +220,7 @@ func validateProviderConnectorAgentExposure(source semanticview.Source) []error 
 	return errs
 }
 
-func surfaceForTool(ctx context.Context, source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry, opts SurfaceOptions) (Surface, error) {
+func capabilitySubjectForTool(ctx context.Context, source semanticview.Source, toolID string, tool runtimecontracts.ToolSchemaEntry, opts CapabilityOptions) (packs.Subject, error) {
 	provider, action, _ := splitToolID(toolID)
 	host := ""
 	if tool.HTTP != nil {
@@ -225,10 +229,10 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 			host = strings.TrimSpace(parsed.Host)
 		}
 	}
-	requires := make([]RequirementStatus, 0, len(tool.Credentials)+1)
+	requires := make([]packs.Requirement, 0, len(tool.Credentials)+1)
 	flowID, err := connectorToolFlowID(source, toolID, tool)
 	if err != nil {
-		return Surface{}, err
+		return packs.Subject{}, err
 	}
 	for _, key := range tool.Credentials {
 		key = strings.TrimSpace(key)
@@ -239,19 +243,18 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 		if resolved, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key); mapped {
 			storeKey = strings.TrimSpace(resolved)
 		}
-		bound := false
-		if opts.StaticCredentials != nil && storeKey != "" {
-			_, ok, err := opts.StaticCredentials.Get(ctx, storeKey)
-			if err != nil {
-				return Surface{}, err
-			}
-			bound = ok
+		if storeKey == "" {
+			return packs.Subject{}, fmt.Errorf("provider connector tool %q credential %q has no deployment binding", toolID, key)
+		}
+		descriptor, err := runtimecredentials.Describe(ctx, opts.StaticCredentials, source, storeKey)
+		if err != nil {
+			return packs.Subject{}, err
 		}
 		status := "UNBOUND"
-		if bound {
+		if descriptor.Present {
 			status = "BOUND"
 		}
-		requires = append(requires, RequirementStatus{Kind: "secret", Name: key, Status: status, Bound: bound})
+		requires = append(requires, packs.RequirementWithStatus(packs.RequirementSecret, storeKey, "deployment", status, descriptor.Source))
 	}
 	if tool.ManagedCredential != nil {
 		key := strings.TrimSpace(tool.ManagedCredential.Key)
@@ -263,69 +266,45 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 			if resolved, mapped := semanticview.CredentialStoreKeyForFlow(source, flowID, key); mapped {
 				storeKey = strings.TrimSpace(resolved)
 			}
-			status := "UNBOUND"
-			bound := false
-			if opts.ManagedCredentials != nil && strings.TrimSpace(storeKey) != "" {
-				record, ok, err := opts.ManagedCredentials.Get(ctx, storeKey)
-				if err != nil {
-					return Surface{}, err
-				}
-				if ok {
-					desc := record.Descriptor()
-					status = strings.ToUpper(strings.TrimSpace(desc.Status))
-					bound = desc.Status == runtimemanagedcredentials.StatusConnected
-					if bound {
-						if err := runtimemanagedcredentials.GrantTypeCovers(desc.GrantType, requiredGrantType); err != nil {
-							status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
-							bound = false
-						}
-					}
-					if bound {
-						if err := managedcredentialmodel.GrantModelCovers(desc.GrantModel, requiredGrantModel); err != nil {
-							status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
-							bound = false
-						}
-					}
-					if bound {
-						if err := managedcredentialmodel.TokenRequestProfileCovers(desc.TokenRequest, requiredTokenRequest); err != nil {
-							status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
-							bound = false
-						}
-					}
-					if bound && !managedCredentialScopesCover(desc.Scopes, tool.ManagedCredential.Scopes) {
-						status = strings.ToUpper(runtimemanagedcredentials.StatusScopeInsufficient)
-						bound = false
-					}
+			if storeKey == "" {
+				return packs.Subject{}, fmt.Errorf("provider connector tool %q managed credential %q has no deployment binding", toolID, key)
+			}
+			descriptors, err := runtimemanagedcredentials.ListRequirementDescriptors(ctx, opts.ManagedCredentials, source)
+			if err != nil {
+				return packs.Subject{}, err
+			}
+			descriptor := runtimemanagedcredentials.RequirementDescriptor{Descriptor: runtimemanagedcredentials.Descriptor{Key: storeKey, Status: runtimemanagedcredentials.StatusUnconnected}}
+			for _, candidate := range descriptors {
+				if strings.TrimSpace(candidate.Key) == storeKey {
+					descriptor = candidate
+					break
 				}
 			}
-			if strings.TrimSpace(status) == "" {
-				status = "UNBOUND"
-			}
-			requires = append(requires, RequirementStatus{
-				Kind:                "managed_credential",
-				Name:                key,
-				Status:              status,
-				Bound:               bound,
+			required := runtimemanagedcredentials.Requirement{
+				Kind:                "tool",
+				Name:                toolID,
 				GrantType:           requiredGrantType,
 				Scopes:              append([]string{}, tool.ManagedCredential.Scopes...),
 				GrantModel:          requiredGrantModel,
 				TokenRequest:        requiredTokenRequest,
 				InstallationIDInput: strings.TrimSpace(tool.ManagedCredential.InstallationIDInput),
-			})
+			}
+			evaluation := runtimemanagedcredentials.EvaluateRequirement(descriptor, required)
+			status := strings.ToUpper(strings.TrimSpace(evaluation.Descriptor.Status))
+			if status == "" {
+				status = "UNCONNECTED"
+			}
+			requirement := packs.RequirementWithStatus(packs.RequirementManagedCredential, storeKey, "deployment", status, "managed_credential_store")
+			requirement.GrantType = requiredGrantType
+			requirement.Scopes = normalizeStringSet(tool.ManagedCredential.Scopes)
+			requirement.GrantModel = requiredGrantModel
+			tokenRequest := tokenRequestFields(requiredTokenRequest)
+			requirement.TokenRequest = &tokenRequest
+			requirement.InstallationIDInput = strings.TrimSpace(tool.ManagedCredential.InstallationIDInput)
+			requires = append(requires, requirement)
 		}
 	}
-	sort.Slice(requires, func(i, j int) bool {
-		if requires[i].Kind != requires[j].Kind {
-			return requires[i].Kind < requires[j].Kind
-		}
-		return requires[i].Name < requires[j].Name
-	})
 	actionLabel := connectorActionLabel(provider, action, tool)
-	can := []string{
-		strings.TrimSpace(actionLabel + endpointSuffix(host)),
-		"lower through platform.activity_requested",
-		"journal non-idempotent attempts in activity_attempts",
-	}
 	var generation *GenerationSurface
 	type generationSource interface {
 		ConnectorGenerationSurface(string) (GenerationSurface, bool)
@@ -336,37 +315,134 @@ func surfaceForTool(ctx context.Context, source semanticview.Source, toolID stri
 			generation = &copy
 		}
 	}
-	return Surface{
-		ToolID:       strings.TrimSpace(toolID),
-		Provider:     provider,
-		Action:       action,
-		EndpointHost: host,
-		EffectClass:  string(runtimecontracts.NormalizeActivityEffectClass(tool.EffectClass)),
-		Generation:   generation,
-		Can:          can,
-		Cannot: []string{
-			"bypass activity_attempts",
-			"retry non_idempotent_write automatically",
-			"expose credential values",
-		},
-		Requires: requires,
-	}, nil
-}
-
-func managedCredentialScopesCover(actual, required []string) bool {
-	if len(required) == 0 {
-		return true
+	sourceKind := "flow_local"
+	provenance := ""
+	sourcePath := ""
+	type importedSource interface {
+		ConnectorPackImportSource(string) (string, bool)
 	}
-	have := map[string]struct{}{}
-	for _, scope := range normalizeStringSet(actual) {
-		have[scope] = struct{}{}
-	}
-	for _, scope := range normalizeStringSet(required) {
-		if _, ok := have[scope]; !ok {
-			return false
+	if imported, ok := source.(importedSource); ok {
+		if importSource, exists := imported.ConnectorPackImportSource(toolID); exists {
+			sourceKind = "connector_pack_import"
+			sourcePath = strings.TrimSpace(importSource)
+			if loaded, found := opts.Registry.Lookup(provider, toolID); found {
+				provenance = strings.TrimSpace(loaded.Envelope.Provenance.Source)
+			}
 		}
 	}
-	return true
+	subject := packs.Subject{
+		ID:            strings.TrimSpace(toolID),
+		Kind:          packs.SubjectProviderConnector,
+		Provider:      provider,
+		Action:        action,
+		Source:        sourceKind,
+		Provenance:    provenance,
+		SourcePath:    sourcePath,
+		Applicability: "effective",
+		Status:        packs.StatusReady,
+		Capabilities: []packs.Capability{
+			{Code: packs.CapabilityCallProviderAction, Target: strings.TrimSpace(actionLabel + endpointSuffix(host))},
+			{Code: packs.CapabilityLowerThroughActivity},
+			{Code: packs.CapabilityJournalAttempts},
+		},
+		Requirements: requires,
+		Evidence: []packs.Evidence{{Kind: "connector", Fields: map[string]string{
+			"effect_class":  string(runtimecontracts.NormalizeActivityEffectClass(tool.EffectClass)),
+			"endpoint_host": host,
+		}}},
+	}
+	for _, code := range []string{packs.GuaranteeActivityJournal, packs.GuaranteeNoAutomaticWriteRetry, packs.GuaranteeCredentialRedaction} {
+		guarantee, err := packs.NewGuarantee(code)
+		if err != nil {
+			return packs.Subject{}, err
+		}
+		subject.Guarantees = append(subject.Guarantees, guarantee)
+	}
+	for _, requirement := range subject.Requirements {
+		if requirement.Satisfied != nil && !*requirement.Satisfied {
+			subject.Status = packs.StatusNotReady
+			break
+		}
+	}
+	if generation != nil {
+		subject.Evidence = append(subject.Evidence, generationEvidence(*generation))
+	}
+	normalized, err := packs.NormalizeSubjects([]packs.Subject{subject})
+	if err != nil {
+		return packs.Subject{}, err
+	}
+	return normalized[0], nil
+}
+
+func availableCapabilitySubject(installed InstalledTool) (packs.Subject, error) {
+	provider, action, _ := splitToolID(installed.ToolID)
+	host := ""
+	if installed.Tool.HTTP != nil {
+		if parsed, err := url.Parse(strings.TrimSpace(installed.Tool.HTTP.URL)); err == nil {
+			host = strings.TrimSpace(parsed.Host)
+		}
+	}
+	subject := packs.Subject{
+		ID:            strings.TrimSpace(installed.ToolID),
+		Kind:          packs.SubjectProviderConnector,
+		Provider:      provider,
+		Action:        action,
+		Source:        "connector_pack",
+		Provenance:    strings.TrimSpace(installed.Pack.Envelope.Provenance.Source),
+		SourcePath:    strings.TrimSpace(installed.Pack.Directory),
+		Applicability: "installed",
+		Status:        packs.StatusAvailable,
+		Capabilities: []packs.Capability{
+			{Code: packs.CapabilityCallProviderAction, Target: strings.TrimSpace(connectorActionLabel(provider, action, installed.Tool) + endpointSuffix(host))},
+			{Code: packs.CapabilityLowerThroughActivity},
+			{Code: packs.CapabilityJournalAttempts},
+		},
+		Requirements: []packs.Requirement{packs.RequirementWithStatus(packs.RequirementImport, installed.ToolID, "package", "NOT_IMPORTED", "connector_pack_registry")},
+	}
+	for _, code := range []string{packs.GuaranteeActivityJournal, packs.GuaranteeNoAutomaticWriteRetry, packs.GuaranteeCredentialRedaction} {
+		guarantee, err := packs.NewGuarantee(code)
+		if err != nil {
+			return packs.Subject{}, err
+		}
+		subject.Guarantees = append(subject.Guarantees, guarantee)
+	}
+	if generation, ok := GenerationSurfaceForPackTool(installed.Pack, installed.ToolID); ok {
+		subject.Evidence = append(subject.Evidence, generationEvidence(generation))
+	}
+	normalized, err := packs.NormalizeSubjects([]packs.Subject{subject})
+	if err != nil {
+		return packs.Subject{}, err
+	}
+	return normalized[0], nil
+}
+
+func tokenRequestFields(profile managedcredentialmodel.TokenRequestProfile) packs.TokenRequestProfile {
+	profile = managedcredentialmodel.NormalizeTokenRequestProfile(profile)
+	headers := make(map[string]string, len(profile.StaticHeaders))
+	for key, value := range profile.StaticHeaders {
+		headers[key] = value
+	}
+	return packs.TokenRequestProfile{ClientAuth: profile.ClientAuth, Body: profile.Body, StaticHeaders: headers}
+}
+
+func generationEvidence(generation GenerationSurface) packs.Evidence {
+	permissions := make([]string, 0, len(generation.Permissions))
+	for _, permission := range generation.Permissions {
+		permissions = append(permissions, strings.TrimSpace(permission.ID)+":"+strings.TrimSpace(permission.Note))
+	}
+	sort.Strings(permissions)
+	return packs.Evidence{Kind: "generation", Fields: map[string]string{
+		"generator":     strings.TrimSpace(generation.GeneratorVersion),
+		"source":        strings.TrimSpace(generation.SourcePath),
+		"source_hash":   strings.TrimSpace(generation.SourceSHA256),
+		"profile":       strings.TrimSpace(generation.ProfilePath),
+		"profile_hash":  strings.TrimSpace(generation.ProfileSHA256),
+		"manifest_hash": strings.TrimSpace(generation.ManifestSHA256),
+		"operation":     strings.TrimSpace(generation.OperationID),
+		"permissions":   strings.Join(permissions, "; "),
+		"fixture":       strings.TrimSpace(generation.FixtureID) + ":" + strings.TrimSpace(generation.FixtureStatus),
+		"review":        strings.TrimSpace(generation.ReviewStatus),
+	}}
 }
 
 func normalizeStringSet(values []string) []string {

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -339,7 +339,6 @@ func capabilitySubjectForTool(ctx context.Context, source semanticview.Source, t
 		Provenance:    provenance,
 		SourcePath:    sourcePath,
 		Applicability: "effective",
-		Status:        packs.StatusReady,
 		Capabilities: []packs.Capability{
 			{Code: packs.CapabilityCallProviderAction, Target: strings.TrimSpace(actionLabel + endpointSuffix(host))},
 			{Code: packs.CapabilityLowerThroughActivity},
@@ -357,12 +356,6 @@ func capabilitySubjectForTool(ctx context.Context, source semanticview.Source, t
 			return packs.Subject{}, err
 		}
 		subject.Guarantees = append(subject.Guarantees, guarantee)
-	}
-	for _, requirement := range subject.Requirements {
-		if requirement.Satisfied != nil && !*requirement.Satisfied {
-			subject.Status = packs.StatusNotReady
-			break
-		}
 	}
 	if generation != nil {
 		subject.Evidence = append(subject.Evidence, generationEvidence(*generation))
@@ -391,7 +384,6 @@ func availableCapabilitySubject(installed InstalledTool) (packs.Subject, error) 
 		Provenance:    strings.TrimSpace(installed.Pack.Envelope.Provenance.Source),
 		SourcePath:    strings.TrimSpace(installed.Pack.Directory),
 		Applicability: "installed",
-		Status:        packs.StatusAvailable,
 		Capabilities: []packs.Capability{
 			{Code: packs.CapabilityCallProviderAction, Target: strings.TrimSpace(connectorActionLabel(provider, action, installed.Tool) + endpointSuffix(host))},
 			{Code: packs.CapabilityLowerThroughActivity},

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -11,6 +11,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/division-sh/swarm/internal/packs"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
@@ -193,30 +194,50 @@ func TestSurfacesReportManagedCredentialRequirementsWithoutSecretValues(t *testi
 		ExpiresAt:    time.Now().Add(time.Hour),
 	})
 
-	surfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: store})
+	surfaces, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: store})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions: %v", err)
+		t.Fatalf("CapabilitySubjects: %v", err)
 	}
 	if len(surfaces) != 1 {
 		t.Fatalf("surfaces = %#v, want one", surfaces)
 	}
-	requires := surfaces[0].Requires
-	if len(requires) != 1 || requires[0].Kind != "managed_credential" || requires[0].Name != "slack_oauth" || !requires[0].Bound || requires[0].Status != "CONNECTED" {
+	requires := surfaces[0].Requirements
+	if len(requires) != 1 || requires[0].Kind != "managed_credential" || requires[0].Name != "slack_oauth" || !requirementSatisfied(requires[0]) || requires[0].Status != "CONNECTED" {
 		t.Fatalf("requirements = %#v, want connected managed slack_oauth", requires)
 	}
-	rendered := strings.Join(surfaces[0].Can, " ") + strings.Join(surfaces[0].Cannot, " ") + joinRequirementStatuses(requires)
+	rendered := packs.RenderSubject(surfaces[0], true)
 	for _, secret := range []string{"xoxb-access-secret", "refresh-secret", "client-secret"} {
 		if strings.Contains(rendered, secret) {
 			t.Fatalf("surface leaked managed credential secret %q: %s", secret, rendered)
 		}
 	}
 
-	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	unbound, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions without store: %v", err)
+		t.Fatalf("CapabilitySubjects without store: %v", err)
 	}
-	if len(unbound) != 1 || len(unbound[0].Requires) != 1 || unbound[0].Requires[0].Bound || unbound[0].Requires[0].Status != "UNBOUND" {
+	if len(unbound) != 1 || len(unbound[0].Requirements) != 1 || requirementSatisfied(unbound[0].Requirements[0]) || unbound[0].Requirements[0].Status != "UNCONNECTED" {
 		t.Fatalf("unbound managed requirements = %#v", unbound)
+	}
+	for _, state := range []struct {
+		status      string
+		want        string
+		remediation string
+	}{
+		{runtimemanagedcredentials.StatusPendingConsent, "PENDING_CONSENT", "swarm connections connect slack_oauth"},
+		{runtimemanagedcredentials.StatusRefreshFailed, "REFRESH_FAILED", "swarm connections disconnect slack_oauth && swarm connections connect slack_oauth"},
+	} {
+		record := runtimemanagedcredentials.Record{
+			Key: "slack_oauth", Provider: "slack", GrantType: runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+			Scopes: []string{"chat:write"}, Status: state.status,
+		}
+		got, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: runtimemanagedcredentials.NewMemoryStore(record)})
+		if err != nil {
+			t.Fatalf("CapabilitySubjects status %s: %v", state.status, err)
+		}
+		if len(got) != 1 || len(got[0].Requirements) != 1 || got[0].Requirements[0].Status != state.want || requirementSatisfied(got[0].Requirements[0]) || got[0].Requirements[0].Remediation != state.remediation || got[0].Status != packs.StatusNotReady {
+			t.Fatalf("status %s subject = %#v", state.status, got)
+		}
 	}
 
 	insufficient := runtimemanagedcredentials.NewMemoryStore(runtimemanagedcredentials.Record{
@@ -232,11 +253,11 @@ func TestSurfacesReportManagedCredentialRequirementsWithoutSecretValues(t *testi
 		Status:       runtimemanagedcredentials.StatusConnected,
 		ExpiresAt:    time.Now().Add(time.Hour),
 	})
-	scopeSurfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: insufficient})
+	scopeSurfaces, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: insufficient})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions insufficient scopes: %v", err)
+		t.Fatalf("CapabilitySubjects insufficient scopes: %v", err)
 	}
-	if len(scopeSurfaces) != 1 || len(scopeSurfaces[0].Requires) != 1 || scopeSurfaces[0].Requires[0].Bound || scopeSurfaces[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+	if len(scopeSurfaces) != 1 || len(scopeSurfaces[0].Requirements) != 1 || requirementSatisfied(scopeSurfaces[0].Requirements[0]) || scopeSurfaces[0].Requirements[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("scope-insufficient managed requirements = %#v, want SCOPE_INSUFFICIENT unbound", scopeSurfaces)
 	}
 }
@@ -256,7 +277,7 @@ func TestSurfacesReportBoundAndUnboundRequirementsWithoutSecretValues(t *testing
 		t.Fatalf("Set: %v", err)
 	}
 
-	surfaces, err := Surfaces(ctx, source, store)
+	surfaces, err := CapabilitySubjects(ctx, source, CapabilityOptions{StaticCredentials: store})
 	if err != nil {
 		t.Fatalf("Surfaces: %v", err)
 	}
@@ -264,22 +285,30 @@ func TestSurfacesReportBoundAndUnboundRequirementsWithoutSecretValues(t *testing
 		t.Fatalf("surfaces = %#v, want one", surfaces)
 	}
 	surface := surfaces[0]
-	if surface.ToolID != "telegram.send_message" || surface.Provider != "telegram" || surface.Action != "send_message" {
+	if surface.ID != "telegram.send_message" || surface.Provider != "telegram" || surface.Action != "send_message" {
 		t.Fatalf("surface identity = %#v", surface)
 	}
-	if len(surface.Requires) != 1 || surface.Requires[0].Name != "telegram_bot_token" || !surface.Requires[0].Bound {
-		t.Fatalf("requirements = %#v, want bound telegram_bot_token", surface.Requires)
+	if len(surface.Requirements) != 1 || surface.Requirements[0].Name != "telegram_bot_token" || !requirementSatisfied(surface.Requirements[0]) {
+		t.Fatalf("requirements = %#v, want bound telegram_bot_token", surface.Requirements)
 	}
-	if strings.Contains(strings.Join(surface.Can, " ")+strings.Join(surface.Cannot, " "), "provider-secret") {
+	if strings.Contains(packs.RenderSubject(surface, true), "provider-secret") {
 		t.Fatal("surface leaked credential value")
 	}
 
-	unbound, err := Surfaces(ctx, source, nil)
+	unbound, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
 		t.Fatalf("Surfaces without store: %v", err)
 	}
-	if len(unbound) != 1 || len(unbound[0].Requires) != 1 || unbound[0].Requires[0].Bound {
+	if len(unbound) != 1 || len(unbound[0].Requirements) != 1 || requirementSatisfied(unbound[0].Requirements[0]) {
 		t.Fatalf("unbound requirements = %#v", unbound)
+	}
+	t.Setenv("telegram_bot_token", "env-provider-secret")
+	envBound, err := CapabilitySubjects(ctx, source, CapabilityOptions{StaticCredentials: runtimecredentials.NewEnvStore()})
+	if err != nil {
+		t.Fatalf("CapabilitySubjects env store: %v", err)
+	}
+	if len(envBound) != 1 || len(envBound[0].Requirements) != 1 || !requirementSatisfied(envBound[0].Requirements[0]) || envBound[0].Requirements[0].Source != runtimecredentials.SourceEnv || strings.Contains(packs.RenderSubject(envBound[0], true), "env-provider-secret") {
+		t.Fatalf("env-bound subject = %#v", envBound)
 	}
 }
 
@@ -336,15 +365,44 @@ func TestSurfacesResolveImportedFlowCredentialBindings(t *testing.T) {
 		t.Fatalf("Set: %v", err)
 	}
 
-	surfaces, err := Surfaces(ctx, source, store)
+	surfaces, err := CapabilitySubjects(ctx, source, CapabilityOptions{StaticCredentials: store})
 	if err != nil {
 		t.Fatalf("Surfaces: %v", err)
 	}
 	if len(surfaces) != 1 {
 		t.Fatalf("surfaces = %#v, want one", surfaces)
 	}
-	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Name != "telegram_bot_token" || !surfaces[0].Requires[0].Bound {
-		t.Fatalf("requirements = %#v, want package-local telegram_bot_token marked bound via deployment binding", surfaces[0].Requires)
+	if len(surfaces[0].Requirements) != 1 || surfaces[0].Requirements[0].Name != "tenant_telegram_bot_token" || !requirementSatisfied(surfaces[0].Requirements[0]) {
+		t.Fatalf("requirements = %#v, want package-local telegram_bot_token marked bound via deployment binding", surfaces[0].Requirements)
+	}
+}
+
+func TestCapabilitySubjectsResolveImportedManagedCredentialBindings(t *testing.T) {
+	ctx := context.Background()
+	tool := slackConnectorTool("https://slack.com/api/chat.postMessage")
+	source := providerConnectorScopedSource{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Tools: map[string]runtimecontracts.ToolSchemaEntry{"slack.post_message": tool}}),
+		projectScopes: []semanticview.ProjectScope{
+			{Key: "", Manifest: runtimecontracts.ProjectPackageDocument{Flows: []runtimecontracts.ProjectFlowRef{{
+				ID: "worker", Flow: "worker", Bind: runtimecontracts.FlowPackageBind{Credentials: map[string]string{"slack_oauth": "tenant_slack_oauth"}},
+			}}}},
+			{Key: "flows/worker", Manifest: runtimecontracts.ProjectPackageDocument{Requires: runtimecontracts.FlowPackageRequires{Credentials: []string{"slack_oauth"}}}},
+		},
+		flowScopes: []semanticview.FlowScope{{ID: "worker", PackageKey: "flows/worker", Tools: map[string]runtimecontracts.ToolSchemaEntry{"slack.post_message": tool}}},
+	}
+	record := runtimemanagedcredentials.Record{
+		Key: "tenant_slack_oauth", Provider: "slack", GrantType: runtimemanagedcredentials.GrantAuthorizationCodePKCE,
+		Scopes: []string{"chat:write"}, AccessToken: "secret", Status: runtimemanagedcredentials.StatusConnected,
+	}
+	subjects, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: runtimemanagedcredentials.NewMemoryStore(record)})
+	if err != nil {
+		t.Fatalf("CapabilitySubjects: %v", err)
+	}
+	if len(subjects) != 1 || len(subjects[0].Requirements) != 1 || subjects[0].Requirements[0].Name != "tenant_slack_oauth" || !requirementSatisfied(subjects[0].Requirements[0]) {
+		t.Fatalf("managed import-boundary subjects = %#v", subjects)
+	}
+	if strings.Contains(packs.RenderSubject(subjects[0], true), "secret") {
+		t.Fatalf("managed subject leaked token: %#v", subjects[0])
 	}
 }
 
@@ -359,6 +417,65 @@ func TestDefaultPackRegistryLoadsTelegramFromVerifiedPlatformPack(t *testing.T) 
 	if strings.Contains(tool.HTTP.URL, "provider-secret") {
 		t.Fatal("builtin telegram tool leaked a concrete credential value")
 	}
+}
+
+func TestCapabilitySubjectsEnumerateExactInstalledInventoryWithoutMakingToolsEffective(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	subjects, err := CapabilitySubjects(context.Background(), source, CapabilityOptions{IncludeInstalled: true})
+	if err != nil {
+		t.Fatalf("CapabilitySubjects: %v", err)
+	}
+	want := []string{
+		"github.add_labels_to_issue",
+		"github.create_issue",
+		"github.create_issue_comment",
+		"microsoft_graph.send_mail",
+		"notion.append_block_children",
+		"slack.post_message",
+		"telegram.send_message",
+	}
+	if len(subjects) != len(want) {
+		t.Fatalf("subjects = %#v, want %d installed actions", subjects, len(want))
+	}
+	for i, subject := range subjects {
+		if subject.ID != want[i] || subject.Status != packs.StatusAvailable || subject.Applicability != "installed" || subject.Source != "connector_pack" {
+			t.Fatalf("subject[%d] = %#v, want AVAILABLE %s", i, subject, want[i])
+		}
+		if len(subject.Requirements) != 1 || subject.Requirements[0].Kind != packs.RequirementImport || requirementSatisfied(subject.Requirements[0]) {
+			t.Fatalf("subject[%d] requirements = %#v, want unsatisfied import teaching row", i, subject.Requirements)
+		}
+	}
+	if len(source.ToolEntries()) != 0 {
+		t.Fatalf("installed inventory became effective tools: %#v", source.ToolEntries())
+	}
+}
+
+func TestCapabilitySubjectsEffectiveFlowLocalIdentityReplacesAvailableTeachingRow(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Tools: map[string]runtimecontracts.ToolSchemaEntry{
+		"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+	}})
+	subjects, err := CapabilitySubjects(context.Background(), source, CapabilityOptions{IncludeInstalled: true})
+	if err != nil {
+		t.Fatalf("CapabilitySubjects: %v", err)
+	}
+	if len(subjects) != 7 {
+		t.Fatalf("subjects = %#v, want one effective identity replacing its installed row", subjects)
+	}
+	for _, subject := range subjects {
+		if subject.ID != "telegram.send_message" {
+			continue
+		}
+		if subject.Source != "flow_local" || subject.Applicability != "effective" || subject.Status != packs.StatusNotReady {
+			t.Fatalf("telegram subject = %#v, want effective flow-local NOT_READY", subject)
+		}
+		for _, requirement := range subject.Requirements {
+			if requirement.Kind == packs.RequirementImport {
+				t.Fatalf("effective telegram subject carries misleading import remediation: %#v", subject)
+			}
+		}
+		return
+	}
+	t.Fatal("effective telegram subject missing")
 }
 
 func TestDefaultPackRegistryLoadsSlackManagedCredentialPack(t *testing.T) {
@@ -521,15 +638,15 @@ func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *t
 		t.Fatalf("SourceWithConnectorPackImports: %v", err)
 	}
 
-	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	unbound, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions unbound: %v", err)
+		t.Fatalf("CapabilitySubjects unbound: %v", err)
 	}
-	if len(unbound) != 1 || len(unbound[0].Requires) != 1 {
+	if len(unbound) != 1 || len(unbound[0].Requirements) != 1 {
 		t.Fatalf("unbound surfaces = %#v, want one Notion managed credential requirement", unbound)
 	}
-	requirement := unbound[0].Requires[0]
-	if requirement.Kind != "managed_credential" || requirement.Name != "notion_oauth" || requirement.Bound || requirement.Status != "UNBOUND" {
+	requirement := unbound[0].Requirements[0]
+	if requirement.Kind != "managed_credential" || requirement.Name != "notion_oauth" || requirementSatisfied(requirement) || requirement.Status != "UNCONNECTED" {
 		t.Fatalf("unbound requirement = %#v, want unbound notion_oauth", requirement)
 	}
 	if requirement.GrantModel != managedcredentialmodel.GrantModelWorkspace || requirement.TokenRequest.ClientAuth != managedcredentialmodel.TokenClientAuthBasic || requirement.TokenRequest.Body != managedcredentialmodel.TokenBodyJSON {
@@ -537,22 +654,22 @@ func TestNotionConnectorPackReportsWorkspaceGrantAndTokenProfileRequirement(t *t
 	}
 
 	matchingStore := runtimemanagedcredentials.NewMemoryStore(notionConnectedRecord())
-	bound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: matchingStore})
+	bound, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: matchingStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions bound: %v", err)
+		t.Fatalf("CapabilitySubjects bound: %v", err)
 	}
-	if len(bound) != 1 || len(bound[0].Requires) != 1 || !bound[0].Requires[0].Bound || bound[0].Requires[0].Status != "CONNECTED" {
+	if len(bound) != 1 || len(bound[0].Requirements) != 1 || !requirementSatisfied(bound[0].Requirements[0]) || bound[0].Requirements[0].Status != "CONNECTED" {
 		t.Fatalf("bound requirement = %#v, want connected Notion credential", bound)
 	}
 
 	wrongProfile := notionConnectedRecord()
 	wrongProfile.TokenRequest = managedcredentialmodel.DefaultTokenRequestProfile()
 	wrongProfileStore := runtimemanagedcredentials.NewMemoryStore(wrongProfile)
-	mismatch, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: wrongProfileStore})
+	mismatch, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: wrongProfileStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions mismatch: %v", err)
+		t.Fatalf("CapabilitySubjects mismatch: %v", err)
 	}
-	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+	if len(mismatch) != 1 || len(mismatch[0].Requirements) != 1 || requirementSatisfied(mismatch[0].Requirements[0]) || mismatch[0].Requirements[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("mismatch requirement = %#v, want fail-closed token profile mismatch", mismatch)
 	}
 }
@@ -569,15 +686,15 @@ func TestGitHubConnectorPackReportsInstallationGrantRequirement(t *testing.T) {
 		t.Fatalf("SourceWithConnectorPackImports: %v", err)
 	}
 
-	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	unbound, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions unbound: %v", err)
+		t.Fatalf("CapabilitySubjects unbound: %v", err)
 	}
-	if len(unbound) != 1 || len(unbound[0].Requires) != 1 {
+	if len(unbound) != 1 || len(unbound[0].Requirements) != 1 {
 		t.Fatalf("unbound surfaces = %#v, want one GitHub managed credential requirement", unbound)
 	}
-	requirement := unbound[0].Requires[0]
-	if requirement.Kind != "managed_credential" || requirement.Name != "github_app" || requirement.Bound || requirement.Status != "UNBOUND" {
+	requirement := unbound[0].Requirements[0]
+	if requirement.Kind != "managed_credential" || requirement.Name != "github_app" || requirementSatisfied(requirement) || requirement.Status != "UNCONNECTED" {
 		t.Fatalf("unbound requirement = %#v, want unbound github_app", requirement)
 	}
 	if requirement.GrantType != runtimemanagedcredentials.GrantGitHubAppInstallation ||
@@ -587,22 +704,22 @@ func TestGitHubConnectorPackReportsInstallationGrantRequirement(t *testing.T) {
 	}
 
 	matchingStore := runtimemanagedcredentials.NewMemoryStore(githubAppConnectedRecord())
-	bound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: matchingStore})
+	bound, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: matchingStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions bound: %v", err)
+		t.Fatalf("CapabilitySubjects bound: %v", err)
 	}
-	if len(bound) != 1 || len(bound[0].Requires) != 1 || !bound[0].Requires[0].Bound || bound[0].Requires[0].Status != "CONNECTED" {
+	if len(bound) != 1 || len(bound[0].Requirements) != 1 || !requirementSatisfied(bound[0].Requirements[0]) || bound[0].Requirements[0].Status != "CONNECTED" {
 		t.Fatalf("bound requirement = %#v, want connected GitHub App credential", bound)
 	}
 
 	wrongGrant := githubAppConnectedRecord()
 	wrongGrant.GrantType = runtimemanagedcredentials.GrantClientCredentials
 	wrongGrantStore := runtimemanagedcredentials.NewMemoryStore(wrongGrant)
-	mismatch, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: wrongGrantStore})
+	mismatch, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: wrongGrantStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions mismatch: %v", err)
+		t.Fatalf("CapabilitySubjects mismatch: %v", err)
 	}
-	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+	if len(mismatch) != 1 || len(mismatch[0].Requirements) != 1 || requirementSatisfied(mismatch[0].Requirements[0]) || mismatch[0].Requirements[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("mismatch requirement = %#v, want fail-closed grant_type mismatch", mismatch)
 	}
 }
@@ -639,27 +756,22 @@ func TestGitHubConnectorPackImportsMultipleActionsExplicitly(t *testing.T) {
 			t.Fatalf("imported GitHub tool %s = %#v, want github_app provider connector", toolID, tool)
 		}
 	}
-	surfaces, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	surfaces, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions: %v", err)
+		t.Fatalf("CapabilitySubjects: %v", err)
 	}
 	if len(surfaces) != 3 {
 		t.Fatalf("surfaces = %#v, want three GitHub action surfaces", surfaces)
 	}
 	seen := map[string]bool{}
 	for _, surface := range surfaces {
-		seen[surface.ToolID] = true
-		if len(surface.Requires) != 1 || surface.Requires[0].Kind != "managed_credential" || surface.Requires[0].Name != "github_app" || surface.Requires[0].Bound {
-			t.Fatalf("surface %s requirements = %#v, want unbound github_app managed credential", surface.ToolID, surface.Requires)
+		seen[surface.ID] = true
+		if len(surface.Requirements) != 1 || surface.Requirements[0].Kind != "managed_credential" || surface.Requirements[0].Name != "github_app" || requirementSatisfied(surface.Requirements[0]) {
+			t.Fatalf("surface %s requirements = %#v, want unbound github_app managed credential", surface.ID, surface.Requirements)
 		}
-		if surface.Generation == nil || surface.Generation.OperationID == "" || surface.Generation.SourcePath == "" || surface.Generation.ProfilePath != "catalog/generator-profiles/github.yaml" {
-			t.Fatalf("surface %s generation = %#v, want generated GitHub freshness evidence", surface.ToolID, surface.Generation)
-		}
-		if len(surface.Generation.Permissions) != 1 || surface.Generation.Permissions[0].ID != "issues:write" || surface.Generation.Permissions[0].Note == "" {
-			t.Fatalf("surface %s generation permissions = %#v", surface.ToolID, surface.Generation.Permissions)
-		}
-		if surface.Generation.FixtureStatus != GenerationFixturePassing || surface.Generation.ReviewStatus != GenerationReviewApproved {
-			t.Fatalf("surface %s generation status = %#v", surface.ToolID, surface.Generation)
+		generation := evidenceByKind(surface.Evidence, "generation")
+		if generation == nil || generation["operation"] == "" || generation["source"] == "" || generation["profile"] != "catalog/generator-profiles/github.yaml" || !strings.Contains(generation["permissions"], "issues:write") || !strings.HasSuffix(generation["fixture"], ":passing") || generation["review"] != "approved" {
+			t.Fatalf("surface %s generation = %#v, want generated GitHub freshness evidence", surface.ID, generation)
 		}
 	}
 	for _, toolID := range []string{"github.add_labels_to_issue", "github.create_issue", "github.create_issue_comment"} {
@@ -681,18 +793,18 @@ func TestMicrosoftGraphConnectorPackReportsDefaultScopeManagedCredentialRequirem
 		t.Fatalf("SourceWithConnectorPackImports: %v", err)
 	}
 
-	unbound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{})
+	unbound, err := CapabilitySubjects(ctx, source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions unbound: %v", err)
+		t.Fatalf("CapabilitySubjects unbound: %v", err)
 	}
-	if len(unbound) != 1 || len(unbound[0].Requires) != 1 {
+	if len(unbound) != 1 || len(unbound[0].Requirements) != 1 {
 		t.Fatalf("unbound surfaces = %#v, want one Microsoft Graph managed credential requirement", unbound)
 	}
-	requirement := unbound[0].Requires[0]
-	if requirement.Kind != "managed_credential" || requirement.Name != "microsoft_graph_app" || requirement.Bound || requirement.Status != "UNBOUND" {
+	requirement := unbound[0].Requirements[0]
+	if requirement.Kind != "managed_credential" || requirement.Name != "microsoft_graph_app" || requirementSatisfied(requirement) || requirement.Status != "UNCONNECTED" {
 		t.Fatalf("unbound requirement = %#v, want unbound microsoft_graph_app", requirement)
 	}
-	if requirement.GrantModel != managedcredentialmodel.GrantModelScope || !managedcredentialmodel.TokenRequestProfileEqual(requirement.TokenRequest, managedcredentialmodel.DefaultTokenRequestProfile()) {
+	if requirement.GrantModel != managedcredentialmodel.GrantModelScope || requirement.TokenRequest.ClientAuth != managedcredentialmodel.TokenClientAuthPost || requirement.TokenRequest.Body != managedcredentialmodel.TokenBodyForm {
 		t.Fatalf("unbound requirement shape = %#v, want scope_grant post/form", requirement)
 	}
 	if got := strings.Join(requirement.Scopes, " "); got != "https://graph.microsoft.com/.default" {
@@ -700,22 +812,22 @@ func TestMicrosoftGraphConnectorPackReportsDefaultScopeManagedCredentialRequirem
 	}
 
 	matchingStore := runtimemanagedcredentials.NewMemoryStore(microsoftGraphConnectedRecord())
-	bound, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: matchingStore})
+	bound, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: matchingStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions bound: %v", err)
+		t.Fatalf("CapabilitySubjects bound: %v", err)
 	}
-	if len(bound) != 1 || len(bound[0].Requires) != 1 || !bound[0].Requires[0].Bound || bound[0].Requires[0].Status != "CONNECTED" {
+	if len(bound) != 1 || len(bound[0].Requirements) != 1 || !requirementSatisfied(bound[0].Requirements[0]) || bound[0].Requirements[0].Status != "CONNECTED" {
 		t.Fatalf("bound requirement = %#v, want connected Microsoft Graph credential", bound)
 	}
 
 	wrongScope := microsoftGraphConnectedRecord()
 	wrongScope.Scopes = []string{"Mail.Send"}
 	wrongScopeStore := runtimemanagedcredentials.NewMemoryStore(wrongScope)
-	mismatch, err := SurfacesWithOptions(ctx, source, SurfaceOptions{ManagedCredentials: wrongScopeStore})
+	mismatch, err := CapabilitySubjects(ctx, source, CapabilityOptions{ManagedCredentials: wrongScopeStore})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions mismatch: %v", err)
+		t.Fatalf("CapabilitySubjects mismatch: %v", err)
 	}
-	if len(mismatch) != 1 || len(mismatch[0].Requires) != 1 || mismatch[0].Requires[0].Bound || mismatch[0].Requires[0].Status != "SCOPE_INSUFFICIENT" {
+	if len(mismatch) != 1 || len(mismatch[0].Requirements) != 1 || requirementSatisfied(mismatch[0].Requirements[0]) || mismatch[0].Requirements[0].Status != "SCOPE_INSUFFICIENT" {
 		t.Fatalf("mismatch requirement = %#v, want fail-closed .default scope mismatch", mismatch)
 	}
 }
@@ -832,15 +944,18 @@ func TestConnectorPackImportRequiresExplicitEnableAndReportsSurface(t *testing.T
 	if errs := ValidateSource(source); len(errs) != 0 {
 		t.Fatalf("ValidateSource imported connector errors = %#v", errs)
 	}
-	surfaces, err := Surfaces(context.Background(), source, nil)
+	surfaces, err := CapabilitySubjects(context.Background(), source, CapabilityOptions{})
 	if err != nil {
 		t.Fatalf("Surfaces: %v", err)
 	}
-	if len(surfaces) != 1 || surfaces[0].ToolID != "telegram.send_message" {
+	if len(surfaces) != 1 || surfaces[0].ID != "telegram.send_message" {
 		t.Fatalf("surfaces = %#v, want telegram.send_message", surfaces)
 	}
-	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Name != "telegram_bot_token" || surfaces[0].Requires[0].Bound {
-		t.Fatalf("surface requirements = %#v, want unbound telegram_bot_token", surfaces[0].Requires)
+	if surfaces[0].Source != "connector_pack_import" || surfaces[0].Applicability != "effective" || surfaces[0].Provenance != packs.ProvenancePlatform {
+		t.Fatalf("surface source = %#v, want effective platform connector pack import", surfaces[0])
+	}
+	if len(surfaces[0].Requirements) != 1 || surfaces[0].Requirements[0].Name != "telegram_bot_token" || requirementSatisfied(surfaces[0].Requirements[0]) {
+		t.Fatalf("surface requirements = %#v, want unbound telegram_bot_token", surfaces[0].Requirements)
 	}
 }
 
@@ -877,15 +992,15 @@ func TestSlackConnectorPackImportRequiresExplicitEnableAndReportsManagedSurface(
 	if errs := ValidateSource(source); len(errs) != 0 {
 		t.Fatalf("ValidateSource imported Slack connector errors = %#v", errs)
 	}
-	surfaces, err := SurfacesWithOptions(context.Background(), source, SurfaceOptions{})
+	surfaces, err := CapabilitySubjects(context.Background(), source, CapabilityOptions{})
 	if err != nil {
-		t.Fatalf("SurfacesWithOptions: %v", err)
+		t.Fatalf("CapabilitySubjects: %v", err)
 	}
-	if len(surfaces) != 1 || surfaces[0].ToolID != "slack.post_message" {
+	if len(surfaces) != 1 || surfaces[0].ID != "slack.post_message" {
 		t.Fatalf("surfaces = %#v, want slack.post_message", surfaces)
 	}
-	if len(surfaces[0].Requires) != 1 || surfaces[0].Requires[0].Kind != "managed_credential" || surfaces[0].Requires[0].Name != "slack_oauth" || surfaces[0].Requires[0].Bound {
-		t.Fatalf("surface requirements = %#v, want unbound managed slack_oauth", surfaces[0].Requires)
+	if len(surfaces[0].Requirements) != 1 || surfaces[0].Requirements[0].Kind != "managed_credential" || surfaces[0].Requirements[0].Name != "slack_oauth" || requirementSatisfied(surfaces[0].Requirements[0]) {
+		t.Fatalf("surface requirements = %#v, want unbound managed slack_oauth", surfaces[0].Requirements)
 	}
 }
 
@@ -1144,10 +1259,23 @@ func joinErrors(errs []error) string {
 	return strings.Join(parts, "\n")
 }
 
-func joinRequirementStatuses(requirements []RequirementStatus) string {
+func joinRequirementStatuses(requirements []packs.Requirement) string {
 	parts := make([]string, 0, len(requirements))
 	for _, req := range requirements {
 		parts = append(parts, req.Kind+":"+req.Name+"="+req.Status)
 	}
 	return strings.Join(parts, "; ")
+}
+
+func requirementSatisfied(requirement packs.Requirement) bool {
+	return requirement.Satisfied != nil && *requirement.Satisfied
+}
+
+func evidenceByKind(evidence []packs.Evidence, kind string) map[string]string {
+	for _, item := range evidence {
+		if item.Kind == kind {
+			return item.Fields
+		}
+	}
+	return nil
 }

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -408,8 +408,45 @@ func DerivedRequires(manifest Manifest) packs.Requires {
 	return packs.Requires{}
 }
 
-func (p LoadedPack) CapabilitySurface(boundSecrets map[string]bool) packs.CapabilitySurface {
-	return p.Envelope.Surface(boundSecrets)
+func (p LoadedPack) CapabilitySubject() (packs.Subject, error) {
+	capabilities := DerivedCapabilities(p.Manifest)
+	subject := packs.Subject{
+		ID:            strings.TrimSpace(p.Envelope.ID),
+		Kind:          packs.SubjectProviderTrigger,
+		Provider:      NormalizeProviderName(p.Manifest.Provider),
+		Source:        "trigger_pack",
+		Provenance:    strings.TrimSpace(p.Envelope.Provenance.Source),
+		SourcePath:    strings.TrimSpace(p.SourcePath),
+		Applicability: "installed",
+		Status:        packs.StatusAvailable,
+	}
+	if route := strings.TrimSpace(capabilities.Can.ReceiveHTTPSRoute); route != "" {
+		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityReceiveHTTPSRoute, Target: route})
+	}
+	if secret := strings.TrimSpace(capabilities.Can.VerifySecret); secret != "" {
+		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityVerifySecret, Target: secret})
+	}
+	for _, event := range capabilities.Can.EmitEvents {
+		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityEmitEvent, Target: strings.TrimSpace(event)})
+	}
+	if capabilities.Can.PersistDedupeMarkers {
+		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityPersistDedupeMarkers})
+	}
+	for _, code := range capabilities.Cannot {
+		guarantee, err := packs.NewGuarantee(code)
+		if err != nil {
+			return packs.Subject{}, err
+		}
+		subject.Guarantees = append(subject.Guarantees, guarantee)
+	}
+	for _, secret := range DerivedRequires(p.Manifest).Secrets {
+		subject.Requirements = append(subject.Requirements, packs.TargetScopedRequirement(packs.RequirementSecret, secret))
+	}
+	normalized, err := packs.NormalizeSubjects([]packs.Subject{subject})
+	if err != nil {
+		return packs.Subject{}, err
+	}
+	return normalized[0], nil
 }
 
 func (r *Registry) Accept(req Request) (Delivery, error) {

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -418,7 +418,6 @@ func (p LoadedPack) CapabilitySubject() (packs.Subject, error) {
 		Provenance:    strings.TrimSpace(p.Envelope.Provenance.Source),
 		SourcePath:    strings.TrimSpace(p.SourcePath),
 		Applicability: "installed",
-		Status:        packs.StatusAvailable,
 	}
 	if route := strings.TrimSpace(capabilities.Can.ReceiveHTTPSRoute); route != "" {
 		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityReceiveHTTPSRoute, Target: route})

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -59,6 +59,16 @@ func TestPlatformPackInventoryIsCompleteFilesystemOnlyAndFreshlyStamped(t *testi
 		if err != nil {
 			t.Fatalf("load %s: %v", dir, err)
 		}
+		subject, err := pack.CapabilitySubject()
+		if err != nil {
+			t.Fatalf("capability subject %s: %v", dir, err)
+		}
+		if subject.Kind != packs.SubjectProviderTrigger || subject.Status != packs.StatusAvailable || subject.Provider != pack.Manifest.Provider || len(subject.Capabilities) != 4 || len(subject.Guarantees) != 3 {
+			t.Fatalf("capability subject %s = %#v", dir, subject)
+		}
+		if len(subject.Requirements) != 1 || subject.Requirements[0].Scope != packs.RequirementScopeTarget || subject.Requirements[0].Satisfied != nil || subject.Requirements[0].Status != "" {
+			t.Fatalf("capability subject %s requirements = %#v, want target-scoped unevaluated", dir, subject.Requirements)
+		}
 		providers = append(providers, pack.Manifest.Provider)
 	}
 	sort.Strings(providers)
@@ -314,11 +324,18 @@ func TestProviderTriggerPackRequiresReadbackDoesNotRequireBoundSecretAtLoad(t *t
 	if err != nil {
 		t.Fatalf("LoadPackFS: %v", err)
 	}
-	surface := pack.CapabilitySurface(nil)
-	if len(surface.Requires) != 1 || surface.Requires[0].Name != "webhook_signing.stripe" || surface.Requires[0].Bound {
-		t.Fatalf("surface requires = %+v, want unbound stripe signing secret", surface.Requires)
+	pack.Envelope.Capabilities.Can.ReceiveHTTPSRoute = "/envelope-must-not-render"
+	surface, err := pack.CapabilitySubject()
+	if err != nil {
+		t.Fatalf("CapabilitySubject: %v", err)
 	}
-	renderedCan := strings.Join(surface.Can, "\n")
+	if surface.Status != packs.StatusAvailable || len(surface.Requirements) != 1 || surface.Requirements[0].Name != "webhook_signing.stripe" || surface.Requirements[0].Scope != packs.RequirementScopeTarget || surface.Requirements[0].Satisfied != nil {
+		t.Fatalf("surface requirements = %+v status=%s, want AVAILABLE target-scoped unevaluated stripe signing secret", surface.Requirements, surface.Status)
+	}
+	renderedCan := packs.RenderSubject(surface, false)
+	if strings.Contains(renderedCan, "/envelope-must-not-render") || !strings.Contains(renderedCan, "/webhooks/{entity}/stripe") {
+		t.Fatalf("capability surface did not derive accepted body truth: %s", renderedCan)
+	}
 	if strings.Contains(renderedCan, "stripe-secret") {
 		t.Fatal("capability surface leaked a concrete secret value")
 	}
@@ -345,6 +362,13 @@ func TestExternalProviderTriggerPackUsesSameVerifier(t *testing.T) {
 	}
 	if len(loaded) != 1 || loaded[0].Manifest.Provider != "stripe" {
 		t.Fatalf("loaded external packs = %+v, want stripe", loaded)
+	}
+	subject, err := loaded[0].CapabilitySubject()
+	if err != nil {
+		t.Fatalf("CapabilitySubject: %v", err)
+	}
+	if subject.Provenance != packs.ProvenanceExternal || subject.SourcePath != dir || subject.Status != packs.StatusAvailable {
+		t.Fatalf("external capability subject = %#v", subject)
 	}
 }
 

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -105,6 +105,7 @@ func (s *rollbackTrackingInboundStore) DeleteInboundEvent(context.Context, strin
 
 type recordingInboundStore struct {
 	target          InboundTarget
+	resolveErr      error
 	inserted        bool
 	recorded        bool
 	providerEventID string
@@ -121,7 +122,7 @@ func (s *recordingInboundStore) RecordInboundEvent(_ context.Context, providerEv
 }
 
 func (s *recordingInboundStore) ResolveInboundTarget(context.Context, string, string) (InboundTarget, error) {
-	return s.target, nil
+	return s.target, s.resolveErr
 }
 
 func (*recordingInboundStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
@@ -171,6 +172,28 @@ func TestInboundGateway_Returns503WhenRuntimeShutdownAdmissionClosed(t *testing.
 	}
 	if store.recorded {
 		t.Fatal("did not expect inbound event recording after shutdown admission closed")
+	}
+}
+
+func TestInboundGateway_UnknownTargetFailsBeforeProviderAdmission(t *testing.T) {
+	bus, err := runtimebus.NewEventBus(nil)
+	if err != nil {
+		t.Fatalf("NewEventBus: %v", err)
+	}
+	store := &recordingInboundStore{resolveErr: errors.New("target not found")}
+	g := newTestInboundGateway(t, bus, nil, nil, store)
+
+	// A GitHub request without a signature would fail provider admission with 401
+	// if target resolution did not gate the provider interpreter first.
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/unknown/github", strings.NewReader(`{"id":"evt-1"}`))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound || !strings.Contains(rec.Body.String(), "unknown entity") {
+		t.Fatalf("response = %d %q, want target-gate 404", rec.Code, rec.Body.String())
+	}
+	if store.recorded {
+		t.Fatal("unknown target reached provider marker persistence")
 	}
 }
 

--- a/internal/runtime/managedcredentials/requirements.go
+++ b/internal/runtime/managedcredentials/requirements.go
@@ -26,6 +26,11 @@ type RequirementDescriptor struct {
 	RequiredBy []Requirement `json:"required_by,omitempty"`
 }
 
+type RequirementEvaluation struct {
+	Descriptor RequirementDescriptor
+	Satisfied  bool
+}
+
 func BuildRequirementIndex(source semanticview.Source) map[string][]Requirement {
 	index := map[string][]Requirement{}
 	if source == nil {
@@ -125,42 +130,43 @@ func MissingOrUnusableRequired(ctx context.Context, store Store, source semantic
 		if len(desc.RequiredBy) == 0 {
 			continue
 		}
-		if !desc.Present || desc.Status != StatusConnected {
-			out = append(out, desc)
-			continue
-		}
 		for _, req := range desc.RequiredBy {
-			if err := GrantTypeCovers(desc.GrantType, req.GrantType); err != nil {
-				scoped := desc
-				scoped.Status = StatusScopeInsufficient
-				scoped.Failure = "grant-type-insufficient: " + err.Error()
-				out = append(out, scoped)
-				break
-			}
-			if err := managedcredentialmodel.GrantModelCovers(desc.GrantModel, req.GrantModel); err != nil {
-				scoped := desc
-				scoped.Status = StatusScopeInsufficient
-				scoped.Failure = "grant-model-insufficient: " + err.Error()
-				out = append(out, scoped)
-				break
-			}
-			if err := managedcredentialmodel.TokenRequestProfileCovers(desc.TokenRequest, req.TokenRequest); err != nil {
-				scoped := desc
-				scoped.Status = StatusScopeInsufficient
-				scoped.Failure = "token-request-insufficient: " + err.Error()
-				out = append(out, scoped)
-				break
-			}
-			if err := ensureScopes(desc.Scopes, req.Scopes); err != nil {
-				scoped := desc
-				scoped.Status = StatusScopeInsufficient
-				scoped.Failure = "scope-insufficient: " + err.Error()
-				out = append(out, scoped)
+			evaluation := EvaluateRequirement(desc, req)
+			if !evaluation.Satisfied {
+				out = append(out, evaluation.Descriptor)
 				break
 			}
 		}
 	}
 	return out, nil
+}
+
+func EvaluateRequirement(desc RequirementDescriptor, req Requirement) RequirementEvaluation {
+	if !desc.Present || desc.Status != StatusConnected {
+		return RequirementEvaluation{Descriptor: desc}
+	}
+	scoped := desc
+	if err := GrantTypeCovers(desc.GrantType, req.GrantType); err != nil {
+		scoped.Status = StatusScopeInsufficient
+		scoped.Failure = "grant-type-insufficient: " + err.Error()
+		return RequirementEvaluation{Descriptor: scoped}
+	}
+	if err := managedcredentialmodel.GrantModelCovers(desc.GrantModel, req.GrantModel); err != nil {
+		scoped.Status = StatusScopeInsufficient
+		scoped.Failure = "grant-model-insufficient: " + err.Error()
+		return RequirementEvaluation{Descriptor: scoped}
+	}
+	if err := managedcredentialmodel.TokenRequestProfileCovers(desc.TokenRequest, req.TokenRequest); err != nil {
+		scoped.Status = StatusScopeInsufficient
+		scoped.Failure = "token-request-insufficient: " + err.Error()
+		return RequirementEvaluation{Descriptor: scoped}
+	}
+	if err := ensureScopes(desc.Scopes, req.Scopes); err != nil {
+		scoped.Status = StatusScopeInsufficient
+		scoped.Failure = "scope-insufficient: " + err.Error()
+		return RequirementEvaluation{Descriptor: scoped}
+	}
+	return RequirementEvaluation{Descriptor: scoped, Satisfied: true}
 }
 
 func describe(ctx context.Context, store Store, key string) (Descriptor, bool, error) {

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -131,6 +131,37 @@ func TestActivityHTTPResponseSuccessPolicyParityCases(t *testing.T) {
 	}
 }
 
+func TestActivityCredentialRedactionGuarantee(t *testing.T) {
+	const secret = "provider-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"state":"provider-secret"}`)
+	}))
+	defer server.Close()
+
+	policy := runtimecontracts.HTTPResponseSuccess{Kind: "json_field_equals", Path: "response.body.state", Equals: "accepted"}
+	_, err := executePreparedActivityHTTPTool(context.Background(), preparedActivityHTTPTool{
+		toolName: "redaction_guarantee_probe",
+		method:   http.MethodPost,
+		url:      server.URL,
+		timeout:  time.Second,
+		client:   server.Client(),
+		secrets:  []string{secret},
+		success:  &policy,
+	})
+	failure, ok := runtimefailures.As(err)
+	if err == nil || !ok || failure.Failure.Detail.Code != "provider_response_rejected" {
+		t.Fatalf("failure = %#v, want redacted provider_response_rejected", failure)
+	}
+	raw, marshalErr := runtimefailures.MarshalEnvelope(failure.Failure)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if strings.Contains(string(raw), secret) || strings.Contains(err.Error(), secret) {
+		t.Fatalf("credential value leaked through failure: envelope=%s error=%v", raw, err)
+	}
+}
+
 func TestPipelineActivityDispatcherDispatchesDurableActivityRequestEvent(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
 	bus := &recordingPipelineBus{}

--- a/internal/userfacing/human_code_projection.go
+++ b/internal/userfacing/human_code_projection.go
@@ -1,0 +1,133 @@
+package userfacing
+
+import "strings"
+
+type HumanCodeFamily string
+
+const (
+	HumanCodeRunStatus                   HumanCodeFamily = "run_status"
+	HumanCodeOperationalState            HumanCodeFamily = "operational_state"
+	HumanCodeRunBlockingLayer            HumanCodeFamily = "run_blocking_layer"
+	HumanCodeRunBlockingReason           HumanCodeFamily = "run_blocking_reason"
+	HumanCodeAgentStatus                 HumanCodeFamily = "agent_status"
+	HumanCodeConversationMode            HumanCodeFamily = "conversation_mode"
+	HumanCodeSessionScope                HumanCodeFamily = "session_scope"
+	HumanCodeDeliveryStatus              HumanCodeFamily = "delivery_status"
+	HumanCodeAgentLifecycleState         HumanCodeFamily = "agent_lifecycle_state"
+	HumanCodeAgentLifecycleBlockingLayer HumanCodeFamily = "agent_lifecycle_blocking_layer"
+	HumanCodeWatchdogState               HumanCodeFamily = "watchdog_state"
+	HumanCodeWatchdogBlockingLayer       HumanCodeFamily = "watchdog_blocking_layer"
+	HumanCodeWatchdogAction              HumanCodeFamily = "watchdog_action"
+	HumanCodeWatchdogOutcome             HumanCodeFamily = "watchdog_outcome"
+	HumanCodeProviderSubjectKind         HumanCodeFamily = "provider_subject_kind"
+	HumanCodeProviderSubjectStatus       HumanCodeFamily = "provider_subject_status"
+	HumanCodeProviderCapability          HumanCodeFamily = "provider_capability"
+	HumanCodeProviderGuarantee           HumanCodeFamily = "provider_guarantee"
+	HumanCodeProviderRequirementStatus   HumanCodeFamily = "provider_requirement_status"
+)
+
+var humanCodePhrases = map[HumanCodeFamily]map[string]string{
+	HumanCodeRunStatus: {
+		"running": "running", "paused": "paused", "completed": "completed",
+		"failed": "failed", "cancelled": "cancelled", "forked": "forked",
+	},
+	HumanCodeOperationalState: {
+		"running": "running", "stalled": "stalled", "paused": "paused",
+		"completed": "completed", "failed": "failed", "cancelled": "cancelled", "forked": "forked",
+	},
+	HumanCodeRunBlockingLayer: {
+		"scoring_terminal_outcome": "scoring outcome",
+		"delivery_lifecycle":       "delivery lifecycle",
+	},
+	HumanCodeRunBlockingReason: {
+		"terminal_scoring_outcome_missing": "waiting for a terminal scoring outcome",
+		"no_active_deliveries":             "no active deliveries",
+	},
+	HumanCodeAgentStatus: {
+		"idle": "idle", "running": "running", "paused": "paused",
+		"failed": "failed", "terminated": "terminated",
+	},
+	HumanCodeConversationMode: {
+		"task": "task", "session": "session", "session_per_entity": "session per entity",
+	},
+	HumanCodeSessionScope: {
+		"global": "global", "flow": "flow", "entity": "entity",
+	},
+	HumanCodeDeliveryStatus: {
+		"pending": "pending", "in_progress": "in progress", "delivered": "delivered",
+		"failed": "failed", "dead_letter": "dead letter",
+	},
+	HumanCodeAgentLifecycleState: {
+		"queued": "queued", "launching": "launching", "active": "active",
+		"retrying": "retrying", "exhausted": "exhausted",
+	},
+	HumanCodeAgentLifecycleBlockingLayer: {
+		"delivery_queue":    "delivery queue",
+		"session_launch":    "session launch",
+		"session_execution": "session execution",
+		"delivery_retry":    "delivery retry",
+		"delivery_terminal": "delivery terminal",
+	},
+	HumanCodeWatchdogState: {
+		"healthy_long_running": "healthy, long-running",
+		"no_output":            "no output",
+	},
+	HumanCodeWatchdogBlockingLayer: {
+		"session_execution": "session execution",
+	},
+	HumanCodeWatchdogAction: {
+		"turn_long_running": "turn running for a long time",
+		"session_no_output": "session produced no output",
+	},
+	HumanCodeWatchdogOutcome: {
+		"observed": "observed", "warning_emitted": "warning emitted",
+	},
+	HumanCodeProviderSubjectKind: {
+		"provider_trigger":   "provider trigger pack",
+		"provider_connector": "provider connector",
+	},
+	HumanCodeProviderSubjectStatus: {
+		"READY": "READY", "NOT_READY": "NOT READY", "AVAILABLE": "AVAILABLE",
+	},
+	HumanCodeProviderCapability: {
+		"receive_https_route":       "receive HTTPS route",
+		"verify_secret":             "verify named secret",
+		"emit_event":                "emit named event",
+		"persist_dedupe_markers":    "persist dedupe markers",
+		"call_provider_action":      "call provider action",
+		"lower_through_activity":    "lower through platform.activity_requested",
+		"journal_activity_attempts": "journal non-idempotent attempts in activity_attempts",
+	},
+	HumanCodeProviderGuarantee: {
+		"emit_undeclared_events":                   "emit undeclared events",
+		"run_code_before_admission":                "run code before admission",
+		"touch_unbound_resources":                  "touch unbound resources",
+		"bypass_activity_attempts":                 "bypass activity_attempts",
+		"retry_non_idempotent_write_automatically": "retry non_idempotent_write automatically",
+		"expose_credential_values":                 "expose credential values",
+	},
+	HumanCodeProviderRequirementStatus: {
+		"BOUND": "BOUND", "UNBOUND": "UNBOUND", "CONNECTED": "CONNECTED",
+		"UNCONNECTED": "UNCONNECTED", "PENDING_CONSENT": "PENDING CONSENT",
+		"REFRESH_FAILED": "REFRESH FAILED", "SCOPE_INSUFFICIENT": "SCOPE INSUFFICIENT",
+		"NOT_IMPORTED": "NOT IMPORTED", "UNKNOWN": "UNKNOWN",
+	},
+}
+
+func ProjectHumanCode(family HumanCodeFamily, raw string) string {
+	if phrase, ok := humanCodePhrases[family][strings.TrimSpace(raw)]; ok {
+		return phrase
+	}
+	return raw
+}
+
+func HumanCodePhrases() map[HumanCodeFamily]map[string]string {
+	out := make(map[HumanCodeFamily]map[string]string, len(humanCodePhrases))
+	for family, phrases := range humanCodePhrases {
+		out[family] = make(map[string]string, len(phrases))
+		for code, phrase := range phrases {
+			out[family][code] = phrase
+		}
+	}
+	return out
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6929,7 +6929,7 @@ tool_model:
       \ \"{{response.body.status[0].summary}}\"\n  credentials:\n    - domainr_api_key"
   provider_capability_surface:
     promoted_by: '#1929'
-    owner: internal/packs typed capability-surface model and deterministic renderer
+    owner: internal/packs typed capability-surface model and deterministic renderer consuming internal/userfacing human-code projection
     description: >
       Provider trigger packs and provider connector declarations expose one typed proof-ready model to local preflight and
       doctor. Body-specific owners derive capability and guarantee facts from accepted manifests or ToolSchemaEntry values;
@@ -6962,6 +6962,11 @@ tool_model:
         Installed capability that is not effective in the current contract. All provider-trigger pack subjects are
         AVAILABLE until #1944 contributes a selected-target readiness subject. Unimported connector actions are AVAILABLE
         and carry import remediation but MUST remain absent from ToolEntries, agent surfaces, validation, and execution.
+      rollup_rule: >
+        `internal/packs NormalizeSubjects` derives status from kind, applicability, and validated requirement state.
+        Body adapters MUST NOT compute status. A supplied status that contradicts the derived tuple, an installed connector
+        without import remediation, an effective connector with an import requirement, or a status/satisfied/remediation
+        inconsistency fails closed.
     facts:
       capability_shape: {code: stable_machine_code, target: optional_body_derived_target}
       guarantee_shape: {code: stable_machine_code, enforced_by: registry_pinned_enforcement_id}
@@ -6978,12 +6983,25 @@ tool_model:
       - journal_activity_attempts
       unknown_projection: Unknown capability codes remain verbatim in human output and structured JSON.
     guarantee_enforcement_registry:
-      emit_undeclared_events: provider_trigger_event_name_policy
-      run_code_before_admission: provider_trigger_admission_sequence
-      touch_unbound_resources: provider_trigger_resource_binding_gate
-      bypass_activity_attempts: activity_attempts
-      retry_non_idempotent_write_automatically: activity_effect_retry_policy
-      expose_credential_values: credential_redaction_boundary
+      claims:
+        emit_undeclared_events:
+          enforced_by: internal/providertriggers.Manifest.resolveEventName
+          execution_proof: internal/providertriggers TestStripeManifestAcceptsLiteralEventType
+        run_code_before_admission:
+          enforced_by: internal/providertriggers.Manifest.Accept
+          execution_proof: internal/runtime TestInboundGateway_GitHubAdapterRejectsInvalidSignatureBeforeMarkerAndPublish
+        touch_unbound_resources:
+          enforced_by: internal/runtime.InboundGateway.handleWebhook
+          execution_proof: internal/runtime TestInboundGateway_UnknownTargetFailsBeforeProviderAdmission
+        bypass_activity_attempts:
+          enforced_by: internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent
+          execution_proof: internal/runtime/pipeline TestGeneratedSyntheticConnectorUsesCanonicalActivityJournalOnReplay
+        retry_non_idempotent_write_automatically:
+          enforced_by: internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent
+          execution_proof: internal/runtime/pipeline TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry
+        expose_credential_values:
+          enforced_by: internal/runtime/pipeline.executePreparedActivityHTTPTool
+          execution_proof: internal/runtime/pipeline TestActivityHTTPResponseSuccessPolicyParityCases/secret_redaction
       rule: >
         A known guarantee without exactly one registry enforcement owner fails closed. Human output renders guarantees as
         `cannot <verb> - enforced by <id>`; it does not present CANNOT as a product limitation.
@@ -7016,6 +7034,7 @@ tool_model:
         redacted SQLite/Postgres signing-binding readback, ambiguity, and mutation/remediation.
     projection:
       structured_owner: local preflight report capability_subjects
+      human_phrase_owner: platform-spec.yaml#cli_specification.foundations.output_contract.shared_renderer_contract.human_code_projection
       text_rule: Human text is a deterministic projection of the same typed records emitted in JSON.
       ordering:
       - unsatisfied requirements with inline remediation
@@ -16488,7 +16507,7 @@ cli_specification:
         human_code_projection:
           promoted_by: '#1817'
           canonical_owner: platform-spec.yaml#cli_specification.foundations.output_contract.shared_renderer_contract.human_code_projection
-          implementation_owner: cmd/swarm/cli_output.go formatCLIHumanCode and cliHumanCodePhrases
+          implementation_owner: internal/userfacing/human_code_projection.go ProjectHumanCode and HumanCodePhrases; cmd/swarm/cli_output.go formatCLIHumanCode is the CLI adapter
           scope: >
             Authoritative human projection for current public status, mode, state, layer, action, outcome, and
             blocking-reason codes rendered by CLI detail, table, summary, stream, mutation, fork, and identifier
@@ -16522,6 +16541,43 @@ cli_specification:
             delivery_status:
               machine_owner: persisted event_deliveries.status contract and components.schemas.DeliveryStatus
               phrases: {pending: pending, in_progress: in progress, delivered: delivered, failed: failed, dead_letter: dead letter}
+            provider_subject_kind:
+              machine_owner: internal/packs SubjectKind
+              phrases: {provider_trigger: provider trigger pack, provider_connector: provider connector}
+            provider_subject_status:
+              machine_owner: internal/packs NormalizeSubjects derived SubjectStatus
+              phrases: {READY: READY, NOT_READY: NOT READY, AVAILABLE: AVAILABLE}
+            provider_capability:
+              machine_owner: internal/packs capability code constants populated from accepted provider bodies
+              phrases:
+                receive_https_route: receive HTTPS route
+                verify_secret: verify named secret
+                emit_event: emit named event
+                persist_dedupe_markers: persist dedupe markers
+                call_provider_action: call provider action
+                lower_through_activity: lower through platform.activity_requested
+                journal_activity_attempts: journal non-idempotent attempts in activity_attempts
+            provider_guarantee:
+              machine_owner: tool_model.provider_capability_surface.guarantee_enforcement_registry.claims
+              phrases:
+                emit_undeclared_events: emit undeclared events
+                run_code_before_admission: run code before admission
+                touch_unbound_resources: touch unbound resources
+                bypass_activity_attempts: bypass activity_attempts
+                retry_non_idempotent_write_automatically: retry non_idempotent_write automatically
+                expose_credential_values: expose credential values
+            provider_requirement_status:
+              machine_owner: internal/packs requirement validation consuming canonical credential descriptors
+              phrases:
+                BOUND: BOUND
+                UNBOUND: UNBOUND
+                CONNECTED: CONNECTED
+                UNCONNECTED: UNCONNECTED
+                PENDING_CONSENT: PENDING CONSENT
+                REFRESH_FAILED: REFRESH FAILED
+                SCOPE_INSUFFICIENT: SCOPE INSUFFICIENT
+                NOT_IMPORTED: NOT IMPORTED
+                UNKNOWN: UNKNOWN
             operational_state:
               machine_owner: internal/store/run_operational_status_read_surface.go ProjectRunOperationalStatus and components.schemas.OperationalState
               phrases: {running: running, stalled: stalled, paused: paused, completed: completed, failed: failed, cancelled: cancelled, forked: forked}
@@ -16577,7 +16633,8 @@ cli_specification:
             Every public human renderer of a registered family must call the shared projector, including identity
             phrases. Current consumers include run list/status/start/reattach/terminal/fork, run trace snapshot/detail/
             summary/follow and foreground start trace, agent list/view/diagnose/deliveries and agent ambiguity,
-            bundle agents, event view/publish/replay, and their shared row/detail writers. Validators, replay-only
+            bundle agents, event view/publish/replay, provider capability findings through internal/packs RenderSubject,
+            and their shared row/detail writers. Validators, replay-only
             validation, event-follow counts, machine output, and the private run-fork runtime-owner harness are not
             human phrase consumers.
           vocabulary_guard:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6927,6 +6927,120 @@ tool_model:
       \ Domain to check (e.g., example.com)\n  http:\n    method: GET\n    url: \"https://api.domainr.com/v2/status?domain={{input.domain}}\"\
       \n    headers:\n      Authorization: \"Bearer {{credentials.domainr_api_key}}\"\n  response_mapping:\n    available:\
       \ \"{{response.body.status[0].summary}}\"\n  credentials:\n    - domainr_api_key"
+  provider_capability_surface:
+    promoted_by: '#1929'
+    owner: internal/packs typed capability-surface model and deterministic renderer
+    description: >
+      Provider trigger packs and provider connector declarations expose one typed proof-ready model to local preflight and
+      doctor. Body-specific owners derive capability and guarantee facts from accepted manifests or ToolSchemaEntry values;
+      credential owners derive connector requirement state. The common owner normalizes subject identity, applicability,
+      status, requirements, enforcement evidence, ordering, and text/JSON projections. Pack envelope capabilities and
+      requires remain import-time derive-and-compare integrity assertions and MUST NOT be read as runtime surface truth.
+    subject:
+      required_fields:
+      - id
+      - kind
+      - provider
+      - source
+      - applicability
+      - status
+      kinds:
+        provider_trigger: accepted provider-trigger manifest packaged by the verified trigger pack
+        provider_connector: effective ToolSchemaEntry or installed connector-pack action
+      source_values:
+        trigger_pack: verified platform or external trigger pack
+        connector_pack_import: explicitly imported connector action
+        connector_pack: installed but not imported connector action
+        flow_local: flow-local ToolSchemaEntry with category provider_connector
+      applicability_values:
+        effective: callable connector declaration selected by the contract
+        installed: verified pack inventory that is not an effective callable connector
+    status:
+      READY: effective connector whose every static or managed credential requirement is satisfied
+      NOT_READY: effective connector with at least one unsatisfied static or managed credential requirement
+      AVAILABLE: >
+        Installed capability that is not effective in the current contract. All provider-trigger pack subjects are
+        AVAILABLE until #1944 contributes a selected-target readiness subject. Unimported connector actions are AVAILABLE
+        and carry import remediation but MUST remain absent from ToolEntries, agent surfaces, validation, and execution.
+    facts:
+      capability_shape: {code: stable_machine_code, target: optional_body_derived_target}
+      guarantee_shape: {code: stable_machine_code, enforced_by: registry_pinned_enforcement_id}
+      truth_rule: >
+        Trigger facts derive from the accepted Manifest. Connector facts derive from the effective ToolSchemaEntry or the
+        verified installed connector body. Envelope narrative is never a renderer source.
+      known_capability_codes:
+      - receive_https_route
+      - verify_secret
+      - emit_event
+      - persist_dedupe_markers
+      - call_provider_action
+      - lower_through_activity
+      - journal_activity_attempts
+      unknown_projection: Unknown capability codes remain verbatim in human output and structured JSON.
+    guarantee_enforcement_registry:
+      emit_undeclared_events: provider_trigger_event_name_policy
+      run_code_before_admission: provider_trigger_admission_sequence
+      touch_unbound_resources: provider_trigger_resource_binding_gate
+      bypass_activity_attempts: activity_attempts
+      retry_non_idempotent_write_automatically: activity_effect_retry_policy
+      expose_credential_values: credential_redaction_boundary
+      rule: >
+        A known guarantee without exactly one registry enforcement owner fails closed. Human output renders guarantees as
+        `cannot <verb> - enforced by <id>`; it does not present CANNOT as a product limitation.
+    requirements:
+      shape: >
+        kind, name, scope, optional status, optional satisfied, optional remediation, optional non-secret source and
+        managed-credential grant/profile detail. Secret values, tokens, private keys, and provider client secrets are
+        forbidden in every field.
+      static_connector_owner: internal/runtime/credentials Describe/ListDescriptors after import-boundary key resolution
+      managed_connector_owner: >
+        internal/runtime/managedcredentials ListRequirementDescriptors plus EvaluateRequirement for lifecycle,
+        grant_type, grant_model, token_request, scope, and installation-input coverage
+      connector_statuses:
+      - BOUND
+      - UNBOUND
+      - CONNECTED
+      - UNCONNECTED
+      - PENDING_CONSENT
+      - REFRESH_FAILED
+      - SCOPE_INSUFFICIENT
+      remediations:
+        UNBOUND: swarm secrets set <resolved-deployment-key>
+        UNCONNECTED: swarm connections connect <resolved-deployment-key>
+        PENDING_CONSENT: swarm connections connect <resolved-deployment-key>
+        REFRESH_FAILED: swarm connections disconnect <resolved-deployment-key> && swarm connections connect <resolved-deployment-key>
+        SCOPE_INSUFFICIENT: swarm connections connect <resolved-deployment-key>
+      trigger_rule: >
+        Trigger signing requirements render with `scope: target` and no status, satisfied value, binding remediation,
+        READY/NOT_READY claim, selected-store query, or inferred global binding. #1944 owns target selection, enablement,
+        redacted SQLite/Postgres signing-binding readback, ambiguity, and mutation/remediation.
+    projection:
+      structured_owner: local preflight report capability_subjects
+      text_rule: Human text is a deterministic projection of the same typed records emitted in JSON.
+      ordering:
+      - unsatisfied requirements with inline remediation
+      - CAN facts grouped by target
+      - guarantees with enforced_by
+      - optional evidence in verbose rendering
+      subject_order: kind then stable subject id
+      consumers:
+      - swarm doctor
+      - swarm serve
+      - local preflight mode serve_dev
+      - local preflight mode run_local
+      future_consumer: '#1769 describe --prove consumes this model and MUST NOT reconstruct a second surface.'
+    current_inventory:
+      trigger_packs: [github, intercom, shopify, slack, stripe, telegram, twilio, typeform]
+      connector_packs: [github, microsoft_graph, notion, slack, telegram]
+      connector_action_count: 7
+      inventory_rule: >
+        The verified connector PackRegistry enumerates installed actions deterministically. An effective connector identity
+        replaces the same installed teaching row so readback cannot suggest importing an already effective flow-local or
+        imported tool.
+    failure_policy: >
+      Capability derivation, descriptor readback, registry lookup, duplicate subject identity, or projection validation
+      failure emits a typed blocking diagnostic. Consumers MUST NOT silently omit a subject, parse prose back into fields,
+      fall back to envelope narrative, or preserve a legacy surface alongside this owner.
   provider_connector_tools:
     description: >
       Outbound provider connectors are authored HTTP tools represented by the existing `ToolSchemaEntry` model with
@@ -6941,7 +7055,7 @@ tool_model:
       execution: "handler `activity` lowering to `platform.activity_requested`."
       non_idempotent_journal: "`activity_attempts`."
       credentials: "static credential store keys listed under tool `credentials`, or managed credential handles listed under tool `managed_credential`; exactly one credential mode owns connector auth."
-      readback: "local preflight/doctor provider connector CAN/CANNOT plus typed requirement status findings."
+      readback: "tool_model.provider_capability_surface, consuming canonical static and managed credential descriptors."
       display: "first CAN action label is derived from the authored tool `description`; if absent, it falls back to normalized `<action> via <Provider>`."
     stage_1_profile:
       required:
@@ -6976,14 +7090,10 @@ tool_model:
         later gated surface, so first-party connector packs are migrated aggressively before any external connector-pack
         compatibility promise exists.
       capability_surface: >
-        Connector pack CAN/CANNOT/readback is kind-specific. Connector CAN rows include calling the declared provider
-        action or actions, lowering through `platform.activity_requested`, and journaling non-idempotent attempts in
-        `activity_attempts`. Connector CANNOT rows include bypassing `activity_attempts`, automatically retrying
-        non-idempotent writes, or exposing credential values. Requirement rows are typed: static secret requirements render
-        BOUND/UNBOUND from the static credential store, while managed credential requirements render managed credential
-        lifecycle status such as CONNECTED, UNCONNECTED, PENDING_CONSENT, REFRESH_FAILED, or SCOPE_INSUFFICIENT plus the
-        required grant_type, scopes, grant_model, token_request profile, and installation_id_input when present without
-        exposing token values.
+        Connector body facts and deployment readiness consume `tool_model.provider_capability_surface`. Effective imported
+        and flow-local connectors use the same typed model; installed unimported actions render AVAILABLE without becoming
+        effective tools. Static and managed requirement states consume their canonical descriptor owners rather than a
+        connector-local store or coverage interpreter.
       collision_policy: >
         No packed-vs-packed or packed-vs-flow-local connector shadowing is allowed in this slice. Any duplicate tool id
         fails closed before runtime construction and names both sources with remediation to remove one source or rename the
@@ -7390,15 +7500,11 @@ tool_model:
         paths and provenance values. The tuple `(id, version, manifest_hash)` is immutable within boot admission; competing
         instances fail before registration. Explicit override or replacement semantics require a later gated affordance.
       capability_surface: >
-        Provider-trigger pack readback renders CAN/CANNOT truth from the verified envelope after derivation/equality checks.
-        The first trigger surface includes CAN receive HTTPS at `/webhooks/{entity}/{provider}`, CAN verify the named signing
-        secret, CAN emit the declared event name, CAN persist dedupe markers, and CANNOT run code before admission, emit
-        undeclared events, or touch unbound resources. Requirement readback marks each declared secret as BOUND or UNBOUND
-        without exposing secret values. `swarm doctor` is the first operator surface for this readback and renders the same
-        verified first-party and declared external provider-trigger pack capability surface that serve admits at boot.
-        Connector-pack readback uses connector-specific CAN/CANNOT rows defined by `tool_model.provider_connector_tools`;
-        trigger rows MUST NOT be reused to describe connector proof. Connector requirement readback is typed and may include
-        static secrets or managed credentials with their own lifecycle statuses.
+        Readback consumes `tool_model.provider_capability_surface`. Trigger facts derive from the accepted body manifest,
+        while envelope capabilities/requires remain integrity assertions only. Trigger pack subjects render AVAILABLE with
+        target-scoped unevaluated signing requirements; global BOUND/UNBOUND and READY/NOT_READY claims are forbidden until
+        #1944 supplies a selected-target owner. Connector facts and readiness remain kind-specific inputs to the common
+        model and consume canonical credential descriptor owners.
       unbound_requirement_policy: >
         A missing deployment binding for a declared signing secret, static connector secret, or managed connector credential
         does not reject pack import. Runtime webhook admission still fails closed before signature verification, dedupe

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7001,7 +7001,7 @@ tool_model:
           execution_proof: internal/runtime/pipeline TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry
         expose_credential_values:
           enforced_by: internal/runtime/pipeline.executePreparedActivityHTTPTool
-          execution_proof: internal/runtime/pipeline TestActivityHTTPResponseSuccessPolicyParityCases/secret_redaction
+          execution_proof: internal/runtime/pipeline TestActivityCredentialRedactionGuarantee
       rule: >
         A known guarantee without exactly one registry enforcement owner fails closed. Human output renders guarantees as
         `cannot <verb> - enforced by <id>`; it does not present CANNOT as a product limitation.


### PR DESCRIPTION
## Summary

- add one typed provider capability-surface model and deterministic renderer under `internal/packs`
- derive trigger facts from accepted trigger manifests and connector readiness from effective `ToolSchemaEntry` values plus canonical static/managed credential descriptors
- render all eight trigger packs as AVAILABLE with target-scoped unevaluated signing requirements
- enumerate all five connector packs/seven actions as AVAILABLE without injecting omitted actions into effective tools
- feed doctor, serve, serve_dev, and run_local through one structured report whose text and JSON consume the same records
- remove envelope runtime rendering, duplicate connector requirement interpretation, both command-local renderers, and doctor-only trigger append ownership

Closes #1929

Parent context: #1770. Target-scoped trigger enablement and signing readiness remain explicitly owned by #1944. Future `describe --prove` consumption remains #1769.

## Governing authority

Authoritative sections updated/consumed:

- `platform-spec.yaml#tool_model.provider_capability_surface`
- `platform-spec.yaml#tool_model.provider_connector_tools`
- `platform-spec.yaml#tool_model.credential_store`
- `platform-spec.yaml#tool_model.managed_credential_store`
- `platform-spec.yaml#tool_model.provider_trigger_adapters.manifest_interpreter_owner`
- `platform-spec.yaml#tool_model.provider_trigger_adapters.pack_envelope_source_authority`
- `platform-spec.yaml#tool_model.provider_trigger_adapters.secret_binding`
- `platform-spec.yaml#contract_formats.package_manifest.fields.connector_packs`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`

Binding audit/gate:

- repaired Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/1929#issuecomment-4936522296
- independent approved re-gate: https://github.com/division-sh/swarm/issues/1929#issuecomment-4939050365

## Semantic migration

**New canonical owner:** `internal/packs` typed `Subject`, capability, guarantee, requirement, evidence, status, normalization, registry, and rendering model. Body-specific facts remain owned by `internal/providertriggers` accepted manifests and effective connector `ToolSchemaEntry` values. Connector readiness consumes `internal/runtime/credentials` descriptors and `internal/runtime/managedcredentials` requirement evaluation.

**Old paths now invalid and removed:**

- `packs.Envelope.Surface*` as runtime readback truth
- `providertriggers.LoadedPack.CapabilitySurface`
- `providerconnectors.Surface`, duplicate `RequirementStatus`, and `SurfacesWithOptions`
- connector-local static store reads and managed grant/profile/scope interpretation
- `providerTriggerPackSurfaceMessage` and `providerConnectorSurfaceMessage` formatter families
- doctor append-after-preflight trigger ownership
- message-only capability truth without structured records

**Production paths checked:** doctor, serve, serve_dev, run_local, trigger body admission, connector import/effective-tool construction, installed inventory, static file/env credentials, managed lifecycle/coverage, import-boundary key mapping, generated GitHub evidence, and unchanged trigger/connector runtime execution suites.

**Migration completeness:** complete for the approved #1929 class. No compatibility aliases or dual renderer remains. #1944 is a different target-scoped state class and no selected-store query, target selector, or binding writer is introduced here.

## Verification

- `go run ./cmd/swarm-openapi-gen --check`
- `go vet ./internal/packs ./internal/providertriggers ./internal/providerconnectors ./internal/runtime/managedcredentials ./cmd/swarm`
- focused capability, provider, inventory, lifecycle, mode, projection, redaction, and static-absence suites
- host Postgres full suite:
  - `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
