### PR TITLE
[agent-c][issue #1848] Add durable staged joins

### DIFF
--- a/.github/test-shards/go-test-shards.json
+++ b/.github/test-shards/go-test-shards.json
@@ -37,6 +37,7 @@
         "github.com/division-sh/swarm/internal/runtime/credentials",
         "github.com/division-sh/swarm/internal/runtime/diaglog",
         "github.com/division-sh/swarm/internal/runtime/flowdata",
+        "github.com/division-sh/swarm/internal/runtime/joinruntime",
         "github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest",
         "github.com/division-sh/swarm/internal/runtime/manager",
         "github.com/division-sh/swarm/internal/runtime/mcp",

--- a/cmd/swarm/context_command_test.go
+++ b/cmd/swarm/context_command_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,13 +20,21 @@ func TestContextListCommandUsesSwarmDirRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out, errOut bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", swarmDir, "context", "list"}, &out, &errOut, rootCommandOptions{})
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"--swarm-dir", swarmDir, "context", "list"}, &out, &errOut, rootCommandOptions{
+		httpClient: &http.Client{Transport: contextNoServerRoundTripper{}},
+	})
 	if code != 0 {
 		t.Fatalf("exit = %d stderr=%s", code, errOut.String())
 	}
 	if !strings.Contains(out.String(), "local") || !strings.Contains(out.String(), "no_server") {
 		t.Fatalf("output = %q, want local no_server row", out.String())
 	}
+}
+
+type contextNoServerRoundTripper struct{}
+
+func (contextNoServerRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("connection refused")
 }
 
 func TestContextListCommandSwarmDirFlagBypassesBrokenConfig(t *testing.T) {

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -311,6 +311,46 @@ func TestVerifyCommandAcceptsJoinTransitionCarrierFixture(t *testing.T) {
 	}
 }
 
+func TestVerifyCommandRejectsTypeInvalidJoinCompletion(t *testing.T) {
+	contractsRoot := writeDescribeStageGraphContracts(t)
+	nodesPath := filepath.Join(contractsRoot, "flows", "support", "nodes.yaml")
+	nodes, err := os.ReadFile(nodesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(nodes), "      join:\n        stage: active", "      join:\n        complete_when: join.missing > 1\n        remaining: ignore\n        stage: active", 1)
+	if updated == string(nodes) {
+		t.Fatal("join fixture mutation did not match")
+	}
+	writeDescribeTestFile(t, nodesPath, updated)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"verify",
+		"--contracts", contractsRoot,
+		"--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code == 0 {
+		t.Fatalf("verify --json code = 0 stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("verify --json stderr = %q, want structured stdout failure", stderr.String())
+	}
+	output := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if output.OK || len(output.Errors) == 0 {
+		t.Fatalf("verify --json output = %#v, want hard invalidity", output)
+	}
+	found := false
+	for _, finding := range output.Errors {
+		if finding.CheckID == "join_validation" && strings.Contains(finding.Message, "join.missing > 1") && strings.Contains(finding.Message, "no matching overload") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("verify --json errors = %#v, want typed join_validation rejection", output.Errors)
+	}
+}
+
 func writeDescribeDefaultedTemplatePolicyContracts(t testing.TB) string {
 	t.Helper()
 	root := t.TempDir()

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -351,6 +351,53 @@ func TestVerifyCommandRejectsTypeInvalidJoinCompletion(t *testing.T) {
 	}
 }
 
+func TestVerifyCommandRejectsTypeInvalidNamedJoinResult(t *testing.T) {
+	contractsRoot := writeDescribeStageGraphContracts(t)
+	flowRoot := filepath.Join(contractsRoot, "flows", "support")
+	writeDescribeTestFile(t, filepath.Join(flowRoot, "types.yaml"), `
+types:
+  JoinResult:
+    value: text
+`)
+	eventsPath := filepath.Join(flowRoot, "events.yaml")
+	events, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeDescribeTestFile(t, eventsPath, strings.Replace(string(events), "  result: string", "  result: JoinResult", 1))
+	nodesPath := filepath.Join(flowRoot, "nodes.yaml")
+	nodes, err := os.ReadFile(nodesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(nodes), "      join:\n        stage: active", "      join:\n        complete_when: join.results[0] > 1\n        remaining: ignore\n        stage: active", 1)
+	if updated == string(nodes) {
+		t.Fatal("join fixture mutation did not match")
+	}
+	writeDescribeTestFile(t, nodesPath, updated)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"verify", "--contracts", contractsRoot, "--json",
+	}, &stdout, &stderr, defaultRootCommandOptions())
+	if code == 0 {
+		t.Fatalf("verify --json code = 0 stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	output := decodeOutputJSON[verifyCommandResult](t, stdout.String())
+	if !reportContainsVerifyError(output.Errors, "join_validation", "no matching overload") {
+		t.Fatalf("verify --json errors = %#v, want named JoinResult typed rejection", output.Errors)
+	}
+}
+
+func reportContainsVerifyError(findings []verifyFindingOutput, checkID, message string) bool {
+	for _, finding := range findings {
+		if finding.CheckID == checkID && strings.Contains(finding.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
 func writeDescribeDefaultedTemplatePolicyContracts(t testing.TB) string {
 	t.Helper()
 	root := t.TempDir()

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -197,37 +197,37 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	if graph.FlowID != "support" || graph.FlowPath != "support" {
 		t.Fatalf("graph identity = %#v, want support namespace", graph)
 	}
-	if len(graph.Nodes) != 5 {
-		t.Fatalf("graph nodes = %#v, want waiting/active/review/timed_out/done", graph.Nodes)
+	if len(graph.Nodes) != 4 {
+		t.Fatalf("graph nodes = %#v, want waiting/active/review/timed_out", graph.Nodes)
 	}
 	if !graph.Nodes[0].Initial || graph.Nodes[0].ID != "waiting" {
 		t.Fatalf("first graph node = %#v, want waiting initial", graph.Nodes[0])
 	}
-	var terminalDone bool
+	var terminalReview bool
 	for _, node := range graph.Nodes {
-		if node.ID == "done" && node.Terminal {
-			terminalDone = true
+		if node.ID == "review" && node.Terminal {
+			terminalReview = true
 		}
 	}
-	if !terminalDone {
-		t.Fatalf("graph nodes = %#v, want terminal done", graph.Nodes)
+	if !terminalReview {
+		t.Fatalf("graph nodes = %#v, want terminal review", graph.Nodes)
 	}
 	if len(graph.Edges) == 0 {
 		t.Fatalf("graph edges missing: %#v", graph)
 	}
 	var foundOpenedAdvance bool
-	var foundAccumulateComplete bool
-	var foundAccumulateTimeout bool
+	var foundJoinComplete bool
+	var foundJoinTimeout bool
 	var foundTimedAdvance bool
 	for _, edge := range graph.Edges {
 		if edge.Source == "handler.advances_to" && edge.NodeID == "support-node" && edge.EventType == "ticket.opened" && edge.To == "active" {
 			foundOpenedAdvance = true
 		}
-		if edge.Source == "handler.accumulate.on_complete" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "review" {
-			foundAccumulateComplete = true
+		if edge.Source == "handler.join.on_complete" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "review" {
+			foundJoinComplete = true
 		}
-		if edge.Source == "handler.accumulate.on_timeout" && edge.NodeID == "support-node" && edge.EventType == "ticket.closed" && edge.To == "timed_out" {
-			foundAccumulateTimeout = true
+		if edge.Source == "handler.join.timeout" && edge.NodeID == "support-node" && edge.EventType == "platform.join_timeout" && edge.TimerID == "active" && edge.After == "1h" && edge.To == "timed_out" {
+			foundJoinTimeout = true
 		}
 		if edge.Source == "timer" && edge.TimerID == "support.active.timed_out" && edge.After == "72h" && edge.To == "timed_out" {
 			foundTimedAdvance = true
@@ -236,11 +236,11 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	if !foundOpenedAdvance {
 		t.Fatalf("graph edges = %#v, want ticket.opened handler.advances_to edge to active", graph.Edges)
 	}
-	if !foundAccumulateComplete {
-		t.Fatalf("graph edges = %#v, want ticket.closed handler.accumulate.on_complete edge to review", graph.Edges)
+	if !foundJoinComplete {
+		t.Fatalf("graph edges = %#v, want ticket.closed handler.join.on_complete edge to review", graph.Edges)
 	}
-	if !foundAccumulateTimeout {
-		t.Fatalf("graph edges = %#v, want ticket.closed handler.accumulate.on_timeout edge to timed_out", graph.Edges)
+	if !foundJoinTimeout {
+		t.Fatalf("graph edges = %#v, want timed platform.join_timeout edge to timed_out", graph.Edges)
 	}
 	if !foundTimedAdvance {
 		t.Fatalf("graph edges = %#v, want stage timer edge to timed_out with delay", graph.Edges)
@@ -271,10 +271,10 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 		"stage graph:",
 		"flow support (support):",
 		"waiting [initial]",
-		"done [terminal]",
+		"review [terminal]",
 		"handler.advances_to support-node on ticket.opened",
-		"handler.accumulate.on_complete support-node on ticket.closed",
-		"handler.accumulate.on_timeout support-node on ticket.closed",
+		"handler.join.on_complete support-node on ticket.closed",
+		"handler.join.timeout support-node on platform.join_timeout after 1h timer active",
 		"timer runtime on timer:support.active.timed_out after 72h timer support.active.timed_out",
 		"active after 48h emit ticket.sla_escalated (timer support.active.ticket.sla_escalated)",
 		"active after 72h advances_to timed_out (timer support.active.timed_out)",
@@ -286,7 +286,7 @@ func TestDescribeCommandGraphRendersStageGraph(t *testing.T) {
 	}
 }
 
-func TestVerifyCommandAcceptsAccumulatorTransitionCarrierFixture(t *testing.T) {
+func TestVerifyCommandAcceptsJoinTransitionCarrierFixture(t *testing.T) {
 	contractsRoot := writeDescribeStageGraphContracts(t)
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
@@ -380,9 +380,9 @@ stages:
         emit: ticket.sla_escalated
       - after: 72h
         advances_to: timed_out
-  review: {}
-  timed_out: {}
-  done:
+  review:
+    terminal: true
+  timed_out:
     terminal: true
 `)
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
@@ -398,6 +398,8 @@ ticket.closed:
   swarm:
     source: external
   entity_id: string
+  line_item_id: string
+  result: string
 ticket.sla_escalated:
   swarm:
     consumer: [operator]
@@ -412,7 +414,10 @@ accumulate.timeout:
     source: platform
 `)
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), `
-ticket: {}
+ticket:
+  expected_line_item_ids:
+    type: "[text]"
+    initial: []
 `)
 	writeDescribeTestFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
 support-node:
@@ -435,14 +440,16 @@ support-node:
             line_item_index: fan_out.index
       advances_to: active
     ticket.closed:
-      advances_to: done
-      accumulate:
-        completion: timeout
-        timeout_ms: 1000
+      join:
+        stage: active
+        members:
+          from: entity.expected_line_item_ids
+          by: payload.line_item_id
+        output: payload.result
         on_complete:
-          - condition: "true"
-            advances_to: review
-        on_timeout:
+          advances_to: review
+        timeout:
+          after: 1h
           advances_to: timed_out
 `)
 	return root

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -31,9 +31,12 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
@@ -3777,6 +3780,137 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 	}
 }
 
+func TestRunServeRuntimeJoinFailureReachesAPIAndCLI(t *testing.T) {
+	endpoint, db, bundleHash := startServedJoinProofRuntime(t)
+	initial := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name":      "order.started",
+		"bundle_hash":     bundleHash,
+		"payload":         map[string]any{"expected": []any{"a"}, "dispatch_id": "dispatch-1"},
+		"idempotency_key": "join-failure-run-" + uuid.NewString(),
+	})
+	if !initial.NewRunCreated || initial.RunID == "" || initial.EventID == "" {
+		t.Fatalf("join failure initial run = %#v", initial)
+	}
+	waitServedEventPublishDeliveryStatusCountForRun(t, db, "postgres", initial.RunID, initial.EventID, "node", "starter", "delivered", 1)
+	entityID := servedJoinEntityID(t, db, initial.RunID)
+
+	arrival := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name": "item.completed", "run_id": initial.RunID, "source_event_id": initial.EventID,
+		"payload":         map[string]any{"dispatch_id": "dispatch-1", "member_id": "a", "result": map[string]any{"ok": true}},
+		"idempotency_key": "join-failure-arrival-" + uuid.NewString(),
+	})
+	waitServedEventPublishDeliveryStatusCountForRun(t, db, "postgres", initial.RunID, arrival.EventID, "node", "join-node", "dead_letter", 1)
+	waitServedEventPublishReceiptOutcomeCount(t, db, "postgres", arrival.EventID, "node", "join-node", "dead_letter", 1)
+
+	type failureReadback struct {
+		EntityID   string `json:"entity_id"`
+		Deliveries []struct {
+			SubscriberType string                    `json:"subscriber_type"`
+			SubscriberID   string                    `json:"subscriber_id"`
+			Status         string                    `json:"status"`
+			Failure        *runtimefailures.Envelope `json:"failure"`
+		} `json:"deliveries"`
+		DeadLetters []struct {
+			Failure runtimefailures.Envelope `json:"failure"`
+		} `json:"dead_letters"`
+	}
+	var event failureReadback
+	requireServedJSONRPCResult(t, endpoint, "event.get", map[string]any{"event_id": arrival.EventID}, &event)
+	if event.EntityID != entityID || len(event.Deliveries) == 0 || len(event.DeadLetters) == 0 {
+		t.Fatalf("join event.get evidence = %#v", event)
+	}
+	found := false
+	for _, delivery := range event.Deliveries {
+		if delivery.SubscriberType == "node" && delivery.SubscriberID == "join-node" && delivery.Status == "dead_letter" &&
+			delivery.Failure != nil && delivery.Failure.Class == runtimefailures.ClassEarlyArrival && delivery.Failure.Detail.Code == "join_not_armed" {
+			found = true
+		}
+	}
+	if !found || event.DeadLetters[0].Failure.Class != runtimefailures.ClassEarlyArrival || event.DeadLetters[0].Failure.Detail.Code != "join_not_armed" {
+		t.Fatalf("join event.get typed failure = %#v", event)
+	}
+	stdout, stderr, code := runServedCLICommand(t, endpoint, []string{"event", "view", arrival.EventID})
+	if code != 0 || strings.TrimSpace(stderr) != "" {
+		t.Fatalf("join event view code=%d stderr=%s stdout=%s", code, stderr, stdout)
+	}
+	for _, want := range []string{"subscriber=node/join-node", "status=dead letter", "failure=platform.early_arrival/join_not_armed", "dead_letters:"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("join event view missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer(t *testing.T) {
+	endpoint, db, bundleHash := startServedJoinProofRuntime(t)
+	initial := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name": "order.started", "bundle_hash": bundleHash,
+		"payload":         map[string]any{"expected": []any{"a", "b"}, "dispatch_id": "dispatch-1"},
+		"idempotency_key": "join-fork-run-" + uuid.NewString(),
+	})
+	waitServedEventPublishDeliveryStatusCountForRun(t, db, "postgres", initial.RunID, initial.EventID, "node", "starter", "delivered", 1)
+	entityID := servedJoinEntityID(t, db, initial.RunID)
+	dispatched := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name": "order.dispatched", "run_id": initial.RunID, "source_event_id": initial.EventID,
+		"payload": map[string]any{}, "idempotency_key": "join-fork-dispatch-" + uuid.NewString(),
+	})
+	waitServedEventPublishDeliveryStatusCountForRun(t, db, "postgres", initial.RunID, dispatched.EventID, "node", "dispatcher", "delivered", 1)
+	arrival := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
+		"event_name": "item.completed", "run_id": initial.RunID, "source_event_id": dispatched.EventID,
+		"payload":         map[string]any{"dispatch_id": "dispatch-1", "member_id": "a", "result": map[string]any{"ok": true}},
+		"idempotency_key": "join-fork-arrival-" + uuid.NewString(),
+	})
+	waitServedEventPublishDeliveryStatusCountForRun(t, db, "postgres", initial.RunID, arrival.EventID, "node", "join-node", "delivered", 1)
+	forkEventID := seedServedJoinForkFrontier(t, db, initial.RunID, entityID, arrival.EventID)
+
+	var fork apiv1.RunForkExecutionResult
+	requireServedJSONRPCResult(t, endpoint, "run.fork", map[string]any{
+		"source_run_id": initial.RunID, "fork_event_id": forkEventID, "idempotency_key": "join-fork-" + uuid.NewString(),
+	}, &fork)
+	if fork.ForkRunID == "" || fork.SourceRunID != initial.RunID || fork.ExecutedEventCount != 1 {
+		t.Fatalf("join run.fork result = %#v", fork)
+	}
+	forkCtx := runtimecorrelation.WithRunID(context.Background(), fork.ForkRunID)
+	instance, ok, err := runtimepipeline.NewWorkflowInstanceStore(db).Load(forkCtx, entityID)
+	if err != nil || !ok {
+		t.Fatalf("load fork join instance = %#v, %v, %v", instance, ok, err)
+	}
+	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", joinruntime.ActivationKey("awaiting", "awaiting", "dispatch-1"))
+	if err != nil || !ok || activation.Status != joinruntime.StatusOpen || activation.Completed() != 1 || activation.Expected() != 2 {
+		t.Fatalf("fork join activation = %#v, %v, %v", activation, ok, err)
+	}
+	if output, ok := activation.Outputs["a"]; !ok || output.Hash == "" {
+		t.Fatalf("fork join output = %#v", activation.Outputs)
+	}
+	var fireEvent string
+	var firePayload []byte
+	var reconstructed int
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT fire_event, fire_payload, COUNT(*) OVER ()
+		FROM timers
+		WHERE run_id = $1::uuid
+		  AND source_timer_id IS NOT NULL
+		  AND forked_from_run_id = $2::uuid
+		  AND forked_from_event_id = $3::uuid
+		  AND reconstruction_owner = $4
+		  AND status = 'active'
+	`, fork.ForkRunID, initial.RunID, forkEventID, store.RunForkHistoricalReplayTimerReconstructionOwner).Scan(&fireEvent, &firePayload, &reconstructed); err != nil {
+		t.Fatalf("load reconstructed join timer: %v", err)
+	}
+	var timerPayload map[string]any
+	if err := json.Unmarshal(firePayload, &timerPayload); err != nil {
+		t.Fatalf("decode reconstructed join timer payload: %v", err)
+	}
+	handle, ok := timeridentity.ParseTimerHandle(timerPayload)
+	if reconstructed != 1 || fireEvent != "platform.join_timeout" || !ok || handle.Kind != timeridentity.TimerHandleJoinTimeout ||
+		handle.Join.Stage != "awaiting" || handle.Join.JoinID != "awaiting" {
+		t.Fatalf("fork join timer = event:%q count:%d handle:%#v parsed:%v", fireEvent, reconstructed, handle, ok)
+	}
+}
+
 func TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity(t *testing.T) {
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
@@ -6838,6 +6972,218 @@ scorer:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
 	return root
+}
+
+func startServedJoinProofRuntime(t *testing.T) (string, *sql.DB, string) {
+	t.Helper()
+	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	root := writeServedJoinProofFixture(t)
+	bundleHash := seedServeRuntimeBundleCatalogRoot(t, context.Background(), pg, root)
+	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
+		ConfigPath:              writeServeRuntimeTestConfig(t),
+		BundleHash:              bundleHash,
+		PlatformSpecPath:        defaultPlatformSpecPath,
+		StoreMode:               "postgres",
+		StoreModeSet:            true,
+		APIListenAddr:           "127.0.0.1:0",
+		MCPListenAddr:           "127.0.0.1:0",
+		SelfCheck:               true,
+		RequireBundleMatch:      true,
+		Verbose:                 true,
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+	})
+	return endpoint, db, bundleHash
+}
+
+func writeServedJoinProofFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: served-join-proof
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: served-join-proof
+stages:
+  new:
+    initial: true
+  dispatching:
+    {}
+  awaiting: {}
+  ready:
+    terminal: true
+  attention:
+    terminal: true
+pins:
+  inputs:
+    events:
+      - name: order_started
+        event: order.started
+        source: external
+      - name: order_dispatched
+        event: order.dispatched
+        source: external
+      - name: item_completed
+        event: item.completed
+        source: external
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+order:
+  expected:
+    type: "[text]"
+    initial: []
+  dispatch_id: text
+  probe: text
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "types.yaml"), `
+types:
+  JoinResult:
+    ok: boolean
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), `
+order.started:
+  swarm:
+    source: external
+  expected: "[text]"
+  dispatch_id: text
+order.dispatched:
+  swarm:
+    source: external
+item.completed:
+  swarm:
+    source: external
+  dispatch_id: text
+  member_id: text
+  result: JoinResult
+fork.probe:
+  swarm:
+    source: external
+  marker: text
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+starter:
+  id: starter
+  execution_type: system_node
+  subscribes_to: [order.started]
+  event_handlers:
+    order.started:
+      create_entity: true
+      data_accumulation:
+        source_event: order.started
+        writes:
+          - source_field: expected
+            target_field: expected
+          - source_field: dispatch_id
+            target_field: dispatch_id
+      advances_to: dispatching
+dispatcher:
+  id: dispatcher
+  execution_type: system_node
+  subscribes_to: [order.dispatched]
+  event_handlers:
+    order.dispatched:
+      advances_to: awaiting
+join-node:
+  id: join-node
+  execution_type: system_node
+  subscribes_to: [item.completed]
+  event_handlers:
+    item.completed:
+      join:
+        stage: awaiting
+        members:
+          from: entity.expected
+          by: payload.member_id
+        window:
+          from: entity.dispatch_id
+          by: payload.dispatch_id
+        output: payload.result
+        on_complete:
+          advances_to: ready
+        timeout:
+          after: 1h
+          advances_to: attention
+fork-probe:
+  id: fork-probe
+  execution_type: system_node
+  subscribes_to: [fork.probe]
+  event_handlers:
+    fork.probe:
+      data_accumulation:
+        source_event: fork.probe
+        writes:
+          - source_field: marker
+            target_field: probe
+`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "policy.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "tools.yaml"), `{}`)
+	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "agents.yaml"), `{}`)
+	return root
+}
+
+func servedJoinEntityID(t *testing.T, db *sql.DB, runID string) string {
+	t.Helper()
+	deadline := time.Now().Add(servedProofPollDeadline)
+	for time.Now().Before(deadline) {
+		var entityID string
+		err := db.QueryRowContext(context.Background(), `
+			SELECT entity_id::text
+			FROM entity_state
+			WHERE run_id = $1::uuid
+			  AND entity_type = 'order'
+			ORDER BY created_at, entity_id
+			LIMIT 1
+		`, runID).Scan(&entityID)
+		if err == nil && strings.TrimSpace(entityID) != "" {
+			return entityID
+		}
+		if err != nil && err != sql.ErrNoRows {
+			t.Fatalf("load served join entity: %v", err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("served join entity was not created for run %s\n%s", runID, servedEventPublishDebugSummary(t, db, "postgres", runID))
+	return ""
+}
+
+func seedServedJoinForkFrontier(t *testing.T, db *sql.DB, runID, entityID, sourceEventID string) string {
+	t.Helper()
+	var flowInstance string
+	if err := db.QueryRowContext(context.Background(), `
+		SELECT COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid
+		  AND entity_id = $2::uuid
+	`, runID, entityID).Scan(&flowInstance); err != nil {
+		t.Fatalf("load served join flow instance: %v", err)
+	}
+	eventID := uuid.NewString()
+	deliveryID := uuid.NewString()
+	createdAt := time.Now().UTC()
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO events (
+			event_id, run_id, event_name, entity_id, flow_instance, scope, source_event_id,
+			payload, produced_by, produced_by_type, created_at
+		)
+		VALUES (
+			$1::uuid, $2::uuid, 'fork.probe', $3::uuid, $4, 'entity', $5::uuid,
+			'{"marker":"replayed"}'::jsonb, 'join-proof', 'platform', $6
+		)
+	`, eventID, runID, entityID, flowInstance, sourceEventID, createdAt); err != nil {
+		t.Fatalf("seed served join fork event: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, 'node', 'fork-probe', 'pending', 'join_fork_replay_proof', $4)
+	`, deliveryID, runID, eventID, createdAt); err != nil {
+		t.Fatalf("seed served join fork delivery: %v", err)
+	}
+	return eventID
 }
 
 func writeServedEventPublishTargetRouteFixture(t *testing.T) string {

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -235,10 +235,20 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "workflow instance SQLite implementation is the explicit backend-local pipeline instance SQL owner",
 		},
+		"internal/runtime/pipeline/workflow_join_lifecycle.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          1848,
+			Reason:         "join stage arm, expected-zero intent, and timeout lifecycle consume the selected workflow instance RunPipelineMutation owner as one unit of work",
+		},
 		"internal/runtime/pipeline/workflow_nodes.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,
 			Reason:         "workflow node construction carries pipeline SQL dependency to explicit node/unit-of-work owners",
+		},
+		"internal/runtime/pipeline/workflow_state_persistence.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          1848,
+			Reason:         "workflow state, timer, and join lifecycle persistence share the selected workflow instance RunPipelineMutation owner",
 		},
 		"internal/runtime/pipeline/workflow_timer_lifecycle.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -552,7 +552,24 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID, initial str
 				}
 			}
 			for _, carrier := range runtimecontracts.HandlerAdvanceCarriers(handler) {
-				edges = appendStageGraphEdge(edges, from, carrier.AdvancesTo, stateSet, carrier.Source(), nodeID, eventType)
+				carrierFrom := from
+				carrierEvent := eventType
+				joinTimed := false
+				if handler.Join != nil && (carrier.Kind == runtimecontracts.HandlerAdvanceCarrierJoinOnComplete || carrier.Kind == runtimecontracts.HandlerAdvanceCarrierJoinTimeout) {
+					carrierFrom = []string{strings.TrimSpace(handler.Join.Stage)}
+				}
+				if handler.Join != nil && carrier.Kind == runtimecontracts.HandlerAdvanceCarrierJoinTimeout {
+					carrierEvent = "platform.join_timeout"
+					joinTimed = true
+				}
+				before := len(edges)
+				edges = appendStageGraphEdge(edges, carrierFrom, carrier.AdvancesTo, stateSet, carrier.Source(), nodeID, carrierEvent)
+				if joinTimed && len(edges) > before {
+					edge := &edges[len(edges)-1]
+					edge.After = strings.TrimSpace(handler.Join.Timeout.After)
+					edge.TimerID = strings.TrimSpace(handler.Join.EffectiveID())
+					edge.Timed = true
+				}
 			}
 		}
 	}

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -329,6 +329,38 @@ func TestBuildStageGraphShowsFanOutMultiplicity(t *testing.T) {
 	}
 }
 
+func TestBuildStageGraphShowsJoinCompleteAndTimeoutEdges(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true, Entries: []runtimecontracts.FlowStageDeclaration{{ID: "awaiting", Initial: true}, {ID: "ready"}, {ID: "attention", Terminal: true}}}},
+		Semantics:  runtimecontracts.WorkflowSemanticView{InitialStage: "awaiting"},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{"join-node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"item.completed": {Join: &runtimecontracts.JoinSpec{
+			ID: "line_items", Stage: "awaiting",
+			OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready"},
+			Timeout:    runtimecontracts.JoinTimeoutSpec{After: "24h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention"}},
+		}}}}},
+	}
+	view, err := Build(context.Background(), semanticview.Wrap(bundle), BuildOptions{IncludeStageGraph: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph := view.StageGraphs[0]
+	var complete, timeout StageGraphEdgeView
+	for _, edge := range graph.Edges {
+		switch edge.Source {
+		case string(runtimecontracts.HandlerAdvanceCarrierJoinOnComplete):
+			complete = edge
+		case string(runtimecontracts.HandlerAdvanceCarrierJoinTimeout):
+			timeout = edge
+		}
+	}
+	if len(complete.From) != 1 || complete.From[0] != "awaiting" || complete.To != "ready" {
+		t.Fatalf("complete edge = %#v", complete)
+	}
+	if len(timeout.From) != 1 || timeout.From[0] != "awaiting" || timeout.To != "attention" || !timeout.Timed || timeout.After != "24h" || timeout.TimerID != "line_items" {
+		t.Fatalf("timeout edge = %#v", timeout)
+	}
+}
+
 func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
 	flow := runtimecontracts.FlowContractView{
 		Path: "analysis",

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -233,6 +233,7 @@ var bootCheckRegistry = []Check{
 	{ID: policySheetValidationCheckID, Severity: SeverityHardInvalidity, Run: checkPolicySheetValidationValueRows},
 	{ID: computeModuleCheckID, Severity: SeverityHardInvalidity, Run: checkComputeModuleValueRows},
 	{ID: fanOutValidationCheckID, Severity: SeverityHardInvalidity, Run: checkFanOutValidation},
+	{ID: joinValidationCheckID, Severity: SeverityHardInvalidity, Run: checkJoinValidation},
 	{ID: "tool_resolution", Severity: "warning", Run: checkToolResolution},
 	{ID: "required_mcp_tool_availability", Severity: SeverityHardInvalidity, Run: checkRequiredMCPToolAvailability},
 	{ID: "platform_tool_usage_hints", Severity: SeverityHardInvalidity, Run: checkPlatformToolUsageHints},

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 74 {
-		t.Fatalf("bootCheckRegistry count = %d, want 74", got)
+	if got := len(bootCheckRegistry); got != 75 {
+		t.Fatalf("bootCheckRegistry count = %d, want 75", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -59,6 +59,7 @@ var stableHardInvalidityRemediation = map[string]string{
 	"expression_field_reference_validation":   "Fix the expression field reference so it uses the supported namespace and declared field path.",
 	"event_metadata_authority":                "Move platform-owned event metadata out of authored business payload declarations.",
 	"fan_out_validation":                      "Fix fan_out so items_from names a declared collection, as names the item binding, identity uses that binding, and the emitted payload carries the identity.",
+	"join_validation":                         "Use the canonical staged handler.join contract with typed membership, mandatory timeout, and supported entity/join outcomes.",
 	"flow_boundary_create_entity_validation":  "Fix the cross-flow create_entity declaration so it preserves the receiving flow boundary.",
 	"flow_data_access_validation":             "Use the supported flow data access form for the referenced field or remove the unsupported access.",
 	"flow_package_dependency_binding":         "Declare the required imported package binding or remove the unresolved dependency reference.",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -6351,8 +6351,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 74 {
-		t.Fatalf("bootCheckRegistry count = %d, want 74", got)
+	if got := len(bootCheckRegistry); got != 75 {
+		t.Fatalf("bootCheckRegistry count = %d, want 75", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/workflow_expression_checks.go
+++ b/internal/runtime/bootverify/workflow_expression_checks.go
@@ -80,7 +80,7 @@ func (c *checkerContext) dataAccumulationExpressions() []Finding {
 				if expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleDataAccumulation {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias}); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias, AllowJoin: expr.AllowJoin}); err != nil {
 					c.dataAccumulationExprFindings = append(c.dataAccumulationExprFindings, Finding{
 						CheckID:  "data_accumulation_expression_validation",
 						Severity: "error",
@@ -109,7 +109,7 @@ func (c *checkerContext) emitFieldExpressions() []Finding {
 					expr.Phase != runtimepipeline.WorkflowEntityFieldLifecycleGuardEscalation {
 					continue
 				}
-				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias}); err != nil {
+				if err := workflowexpr.ValidateValueExpressionWithOptions(expr.Expression, workflowexpr.ValueExpressionOptions{AllowBareItem: expr.AllowBareItem, ItemAlias: expr.ItemAlias, AllowJoin: expr.AllowJoin}); err != nil {
 					c.emitFieldExprFindings = append(c.emitFieldExprFindings, Finding{
 						CheckID:  "emit_field_expression_validation",
 						Severity: "error",
@@ -289,6 +289,7 @@ type expressionReference struct {
 	SelfTargetField string
 	AllowBareItem   bool
 	ItemAlias       string
+	AllowJoin       bool
 }
 
 type handlerCondition struct {
@@ -432,6 +433,22 @@ func handlerEntityExpressions(handler runtimecontracts.SystemNodeEventHandler) [
 			appendRuleExpressions("accumulate.on_timeout", *handler.Accumulate.OnTimeout)
 		}
 	}
+	if handler.Join != nil {
+		if from := strings.TrimSpace(handler.Join.Members.From); from != "" {
+			out = append(out, expressionReference{Kind: "join.members.from", Expression: from, Phase: runtimepipeline.WorkflowEntityFieldLifecycleRule})
+		}
+		if handler.Join.Window != nil {
+			if from := strings.TrimSpace(handler.Join.Window.From); from != "" {
+				out = append(out, expressionReference{Kind: "join.window.from", Expression: from, Phase: runtimepipeline.WorkflowEntityFieldLifecycleRule})
+			}
+		}
+		before := len(out)
+		appendRuleExpressions("join.on_complete", handler.Join.OnComplete)
+		appendRuleExpressions("join.timeout", handler.Join.Timeout.Outcome)
+		for i := before; i < len(out); i++ {
+			out[i].AllowJoin = true
+		}
+	}
 	if handler.Filter != nil {
 		if predicate := strings.TrimSpace(handler.Filter.Predicate); predicate != "" {
 			out = append(out, expressionReference{Kind: "filter predicate", Expression: predicate, Phase: runtimepipeline.WorkflowEntityFieldLifecycleFilter})
@@ -495,6 +512,7 @@ func handlerEmitExpressionsForSource(source semanticview.Source, flowID, nodeID,
 				Expression: expr,
 				Phase:      phase,
 				ItemAlias:  strings.TrimSpace(itemAlias),
+				AllowJoin:  strings.HasPrefix(strings.TrimSpace(kindPrefix), "handler.join."),
 			})
 		}
 	}

--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -14,7 +14,6 @@ import (
 const joinValidationCheckID = "join_validation"
 
 var joinPolicyDelayPattern = regexp.MustCompile(`^\{\{\s*([a-zA-Z_][a-zA-Z0-9_.-]*)\s*\}\}(ms|s|m|h|d)$`)
-var joinFieldReferencePattern = regexp.MustCompile(`\bjoin\.([a-zA-Z_][a-zA-Z0-9_]*)`)
 
 func checkJoinValidation(c *checkerContext) []Finding {
 	if c == nil || c.source == nil {
@@ -134,14 +133,8 @@ func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimeco
 }
 
 func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool) []Finding {
-	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true}); err != nil {
+	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true, RequireBool: joinOnly}); err != nil {
 		return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s expression %q is invalid: %v", label, expression, err))}
-	}
-	allowed := map[string]struct{}{"expected": {}, "completed": {}, "missing": {}, "results": {}, "timed_out": {}}
-	for _, match := range joinFieldReferencePattern.FindAllStringSubmatch(workflowexpr.StripStringLiterals(expression), -1) {
-		if _, ok := allowed[match[1]]; !ok {
-			return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s references unsupported join.%s", label, match[1]))}
-		}
 	}
 	for _, root := range []string{"payload", "event", "policy", "computed", "fan_out", "accumulated", "_entity"} {
 		if workflowexpr.ExpressionReferencesRoot(expression, root) {

--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -36,6 +36,7 @@ func checkJoinValidation(c *checkerContext) []Finding {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, err.Error()))
 			}
 			spec := *handler.Join
+			resultType := c.joinOutputType(flowID, eventType, spec)
 			prefix := fmt.Sprintf("join %s", spec.EffectiveID())
 			if !flowUsesAuthoredStages(c.source, flowID) {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" requires an authored stages: lifecycle"))
@@ -58,7 +59,7 @@ func checkJoinValidation(c *checkerContext) []Finding {
 				if spec.Remaining != runtimecontracts.JoinRemainingIgnore {
 					findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" complete_when requires remaining: ignore"))
 				}
-				findings = append(findings, validateJoinExpression(flowID, nodeID, eventType, "complete_when", spec.CompleteWhen, true)...)
+				findings = append(findings, validateJoinExpression(flowID, nodeID, eventType, "complete_when", spec.CompleteWhen, true, resultType)...)
 			} else if spec.Remaining != "" {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" remaining is forbidden when complete_when is omitted"))
 			}
@@ -70,11 +71,23 @@ func checkJoinValidation(c *checkerContext) []Finding {
 			} else if !joinDelayValid(c.source, flowID, spec.Timeout.After) {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("%s timeout.after %q must be a positive duration or resolved policy-scalar duration", prefix, spec.Timeout.After)))
 			}
-			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "on_complete", spec.OnComplete, c.source.FlowStates(flowID))...)
-			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "timeout", spec.Timeout.Outcome, c.source.FlowStates(flowID))...)
+			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "on_complete", spec.OnComplete, c.source.FlowStates(flowID), resultType)...)
+			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "timeout", spec.Timeout.Outcome, c.source.FlowStates(flowID), resultType)...)
 		}
 	}
 	return findings
+}
+
+func (c *checkerContext) joinOutputType(flowID, eventType string, spec runtimecontracts.JoinSpec) string {
+	if c == nil || c.source == nil {
+		return ""
+	}
+	field := joinPathField(spec.Output, "payload")
+	if field == "" {
+		return ""
+	}
+	proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
+	return proof.Entry.Payload.Properties[field].Type
 }
 
 func (c *checkerContext) validateJoinPaths(flowID, nodeID, eventType string, spec runtimecontracts.JoinSpec) []Finding {
@@ -114,26 +127,26 @@ func (c *checkerContext) validateJoinPaths(flowID, nodeID, eventType string, spe
 	return out
 }
 
-func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimecontracts.HandlerRuleEntry, states []string) []Finding {
+func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimecontracts.HandlerRuleEntry, states []string, resultType string) []Finding {
 	out := make([]Finding, 0)
 	if target := strings.TrimSpace(rule.AdvancesTo); target != "" && !containsString(states, target) {
 		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s advances_to references unknown stage %s", label, target)))
 	}
 	for field, expr := range rule.Emit.Fields {
 		if text := joinExpressionText(expr); text != "" {
-			out = append(out, validateJoinExpression(flowID, nodeID, eventType, label+" emit.fields."+field, text, false)...)
+			out = append(out, validateJoinExpression(flowID, nodeID, eventType, label+" emit.fields."+field, text, false, resultType)...)
 		}
 	}
 	for idx, write := range rule.DataAccumulation.Writes {
 		if text := joinExpressionText(write.Value); text != "" {
-			out = append(out, validateJoinExpression(flowID, nodeID, eventType, fmt.Sprintf("%s data_accumulation.writes[%d]", label, idx), text, false)...)
+			out = append(out, validateJoinExpression(flowID, nodeID, eventType, fmt.Sprintf("%s data_accumulation.writes[%d]", label, idx), text, false, resultType)...)
 		}
 	}
 	return out
 }
 
-func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool) []Finding {
-	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true, RequireBool: joinOnly}); err != nil {
+func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool, resultType string) []Finding {
+	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true, RequireBool: joinOnly, JoinResultType: resultType}); err != nil {
 		return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s expression %q is invalid: %v", label, expression, err))}
 	}
 	for _, root := range []string{"payload", "event", "policy", "computed", "fan_out", "accumulated", "_entity"} {

--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -1,0 +1,257 @@
+package bootverify
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
+)
+
+const joinValidationCheckID = "join_validation"
+
+var joinPolicyDelayPattern = regexp.MustCompile(`^\{\{\s*([a-zA-Z_][a-zA-Z0-9_.-]*)\s*\}\}(ms|s|m|h|d)$`)
+var joinFieldReferencePattern = regexp.MustCompile(`\bjoin\.([a-zA-Z_][a-zA-Z0-9_]*)`)
+
+func checkJoinValidation(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	findings := make([]Finding, 0)
+	seenIDs := map[string]string{}
+	for _, nodeID := range sortedNodeIDs(c.source) {
+		node := c.source.NodeEntries()[nodeID]
+		flowID := nodeFlowID(c.source, nodeID)
+		for eventType, handler := range node.EventHandlers {
+			eventType = strings.TrimSpace(eventType)
+			if flowUsesAuthoredStages(c.source, flowID) && stagedBarrierAccumulator(handler.Accumulate) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, "staged finite barriers must use handler.join; barrier-shaped accumulate fields are retired for stages: bundles"))
+			}
+			if handler.Join == nil {
+				continue
+			}
+			if err := runtimecontracts.ValidateJoinHandlerIsolation(handler); err != nil {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, err.Error()))
+			}
+			spec := *handler.Join
+			prefix := fmt.Sprintf("join %s", spec.EffectiveID())
+			if !flowUsesAuthoredStages(c.source, flowID) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" requires an authored stages: lifecycle"))
+			}
+			if spec.Stage == "" || !containsString(c.source.FlowStates(flowID), spec.Stage) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("%s references unknown stage %q", prefix, spec.Stage)))
+			}
+			identityKey := strings.Join([]string{flowID, spec.Stage, spec.EffectiveID()}, "|")
+			location := nodeID + ":" + eventType
+			if prior, duplicate := seenIDs[identityKey]; duplicate {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("%s has duplicate effective identity; already declared at %s (add explicit unique id values)", prefix, prior)))
+			} else {
+				seenIDs[identityKey] = location
+			}
+			findings = append(findings, c.validateJoinPaths(flowID, nodeID, eventType, spec)...)
+			if spec.Window == nil && joinStageCanReenter(c.source, flowID, spec.Stage) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" stage is re-entrant; window.from and window.by are required"))
+			}
+			if spec.HasCustomCompletion() {
+				if spec.Remaining != runtimecontracts.JoinRemainingIgnore {
+					findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" complete_when requires remaining: ignore"))
+				}
+				findings = append(findings, validateJoinExpression(flowID, nodeID, eventType, "complete_when", spec.CompleteWhen, true)...)
+			} else if spec.Remaining != "" {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" remaining is forbidden when complete_when is omitted"))
+			}
+			if !spec.OnCompleteFound || joinRuleEmpty(spec.OnComplete) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" requires a non-empty on_complete outcome"))
+			}
+			if !spec.TimeoutFound || strings.TrimSpace(spec.Timeout.After) == "" || joinRuleEmpty(spec.Timeout.Outcome) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" requires timeout.after and a non-empty timeout outcome; bare joins are invalid"))
+			} else if !joinDelayValid(c.source, flowID, spec.Timeout.After) {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("%s timeout.after %q must be a positive duration or resolved policy-scalar duration", prefix, spec.Timeout.After)))
+			}
+			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "on_complete", spec.OnComplete, c.source.FlowStates(flowID))...)
+			findings = append(findings, validateJoinOutcome(flowID, nodeID, eventType, "timeout", spec.Timeout.Outcome, c.source.FlowStates(flowID))...)
+		}
+	}
+	return findings
+}
+
+func (c *checkerContext) validateJoinPaths(flowID, nodeID, eventType string, spec runtimecontracts.JoinSpec) []Finding {
+	out := make([]Finding, 0, 5)
+	view := wave1EntityContractForFlow(c.source, flowID)
+	memberField := joinPathField(spec.Members.From, "entity")
+	if memberField == "" {
+		out = append(out, joinFinding(flowID, nodeID, eventType, "join.members.from must be a top-level entity.<field> path"))
+	} else if field, ok := view.Contract.Fields[memberField]; !view.Defined || !ok {
+		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.members.from references undeclared entity field %s", memberField)))
+	} else if !joinTextListType(field.Type) {
+		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.members.from field %s must be ordered list<text>, got %q", memberField, field.Type)))
+	}
+	proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
+	memberBy := joinPathField(spec.Members.By, "payload")
+	if memberBy == "" {
+		out = append(out, joinFinding(flowID, nodeID, eventType, "join.members.by must be a top-level payload.<field> path"))
+	} else if field, ok := proof.Entry.Payload.Properties[memberBy]; !proof.HasSchema || !ok || !joinTextType(field.Type) {
+		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.members.by must reference a declared text payload field %s", memberBy)))
+	}
+	output := joinPathField(spec.Output, "payload")
+	if output == "" {
+		out = append(out, joinFinding(flowID, nodeID, eventType, "join.output must be a top-level payload.<field> path"))
+	} else if _, ok := proof.Entry.Payload.Properties[output]; !proof.HasSchema || !ok {
+		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.output references undeclared payload field %s", output)))
+	}
+	if spec.Window != nil {
+		windowFrom := joinPathField(spec.Window.From, "entity")
+		if field, ok := view.Contract.Fields[windowFrom]; windowFrom == "" || !view.Defined || !ok || !joinTextType(field.Type) {
+			out = append(out, joinFinding(flowID, nodeID, eventType, "join.window.from must reference a declared top-level text entity field"))
+		}
+		windowBy := joinPathField(spec.Window.By, "payload")
+		if field, ok := proof.Entry.Payload.Properties[windowBy]; windowBy == "" || !proof.HasSchema || !ok || !joinTextType(field.Type) {
+			out = append(out, joinFinding(flowID, nodeID, eventType, "join.window.by must reference a declared top-level text payload field"))
+		}
+	}
+	return out
+}
+
+func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimecontracts.HandlerRuleEntry, states []string) []Finding {
+	out := make([]Finding, 0)
+	if target := strings.TrimSpace(rule.AdvancesTo); target != "" && !containsString(states, target) {
+		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s advances_to references unknown stage %s", label, target)))
+	}
+	for field, expr := range rule.Emit.Fields {
+		if text := joinExpressionText(expr); text != "" {
+			out = append(out, validateJoinExpression(flowID, nodeID, eventType, label+" emit.fields."+field, text, false)...)
+		}
+	}
+	for idx, write := range rule.DataAccumulation.Writes {
+		if text := joinExpressionText(write.Value); text != "" {
+			out = append(out, validateJoinExpression(flowID, nodeID, eventType, fmt.Sprintf("%s data_accumulation.writes[%d]", label, idx), text, false)...)
+		}
+	}
+	return out
+}
+
+func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool) []Finding {
+	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true}); err != nil {
+		return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s expression %q is invalid: %v", label, expression, err))}
+	}
+	allowed := map[string]struct{}{"expected": {}, "completed": {}, "missing": {}, "results": {}, "timed_out": {}}
+	for _, match := range joinFieldReferencePattern.FindAllStringSubmatch(workflowexpr.StripStringLiterals(expression), -1) {
+		if _, ok := allowed[match[1]]; !ok {
+			return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s references unsupported join.%s", label, match[1]))}
+		}
+	}
+	for _, root := range []string{"payload", "event", "policy", "computed", "fan_out", "accumulated", "_entity"} {
+		if workflowexpr.ExpressionReferencesRoot(expression, root) {
+			return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s may not reference %s.*", label, root))}
+		}
+	}
+	if joinOnly && workflowexpr.ExpressionReferencesRoot(expression, "entity") {
+		return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s may reference only join.*", label))}
+	}
+	return nil
+}
+
+func joinFinding(flowID, nodeID, eventType, detail string) Finding {
+	return NewHardInvalidityFinding(joinValidationCheckID, nodeID,
+		fmt.Sprintf("flow %s node %s handler %s: %s", defaultFlowLabel(flowID), nodeID, eventType, detail),
+		"Use the canonical staged handler.join contract with typed membership, mandatory timeout, and supported entity/join outcome expressions.")
+}
+
+func joinRuleEmpty(rule runtimecontracts.HandlerRuleEntry) bool {
+	return strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && !rule.DataAccumulation.HasWrites()
+}
+
+func stagedBarrierAccumulator(spec *runtimecontracts.AccumulateSpec) bool {
+	if spec == nil {
+		return false
+	}
+	return strings.TrimSpace(spec.ExpectedFrom) != "" || spec.Threshold > 0 || spec.TimeoutMS > 0 || strings.TrimSpace(string(spec.Completion.Mode)) != "" || len(spec.OnComplete) > 0 || spec.OnTimeout != nil
+}
+
+func joinPathField(path, root string) string {
+	path = strings.TrimSpace(path)
+	prefix := root + "."
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	field := strings.TrimPrefix(path, prefix)
+	if field == "" || strings.Contains(field, ".") {
+		return ""
+	}
+	return field
+}
+
+func joinTextType(typeRef string) bool {
+	switch strings.ToLower(strings.TrimSpace(typeRef)) {
+	case "text", "string":
+		return true
+	default:
+		return false
+	}
+}
+
+func joinTextListType(typeRef string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(typeRef), " ", ""))
+	switch normalized {
+	case "list<text>", "list<string>", "[text]", "[string]", "[]text", "[]string", "text[]", "string[]":
+		return true
+	default:
+		return false
+	}
+}
+
+func joinExpressionText(expr runtimecontracts.ExpressionValue) string {
+	if expr.Kind == runtimecontracts.ExpressionKindRef {
+		return strings.TrimSpace(expr.Ref)
+	}
+	if expr.Kind == runtimecontracts.ExpressionKindCEL {
+		return strings.TrimSpace(expr.CEL)
+	}
+	return ""
+}
+
+func joinDelayValid(source semanticview.Source, flowID, raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if _, ok := timeridentity.ParseDelayDuration(raw); ok {
+		return true
+	}
+	match := joinPolicyDelayPattern.FindStringSubmatch(raw)
+	if len(match) != 3 {
+		return false
+	}
+	value, ok := source.ResolvedPolicyForFlow(flowID).Values[match[1]]
+	if !ok {
+		return false
+	}
+	_, ok = timeridentity.ParseDelayDuration(fmt.Sprint(value.Value) + match[2])
+	return ok
+}
+
+func joinStageCanReenter(source semanticview.Source, flowID, stage string) bool {
+	states := declaredStatesForFlow(source, flowID)
+	edges := authoredStateGraphEdges(source, flowID, source.FlowInitialStage(flowID), states)
+	stage = strings.TrimSpace(stage)
+	seen := map[string]struct{}{}
+	queue := make([]string, 0, len(edges[stage]))
+	for next := range edges[stage] {
+		queue = append(queue, next)
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current == stage {
+			return true
+		}
+		if _, ok := seen[current]; ok {
+			continue
+		}
+		seen[current] = struct{}{}
+		for next := range edges[current] {
+			queue = append(queue, next)
+		}
+	}
+	return false
+}

--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -36,7 +36,7 @@ func checkJoinValidation(c *checkerContext) []Finding {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, err.Error()))
 			}
 			spec := *handler.Join
-			resultType := c.joinOutputType(flowID, eventType, spec)
+			resultType := c.joinOutputType(flowID, nodeID, eventType, spec)
 			prefix := fmt.Sprintf("join %s", spec.EffectiveID())
 			if !flowUsesAuthoredStages(c.source, flowID) {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, prefix+" requires an authored stages: lifecycle"))
@@ -78,16 +78,23 @@ func checkJoinValidation(c *checkerContext) []Finding {
 	return findings
 }
 
-func (c *checkerContext) joinOutputType(flowID, eventType string, spec runtimecontracts.JoinSpec) string {
+func (c *checkerContext) joinOutputType(flowID, nodeID, eventType string, spec runtimecontracts.JoinSpec) runtimecontracts.CatalogTypeReference {
 	if c == nil || c.source == nil {
-		return ""
+		return runtimecontracts.CatalogTypeReference{}
 	}
-	field := joinPathField(spec.Output, "payload")
-	if field == "" {
-		return ""
+	for _, plan := range c.source.WorkflowJoins() {
+		if strings.TrimSpace(plan.FlowID) == strings.TrimSpace(flowID) &&
+			strings.TrimSpace(plan.NodeID) == strings.TrimSpace(nodeID) &&
+			strings.TrimSpace(plan.HandlerEvent) == strings.TrimSpace(eventType) {
+			return plan.ResultType
+		}
 	}
-	proof := semanticview.ResolveFlowEventProof(c.source, flowID, eventType)
-	return proof.Entry.Payload.Properties[field].Type
+	if bundle, ok := semanticview.Bundle(c.source); ok {
+		if resultType, found := runtimecontracts.ResolveEventFieldType(bundle, flowID, eventType, joinPathField(spec.Output, "payload")); found {
+			return resultType
+		}
+	}
+	return runtimecontracts.CatalogTypeReference{}
 }
 
 func (c *checkerContext) validateJoinPaths(flowID, nodeID, eventType string, spec runtimecontracts.JoinSpec) []Finding {
@@ -127,7 +134,7 @@ func (c *checkerContext) validateJoinPaths(flowID, nodeID, eventType string, spe
 	return out
 }
 
-func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimecontracts.HandlerRuleEntry, states []string, resultType string) []Finding {
+func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimecontracts.HandlerRuleEntry, states []string, resultType runtimecontracts.CatalogTypeReference) []Finding {
 	out := make([]Finding, 0)
 	if target := strings.TrimSpace(rule.AdvancesTo); target != "" && !containsString(states, target) {
 		out = append(out, joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s advances_to references unknown stage %s", label, target)))
@@ -145,7 +152,7 @@ func validateJoinOutcome(flowID, nodeID, eventType, label string, rule runtimeco
 	return out
 }
 
-func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool, resultType string) []Finding {
+func validateJoinExpression(flowID, nodeID, eventType, label, expression string, joinOnly bool, resultType runtimecontracts.CatalogTypeReference) []Finding {
 	if err := workflowexpr.ValidateValueExpressionWithOptions(expression, workflowexpr.ValueExpressionOptions{AllowJoin: true, RequireBool: joinOnly, JoinResultType: resultType}); err != nil {
 		return []Finding{joinFinding(flowID, nodeID, eventType, fmt.Sprintf("join.%s expression %q is invalid: %v", label, expression, err))}
 	}

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -31,6 +31,26 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 			h.Join.CompleteWhen = "join.completed >= 1"
 			h.Join.Remaining = "terminate"
 		}, wantError: "requires remaining: ignore"},
+		{name: "unsupported dotted join fact", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join.active == 0"
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "unsupported join.active"},
+		{name: "bracket join fact rejected", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = `join["active"] == 0`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "bracket access on join is unsupported"},
+		{name: "approved fact bracket spelling rejected", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = `join["completed"] >= 1`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "bracket access on join is unsupported"},
+		{name: "bare join root rejected", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join == join"
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "join must be accessed as join.<field>"},
+		{name: "custom completion must be boolean", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join.expected"
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "must return bool"},
 		{name: "outcome payload forbidden", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
 			h.Join.OnComplete.Emit.Fields["results"] = runtimecontracts.CELExpression("payload.result")
 		}, wantError: "may not reference payload.*"},

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -1,0 +1,131 @@
+package bootverify
+
+import (
+	"context"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRun_ValidatesStagedJoinContract(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*runtimecontracts.SystemNodeEventHandler, *runtimecontracts.WorkflowContractBundle)
+		wantError string
+	}{
+		{name: "valid"},
+		{name: "bare join", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.TimeoutFound = false
+			h.Join.Timeout = runtimecontracts.JoinTimeoutSpec{}
+		}, wantError: "bare joins are invalid"},
+		{name: "members must be list text", mutate: func(_ *runtimecontracts.SystemNodeEventHandler, b *runtimecontracts.WorkflowContractBundle) {
+			entity := b.RootEntities["Order"]
+			entity.Fields["expected"] = runtimecontracts.EntityFieldDecl{Type: "text"}
+			b.RootEntities["Order"] = entity
+		}, wantError: "must be ordered list<text>"},
+		{name: "custom completion requires remaining", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join.completed >= 1"
+		}, wantError: "requires remaining: ignore"},
+		{name: "terminate unsupported", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join.completed >= 1"
+			h.Join.Remaining = "terminate"
+		}, wantError: "requires remaining: ignore"},
+		{name: "outcome payload forbidden", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.OnComplete.Emit.Fields["results"] = runtimecontracts.CELExpression("payload.result")
+		}, wantError: "may not reference payload.*"},
+		{name: "reentry requires window", mutate: func(_ *runtimecontracts.SystemNodeEventHandler, b *runtimecontracts.WorkflowContractBundle) {
+			node := b.Nodes["join-node"]
+			node.EventHandlers["retry.requested"] = runtimecontracts.SystemNodeEventHandler{AdvancesTo: "awaiting"}
+			b.Nodes["join-node"] = node
+		}, wantError: "stage is re-entrant"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := joinValidationBundle()
+			h := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+			if tc.mutate != nil {
+				tc.mutate(&h, bundle)
+				bundle.Nodes["join-node"].EventHandlers["item.completed"] = h
+			}
+			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+			if tc.wantError == "" {
+				if reportContains(report.HardInvalidities(), joinValidationCheckID, "") {
+					t.Fatalf("unexpected join invalidity: %#v", report.HardInvalidities())
+				}
+				if reportContains(report.LintEvidence(), "entity_reader_coverage", "expected") {
+					t.Fatalf("join.members.from must count as canonical entity reader coverage: %#v", report.LintEvidence())
+				}
+				return
+			}
+			if !reportContains(report.HardInvalidities(), joinValidationCheckID, tc.wantError) {
+				t.Fatalf("expected %q, got %#v", tc.wantError, report.HardInvalidities())
+			}
+		})
+	}
+}
+
+func TestRun_RejectsStagedBarrierAccumulate(t *testing.T) {
+	bundle := joinValidationBundle()
+	h := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+	h.Join = nil
+	h.Accumulate = &runtimecontracts.AccumulateSpec{ExpectedFrom: "entity.expected", Completion: runtimecontracts.ParseAccumulateCompletion("all")}
+	bundle.Nodes["join-node"].EventHandlers["item.completed"] = h
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.HardInvalidities(), joinValidationCheckID, "must use handler.join") {
+		t.Fatalf("expected staged accumulate retirement, got %#v", report.HardInvalidities())
+	}
+}
+
+func TestJoinMembersContributeCanonicalEntityReaderCoverage(t *testing.T) {
+	bundle := joinValidationBundle()
+	source := semanticview.Wrap(bundle)
+	handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+	var memberReference *expressionReference
+	for _, ref := range handlerEntityExpressions(handler) {
+		if ref.Kind == "join.members.from" {
+			candidate := ref
+			memberReference = &candidate
+			break
+		}
+	}
+	if memberReference == nil {
+		t.Fatal("join.members.from missing from canonical handler expression inventory")
+	}
+	if _, ownerFlowID, err := wave1ResolveEntityPathWithOwner(source, "", memberReference.Expression); err != nil || ownerFlowID != "" {
+		t.Fatalf("join.members.from direct resolution = owner:%q err:%v", ownerFlowID, err)
+	}
+	resolved := wave1ResolvedExpressionRefs(source, "", "join-node", "item.completed", *memberReference)
+	if len(resolved) != 1 || resolved[0].OwnerFlowID != "" || resolved[0].Field != "expected" {
+		t.Fatalf("join.members.from resolved refs = %#v", resolved)
+	}
+	readers := wave1EntityReaderCoverageByFlow(source)
+	if _, ok := readers[""]["expected"]; !ok {
+		t.Fatalf("join.members.from reader coverage = %#v", readers)
+	}
+}
+
+func joinValidationBundle() *runtimecontracts.WorkflowContractBundle {
+	spec := runtimecontracts.JoinSpec{
+		ID: "awaiting", Stage: "awaiting",
+		Members: runtimecontracts.JoinMembersSpec{From: "entity.expected", By: "payload.member_id"},
+		Output:  "payload.result", OnCompleteFound: true,
+		OnComplete:   runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready", Emit: runtimecontracts.EmitSpec{Event: "join.completed", Fields: map[string]runtimecontracts.ExpressionValue{"results": runtimecontracts.CELExpression("join.results")}}},
+		TimeoutFound: true,
+		Timeout:      runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention", Emit: runtimecontracts.EmitSpec{Event: "join.timed_out", Fields: map[string]runtimecontracts.ExpressionValue{"missing": runtimecontracts.CELExpression("join.missing")}}}},
+	}
+	return &runtimecontracts.WorkflowContractBundle{
+		RootSchema:   &runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true, Entries: []runtimecontracts.FlowStageDeclaration{{ID: "awaiting", Initial: true}, {ID: "ready"}, {ID: "attention", Terminal: true}}}},
+		RootEntities: runtimecontracts.EntityContractsDocument{"Order": {Fields: map[string]runtimecontracts.EntityFieldDecl{"expected": {Type: "[text]", Initial: []any{}}}}},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"item.completed": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"member_id": {Type: "text"}, "result": {Type: "jsonb"}}}},
+			"join.completed": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"results": {Type: "list<jsonb>"}}}},
+			"join.timed_out": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"missing": {Type: "list<text>"}}}},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{"join-node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"item.completed": {Join: &spec}}}},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "awaiting", Stages: []runtimecontracts.WorkflowStageContract{{ID: "awaiting"}, {ID: "ready"}, {ID: "attention"}}, TerminalStages: []string{"attention"},
+			Transitions: []runtimecontracts.WorkflowTransitionContract{{ID: "complete", From: []string{"awaiting"}, To: "ready"}, {ID: "timeout", From: []string{"awaiting"}, To: "attention"}},
+		},
+	}
+}

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -64,6 +64,42 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 			h.Join.CompleteWhen = "join.results[0] > 1"
 			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
 		}, wantError: "no matching overload"},
+		{name: "custom completion preserves named result fields", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
+			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Types: map[string]runtimecontracts.NamedTypeDecl{
+				"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{"value": {Type: "text"}}},
+			}}
+			event := bundle.Events["item.completed"]
+			event.Payload.Properties["result"] = runtimecontracts.EventFieldSpec{Type: "JoinResult"}
+			bundle.Events["item.completed"] = event
+			h.Join.CompleteWhen = `join.results[0].value == "ok"`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}},
+		{name: "custom completion rejects named result as scalar", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
+			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Types: map[string]runtimecontracts.NamedTypeDecl{
+				"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{"value": {Type: "text"}}},
+			}}
+			event := bundle.Events["item.completed"]
+			event.Payload.Properties["result"] = runtimecontracts.EventFieldSpec{Type: "JoinResult"}
+			bundle.Events["item.completed"] = event
+			h.Join.CompleteWhen = `join.results[0] > 1`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "no matching overload"},
+		{name: "custom completion preserves enum result", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
+			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Enums: map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}}}}
+			event := bundle.Events["item.completed"]
+			event.Payload.Properties["result"] = runtimecontracts.EventFieldSpec{Type: "Decision"}
+			bundle.Events["item.completed"] = event
+			h.Join.CompleteWhen = `join.results[0] > 1`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "no matching overload"},
+		{name: "custom completion preserves scalar alias result", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
+			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Scalars: map[string]runtimecontracts.ScalarTypeDecl{"Score": {Base: "integer"}}}
+			event := bundle.Events["item.completed"]
+			event.Payload.Properties["result"] = runtimecontracts.EventFieldSpec{Type: "Score"}
+			bundle.Events["item.completed"] = event
+			h.Join.CompleteWhen = `join.results[0].startsWith("1")`
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "no matching overload"},
 		{name: "outcome payload forbidden", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
 			h.Join.OnComplete.Emit.Fields["results"] = runtimecontracts.CELExpression("payload.result")
 		}, wantError: "may not reference payload.*"},

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -51,6 +51,19 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 			h.Join.CompleteWhen = "join.expected"
 			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
 		}, wantError: "must return bool"},
+		{name: "custom completion rejects invalid missing operand", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
+			h.Join.CompleteWhen = "join.missing > 1"
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "no matching overload"},
+		{name: "custom completion types results from output schema", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
+			event := bundle.Events["item.completed"]
+			result := event.Payload.Properties["result"]
+			result.Type = "text"
+			event.Payload.Properties["result"] = result
+			bundle.Events["item.completed"] = event
+			h.Join.CompleteWhen = "join.results[0] > 1"
+			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
+		}, wantError: "no matching overload"},
 		{name: "outcome payload forbidden", mutate: func(h *runtimecontracts.SystemNodeEventHandler, _ *runtimecontracts.WorkflowContractBundle) {
 			h.Join.OnComplete.Emit.Fields["results"] = runtimecontracts.CELExpression("payload.result")
 		}, wantError: "may not reference payload.*"},

--- a/internal/runtime/bootverify/workflow_payload_completeness_checks.go
+++ b/internal/runtime/bootverify/workflow_payload_completeness_checks.go
@@ -295,6 +295,10 @@ func payloadCompletenessDeclarativeSiteLabel(site runtimecontracts.HandlerDeclar
 		return payloadCompletenessRuleLabel("accumulate.on_timeout", site.RuleIndex, site.RuleID, "emit")
 	case "handler.accumulate.on_timeout.fan_out.emit":
 		return payloadCompletenessRuleLabel("accumulate.on_timeout", site.RuleIndex, site.RuleID, "fan_out.emit")
+	case "handler.join.on_complete.emit":
+		return payloadCompletenessRuleLabel("join.on_complete", site.RuleIndex, site.RuleID, "emit")
+	case "handler.join.timeout.emit":
+		return payloadCompletenessRuleLabel("join.timeout", site.RuleIndex, site.RuleID, "emit")
 	default:
 		if label := strings.TrimSpace(site.SiteKey); label != "" {
 			return label

--- a/internal/runtime/contracts/catalog_type_reference.go
+++ b/internal/runtime/contracts/catalog_type_reference.go
@@ -1,0 +1,126 @@
+package contracts
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CatalogTypeKind string
+
+const (
+	CatalogTypeDynamic CatalogTypeKind = "dynamic"
+	CatalogTypeText    CatalogTypeKind = "text"
+	CatalogTypeInteger CatalogTypeKind = "integer"
+	CatalogTypeNumber  CatalogTypeKind = "number"
+	CatalogTypeBoolean CatalogTypeKind = "boolean"
+	CatalogTypeList    CatalogTypeKind = "list"
+	CatalogTypeMap     CatalogTypeKind = "map"
+	CatalogTypeObject  CatalogTypeKind = "object"
+)
+
+// CatalogTypeReference preserves the declaring catalog for a contract type.
+// Consumers resolve through this owner instead of reducing named types to dyn.
+type CatalogTypeReference struct {
+	Type    string
+	Catalog TypeCatalogDocument
+}
+
+type ResolvedCatalogType struct {
+	Kind    CatalogTypeKind
+	Name    string
+	Element *ResolvedCatalogType
+	Key     *ResolvedCatalogType
+	Value   *ResolvedCatalogType
+}
+
+func (r CatalogTypeReference) Empty() bool {
+	return strings.TrimSpace(r.Type) == ""
+}
+
+func (r CatalogTypeReference) Resolve() (ResolvedCatalogType, error) {
+	return r.ResolveReference(r.Type)
+}
+
+func (r CatalogTypeReference) ResolveReference(typeRef string) (ResolvedCatalogType, error) {
+	return resolveCatalogTypeReference(strings.TrimSpace(typeRef), r.Catalog, map[string]struct{}{})
+}
+
+func (r CatalogTypeReference) NamedFields(name string) (map[string]TypeFieldSpec, bool) {
+	decl, ok := r.Catalog.Types[strings.TrimSpace(name)]
+	if !ok {
+		return nil, false
+	}
+	return decl.Fields, true
+}
+
+func resolveCatalogTypeReference(typeRef string, catalog TypeCatalogDocument, resolving map[string]struct{}) (ResolvedCatalogType, error) {
+	if typeRef == "" {
+		return ResolvedCatalogType{Kind: CatalogTypeDynamic}, nil
+	}
+	if isEventListType(typeRef) {
+		element, err := resolveCatalogTypeReference(eventListItemType(typeRef), catalog, resolving)
+		if err != nil {
+			return ResolvedCatalogType{}, err
+		}
+		return ResolvedCatalogType{Kind: CatalogTypeList, Element: &element}, nil
+	}
+	if keyRef, valueRef, ok := parseWave1MapTypeRef(typeRef); ok {
+		key, err := resolveCatalogTypeReference(keyRef, catalog, resolving)
+		if err != nil {
+			return ResolvedCatalogType{}, err
+		}
+		value, err := resolveCatalogTypeReference(valueRef, catalog, resolving)
+		if err != nil {
+			return ResolvedCatalogType{}, err
+		}
+		return ResolvedCatalogType{Kind: CatalogTypeMap, Key: &key, Value: &value}, nil
+	}
+	if scalar, ok := catalog.Scalars[typeRef]; ok {
+		if _, cycle := resolving[typeRef]; cycle {
+			return ResolvedCatalogType{}, fmt.Errorf("catalog scalar alias cycle at %s", typeRef)
+		}
+		resolving[typeRef] = struct{}{}
+		defer delete(resolving, typeRef)
+		return resolveCatalogTypeReference(strings.TrimSpace(scalar.Base), catalog, resolving)
+	}
+	if _, ok := catalog.Enums[typeRef]; ok {
+		return ResolvedCatalogType{Kind: CatalogTypeText, Name: typeRef}, nil
+	}
+	if _, ok := catalog.Types[typeRef]; ok {
+		return ResolvedCatalogType{Kind: CatalogTypeObject, Name: typeRef}, nil
+	}
+	normalized, _ := normalizeEventFieldType(typeRef)
+	if normalized == "" {
+		normalized = typeRef
+	}
+	switch strings.ToLower(strings.TrimSpace(normalized)) {
+	case "text", "string", "uuid", "timestamp", "timestamptz":
+		return ResolvedCatalogType{Kind: CatalogTypeText}, nil
+	case "integer", "int", "bigint":
+		return ResolvedCatalogType{Kind: CatalogTypeInteger}, nil
+	case "numeric", "number", "float", "double", "real":
+		return ResolvedCatalogType{Kind: CatalogTypeNumber}, nil
+	case "boolean", "bool":
+		return ResolvedCatalogType{Kind: CatalogTypeBoolean}, nil
+	case "object", "json", "jsonb", "array":
+		return ResolvedCatalogType{Kind: CatalogTypeDynamic}, nil
+	default:
+		return ResolvedCatalogType{}, fmt.Errorf("unknown catalog type %q", typeRef)
+	}
+}
+
+func ResolveEventFieldType(bundle *WorkflowContractBundle, flowID, eventType, field string) (CatalogTypeReference, bool) {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		return CatalogTypeReference{}, false
+	}
+	entry, _, catalog, ok := eventSchemaDeclarationForFlowEvent(bundle, flowID, eventType)
+	if !ok {
+		return CatalogTypeReference{}, false
+	}
+	decl, ok := entry.Payload.Properties[field]
+	if !ok || strings.TrimSpace(decl.Type) == "" {
+		return CatalogTypeReference{}, false
+	}
+	return CatalogTypeReference{Type: strings.TrimSpace(decl.Type), Catalog: cloneTypeCatalogDocument(catalog)}, true
+}

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -55,6 +55,12 @@ func (b *WorkflowContractBundle) WorkflowTimers() []WorkflowTimerContract {
 	}
 	return b.Semantics.Timers
 }
+func (b *WorkflowContractBundle) WorkflowJoins() []WorkflowJoinPlan {
+	if b == nil {
+		return nil
+	}
+	return append([]WorkflowJoinPlan(nil), b.Semantics.Joins...)
+}
 func (b *WorkflowContractBundle) WorkflowTimerByID(id string) (WorkflowTimerContract, bool) {
 	id = strings.TrimSpace(id)
 	if b == nil || id == "" {

--- a/internal/runtime/contracts/workflow_contract_effective.go
+++ b/internal/runtime/contracts/workflow_contract_effective.go
@@ -262,6 +262,13 @@ func EffectiveSystemNodeSubscriptions(node SystemNodeContract) []string {
 			break
 		}
 	}
+	for _, handler := range node.EventHandlers {
+		if handler.Join != nil {
+			appendSubscription("platform.join_timeout")
+			appendSubscription("platform.join_complete")
+			break
+		}
+	}
 	sort.Strings(out)
 	return out
 }
@@ -325,6 +332,12 @@ func DefaultSystemNodeHandlerSourceEvent(handler SystemNodeEventHandler, trigger
 			accumulate.OnTimeout = &timeout
 		}
 		handler.Accumulate = &accumulate
+	}
+	if handler.Join != nil {
+		join := *handler.Join
+		join.OnComplete.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(join.OnComplete.DataAccumulation, triggerEvent)
+		join.Timeout.Outcome.DataAccumulation = defaultWorkflowDataAccumulationSourceEvent(join.Timeout.Outcome.DataAccumulation, triggerEvent)
+		handler.Join = &join
 	}
 	return handler
 }

--- a/internal/runtime/contracts/workflow_contract_emit.go
+++ b/internal/runtime/contracts/workflow_contract_emit.go
@@ -56,6 +56,10 @@ func HandlerEmitEvents(handler SystemNodeEventHandler) []string {
 			out = append(out, ruleEmitEvents(*handler.Accumulate.OnTimeout)...)
 		}
 	}
+	if handler.Join != nil {
+		out = append(out, ruleEmitEvents(handler.Join.OnComplete)...)
+		out = append(out, ruleEmitEvents(handler.Join.Timeout.Outcome)...)
+	}
 	if handler.FanOut != nil {
 		if eventType := handler.FanOut.Emit.EventType(); eventType != "" {
 			out = append(out, eventType)
@@ -115,6 +119,10 @@ func HandlerDeclarativeEmitSites(handler SystemNodeEventHandler) []HandlerDeclar
 				add("handler.accumulate.on_timeout.fan_out.emit", "handler.accumulate.on_timeout.fan_out.emit", handler.Accumulate.OnTimeout.ID, 0, handler.Accumulate.OnTimeout.FanOut.Emit, handler.Accumulate.OnTimeout.FanOut.As)
 			}
 		}
+	}
+	if handler.Join != nil {
+		add("handler.join.on_complete.emit", "handler.join.on_complete.emit", handler.Join.EffectiveID(), 0, handler.Join.OnComplete.Emit)
+		add("handler.join.timeout.emit", "handler.join.timeout.emit", handler.Join.EffectiveID(), 0, handler.Join.Timeout.Outcome.Emit)
 	}
 	if handler.FanOut != nil {
 		add("handler.fan_out.emit", "handler.fan_out.emit", "", -1, handler.FanOut.Emit, handler.FanOut.As)
@@ -222,6 +230,9 @@ func HandlerHasNestedEmitSites(handler SystemNodeEventHandler) bool {
 		if len(handler.Accumulate.OnComplete) > 0 || handler.Accumulate.OnTimeout != nil {
 			return true
 		}
+	}
+	if handler.Join != nil {
+		return true
 	}
 	return false
 }
@@ -409,6 +420,14 @@ func rejectEventlessEmitSpecs(handler SystemNodeEventHandler) error {
 			if err := requireRuleEmitEvents("accumulate.on_timeout", 0, *handler.Accumulate.OnTimeout); err != nil {
 				return err
 			}
+		}
+	}
+	if handler.Join != nil {
+		if err := requireRuleEmitEvents("join.on_complete", 0, handler.Join.OnComplete); err != nil {
+			return err
+		}
+		if err := requireRuleEmitEvents("join.timeout", 0, handler.Join.Timeout.Outcome); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/runtime/contracts/workflow_contract_join.go
+++ b/internal/runtime/contracts/workflow_contract_join.go
@@ -1,0 +1,300 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	JoinRemainingIgnore = "ignore"
+)
+
+var joinIDPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*$`)
+
+type JoinSpec struct {
+	ID              string           `yaml:"id"`
+	Stage           string           `yaml:"stage"`
+	Members         JoinMembersSpec  `yaml:"members"`
+	Window          *JoinWindowSpec  `yaml:"window"`
+	Output          string           `yaml:"output"`
+	OutputPath      paths.Path       `yaml:"-"`
+	CompleteWhen    string           `yaml:"complete_when"`
+	Remaining       string           `yaml:"remaining"`
+	OnComplete      HandlerRuleEntry `yaml:"-"`
+	Timeout         JoinTimeoutSpec  `yaml:"-"`
+	OnCompleteFound bool             `yaml:"-"`
+	TimeoutFound    bool             `yaml:"-"`
+}
+
+type JoinMembersSpec struct {
+	From     string     `yaml:"from"`
+	FromPath paths.Path `yaml:"-"`
+	By       string     `yaml:"by"`
+	ByPath   paths.Path `yaml:"-"`
+}
+
+type JoinWindowSpec struct {
+	From     string     `yaml:"from"`
+	FromPath paths.Path `yaml:"-"`
+	By       string     `yaml:"by"`
+	ByPath   paths.Path `yaml:"-"`
+}
+
+type JoinTimeoutSpec struct {
+	After   string           `yaml:"after"`
+	Outcome HandlerRuleEntry `yaml:"-"`
+}
+
+var joinFieldOptions = map[string]struct{}{
+	"id":            {},
+	"stage":         {},
+	"members":       {},
+	"window":        {},
+	"output":        {},
+	"complete_when": {},
+	"remaining":     {},
+	"on_complete":   {},
+	"timeout":       {},
+}
+
+var joinMembersFieldOptions = map[string]struct{}{
+	"from": {},
+	"by":   {},
+}
+
+var joinWindowFieldOptions = map[string]struct{}{
+	"from": {},
+	"by":   {},
+}
+
+var joinTimeoutFieldOptions = map[string]struct{}{
+	"after":             {},
+	"data_accumulation": {},
+	"emit":              {},
+	"advances_to":       {},
+}
+
+var joinOutcomeFieldOptions = map[string]struct{}{
+	"data_accumulation": {},
+	"emit":              {},
+	"advances_to":       {},
+}
+
+func (s *JoinSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateJoinMapping("join", node, joinFieldOptions); err != nil {
+		return err
+	}
+	var aux struct {
+		ID           string          `yaml:"id"`
+		Stage        string          `yaml:"stage"`
+		Members      JoinMembersSpec `yaml:"members"`
+		Window       *JoinWindowSpec `yaml:"window"`
+		Output       string          `yaml:"output"`
+		CompleteWhen string          `yaml:"complete_when"`
+		Remaining    string          `yaml:"remaining"`
+		OnComplete   yaml.Node       `yaml:"on_complete"`
+		Timeout      yaml.Node       `yaml:"timeout"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = JoinSpec{
+		ID:           strings.TrimSpace(aux.ID),
+		Stage:        strings.TrimSpace(aux.Stage),
+		Members:      aux.Members,
+		Window:       aux.Window,
+		Output:       strings.TrimSpace(aux.Output),
+		OutputPath:   paths.Parse(aux.Output),
+		CompleteWhen: strings.TrimSpace(aux.CompleteWhen),
+		Remaining:    strings.TrimSpace(strings.ToLower(aux.Remaining)),
+	}
+	if s.ID == "" {
+		s.ID = s.Stage
+	}
+	if s.ID != "" && !joinIDPattern.MatchString(s.ID) {
+		return fmt.Errorf("join.id %q must be a simple stable identifier", s.ID)
+	}
+	if err := validateJoinMapping("join.on_complete", &aux.OnComplete, joinOutcomeFieldOptions); err != nil {
+		return err
+	}
+	if aux.OnComplete.Kind != 0 && !yamlNodeIsNull(&aux.OnComplete) {
+		rule, err := decodeHandlerRuleEntryNode(&aux.OnComplete, handlerRuleDecodeContextJoinOnComplete)
+		if err != nil {
+			return err
+		}
+		if rule != nil {
+			s.OnComplete = *rule
+			s.OnCompleteFound = true
+		}
+	}
+	if err := decodeJoinTimeout(&aux.Timeout, &s.Timeout); err != nil {
+		return err
+	}
+	s.TimeoutFound = aux.Timeout.Kind != 0 && !yamlNodeIsNull(&aux.Timeout)
+	return nil
+}
+
+func (s *JoinMembersSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateJoinMapping("join.members", node, joinMembersFieldOptions); err != nil {
+		return err
+	}
+	type wire struct {
+		From string `yaml:"from"`
+		By   string `yaml:"by"`
+	}
+	var aux wire
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = JoinMembersSpec{
+		From:     strings.TrimSpace(aux.From),
+		FromPath: paths.Parse(aux.From),
+		By:       strings.TrimSpace(aux.By),
+		ByPath:   paths.Parse(aux.By),
+	}
+	return nil
+}
+
+func (s *JoinWindowSpec) UnmarshalYAML(node *yaml.Node) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateJoinMapping("join.window", node, joinWindowFieldOptions); err != nil {
+		return err
+	}
+	type wire struct {
+		From string `yaml:"from"`
+		By   string `yaml:"by"`
+	}
+	var aux wire
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	*s = JoinWindowSpec{
+		From:     strings.TrimSpace(aux.From),
+		FromPath: paths.Parse(aux.From),
+		By:       strings.TrimSpace(aux.By),
+		ByPath:   paths.Parse(aux.By),
+	}
+	return nil
+}
+
+func decodeJoinTimeout(node *yaml.Node, out *JoinTimeoutSpec) error {
+	if out == nil || node == nil || node.Kind == 0 || yamlNodeIsNull(node) {
+		return nil
+	}
+	if err := validateJoinMapping("join.timeout", node, joinTimeoutFieldOptions); err != nil {
+		return err
+	}
+	var wire struct {
+		After string `yaml:"after"`
+	}
+	if err := node.Decode(&wire); err != nil {
+		return err
+	}
+	clone := *node
+	clone.Content = make([]*yaml.Node, 0, len(node.Content))
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if strings.TrimSpace(node.Content[i].Value) == "after" {
+			continue
+		}
+		clone.Content = append(clone.Content, node.Content[i], node.Content[i+1])
+	}
+	rule, err := decodeHandlerRuleEntryNode(&clone, handlerRuleDecodeContextJoinTimeout)
+	if err != nil {
+		return err
+	}
+	out.After = strings.TrimSpace(wire.After)
+	if rule != nil {
+		out.Outcome = *rule
+	}
+	return nil
+}
+
+func validateJoinMapping(context string, node *yaml.Node, allowed map[string]struct{}) error {
+	if node == nil || node.Kind == 0 || yamlNodeIsNull(node) {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s must be a mapping", context)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if _, ok := allowed[key]; !ok {
+			return NewUndefinedFieldDiagnostic(context, key, allowed)
+		}
+	}
+	return nil
+}
+
+func yamlNodeIsNull(node *yaml.Node) bool {
+	return node != nil && node.Kind == yaml.ScalarNode && strings.EqualFold(strings.TrimSpace(node.Tag), "!!null")
+}
+
+func (s JoinSpec) HasCustomCompletion() bool {
+	return strings.TrimSpace(s.CompleteWhen) != ""
+}
+
+func (s JoinSpec) EffectiveID() string {
+	if id := strings.TrimSpace(s.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(s.Stage)
+}
+
+func (s JoinSpec) TimeoutOutcome() HandlerRuleEntry {
+	return s.Timeout.Outcome
+}
+
+func joinOutcomeEmpty(rule HandlerRuleEntry) bool {
+	return strings.TrimSpace(rule.AdvancesTo) == "" && rule.Emit.Empty() && !rule.DataAccumulation.HasWrites()
+}
+
+func ValidateJoinHandlerIsolation(handler SystemNodeEventHandler) error {
+	if handler.Join == nil {
+		return nil
+	}
+	conflicts := make([]string, 0, 12)
+	add := func(name string, present bool) {
+		if present {
+			conflicts = append(conflicts, name)
+		}
+	}
+	add("create_entity", handler.CreateEntity)
+	add("select_or_create_entity", handler.SelectOrCreateEntity != nil && !handler.SelectOrCreateEntity.Empty())
+	add("guard", handler.Guard != nil)
+	add("condition", strings.TrimSpace(handler.Condition) != "")
+	add("rules", len(handler.Rules) > 0)
+	add("on_complete", len(handler.OnComplete) > 0)
+	add("accumulate", handler.Accumulate != nil)
+	add("advances_to", strings.TrimSpace(handler.AdvancesTo) != "")
+	add("sets_gate", handler.SetsGate != nil)
+	add("clear_gates", len(handler.ClearGates) > 0)
+	add("data_accumulation", handler.DataAccumulation.HasWrites())
+	add("emit", !handler.Emit.Empty())
+	add("on_success", !handler.OnSuccess.Empty())
+	add("action", strings.TrimSpace(handler.Action.ID) != "")
+	add("activity", !handler.Activity.Empty())
+	add("compute", handler.Compute != nil)
+	add("query", handler.Query != nil)
+	add("fan_out", handler.FanOut != nil)
+	add("group_by", handler.GroupBy != nil)
+	add("filter", handler.Filter != nil)
+	add("reduce", handler.Reduce != nil)
+	add("count", handler.Count != nil)
+	add("clear", handler.Clear != nil)
+	if len(conflicts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("handler.join is an outcome-owning finite barrier and cannot be combined with handler fields %s", strings.Join(conflicts, ", "))
+}

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -22,6 +22,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		TerminalStages:         deriveWorkflowTerminalStages(bundle.RootSchema, bundle.Paths.Flows, bundle.FlowSchemas),
 		Transitions:            deriveStageTimerTransitions(bundle),
 		Timers:                 deriveWorkflowSemanticTimers(bundle),
+		Joins:                  nil,
 		Guards:                 deriveWorkflowGuardEntries(bundle),
 		Actions:                deriveWorkflowActionEntries(bundle),
 		GuardByID:              map[string]GuardActionEntry{},
@@ -152,6 +153,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				OnComplete:           handler.OnComplete,
 				Rules:                handler.Rules,
 				Accumulate:           handler.Accumulate,
+				Join:                 handler.Join,
 				Compute:              handler.Compute,
 				Query:                handler.Query,
 				FanOut:               handler.FanOut,
@@ -162,6 +164,14 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 				Clear:                handler.Clear,
 			}
 			semantics.HandlerTransitions = append(semantics.HandlerTransitions, transition)
+			if handler.Join != nil {
+				semantics.Joins = append(semantics.Joins, WorkflowJoinPlan{
+					FlowID:       strings.TrimSpace(source.FlowID),
+					NodeID:       nodeID,
+					HandlerEvent: rawEventType,
+					Spec:         *handler.Join,
+				})
+			}
 			if derivedTransition, ok := deriveWorkflowTransitionContract(transition); ok {
 				semantics.Transitions = append(semantics.Transitions, derivedTransition)
 			}
@@ -169,6 +179,7 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 			if timeoutTransition, ok := deriveAccumulateTimeoutTransition(transition); ok {
 				semantics.Transitions = append(semantics.Transitions, timeoutTransition)
 			}
+			semantics.Transitions = append(semantics.Transitions, deriveJoinTransitions(transition)...)
 			if semantics.HandlerTransitionIndex[nodeID] == nil {
 				semantics.HandlerTransitionIndex[nodeID] = map[string]HandlerTransitionSemantic{}
 			}
@@ -351,6 +362,34 @@ func deriveAccumulateTimeoutTransition(transition HandlerTransitionSemantic) (Wo
 		}, true
 	}
 	return WorkflowTransitionContract{}, false
+}
+
+func deriveJoinTransitions(transition HandlerTransitionSemantic) []WorkflowTransitionContract {
+	if transition.Join == nil {
+		return nil
+	}
+	join := transition.Join
+	from := []string{strings.TrimSpace(join.Stage)}
+	out := make([]WorkflowTransitionContract, 0, 2)
+	if target := strings.TrimSpace(join.OnComplete.AdvancesTo); target != "" {
+		out = append(out, WorkflowTransitionContract{
+			ID:      strings.TrimSpace(transition.ID) + ":join:" + join.EffectiveID() + ":complete",
+			From:    from,
+			To:      target,
+			Trigger: strings.TrimSpace(transition.EventType),
+			Node:    strings.TrimSpace(transition.NodeID),
+		})
+	}
+	if target := strings.TrimSpace(join.Timeout.Outcome.AdvancesTo); target != "" {
+		out = append(out, WorkflowTransitionContract{
+			ID:      strings.TrimSpace(transition.ID) + ":join:" + join.EffectiveID() + ":timeout",
+			From:    from,
+			To:      target,
+			Trigger: "platform.join_timeout",
+			Node:    strings.TrimSpace(transition.NodeID),
+		})
+	}
+	return out
 }
 
 func deriveRuleTransitions(transition HandlerTransitionSemantic) []WorkflowTransitionContract {

--- a/internal/runtime/contracts/workflow_contract_semantics.go
+++ b/internal/runtime/contracts/workflow_contract_semantics.go
@@ -165,11 +165,13 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 			}
 			semantics.HandlerTransitions = append(semantics.HandlerTransitions, transition)
 			if handler.Join != nil {
+				resultType, _ := ResolveEventFieldType(bundle, strings.TrimSpace(source.FlowID), rawEventType, joinOutputField(handler.Join.Output))
 				semantics.Joins = append(semantics.Joins, WorkflowJoinPlan{
 					FlowID:       strings.TrimSpace(source.FlowID),
 					NodeID:       nodeID,
 					HandlerEvent: rawEventType,
 					Spec:         *handler.Join,
+					ResultType:   resultType,
 				})
 			}
 			if derivedTransition, ok := deriveWorkflowTransitionContract(transition); ok {
@@ -188,6 +190,18 @@ func populateWorkflowSemantics(bundle *WorkflowContractBundle) {
 		semantics.NodeHandlers[nodeID] = handlers
 	}
 	bundle.Semantics = semantics
+}
+
+func joinOutputField(path string) string {
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(path, "payload.") {
+		return ""
+	}
+	field := strings.TrimPrefix(path, "payload.")
+	if field == "" || strings.Contains(field, ".") {
+		return ""
+	}
+	return field
 }
 
 func semanticInputEventPins(pins FlowInputPins) []FlowInputEventPin {

--- a/internal/runtime/contracts/workflow_contract_semantics_test.go
+++ b/internal/runtime/contracts/workflow_contract_semantics_test.go
@@ -57,6 +57,36 @@ func TestWorkflowSemanticsRuleActionUsesHandlerAdvancesToFallback(t *testing.T) 
 	}
 }
 
+func TestWorkflowSemanticsJoinPlanPreservesDeclaringResultCatalog(t *testing.T) {
+	spec := JoinSpec{Output: "payload.result"}
+	bundle := &WorkflowContractBundle{
+		RootTypes: TypeCatalogDocument{Types: map[string]NamedTypeDecl{
+			"JoinResult": {Fields: map[string]TypeFieldSpec{"value": {Type: "text"}}},
+		}},
+		Events: map[string]EventCatalogEntry{
+			"item.completed": {Payload: EventPayloadSpec{Properties: map[string]EventFieldSpec{"result": {Type: "JoinResult"}}}},
+		},
+		Nodes: map[string]SystemNodeContract{
+			"join-node": {EventHandlers: map[string]SystemNodeEventHandler{"item.completed": {Join: &spec}}},
+		},
+	}
+
+	populateWorkflowSemantics(bundle)
+
+	joins := bundle.WorkflowJoins()
+	if len(joins) != 1 || joins[0].ResultType.Type != "JoinResult" {
+		t.Fatalf("join result type = %#v", joins)
+	}
+	resolved, err := joins[0].ResultType.Resolve()
+	if err != nil || resolved.Kind != CatalogTypeObject || resolved.Name != "JoinResult" {
+		t.Fatalf("resolved join result = %#v, %v", resolved, err)
+	}
+	delete(bundle.RootTypes.Types, "JoinResult")
+	if _, ok := joins[0].ResultType.NamedFields("JoinResult"); !ok {
+		t.Fatal("join plan did not retain the declaring type catalog")
+	}
+}
+
 func TestWorkflowSemanticsDerivesTopLevelAndAccumulateCompletionTransitions(t *testing.T) {
 	bundle := &WorkflowContractBundle{
 		Nodes: map[string]SystemNodeContract{

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -323,6 +323,7 @@ type WorkflowJoinPlan struct {
 	NodeID       string
 	HandlerEvent string
 	Spec         JoinSpec
+	ResultType   CatalogTypeReference
 }
 
 type PolicySheetRowKind string

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -79,6 +79,7 @@ type WorkflowSemanticView struct {
 	TerminalStages         []string
 	Transitions            []WorkflowTransitionContract
 	Timers                 []WorkflowTimerContract
+	Joins                  []WorkflowJoinPlan
 	Guards                 []GuardActionEntry
 	Actions                []GuardActionEntry
 	GuardByID              map[string]GuardActionEntry
@@ -293,6 +294,7 @@ type HandlerTransitionSemantic struct {
 	OnComplete           []HandlerRuleEntry
 	Rules                []HandlerRuleEntry
 	Accumulate           *AccumulateSpec
+	Join                 *JoinSpec
 	Compute              *ComputeSpec
 	Query                *QuerySpec
 	FanOut               *FanOutSpec
@@ -314,6 +316,13 @@ type HandlerRuleEntry struct {
 	DataAccumulation WorkflowDataAccumulation `yaml:"data_accumulation"`
 	Compute          *ComputeSpec             `yaml:"compute"`
 	FanOut           *FanOutSpec              `yaml:"fan_out"`
+}
+
+type WorkflowJoinPlan struct {
+	FlowID       string
+	NodeID       string
+	HandlerEvent string
+	Spec         JoinSpec
 }
 
 type PolicySheetRowKind string
@@ -1697,6 +1706,7 @@ type SystemNodeEventHandler struct {
 	OnComplete           []HandlerRuleEntry        `yaml:"on_complete"`
 	Rules                []HandlerRuleEntry        `yaml:"rules"`
 	Accumulate           *AccumulateSpec           `yaml:"accumulate"`
+	Join                 *JoinSpec                 `yaml:"join"`
 	Compute              *ComputeSpec              `yaml:"compute"`
 	Query                *QuerySpec                `yaml:"query"`
 	FanOut               *FanOutSpec               `yaml:"fan_out"`

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -809,6 +809,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		OnComplete           yaml.Node                `yaml:"on_complete"`
 		Rules                yaml.Node                `yaml:"rules"`
 		Accumulate           *AccumulateSpec          `yaml:"accumulate"`
+		Join                 *JoinSpec                `yaml:"join"`
 		Compute              *ComputeSpec             `yaml:"compute"`
 		Query                yaml.Node                `yaml:"query"`
 		FanOut               *FanOutSpec              `yaml:"fan_out"`
@@ -834,6 +835,7 @@ func (h *SystemNodeEventHandler) UnmarshalYAML(node *yaml.Node) error {
 		Logic:            strings.TrimSpace(aux.Logic),
 		PolicyRef:        strings.TrimSpace(aux.PolicyRef),
 		Accumulate:       aux.Accumulate,
+		Join:             aux.Join,
 		Compute:          aux.Compute,
 		FanOut:           aux.FanOut,
 		GroupBy:          aux.GroupBy,
@@ -1163,6 +1165,7 @@ var handlerFieldOptions = map[string]struct{}{
 	"on_complete":             {},
 	"rules":                   {},
 	"accumulate":              {},
+	"join":                    {},
 	"compute":                 {},
 	"query":                   {},
 	"fan_out":                 {},
@@ -1260,6 +1263,8 @@ const (
 	handlerRuleDecodeContextOnComplete           handlerRuleDecodeContext = "on_complete"
 	handlerRuleDecodeContextAccumulateOnComplete handlerRuleDecodeContext = "accumulate.on_complete"
 	handlerRuleDecodeContextAccumulateOnTimeout  handlerRuleDecodeContext = "accumulate.on_timeout"
+	handlerRuleDecodeContextJoinOnComplete       handlerRuleDecodeContext = "join.on_complete"
+	handlerRuleDecodeContextJoinTimeout          handlerRuleDecodeContext = "join.timeout"
 )
 
 func decodeHandlerRuleEntryNode(node *yaml.Node, context handlerRuleDecodeContext) (*HandlerRuleEntry, error) {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"gopkg.in/yaml.v3"
 )
 
@@ -295,6 +296,77 @@ stages: []
 	}
 	if len(doc.LoweredStates()) != 0 || doc.LoweredInitialState() != "" || len(doc.LoweredTerminalStates()) != 0 {
 		t.Fatalf("lowered explicit stateless lifecycle = initial %q states %#v terminals %#v, want empty", doc.LoweredInitialState(), doc.LoweredStates(), doc.LoweredTerminalStates())
+	}
+}
+
+func TestSystemNodeHandlerDecodeJoinCanonicalShape(t *testing.T) {
+	var nodes map[string]SystemNodeContract
+	err := yaml.Unmarshal([]byte(`
+coordinator:
+  id: coordinator
+  execution_type: system_node
+  event_handlers:
+    item.completed:
+      join:
+        stage: awaiting_items
+        members:
+          from: entity.expected_item_ids
+          by: payload.item_id
+        window:
+          from: entity.dispatch_id
+          by: payload.dispatch_id
+        output: payload.result
+        complete_when: join.completed >= 2
+        remaining: ignore
+        on_complete:
+          emit:
+            event: items.completed
+            fields:
+              results: join.results
+          advances_to: ready
+        timeout:
+          after: 24h
+          emit:
+            event: items.timed_out
+            fields:
+              missing: join.missing
+          advances_to: attention
+`), &nodes)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal join: %v", err)
+	}
+	join := nodes["coordinator"].EventHandlers["item.completed"].Join
+	if join == nil {
+		t.Fatal("join = nil")
+	}
+	if got, want := join.EffectiveID(), "awaiting_items"; got != want {
+		t.Fatalf("join id = %q, want %q", got, want)
+	}
+	if join.Members.FromPath.Root != paths.RootEntity || join.Members.ByPath.Root != paths.RootPayload {
+		t.Fatalf("join member paths = %#v/%#v", join.Members.FromPath, join.Members.ByPath)
+	}
+	if join.Window == nil || join.Window.FromPath.Root != paths.RootEntity || join.Window.ByPath.Root != paths.RootPayload {
+		t.Fatalf("join window = %#v", join.Window)
+	}
+	if !join.OnCompleteFound || join.OnComplete.Emit.EventType() != "items.completed" || join.OnComplete.AdvancesTo != "ready" {
+		t.Fatalf("join on_complete = %#v", join.OnComplete)
+	}
+	if !join.TimeoutFound || join.Timeout.After != "24h" || join.Timeout.Outcome.Emit.EventType() != "items.timed_out" {
+		t.Fatalf("join timeout = %#v", join.Timeout)
+	}
+}
+
+func TestSystemNodeHandlerDecodeJoinRejectsUnsupportedFields(t *testing.T) {
+	for _, input := range []string{
+		`join: {stage: waiting, members: {from: entity.ids, by: payload.id}, output: payload.result, interrupting: true}`,
+		`join: {stage: waiting, members: {from: entity.ids, by: payload.id, dedup_by: payload.id}, output: payload.result}`,
+		`join: {stage: waiting, members: {from: entity.ids, by: payload.id}, output: payload.result, on_complete: {action: {id: noop}}}`,
+		`join: {stage: waiting, members: {from: entity.ids, by: payload.id}, output: payload.result, timeout: {after: 1h, repeat: 2}}`,
+	} {
+		var handler SystemNodeEventHandler
+		if err := yaml.Unmarshal([]byte(input), &handler); err == nil {
+			t.Fatalf("yaml.Unmarshal(%q) error = nil", input)
+		}
 	}
 }
 

--- a/internal/runtime/contracts/workflow_transition_carriers.go
+++ b/internal/runtime/contracts/workflow_transition_carriers.go
@@ -10,6 +10,8 @@ const (
 	HandlerAdvanceCarrierRules                HandlerAdvanceCarrierKind = "handler.rules"
 	HandlerAdvanceCarrierAccumulateOnComplete HandlerAdvanceCarrierKind = "handler.accumulate.on_complete"
 	HandlerAdvanceCarrierAccumulateOnTimeout  HandlerAdvanceCarrierKind = "handler.accumulate.on_timeout"
+	HandlerAdvanceCarrierJoinOnComplete       HandlerAdvanceCarrierKind = "handler.join.on_complete"
+	HandlerAdvanceCarrierJoinTimeout          HandlerAdvanceCarrierKind = "handler.join.timeout"
 )
 
 // HandlerAdvanceCarrier describes one authored handler site that can carry an advances_to target.
@@ -28,12 +30,12 @@ func (c HandlerAdvanceCarrier) Source() string {
 
 // HandlerAdvanceCarriers returns the complete authored advances_to carrier set for a handler.
 func HandlerAdvanceCarriers(handler SystemNodeEventHandler) []HandlerAdvanceCarrier {
-	return handlerAdvanceCarriers(handler.AdvancesTo, handler.OnComplete, handler.Rules, handler.Accumulate)
+	return handlerAdvanceCarriers(handler.AdvancesTo, handler.OnComplete, handler.Rules, handler.Accumulate, handler.Join)
 }
 
 // HandlerTransitionAdvanceCarriers returns the complete authored advances_to carrier set for a semantic transition.
 func HandlerTransitionAdvanceCarriers(transition HandlerTransitionSemantic) []HandlerAdvanceCarrier {
-	return handlerAdvanceCarriers(transition.AdvancesTo, transition.OnComplete, transition.Rules, transition.Accumulate)
+	return handlerAdvanceCarriers(transition.AdvancesTo, transition.OnComplete, transition.Rules, transition.Accumulate, transition.Join)
 }
 
 // HandlerAdvanceTargets returns the carrier targets without source metadata.
@@ -53,6 +55,7 @@ func handlerAdvanceCarriers(
 	onComplete []HandlerRuleEntry,
 	rules []HandlerRuleEntry,
 	accumulate *AccumulateSpec,
+	join *JoinSpec,
 ) []HandlerAdvanceCarrier {
 	out := make([]HandlerAdvanceCarrier, 0, 1+len(onComplete)+len(rules))
 	if target := strings.TrimSpace(advancesTo); target != "" {
@@ -93,6 +96,10 @@ func handlerAdvanceCarriers(
 				})
 			}
 		}
+	}
+	if join != nil {
+		appendRuleCarriers(HandlerAdvanceCarrierJoinOnComplete, []HandlerRuleEntry{join.OnComplete})
+		appendRuleCarriers(HandlerAdvanceCarrierJoinTimeout, []HandlerRuleEntry{join.Timeout.Outcome})
 	}
 	return out
 }

--- a/internal/runtime/core/paths/path.go
+++ b/internal/runtime/core/paths/path.go
@@ -15,6 +15,7 @@ const (
 	RootGates
 	RootAccumulated
 	RootFanOut
+	RootJoin
 	RootComputed
 )
 
@@ -38,6 +39,8 @@ func (r PathRoot) String() string {
 		return "accumulated"
 	case RootFanOut:
 		return "fan_out"
+	case RootJoin:
+		return "join"
 	case RootComputed:
 		return "computed"
 	default:
@@ -95,6 +98,8 @@ func parseRoot(text string) PathRoot {
 		return RootAccumulated
 	case "fan_out":
 		return RootFanOut
+	case "join":
+		return RootJoin
 	case "computed":
 		return RootComputed
 	default:

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -26,14 +26,26 @@ type TimerHandleKind string
 const (
 	TimerHandleWorkflowTimer       TimerHandleKind = "workflow_timer"
 	TimerHandleAccumulationTimeout TimerHandleKind = "accumulation_timeout"
+	TimerHandleJoinTimeout         TimerHandleKind = "join_timeout"
+	TimerHandleJoinComplete        TimerHandleKind = "join_complete"
 	timerHandlePayloadKey                          = "timer_handle"
 	accumulationTimeoutTaskPrefix                  = "accumulate_timeout:"
+	joinTimeoutTaskPrefix                          = "join_timeout:"
+	joinCompleteTaskPrefix                         = "join_complete:"
 )
 
 type TimerHandle struct {
 	Kind    TimerHandleKind
 	TimerID string
 	Bucket  AccumulatorBucketRef
+	Join    JoinRef
+}
+
+type JoinRef struct {
+	NodeID       string
+	HandlerEvent string
+	JoinID       string
+	Window       string
 }
 
 type AccumulatorBucketRef struct {
@@ -153,12 +165,22 @@ func AccumulationTimeoutHandle(bucket AccumulatorBucketRef) TimerHandle {
 	}
 }
 
+func JoinTimeoutHandle(ref JoinRef) TimerHandle {
+	return TimerHandle{Kind: TimerHandleJoinTimeout, Join: ref.Normalize()}
+}
+
+func JoinCompleteHandle(ref JoinRef) TimerHandle {
+	return TimerHandle{Kind: TimerHandleJoinComplete, Join: ref.Normalize()}
+}
+
 func (h TimerHandle) Valid() bool {
 	switch h.Kind {
 	case TimerHandleWorkflowTimer:
 		return strings.TrimSpace(h.TimerID) != ""
 	case TimerHandleAccumulationTimeout:
 		return h.Bucket.Valid()
+	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
+		return h.Join.Valid()
 	default:
 		return false
 	}
@@ -173,6 +195,10 @@ func (h TimerHandle) TaskID() string {
 			return ""
 		}
 		return accumulationTimeoutTaskPrefix + h.Bucket.Key()
+	case TimerHandleJoinTimeout:
+		return joinTimeoutTaskPrefix + h.Join.Key()
+	case TimerHandleJoinComplete:
+		return joinCompleteTaskPrefix + h.Join.Key()
 	default:
 		return ""
 	}
@@ -190,6 +216,8 @@ func (h TimerHandle) PayloadMetadata() map[string]any {
 		handle["timer_id"] = strings.TrimSpace(h.TimerID)
 	case TimerHandleAccumulationTimeout:
 		handle["bucket"] = h.Bucket.PayloadValue()
+	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
+		handle["join"] = h.Join.PayloadValue()
 	}
 	return map[string]any{
 		timerHandlePayloadKey: handle,
@@ -212,9 +240,79 @@ func ParseTimerHandle(payload map[string]any) (TimerHandle, bool) {
 		}
 		handle := AccumulationTimeoutHandle(bucket)
 		return handle, handle.Valid()
+	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
+		ref, ok := joinRefFromAny(handleMap["join"])
+		if !ok {
+			return TimerHandle{}, false
+		}
+		handle := JoinTimeoutHandle(ref)
+		if TimerHandleKind(strings.TrimSpace(asString(handleMap["kind"]))) == TimerHandleJoinComplete {
+			handle = JoinCompleteHandle(ref)
+		}
+		return handle, handle.Valid()
 	default:
 		return TimerHandle{}, false
 	}
+}
+
+func NewJoinRef(nodeID, handlerEvent, joinID, window string) JoinRef {
+	return JoinRef{
+		NodeID:       strings.TrimSpace(nodeID),
+		HandlerEvent: strings.TrimSpace(handlerEvent),
+		JoinID:       strings.TrimSpace(joinID),
+		Window:       strings.TrimSpace(window),
+	}
+}
+
+func (r JoinRef) Normalize() JoinRef {
+	return NewJoinRef(r.NodeID, r.HandlerEvent, r.JoinID, r.Window)
+}
+
+func (r JoinRef) Valid() bool {
+	r = r.Normalize()
+	return r.NodeID != "" && r.HandlerEvent != "" && r.JoinID != ""
+}
+
+func (r JoinRef) Key() string {
+	r = r.Normalize()
+	if !r.Valid() {
+		return ""
+	}
+	parts := []string{r.NodeID, r.HandlerEvent, r.JoinID, r.Window}
+	for i := range parts {
+		parts[i] = base64.RawURLEncoding.EncodeToString([]byte(parts[i]))
+	}
+	return strings.Join(parts, ".")
+}
+
+func (r JoinRef) PayloadValue() map[string]any {
+	r = r.Normalize()
+	if !r.Valid() {
+		return nil
+	}
+	return map[string]any{
+		"node_id":       r.NodeID,
+		"handler_event": r.HandlerEvent,
+		"join_id":       r.JoinID,
+		"window":        r.Window,
+	}
+}
+
+func ParseJoinRef(payload map[string]any) (JoinRef, TimerHandleKind, bool) {
+	handle, ok := ParseTimerHandle(payload)
+	if !ok || (handle.Kind != TimerHandleJoinTimeout && handle.Kind != TimerHandleJoinComplete) {
+		return JoinRef{}, "", false
+	}
+	return handle.Join, handle.Kind, handle.Join.Valid()
+}
+
+func joinRefFromAny(value any) (JoinRef, bool) {
+	raw, ok := stringAnyMap(value)
+	if !ok {
+		return JoinRef{}, false
+	}
+	ref := NewJoinRef(asString(raw["node_id"]), asString(raw["handler_event"]), asString(raw["join_id"]), asString(raw["window"]))
+	return ref, ref.Valid()
 }
 
 func NewAccumulatorBucketRef(nodeID, eventType string) AccumulatorBucketRef {

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -44,6 +44,7 @@ type TimerHandle struct {
 type JoinRef struct {
 	NodeID       string
 	HandlerEvent string
+	Stage        string
 	JoinID       string
 	Window       string
 }
@@ -255,22 +256,23 @@ func ParseTimerHandle(payload map[string]any) (TimerHandle, bool) {
 	}
 }
 
-func NewJoinRef(nodeID, handlerEvent, joinID, window string) JoinRef {
+func NewJoinRef(nodeID, handlerEvent, stage, joinID, window string) JoinRef {
 	return JoinRef{
 		NodeID:       strings.TrimSpace(nodeID),
 		HandlerEvent: strings.TrimSpace(handlerEvent),
+		Stage:        strings.TrimSpace(stage),
 		JoinID:       strings.TrimSpace(joinID),
 		Window:       strings.TrimSpace(window),
 	}
 }
 
 func (r JoinRef) Normalize() JoinRef {
-	return NewJoinRef(r.NodeID, r.HandlerEvent, r.JoinID, r.Window)
+	return NewJoinRef(r.NodeID, r.HandlerEvent, r.Stage, r.JoinID, r.Window)
 }
 
 func (r JoinRef) Valid() bool {
 	r = r.Normalize()
-	return r.NodeID != "" && r.HandlerEvent != "" && r.JoinID != ""
+	return r.NodeID != "" && r.HandlerEvent != "" && r.Stage != "" && r.JoinID != ""
 }
 
 func (r JoinRef) Key() string {
@@ -278,7 +280,7 @@ func (r JoinRef) Key() string {
 	if !r.Valid() {
 		return ""
 	}
-	parts := []string{r.NodeID, r.HandlerEvent, r.JoinID, r.Window}
+	parts := []string{r.NodeID, r.HandlerEvent, r.Stage, r.JoinID, r.Window}
 	for i := range parts {
 		parts[i] = base64.RawURLEncoding.EncodeToString([]byte(parts[i]))
 	}
@@ -293,6 +295,7 @@ func (r JoinRef) PayloadValue() map[string]any {
 	return map[string]any{
 		"node_id":       r.NodeID,
 		"handler_event": r.HandlerEvent,
+		"stage":         r.Stage,
 		"join_id":       r.JoinID,
 		"window":        r.Window,
 	}
@@ -311,7 +314,7 @@ func joinRefFromAny(value any) (JoinRef, bool) {
 	if !ok {
 		return JoinRef{}, false
 	}
-	ref := NewJoinRef(asString(raw["node_id"]), asString(raw["handler_event"]), asString(raw["join_id"]), asString(raw["window"]))
+	ref := NewJoinRef(asString(raw["node_id"]), asString(raw["handler_event"]), asString(raw["stage"]), asString(raw["join_id"]), asString(raw["window"]))
 	return ref, ref.Valid()
 }
 

--- a/internal/runtime/core/timeridentity/timeridentity_test.go
+++ b/internal/runtime/core/timeridentity/timeridentity_test.go
@@ -125,3 +125,15 @@ func TestParseAccumulatorBucketKey(t *testing.T) {
 		t.Fatalf("bucket = %#v", bucket)
 	}
 }
+
+func TestJoinHandleRoundTripIncludesStageIdentity(t *testing.T) {
+	awaiting := JoinTimeoutHandle(NewJoinRef("join-node", "item.completed", "awaiting", "shared", "window-1"))
+	reviewing := JoinTimeoutHandle(NewJoinRef("join-node", "item.completed", "reviewing", "shared", "window-1"))
+	if awaiting.TaskID() == reviewing.TaskID() {
+		t.Fatalf("join task ids collide across stages: %q", awaiting.TaskID())
+	}
+	parsed, ok := ParseTimerHandle(awaiting.PayloadMetadata())
+	if !ok || parsed.Join.Stage != "awaiting" || parsed.Join.JoinID != "shared" || parsed.Join.Window != "window-1" {
+		t.Fatalf("parsed join handle = %#v, %v", parsed, ok)
+	}
+}

--- a/internal/runtime/core/values/context.go
+++ b/internal/runtime/core/values/context.go
@@ -13,6 +13,7 @@ type Context struct {
 	Payload        Bucket
 	Accumulated    Bucket
 	FanOut         Bucket
+	Join           Bucket
 	Computed       Bucket
 }
 
@@ -28,6 +29,7 @@ func NewContext() Context {
 		Payload:        Wrap(map[string]any{}),
 		Accumulated:    Wrap(map[string]any{}),
 		FanOut:         Wrap(map[string]any{}),
+		Join:           Wrap(map[string]any{}),
 		Computed:       Wrap(map[string]any{}),
 	}
 }
@@ -44,6 +46,7 @@ func (c Context) Clone() Context {
 		Payload:        c.Payload.Clone(),
 		Accumulated:    c.Accumulated.Clone(),
 		FanOut:         c.FanOut.Clone(),
+		Join:           c.Join.Clone(),
 		Computed:       c.Computed.Clone(),
 	}
 }
@@ -88,6 +91,8 @@ func (c Context) Bucket(root paths.PathRoot) Bucket {
 		return c.Accumulated
 	case paths.RootFanOut:
 		return c.FanOut
+	case paths.RootJoin:
+		return c.Join
 	case paths.RootComputed:
 		return c.Computed
 	default:

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -16,6 +16,7 @@ type ContextOverlay struct {
 	Payload     map[string]any
 	Accumulated map[string]any
 	FanOut      map[string]any
+	Join        map[string]any
 }
 
 type ContextBuilderInput struct {
@@ -73,6 +74,11 @@ func WithAccumulated(base BaseContext, accumulated map[string]any) BaseContext {
 
 func WithFanOutItem(base BaseContext, fanOut map[string]any) BaseContext {
 	base.FanOut = values.Wrap(cloneStringAnyMap(fanOut))
+	return base
+}
+
+func WithJoin(base BaseContext, join map[string]any) BaseContext {
+	base.Join = values.Wrap(cloneStringAnyMap(join))
 	return base
 }
 

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
@@ -36,6 +37,7 @@ const (
 	StepQuery      Step = "query"
 	StepClearGates Step = "clear_gates"
 	StepGuard      Step = "guard"
+	StepJoin       Step = "join"
 	StepAccumulate Step = "accumulate"
 	StepFilter     Step = "filter"
 	StepGroupBy    Step = "group_by"
@@ -60,6 +62,7 @@ var OrderedSteps = []Step{
 	StepQuery,
 	StepClearGates,
 	StepGuard,
+	StepJoin,
 	StepAccumulate,
 	StepFilter,
 	StepGroupBy,
@@ -111,6 +114,8 @@ const (
 	handlerRuleSourceOnComplete           handlerRuleSource = "handler.on_complete"
 	handlerRuleSourceAccumulateOnComplete handlerRuleSource = "handler.accumulate.on_complete"
 	handlerRuleSourceAccumulateOnTimeout  handlerRuleSource = "handler.accumulate.on_timeout"
+	handlerRuleSourceJoinOnComplete       handlerRuleSource = "handler.join.on_complete"
+	handlerRuleSourceJoinTimeout          handlerRuleSource = "handler.join.timeout"
 )
 
 type contextTx struct {
@@ -179,6 +184,12 @@ func (e *Executor) ValidateRequest(req ExecutionRequest) error {
 	}
 	if req.Handler.CreateEntity && req.Handler.Accumulate != nil {
 		return fmt.Errorf("%w: handler declares both create_entity and accumulate", ErrInvalidConfig)
+	}
+	if req.Handler.Join != nil && req.Handler.Accumulate != nil {
+		return fmt.Errorf("%w: handler declares both join and accumulate", ErrInvalidConfig)
+	}
+	if err := runtimecontracts.ValidateJoinHandlerIsolation(req.Handler); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 	if req.Handler.CreateEntity && req.Handler.SelectEntity != nil && !req.Handler.SelectEntity.Empty() {
 		return fmt.Errorf("%w: handler declares both create_entity and select_entity", ErrInvalidConfig)
@@ -664,6 +675,7 @@ func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame
 			Computed:    map[string]any{},
 			Accumulated: map[string]any{},
 			FanOut:      map[string]any{},
+			Join:        map[string]any{},
 			Transformed: map[string]any{},
 		},
 		result: ExecutionResult{
@@ -697,6 +709,8 @@ func (e *Executor) runStep(frame *executionFrame, step Step) (bool, error) {
 		return false, e.stepClearGates(frame)
 	case StepGuard:
 		return e.stepGuard(frame)
+	case StepJoin:
+		return e.stepJoin(frame)
 	case StepAccumulate:
 		return e.stepAccumulate(frame)
 	case StepFilter:
@@ -736,6 +750,160 @@ func (e *Executor) runStep(frame *executionFrame, step Step) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
+	spec := frame.req.Handler.Join
+	if spec == nil {
+		return false, nil
+	}
+	payload := frame.payload
+	ref, timerKind, internal := timeridentity.ParseJoinRef(payload)
+	if internal && (ref.NodeID != frame.req.NodeID.String() || ref.HandlerEvent != strings.TrimSpace(frame.req.HandlerEventKey) || ref.JoinID != spec.EffectiveID()) {
+		return false, failures.New(failures.ClassUnexpectedArrival, "join_timer_identity_mismatch", "runtime.engine", "join", map[string]any{
+			"row_id": spec.EffectiveID(), "node_id": frame.req.NodeID.String(), "handler_event": strings.TrimSpace(frame.req.HandlerEventKey),
+		})
+	}
+	window := ""
+	if internal {
+		window = ref.Window
+	} else if spec.Window != nil {
+		value, ok := resolveContractPath(e.currentContext(frame), frame.state, spec.Window.ByPath, spec.Window.By)
+		if !ok || strings.TrimSpace(asString(value)) == "" {
+			return false, failures.New(failures.ClassUnexpectedArrival, "join_window_missing", "runtime.engine", "join", map[string]any{
+				"row_id": spec.EffectiveID(), "window_by": spec.Window.By,
+			})
+		}
+		window = strings.TrimSpace(asString(value))
+	}
+	key := joinruntime.ActivationKey(spec.EffectiveID(), window)
+	activation, found, err := joinruntime.Load(frame.state.State.StateCarrier.StateBuckets, frame.req.NodeID.String(), key)
+	if err != nil {
+		return false, fmt.Errorf("load join activation %s: %w", key, err)
+	}
+	if !found {
+		return false, e.joinArrivalFailure(frame, failures.ClassEarlyArrival, "join_not_armed", spec, window, "")
+	}
+	if internal && timerKind == timeridentity.TimerHandleJoinComplete {
+		if activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonComplete || !activation.OutcomePending || activation.OutcomeFired {
+			frame.result.Status = OutcomeDiscarded
+			return true, nil
+		}
+		activation.OutcomePending = false
+		activation.OutcomeFired = true
+		if err := e.storeJoinActivation(frame, activation); err != nil {
+			return false, err
+		}
+		e.selectJoinOutcome(frame, &spec.OnComplete, handlerRuleSourceJoinOnComplete, activation)
+		return false, nil
+	}
+	if activation.Status == joinruntime.StatusClosed {
+		if internal {
+			frame.result.Status = OutcomeDiscarded
+			return true, nil
+		}
+		return false, e.joinArrivalFailure(frame, failures.ClassStaleArrival, "join_closed", spec, window, "")
+	}
+	if internal && timerKind == timeridentity.TimerHandleJoinTimeout {
+		if !activation.Close(joinruntime.CloseReasonTimeout, false, true) {
+			frame.result.Status = OutcomeDiscarded
+			return true, nil
+		}
+		if err := e.storeJoinActivation(frame, activation); err != nil {
+			return false, err
+		}
+		timeout := spec.Timeout.Outcome
+		e.selectJoinOutcome(frame, &timeout, handlerRuleSourceJoinTimeout, activation)
+		return false, nil
+	}
+	if internal {
+		return false, e.joinArrivalFailure(frame, failures.ClassUnexpectedArrival, "join_internal_event_invalid", spec, window, "")
+	}
+	if strings.TrimSpace(frame.state.State.CurrentState) != strings.TrimSpace(spec.Stage) {
+		return false, e.joinArrivalFailure(frame, failures.ClassStaleArrival, "join_stage_closed", spec, window, "")
+	}
+	memberValue, ok := resolveContractPath(e.currentContext(frame), frame.state, spec.Members.ByPath, spec.Members.By)
+	member := strings.TrimSpace(asString(memberValue))
+	if !ok || member == "" {
+		return false, e.joinArrivalFailure(frame, failures.ClassUnexpectedArrival, "join_member_missing", spec, window, member)
+	}
+	output, ok := resolveContractPath(e.currentContext(frame), frame.state, spec.OutputPath, spec.Output)
+	if !ok {
+		return false, e.joinArrivalFailure(frame, failures.ClassUnexpectedArrival, "join_output_missing", spec, window, member)
+	}
+	disposition, err := activation.Add(member, output)
+	if err != nil {
+		return false, err
+	}
+	switch disposition {
+	case joinruntime.AddUnexpected:
+		return false, e.joinArrivalFailure(frame, failures.ClassUnexpectedArrival, "join_member_unexpected", spec, window, member)
+	case joinruntime.AddConflictingDuplicate:
+		return false, e.joinArrivalFailure(frame, failures.ClassConflictingDuplicate, "join_member_conflicting_duplicate", spec, window, member)
+	case joinruntime.AddExactDuplicate:
+		frame.state.Join = activation.Context()
+		frame.result.Status = OutcomeWaiting
+		return true, nil
+	case joinruntime.AddAccepted:
+	default:
+		return false, fmt.Errorf("unsupported join add disposition %q", disposition)
+	}
+	frame.state.Join = activation.Context()
+	complete := activation.Completed() == activation.Expected()
+	if spec.HasCustomCompletion() {
+		complete, err = e.evaluator.EvalBool(spec.CompleteWhen, e.currentContext(frame))
+		if err != nil {
+			return false, fmt.Errorf("join complete_when: %w", err)
+		}
+	}
+	if !complete {
+		if err := e.storeJoinActivation(frame, activation); err != nil {
+			return false, err
+		}
+		frame.result.Status = OutcomeWaiting
+		return true, nil
+	}
+	activation.Close(joinruntime.CloseReasonComplete, false, true)
+	if err := e.storeJoinActivation(frame, activation); err != nil {
+		return false, err
+	}
+	e.selectJoinOutcome(frame, &spec.OnComplete, handlerRuleSourceJoinOnComplete, activation)
+	return false, nil
+}
+
+func (e *Executor) storeJoinActivation(frame *executionFrame, activation joinruntime.Activation) error {
+	if frame.state.State.StateCarrier.StateBuckets == nil {
+		frame.state.State.StateCarrier.StateBuckets = map[string]map[string]any{}
+	}
+	if err := joinruntime.Store(frame.state.State.StateCarrier.StateBuckets, activation); err != nil {
+		return fmt.Errorf("store join activation: %w", err)
+	}
+	frame.result.StateMutation.SetStateBuckets(frame.state.State.StateCarrier.StateBuckets)
+	frame.state.Join = activation.Context()
+	return nil
+}
+
+func (e *Executor) selectJoinOutcome(frame *executionFrame, rule *runtimecontracts.HandlerRuleEntry, source handlerRuleSource, activation joinruntime.Activation) {
+	frame.state.Join = activation.Context()
+	frame.rule = rule
+	frame.ruleSource = source
+	e.applyRule(frame, rule)
+}
+
+func (e *Executor) joinArrivalFailure(frame *executionFrame, class failures.Class, code string, spec *runtimecontracts.JoinSpec, window, member string) error {
+	attributes := map[string]any{
+		"row_id":        spec.EffectiveID(),
+		"stage":         strings.TrimSpace(spec.Stage),
+		"node_id":       frame.req.NodeID.String(),
+		"handler_event": strings.TrimSpace(frame.req.HandlerEventKey),
+	}
+	if strings.TrimSpace(window) != "" {
+		attributes["window"] = strings.TrimSpace(window)
+	}
+	if strings.TrimSpace(member) != "" {
+		attributes["member"] = strings.TrimSpace(member)
+	}
+	return failures.New(class, code, "runtime.engine", "join", attributes)
 }
 
 func (e *Executor) stepQuery(frame *executionFrame) error {
@@ -1674,6 +1842,9 @@ func (e *Executor) stepGroupBy(frame *executionFrame) error {
 }
 
 func (e *Executor) stepOnComplete(frame *executionFrame) error {
+	if frame.ruleSource == handlerRuleSourceJoinOnComplete || frame.ruleSource == handlerRuleSourceJoinTimeout {
+		return nil
+	}
 	if isAccumulationTimeoutEvent(frame.req.Event.Type()) &&
 		frame.req.Handler.Accumulate != nil &&
 		frame.req.Handler.Accumulate.OnTimeout != nil &&
@@ -1821,6 +1992,10 @@ func (e *Executor) stepDataWrites(frame *executionFrame) error {
 		frame.topLevelDataWritesApplied = true
 	}
 	return nil
+}
+
+func joinExpressionOptions(frame *executionFrame) workflowexpr.ValueExpressionOptions {
+	return workflowexpr.ValueExpressionOptions{AllowJoin: frame != nil && (frame.ruleSource == handlerRuleSourceJoinOnComplete || frame.ruleSource == handlerRuleSourceJoinTimeout)}
 }
 
 func (e *Executor) stepProjection(frame *executionFrame) error {
@@ -2068,7 +2243,7 @@ func (e *Executor) stepTransform(frame *executionFrame) error {
 	}
 	// Resolve emit.fields against the current execution context so
 	// data_accumulation and rule-selected writes are visible to emitted payloads.
-	transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
+	transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, joinExpressionOptions(frame))
 	if err != nil {
 		return err
 	}
@@ -2104,7 +2279,7 @@ func (e *Executor) stepEmits(frame *executionFrame) error {
 		if emitSpec.HasFields() && len(activeEmits) == 1 && len(frame.state.Transformed) > 0 {
 			payload = frame.state.Transformed
 		} else if emitSpec.HasFields() {
-			transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, workflowexpr.ValueExpressionOptions{})
+			transformed, err := emitFieldsPayload(e.currentContext(frame), frame.state, emitSpec, joinExpressionOptions(frame))
 			if err != nil {
 				return err
 			}
@@ -2561,6 +2736,7 @@ func (e *Executor) currentContext(frame *executionFrame) BaseContext {
 	ctx = WithEvent(ctx, frame.req.Event.ContextMap(frame.state.State.CurrentState))
 	ctx = WithAccumulated(ctx, frame.state.Accumulated)
 	ctx = WithFanOutItem(ctx, frame.state.FanOut)
+	ctx = WithJoin(ctx, frame.state.Join)
 	ctx.Metadata = values.Wrap(cloneStringAnyMap(frame.state.State.StateCarrier.Metadata))
 	ctx.Gates = values.Wrap(boolMapToAnyMap(frame.state.State.StateCarrier.Gates))
 	ctx.Entity = values.Wrap(frame.state.State.EntityContext())
@@ -2587,6 +2763,8 @@ func (e *Executor) writeStepValue(frame *executionFrame, target string, value an
 	case paths.RootFanOut:
 		frame.state.SetFanOut(strings.Join(parsed.Segments, "."), value)
 		return nil
+	case paths.RootJoin:
+		return fmt.Errorf("join context is read-only")
 	}
 	if frame.state.State.StateCarrier.Metadata == nil {
 		frame.state.State.StateCarrier.Metadata = map[string]any{}
@@ -2639,6 +2817,8 @@ func (e *Executor) clearStepValue(frame *executionFrame, target string) error {
 		delete(frame.state.Accumulated, strings.Join(parsed.Segments, "."))
 	case paths.RootFanOut:
 		delete(frame.state.FanOut, strings.Join(parsed.Segments, "."))
+	case paths.RootJoin:
+		return fmt.Errorf("join context is read-only")
 	case paths.RootEntity, paths.RootMetadata:
 		if parsed.Root == paths.RootEntity {
 			if _, resolved, _, err := resolveHandlerEntityWriteTarget(e.deps.Source, frame.req.FlowID.String(), target); err != nil {
@@ -2785,7 +2965,7 @@ func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecont
 			continue
 		}
 		switch parsed := paths.Parse(target); parsed.Root {
-		case paths.RootComputed, paths.RootAccumulated, paths.RootFanOut, paths.RootGates, paths.RootEvent, paths.RootPayload, paths.RootPolicy:
+		case paths.RootComputed, paths.RootAccumulated, paths.RootFanOut, paths.RootJoin, paths.RootGates, paths.RootEvent, paths.RootPayload, paths.RootPolicy:
 			return fmt.Errorf("data_accumulation target %s: unsupported target scope", target)
 		}
 		if write.Value.HasLiteralValue() {
@@ -2795,7 +2975,7 @@ func (e *Executor) applyDataAccumulation(frame *executionFrame, spec runtimecont
 			continue
 		}
 		if write.Value.HasCELValue() {
-			value, err := evalWorkflowValueExpression(current, frame.state, write.Value.CEL, workflowexpr.ValueExpressionOptions{})
+			value, err := evalWorkflowValueExpression(current, frame.state, write.Value.CEL, joinExpressionOptions(frame))
 			if err != nil {
 				return fmt.Errorf("data_accumulation target %s: %w", target, err)
 			}

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -104,6 +104,7 @@ type executionFrame struct {
 	ruleDataWritesApplied     bool
 	projectionApplied         bool
 	transitionApplied         bool
+	joinResultType            runtimecontracts.CatalogTypeReference
 }
 
 type handlerRuleSource string
@@ -757,6 +758,11 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	if spec == nil {
 		return false, nil
 	}
+	resultType, found := e.joinResultType(frame.req)
+	if !found || resultType.Empty() {
+		return false, fmt.Errorf("join %s has no resolved output type in the semantic plan", spec.EffectiveID())
+	}
+	frame.joinResultType = resultType
 	payload := frame.payload
 	ref, timerKind, internal := timeridentity.ParseJoinRef(payload)
 	if internal && (ref.NodeID != frame.req.NodeID.String() || ref.HandlerEvent != strings.TrimSpace(frame.req.HandlerEventKey) || ref.Stage != strings.TrimSpace(spec.Stage) || ref.JoinID != spec.EffectiveID()) {
@@ -851,7 +857,7 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	frame.state.Join = activation.Context()
 	complete, err := joinruntime.CompletionSatisfied(activation, spec.CompleteWhen, func(expression string, joinContext map[string]any) (bool, error) {
 		frame.state.Join = joinContext
-		return e.evaluator.EvalBool(expression, e.currentContext(frame))
+		return workflowexpr.EvalJoinBool(expression, joinContext, frame.joinResultType)
 	})
 	if err != nil {
 		return false, fmt.Errorf("join complete_when: %w", err)
@@ -1995,7 +2001,30 @@ func (e *Executor) stepDataWrites(frame *executionFrame) error {
 }
 
 func joinExpressionOptions(frame *executionFrame) workflowexpr.ValueExpressionOptions {
-	return workflowexpr.ValueExpressionOptions{AllowJoin: frame != nil && (frame.ruleSource == handlerRuleSourceJoinOnComplete || frame.ruleSource == handlerRuleSourceJoinTimeout)}
+	allowJoin := frame != nil && (frame.ruleSource == handlerRuleSourceJoinOnComplete || frame.ruleSource == handlerRuleSourceJoinTimeout)
+	if !allowJoin {
+		return workflowexpr.ValueExpressionOptions{}
+	}
+	return workflowexpr.ValueExpressionOptions{AllowJoin: true, JoinResultType: frame.joinResultType}
+}
+
+func (e *Executor) joinResultType(req ExecutionRequest) (runtimecontracts.CatalogTypeReference, bool) {
+	if e == nil || e.deps.Source == nil {
+		return runtimecontracts.CatalogTypeReference{}, false
+	}
+	for _, plan := range e.deps.Source.WorkflowJoins() {
+		planFlowID := strings.TrimSpace(plan.FlowID)
+		requestFlowID := strings.TrimSpace(req.FlowID.String())
+		flowMatches := planFlowID == requestFlowID
+		if planFlowID == "" {
+			flowMatches = requestFlowID == "" || requestFlowID == strings.TrimSpace(e.deps.Source.WorkflowName())
+		}
+		if flowMatches && strings.TrimSpace(plan.NodeID) == strings.TrimSpace(req.NodeID.String()) &&
+			strings.TrimSpace(plan.HandlerEvent) == strings.TrimSpace(req.HandlerEventKey) {
+			return plan.ResultType, true
+		}
+	}
+	return runtimecontracts.CatalogTypeReference{}, false
 }
 
 func (e *Executor) stepProjection(frame *executionFrame) error {

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -759,7 +759,7 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	}
 	payload := frame.payload
 	ref, timerKind, internal := timeridentity.ParseJoinRef(payload)
-	if internal && (ref.NodeID != frame.req.NodeID.String() || ref.HandlerEvent != strings.TrimSpace(frame.req.HandlerEventKey) || ref.JoinID != spec.EffectiveID()) {
+	if internal && (ref.NodeID != frame.req.NodeID.String() || ref.HandlerEvent != strings.TrimSpace(frame.req.HandlerEventKey) || ref.Stage != strings.TrimSpace(spec.Stage) || ref.JoinID != spec.EffectiveID()) {
 		return false, failures.New(failures.ClassUnexpectedArrival, "join_timer_identity_mismatch", "runtime.engine", "join", map[string]any{
 			"row_id": spec.EffectiveID(), "node_id": frame.req.NodeID.String(), "handler_event": strings.TrimSpace(frame.req.HandlerEventKey),
 		})
@@ -776,7 +776,7 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 		}
 		window = strings.TrimSpace(asString(value))
 	}
-	key := joinruntime.ActivationKey(spec.EffectiveID(), window)
+	key := joinruntime.ActivationKey(spec.Stage, spec.EffectiveID(), window)
 	activation, found, err := joinruntime.Load(frame.state.State.StateCarrier.StateBuckets, frame.req.NodeID.String(), key)
 	if err != nil {
 		return false, fmt.Errorf("load join activation %s: %w", key, err)
@@ -849,12 +849,12 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 		return false, fmt.Errorf("unsupported join add disposition %q", disposition)
 	}
 	frame.state.Join = activation.Context()
-	complete := activation.Completed() == activation.Expected()
-	if spec.HasCustomCompletion() {
-		complete, err = e.evaluator.EvalBool(spec.CompleteWhen, e.currentContext(frame))
-		if err != nil {
-			return false, fmt.Errorf("join complete_when: %w", err)
-		}
+	complete, err := joinruntime.CompletionSatisfied(activation, spec.CompleteWhen, func(expression string, joinContext map[string]any) (bool, error) {
+		frame.state.Join = joinContext
+		return e.evaluator.EvalBool(expression, e.currentContext(frame))
+	})
+	if err != nil {
+		return false, fmt.Errorf("join complete_when: %w", err)
 	}
 	if !complete {
 		if err := e.storeJoinActivation(frame, activation); err != nil {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -22,6 +22,7 @@ import (
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
 	"github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"gopkg.in/yaml.v3"
@@ -980,20 +981,20 @@ func TestExecutor_StepOrderIsStable(t *testing.T) {
 		t.Fatalf("NewExecutor error: %v", err)
 	}
 	steps := exec.Steps()
-	if len(steps) != 21 {
-		t.Fatalf("step count = %d, want 21", len(steps))
+	if len(steps) != 22 {
+		t.Fatalf("step count = %d, want 22", len(steps))
 	}
 	if steps[0] != StepQuery || steps[len(steps)-1] != StepClear {
 		t.Fatalf("unexpected step order: %v", steps)
 	}
-	if steps[5] != StepGroupBy {
-		t.Fatalf("expected group_by at index 5, got order %v", steps)
+	if steps[5] != StepFilter {
+		t.Fatalf("expected filter at index 5, got order %v", steps)
 	}
-	if steps[15] != StepProjection {
-		t.Fatalf("expected projection after data_writes at index 15, got order %v", steps)
+	if steps[16] != StepProjection {
+		t.Fatalf("expected projection after data_writes at index 16, got order %v", steps)
 	}
-	if steps[19] != StepActivity {
-		t.Fatalf("expected activity after action at index 19, got order %v", steps)
+	if steps[20] != StepActivity {
+		t.Fatalf("expected activity after action at index 20, got order %v", steps)
 	}
 }
 
@@ -1770,6 +1771,64 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 	}
 	if _, ok := loadAccumulatorForBucket(state, accumulatorBucketRef("lifecycle-orchestrator", "component-scaffold/b/component.scaffolded")); ok {
 		t.Fatalf("second concrete event bucket survived: %#v", second.StateMutation.StateCarrier.StateBuckets)
+	}
+}
+
+func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source: stubSource(), StateRepo: stubStateRepo{}, TxRunner: stubRunner{}, Locker: stubLocker{}, Outbox: stubOutbox{}, Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := runtimecontracts.JoinSpec{
+		ID: "line_items", Stage: "awaiting", Output: "payload.result", OutputPath: runtimepaths.Parse("payload.result"),
+		Members:    runtimecontracts.JoinMembersSpec{From: "entity.expected", FromPath: runtimepaths.Parse("entity.expected"), By: "payload.member_id", ByPath: runtimepaths.Parse("payload.member_id")},
+		OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready"}, OnCompleteFound: true,
+		Timeout: runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention"}}, TimeoutFound: true,
+	}
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	activation, err := joinruntime.NewActivation(spec.ID, spec.Stage, "join-node", "item.completed", "", []string{"a", "b"}, now, now.Add(time.Hour), "join-timeout", "platform.join_timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	buckets := map[string]map[string]any{}
+	if err := joinruntime.Store(buckets, activation); err != nil {
+		t.Fatal(err)
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{Join: &spec}
+	first, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: handler,
+		Event: eventtest.RootIngress("evt-b", "item.completed", "", "", json.RawMessage(`{"member_id":"b","result":{"score":2}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
+		State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, buckets),
+	})
+	if err != nil {
+		t.Fatalf("first arrival: %v", err)
+	}
+	if first.Status != OutcomeWaiting {
+		t.Fatalf("first status = %s, want waiting", first.Status)
+	}
+	second, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: handler,
+		Event: eventtest.RootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now.Add(time.Second)),
+		State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, first.StateMutation.StateCarrier.StateBuckets),
+	})
+	if err != nil {
+		t.Fatalf("second arrival: %v", err)
+	}
+	if second.StateMutation.NextState != "ready" {
+		t.Fatalf("next state = %q, want ready", second.StateMutation.NextState)
+	}
+	closed, ok, err := joinruntime.Load(second.StateMutation.StateCarrier.StateBuckets, "join-node", activation.Key())
+	if err != nil || !ok {
+		t.Fatalf("load closed activation = %#v, %v, %v", closed, ok, err)
+	}
+	if closed.Status != joinruntime.StatusClosed || closed.CloseReason != joinruntime.CloseReasonComplete {
+		t.Fatalf("closed activation = %#v", closed)
+	}
+	results := closed.Results()
+	if len(results) != 2 || results[0].(map[string]any)["score"] != float64(1) || results[1].(map[string]any)["score"] != float64(2) {
+		t.Fatalf("results = %#v, want membership order a,b", results)
 	}
 }
 

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -1775,8 +1775,11 @@ func TestExecutor_AccumulatorBucketUsesMatchedHandlerEventKeyForScopedConcreteEv
 }
 
 func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
+	resultType := runtimecontracts.CatalogTypeReference{Type: "jsonb"}
 	exec, err := NewExecutor(RuntimeDependencies{
-		Source: stubSource(), StateRepo: stubStateRepo{}, TxRunner: stubRunner{}, Locker: stubLocker{}, Outbox: stubOutbox{}, Dispatcher: stubDispatcher{},
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "orders", Joins: []runtimecontracts.WorkflowJoinPlan{{FlowID: "orders", NodeID: "join-node", HandlerEvent: "item.completed", ResultType: resultType}},
+		}}), StateRepo: stubStateRepo{}, TxRunner: stubRunner{}, Locker: stubLocker{}, Outbox: stubOutbox{}, Dispatcher: stubDispatcher{},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1829,6 +1832,70 @@ func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
 	results := closed.Results()
 	if len(results) != 2 || results[0].(map[string]any)["score"] != float64(1) || results[1].(map[string]any)["score"] != float64(2) {
 		t.Fatalf("results = %#v, want membership order a,b", results)
+	}
+}
+
+func TestExecutor_JoinCompletionConsumesCatalogResultType(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		expression string
+		wantErr    bool
+	}{
+		{name: "named field", expression: `join.results[0].score > 0`},
+		{name: "named value is not scalar", expression: `join.results[0] > 1`, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := runtimecontracts.JoinSpec{
+				ID: "line_items", Stage: "awaiting", Output: "payload.result", OutputPath: runtimepaths.Parse("payload.result"),
+				Members:      runtimecontracts.JoinMembersSpec{From: "entity.expected", FromPath: runtimepaths.Parse("entity.expected"), By: "payload.member_id", ByPath: runtimepaths.Parse("payload.member_id")},
+				CompleteWhen: tc.expression,
+				Remaining:    runtimecontracts.JoinRemainingIgnore,
+				OnComplete:   runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready"}, OnCompleteFound: true,
+				Timeout: runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention"}}, TimeoutFound: true,
+			}
+			resultType := runtimecontracts.CatalogTypeReference{
+				Type: "JoinResult",
+				Catalog: runtimecontracts.TypeCatalogDocument{Types: map[string]runtimecontracts.NamedTypeDecl{
+					"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{"score": {Type: "integer"}}},
+				}},
+			}
+			source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Semantics: runtimecontracts.WorkflowSemanticView{
+				Name:  "orders",
+				Joins: []runtimecontracts.WorkflowJoinPlan{{FlowID: "orders", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec, ResultType: resultType}},
+			}})
+			exec, err := NewExecutor(RuntimeDependencies{
+				Source: source, StateRepo: stubStateRepo{}, TxRunner: stubRunner{}, Locker: stubLocker{}, Outbox: stubOutbox{}, Dispatcher: stubDispatcher{},
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+			activation, err := joinruntime.NewActivation(spec.ID, spec.Stage, "join-node", "item.completed", "", []string{"a"}, now, now.Add(time.Hour), "join-timeout", "platform.join_timeout")
+			if err != nil {
+				t.Fatal(err)
+			}
+			buckets := map[string]map[string]any{}
+			if err := joinruntime.Store(buckets, activation); err != nil {
+				t.Fatal(err)
+			}
+			result, err := exec.Execute(context.Background(), ExecutionRequest{
+				EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: runtimecontracts.SystemNodeEventHandler{Join: &spec},
+				Event: eventtest.RootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
+				State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a"}}, nil, buckets),
+			})
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "no matching overload") {
+					t.Fatalf("Execute error = %v, want catalog-backed typed rejection", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute error = %v", err)
+			}
+			if result.StateMutation.NextState != "ready" {
+				t.Fatalf("next state = %q, want ready", result.StateMutation.NextState)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/engine/helpers.go
+++ b/internal/runtime/engine/helpers.go
@@ -242,6 +242,7 @@ func evalWorkflowValueExpression(base BaseContext, state ExecutionState, express
 		Policy:         base.Policy.Raw(),
 		Computed:       base.Computed.Raw(),
 		FanOut:         state.FanOut,
+		Join:           state.Join,
 	}, opts)
 }
 

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -247,6 +247,7 @@ type ExecutionState struct {
 	Computed    map[string]any
 	Accumulated map[string]any
 	FanOut      map[string]any
+	Join        map[string]any
 	Transformed map[string]any
 }
 
@@ -260,6 +261,10 @@ func (s ExecutionState) AccumulatedBucket() values.Bucket {
 
 func (s ExecutionState) FanOutBucket() values.Bucket {
 	return values.Wrap(s.FanOut)
+}
+
+func (s ExecutionState) JoinBucket() values.Bucket {
+	return values.Wrap(s.Join)
 }
 
 func (s *ExecutionState) SetComputed(key string, value any) {
@@ -281,6 +286,13 @@ func (s *ExecutionState) SetFanOut(key string, value any) {
 		s.FanOut = map[string]any{}
 	}
 	values.Wrap(s.FanOut).Set(key, value)
+}
+
+func (s *ExecutionState) SetJoin(key string, value any) {
+	if s.Join == nil {
+		s.Join = map[string]any{}
+	}
+	values.Wrap(s.Join).Set(key, value)
 }
 
 type EmitIntent struct {

--- a/internal/runtime/joinruntime/join.go
+++ b/internal/runtime/joinruntime/join.go
@@ -121,19 +121,41 @@ func (a Activation) Validate() error {
 }
 
 func (a Activation) Key() string {
-	return ActivationKey(a.JoinID, a.Window)
+	return ActivationKey(a.Stage, a.JoinID, a.Window)
 }
 
-func ActivationKey(joinID, window string) string {
+func ActivationKey(stage, joinID, window string) string {
+	stage = strings.TrimSpace(stage)
 	joinID = strings.TrimSpace(joinID)
 	window = strings.TrimSpace(window)
-	if joinID == "" {
+	if stage == "" || joinID == "" {
 		return ""
 	}
-	if window == "" {
-		return joinID
+	parts := []string{stage, joinID}
+	if window != "" {
+		parts = append(parts, window)
 	}
-	return joinID + "@window=" + base64.RawURLEncoding.EncodeToString([]byte(window))
+	for i := range parts {
+		parts[i] = base64.RawURLEncoding.EncodeToString([]byte(parts[i]))
+	}
+	return strings.Join(parts, ".")
+}
+
+type CompletionEvaluator func(expression string, joinContext map[string]any) (bool, error)
+
+func CompletionSatisfied(activation Activation, completeWhen string, evaluate CompletionEvaluator) (bool, error) {
+	completeWhen = strings.TrimSpace(completeWhen)
+	if completeWhen == "" {
+		return activation.Completed() == activation.Expected(), nil
+	}
+	if evaluate == nil {
+		return false, fmt.Errorf("join completion evaluator is required")
+	}
+	return evaluate(completeWhen, activation.Context())
+}
+
+func SupportedContextFields() []string {
+	return []string{"expected", "completed", "missing", "results", "timed_out"}
 }
 
 func (a *Activation) Add(member string, value any) (AddDisposition, error) {

--- a/internal/runtime/joinruntime/join.go
+++ b/internal/runtime/joinruntime/join.go
@@ -215,6 +215,27 @@ func (a *Activation) Close(reason CloseReason, outcomePending, outcomeFired bool
 	return true
 }
 
+func (a *Activation) CloseForStageExit() bool {
+	if a == nil {
+		return false
+	}
+	if a.Status == StatusOpen {
+		a.Status = StatusClosed
+		a.CloseReason = CloseReasonStageExit
+		a.OutcomePending = false
+		a.OutcomeFired = false
+		return true
+	}
+	if a.Status != StatusClosed || a.CloseReason != CloseReasonComplete || !a.OutcomePending || a.OutcomeFired {
+		return false
+	}
+	// A zero-member completion is closed before its internal event fires. Stage
+	// exit supersedes that pending outcome so a delayed event cannot apply it.
+	a.CloseReason = CloseReasonStageExit
+	a.OutcomePending = false
+	return true
+}
+
 func Load(stateBuckets map[string]map[string]any, nodeID, key string) (Activation, bool, error) {
 	node := stateBuckets[strings.TrimSpace(nodeID)]
 	joins, _ := node[bucketKey].(map[string]any)

--- a/internal/runtime/joinruntime/join.go
+++ b/internal/runtime/joinruntime/join.go
@@ -1,0 +1,316 @@
+package joinruntime
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/computemodule"
+)
+
+const bucketKey = "handler_joins"
+
+type Status string
+
+const (
+	StatusOpen   Status = "open"
+	StatusClosed Status = "closed"
+)
+
+type CloseReason string
+
+const (
+	CloseReasonComplete  CloseReason = "complete"
+	CloseReasonTimeout   CloseReason = "timeout"
+	CloseReasonStageExit CloseReason = "stage_exit"
+)
+
+type MemberOutput struct {
+	Hash  string `json:"hash"`
+	Value any    `json:"value"`
+}
+
+type Activation struct {
+	JoinID          string                  `json:"join_id"`
+	Stage           string                  `json:"stage"`
+	NodeID          string                  `json:"node_id"`
+	HandlerEvent    string                  `json:"handler_event"`
+	Window          string                  `json:"window,omitempty"`
+	Members         []string                `json:"members"`
+	Outputs         map[string]MemberOutput `json:"outputs"`
+	Status          Status                  `json:"status"`
+	CloseReason     CloseReason             `json:"close_reason,omitempty"`
+	ArmedAt         time.Time               `json:"armed_at"`
+	FireAt          time.Time               `json:"fire_at"`
+	TimerTaskID     string                  `json:"timer_task_id"`
+	TimerEventType  string                  `json:"timer_event_type"`
+	TimerCancelled  bool                    `json:"timer_cancelled,omitempty"`
+	OutcomePending  bool                    `json:"outcome_pending,omitempty"`
+	OutcomeFired    bool                    `json:"outcome_fired,omitempty"`
+	CompletionEvent string                  `json:"completion_event,omitempty"`
+}
+
+type AddDisposition string
+
+const (
+	AddAccepted             AddDisposition = "accepted"
+	AddExactDuplicate       AddDisposition = "exact_duplicate"
+	AddConflictingDuplicate AddDisposition = "conflicting_duplicate"
+	AddUnexpected           AddDisposition = "unexpected"
+)
+
+func NewActivation(joinID, stage, nodeID, handlerEvent, window string, members []string, armedAt, fireAt time.Time, taskID, eventType string) (Activation, error) {
+	normalizedMembers, err := normalizeMembers(members)
+	if err != nil {
+		return Activation{}, err
+	}
+	activation := Activation{
+		JoinID:         strings.TrimSpace(joinID),
+		Stage:          strings.TrimSpace(stage),
+		NodeID:         strings.TrimSpace(nodeID),
+		HandlerEvent:   strings.TrimSpace(handlerEvent),
+		Window:         strings.TrimSpace(window),
+		Members:        normalizedMembers,
+		Outputs:        map[string]MemberOutput{},
+		Status:         StatusOpen,
+		ArmedAt:        armedAt.UTC(),
+		FireAt:         fireAt.UTC(),
+		TimerTaskID:    strings.TrimSpace(taskID),
+		TimerEventType: strings.TrimSpace(eventType),
+	}
+	if err := activation.Validate(); err != nil {
+		return Activation{}, err
+	}
+	return activation, nil
+}
+
+func (a Activation) Validate() error {
+	if strings.TrimSpace(a.JoinID) == "" || strings.TrimSpace(a.Stage) == "" || strings.TrimSpace(a.NodeID) == "" || strings.TrimSpace(a.HandlerEvent) == "" {
+		return fmt.Errorf("join activation identity is incomplete")
+	}
+	if a.Status != StatusOpen && a.Status != StatusClosed {
+		return fmt.Errorf("join activation status %q is invalid", a.Status)
+	}
+	if _, err := normalizeMembers(a.Members); err != nil {
+		return err
+	}
+	memberSet := make(map[string]struct{}, len(a.Members))
+	for _, member := range a.Members {
+		memberSet[member] = struct{}{}
+	}
+	for member, output := range a.Outputs {
+		if _, ok := memberSet[strings.TrimSpace(member)]; !ok {
+			return fmt.Errorf("join output member %q is not declared", member)
+		}
+		if strings.TrimSpace(output.Hash) == "" {
+			return fmt.Errorf("join output member %q has empty canonical hash", member)
+		}
+	}
+	if a.Status == StatusOpen && a.CloseReason != "" {
+		return fmt.Errorf("open join activation has close reason %q", a.CloseReason)
+	}
+	if a.Status == StatusOpen && a.TimerCancelled {
+		return fmt.Errorf("open join activation cannot have a cancelled timer")
+	}
+	if a.Status == StatusClosed && a.CloseReason == "" {
+		return fmt.Errorf("closed join activation is missing close reason")
+	}
+	return nil
+}
+
+func (a Activation) Key() string {
+	return ActivationKey(a.JoinID, a.Window)
+}
+
+func ActivationKey(joinID, window string) string {
+	joinID = strings.TrimSpace(joinID)
+	window = strings.TrimSpace(window)
+	if joinID == "" {
+		return ""
+	}
+	if window == "" {
+		return joinID
+	}
+	return joinID + "@window=" + base64.RawURLEncoding.EncodeToString([]byte(window))
+}
+
+func (a *Activation) Add(member string, value any) (AddDisposition, error) {
+	if a == nil {
+		return "", fmt.Errorf("join activation is nil")
+	}
+	member = strings.TrimSpace(member)
+	if !a.HasMember(member) {
+		return AddUnexpected, nil
+	}
+	hash, err := computemodule.CanonicalJSONHash(value)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize join output: %w", err)
+	}
+	if existing, ok := a.Outputs[member]; ok {
+		if existing.Hash == hash {
+			return AddExactDuplicate, nil
+		}
+		return AddConflictingDuplicate, nil
+	}
+	if a.Outputs == nil {
+		a.Outputs = map[string]MemberOutput{}
+	}
+	a.Outputs[member] = MemberOutput{Hash: hash, Value: cloneJSONValue(value)}
+	return AddAccepted, nil
+}
+
+func (a Activation) HasMember(member string) bool {
+	member = strings.TrimSpace(member)
+	for _, candidate := range a.Members {
+		if candidate == member {
+			return true
+		}
+	}
+	return false
+}
+
+func (a Activation) Completed() int { return len(a.Outputs) }
+func (a Activation) Expected() int  { return len(a.Members) }
+
+func (a Activation) Missing() []string {
+	out := make([]string, 0, len(a.Members)-len(a.Outputs))
+	for _, member := range a.Members {
+		if _, ok := a.Outputs[member]; !ok {
+			out = append(out, member)
+		}
+	}
+	return out
+}
+
+func (a Activation) Results() []any {
+	out := make([]any, 0, len(a.Outputs))
+	for _, member := range a.Members {
+		if output, ok := a.Outputs[member]; ok {
+			out = append(out, cloneJSONValue(output.Value))
+		}
+	}
+	return out
+}
+
+func (a Activation) Context() map[string]any {
+	return map[string]any{
+		"expected":  a.Expected(),
+		"completed": a.Completed(),
+		"missing":   a.Missing(),
+		"results":   a.Results(),
+		"timed_out": a.CloseReason == CloseReasonTimeout,
+	}
+}
+
+func (a *Activation) Close(reason CloseReason, outcomePending, outcomeFired bool) bool {
+	if a == nil || a.Status == StatusClosed {
+		return false
+	}
+	a.Status = StatusClosed
+	a.CloseReason = reason
+	a.OutcomePending = outcomePending
+	a.OutcomeFired = outcomeFired
+	return true
+}
+
+func Load(stateBuckets map[string]map[string]any, nodeID, key string) (Activation, bool, error) {
+	node := stateBuckets[strings.TrimSpace(nodeID)]
+	joins, _ := node[bucketKey].(map[string]any)
+	raw, ok := joins[strings.TrimSpace(key)]
+	if !ok {
+		return Activation{}, false, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return Activation{}, false, err
+	}
+	var activation Activation
+	if err := json.Unmarshal(encoded, &activation); err != nil {
+		return Activation{}, false, err
+	}
+	if activation.Outputs == nil {
+		activation.Outputs = map[string]MemberOutput{}
+	}
+	if err := activation.Validate(); err != nil {
+		return Activation{}, false, err
+	}
+	return activation, true, nil
+}
+
+func Store(stateBuckets map[string]map[string]any, activation Activation) error {
+	if err := activation.Validate(); err != nil {
+		return err
+	}
+	nodeID := strings.TrimSpace(activation.NodeID)
+	if stateBuckets == nil {
+		return fmt.Errorf("join state bucket set is nil")
+	}
+	node := stateBuckets[nodeID]
+	if node == nil {
+		node = map[string]any{}
+		stateBuckets[nodeID] = node
+	}
+	joins, _ := node[bucketKey].(map[string]any)
+	if joins == nil {
+		joins = map[string]any{}
+		node[bucketKey] = joins
+	}
+	encoded, err := json.Marshal(activation)
+	if err != nil {
+		return err
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		return err
+	}
+	joins[activation.Key()] = raw
+	return nil
+}
+
+func List(stateBuckets map[string]map[string]any) ([]Activation, error) {
+	out := make([]Activation, 0)
+	for nodeID, node := range stateBuckets {
+		joins, _ := node[bucketKey].(map[string]any)
+		for key := range joins {
+			activation, ok, err := Load(stateBuckets, nodeID, key)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				out = append(out, activation)
+			}
+		}
+	}
+	return out, nil
+}
+
+func normalizeMembers(members []string) ([]string, error) {
+	out := make([]string, 0, len(members))
+	seen := map[string]struct{}{}
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		if member == "" {
+			return nil, fmt.Errorf("join membership contains an empty identity")
+		}
+		if _, ok := seen[member]; ok {
+			return nil, fmt.Errorf("join membership contains duplicate identity %q", member)
+		}
+		seen[member] = struct{}{}
+		out = append(out, member)
+	}
+	return out, nil
+}
+
+func cloneJSONValue(value any) any {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var out any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return value
+	}
+	return out
+}

--- a/internal/runtime/joinruntime/join_test.go
+++ b/internal/runtime/joinruntime/join_test.go
@@ -1,0 +1,62 @@
+package joinruntime
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestActivationOrdersResultsByMembershipAndClassifiesDuplicates(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	activation, err := NewActivation("line_items", "awaiting", "node", "item.done", "dispatch-1", []string{"a", "b"}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := activation.Add("b", map[string]any{"score": 2}); err != nil || got != AddAccepted {
+		t.Fatalf("add b = %q, %v", got, err)
+	}
+	if got, err := activation.Add("a", map[string]any{"score": 1}); err != nil || got != AddAccepted {
+		t.Fatalf("add a = %q, %v", got, err)
+	}
+	if got, want := activation.Results(), []any{map[string]any{"score": float64(1)}, map[string]any{"score": float64(2)}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("results = %#v, want membership order %#v", got, want)
+	}
+	if got, err := activation.Add("a", map[string]any{"score": 1}); err != nil || got != AddExactDuplicate {
+		t.Fatalf("exact duplicate = %q, %v", got, err)
+	}
+	if got, err := activation.Add("a", map[string]any{"score": 9}); err != nil || got != AddConflictingDuplicate {
+		t.Fatalf("conflicting duplicate = %q, %v", got, err)
+	}
+	if got, err := activation.Add("c", map[string]any{"score": 3}); err != nil || got != AddUnexpected {
+		t.Fatalf("unexpected member = %q, %v", got, err)
+	}
+}
+
+func TestActivationPersistsThroughTypedStateBuckets(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	activation, err := NewActivation("join", "awaiting", "node", "item.done", "", []string{}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	activation.Close(CloseReasonComplete, true, false)
+	buckets := map[string]map[string]any{}
+	if err := Store(buckets, activation); err != nil {
+		t.Fatal(err)
+	}
+	loaded, ok, err := Load(buckets, "node", activation.Key())
+	if err != nil || !ok {
+		t.Fatalf("load = %#v, %v, %v", loaded, ok, err)
+	}
+	if !reflect.DeepEqual(loaded, activation) {
+		t.Fatalf("round trip = %#v, want %#v", loaded, activation)
+	}
+}
+
+func TestNewActivationRejectsInvalidMembership(t *testing.T) {
+	now := time.Now().UTC()
+	for _, members := range [][]string{{""}, {"a", "a"}} {
+		if _, err := NewActivation("join", "awaiting", "node", "item.done", "", members, now, now.Add(time.Hour), "task", "platform.join_timeout"); err == nil {
+			t.Fatalf("members %#v accepted", members)
+		}
+	}
+}

--- a/internal/runtime/joinruntime/join_test.go
+++ b/internal/runtime/joinruntime/join_test.go
@@ -60,3 +60,33 @@ func TestNewActivationRejectsInvalidMembership(t *testing.T) {
 		}
 	}
 }
+
+func TestActivationKeyIncludesStageIdentity(t *testing.T) {
+	awaiting := ActivationKey("awaiting", "shared", "window-1")
+	reviewing := ActivationKey("reviewing", "shared", "window-1")
+	if awaiting == "" || reviewing == "" || awaiting == reviewing {
+		t.Fatalf("activation keys = awaiting:%q reviewing:%q, want distinct stage-scoped identities", awaiting, reviewing)
+	}
+}
+
+func TestCompletionSatisfiedUsesOneDefaultAndCustomOwner(t *testing.T) {
+	now := time.Now().UTC()
+	activation, err := NewActivation("join", "awaiting", "node", "item.done", "", []string{}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete, err := CompletionSatisfied(activation, "", nil); err != nil || !complete {
+		t.Fatalf("default zero-member completion = %v, %v, want true", complete, err)
+	}
+	called := false
+	complete, err := CompletionSatisfied(activation, "join.completed >= 1", func(expression string, joinContext map[string]any) (bool, error) {
+		called = true
+		if expression != "join.completed >= 1" || joinContext["completed"] != 0 {
+			t.Fatalf("custom completion input = %q %#v", expression, joinContext)
+		}
+		return false, nil
+	})
+	if err != nil || complete || !called {
+		t.Fatalf("custom zero-member completion = complete:%v called:%v err:%v, want false/true/nil", complete, called, err)
+	}
+}

--- a/internal/runtime/llm/cli_runtime_process.go
+++ b/internal/runtime/llm/cli_runtime_process.go
@@ -122,9 +122,9 @@ func (r *ClaudeCLIRuntime) runStreaming(ctx context.Context, cmd *exec.Cmd, targ
 	go func() { stdoutCh <- readStreamLines(stdout, monitor, false) }()
 	go func() { stderrCh <- readStreamLines(stderr, monitor, true) }()
 
-	waitErr := cmd.Wait()
 	stdoutLines := <-stdoutCh
 	stderrLines := <-stderrCh
+	waitErr := cmd.Wait()
 	if waitErr != nil {
 		stderrText := strings.TrimSpace(string(joinRawLines(stderrLines)))
 		stdoutText := strings.TrimSpace(string(joinRawLines(stdoutLines)))

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -316,6 +316,12 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 			handlerEventKey = bucket.EventType
 		}
 	}
+	if !ok && isJoinLifecycleEvent(events.EventType(trigger)) {
+		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == nodeID {
+			handler, ok = findJoinHandlerForRef(source, ref)
+			handlerEventKey = ref.HandlerEvent
+		}
+	}
 	if !ok {
 		return false, nil
 	}

--- a/internal/runtime/pipeline/engine_adapter.go
+++ b/internal/runtime/pipeline/engine_adapter.go
@@ -43,6 +43,7 @@ func (e pipelineEngineEvaluator) EvalBool(expression string, ctx runtimeengine.B
 		Computed:       cloneStringAnyMap(ctx.Computed.Raw()),
 		Accumulated:    accumulatedItemsForCEL(ctx.Accumulated.Raw()),
 		FanOut:         cloneStringAnyMap(ctx.FanOut.Raw()),
+		Join:           cloneStringAnyMap(ctx.Join.Raw()),
 		WorkflowName:   firstNonEmptyString(strings.TrimSpace(ctx.FlowID), e.workflowName()),
 	}
 	queryCtx.QueryEntityCount = func(predicate string) (int, error) {
@@ -205,6 +206,11 @@ func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identit
 		if !hadState {
 			materializedState = true
 		}
+		if mutation.StateCarrier.StateBuckets != nil {
+			if err := r.coordinator.reconcileClosedJoinSchedules(ctx, entityID.String(), mutation.StateCarrier); err != nil {
+				return err
+			}
+		}
 	}
 	if next := strings.TrimSpace(mutation.NextState); next != "" {
 		if err := r.coordinator.updateEntityState(ctx, entityID.String(), next, ""); err != nil {
@@ -215,7 +221,7 @@ func (r pipelineEngineStateRepo) SaveState(ctx context.Context, entityID identit
 		}
 	}
 	if materializedState {
-		if err := r.coordinator.armWorkflowCurrentStageTimers(ctx, entityID.String(), ""); err != nil {
+		if err := r.coordinator.armWorkflowCurrentStageLifecycle(ctx, entityID.String(), ""); err != nil {
 			return err
 		}
 	}

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -63,7 +63,7 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 		return contractHandlerExecutionResult{}, nil
 	}
 	owners := source.RuntimeEventOwners(trigger)
-	if len(owners) == 0 && !isAccumulationTimeoutEvent(events.EventType(trigger)) {
+	if len(owners) == 0 && !isAccumulationTimeoutEvent(events.EventType(trigger)) && !isJoinLifecycleEvent(events.EventType(trigger)) {
 		return contractHandlerExecutionResult{}, nil
 	}
 	var (
@@ -96,6 +96,17 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 			}
 		}
 	}
+	if !matched && isJoinLifecycleEvent(events.EventType(trigger)) {
+		if ref, _, ok := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); ok {
+			joinHandler, ok := findJoinHandlerForRef(source, ref)
+			if ok {
+				nodeID = ref.NodeID
+				handler = joinHandler
+				handlerEventKey = ref.HandlerEvent
+				matched = true
+			}
+		}
+	}
 	if !matched {
 		return contractHandlerExecutionResult{}, nil
 	}
@@ -108,6 +119,26 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 func isAccumulationTimeoutEvent(eventType events.EventType) bool {
 	eventName := strings.TrimSpace(string(eventType))
 	return strings.HasSuffix(eventName, ".timeout") || strings.EqualFold(eventName, "accumulate.timeout")
+}
+
+func isJoinLifecycleEvent(eventType events.EventType) bool {
+	eventName := strings.TrimSpace(string(eventType))
+	return eventName == joinTimeoutEvent || eventName == joinCompleteEvent
+}
+
+func findJoinHandlerForRef(source interface {
+	NodeEntries() map[string]runtimecontracts.SystemNodeContract
+	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
+}, ref timeridentity.JoinRef) (runtimecontracts.SystemNodeEventHandler, bool) {
+	ref = ref.Normalize()
+	if source == nil || !ref.Valid() {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
+	if _, ok := source.NodeEntries()[ref.NodeID]; !ok {
+		return runtimecontracts.SystemNodeEventHandler{}, false
+	}
+	handler, ok := source.NodeEventHandlers(ref.NodeID)[ref.HandlerEvent]
+	return handler, ok && handler.Join != nil && handler.Join.EffectiveID() == ref.JoinID
 }
 
 func findAccumulationTimeoutHandlerForBucket(source interface {
@@ -187,7 +218,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if !handler.CreateEntity && entityID != "" && originalEntityID != "" && originalEntityID != entityID && strings.TrimSpace(triggerCtx.State.EntityID) == "" {
 		triggerCtx.State.EntityID = entityID
 	}
-	if terminalStateHandlerRejected(pc, flowID, triggerCtx.State, handler) {
+	if handler.Join == nil && terminalStateHandlerRejected(pc, flowID, triggerCtx.State, handler) {
 		outcome := &handlerExecutionOutcome{
 			Status:          HandlerOutcomeTerminalReject,
 			GuardsEvaluated: []string{"not_in_terminal_state"},

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -138,7 +138,7 @@ func findJoinHandlerForRef(source interface {
 		return runtimecontracts.SystemNodeEventHandler{}, false
 	}
 	handler, ok := source.NodeEventHandlers(ref.NodeID)[ref.HandlerEvent]
-	return handler, ok && handler.Join != nil && handler.Join.EffectiveID() == ref.JoinID
+	return handler, ok && handler.Join != nil && handler.Join.EffectiveID() == ref.JoinID && strings.TrimSpace(handler.Join.Stage) == ref.Stage
 }
 
 func findAccumulationTimeoutHandlerForBucket(source interface {

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -100,6 +100,11 @@ func (n *declarativeWorkflowNode) InterceptPolicy(eventType string, evt events.E
 			policy, ok = workflowNodeEventPolicy(n.coordinator.WorkflowNodes(), n.NodeID(), bucket.EventType)
 		}
 	}
+	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
+		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
+			policy, ok = workflowNodeEventPolicy(n.coordinator.WorkflowNodes(), n.NodeID(), ref.HandlerEvent)
+		}
+	}
 	if !ok {
 		return false, false
 	}
@@ -154,6 +159,11 @@ func (n *DeclarativeNode) InterceptPolicy(eventType string, evt events.Event) (b
 	if !ok && isAccumulationTimeoutEvent(events.EventType(eventType)) {
 		if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload())); bucketOK && bucket.NodeID == n.NodeID() {
 			policy, ok = n.policies[bucket.EventType]
+		}
+	}
+	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
+		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
+			policy, ok = n.policies[ref.HandlerEvent]
 		}
 	}
 	if !ok {
@@ -212,6 +222,16 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 				handlerEventKey = bucket.EventType
 				ok = true
 				break
+			}
+		}
+	}
+	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
+		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
+			candidate, found := n.contract.EventHandlers[ref.HandlerEvent]
+			if found && candidate.Join != nil && candidate.Join.EffectiveID() == ref.JoinID {
+				handler = candidate
+				handlerEventKey = ref.HandlerEvent
+				ok = true
 			}
 		}
 	}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -82,6 +82,11 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 	if normalized == "" {
 		return false, fmt.Errorf("workflow expression is empty")
 	}
+	if workflowexpr.ExpressionReferencesRoot(normalized, "join") {
+		if err := workflowexpr.ValidateValueExpressionWithOptions(normalized, workflowexpr.ValueExpressionOptions{AllowJoin: true, RequireBool: true}); err != nil {
+			return false, fmt.Errorf("join expression: %w", err)
+		}
+	}
 	if missing := missingEntityReferences(normalized, normalizedCtx.Entity); len(missing) > 0 {
 		return false, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
 	}

--- a/internal/runtime/pipeline/workflow_expression_evaluator.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator.go
@@ -30,6 +30,7 @@ type workflowExpressionContext struct {
 	Computed                     map[string]any
 	Accumulated                  any
 	FanOut                       map[string]any
+	Join                         map[string]any
 	WorkflowName                 string
 	QueryEntityCount             func(string) (int, error)
 	AllowUnresolvedQueryOperands bool
@@ -51,6 +52,7 @@ func newWorkflowExpressionEvaluator() *workflowExpressionEvaluator {
 		cel.Variable("computed", cel.DynType),
 		cel.Variable("accumulated", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
+		cel.Variable("join", cel.DynType),
 		cel.Function("count_ge",
 			cel.Overload(
 				"count_ge_dyn_dyn",
@@ -96,6 +98,7 @@ func (e *workflowExpressionEvaluator) EvalBool(expression string, ctx workflowEx
 		"computed":    workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Computed)),
 		"accumulated": normalizedCtx.Accumulated,
 		"fan_out":     workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.FanOut)),
+		"join":        workflowNormalizeCELInput(cloneStringAnyMap(normalizedCtx.Join)),
 	})
 	if err != nil {
 		return false, err
@@ -165,6 +168,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 			Computed:                     cloneStringAnyMap(ctx.Computed),
 			Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 			FanOut:                       cloneStringAnyMap(ctx.FanOut),
+			Join:                         cloneStringAnyMap(ctx.Join),
 			WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
 			QueryEntityCount:             ctx.QueryEntityCount,
 			AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,
@@ -203,6 +207,7 @@ func normalizeWorkflowExpression(expression string, ctx workflowExpressionContex
 		Computed:                     cloneStringAnyMap(ctx.Computed),
 		Accumulated:                  cloneAccumulatedItems(ctx.Accumulated),
 		FanOut:                       cloneStringAnyMap(ctx.FanOut),
+		Join:                         cloneStringAnyMap(ctx.Join),
 		WorkflowName:                 strings.TrimSpace(ctx.WorkflowName),
 		QueryEntityCount:             ctx.QueryEntityCount,
 		AllowUnresolvedQueryOperands: ctx.AllowUnresolvedQueryOperands,

--- a/internal/runtime/pipeline/workflow_expression_evaluator_test.go
+++ b/internal/runtime/pipeline/workflow_expression_evaluator_test.go
@@ -158,6 +158,18 @@ func TestWorkflowExpressionEvaluator_AllowsComputedNamespace(t *testing.T) {
 	}
 }
 
+func TestWorkflowExpressionEvaluatorRejectsTypeInvalidJoinExpressionBeforeEval(t *testing.T) {
+	eval := newWorkflowExpressionEvaluator()
+	_, err := eval.EvalBool(`join.missing > 1`, workflowExpressionContext{
+		Join: map[string]any{
+			"expected": 2, "completed": 1, "missing": []any{"b"}, "results": []any{"ok"}, "timed_out": false,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no matching overload") {
+		t.Fatalf("EvalBool type-invalid join error = %v, want typed overload rejection before runtime evaluation", err)
+	}
+}
+
 func TestValidateConditionCEL_RejectsLegacyEventReceiverProjections(t *testing.T) {
 	for _, expression := range []string{
 		`event.entity_id != ""`,

--- a/internal/runtime/pipeline/workflow_instance_activation.go
+++ b/internal/runtime/pipeline/workflow_instance_activation.go
@@ -96,7 +96,7 @@ func (pc *PipelineCoordinator) createFlowInstance(ctx context.Context, triggerCt
 	if err := pc.instanceActivator(ctx, req); err != nil {
 		return err
 	}
-	if err := pc.armWorkflowCurrentStageTimers(ctx, instance.EntityID, ""); err != nil {
+	if err := pc.armWorkflowCurrentStageLifecycle(ctx, instance.EntityID, ""); err != nil {
 		return err
 	}
 	return nil

--- a/internal/runtime/pipeline/workflow_join_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 )
 
 const (
@@ -61,6 +62,10 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 		}
 
 		for _, plan := range workflowJoinPlansForStage(pc.SemanticSource(), instance.WorkflowName, nextStage) {
+			if plan.ResultType.Empty() {
+				lifecycleErr = fmt.Errorf("join %s has no resolved output type in the semantic plan", plan.Spec.EffectiveID())
+				return
+			}
 			members, ok := joinMemberSnapshot(instance.Metadata, plan.Spec.Members.From)
 			if !ok {
 				lifecycleErr = fmt.Errorf("join %s members source %s is not a unique list of non-empty text", plan.Spec.EffectiveID(), plan.Spec.Members.From)
@@ -99,10 +104,7 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 			}
 			kind := timeridentity.TimerHandleJoinTimeout
 			complete, err := joinruntime.CompletionSatisfied(activation, plan.Spec.CompleteWhen, func(expression string, joinContext map[string]any) (bool, error) {
-				return pc.expressionEval.EvalBool(expression, workflowExpressionContext{
-					Join:         joinContext,
-					WorkflowName: instance.WorkflowName,
-				})
+				return workflowexpr.EvalJoinBool(expression, joinContext, plan.ResultType)
 			})
 			if err != nil {
 				lifecycleErr = fmt.Errorf("evaluate join %s completion at arm: %w", plan.Spec.EffectiveID(), err)

--- a/internal/runtime/pipeline/workflow_join_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle.go
@@ -1,0 +1,283 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+const (
+	joinTimeoutEvent  = "platform.join_timeout"
+	joinCompleteEvent = "platform.join_complete"
+)
+
+func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, entityID, currentStage, nextStage string) error {
+	if pc == nil || pc.workflowStore == nil || !pc.workflowStore.Enabled() || pc.SemanticSource() == nil {
+		return nil
+	}
+	entityID = strings.TrimSpace(entityID)
+	currentStage = strings.TrimSpace(currentStage)
+	nextStage = strings.TrimSpace(nextStage)
+	if entityID == "" || nextStage == "" || currentStage == nextStage {
+		return nil
+	}
+
+	toSchedule := make([]Schedule, 0, 2)
+	toCancel := make([]Schedule, 0, 2)
+	now := time.Now().UTC()
+	var lifecycleErr error
+	err := pc.workflowStore.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
+		carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+		if err != nil {
+			lifecycleErr = fmt.Errorf("decode join state: %w", err)
+			return
+		}
+		activations, err := joinruntime.List(carrier.StateBuckets)
+		if err != nil {
+			lifecycleErr = fmt.Errorf("list join state: %w", err)
+			return
+		}
+		for _, activation := range activations {
+			if activation.Status != joinruntime.StatusOpen || activation.Stage != currentStage || activation.Stage == nextStage {
+				continue
+			}
+			activation.Close(joinruntime.CloseReasonStageExit, false, false)
+			activation.TimerCancelled = true
+			if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
+				lifecycleErr = fmt.Errorf("close join %s on stage exit: %w", activation.Key(), err)
+				return
+			}
+			toCancel = append(toCancel, joinSchedule(entityID, *instance, activation, timeridentity.TimerHandleJoinTimeout))
+		}
+
+		for _, plan := range workflowJoinPlansForStage(pc.SemanticSource(), instance.WorkflowName, nextStage) {
+			members, ok := joinMemberSnapshot(instance.Metadata, plan.Spec.Members.From)
+			if !ok {
+				lifecycleErr = fmt.Errorf("join %s members source %s is not a unique list of non-empty text", plan.Spec.EffectiveID(), plan.Spec.Members.From)
+				return
+			}
+			window := ""
+			if plan.Spec.Window != nil {
+				window = strings.TrimSpace(asString(instance.Metadata[joinTopLevelField(plan.Spec.Window.From, "entity")]))
+				if window == "" {
+					lifecycleErr = fmt.Errorf("join %s window source %s resolved empty", plan.Spec.EffectiveID(), plan.Spec.Window.From)
+					return
+				}
+			}
+			key := joinruntime.ActivationKey(plan.Spec.EffectiveID(), window)
+			if _, found, err := joinruntime.Load(carrier.StateBuckets, plan.NodeID, key); err != nil {
+				lifecycleErr = fmt.Errorf("load join %s: %w", key, err)
+				return
+			} else if found {
+				continue
+			}
+			delay := workflowTimerRenderedDelay(plan.Spec.Timeout.After, workflowTimerPolicy(pc.SemanticSource(), plan.FlowID))
+			interval, ok := timeridentity.ParseDelayDuration(delay)
+			if !ok {
+				lifecycleErr = fmt.Errorf("join %s timeout.after %q did not resolve to a positive duration", plan.Spec.EffectiveID(), plan.Spec.Timeout.After)
+				return
+			}
+			ref := timeridentity.NewJoinRef(plan.NodeID, plan.HandlerEvent, plan.Spec.EffectiveID(), window)
+			handle := timeridentity.JoinTimeoutHandle(ref)
+			activation, err := joinruntime.NewActivation(
+				plan.Spec.EffectiveID(), plan.Spec.Stage, plan.NodeID, plan.HandlerEvent, window, members,
+				now, now.Add(interval), handle.TaskID(), joinTimeoutEvent,
+			)
+			if err != nil {
+				lifecycleErr = fmt.Errorf("arm join %s: %w", plan.Spec.EffectiveID(), err)
+				return
+			}
+			kind := timeridentity.TimerHandleJoinTimeout
+			if activation.Expected() == 0 {
+				activation.Close(joinruntime.CloseReasonComplete, true, false)
+				kind = timeridentity.TimerHandleJoinComplete
+				completionHandle := timeridentity.JoinCompleteHandle(ref)
+				activation.FireAt = now
+				activation.TimerTaskID = completionHandle.TaskID()
+				activation.TimerEventType = joinCompleteEvent
+			}
+			if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
+				lifecycleErr = fmt.Errorf("persist join %s: %w", activation.Key(), err)
+				return
+			}
+			toSchedule = append(toSchedule, joinSchedule(entityID, *instance, activation, kind))
+		}
+		instance.StateBuckets = carrier.PersistedStateBuckets()
+	})
+	if err != nil {
+		return err
+	}
+	if lifecycleErr != nil {
+		return lifecycleErr
+	}
+	for _, schedule := range toCancel {
+		if err := pc.persistWorkflowTimerCancellation(ctx, scheduleWithRunIDFromContext(ctx, schedule)); err != nil {
+			return err
+		}
+	}
+	for _, schedule := range toSchedule {
+		if err := pc.persistWorkflowTimerSchedule(ctx, scheduleWithRunIDFromContext(ctx, schedule)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pc *PipelineCoordinator) reconcileClosedJoinSchedules(ctx context.Context, entityID string, carrier runtimeengine.StateCarrier) error {
+	activations, err := joinruntime.List(carrier.StateBuckets)
+	if err != nil {
+		return fmt.Errorf("list join activations: %w", err)
+	}
+	instance, ok, err := pc.workflowStore.Load(ctx, strings.TrimSpace(entityID))
+	if err != nil || !ok {
+		return err
+	}
+	changed := false
+	for _, activation := range activations {
+		if activation.Status != joinruntime.StatusClosed || activation.TimerTaskID == "" || activation.TimerCancelled {
+			continue
+		}
+		if activation.TimerEventType == joinCompleteEvent && activation.OutcomePending && !activation.OutcomeFired {
+			continue
+		}
+		kind := timeridentity.TimerHandleJoinTimeout
+		if activation.TimerEventType == joinCompleteEvent {
+			kind = timeridentity.TimerHandleJoinComplete
+		}
+		if err := pc.persistWorkflowTimerCancellation(ctx, scheduleWithRunIDFromContext(ctx, joinSchedule(entityID, instance, activation, kind))); err != nil {
+			return err
+		}
+		activation.TimerCancelled = true
+		if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
+			return fmt.Errorf("persist join timer cancellation %s: %w", activation.Key(), err)
+		}
+		changed = true
+	}
+	if changed {
+		return pc.workflowStore.Mutate(ctx, strings.TrimSpace(entityID), func(instance *WorkflowInstance) {
+			instance.StateBuckets = carrier.PersistedStateBuckets()
+		})
+	}
+	return nil
+}
+
+func (pc *PipelineCoordinator) armWorkflowCurrentStageLifecycle(ctx context.Context, entityID, sourceEvent string) error {
+	if pc == nil || pc.workflowStore == nil || !pc.workflowStore.Enabled() {
+		return nil
+	}
+	entityID = strings.TrimSpace(entityID)
+	if entityID == "" {
+		return nil
+	}
+	return pc.workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		instance, ok, err := pc.workflowStore.Load(txctx, entityID)
+		if err != nil || !ok {
+			return err
+		}
+		stage := strings.TrimSpace(instance.CurrentState)
+		if stage == "" {
+			return nil
+		}
+		if strings.TrimSpace(sourceEvent) == "" {
+			sourceEvent = "state:" + stage
+		}
+		if err := pc.applyWorkflowTimerIntents(txctx, entityID, "", stage, sourceEvent); err != nil {
+			return err
+		}
+		return pc.applyWorkflowJoinIntents(txctx, entityID, "", stage)
+	})
+}
+
+func workflowJoinPlansForStage(source semanticview.Source, flowID, stage string) []runtimecontracts.WorkflowJoinPlan {
+	if source == nil {
+		return nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	stage = strings.TrimSpace(stage)
+	out := make([]runtimecontracts.WorkflowJoinPlan, 0, 1)
+	for _, plan := range source.WorkflowJoins() {
+		planFlowID := strings.TrimSpace(plan.FlowID)
+		flowMatches := planFlowID == flowID
+		if planFlowID == "" {
+			flowMatches = flowID == "" || flowID == strings.TrimSpace(source.WorkflowName())
+		}
+		if flowMatches && strings.TrimSpace(plan.Spec.Stage) == stage {
+			out = append(out, plan)
+		}
+	}
+	return out
+}
+
+func joinMemberSnapshot(metadata map[string]any, path string) ([]string, bool) {
+	value, ok := metadata[joinTopLevelField(path, "entity")]
+	if !ok {
+		return nil, false
+	}
+	var raw []any
+	switch typed := value.(type) {
+	case []any:
+		raw = typed
+	case []string:
+		raw = make([]any, len(typed))
+		for i := range typed {
+			raw[i] = typed[i]
+		}
+	default:
+		return nil, false
+	}
+	members := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, item := range raw {
+		member, ok := item.(string)
+		member = strings.TrimSpace(member)
+		if !ok || member == "" {
+			return nil, false
+		}
+		if _, duplicate := seen[member]; duplicate {
+			return nil, false
+		}
+		seen[member] = struct{}{}
+		members = append(members, member)
+	}
+	return members, true
+}
+
+func joinTopLevelField(path, root string) string {
+	path = strings.TrimSpace(path)
+	prefix := strings.TrimSpace(root) + "."
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	field := strings.TrimPrefix(path, prefix)
+	if field == "" || strings.Contains(field, ".") {
+		return ""
+	}
+	return field
+}
+
+func joinSchedule(entityID string, instance WorkflowInstance, activation joinruntime.Activation, kind timeridentity.TimerHandleKind) Schedule {
+	ref := timeridentity.NewJoinRef(activation.NodeID, activation.HandlerEvent, activation.JoinID, activation.Window)
+	handle := timeridentity.JoinTimeoutHandle(ref)
+	eventType := joinTimeoutEvent
+	if kind == timeridentity.TimerHandleJoinComplete {
+		handle = timeridentity.JoinCompleteHandle(ref)
+		eventType = joinCompleteEvent
+	}
+	return Schedule{
+		AgentID:      runtimeWorkflowID,
+		EventType:    eventType,
+		Mode:         "once",
+		At:           activation.FireAt,
+		EntityID:     strings.TrimSpace(entityID),
+		FlowInstance: strings.Trim(strings.TrimSpace(instance.StorageRef), "/"),
+		TaskID:       handle.TaskID(),
+		Payload:      mustJSON(handle.PayloadMetadata()),
+	}
+}

--- a/internal/runtime/pipeline/workflow_join_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle.go
@@ -45,16 +45,19 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 			return
 		}
 		for _, activation := range activations {
-			if activation.Status != joinruntime.StatusOpen || activation.Stage != currentStage || activation.Stage == nextStage {
+			if activation.Stage != currentStage || activation.Stage == nextStage || !activation.CloseForStageExit() {
 				continue
 			}
-			activation.Close(joinruntime.CloseReasonStageExit, false, false)
+			kind := timeridentity.TimerHandleJoinTimeout
+			if activation.TimerEventType == joinCompleteEvent {
+				kind = timeridentity.TimerHandleJoinComplete
+			}
 			activation.TimerCancelled = true
 			if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
 				lifecycleErr = fmt.Errorf("close join %s on stage exit: %w", activation.Key(), err)
 				return
 			}
-			toCancel = append(toCancel, joinSchedule(entityID, *instance, activation, timeridentity.TimerHandleJoinTimeout))
+			toCancel = append(toCancel, joinSchedule(entityID, *instance, activation, kind))
 		}
 
 		for _, plan := range workflowJoinPlansForStage(pc.SemanticSource(), instance.WorkflowName, nextStage) {

--- a/internal/runtime/pipeline/workflow_join_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle.go
@@ -74,7 +74,7 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 					return
 				}
 			}
-			key := joinruntime.ActivationKey(plan.Spec.EffectiveID(), window)
+			key := joinruntime.ActivationKey(plan.Spec.Stage, plan.Spec.EffectiveID(), window)
 			if _, found, err := joinruntime.Load(carrier.StateBuckets, plan.NodeID, key); err != nil {
 				lifecycleErr = fmt.Errorf("load join %s: %w", key, err)
 				return
@@ -87,7 +87,7 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 				lifecycleErr = fmt.Errorf("join %s timeout.after %q did not resolve to a positive duration", plan.Spec.EffectiveID(), plan.Spec.Timeout.After)
 				return
 			}
-			ref := timeridentity.NewJoinRef(plan.NodeID, plan.HandlerEvent, plan.Spec.EffectiveID(), window)
+			ref := timeridentity.NewJoinRef(plan.NodeID, plan.HandlerEvent, plan.Spec.Stage, plan.Spec.EffectiveID(), window)
 			handle := timeridentity.JoinTimeoutHandle(ref)
 			activation, err := joinruntime.NewActivation(
 				plan.Spec.EffectiveID(), plan.Spec.Stage, plan.NodeID, plan.HandlerEvent, window, members,
@@ -98,7 +98,17 @@ func (pc *PipelineCoordinator) applyWorkflowJoinIntents(ctx context.Context, ent
 				return
 			}
 			kind := timeridentity.TimerHandleJoinTimeout
-			if activation.Expected() == 0 {
+			complete, err := joinruntime.CompletionSatisfied(activation, plan.Spec.CompleteWhen, func(expression string, joinContext map[string]any) (bool, error) {
+				return pc.expressionEval.EvalBool(expression, workflowExpressionContext{
+					Join:         joinContext,
+					WorkflowName: instance.WorkflowName,
+				})
+			})
+			if err != nil {
+				lifecycleErr = fmt.Errorf("evaluate join %s completion at arm: %w", plan.Spec.EffectiveID(), err)
+				return
+			}
+			if complete {
 				activation.Close(joinruntime.CloseReasonComplete, true, false)
 				kind = timeridentity.TimerHandleJoinComplete
 				completionHandle := timeridentity.JoinCompleteHandle(ref)
@@ -266,7 +276,7 @@ func joinTopLevelField(path, root string) string {
 }
 
 func joinSchedule(entityID string, instance WorkflowInstance, activation joinruntime.Activation, kind timeridentity.TimerHandleKind) Schedule {
-	ref := timeridentity.NewJoinRef(activation.NodeID, activation.HandlerEvent, activation.JoinID, activation.Window)
+	ref := timeridentity.NewJoinRef(activation.NodeID, activation.HandlerEvent, activation.Stage, activation.JoinID, activation.Window)
 	handle := timeridentity.JoinTimeoutHandle(ref)
 	eventType := joinTimeoutEvent
 	if kind == timeridentity.TimerHandleJoinComplete {

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -1,0 +1,594 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestArmWorkflowJoinPersistsActivationAndScheduleAtomically(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		members    []any
+		wantStatus joinruntime.Status
+		wantReason joinruntime.CloseReason
+		wantEvent  string
+		wantKind   timeridentity.TimerHandleKind
+	}{
+		{name: "members wait on timeout", members: []any{"a", "b"}, wantStatus: joinruntime.StatusOpen, wantEvent: joinTimeoutEvent, wantKind: timeridentity.TimerHandleJoinTimeout},
+		{name: "zero members complete immediately", members: []any{}, wantStatus: joinruntime.StatusClosed, wantReason: joinruntime.CloseReasonComplete, wantEvent: joinCompleteEvent, wantKind: timeridentity.TimerHandleJoinComplete},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+			schedules := &recordingSchedulePersistence{}
+			bundle := workflowJoinLifecycleBundle()
+			pc := &PipelineCoordinator{
+				module:             &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+				workflowStore:      store,
+				timerScheduleStore: schedules,
+			}
+			entityID := FlowInstanceEntityID("orders/order-1")
+			ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID: "order-1", StorageRef: "orders/order-1", WorkflowName: "orders", WorkflowVersion: "1.0.0",
+				CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": tc.members},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting"); err != nil {
+				t.Fatalf("arm join: %v", err)
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load instance = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok {
+				t.Fatalf("load activation = %#v, %v, %v", activation, ok, err)
+			}
+			if activation.Status != tc.wantStatus || activation.CloseReason != tc.wantReason {
+				t.Fatalf("activation status = %s/%s, want %s/%s", activation.Status, activation.CloseReason, tc.wantStatus, tc.wantReason)
+			}
+			if got := len(schedules.schedules); got != 1 {
+				t.Fatalf("schedules = %d, want 1", got)
+			}
+			schedule := schedules.schedules[0]
+			if schedule.EventType != tc.wantEvent || schedule.EntityID != entityID {
+				t.Fatalf("schedule = %#v", schedule)
+			}
+			handle, ok := timeridentity.ParseTimerHandle(parsePayloadMap(schedule.Payload))
+			if !ok || handle.Kind != tc.wantKind || handle.Join.JoinID != "awaiting" {
+				t.Fatalf("timer handle = %#v, %v", handle, ok)
+			}
+			if len(schedules.upsertTx) != 1 || !schedules.upsertTx[0] {
+				t.Fatalf("schedule persistence transaction flags = %#v, want [true]", schedules.upsertTx)
+			}
+		})
+	}
+}
+
+func TestArmWorkflowJoinPostgresParity(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		members    []any
+		wantStatus joinruntime.Status
+		wantEvent  string
+	}{
+		{name: "members", members: []any{"a"}, wantStatus: joinruntime.StatusOpen, wantEvent: joinTimeoutEvent},
+		{name: "expected zero", members: []any{}, wantStatus: joinruntime.StatusClosed, wantEvent: joinCompleteEvent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+			store := NewWorkflowInstanceStore(db)
+			schedules := &recordingSchedulePersistence{}
+			pc := &PipelineCoordinator{module: &pipelineFixtureWorkflowModule{source: semanticview.Wrap(workflowJoinLifecycleBundle())}, workflowStore: store, timerScheduleStore: schedules}
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": tc.members}}); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting"); err != nil {
+				t.Fatal(err)
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok || activation.Status != tc.wantStatus {
+				t.Fatalf("activation = %#v, %v, %v", activation, ok, err)
+			}
+			if len(schedules.schedules) != 1 || schedules.schedules[0].EventType != tc.wantEvent || len(schedules.upsertTx) != 1 || !schedules.upsertTx[0] {
+				t.Fatalf("schedule parity = schedules:%#v tx:%#v", schedules.schedules, schedules.upsertTx)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
+	}{
+		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.store(t)
+			bundle := workflowJoinLifecycleBundle()
+			bus := &recordingPipelineBus{}
+			pc := NewPipelineCoordinatorWithOptions(bus, store.db, PipelineCoordinatorOptions{Module: &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)}, WorkflowStore: store})
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			now := time.Now().UTC()
+			activation, err := joinruntime.NewActivation("awaiting", "awaiting", "join-node", "item.completed", "", []string{"a"}, now, now.Add(time.Hour), "join-timeout", joinTimeoutEvent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			carrier := runtimeengine.NewStateCarrier(map[string]any{"expected": []any{"a"}}, nil, map[string]map[string]any{})
+			if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "awaiting", EnteredStageAt: now, Metadata: map[string]any{"entity_id": entityID, "expected": []any{"a"}}, StateBuckets: carrier.PersistedStateBuckets()}); err != nil {
+				t.Fatal(err)
+			}
+			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+			member := eventtest.RootIngress("member-a", events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now)
+			ref := timeridentity.NewJoinRef("join-node", "item.completed", "awaiting", "")
+			handle := timeridentity.JoinTimeoutHandle(ref)
+			timeout := eventtest.RootIngress("timeout-a", events.EventType(joinTimeoutEvent), "", handle.TaskID(), mustJSON(handle.PayloadMetadata()), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now.Add(time.Hour))
+			type raceResult struct {
+				result contractHandlerExecutionResult
+				err    error
+			}
+			start := make(chan struct{})
+			results := make(chan raceResult, 2)
+			var wg sync.WaitGroup
+			for _, evt := range []events.Event{member, timeout} {
+				evt := evt
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					result, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: evt, State: pc.currentWorkflowState(ctx, entityID), HandlerEventKey: "item.completed"}, false)
+					results <- raceResult{result: result, err: err}
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(results)
+			for result := range results {
+				if result.err != nil {
+					envelope, ok := runtimefailures.EnvelopeFromError(result.err)
+					if !ok || envelope.Class != runtimefailures.ClassStaleArrival {
+						t.Fatalf("race error = %v, envelope=%#v", result.err, envelope)
+					}
+				}
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load final instance = %v, %v", ok, err)
+			}
+			if len(instance.TransitionHistory) != 1 {
+				t.Fatalf("persisted transition winners = %d, want 1: %#v", len(instance.TransitionHistory), instance.TransitionHistory)
+			}
+			finalCarrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			closed, ok, err := joinruntime.Load(finalCarrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok || closed.Status != joinruntime.StatusClosed {
+				t.Fatalf("closed activation = %#v, %v, %v", closed, ok, err)
+			}
+			if closed.CloseReason == joinruntime.CloseReasonComplete && instance.CurrentState != "ready" {
+				t.Fatalf("complete close state = %s", instance.CurrentState)
+			}
+			if closed.CloseReason == joinruntime.CloseReasonTimeout && instance.CurrentState != "attention" {
+				t.Fatalf("timeout close state = %s", instance.CurrentState)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinArmArrivalRaceIsEarlyOrAdmittedOnBothStores(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
+	}{
+		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.store(t)
+			bundle := workflowJoinLifecycleBundle()
+			bus := &recordingPipelineBus{}
+			schedules := &recordingSchedulePersistence{}
+			pc := NewPipelineCoordinatorWithOptions(bus, store.db, PipelineCoordinatorOptions{Module: &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)}, WorkflowStore: store, TimerScheduleStore: schedules})
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "dispatching", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{"a", "b"}}}); err != nil {
+				t.Fatal(err)
+			}
+			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+			arrival := eventtest.RootIngress("member-a", events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			start := make(chan struct{})
+			armErr := make(chan error, 1)
+			arrivalErr := make(chan error, 1)
+			go func() {
+				<-start
+				armErr <- pc.updateEntityState(ctx, entityID, "awaiting", "dispatch.completed")
+			}()
+			go func() {
+				<-start
+				_, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: arrival, State: pc.currentWorkflowState(ctx, entityID), HandlerEventKey: "item.completed"}, false)
+				arrivalErr <- err
+			}()
+			close(start)
+			if err := <-armErr; err != nil {
+				t.Fatalf("arm: %v", err)
+			}
+			err := <-arrivalErr
+			if err != nil {
+				envelope, ok := runtimefailures.EnvelopeFromError(err)
+				if !ok || envelope.Class != runtimefailures.ClassEarlyArrival {
+					t.Fatalf("arrival error = %v, envelope=%#v", err, envelope)
+				}
+			}
+			instance, ok, loadErr := store.Load(ctx, entityID)
+			if loadErr != nil || !ok {
+				t.Fatalf("load = %v, %v", ok, loadErr)
+			}
+			carrier, loadErr := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			activation, ok, loadErr := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if loadErr != nil || !ok || activation.Status != joinruntime.StatusOpen {
+				t.Fatalf("activation = %#v, %v, %v", activation, ok, loadErr)
+			}
+			if activation.Completed() < 0 || activation.Completed() > 1 {
+				t.Fatalf("completed = %d, want early 0 or admitted 1", activation.Completed())
+			}
+			if (err == nil) != (activation.Completed() == 1) {
+				t.Fatalf("arrival err=%v completed=%d; want exact early/admitted alternatives", err, activation.Completed())
+			}
+			if len(schedules.schedules) != 1 {
+				t.Fatalf("schedule intents = %d, want 1", len(schedules.schedules))
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinPersistedArrivalClassificationOnBothStores(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
+	}{
+		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.store(t)
+			bundle := workflowJoinLifecycleBundle()
+			schedules := &recordingSchedulePersistence{}
+			newCoordinator := func() *PipelineCoordinator {
+				return NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, store.db, PipelineCoordinatorOptions{Module: &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)}, WorkflowStore: store, TimerScheduleStore: schedules})
+			}
+			pc := newCoordinator()
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "dispatching", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{"a", "b"}}}); err != nil {
+				t.Fatal(err)
+			}
+			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+			deliver := func(coordinator *PipelineCoordinator, id, member, result string) error {
+				evt := eventtest.RootIngress(id, events.EventType("item.completed"), "", "", mustJSON(map[string]any{"member_id": member, "result": map[string]any{"value": result}}), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+				_, err := coordinator.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: evt, State: coordinator.currentWorkflowState(ctx, entityID), HandlerEventKey: "item.completed"}, false)
+				return err
+			}
+			assertClass := func(err error, want runtimefailures.Class) {
+				t.Helper()
+				envelope, ok := runtimefailures.EnvelopeFromError(err)
+				if err == nil || !ok || envelope.Class != want {
+					t.Fatalf("error = %v, envelope=%#v, want %s", err, envelope, want)
+				}
+			}
+
+			assertClass(deliver(pc, "early", "a", "one"), runtimefailures.ClassEarlyArrival)
+			if err := pc.updateEntityState(ctx, entityID, "awaiting", "dispatch.completed"); err != nil {
+				t.Fatal(err)
+			}
+			assertClass(deliver(pc, "unexpected", "c", "other"), runtimefailures.ClassUnexpectedArrival)
+			if err := deliver(pc, "a-first", "a", "one"); err != nil {
+				t.Fatal(err)
+			}
+			pc = newCoordinator()
+			if err := deliver(pc, "a-exact", "a", "one"); err != nil {
+				t.Fatal(err)
+			}
+			assertClass(deliver(pc, "a-conflict", "a", "changed"), runtimefailures.ClassConflictingDuplicate)
+			if err := deliver(pc, "b-complete", "b", "two"); err != nil {
+				t.Fatal(err)
+			}
+			assertClass(deliver(pc, "b-stale", "b", "two"), runtimefailures.ClassStaleArrival)
+
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			closed, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok || closed.Status != joinruntime.StatusClosed || closed.Completed() != 2 {
+				t.Fatalf("closed activation = %#v, %v, %v", closed, ok, err)
+			}
+			results := closed.Results()
+			if len(results) != 2 || results[0].(map[string]any)["value"] != "one" || results[1].(map[string]any)["value"] != "two" {
+				t.Fatalf("persisted results = %#v, want membership order", results)
+			}
+			if instance.CurrentState != "ready" || len(instance.TransitionHistory) != 2 {
+				t.Fatalf("final lifecycle = state:%s history:%#v", instance.CurrentState, instance.TransitionHistory)
+			}
+			if schedules.cancelOwned != 1 || len(schedules.cancelTx) != 1 || !schedules.cancelTx[0] {
+				t.Fatalf("timeout cancellation = count:%d tx:%#v", schedules.cancelOwned, schedules.cancelTx)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinExpectedZeroCompletesAfterRestartOnBothStores(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
+	}{
+		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.store(t)
+			bundle := workflowJoinLifecycleBundle()
+			schedules := &recordingSchedulePersistence{}
+			newCoordinator := func() *PipelineCoordinator {
+				return NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, store.db, PipelineCoordinatorOptions{Module: &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)}, WorkflowStore: store, TimerScheduleStore: schedules})
+			}
+			pc := newCoordinator()
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "dispatching", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{}}}); err != nil {
+				t.Fatal(err)
+			}
+			dispatchHandler := bundle.Nodes["dispatcher"].EventHandlers["order.accepted"]
+			dispatch := eventtest.RootIngress("fan-out-empty", events.EventType("order.accepted"), "", "", json.RawMessage(`{"line_items":[]}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			result, err := pc.executeNodeContractHandler(ctx, "dispatcher", dispatchHandler, workflowTriggerContext{Event: dispatch, State: pc.currentWorkflowState(ctx, entityID), HandlerEventKey: "order.accepted"}, false)
+			if err != nil || !result.Handled || result.Outcome == nil || result.Outcome.FanOutCount != 0 {
+				t.Fatalf("empty fan_out = handled:%v outcome:%#v err:%v", result.Handled, result.Outcome, err)
+			}
+			if len(schedules.schedules) != 1 || schedules.schedules[0].EventType != joinCompleteEvent {
+				t.Fatalf("completion schedules = %#v", schedules.schedules)
+			}
+			armed, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load armed zero join = %v, %v", ok, err)
+			}
+			armedCarrier, err := runtimeengine.StateCarrierFromPersisted(armed.Metadata, armed.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.reconcileClosedJoinSchedules(ctx, entityID, armedCarrier); err != nil {
+				t.Fatalf("reconcile pending zero join: %v", err)
+			}
+			if schedules.cancelOwned != 0 {
+				t.Fatalf("pending expected-zero completion was canceled before fire: %#v", schedules.cancels)
+			}
+			schedule := schedules.schedules[0]
+			pc = newCoordinator()
+			fire := eventtest.RootIngress("join-zero-fire", events.EventType(schedule.EventType), "", schedule.TaskID, schedule.Payload, 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			result, err = pc.executeAuthoritativeNodeHandler(ctx, fire, workflowTriggerContext{Event: fire, State: pc.currentWorkflowState(ctx, entityID)})
+			if err != nil || !result.Handled {
+				t.Fatalf("completion fire = handled:%v err:%v", result.Handled, err)
+			}
+			if _, err := pc.executeAuthoritativeNodeHandler(ctx, fire, workflowTriggerContext{Event: fire, State: pc.currentWorkflowState(ctx, entityID)}); err != nil {
+				t.Fatalf("duplicate completion fire: %v", err)
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok || !activation.OutcomeFired || activation.OutcomePending || !activation.TimerCancelled {
+				t.Fatalf("zero activation = %#v, %v, %v", activation, ok, err)
+			}
+			if instance.CurrentState != "ready" || len(instance.TransitionHistory) != 2 {
+				t.Fatalf("zero completion lifecycle = state:%s history:%#v", instance.CurrentState, instance.TransitionHistory)
+			}
+			if schedules.cancelOwned != 1 {
+				t.Fatalf("fired expected-zero completion cancellation count = %d, want 1", schedules.cancelOwned)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinFailurePersistsCanonicalReceiptAndRuntimeLog(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	ctx := sqliteExactOnceRunContext(t, db)
+	bundle := workflowJoinLifecycleBundle()
+	bus := &recordingPipelineBus{}
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module:                  &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+		WorkflowStore:           store,
+		EventReceiptsCapability: func(context.Context) (bool, error) { return true, nil },
+	})
+	path := "orders/" + uuid.NewString()
+	entityID := FlowInstanceEntityID(path)
+	if err := store.Upsert(ctx, WorkflowInstance{InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0", CurrentState: "dispatching", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{"a"}}}); err != nil {
+		t.Fatal(err)
+	}
+	evt := eventtest.RootIngress(uuid.NewString(), events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+	seedExactOnceEventDelivery(t, store, ctx, evt, "join-node")
+	if resolved := workflowNodeEventHandlerResolutionForDelivery(pc.SemanticSource(), "join-node", evt); !resolved.Matched {
+		t.Fatalf("join handler did not resolve: %#v", resolved)
+	}
+	if !pc.workflowNodeDeliveryAuthorized(ctx, "join-node", evt) {
+		t.Fatal("seeded join delivery was not authorized")
+	}
+	handled, err := pc.executeNodeHandlerPlanResult(ctx, "join-node", evt)
+	if !handled {
+		t.Fatal("join failure was not handled")
+	}
+	envelope, ok := runtimefailures.EnvelopeFromError(err)
+	if !ok || envelope.Class != runtimefailures.ClassEarlyArrival {
+		t.Fatalf("execution failure = %v, envelope=%#v", err, envelope)
+	}
+	var status, failureRaw, receiptOutcome string
+	if err := db.QueryRowContext(ctx, `
+		SELECT d.status, COALESCE(d.failure, ''), COALESCE(r.outcome, '')
+		FROM event_deliveries d
+		LEFT JOIN event_receipts r ON r.event_id = d.event_id AND r.subscriber_type = d.subscriber_type AND r.subscriber_id = d.subscriber_id
+		WHERE d.event_id = ? AND d.subscriber_type = 'node' AND d.subscriber_id = 'join-node'
+	`, evt.ID()).Scan(&status, &failureRaw, &receiptOutcome); err != nil {
+		t.Fatal(err)
+	}
+	var persisted runtimefailures.Envelope
+	if err := json.Unmarshal([]byte(failureRaw), &persisted); err != nil {
+		t.Fatalf("decode persisted failure %q: %v", failureRaw, err)
+	}
+	if status != "dead_letter" || receiptOutcome != "dead_letter" || persisted.Class != runtimefailures.ClassEarlyArrival {
+		t.Fatalf("persisted failure = status:%s receipt:%s failure:%#v", status, receiptOutcome, persisted)
+	}
+	logs := bus.runtimeLogEntries()
+	if len(logs) == 0 || logs[len(logs)-1].Failure == nil || logs[len(logs)-1].Failure.Class != runtimefailures.ClassEarlyArrival {
+		t.Fatalf("runtime logs = %#v", logs)
+	}
+}
+
+func workflowJoinLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
+	spec := runtimecontracts.JoinSpec{
+		ID: "awaiting", Stage: "awaiting",
+		Members: runtimecontracts.JoinMembersSpec{From: "entity.expected", FromPath: runtimepaths.Parse("entity.expected"), By: "payload.member_id", ByPath: runtimepaths.Parse("payload.member_id")},
+		Output:  "payload.result", OutputPath: runtimepaths.Parse("payload.result"), OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready"}, OnCompleteFound: true,
+		Timeout: runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention"}}, TimeoutFound: true,
+	}
+	fanOut := runtimecontracts.FanOutSpec{
+		ItemsFrom: "payload.line_items", ItemsPath: runtimepaths.Parse("payload.line_items"), As: "line_item", Identity: "line_item.id",
+		Emit: runtimecontracts.EmitSpec{Event: "line_item.requested", Fields: map[string]runtimecontracts.ExpressionValue{"line_item_id": runtimecontracts.CELExpression("line_item.id")}},
+	}
+	joinNode := runtimecontracts.SystemNodeContract{EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+		"item.completed": {Join: &spec},
+	}}
+	dispatcher := runtimecontracts.SystemNodeContract{EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+		"order.accepted": {FanOut: &fanOut, AdvancesTo: "awaiting"},
+	}}
+	return &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true, Entries: []runtimecontracts.FlowStageDeclaration{{ID: "dispatching", Initial: true}, {ID: "awaiting"}, {ID: "ready", Terminal: true}, {ID: "attention", Terminal: true}}}},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"join-node":  joinNode,
+			"dispatcher": dispatcher,
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"item.completed":      {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"member_id": {Type: "text"}, "result": {Type: "jsonb"}}}},
+			"order.accepted":      {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"line_items": {Type: "list<jsonb>"}}}},
+			"line_item.requested": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"line_item_id": {Type: "text"}}}},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "orders", Version: "1.0.0", InitialStage: "dispatching", Stages: []runtimecontracts.WorkflowStageContract{{ID: "dispatching"}, {ID: "awaiting"}, {ID: "ready"}, {ID: "attention"}}, TerminalStages: []string{"ready", "attention"},
+			Joins: []runtimecontracts.WorkflowJoinPlan{{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec}},
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				"join-node":  {ID: "join-node", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(joinNode)},
+				"dispatcher": {ID: "dispatcher", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(dispatcher)},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"join-node":  joinNode.EventHandlers,
+				"dispatcher": dispatcher.EventHandlers,
+			},
+			EventOwners: map[string][]string{
+				"item.completed": {"join-node"},
+				"order.accepted": {"dispatcher"},
+			},
+		},
+	}
+}

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -179,6 +179,7 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 			ref := timeridentity.NewJoinRef("join-node", "item.completed", "awaiting", "")
 			handle := timeridentity.JoinTimeoutHandle(ref)
 			timeout := eventtest.RootIngress("timeout-a", events.EventType(joinTimeoutEvent), "", handle.TaskID(), mustJSON(handle.PayloadMetadata()), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now.Add(time.Hour))
+			triggerState := pc.currentWorkflowState(ctx, entityID)
 			type raceResult struct {
 				result contractHandlerExecutionResult
 				err    error
@@ -192,7 +193,7 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 				go func() {
 					defer wg.Done()
 					<-start
-					result, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: evt, State: pc.currentWorkflowState(ctx, entityID), HandlerEventKey: "item.completed"}, false)
+					result, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: evt, State: triggerState, HandlerEventKey: "item.completed"}, false)
 					results <- raceResult{result: result, err: err}
 				}()
 			}

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -62,7 +62,7 @@ func TestArmWorkflowJoinPersistsActivationAndScheduleAtomically(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok {
 				t.Fatalf("load activation = %#v, %v, %v", activation, ok, err)
 			}
@@ -124,7 +124,7 @@ func TestArmWorkflowJoinPostgresParity(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok || activation.Status != tc.wantStatus {
 				t.Fatalf("activation = %#v, %v, %v", activation, ok, err)
 			}
@@ -132,6 +132,148 @@ func TestArmWorkflowJoinPostgresParity(t *testing.T) {
 				t.Fatalf("schedule parity = schedules:%#v tx:%#v", schedules.schedules, schedules.upsertTx)
 			}
 		})
+	}
+}
+
+func TestWorkflowJoinCustomCompletionControlsExpectedZeroOnBothStores(t *testing.T) {
+	for _, tc := range workflowJoinStoreCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.open(t)
+			bundle := workflowJoinLifecycleBundle()
+			node := bundle.Nodes["join-node"]
+			handler := node.EventHandlers["item.completed"]
+			spec := *handler.Join
+			spec.CompleteWhen = "join.completed >= 1"
+			spec.Remaining = runtimecontracts.JoinRemainingIgnore
+			handler.Join = &spec
+			node.EventHandlers["item.completed"] = handler
+			bundle.Nodes["join-node"] = node
+			bundle.Semantics.Joins[0].Spec = spec
+			bundle.Semantics.NodeHandlers["join-node"] = node.EventHandlers
+
+			schedules := &recordingSchedulePersistence{}
+			pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, store.db, PipelineCoordinatorOptions{
+				Module:             &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+				WorkflowStore:      store,
+				TimerScheduleStore: schedules,
+			})
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0",
+				CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting"); err != nil {
+				t.Fatalf("arm custom join: %v", err)
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load custom join = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
+			if err != nil || !ok || activation.Status != joinruntime.StatusOpen || activation.CloseReason != "" {
+				t.Fatalf("custom zero activation = %#v, %v, %v, want open", activation, ok, err)
+			}
+			if len(schedules.schedules) != 1 || schedules.schedules[0].EventType != joinTimeoutEvent {
+				t.Fatalf("custom zero schedules = %#v, want timeout", schedules.schedules)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
+	for _, tc := range workflowJoinStoreCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.open(t)
+			bundle := workflowJoinLifecycleBundle()
+			node := bundle.Nodes["join-node"]
+			first := *node.EventHandlers["item.completed"].Join
+			first.ID = "shared"
+			first.Stage = "awaiting"
+			second := first
+			second.Stage = "reviewing"
+			node.EventHandlers["item.completed"] = runtimecontracts.SystemNodeEventHandler{Join: &first}
+			node.EventHandlers["approval.completed"] = runtimecontracts.SystemNodeEventHandler{Join: &second}
+			bundle.Nodes["join-node"] = node
+			bundle.Events["approval.completed"] = bundle.Events["item.completed"]
+			bundle.RootSchema.StageDeclarations.Entries = append(bundle.RootSchema.StageDeclarations.Entries, runtimecontracts.FlowStageDeclaration{ID: "reviewing"})
+			bundle.Semantics.Stages = append(bundle.Semantics.Stages, runtimecontracts.WorkflowStageContract{ID: "reviewing"})
+			bundle.Semantics.Joins = []runtimecontracts.WorkflowJoinPlan{
+				{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: first},
+				{FlowID: "", NodeID: "join-node", HandlerEvent: "approval.completed", Spec: second},
+			}
+			bundle.Semantics.NodeHandlers["join-node"] = node.EventHandlers
+			bundle.Semantics.EffectiveNodes["join-node"] = runtimecontracts.SystemNodeEffectiveSemantics{ID: "join-node", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(node)}
+
+			schedules := &recordingSchedulePersistence{}
+			pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, store.db, PipelineCoordinatorOptions{
+				Module:             &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+				WorkflowStore:      store,
+				TimerScheduleStore: schedules,
+			})
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0",
+				CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{"a"}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting"); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.applyWorkflowJoinIntents(ctx, entityID, "awaiting", "reviewing"); err != nil {
+				t.Fatal(err)
+			}
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load stage-scoped joins = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			awaiting, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", joinruntime.ActivationKey("awaiting", "shared", ""))
+			if err != nil || !ok || awaiting.CloseReason != joinruntime.CloseReasonStageExit {
+				t.Fatalf("awaiting activation = %#v, %v, %v", awaiting, ok, err)
+			}
+			reviewing, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", joinruntime.ActivationKey("reviewing", "shared", ""))
+			if err != nil || !ok || reviewing.Status != joinruntime.StatusOpen || reviewing.Stage != "reviewing" {
+				t.Fatalf("reviewing activation = %#v, %v, %v", reviewing, ok, err)
+			}
+			if awaiting.Key() == reviewing.Key() || len(schedules.schedules) != 2 {
+				t.Fatalf("stage identities/schedules = awaiting:%q reviewing:%q schedules:%#v", awaiting.Key(), reviewing.Key(), schedules.schedules)
+			}
+		})
+	}
+}
+
+type workflowJoinStoreCase struct {
+	name string
+	open func(*testing.T) (*WorkflowInstanceStore, context.Context)
+}
+
+func workflowJoinStoreCases() []workflowJoinStoreCase {
+	return []workflowJoinStoreCase{
+		{name: "sqlite", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
 	}
 }
 
@@ -176,7 +318,7 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 			}
 			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
 			member := eventtest.RootIngress("member-a", events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now)
-			ref := timeridentity.NewJoinRef("join-node", "item.completed", "awaiting", "")
+			ref := timeridentity.NewJoinRef("join-node", "item.completed", "awaiting", "awaiting", "")
 			handle := timeridentity.JoinTimeoutHandle(ref)
 			timeout := eventtest.RootIngress("timeout-a", events.EventType(joinTimeoutEvent), "", handle.TaskID(), mustJSON(handle.PayloadMetadata()), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now.Add(time.Hour))
 			triggerState := pc.currentWorkflowState(ctx, entityID)
@@ -219,7 +361,7 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 			if err != nil {
 				t.Fatal(err)
 			}
-			closed, ok, err := joinruntime.Load(finalCarrier.StateBuckets, "join-node", "awaiting")
+			closed, ok, err := joinruntime.Load(finalCarrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok || closed.Status != joinruntime.StatusClosed {
 				t.Fatalf("closed activation = %#v, %v, %v", closed, ok, err)
 			}
@@ -300,7 +442,7 @@ func TestWorkflowJoinArmArrivalRaceIsEarlyOrAdmittedOnBothStores(t *testing.T) {
 			if loadErr != nil {
 				t.Fatal(loadErr)
 			}
-			activation, ok, loadErr := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			activation, ok, loadErr := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if loadErr != nil || !ok || activation.Status != joinruntime.StatusOpen {
 				t.Fatalf("activation = %#v, %v, %v", activation, ok, loadErr)
 			}
@@ -390,7 +532,7 @@ func TestWorkflowJoinPersistedArrivalClassificationOnBothStores(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			closed, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			closed, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok || closed.Status != joinruntime.StatusClosed || closed.Completed() != 2 {
 				t.Fatalf("closed activation = %#v, %v, %v", closed, ok, err)
 			}
@@ -482,7 +624,7 @@ func TestWorkflowJoinExpectedZeroCompletesAfterRestartOnBothStores(t *testing.T)
 			if err != nil {
 				t.Fatal(err)
 			}
-			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok || !activation.OutcomeFired || activation.OutcomePending || !activation.TimerCancelled {
 				t.Fatalf("zero activation = %#v, %v, %v", activation, ok, err)
 			}
@@ -555,7 +697,7 @@ func TestWorkflowJoinExpectedZeroStageExitCancelsPendingCompletionOnBothStores(t
 			if err != nil {
 				t.Fatal(err)
 			}
-			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
 			if err != nil || !ok || activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonStageExit || activation.OutcomePending || activation.OutcomeFired || !activation.TimerCancelled {
 				t.Fatalf("exited zero activation = %#v, %v, %v", activation, ok, err)
 			}
@@ -675,4 +817,8 @@ func workflowJoinLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
 			},
 		},
 	}
+}
+
+func workflowJoinActivationKey() string {
+	return joinruntime.ActivationKey("awaiting", "awaiting", "")
 }

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -492,6 +492,86 @@ func TestWorkflowJoinExpectedZeroCompletesAfterRestartOnBothStores(t *testing.T)
 	}
 }
 
+func TestWorkflowJoinExpectedZeroStageExitCancelsPendingCompletionOnBothStores(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
+	}{
+		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+		}},
+		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
+			_, db, cleanup := testutil.StartPostgres(t)
+			t.Cleanup(cleanup)
+			runID := uuid.NewString()
+			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+				t.Fatal(err)
+			}
+			return NewWorkflowInstanceStore(db), runtimecorrelation.WithRunID(context.Background(), runID)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, ctx := tc.store(t)
+			bundle := workflowJoinLifecycleBundle()
+			schedules := &recordingSchedulePersistence{}
+			pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, store.db, PipelineCoordinatorOptions{
+				Module:             &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+				WorkflowStore:      store,
+				TimerScheduleStore: schedules,
+			})
+			path := "orders/" + uuid.NewString()
+			entityID := FlowInstanceEntityID(path)
+			if err := store.Upsert(ctx, WorkflowInstance{
+				InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: "orders", WorkflowVersion: "1.0.0",
+				CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{}},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting"); err != nil {
+				t.Fatalf("arm zero join: %v", err)
+			}
+			if len(schedules.schedules) != 1 || schedules.schedules[0].EventType != joinCompleteEvent {
+				t.Fatalf("completion schedules = %#v", schedules.schedules)
+			}
+			completion := schedules.schedules[0]
+			if err := pc.updateEntityState(ctx, entityID, "dispatching", "manual.abort"); err != nil {
+				t.Fatalf("exit join stage: %v", err)
+			}
+			if schedules.cancelOwned != 1 || len(schedules.cancels) != 1 || schedules.cancels[0].EventType != joinCompleteEvent || len(schedules.cancelTx) != 1 || !schedules.cancelTx[0] {
+				t.Fatalf("completion cancellation = count:%d cancels:%#v tx:%#v", schedules.cancelOwned, schedules.cancels, schedules.cancelTx)
+			}
+
+			instance, ok, err := store.Load(ctx, entityID)
+			if err != nil || !ok {
+				t.Fatalf("load exited instance = %v, %v", ok, err)
+			}
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", "awaiting")
+			if err != nil || !ok || activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonStageExit || activation.OutcomePending || activation.OutcomeFired || !activation.TimerCancelled {
+				t.Fatalf("exited zero activation = %#v, %v, %v", activation, ok, err)
+			}
+
+			fire := eventtest.RootIngress("join-zero-after-exit", events.EventType(completion.EventType), "", completion.TaskID, completion.Payload, 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			result, err := pc.executeAuthoritativeNodeHandler(ctx, fire, workflowTriggerContext{Event: fire, State: pc.currentWorkflowState(ctx, entityID)})
+			if err != nil || !result.Handled {
+				t.Fatalf("late completion fire = handled:%v err:%v", result.Handled, err)
+			}
+			instance, ok, err = store.Load(ctx, entityID)
+			if err != nil || !ok || instance.CurrentState != "dispatching" || len(instance.TransitionHistory) != 1 {
+				t.Fatalf("lifecycle after late completion = instance:%#v found:%v err:%v", instance, ok, err)
+			}
+			if schedules.cancelOwned != 1 {
+				t.Fatalf("late completion repeated cancellation: %d", schedules.cancelOwned)
+			}
+		})
+	}
+}
+
 func TestWorkflowJoinFailurePersistsCanonicalReceiptAndRuntimeLog(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -187,6 +188,44 @@ func TestWorkflowJoinCustomCompletionControlsExpectedZeroOnBothStores(t *testing
 	}
 }
 
+func TestWorkflowJoinArmRejectsCatalogInvalidNamedResultExpression(t *testing.T) {
+	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
+	bundle := workflowJoinLifecycleBundle()
+	node := bundle.Nodes["join-node"]
+	handler := node.EventHandlers["item.completed"]
+	spec := *handler.Join
+	spec.CompleteWhen = "join.results[0] > 1"
+	spec.Remaining = runtimecontracts.JoinRemainingIgnore
+	handler.Join = &spec
+	node.EventHandlers["item.completed"] = handler
+	bundle.Nodes["join-node"] = node
+	bundle.Semantics.Joins[0].Spec = spec
+	bundle.Semantics.Joins[0].ResultType = runtimecontracts.CatalogTypeReference{
+		Type: "JoinResult",
+		Catalog: runtimecontracts.TypeCatalogDocument{Types: map[string]runtimecontracts.NamedTypeDecl{
+			"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{"value": {Type: "text"}}},
+		}},
+	}
+
+	pc := &PipelineCoordinator{
+		module:        &pipelineFixtureWorkflowModule{source: semanticview.Wrap(bundle)},
+		workflowStore: store,
+	}
+	entityID := FlowInstanceEntityID("orders/order-typed")
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	if err := store.Upsert(ctx, WorkflowInstance{
+		InstanceID: "order-typed", StorageRef: "orders/order-typed", WorkflowName: "orders", WorkflowVersion: "1.0.0",
+		CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{"entity_id": entityID, "expected": []any{}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := pc.armWorkflowCurrentStageLifecycle(ctx, entityID, "state:awaiting")
+	if err == nil || !strings.Contains(err.Error(), "no matching overload") {
+		t.Fatalf("arm join error = %v, want catalog-backed typed rejection", err)
+	}
+}
+
 func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
 	for _, tc := range workflowJoinStoreCases() {
 		t.Run(tc.name, func(t *testing.T) {
@@ -204,9 +243,10 @@ func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
 			bundle.Events["approval.completed"] = bundle.Events["item.completed"]
 			bundle.RootSchema.StageDeclarations.Entries = append(bundle.RootSchema.StageDeclarations.Entries, runtimecontracts.FlowStageDeclaration{ID: "reviewing"})
 			bundle.Semantics.Stages = append(bundle.Semantics.Stages, runtimecontracts.WorkflowStageContract{ID: "reviewing"})
+			resultType := runtimecontracts.CatalogTypeReference{Type: "jsonb"}
 			bundle.Semantics.Joins = []runtimecontracts.WorkflowJoinPlan{
-				{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: first},
-				{FlowID: "", NodeID: "join-node", HandlerEvent: "approval.completed", Spec: second},
+				{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: first, ResultType: resultType},
+				{FlowID: "", NodeID: "join-node", HandlerEvent: "approval.completed", Spec: second, ResultType: resultType},
 			}
 			bundle.Semantics.NodeHandlers["join-node"] = node.EventHandlers
 			bundle.Semantics.EffectiveNodes["join-node"] = runtimecontracts.SystemNodeEffectiveSemantics{ID: "join-node", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(node)}
@@ -773,6 +813,7 @@ func TestWorkflowJoinFailurePersistsCanonicalReceiptAndRuntimeLog(t *testing.T) 
 }
 
 func workflowJoinLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
+	resultType := runtimecontracts.CatalogTypeReference{Type: "jsonb"}
 	spec := runtimecontracts.JoinSpec{
 		ID: "awaiting", Stage: "awaiting",
 		Members: runtimecontracts.JoinMembersSpec{From: "entity.expected", FromPath: runtimepaths.Parse("entity.expected"), By: "payload.member_id", ByPath: runtimepaths.Parse("payload.member_id")},
@@ -802,7 +843,7 @@ func workflowJoinLifecycleBundle() *runtimecontracts.WorkflowContractBundle {
 		},
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			Name: "orders", Version: "1.0.0", InitialStage: "dispatching", Stages: []runtimecontracts.WorkflowStageContract{{ID: "dispatching"}, {ID: "awaiting"}, {ID: "ready"}, {ID: "attention"}}, TerminalStages: []string{"ready", "attention"},
-			Joins: []runtimecontracts.WorkflowJoinPlan{{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec}},
+			Joins: []runtimecontracts.WorkflowJoinPlan{{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec, ResultType: resultType}},
 			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
 				"join-node":  {ID: "join-node", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(joinNode)},
 				"dispatcher": {ID: "dispatcher", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(dispatcher)},

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -265,16 +265,19 @@ func TestWorkflowJoinArmArrivalRaceIsEarlyOrAdmittedOnBothStores(t *testing.T) {
 			}
 			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
 			arrival := eventtest.RootIngress("member-a", events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			triggerState := pc.currentWorkflowState(ctx, entityID)
 			start := make(chan struct{})
 			armErr := make(chan error, 1)
 			arrivalErr := make(chan error, 1)
 			go func() {
 				<-start
+				unlock := pc.lockWorkflowEntity(entityID)
+				defer unlock()
 				armErr <- pc.updateEntityState(ctx, entityID, "awaiting", "dispatch.completed")
 			}()
 			go func() {
 				<-start
-				_, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: arrival, State: pc.currentWorkflowState(ctx, entityID), HandlerEventKey: "item.completed"}, false)
+				_, err := pc.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: arrival, State: triggerState, HandlerEventKey: "item.completed"}, false)
 				arrivalErr <- err
 			}()
 			close(start)

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -252,6 +252,11 @@ func workflowNodeInputAliasEventHandlerResolution(source semanticview.Source, no
 }
 
 func workflowNodeHandlerEventKeyForExecution(source semanticview.Source, nodeID string, evt events.Event) string {
+	if isJoinLifecycleEvent(evt.Type()) {
+		if ref, _, ok := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); ok && ref.NodeID == strings.TrimSpace(nodeID) {
+			return ref.HandlerEvent
+		}
+	}
 	if isAccumulationTimeoutEvent(evt.Type()) {
 		if bucket, ok := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload())); ok && strings.TrimSpace(bucket.NodeID) == strings.TrimSpace(nodeID) {
 			return bucket.EventType
@@ -883,6 +888,13 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 			if bucket, bucketOK := timeridentity.ParseAccumulatorBucketRef(parsePayloadMap(evt.Payload())); bucketOK && bucket.NodeID == strings.TrimSpace(node.ID) {
 				if node.Policies != nil {
 					policy, ok = workflowNodePolicyForEventType(node.Policies, bucket.EventType)
+				}
+			}
+		}
+		if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
+			if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == strings.TrimSpace(node.ID) {
+				if node.Policies != nil {
+					policy, ok = workflowNodePolicyForEventType(node.Policies, ref.HandlerEvent)
 				}
 			}
 		}

--- a/internal/runtime/pipeline/workflow_state_persistence.go
+++ b/internal/runtime/pipeline/workflow_state_persistence.go
@@ -40,36 +40,41 @@ func (pc *PipelineCoordinator) updateEntityState(ctx context.Context, entityID, 
 		return nil
 	}
 	source := pc.SemanticSource()
-	currentState := ""
-	if err := pc.workflowStore.Mutate(ctx, entityID, func(instance *WorkflowInstance) {
-		currentState = strings.TrimSpace(instance.CurrentState)
-		enteredStateAt := time.Now().UTC()
-		if currentState == nextState && !instance.EnteredStageAt.IsZero() {
-			enteredStateAt = instance.EnteredStageAt
+	return pc.workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		currentState := ""
+		if err := pc.workflowStore.Mutate(txctx, entityID, func(instance *WorkflowInstance) {
+			currentState = strings.TrimSpace(instance.CurrentState)
+			enteredStateAt := time.Now().UTC()
+			if currentState == nextState && !instance.EnteredStageAt.IsZero() {
+				enteredStateAt = instance.EnteredStageAt
+			}
+			if strings.TrimSpace(instance.WorkflowName) == "" {
+				instance.WorkflowName = source.WorkflowName()
+			}
+			if strings.TrimSpace(instance.WorkflowVersion) == "" {
+				instance.WorkflowVersion = source.WorkflowVersion()
+			}
+			metadata := cloneStringAnyMap(instance.Metadata)
+			if sourceEvent != "" {
+				metadata["last_source_event"] = sourceEvent
+			}
+			instance.Metadata = metadata
+			instance.CurrentState = nextState
+			instance.EnteredStageAt = enteredStateAt
+			if currentState != "" && currentState != nextState {
+				instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), currentState, nextState, sourceEvent))
+			} else if currentState == "" && len(instance.TransitionHistory) == 0 {
+				instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), "", nextState, sourceEvent))
+			}
+		}); err != nil {
+			return err
 		}
-		if strings.TrimSpace(instance.WorkflowName) == "" {
-			instance.WorkflowName = source.WorkflowName()
+		pc.notifyTestEntityStateUpdated(entityID, nextState)
+		if err := pc.reconcileWorkflowStageTimers(txctx, entityID, currentState, nextState, sourceEvent); err != nil {
+			return err
 		}
-		if strings.TrimSpace(instance.WorkflowVersion) == "" {
-			instance.WorkflowVersion = source.WorkflowVersion()
-		}
-		metadata := cloneStringAnyMap(instance.Metadata)
-		if sourceEvent != "" {
-			metadata["last_source_event"] = sourceEvent
-		}
-		instance.Metadata = metadata
-		instance.CurrentState = nextState
-		instance.EnteredStageAt = enteredStateAt
-		if currentState != "" && currentState != nextState {
-			instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), currentState, nextState, sourceEvent))
-		} else if currentState == "" && len(instance.TransitionHistory) == 0 {
-			instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), "", nextState, sourceEvent))
-		}
-	}); err != nil {
-		return err
-	}
-	pc.notifyTestEntityStateUpdated(entityID, nextState)
-	return pc.reconcileWorkflowStageTimers(ctx, entityID, currentState, nextState, sourceEvent)
+		return pc.applyWorkflowJoinIntents(txctx, entityID, currentState, nextState)
+	})
 }
 
 func (pc *PipelineCoordinator) applyWorkflowGateMutation(ctx context.Context, entityID, _sourceEvent, setGate string, clear bool) error {

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -61,6 +61,9 @@ func (s bundleSource) WorkflowInitialStage() string { return s.bundle.WorkflowIn
 func (s bundleSource) WorkflowTimers() []runtimecontracts.WorkflowTimerContract {
 	return s.bundle.WorkflowTimers()
 }
+func (s bundleSource) WorkflowJoins() []runtimecontracts.WorkflowJoinPlan {
+	return s.bundle.WorkflowJoins()
+}
 func (s bundleSource) WorkflowTimerByID(id string) (runtimecontracts.WorkflowTimerContract, bool) {
 	return s.bundle.WorkflowTimerByID(id)
 }

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -15,6 +15,7 @@ type Source interface {
 	WorkflowTransitions() []runtimecontracts.WorkflowTransitionContract
 	WorkflowInitialStage() string
 	WorkflowTimers() []runtimecontracts.WorkflowTimerContract
+	WorkflowJoins() []runtimecontracts.WorkflowJoinPlan
 	WorkflowTimerByID(id string) (runtimecontracts.WorkflowTimerContract, bool)
 	GuardInstructions() []runtimeregistry.GuardInstruction
 	GuardInstructionByID(id string) (runtimeregistry.GuardInstruction, bool)

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -9,7 +9,9 @@ import (
 	"sync"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types/ref"
 )
 
@@ -50,6 +52,7 @@ type ValueExpressionOptions struct {
 	AllowBareItem bool
 	ItemAlias     string
 	AllowJoin     bool
+	RequireBool   bool
 }
 
 func ValidateValueExpression(expression string) error {
@@ -83,11 +86,66 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	if err := ValidateEventReferences(expression); err != nil {
 		return err
 	}
-	_, issues := env.Compile(expression)
+	compiled, issues := env.Compile(expression)
 	if issues != nil && issues.Err() != nil {
 		return issues.Err()
 	}
+	if opts.AllowJoin {
+		if err := validateJoinAccesses(compiled); err != nil {
+			return err
+		}
+	}
+	if opts.RequireBool && compiled.OutputType() != cel.BoolType {
+		return fmt.Errorf("workflow expression must return bool, got %s", compiled.OutputType())
+	}
 	return nil
+}
+
+func validateJoinAccesses(compiled *cel.Ast) error {
+	if compiled == nil || compiled.NativeRep() == nil {
+		return fmt.Errorf("workflow expression AST is unavailable")
+	}
+	allowed := make(map[string]struct{}, len(joinruntime.SupportedContextFields()))
+	for _, field := range joinruntime.SupportedContextFields() {
+		allowed[field] = struct{}{}
+	}
+	root := celast.NavigateAST(compiled.NativeRep())
+	var visit func(celast.NavigableExpr) error
+	visit = func(expr celast.NavigableExpr) error {
+		if expr.Kind() == celast.IdentKind && expr.AsIdent() == "join" {
+			parent, ok := expr.Parent()
+			if !ok {
+				return fmt.Errorf("join must be accessed as join.<field>")
+			}
+			switch parent.Kind() {
+			case celast.SelectKind:
+				selection := parent.AsSelect()
+				if selection.Operand().ID() != expr.ID() {
+					return fmt.Errorf("join must be accessed as join.<field>")
+				}
+				field := strings.TrimSpace(selection.FieldName())
+				if _, ok := allowed[field]; !ok {
+					return fmt.Errorf("unsupported join.%s", field)
+				}
+			case celast.CallKind:
+				call := parent.AsCall()
+				args := call.Args()
+				if call.FunctionName() == "_[_]" && len(args) > 0 && args[0].ID() == expr.ID() {
+					return fmt.Errorf("bracket access on join is unsupported; use join.<field>")
+				}
+				return fmt.Errorf("join must be accessed as join.<field>")
+			default:
+				return fmt.Errorf("join must be accessed as join.<field>")
+			}
+		}
+		for _, child := range expr.Children() {
+			if err := visit(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return visit(root)
 }
 
 func EvalValueExpression(expression string, ctx ValueContext) (any, error) {

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -49,10 +49,11 @@ type ValueContext struct {
 }
 
 type ValueExpressionOptions struct {
-	AllowBareItem bool
-	ItemAlias     string
-	AllowJoin     bool
-	RequireBool   bool
+	AllowBareItem  bool
+	ItemAlias      string
+	AllowJoin      bool
+	RequireBool    bool
+	JoinResultType string
 }
 
 func ValidateValueExpression(expression string) error {
@@ -86,19 +87,30 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	if err := ValidateEventReferences(expression); err != nil {
 		return err
 	}
+	_, err = compileValueExpression(env, expression, opts)
+	return err
+}
+
+func compileValueExpression(env *cel.Env, expression string, opts ValueExpressionOptions) (*cel.Ast, error) {
 	compiled, issues := env.Compile(expression)
 	if issues != nil && issues.Err() != nil {
-		return issues.Err()
+		return nil, issues.Err()
 	}
+	typeChecked := compiled
 	if opts.AllowJoin {
 		if err := validateJoinAccesses(compiled); err != nil {
-			return err
+			return nil, err
+		}
+		var err error
+		typeChecked, err = typeCheckJoinExpression(env, compiled, opts.JoinResultType)
+		if err != nil {
+			return nil, err
 		}
 	}
-	if opts.RequireBool && compiled.OutputType() != cel.BoolType {
-		return fmt.Errorf("workflow expression must return bool, got %s", compiled.OutputType())
+	if opts.RequireBool && typeChecked.OutputType() != cel.BoolType {
+		return nil, fmt.Errorf("workflow expression must return bool, got %s", typeChecked.OutputType())
 	}
-	return nil
+	return compiled, nil
 }
 
 func validateJoinAccesses(compiled *cel.Ast) error {
@@ -148,6 +160,77 @@ func validateJoinAccesses(compiled *cel.Ast) error {
 	return visit(root)
 }
 
+type joinFieldTypeOptimizer struct{}
+
+func (joinFieldTypeOptimizer) Optimize(ctx *cel.OptimizerContext, expression *celast.AST) *celast.AST {
+	matches := celast.MatchDescendants(celast.NavigateAST(expression), func(expr celast.NavigableExpr) bool {
+		if expr.Kind() != celast.SelectKind {
+			return false
+		}
+		operand := expr.AsSelect().Operand()
+		return operand.Kind() == celast.IdentKind && operand.AsIdent() == "join"
+	})
+	for _, match := range matches {
+		ctx.UpdateExpr(match, ctx.NewIdent(joinTypedVariable(match.AsSelect().FieldName())))
+	}
+	return ctx.NewAST(expression.Expr())
+}
+
+func typeCheckJoinExpression(env *cel.Env, compiled *cel.Ast, resultType string) (*cel.Ast, error) {
+	typedEnv, err := env.Extend(
+		cel.Variable(joinTypedVariable("expected"), cel.IntType),
+		cel.Variable(joinTypedVariable("completed"), cel.IntType),
+		cel.Variable(joinTypedVariable("missing"), cel.ListType(cel.StringType)),
+		cel.Variable(joinTypedVariable("results"), cel.ListType(joinResultCELType(resultType))),
+		cel.Variable(joinTypedVariable("timed_out"), cel.BoolType),
+	)
+	if err != nil {
+		return nil, err
+	}
+	optimizer, err := cel.NewStaticOptimizer(joinFieldTypeOptimizer{})
+	if err != nil {
+		return nil, err
+	}
+	typed, issues := optimizer.Optimize(typedEnv, compiled)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	return typed, nil
+}
+
+func joinTypedVariable(field string) string {
+	return "__swarm_join_" + strings.TrimSpace(field)
+}
+
+func joinResultCELType(typeRef string) *cel.Type {
+	typeRef = strings.TrimSpace(typeRef)
+	if strings.HasSuffix(typeRef, "[]") {
+		return cel.ListType(joinResultCELType(strings.TrimSpace(strings.TrimSuffix(typeRef, "[]"))))
+	}
+	if strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]") {
+		return cel.ListType(joinResultCELType(strings.TrimSpace(typeRef[1 : len(typeRef)-1])))
+	}
+	lower := strings.ToLower(typeRef)
+	if strings.HasPrefix(lower, "list<") && strings.HasSuffix(typeRef, ">") {
+		return cel.ListType(joinResultCELType(strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])))
+	}
+	if strings.HasPrefix(lower, "numeric(") {
+		return cel.DoubleType
+	}
+	switch lower {
+	case "text", "string", "uuid", "timestamp", "timestamptz":
+		return cel.StringType
+	case "integer", "int", "bigint":
+		return cel.IntType
+	case "number", "numeric", "float", "double", "real":
+		return cel.DoubleType
+	case "boolean", "bool":
+		return cel.BoolType
+	default:
+		return cel.DynType
+	}
+}
+
 func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 	return EvalValueExpressionWithOptions(expression, ctx, ValueExpressionOptions{})
 }
@@ -182,9 +265,9 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	if missing := MissingEntityReferences(normalized, ctx.Entity); len(missing) > 0 {
 		return nil, fmt.Errorf("entity field(s) unavailable in expression context: %s", strings.Join(missing, ", "))
 	}
-	ast, issues := env.Compile(normalized)
-	if issues != nil && issues.Err() != nil {
-		return nil, issues.Err()
+	ast, err := compileValueExpression(env, normalized, opts)
+	if err != nil {
+		return nil, err
 	}
 	program, err := env.Program(ast)
 	if err != nil {

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -43,11 +43,13 @@ type ValueContext struct {
 	Policy         map[string]any
 	Computed       map[string]any
 	FanOut         map[string]any
+	Join           map[string]any
 }
 
 type ValueExpressionOptions struct {
 	AllowBareItem bool
 	ItemAlias     string
+	AllowJoin     bool
 }
 
 func ValidateValueExpression(expression string) error {
@@ -74,6 +76,9 @@ func ValidateValueExpressionWithOptions(expression string, opts ValueExpressionO
 	}
 	if strings.TrimSpace(opts.ItemAlias) == "" && expressionReferencesFanOutField(expression, "index") {
 		return fmt.Errorf("fan_out.index is only available inside fan_out.emit fields")
+	}
+	if !opts.AllowJoin && ExpressionReferencesRoot(expression, "join") {
+		return fmt.Errorf("join.* is only available inside join completion and timeout outcomes")
 	}
 	if err := ValidateEventReferences(expression); err != nil {
 		return err
@@ -110,6 +115,9 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 	if strings.TrimSpace(opts.ItemAlias) == "" && expressionReferencesFanOutField(normalized, "index") {
 		return nil, fmt.Errorf("fan_out.index is only available inside fan_out.emit fields")
 	}
+	if !opts.AllowJoin && ExpressionReferencesRoot(normalized, "join") {
+		return nil, fmt.Errorf("join.* is only available inside join completion and timeout outcomes")
+	}
 	if err := ValidateEventReferences(normalized); err != nil {
 		return nil, err
 	}
@@ -132,6 +140,7 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 		"policy":   NormalizeCELInputMap(ctx.Policy),
 		"computed": NormalizeCELInputMap(ctx.Computed),
 		"fan_out":  NormalizeCELInputMap(ctx.FanOut),
+		"join":     NormalizeCELInputMap(ctx.Join),
 	}
 	if opts.AllowBareItem {
 		activation["item"] = NormalizeCELValue(ctx.FanOut["item"])
@@ -144,6 +153,31 @@ func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts Va
 		return nil, err
 	}
 	return NormalizeCELValue(out), nil
+}
+
+func ExpressionReferencesRoot(expression, root string) bool {
+	expression = StripStringLiterals(strings.TrimSpace(expression))
+	root = strings.TrimSpace(root)
+	if expression == "" || root == "" {
+		return false
+	}
+	for i := 0; i < len(expression); i++ {
+		if !strings.HasPrefix(expression[i:], root) {
+			continue
+		}
+		if i > 0 && isIdentifierPart(expression[i-1]) {
+			continue
+		}
+		end := i + len(root)
+		if end < len(expression) && isIdentifierPart(expression[end]) {
+			continue
+		}
+		end = skipExpressionWhitespace(expression, end)
+		if end < len(expression) && (expression[end] == '.' || expression[end] == '[') {
+			return true
+		}
+	}
+	return false
 }
 
 func ExpressionReferencesEntity(expression string) bool {
@@ -740,6 +774,7 @@ func newDataExpressionEnv(allowBareItem bool, itemAlias string) (*cel.Env, error
 		cel.Variable("policy", cel.DynType),
 		cel.Variable("computed", cel.DynType),
 		cel.Variable("fan_out", cel.DynType),
+		cel.Variable("join", cel.DynType),
 	}
 	if allowBareItem {
 		variables = append(variables, cel.Variable("item", cel.DynType))

--- a/internal/runtime/workflowexpr/data_expression.go
+++ b/internal/runtime/workflowexpr/data_expression.go
@@ -9,9 +9,11 @@ import (
 	"sync"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
+	celtypes "github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 )
 
@@ -53,7 +55,7 @@ type ValueExpressionOptions struct {
 	ItemAlias      string
 	AllowJoin      bool
 	RequireBool    bool
-	JoinResultType string
+	JoinResultType runtimecontracts.CatalogTypeReference
 }
 
 func ValidateValueExpression(expression string) error {
@@ -176,12 +178,18 @@ func (joinFieldTypeOptimizer) Optimize(ctx *cel.OptimizerContext, expression *ce
 	return ctx.NewAST(expression.Expr())
 }
 
-func typeCheckJoinExpression(env *cel.Env, compiled *cel.Ast, resultType string) (*cel.Ast, error) {
+func typeCheckJoinExpression(env *cel.Env, compiled *cel.Ast, resultType runtimecontracts.CatalogTypeReference) (*cel.Ast, error) {
+	provider := newJoinCatalogTypeProvider(env.CELTypeProvider(), resultType)
+	resultCELType, err := provider.resolve(resultType.Type)
+	if err != nil {
+		return nil, err
+	}
 	typedEnv, err := env.Extend(
+		cel.CustomTypeProvider(provider),
 		cel.Variable(joinTypedVariable("expected"), cel.IntType),
 		cel.Variable(joinTypedVariable("completed"), cel.IntType),
 		cel.Variable(joinTypedVariable("missing"), cel.ListType(cel.StringType)),
-		cel.Variable(joinTypedVariable("results"), cel.ListType(joinResultCELType(resultType))),
+		cel.Variable(joinTypedVariable("results"), cel.ListType(resultCELType)),
 		cel.Variable(joinTypedVariable("timed_out"), cel.BoolType),
 	)
 	if err != nil {
@@ -202,37 +210,136 @@ func joinTypedVariable(field string) string {
 	return "__swarm_join_" + strings.TrimSpace(field)
 }
 
-func joinResultCELType(typeRef string) *cel.Type {
-	typeRef = strings.TrimSpace(typeRef)
-	if strings.HasSuffix(typeRef, "[]") {
-		return cel.ListType(joinResultCELType(strings.TrimSpace(strings.TrimSuffix(typeRef, "[]"))))
+const joinCatalogTypePrefix = "swarm.workflow.join."
+
+type joinCatalogTypeProvider struct {
+	celtypes.Provider
+	result runtimecontracts.CatalogTypeReference
+}
+
+func newJoinCatalogTypeProvider(base celtypes.Provider, result runtimecontracts.CatalogTypeReference) *joinCatalogTypeProvider {
+	return &joinCatalogTypeProvider{Provider: base, result: result}
+}
+
+func (p *joinCatalogTypeProvider) resolve(typeRef string) (*cel.Type, error) {
+	resolved, err := p.result.ResolveReference(typeRef)
+	if err != nil {
+		return nil, err
 	}
-	if strings.HasPrefix(typeRef, "[") && strings.HasSuffix(typeRef, "]") {
-		return cel.ListType(joinResultCELType(strings.TrimSpace(typeRef[1 : len(typeRef)-1])))
-	}
-	lower := strings.ToLower(typeRef)
-	if strings.HasPrefix(lower, "list<") && strings.HasSuffix(typeRef, ">") {
-		return cel.ListType(joinResultCELType(strings.TrimSpace(typeRef[len("list<") : len(typeRef)-1])))
-	}
-	if strings.HasPrefix(lower, "numeric(") {
-		return cel.DoubleType
-	}
-	switch lower {
-	case "text", "string", "uuid", "timestamp", "timestamptz":
-		return cel.StringType
-	case "integer", "int", "bigint":
-		return cel.IntType
-	case "number", "numeric", "float", "double", "real":
-		return cel.DoubleType
-	case "boolean", "bool":
-		return cel.BoolType
+	return p.resolveResolved(resolved)
+}
+
+func (p *joinCatalogTypeProvider) resolveResolved(resolved runtimecontracts.ResolvedCatalogType) (*cel.Type, error) {
+	switch resolved.Kind {
+	case runtimecontracts.CatalogTypeDynamic:
+		return cel.DynType, nil
+	case runtimecontracts.CatalogTypeText:
+		return cel.StringType, nil
+	case runtimecontracts.CatalogTypeInteger:
+		return cel.IntType, nil
+	case runtimecontracts.CatalogTypeNumber:
+		return cel.DoubleType, nil
+	case runtimecontracts.CatalogTypeBoolean:
+		return cel.BoolType, nil
+	case runtimecontracts.CatalogTypeObject:
+		return cel.ObjectType(joinCatalogTypePrefix + resolved.Name), nil
+	case runtimecontracts.CatalogTypeList:
+		if resolved.Element == nil {
+			return nil, fmt.Errorf("catalog list type has no element type")
+		}
+		element, err := p.resolveResolved(*resolved.Element)
+		if err != nil {
+			return nil, err
+		}
+		return cel.ListType(element), nil
+	case runtimecontracts.CatalogTypeMap:
+		if resolved.Key == nil || resolved.Value == nil {
+			return nil, fmt.Errorf("catalog map type is incomplete")
+		}
+		key, err := p.resolveResolved(*resolved.Key)
+		if err != nil {
+			return nil, err
+		}
+		value, err := p.resolveResolved(*resolved.Value)
+		if err != nil {
+			return nil, err
+		}
+		return cel.MapType(key, value), nil
 	default:
-		return cel.DynType
+		return nil, fmt.Errorf("unsupported catalog type kind %q", resolved.Kind)
 	}
+}
+
+func (p *joinCatalogTypeProvider) FindStructType(typeName string) (*celtypes.Type, bool) {
+	if name, ok := joinCatalogTypeName(typeName); ok {
+		if _, found := p.result.NamedFields(name); found {
+			return celtypes.NewTypeTypeWithParam(celtypes.NewObjectType(typeName)), true
+		}
+	}
+	return p.Provider.FindStructType(typeName)
+}
+
+func (p *joinCatalogTypeProvider) FindStructFieldNames(typeName string) ([]string, bool) {
+	if name, ok := joinCatalogTypeName(typeName); ok {
+		fields, found := p.result.NamedFields(name)
+		if !found {
+			return nil, false
+		}
+		names := make([]string, 0, len(fields))
+		for field := range fields {
+			names = append(names, field)
+		}
+		sort.Strings(names)
+		return names, true
+	}
+	return p.Provider.FindStructFieldNames(typeName)
+}
+
+func (p *joinCatalogTypeProvider) FindStructFieldType(typeName, fieldName string) (*celtypes.FieldType, bool) {
+	if name, ok := joinCatalogTypeName(typeName); ok {
+		fields, found := p.result.NamedFields(name)
+		if !found {
+			return nil, false
+		}
+		field, found := fields[strings.TrimSpace(fieldName)]
+		if !found {
+			return nil, false
+		}
+		fieldType, err := p.resolve(field.Type)
+		if err != nil {
+			return nil, false
+		}
+		return &celtypes.FieldType{Type: fieldType}, true
+	}
+	return p.Provider.FindStructFieldType(typeName, fieldName)
+}
+
+func joinCatalogTypeName(typeName string) (string, bool) {
+	if !strings.HasPrefix(typeName, joinCatalogTypePrefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(typeName, joinCatalogTypePrefix)
+	return name, name != ""
 }
 
 func EvalValueExpression(expression string, ctx ValueContext) (any, error) {
 	return EvalValueExpressionWithOptions(expression, ctx, ValueExpressionOptions{})
+}
+
+func EvalJoinBool(expression string, join map[string]any, resultType runtimecontracts.CatalogTypeReference) (bool, error) {
+	value, err := EvalValueExpressionWithOptions(expression, ValueContext{Join: join}, ValueExpressionOptions{
+		AllowJoin:      true,
+		RequireBool:    true,
+		JoinResultType: resultType,
+	})
+	if err != nil {
+		return false, err
+	}
+	result, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("workflow join expression returned non-bool %T", value)
+	}
+	return result, nil
 }
 
 func EvalValueExpressionWithOptions(expression string, ctx ValueContext, opts ValueExpressionOptions) (any, error) {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -77,6 +77,40 @@ func TestValidateValueExpression_RejectsAccumulatedNamespace(t *testing.T) {
 	}
 }
 
+func TestJoinExpressionTypeCheckingMatchesRuntimeContext(t *testing.T) {
+	opts := ValueExpressionOptions{AllowJoin: true, RequireBool: true, JoinResultType: "text"}
+	for _, expression := range []string{
+		`join.completed <= join.expected`,
+		`join.missing.size() > 0`,
+		`join.results.all(result, result != "")`,
+		`join.timed_out == false`,
+	} {
+		t.Run("valid "+expression, func(t *testing.T) {
+			if err := ValidateValueExpressionWithOptions(expression, opts); err != nil {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %v", expression, err)
+			}
+		})
+	}
+	for _, expression := range []string{
+		`join.missing > 1`,
+		`join.timed_out > 0`,
+		`join.results[0] > 1`,
+	} {
+		t.Run("invalid "+expression, func(t *testing.T) {
+			err := ValidateValueExpressionWithOptions(expression, opts)
+			if err == nil || !strings.Contains(err.Error(), "no matching overload") {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %v, want typed overload rejection", expression, err)
+			}
+			_, evalErr := EvalValueExpressionWithOptions(expression, ValueContext{Join: map[string]any{
+				"expected": 2, "completed": 1, "missing": []any{"b"}, "results": []any{"ok"}, "timed_out": false,
+			}}, opts)
+			if evalErr == nil || !strings.Contains(evalErr.Error(), "no matching overload") {
+				t.Fatalf("EvalValueExpressionWithOptions(%q) error = %v, want the same typed rejection before evaluation", expression, evalErr)
+			}
+		})
+	}
+}
+
 func TestValidateValueExpression_RejectsRetiredFanOutTarget(t *testing.T) {
 	tests := []string{
 		`fan_out.target`,

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -3,6 +3,8 @@ package workflowexpr
 import (
 	"strings"
 	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
 func TestEvalValueExpression_AllowsNullPresenceCheckOnMissingField(t *testing.T) {
@@ -78,7 +80,7 @@ func TestValidateValueExpression_RejectsAccumulatedNamespace(t *testing.T) {
 }
 
 func TestJoinExpressionTypeCheckingMatchesRuntimeContext(t *testing.T) {
-	opts := ValueExpressionOptions{AllowJoin: true, RequireBool: true, JoinResultType: "text"}
+	opts := ValueExpressionOptions{AllowJoin: true, RequireBool: true, JoinResultType: runtimecontracts.CatalogTypeReference{Type: "text"}}
 	for _, expression := range []string{
 		`join.completed <= join.expected`,
 		`join.missing.size() > 0`,
@@ -106,6 +108,49 @@ func TestJoinExpressionTypeCheckingMatchesRuntimeContext(t *testing.T) {
 			}}, opts)
 			if evalErr == nil || !strings.Contains(evalErr.Error(), "no matching overload") {
 				t.Fatalf("EvalValueExpressionWithOptions(%q) error = %v, want the same typed rejection before evaluation", expression, evalErr)
+			}
+		})
+	}
+}
+
+func TestJoinExpressionTypeCheckingPreservesCatalogTypes(t *testing.T) {
+	catalog := runtimecontracts.TypeCatalogDocument{
+		Scalars: map[string]runtimecontracts.ScalarTypeDecl{"Score": {Base: "integer"}},
+		Enums:   map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}}},
+		Types: map[string]runtimecontracts.NamedTypeDecl{
+			"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{
+				"value": {Type: "text"},
+				"score": {Type: "Score"},
+			}},
+		},
+	}
+	for _, tc := range []struct {
+		name       string
+		resultType string
+		expression string
+		wantErr    bool
+	}{
+		{name: "named object field", resultType: "JoinResult", expression: `join.results[0].value == "ok"`},
+		{name: "named object operator", resultType: "JoinResult", expression: `join.results[0] > 1`, wantErr: true},
+		{name: "named object unknown field", resultType: "JoinResult", expression: `join.results[0].missing == "x"`, wantErr: true},
+		{name: "nested scalar alias field", resultType: "JoinResult", expression: `join.results[0].score > 1`},
+		{name: "enum equality", resultType: "Decision", expression: `join.results[0] == "accept"`},
+		{name: "enum numeric operator", resultType: "Decision", expression: `join.results[0] > 1`, wantErr: true},
+		{name: "scalar alias", resultType: "Score", expression: `join.results[0] > 1`},
+		{name: "scalar alias mismatch", resultType: "Score", expression: `join.results[0].startsWith("1")`, wantErr: true},
+		{name: "list", resultType: "list<Score>", expression: `join.results[0][0] > 1`},
+		{name: "map", resultType: "map[text]Score", expression: `join.results[0]["a"] > 1`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateValueExpressionWithOptions(tc.expression, ValueExpressionOptions{
+				AllowJoin: true, RequireBool: true,
+				JoinResultType: runtimecontracts.CatalogTypeReference{Type: tc.resultType, Catalog: catalog},
+			})
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) succeeded, want typed rejection", tc.expression)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateValueExpressionWithOptions(%q) error = %v", tc.expression, err)
 			}
 		})
 	}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2783,6 +2783,58 @@ handler_specification:
         runtime-owned JSON result contract is part of this pattern.
       side_effect: Writes fan_out.count to handler context (available for data_accumulation). `fan_out.index`
         is scoped to per-item emit field evaluation and is not a durable handler value.
+    join:
+      field: join
+      type: object
+      purpose: >-
+        Declare one stage-anchored finite-membership barrier on an arriving event. Join is the sole public barrier owner
+        for stages: bundles; open/windowed stream accumulation remains owned by accumulate.
+      sub_fields:
+        id: Optional stable simple identifier. It defaults to stage; collisions in the same flow/stage require explicit unique IDs.
+        stage: Required stage in the same flow. Arrivals are admitted only against a persisted activation for this stage.
+        members: >-
+          Required `{from: entity.<field>, by: payload.<field>}`. from names a declared ordered list<text> that is
+          snapshotted once at stage arm; by names the declared text member identity on each arrival and is the sole
+          membership/dedup key.
+        window: >-
+          Optional `{from: entity.<field>, by: payload.<field>}` text identity. It is required when the static transition
+          graph permits re-entry into the join stage. from is snapshotted at arm and by must match exactly on arrival.
+        output: Required top-level declared payload field captured with its canonical value/hash per admitted member.
+        complete_when: >-
+          Optional CEL boolean over join.expected, join.completed, join.missing, join.results, and join.timed_out only.
+          Omission means all declared members. Authoring the default-all tautology is unnecessary.
+        remaining: >-
+          Required exactly as ignore when complete_when is authored and forbidden otherwise. terminate is unsupported
+          until a durable contributor-lifecycle/cancellation owner is promoted.
+        on_complete: >-
+          Required non-empty outcome using only existing data_accumulation, emit, and advances_to fields. Expressions may
+          read declared entity.* and typed join.* only.
+        timeout: >-
+          Required `{after: <positive literal or policy-scalar duration>, ...outcome}`. Bare joins are invalid. The outcome
+          supports the same fields and expression roots as on_complete.
+      context:
+        expected: Snapshotted member count.
+        completed: Persisted admitted-member count.
+        missing: Membership-ordered member IDs without output.
+        results: Membership-ordered typed outputs, independent of arrival order.
+        timed_out: True only while evaluating the timeout outcome.
+      execution: >-
+        The stage transition, membership/window snapshot, typed activation, timeout intent, and expected-zero completion
+        intent commit in one selected-store transaction. Arrivals never create activations. The existing entity lock and
+        selected-store row transaction admit exactly one arrival-versus-timeout close winner; losers observe closed state.
+      duplicate_policy: >-
+        An exact same-member/same-canonical-output arrival is idempotent. The same member with different canonical output
+        fails as platform.conflicting_duplicate. Non-members, arrivals before arm, and arrivals after close fail through
+        platform.unexpected_arrival, platform.early_arrival, and platform.stale_arrival respectively.
+      timeout_policy: >-
+        Timeout is evaluated once at arm and fire_at is persisted. It is the only missing/dead-contributor escape in this
+        slice. join.terminated, join.active, and remaining: terminate are invalid until a real contributor lifecycle owner lands.
+      staged_accumulate_retirement: >-
+        A stages: bundle may not author finite-barrier accumulate fields such as expected_from, threshold/completion,
+        timeout_ms, on_complete, or on_timeout. Non-staged migration remains separately tracked; accumulate continues to
+        own open/windowed streams.
+      graph_surface: >-
+        describe --graph renders stage-scoped join completion and timeout edges. Timeout edges include after and the join ID.
     query:
       field: query
       type: object or list of objects
@@ -4021,6 +4073,33 @@ engine:
       replays events through the same tracking — already-received items are skipped, accumulator state is consistent.
     cleanup: After completion fires and the handler commits, the accumulator record can be archived or deleted. The entity
       has moved past the accumulation state.
+  join_engine:
+    description: >-
+      The join engine is the canonical durable owner for staged finite-membership barrier activation, arrivals, deterministic
+      output assembly, timeout, and close. It consumes the typed lowered handler.join plan; route, timer, store, and test
+      surfaces do not reconstruct join semantics independently.
+    persisted_activation:
+      identity: entity + node + handler event + effective join ID + optional window
+      fields:
+      - ordered snapshotted members
+      - per-member canonical output value and hash
+      - open/closed status and close reason
+      - armed_at and persisted fire_at
+      - exact timer task/event identity
+      - expected-zero pending/fired completion disposition
+    arm: >-
+      Stage entry snapshots members and optional window only after transition data writes are visible. Empty membership
+      atomically persists a closed completion plus immediate internal completion intent; it never waits for an arrival.
+    arrival: >-
+      Runtime loads the persisted activation inside the entity lock and selected-store transaction, checks exact window and
+      member identity, stores canonical output, and evaluates default-all or complete_when over persisted join context.
+    ordering: join.results and join.missing always follow declared membership order, never arrival or map iteration order.
+    close: >-
+      Completion, timeout, and stage exit persist one closed reason. Completion/timeout outcomes and timer cancellation share
+      the selected-store transaction; in-memory scheduler registration/cancellation happens only after commit.
+    recovery: >-
+      Restart, replay, and fork consume persisted members/window/close/timer facts. They do not re-read mutable entity
+      membership, synthesize an arrival-owned activation, or resurrect a closed timeout.
   runtime_store_backend_selection:
     promoted_by: '#1084'
     parent_tracker: '#1066'
@@ -5588,6 +5667,8 @@ engine:
       policy: Policy values from flow policy.yaml merged with root policy.yaml
       fan_out: Available after fan_out step for count metadata (fan_out.count). fan_out.index is available only
         while evaluating fan_out.emit.fields for one item.
+      join: Available only while evaluating join complete_when and selected on_complete/timeout outcomes. The typed fields
+        are expected, completed, missing, results, and timed_out; join is read-only and never persisted as entity state.
       accumulated: Available inside on_complete after accumulation (list of received items)
     ambient_time: >
       CEL guard/rule/filter/on_complete conditions must not call ambient time functions such as `now()` or

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2813,11 +2813,15 @@ handler_specification:
           Required `{after: <positive literal or policy-scalar duration>, ...outcome}`. Bare joins are invalid. The outcome
           supports the same fields and expression roots as on_complete.
       context:
-        expected: Snapshotted member count.
-        completed: Persisted admitted-member count.
-        missing: Membership-ordered member IDs without output.
-        results: Membership-ordered typed outputs, independent of arrival order.
-        timed_out: True only while evaluating the timeout outcome.
+        expected: Integer snapshotted member count.
+        completed: Integer persisted admitted-member count.
+        missing: list<text> of membership-ordered member IDs without output.
+        results: List of the declared join.output payload type, membership-ordered and independent of arrival order.
+        timed_out: Boolean true only while evaluating the timeout outcome.
+      expression_typing: >-
+        Verify and runtime evaluation type-check every direct join.* access against the context types above. A boolean
+        result alone is insufficient: expressions with invalid typed operands fail closed at load and may not reach
+        execution. Bracket, dynamic, bare-root, and undeclared join access remain invalid.
       execution: >-
         The stage transition, membership/window snapshot, typed activation, timeout intent, and any zero-member completion
         intent commit in one selected-store transaction. Empty membership evaluates the same default-all or authored

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -2819,9 +2819,11 @@ handler_specification:
         results: Membership-ordered typed outputs, independent of arrival order.
         timed_out: True only while evaluating the timeout outcome.
       execution: >-
-        The stage transition, membership/window snapshot, typed activation, timeout intent, and expected-zero completion
-        intent commit in one selected-store transaction. Arrivals never create activations. The existing entity lock and
-        selected-store row transaction admit exactly one arrival-versus-timeout close winner; losers observe closed state.
+        The stage transition, membership/window snapshot, typed activation, timeout intent, and any zero-member completion
+        intent commit in one selected-store transaction. Empty membership evaluates the same default-all or authored
+        complete_when plan used on arrival; an unsatisfied custom condition remains open until an arrival satisfies it or
+        timeout closes it. Arrivals never create activations. The existing entity lock and selected-store row transaction
+        admit exactly one arrival-versus-timeout close winner; losers observe closed state.
       duplicate_policy: >-
         An exact same-member/same-canonical-output arrival is idempotent. The same member with different canonical output
         fails as platform.conflicting_duplicate. Non-members, arrivals before arm, and arrivals after close fail through
@@ -4079,7 +4081,9 @@ engine:
       output assembly, timeout, and close. It consumes the typed lowered handler.join plan; route, timer, store, and test
       surfaces do not reconstruct join semantics independently.
     persisted_activation:
-      identity: entity + node + handler event + effective join ID + optional window
+      identity: >-
+        flow instance + stage + effective join ID + optional window. Node and handler event remain exact internal routing
+        identity for arrival and timer delivery, but may not narrow or replace the verified stage-scoped semantic identity.
       fields:
       - ordered snapshotted members
       - per-member canonical output value and hash
@@ -4089,7 +4093,8 @@ engine:
       - expected-zero pending/fired completion disposition
     arm: >-
       Stage entry snapshots members and optional window only after transition data writes are visible. Empty membership
-      atomically persists a closed completion plus immediate internal completion intent; it never waits for an arrival.
+      evaluates the same canonical completion plan as arrival: default-all closes immediately, while authored complete_when
+      closes only when that boolean is true. A false custom condition persists an open activation and its mandatory timeout.
     arrival: >-
       Runtime loads the persisted activation inside the entity lock and selected-store transaction, checks exact window and
       member identity, stores canonical output, and evaluates default-all or complete_when over persisted join context.


### PR DESCRIPTION
## Summary
- add the strict handler.join contract, shared semantic lowering, boot verification, join.* expression context, and describe --graph complete/timeout edges
- add a typed durable join activation/close owner with ordered membership snapshots, canonical output hashes, exact duplicate handling, mandatory timeout, and atomic selected-store lifecycle
- prove expected-zero completion, arm/arrival and arrival/timeout races, restart/reload, deterministic result order, canonical failure persistence, and SQLite/Postgres parity

## Governing context
No exact authoritative join section existed before this change. The binding context is issue #1848's approved Pre-Implementation Coverage Audit and Gate C repair/approval, parent #1771's E6 doctrine, #1847's fan-out identity/empty semantics, #1835's barrier ownership split, #1924's shared stale-arrival classification, and the adjacent platform-spec.yaml state-machine, accumulate, fan-out, timer, failure, composition-routing, and reachability sections.

This PR promotes the approved public join contract and join engine into authoritative platform-spec.yaml.

## Semantic migration
- New canonical owner: the typed handler.join plan plus internal/runtime/joinruntime persisted activation/close model.
- Old path now invalid: barrier-shaped accumulate fields in stages: bundles fail boot verification; accumulate remains authoritative only for open/windowed streams.
- Production paths checked: strict decode/lowering, semantic and authoring views, verifier consumers, engine execution, selected-store persistence, stage entry/exit, timer scheduling/cancellation/recovery, replay/reload state, failure receipts/runtime logs, and graph rendering.
- Migration is complete for staged finite joins. Non-staged barrier retirement remains tracked by #1948; Empire corpus adoption by #1947; cross-flow pin derivation by #1835; contributor termination by #1949.

## Verification
- `SWARM_TEST_POSTGRES_DSN='postgres://swarm_test:swarm-test@127.0.0.1:5432/postgres?sslmode=disable' go test ./...`
- focused SQLite/Postgres join lifecycle and race matrix
- CLI verify and describe --graph supported-surface proofs
- `git diff --check`

Closes #1848