### PR TITLE
[agent-e][issue #1819] Unify public CLI runtime log projection

### DIFF
--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -515,8 +515,8 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Reason: "conversation status is a separate conversation-detail taxonomy owned by #1820",
 	},
 	"conversations.go\x00writeConversationTurnDetailResult": {
-		Names:  []string{"outcome", "status"},
-		Reason: "conversation session status and turn outcome are separate detail taxonomies owned by #1820",
+		Names:  []string{"action", "outcome", "status"},
+		Reason: "runtime-log action is exact LogEntry evidence; conversation session status and turn outcome are separate detail taxonomies owned by #1820",
 	},
 	"forkchat.go\x00writeForkChatSessionHeader": {
 		Names:  []string{"state"},
@@ -534,13 +534,9 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Names:  []string{"mode"},
 		Reason: "preflight mode is a typed diagnostic rendering input, not a registered conversation mode",
 	},
-	"logs.go\x00writeRuntimeLogListResult": {
-		Names:  []string{"action"},
-		Reason: "runtime-log action is exact log evidence owned by #1819, not a registered watchdog action",
-	},
 	"logs.go\x00writeRuntimeLogFollowEntry": {
 		Names:  []string{"action"},
-		Reason: "runtime-log action is exact log evidence owned by #1819, not a registered watchdog action",
+		Reason: "runtime-log action is exact LogEntry evidence, not a registered watchdog action",
 	},
 	"main.go\x00emit": {
 		Names:  []string{"status"},

--- a/cmd/swarm/cli_identifier_registry_test.go
+++ b/cmd/swarm/cli_identifier_registry_test.go
@@ -334,6 +334,9 @@ func TestCLIIdentifierDisplayColumnsUseFamilyAwareOwner(t *testing.T) {
 		"forkchat.go\x00FORK_ID":             cliIdentifierFamilyFork,
 		"forkchat.go\x00SOURCE_SESSION":      cliIdentifierFamilySession,
 		"forkchat.go\x00SOURCE_AGENT":        cliIdentifierFamilyAgent,
+		"logs.go\x00RUN":                     cliIdentifierFamilyRun,
+		"logs.go\x00ENTITY":                  cliIdentifierFamilyEntity,
+		"logs.go\x00SESSION":                 cliIdentifierFamilySession,
 	}
 	seen := map[string]int{}
 	keyColumnExceptions := map[string]bool{

--- a/cmd/swarm/cli_output_conformance_registry_test.go
+++ b/cmd/swarm/cli_output_conformance_registry_test.go
@@ -161,6 +161,7 @@ var cliOutputSharedDisplayProofs = map[string][]string{
 	"writeForkChatSessionHeader":             {"writeCLIFieldLine"},
 	"writeMailboxDetailResult":               {"writeCLIFieldLine"},
 	"writeMailboxListResult":                 {"writeCLITable"},
+	"writeRuntimeLogListResult":              {"writeCLITable"},
 	"writeRuntimeIncidentListResult":         {"writeCLITable"},
 	"writeSecretsTable":                      {"writeCLITable"},
 }
@@ -538,9 +539,6 @@ func TestCLIOutputConformanceNoStaleActiveSplitOwners(t *testing.T) {
 func TestCLIOutputConformanceNoUnclassifiedLiteralTabTables(t *testing.T) {
 	root := driftTestRepoRoot(t)
 	dir := filepath.Join(root, "cmd", "swarm")
-	allowedFiles := map[string]string{
-		"logs.go": "split to #1819 logs formatting",
-	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("read %s: %v", dir, err)
@@ -556,7 +554,7 @@ func TestCLIOutputConformanceNoUnclassifiedLiteralTabTables(t *testing.T) {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		for _, imp := range file.Imports {
-			if imp.Path != nil && imp.Path.Value == strconv.Quote("text/tabwriter") && allowedFiles[name] == "" {
+			if imp.Path != nil && imp.Path.Value == strconv.Quote("text/tabwriter") {
 				t.Errorf("%s imports text/tabwriter; table/list display must consume writeCLITable", name)
 			}
 		}
@@ -572,9 +570,6 @@ func TestCLIOutputConformanceNoUnclassifiedLiteralTabTables(t *testing.T) {
 				}
 				value, err := strconv.Unquote(lit.Value)
 				if err != nil || !strings.Contains(value, "\t") {
-					continue
-				}
-				if allowedFiles[name] != "" {
 					continue
 				}
 				t.Errorf("%s contains fmt print literal tab %q; table/list display must consume writeCLITable", name, value)

--- a/cmd/swarm/conversations.go
+++ b/cmd/swarm/conversations.go
@@ -306,8 +306,12 @@ func runConversationTurnCommand(ctx context.Context, out, errOut io.Writer, opts
 	if err := validateConversationTurnDetailResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
 	}
+	runtimeLogProjections, err := projectRuntimeLogEntries("conversation.get_turn result.turn.runtime_log_entries", result.Turn.RuntimeLogEntries)
+	if err != nil {
+		return returnCLIAPIError(errOut, err, conversationTurnAPIErrorClassifier())
+	}
 	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
-		writeConversationTurnDetailResult(w, result)
+		writeConversationTurnDetailResult(w, result, runtimeLogProjections)
 	}, func() ([]string, error) {
 		return []string{fmt.Sprintf("%s %d %s", result.Session.SessionID, result.Turn.TurnIndex, firstNonEmpty(result.Turn.Outcome, result.Session.Status))}, nil
 	})
@@ -683,7 +687,7 @@ func writeConversationDetailResult(out io.Writer, result conversationDetail) {
 	})
 }
 
-func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDetail) {
+func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDetail, runtimeLogProjections []runtimeLogSemanticProjection) {
 	if out == nil {
 		return
 	}
@@ -720,15 +724,25 @@ func writeConversationTurnDetailResult(out io.Writer, result conversationTurnDet
 	}
 	if len(turn.RuntimeLogEntries) > 0 {
 		fmt.Fprintln(out, "Runtime logs:")
-		for _, log := range turn.RuntimeLogEntries {
-			fmt.Fprintf(out, "log_id=%s ts=%s level=%s component=%s source=%s message=%s\n",
-				log.LogID,
-				log.TS,
-				log.Level,
-				log.Component,
-				log.Source,
-				runtimeLogMessage(log),
-			)
+		for i, log := range turn.RuntimeLogEntries {
+			projection := runtimeLogProjections[i]
+			fields := []string{
+				"log_id=" + log.LogID,
+				"ts=" + log.TS,
+				"level=" + log.Level,
+				"component=" + log.Component,
+			}
+			if projection.Action != "" {
+				fields = append(fields, "action="+projection.Action)
+			}
+			fields = append(fields, "source="+log.Source)
+			if projection.Failure != "" {
+				fields = append(fields, "failure="+projection.Failure)
+			}
+			if projection.MessageVisible {
+				fields = append(fields, "message="+projection.Message)
+			}
+			fmt.Fprintln(out, strings.Join(fields, " "))
 		}
 	}
 }

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -170,6 +170,112 @@ func TestConversationTurnUsesConversationGetTurnAndRendersDeepTurn(t *testing.T)
 	}
 }
 
+func TestConversationTurnRuntimeLogProjection(t *testing.T) {
+	_, failureValue := runtimeLogTestFailure(t)
+
+	for _, tc := range []struct {
+		name      string
+		configure func(map[string]any)
+		want      []string
+		doNotWant []string
+	}{
+		{
+			name: "exact redundant message keeps action visible",
+			configure: func(log map[string]any) {
+				log["component"] = "eventbus"
+				log["message"] = "Event was published to the event bus"
+				log["details"] = map[string]any{"action": "published"}
+			},
+			want:      []string{"component=eventbus action=published source=runtime"},
+			doNotWant: []string{"message=Event was published to the event bus"},
+		},
+		{
+			name: "near match remains visible",
+			configure: func(log map[string]any) {
+				log["component"] = "eventbus"
+				log["message"] = "Event was published to the event bus."
+				log["details"] = map[string]any{"action": "published"}
+			},
+			want: []string{"component=eventbus action=published source=runtime", "message=Event was published to the event bus."},
+		},
+		{
+			name: "valid failure uses canonical class and detail",
+			configure: func(log map[string]any) {
+				log["component"] = "connector"
+				log["message"] = "Connector request failed"
+				log["failure"] = failureValue
+				log["details"] = map[string]any{"action": "request_failed", "failure": failureValue}
+			},
+			want: []string{"component=connector action=request_failed source=runtime failure=connector_failure/waiting message=Connector request failed"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setCLIAPITestToken(t, "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validConversationTurnDetail("sess-1", 2)
+				turn := result["turn"].(map[string]any)
+				log := turn["runtime_log_entries"].([]map[string]any)[0]
+				tc.configure(log)
+				writeJSONRPCResult(t, w, req.ID, result)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"conversation", "turn", "sess-1", "2"}, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 0 {
+				t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+				}
+			}
+			for _, unwanted := range tc.doNotWant {
+				if strings.Contains(stdout.String(), unwanted) {
+					t.Fatalf("stdout contains %q:\n%s", unwanted, stdout.String())
+				}
+			}
+		})
+	}
+}
+
+func TestConversationTurnMalformedRuntimeLogFailureIsVisibleAndFailsClosed(t *testing.T) {
+	for _, args := range [][]string{
+		{"conversation", "turn", "sess-1", "2"},
+		{"conversation", "turn", "sess-1", "2", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			setCLIAPITestToken(t, "test-token")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validConversationTurnDetail("sess-1", 2)
+				turn := result["turn"].(map[string]any)
+				log := turn["runtime_log_entries"].([]map[string]any)[0]
+				log["failure"] = map[string]any{"schema_version": "platform.failure/v1", "class": "platform.unknown"}
+				writeJSONRPCResult(t, w, req.ID, result)
+			}))
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+			if code != 3 {
+				t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			for _, want := range []string{"WARNING:", "log-1", "platform.failure/v1", "platform.unknown"} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q: %s", want, stderr.String())
+				}
+			}
+			if strings.TrimSpace(stdout.String()) != "" {
+				t.Fatalf("stdout = %q, want no successful document", stdout.String())
+			}
+		})
+	}
+}
+
 func TestConversationCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	var calls atomic.Int32

--- a/cmd/swarm/conversations_test.go
+++ b/cmd/swarm/conversations_test.go
@@ -241,6 +241,89 @@ func TestConversationTurnRuntimeLogProjection(t *testing.T) {
 	}
 }
 
+func TestConversationTurnJSONPreservesCanonicalRuntimeLogShape(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	failureRaw := runtimeLogDataLimitFailure(t, "9007199254740993")
+	failureValue, err := runtimeLogDecodeJSONValue(failureRaw)
+	if err != nil {
+		t.Fatalf("decode failure fixture: %v", err)
+	}
+	const (
+		fullLogID     = "log-1234567890abcdef"
+		fullRunID     = "run-1234567890abcdef"
+		fullEntityID  = "entity-1234567890abcdef"
+		fullSessionID = "session-1234567890abcdef"
+		fullTimestamp = "2026-05-20T01:01:01.123456789-03:00"
+		exactMessage  = "Event was published to the event bus"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		result := validConversationTurnDetail("sess-1", 2)
+		turn := result["turn"].(map[string]any)
+		log := turn["runtime_log_entries"].([]map[string]any)[0]
+		log["log_id"] = fullLogID
+		log["ts"] = fullTimestamp
+		log["component"] = "eventbus"
+		log["run_id"] = fullRunID
+		log["entity_id"] = fullEntityID
+		log["session_id"] = fullSessionID
+		log["failure"] = failureValue
+		log["message"] = exactMessage
+		log["details"] = map[string]any{
+			"action":   "published",
+			"run_id":   fullRunID,
+			"failure":  failureValue,
+			"evidence": json.Number("9007199254740993"),
+		}
+		writeJSONRPCResult(t, w, req.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"conversation", "turn", "sess-1", "2", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	decoded, err := runtimeLogDecodeJSONValue(stdout.Bytes())
+	if err != nil {
+		t.Fatalf("decode CLI JSON: %v\n%s", err, stdout.String())
+	}
+	result := decoded.(map[string]any)
+	turn := result["turn"].(map[string]any)
+	logs := turn["runtime_log_entries"].([]any)
+	if len(logs) != 1 {
+		t.Fatalf("runtime_log_entries = %#v", logs)
+	}
+	log := logs[0].(map[string]any)
+	for key, want := range map[string]string{
+		"log_id": fullLogID, "ts": fullTimestamp, "run_id": fullRunID,
+		"entity_id": fullEntityID, "session_id": fullSessionID, "message": exactMessage,
+	} {
+		if got := log[key]; got != want {
+			t.Errorf("runtime log %s = %#v, want %q", key, got, want)
+		}
+	}
+	if !reflect.DeepEqual(log["failure"], failureValue) {
+		t.Errorf("top-level failure changed:\ngot:  %#v\nwant: %#v", log["failure"], failureValue)
+	}
+	details := log["details"].(map[string]any)
+	if details["action"] != "published" || details["run_id"] != fullRunID || !reflect.DeepEqual(details["failure"], failureValue) {
+		t.Errorf("machine details were projected or elided: %#v", details)
+	}
+	if evidence, ok := details["evidence"].(json.Number); !ok || evidence.String() != "9007199254740993" {
+		t.Errorf("details.evidence = %#v, want exact large json.Number", details["evidence"])
+	}
+	failure := log["failure"].(map[string]any)
+	if failure["class"] != "platform.data_limit_exceeded" {
+		t.Errorf("failure.class = %#v, want canonical machine class", failure["class"])
+	}
+	if strings.Contains(stdout.String(), `"failure":"data_limit_exceeded/limit"`) {
+		t.Fatalf("human failure projection leaked into JSON: %s", stdout.String())
+	}
+}
+
 func TestConversationTurnMalformedRuntimeLogFailureIsVisibleAndFailsClosed(t *testing.T) {
 	for _, args := range [][]string{
 		{"conversation", "turn", "sess-1", "2"},

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -50,20 +50,6 @@ type runtimeLogListResult struct {
 	NextCursor string            `json:"next_cursor,omitempty"`
 }
 
-type runtimeLogEntry struct {
-	LogID     string         `json:"log_id"`
-	TS        string         `json:"ts"`
-	Level     string         `json:"level"`
-	Component string         `json:"component"`
-	Source    string         `json:"source"`
-	RunID     string         `json:"run_id,omitempty"`
-	EntityID  string         `json:"entity_id,omitempty"`
-	SessionID string         `json:"session_id,omitempty"`
-	ErrorCode string         `json:"error_code,omitempty"`
-	Message   *string        `json:"message"`
-	Details   map[string]any `json:"details,omitempty"`
-}
-
 type runtimeLogSubscriptionResult struct {
 	SubscriptionID string `json:"subscription_id"`
 }
@@ -153,7 +139,9 @@ func runLogsSnapshotCommand(ctx context.Context, out, errOut io.Writer, opts run
 	if err := validateRuntimeLogListResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
 	}
-	writeRuntimeLogListResult(out, result)
+	if err := writeRuntimeLogListResult(out, result, params); err != nil {
+		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+	}
 	return nil
 }
 
@@ -175,6 +163,7 @@ func runLogsFollowCommand(ctx context.Context, out, errOut io.Writer, opts runti
 		return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
 	}
 	defer sub.close()
+	lastDate := ""
 	for {
 		select {
 		case <-ctx.Done():
@@ -191,7 +180,11 @@ func runLogsFollowCommand(ctx context.Context, out, errOut io.Writer, opts runti
 				}
 				return nil
 			}
-			writeRuntimeLogFollowEntry(out, log)
+			var err error
+			lastDate, err = writeRuntimeLogFollowEntry(out, log, lastDate)
+			if err != nil {
+				return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
+			}
 		case err := <-sub.errs:
 			if err != nil {
 				return returnCLIAPIError(errOut, err, runtimeLogErrorClassifier())
@@ -341,6 +334,9 @@ func validateRuntimeLogEntry(prefix string, log runtimeLogEntry) error {
 	if log.Message == nil {
 		return fmt.Errorf("malformed %s: message is required", prefix)
 	}
+	if _, err := projectRuntimeLogEntry(prefix, log); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -447,46 +443,112 @@ func (s *runtimeLogSubscription) close() {
 	_ = s.conn.Close()
 }
 
-func writeRuntimeLogListResult(out io.Writer, result runtimeLogListResult) {
+func writeRuntimeLogListResult(out io.Writer, result runtimeLogListResult, params map[string]any) error {
 	if out == nil {
-		return
+		return nil
 	}
 	if len(result.Logs) == 0 {
-		fmt.Fprintln(out, "No runtime logs match the filter.")
-		return
+		writeCLIEmptyState(out, runtimeLogEmptyMessage(params))
+		return nil
 	}
-	fmt.Fprintln(out, "TIME\tLEVEL\tCOMPONENT\tACTION\tSOURCE\tRUN\tENTITY\tSESSION\tERROR\tMESSAGE")
-	for _, log := range result.Logs {
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			log.TS,
-			log.Level,
-			log.Component,
-			runtimeLogDash(runtimeLogAction(log)),
-			log.Source,
-			runtimeLogDash(log.RunID),
-			runtimeLogDash(log.EntityID),
-			runtimeLogDash(log.SessionID),
-			runtimeLogDash(log.ErrorCode),
-			runtimeLogMessage(log),
-		)
+
+	type projectedRow struct {
+		log        runtimeLogEntry
+		projection runtimeLogSemanticProjection
+		date       string
+		time       string
+	}
+	rows := make([]projectedRow, 0, len(result.Logs))
+	dates := map[string]struct{}{}
+	showAction, showRun, showEntity, showSession, showFailure, showMessage := false, false, false, false, false, false
+	for i, log := range result.Logs {
+		projection, err := projectRuntimeLogEntry(fmt.Sprintf("runtime.logs result: logs[%d]", i), log)
+		if err != nil {
+			return err
+		}
+		date, clock, err := runtimeLogDisplayTime(log.TS)
+		if err != nil {
+			return err
+		}
+		dates[date] = struct{}{}
+		showAction = showAction || projection.Action != ""
+		showRun = showRun || strings.TrimSpace(log.RunID) != ""
+		showEntity = showEntity || strings.TrimSpace(log.EntityID) != ""
+		showSession = showSession || strings.TrimSpace(log.SessionID) != ""
+		showFailure = showFailure || projection.Failure != ""
+		showMessage = showMessage || projection.MessageVisible
+		rows = append(rows, projectedRow{log: log, projection: projection, date: date, time: clock})
+	}
+
+	type column struct {
+		spec    cliTableColumn
+		include bool
+		value   func(projectedRow) string
+	}
+	columns := []column{
+		{spec: cliTableColumn{Header: "DATE"}, include: len(dates) > 1, value: func(row projectedRow) string { return row.date }},
+		{spec: cliTableColumn{Header: "TIME"}, include: true, value: func(row projectedRow) string { return row.time }},
+		{spec: cliTableColumn{Header: "LEVEL"}, include: true, value: func(row projectedRow) string { return row.log.Level }},
+		{spec: cliTableColumn{Header: "COMPONENT"}, include: true, value: func(row projectedRow) string { return row.log.Component }},
+		{spec: cliTableColumn{Header: "ACTION"}, include: showAction, value: func(row projectedRow) string { return row.projection.Action }},
+		{spec: cliTableColumn{Header: "SOURCE"}, include: true, value: func(row projectedRow) string { return row.log.Source }},
+		{spec: cliTableColumn{Header: "RUN", IdentifierFamily: cliIdentifierFamilyRun}, include: showRun, value: func(row projectedRow) string { return row.log.RunID }},
+		{spec: cliTableColumn{Header: "ENTITY", IdentifierFamily: cliIdentifierFamilyEntity}, include: showEntity, value: func(row projectedRow) string { return row.log.EntityID }},
+		{spec: cliTableColumn{Header: "SESSION", IdentifierFamily: cliIdentifierFamilySession}, include: showSession, value: func(row projectedRow) string { return row.log.SessionID }},
+		{spec: cliTableColumn{Header: "FAILURE", Truncatable: true}, include: showFailure, value: func(row projectedRow) string { return row.projection.Failure }},
+		{spec: cliTableColumn{Header: "MESSAGE", Truncatable: true}, include: showMessage, value: func(row projectedRow) string {
+			if !row.projection.MessageVisible {
+				return ""
+			}
+			return row.projection.Message
+		}},
+	}
+	table := cliTable{}
+	for _, candidate := range columns {
+		if candidate.include {
+			table.Columns = append(table.Columns, candidate.spec)
+		}
+	}
+	for _, row := range rows {
+		values := make([]string, 0, len(table.Columns))
+		for _, candidate := range columns {
+			if candidate.include {
+				values = append(values, candidate.value(row))
+			}
+		}
+		table.Rows = append(table.Rows, values)
 	}
 	if strings.TrimSpace(result.NextCursor) != "" {
-		fmt.Fprintf(out, "next_cursor=%s\n", result.NextCursor)
+		table.FooterLines = []string{"Next cursor: " + result.NextCursor}
 	}
+	writeCLITable(out, table)
+	return nil
 }
 
-func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry) {
+func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry, lastDate string) (string, error) {
 	if out == nil {
-		return
+		return lastDate, nil
+	}
+	projection, err := projectRuntimeLogEntry("runtime.subscribe_logs notification", log)
+	if err != nil {
+		return lastDate, err
+	}
+	date, clock, err := runtimeLogDisplayTime(log.TS)
+	if err != nil {
+		return lastDate, err
+	}
+	if date != lastDate {
+		fmt.Fprintf(out, "--- %s UTC ---\n", date)
+		lastDate = date
 	}
 	fields := []string{
 		"log_id=" + log.LogID,
-		"ts=" + log.TS,
+		"ts=" + clock,
 		"level=" + log.Level,
 		"component=" + log.Component,
 	}
-	if action := runtimeLogAction(log); action != "" {
-		fields = append(fields, "action="+action)
+	if projection.Action != "" {
+		fields = append(fields, "action="+projection.Action)
 	}
 	fields = append(fields, "source="+log.Source)
 	if log.RunID != "" {
@@ -498,14 +560,52 @@ func writeRuntimeLogFollowEntry(out io.Writer, log runtimeLogEntry) {
 	if log.SessionID != "" {
 		fields = append(fields, "session_id="+log.SessionID)
 	}
-	if log.ErrorCode != "" {
-		fields = append(fields, "error_code="+log.ErrorCode)
+	if projection.Failure != "" {
+		fields = append(fields, "failure="+projection.Failure)
 	}
-	fields = append(fields, "message="+runtimeLogMessage(log))
-	if len(log.Details) > 0 {
-		fields = append(fields, "details="+runtimeLogCompactJSON(log.Details))
+	if projection.MessageVisible {
+		fields = append(fields, "message="+projection.Message)
+	}
+	if len(projection.ResidualDetails) > 0 {
+		fields = append(fields, "details="+runtimeLogCompactJSON(projection.ResidualDetails))
 	}
 	fmt.Fprintf(out, "log %s\n", strings.Join(fields, " "))
+	return lastDate, nil
+}
+
+func runtimeLogDisplayTime(raw string) (string, string, error) {
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("malformed runtime log timestamp %q: %w", raw, err)
+	}
+	at = at.UTC()
+	return at.Format("2006-01-02"), at.Format("15:04:05.000"), nil
+}
+
+func runtimeLogEmptyMessage(params map[string]any) string {
+	var filters []string
+	for _, item := range []struct {
+		param string
+		flag  string
+	}{
+		{param: "run_id", flag: "--run-id"},
+		{param: "entity_id", flag: "--entity-id"},
+		{param: "session_id", flag: "--session-id"},
+		{param: "component", flag: "--component"},
+		{param: "level", flag: "--level"},
+		{param: "error_code", flag: "--error-code"},
+		{param: "source", flag: "--source"},
+		{param: "since", flag: "--since"},
+		{param: "until", flag: "--until"},
+	} {
+		if value := strings.TrimSpace(fmt.Sprint(params[item.param])); value != "" && value != "<nil>" {
+			filters = append(filters, item.flag+" "+value)
+		}
+	}
+	if len(filters) == 0 {
+		return "No runtime log entries have been recorded."
+	}
+	return "No log entries match " + strings.Join(filters, " ") + ". Remove filters or widen the time range."
 }
 
 func runtimeLogCompactJSON(value map[string]any) string {
@@ -514,14 +614,6 @@ func runtimeLogCompactJSON(value map[string]any) string {
 		return "{}"
 	}
 	return string(raw)
-}
-
-func runtimeLogDash(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "-"
-	}
-	return value
 }
 
 func runtimeLogAction(log runtimeLogEntry) string {

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -614,6 +615,57 @@ func TestRuntimeLogProjectionPreservesMismatchedResidualEvidence(t *testing.T) {
 	}
 }
 
+func TestRuntimeLogFailureEquivalencePreservesExactLargeNumbers(t *testing.T) {
+	topFailure := runtimeLogDataLimitFailure(t, "9007199254740992")
+	identicalFailure := runtimeLogDataLimitFailure(t, "9007199254740992")
+	distinctFailure := runtimeLogDataLimitFailure(t, "9007199254740993")
+
+	for _, tc := range []struct {
+		name            string
+		detailFailure   json.RawMessage
+		wantResidual    bool
+		wantLimitNumber string
+	}{
+		{name: "identical large number deduplicates", detailFailure: identicalFailure},
+		{name: "distinct large number remains", detailFailure: distinctFailure, wantResidual: true, wantLimitNumber: "9007199254740993"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := fmt.Sprintf(`{
+				"log_id":"log-large-number",
+				"ts":"2026-05-19T10:00:01Z",
+				"level":"error",
+				"component":"runtime",
+				"source":"runtime",
+				"failure":%s,
+				"message":"Data limit exceeded",
+				"details":{"failure":%s}
+			}`, topFailure, tc.detailFailure)
+			var log runtimeLogEntry
+			if err := json.Unmarshal([]byte(raw), &log); err != nil {
+				t.Fatalf("decode runtime log: %v", err)
+			}
+			projection, err := projectRuntimeLogEntry("test", log)
+			if err != nil {
+				t.Fatalf("project runtime log: %v", err)
+			}
+			residualFailure, exists := projection.ResidualDetails["failure"]
+			if exists != tc.wantResidual {
+				t.Fatalf("residual failure exists=%t, want %t: %#v", exists, tc.wantResidual, projection.ResidualDetails)
+			}
+			if !tc.wantResidual {
+				return
+			}
+			failureMap := residualFailure.(map[string]any)
+			detail := failureMap["detail"].(map[string]any)
+			attributes := detail["attributes"].(map[string]any)
+			limit, ok := attributes["limit"].(json.Number)
+			if !ok || limit.String() != tc.wantLimitNumber {
+				t.Fatalf("residual limit = %#v, want exact json.Number(%s)", attributes["limit"], tc.wantLimitNumber)
+			}
+		})
+	}
+}
+
 func TestRuntimeLogSnapshotProjectionCoversMixedRowsDatesAndFailures(t *testing.T) {
 	failureRaw, _ := runtimeLogTestFailure(t)
 	exactMessage := "Event was published to the event bus"
@@ -939,6 +991,30 @@ func runtimeLogTestFailure(t *testing.T) (json.RawMessage, map[string]any) {
 		t.Fatalf("decode test failure: %v", err)
 	}
 	return raw, value
+}
+
+func runtimeLogDataLimitFailure(t *testing.T, limit string) json.RawMessage {
+	t.Helper()
+	failure := runtimefailures.Normalize(
+		runtimefailures.New(
+			runtimefailures.ClassDataLimitExceeded,
+			"limit",
+			"runtime",
+			"read",
+			map[string]any{
+				"limit_kind": "bytes",
+				"limit":      json.Number(limit),
+				"actual":     json.Number(limit),
+			},
+		),
+		"runtime",
+		"read",
+	)
+	raw, err := runtimefailures.MarshalEnvelope(failure)
+	if err != nil {
+		t.Fatalf("marshal data-limit failure: %v", err)
+	}
+	return raw
 }
 
 func writeRuntimeLogJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -12,11 +12,14 @@ import (
 	"sync/atomic"
 	"testing"
 
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/gorilla/websocket"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
+	_, failureValue := runtimeLogTestFailure(t)
 	var captured jsonRPCRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/rpc" {
@@ -28,8 +31,11 @@ func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Errorf("decode request: %v", err)
 		}
+		log := validRuntimeLogEntry("log-1")
+		log["failure"] = failureValue
+		log["details"] = map[string]any{"attempt": 2, "action": "delivery_failed", "failure": failureValue}
 		writeJSONRPCResult(t, w, captured.ID, map[string]any{
-			"logs":        []any{validRuntimeLogEntry("log-1")},
+			"logs":        []any{log},
 			"next_cursor": "log-cursor-2",
 		})
 	}))
@@ -74,7 +80,7 @@ func TestLogsUsesRuntimeLogsV1RPCWithSnapshotFilters(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"TIME", "ACTION", "delivery_failed", "log message", "run-1", "entity-1", "session-1", "DELIVERY_FAILED", "next_cursor=log-cursor-2"} {
+	for _, want := range []string{"TIME", "ACTION", "delivery_failed", "connector_failure/waiting", "log message", "run-1", "entity-1", "session-1", "Next cursor: log-cursor-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -128,13 +134,53 @@ func TestLogsFollowUsesRuntimeSubscribeLogsV1WS(t *testing.T) {
 	if !reflect.DeepEqual(req.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", req.Params, wantParams)
 	}
-	for _, want := range []string{"log log_id=log-live-1", "action=delivery_failed", "run_id=run-1", "message=log message", "details={\"action\":\"delivery_failed\",\"attempt\":2}"} {
+	for _, want := range []string{"--- 2026-05-19 UTC ---", "log log_id=log-live-1", "ts=10:00:01.000", "action=delivery_failed", "run_id=run-1", "message=log message", "details={\"attempt\":2}"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestLogsFollowProjectsExactMessageAndValidFailureThroughWebSocket(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	_, failureValue := runtimeLogTestFailure(t)
+	exact := validRuntimeLogEntry("log-exact")
+	exact["component"] = "eventbus"
+	exact["message"] = "Event was published to the event bus"
+	exact["details"] = map[string]any{"action": "published"}
+	failing := validRuntimeLogEntry("log-failure")
+	failing["component"] = "connector"
+	failing["message"] = "Connector request failed"
+	failing["failure"] = failureValue
+	failing["details"] = map[string]any{"action": "request_failed", "failure": failureValue}
+
+	server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
+		logs:           []map[string]any{exact, failing},
+		closeAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"logs", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{
+		"log_id=log-exact ts=10:00:01.000 level=info component=eventbus action=published source=runtime",
+		"log_id=log-failure ts=10:00:01.000 level=info component=connector action=request_failed source=runtime",
+		"failure=connector_failure/waiting",
+		"message=Connector request failed",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "message=Event was published to the event bus") {
+		t.Fatalf("stdout retained exact redundant message:\n%s", text)
 	}
 }
 
@@ -417,20 +463,316 @@ func TestLogsRenderMissingActionGracefully(t *testing.T) {
 	}
 
 	var snapshot bytes.Buffer
-	writeRuntimeLogListResult(&snapshot, runtimeLogListResult{Logs: []runtimeLogEntry{log}})
-	for _, want := range []string{"ACTION", "scheduler\t-\truntime", "without action"} {
+	if err := writeRuntimeLogListResult(&snapshot, runtimeLogListResult{Logs: []runtimeLogEntry{log}}, nil); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	for _, want := range []string{"TIME", "scheduler", "runtime", "without action"} {
 		if !strings.Contains(snapshot.String(), want) {
 			t.Fatalf("snapshot missing %q:\n%s", want, snapshot.String())
 		}
 	}
+	if strings.Contains(snapshot.String(), "ACTION") {
+		t.Fatalf("snapshot = %q, want page-empty ACTION elided", snapshot.String())
+	}
 
 	var follow bytes.Buffer
-	writeRuntimeLogFollowEntry(&follow, log)
+	if _, err := writeRuntimeLogFollowEntry(&follow, log, ""); err != nil {
+		t.Fatalf("write follow: %v", err)
+	}
 	if strings.Contains(follow.String(), "action=") {
 		t.Fatalf("follow = %q, want no action field", follow.String())
 	}
 	if !strings.Contains(follow.String(), "source=runtime") {
 		t.Fatalf("follow = %q, want source", follow.String())
+	}
+}
+
+func TestRuntimeLogProjectionExactMessageAndResidualDetails(t *testing.T) {
+	failureRaw, failureValue := runtimeLogTestFailure(t)
+	exactMessage := "Event was published to the event bus"
+	log := runtimeLogEntry{
+		LogID:     "log-1",
+		TS:        "2026-05-19T10:00:01Z",
+		Level:     "info",
+		Component: "eventbus",
+		Source:    "agent-1",
+		RunID:     "run-1",
+		EntityID:  "entity-1",
+		SessionID: "session-1",
+		Failure:   failureRaw,
+		Message:   &exactMessage,
+		Details: map[string]any{
+			"component":  "eventbus",
+			"action":     "published",
+			"agent_id":   "agent-1",
+			"run_id":     "run-1",
+			"entity_id":  "entity-1",
+			"session_id": "session-1",
+			"failure":    failureValue,
+			"attempt":    float64(2),
+		},
+	}
+
+	projection, err := projectRuntimeLogEntry("test", log)
+	if err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	if projection.Action != "published" || projection.MessageVisible {
+		t.Fatalf("projection = %#v, want published action and suppressed exact message", projection)
+	}
+	if projection.Failure != "connector_failure/waiting" {
+		t.Fatalf("failure = %q", projection.Failure)
+	}
+	if !reflect.DeepEqual(projection.ResidualDetails, map[string]any{"attempt": float64(2)}) {
+		t.Fatalf("residual details = %#v", projection.ResidualDetails)
+	}
+
+	nearMessage := exactMessage + "."
+	log.Message = &nearMessage
+	projection, err = projectRuntimeLogEntry("test", log)
+	if err != nil {
+		t.Fatalf("project near match: %v", err)
+	}
+	if !projection.MessageVisible || projection.Message != nearMessage {
+		t.Fatalf("near-match projection = %#v", projection)
+	}
+}
+
+func TestRuntimeLogRedundantMessageTuplesMatchSpec(t *testing.T) {
+	cli := loadCLISpecification(t)
+	catalog := driftMappingValue(cli, "command_catalog")
+	logs := driftMappingValue(catalog, "logs")
+	output := driftMappingValue(logs, "output")
+	projection := driftMappingValue(output, "semantic_projection")
+	tuples := driftMappingValue(projection, "exact_redundant_message_tuples")
+	if tuples == nil || tuples.Kind != yaml.SequenceNode {
+		t.Fatal("logs semantic projection exact_redundant_message_tuples must be a sequence")
+	}
+	want := map[runtimeLogMessageTuple]struct{}{}
+	for _, row := range tuples.Content {
+		want[runtimeLogMessageTuple{
+			Component: yamlScalar(t, row, "component"),
+			Action:    yamlScalar(t, row, "action"),
+			Message:   yamlScalar(t, row, "message"),
+		}] = struct{}{}
+	}
+	if !reflect.DeepEqual(runtimeLogRedundantMessageTuples, want) {
+		t.Fatalf("runtime-log redundant-message registry differs from authoritative spec:\ngot:  %#v\nwant: %#v", runtimeLogRedundantMessageTuples, want)
+	}
+}
+
+func TestRuntimeLogProjectionPreservesMismatchedResidualEvidence(t *testing.T) {
+	failureRaw, failureValue := runtimeLogTestFailure(t)
+	message := "meaningful"
+	base := runtimeLogEntry{
+		LogID:     "log-1",
+		TS:        "2026-05-19T10:00:01Z",
+		Level:     "warn",
+		Component: "runtime",
+		Source:    "runtime",
+		RunID:     "run-1",
+		EntityID:  "entity-1",
+		SessionID: "session-1",
+		Failure:   failureRaw,
+		Message:   &message,
+	}
+
+	for _, tc := range []struct {
+		name  string
+		key   string
+		value any
+	}{
+		{name: "mismatched component", key: "component", value: "scheduler"},
+		{name: "malformed component", key: "component", value: map[string]any{"unexpected": true}},
+		{name: "malformed action", key: "action", value: map[string]any{"unexpected": true}},
+		{name: "mismatched agent", key: "agent_id", value: "agent-2"},
+		{name: "malformed agent", key: "agent_id", value: map[string]any{"unexpected": true}},
+		{name: "mismatched run", key: "run_id", value: "run-2"},
+		{name: "malformed run", key: "run_id", value: map[string]any{"unexpected": true}},
+		{name: "mismatched entity", key: "entity_id", value: "entity-2"},
+		{name: "malformed entity", key: "entity_id", value: map[string]any{"unexpected": true}},
+		{name: "mismatched session", key: "session_id", value: "session-2"},
+		{name: "malformed session", key: "session_id", value: map[string]any{"unexpected": true}},
+		{name: "mismatched failure", key: "failure", value: map[string]any{"class": "different"}},
+		{name: "malformed failure detail", key: "failure", value: "not-an-envelope"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log := base
+			log.Details = map[string]any{
+				"component": "runtime", "action": "failed", "agent_id": "runtime", "run_id": "run-1",
+				"entity_id": "entity-1", "session_id": "session-1", "failure": failureValue, "extra": "kept",
+			}
+			log.Details[tc.key] = tc.value
+			projection, err := projectRuntimeLogEntry("test", log)
+			if err != nil {
+				t.Fatalf("project: %v", err)
+			}
+			if !reflect.DeepEqual(projection.ResidualDetails[tc.key], tc.value) || projection.ResidualDetails["extra"] != "kept" {
+				t.Fatalf("residual details = %#v", projection.ResidualDetails)
+			}
+		})
+	}
+}
+
+func TestRuntimeLogSnapshotProjectionCoversMixedRowsDatesAndFailures(t *testing.T) {
+	failureRaw, _ := runtimeLogTestFailure(t)
+	exactMessage := "Event was published to the event bus"
+	meaningfulMessage := "Connector request failed"
+	logs := []runtimeLogEntry{
+		{LogID: "log-1", TS: "2026-05-19T23:59:59.123456Z", Level: "info", Component: "eventbus", Source: "runtime", Message: &exactMessage, Details: map[string]any{"action": "published"}},
+		{LogID: "log-2", TS: "2026-05-20T00:00:00.987654Z", Level: "error", Component: "connector", Source: "runtime", Failure: failureRaw, Message: &meaningfulMessage, Details: map[string]any{"action": "request_failed"}},
+	}
+
+	var out bytes.Buffer
+	if err := writeRuntimeLogListResult(&out, runtimeLogListResult{Logs: logs, NextCursor: "cursor-2"}, nil); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{"DATE", "TIME", "ACTION", "FAILURE", "MESSAGE", "2026-05-19", "23:59:59.123", "2026-05-20", "00:00:00.987", "connector_failure/waiting", "Connector request failed", "Next cursor: cursor-2"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("snapshot missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, exactMessage) || strings.Contains(text, "\t") {
+		t.Fatalf("snapshot contains suppressed message or literal tab:\n%s", text)
+	}
+	if strings.Index(text, "23:59:59.123") > strings.Index(text, "00:00:00.987") {
+		t.Fatalf("snapshot reordered rows:\n%s", text)
+	}
+}
+
+func TestRuntimeLogSnapshotElidesPageEmptyOptionalColumns(t *testing.T) {
+	message := ""
+	log := runtimeLogEntry{LogID: "log-1", TS: "2026-05-19T10:00:01Z", Level: "info", Component: "runtime", Source: "runtime", Message: &message}
+	var out bytes.Buffer
+	if err := writeRuntimeLogListResult(&out, runtimeLogListResult{Logs: []runtimeLogEntry{log}}, nil); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	header := strings.Split(out.String(), "\n")[0]
+	if got, want := strings.Fields(header), []string{"TIME", "LEVEL", "COMPONENT", "SOURCE"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("header = %q", header)
+	}
+}
+
+func TestRuntimeLogSnapshotConvertsSingleDayTimeToUTCWithoutDateColumn(t *testing.T) {
+	message := "visible"
+	log := runtimeLogEntry{LogID: "log-1", TS: "2026-05-19T07:00:01.234567-03:00", Level: "info", Component: "runtime", Source: "runtime", Message: &message}
+	var out bytes.Buffer
+	if err := writeRuntimeLogListResult(&out, runtimeLogListResult{Logs: []runtimeLogEntry{log}}, nil); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	text := out.String()
+	header := strings.Split(text, "\n")[0]
+	if strings.Contains(header, "DATE") || !strings.Contains(text, "10:00:01.234") || strings.Contains(text, "07:00:01.234") {
+		t.Fatalf("single-day UTC projection =\n%s", text)
+	}
+}
+
+func TestRuntimeLogEmptyStateDistinguishesFilters(t *testing.T) {
+	var unfiltered bytes.Buffer
+	if err := writeRuntimeLogListResult(&unfiltered, runtimeLogListResult{Logs: []runtimeLogEntry{}}, nil); err != nil {
+		t.Fatalf("write unfiltered: %v", err)
+	}
+	if got := strings.TrimSpace(unfiltered.String()); got != "No runtime log entries have been recorded." {
+		t.Fatalf("unfiltered = %q", got)
+	}
+
+	params := map[string]any{
+		"run_id": "run-1", "entity_id": "entity-1", "session_id": "session-1",
+		"component": "runtime", "level": "warn", "error_code": "waiting", "source": "agent-1",
+		"since": "2026-05-19T10:00:00Z", "until": "2026-05-19T11:00:00Z",
+		"limit": 10, "cursor": "ignored", "order": "asc",
+	}
+	var filtered bytes.Buffer
+	if err := writeRuntimeLogListResult(&filtered, runtimeLogListResult{Logs: []runtimeLogEntry{}}, params); err != nil {
+		t.Fatalf("write filtered: %v", err)
+	}
+	want := "No log entries match --run-id run-1 --entity-id entity-1 --session-id session-1 --component runtime --level warn --error-code waiting --source agent-1 --since 2026-05-19T10:00:00Z --until 2026-05-19T11:00:00Z. Remove filters or widen the time range."
+	if got := strings.TrimSpace(filtered.String()); got != want {
+		t.Fatalf("filtered = %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeLogFollowProjectionDeduplicatesDetailsAndSeparatesDates(t *testing.T) {
+	failureRaw, failureValue := runtimeLogTestFailure(t)
+	message := "Connector request failed"
+	log := runtimeLogEntry{
+		LogID: "log-1", TS: "2026-05-19T23:59:59.123Z", Level: "error", Component: "connector", Source: "agent-1",
+		RunID: "run-1", EntityID: "entity-1", SessionID: "session-1", Failure: failureRaw, Message: &message,
+		Details: map[string]any{
+			"component": "connector", "action": "request_failed", "agent_id": "agent-1", "run_id": "run-1",
+			"entity_id": "entity-1", "session_id": "session-1", "failure": failureValue, "attempt": float64(2),
+		},
+	}
+	var out bytes.Buffer
+	lastDate, err := writeRuntimeLogFollowEntry(&out, log, "")
+	if err != nil {
+		t.Fatalf("write first follow row: %v", err)
+	}
+	log.LogID = "log-2"
+	log.TS = "2026-05-20T00:00:00.456Z"
+	if _, err := writeRuntimeLogFollowEntry(&out, log, lastDate); err != nil {
+		t.Fatalf("write second follow row: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{"--- 2026-05-19 UTC ---", "--- 2026-05-20 UTC ---", "action=request_failed", "run_id=run-1", "failure=connector_failure/waiting", "message=Connector request failed", "details={\"attempt\":2}"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("follow missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Count(text, "run_id=run-1") != 2 || strings.Contains(text, "\"run_id\"") || strings.Contains(text, "\"failure\"") || strings.Contains(text, "\"action\"") {
+		t.Fatalf("follow retained projected duplicates:\n%s", text)
+	}
+}
+
+func TestLogsMalformedFailureEvidenceIsVisibleAndFailsClosed(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		log := validRuntimeLogEntry("log-invalid-failure")
+		log["failure"] = map[string]any{"schema_version": "platform.failure/v1", "class": "platform.unknown"}
+		writeJSONRPCResult(t, w, req.ID, map[string]any{"logs": []any{log}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"logs"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"WARNING:", "log-invalid-failure", "platform.failure/v1", "platform.unknown"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q: %s", want, stderr.String())
+		}
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want no successful table", stdout.String())
+	}
+}
+
+func TestLogsFollowMalformedFailureEvidenceIsVisibleAndFailsClosed(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	log := validRuntimeLogEntry("log-invalid-follow-failure")
+	log["failure"] = map[string]any{"schema_version": "platform.failure/v1", "class": "platform.unknown"}
+	server, _ := newRuntimeLogWSServer(t, runtimeLogWSServerOptions{
+		logs:           []map[string]any{log},
+		closeAfterRows: true,
+	})
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"logs", "--follow"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 3 {
+		t.Fatalf("code = %d, want 3 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"WARNING:", "log-invalid-follow-failure", "platform.failure/v1", "platform.unknown"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q: %s", want, stderr.String())
+		}
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want no successful log line", stdout.String())
 	}
 }
 
@@ -579,6 +921,24 @@ func validRuntimeLogEntry(logID string) map[string]any {
 			"action":  "delivery_failed",
 		},
 	}
+}
+
+func runtimeLogTestFailure(t *testing.T) (json.RawMessage, map[string]any) {
+	t.Helper()
+	failure := runtimefailures.Normalize(
+		runtimefailures.New(runtimefailures.ClassConnectorFailure, "waiting", "connector", "wait", nil),
+		"connector",
+		"wait",
+	)
+	raw, err := runtimefailures.MarshalEnvelope(failure)
+	if err != nil {
+		t.Fatalf("marshal test failure: %v", err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decode test failure: %v", err)
+	}
+	return raw, value
 }
 
 func writeRuntimeLogJSONRPCError(t *testing.T, w http.ResponseWriter, id string, code string) {

--- a/cmd/swarm/runtime_log_projection.go
+++ b/cmd/swarm/runtime_log_projection.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+)
+
+type runtimeLogEntry struct {
+	LogID     string          `json:"log_id"`
+	TS        string          `json:"ts"`
+	Level     string          `json:"level"`
+	Component string          `json:"component"`
+	Source    string          `json:"source"`
+	RunID     string          `json:"run_id,omitempty"`
+	EntityID  string          `json:"entity_id,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+	ErrorCode string          `json:"error_code,omitempty"`
+	Failure   json.RawMessage `json:"failure,omitempty"`
+	Message   *string         `json:"message"`
+	Details   map[string]any  `json:"details,omitempty"`
+}
+
+type runtimeLogSemanticProjection struct {
+	Action          string
+	Failure         string
+	Message         string
+	MessageVisible  bool
+	ResidualDetails map[string]any
+}
+
+type runtimeLogFailureEvidenceError struct {
+	prefix string
+	logID  string
+	raw    string
+	cause  error
+}
+
+func (e *runtimeLogFailureEvidenceError) Error() string {
+	if e == nil {
+		return ""
+	}
+	subject := strings.TrimSpace(e.prefix)
+	if subject == "" {
+		subject = "runtime log"
+	}
+	if logID := strings.TrimSpace(e.logID); logID != "" {
+		subject += " " + logID
+	}
+	return fmt.Sprintf("WARNING: %s contains malformed failure evidence: %s", subject, e.raw)
+}
+
+func (e *runtimeLogFailureEvidenceError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+type runtimeLogMessageTuple struct {
+	Component string
+	Action    string
+	Message   string
+}
+
+var runtimeLogRedundantMessageTuples = map[runtimeLogMessageTuple]struct{}{
+	{
+		Component: "eventbus",
+		Action:    "published",
+		Message:   "Event was published to the event bus",
+	}: {},
+}
+
+func projectRuntimeLogEntries(prefix string, logs []runtimeLogEntry) ([]runtimeLogSemanticProjection, error) {
+	projections := make([]runtimeLogSemanticProjection, 0, len(logs))
+	for i, log := range logs {
+		projection, err := projectRuntimeLogEntry(fmt.Sprintf("%s[%d]", prefix, i), log)
+		if err != nil {
+			return nil, err
+		}
+		projections = append(projections, projection)
+	}
+	return projections, nil
+}
+
+func projectRuntimeLogEntry(prefix string, log runtimeLogEntry) (runtimeLogSemanticProjection, error) {
+	projection := runtimeLogSemanticProjection{
+		Action:  runtimeLogAction(log),
+		Message: runtimeLogMessage(log),
+	}
+	projection.MessageVisible = projection.Message != "" && !runtimeLogMessageIsRedundant(log)
+
+	rawFailure := bytes.TrimSpace(log.Failure)
+	if len(rawFailure) > 0 {
+		failure, err := runtimefailures.UnmarshalEnvelope(rawFailure)
+		if err != nil {
+			return runtimeLogSemanticProjection{}, &runtimeLogFailureEvidenceError{
+				prefix: prefix,
+				logID:  log.LogID,
+				raw:    runtimeLogCompactRawJSON(rawFailure),
+				cause:  err,
+			}
+		}
+		projection.Failure = runtimeLogFailureSummary(failure)
+	}
+
+	projection.ResidualDetails = runtimeLogResidualDetails(log, projection)
+	return projection, nil
+}
+
+func runtimeLogMessageIsRedundant(log runtimeLogEntry) bool {
+	if log.Message == nil || len(log.Details) == 0 {
+		return false
+	}
+	rawAction, ok := log.Details["action"].(string)
+	if !ok {
+		return false
+	}
+	_, ok = runtimeLogRedundantMessageTuples[runtimeLogMessageTuple{
+		Component: log.Component,
+		Action:    rawAction,
+		Message:   *log.Message,
+	}]
+	return ok
+}
+
+func runtimeLogFailureSummary(failure runtimefailures.Envelope) string {
+	class := strings.TrimPrefix(strings.TrimSpace(string(failure.Class)), "platform.")
+	return class + "/" + strings.TrimSpace(failure.Detail.Code)
+}
+
+func runtimeLogResidualDetails(log runtimeLogEntry, projection runtimeLogSemanticProjection) map[string]any {
+	if len(log.Details) == 0 {
+		return nil
+	}
+	residual := make(map[string]any, len(log.Details))
+	for key, value := range log.Details {
+		residual[key] = value
+	}
+
+	runtimeLogRemoveEquivalentString(residual, "component", log.Component)
+	if projection.Action != "" {
+		runtimeLogRemoveEquivalentString(residual, "action", projection.Action)
+	}
+	runtimeLogRemoveEquivalentString(residual, "agent_id", log.Source)
+	runtimeLogRemoveEquivalentString(residual, "run_id", log.RunID)
+	runtimeLogRemoveEquivalentString(residual, "entity_id", log.EntityID)
+	runtimeLogRemoveEquivalentString(residual, "session_id", log.SessionID)
+
+	rawFailure := bytes.TrimSpace(log.Failure)
+	if len(rawFailure) > 0 {
+		if detailFailure, ok := residual["failure"]; ok && runtimeLogJSONEquivalent(rawFailure, detailFailure) {
+			delete(residual, "failure")
+		}
+	}
+	if len(residual) == 0 {
+		return nil
+	}
+	return residual
+}
+
+func runtimeLogRemoveEquivalentString(details map[string]any, key, expected string) {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return
+	}
+	value, ok := details[key].(string)
+	if !ok || strings.TrimSpace(value) != expected {
+		return
+	}
+	delete(details, key)
+}
+
+func runtimeLogJSONEquivalent(raw json.RawMessage, value any) bool {
+	left, err := runtimeLogDecodeJSONValue(raw)
+	if err != nil {
+		return false
+	}
+	rightRaw, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	right, err := runtimeLogDecodeJSONValue(rightRaw)
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func runtimeLogDecodeJSONValue(raw []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("trailing JSON value")
+		}
+		return nil, err
+	}
+	return value, nil
+}
+
+func runtimeLogCompactRawJSON(raw []byte) string {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return compact.String()
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/cmd/swarm/runtime_log_projection.go
+++ b/cmd/swarm/runtime_log_projection.go
@@ -27,6 +27,21 @@ type runtimeLogEntry struct {
 	Details   map[string]any  `json:"details,omitempty"`
 }
 
+func (e *runtimeLogEntry) UnmarshalJSON(raw []byte) error {
+	type wire runtimeLogEntry
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var decoded wire
+	if err := decoder.Decode(&decoded); err != nil {
+		return err
+	}
+	if err := runtimeLogRequireJSONEOF(decoder); err != nil {
+		return err
+	}
+	*e = runtimeLogEntry(decoded)
+	return nil
+}
+
 type runtimeLogSemanticProjection struct {
 	Action          string
 	Failure         string
@@ -200,14 +215,21 @@ func runtimeLogDecodeJSONValue(raw []byte) (any, error) {
 	if err := decoder.Decode(&value); err != nil {
 		return nil, err
 	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return nil, fmt.Errorf("trailing JSON value")
-		}
+	if err := runtimeLogRequireJSONEOF(decoder); err != nil {
 		return nil, err
 	}
 	return value, nil
+}
+
+func runtimeLogRequireJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("trailing JSON value")
+		}
+		return err
+	}
+	return nil
 }
 
 func runtimeLogCompactRawJSON(raw []byte) string {

--- a/internal/apispec/cli_topology_spec_test.go
+++ b/internal/apispec/cli_topology_spec_test.go
@@ -142,6 +142,39 @@ func TestCLIOutputConformanceRegistryPromotedAsCurrentStateOwner(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, color, "consumer_registry"), "output_conformance_registry")
 }
 
+func TestCLIRuntimeLogSemanticProjectionOwnsAllPublicCLIConsumers(t *testing.T) {
+	catalog := mustMappingValue(t, cliSpecification(t), "command_catalog")
+	logs := mustMappingValue(t, catalog, "logs")
+	projection := mustMappingValue(t, mustMappingValue(t, logs, "output"), "semantic_projection")
+
+	assertScalarValue(t, mustMappingValue(t, projection, "canonical_owner"), "cmd/swarm/runtime_log_projection.go projectRuntimeLogEntry")
+	consumers := mustMappingValue(t, projection, "consumers")
+	for _, want := range []string{"swarm logs snapshot", "swarm logs --follow", "swarm conversation turn embedded runtime_log_entries"} {
+		assertSequenceContainsSubstring(t, consumers, want)
+	}
+
+	tuples := mustMappingValue(t, projection, "exact_redundant_message_tuples")
+	if tuples.Kind != yaml.SequenceNode || len(tuples.Content) != 1 {
+		t.Fatalf("runtime-log redundant tuple count = %d, want 1", len(tuples.Content))
+	}
+	tuple := tuples.Content[0]
+	assertScalarValue(t, mustMappingValue(t, tuple, "component"), "eventbus")
+	assertScalarValue(t, mustMappingValue(t, tuple, "action"), "published")
+	assertScalarValue(t, mustMappingValue(t, tuple, "message"), "Event was published to the event bus")
+	assertScalarContains(t, mustMappingValue(t, projection, "follow_residual_details_rule"), "run_id")
+	assertScalarContains(t, mustMappingValue(t, projection, "follow_residual_details_rule"), "type/value mismatches")
+
+	conversation := mustMappingValue(t, catalog, "conversation_turn")
+	conversationOutput := mustMappingValue(t, conversation, "output")
+	assertScalarContains(t, mustMappingValue(t, conversationOutput, "runtime_log_projection"), "same raw-retaining semantic projection owner")
+	assertScalarContains(t, mustMappingValue(t, conversationOutput, "runtime_log_projection"), "component= and action= remain visible")
+
+	outputContract := mustMappingValue(t, mustMappingValue(t, cliSpecification(t), "foundations"), "output_contract")
+	rows := mustMappingValue(t, mustMappingValue(t, mustMappingValue(t, outputContract, "command_support"), "output_conformance_registry"), "rows")
+	logsRegistry := mustMappingValue(t, rows, "logs")
+	assertScalarValue(t, mustMappingValue(t, logsRegistry, "owner_issue"), "#1712")
+}
+
 func TestCLIHumanCodeProjectionOwnsCurrentProducerTuples(t *testing.T) {
 	outputContract := mustMappingValue(t, mustMappingValue(t, cliSpecification(t), "foundations"), "output_contract")
 	sharedRenderer := mustMappingValue(t, outputContract, "shared_renderer_contract")

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16484,7 +16484,6 @@ cli_specification:
             warning/blocked, and inactive classes; implementation of emoji marks is optional for the first #1814
             slice.
         sibling_exclusions:
-        - Logs formatting and log table policy remain owned by #1819.
         - Broad short-ID adoption and ID-prefix drillability remain owned by #1815.
         - Run-trace business-event fidelity and runtime-log hiding remain owned by #1816.
         - Conversation/detail-depth rewrites remain owned by #1820.
@@ -17112,8 +17111,8 @@ cli_specification:
             logs:
               command: swarm logs
               classification: split
-              owner_issue: '#1819'
-              reason: logs formatting remains on the dedicated logs-formatting owner.
+              owner_issue: '#1712'
+              reason: logs human projection consumes the shared display and semantic projection owners; full shared JSON/quiet output-mode route-through remains tracked by the active CLI output umbrella.
             incidents:
               command: swarm incidents
               classification: split
@@ -19811,6 +19810,13 @@ cli_specification:
         validation: CLI validates integer range 1 through 1000000, matching the v1 handler bound.
       output:
         success_detail: Conversation/turn header with session_id, turn_index, turn_id, timing, parse_ok, dispatch metadata, advertised tool summary, runtime_log_entries count, raw turn-block summary, optional assistant_visible_output, and compact runtime log lines when returned by the API.
+        runtime_log_line: log_id=<id> ts=<full timestamp> level=<level> component=<component> [action=<details.action>] source=<source> [failure=<class-without-platform-prefix>/<detail>] [message=<message>]
+        runtime_log_projection: >
+          Embedded runtime_log_entries consume the same raw-retaining semantic projection owner as swarm logs for
+          action, MESSAGE disposition, canonical failure class/detail, and malformed failure evidence. The exact
+          redundant-message registry may omit only message=; component= and action= remain visible. Unknown or
+          near-match messages remain exact. A malformed top-level failure emits one warning with compact raw evidence,
+          fails closed with exit 3, and produces no successful human or JSON document.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -20136,9 +20142,40 @@ cli_specification:
         - --cursor
         - --order
       output:
-        snapshot_table: TIME / LEVEL / COMPONENT / ACTION / SOURCE / RUN / ENTITY / SESSION / ERROR / MESSAGE plus next_cursor when present
-        snapshot_empty: No runtime logs match the filter.
-        follow_notification_line: log log_id=<id> ts=<timestamp> level=<level> component=<component> [action=<details.action>] source=<source> [run_id=<run>] [entity_id=<entity>] [session_id=<session>] [error_code=<code>] message=<message> [details=<compact-json>]
+        semantic_projection:
+          canonical_owner: cmd/swarm/runtime_log_projection.go projectRuntimeLogEntry
+          consumers:
+          - swarm logs snapshot
+          - swarm logs --follow
+          - swarm conversation turn embedded runtime_log_entries
+          exact_redundant_message_tuples:
+          - component: eventbus
+            action: published
+            message: Event was published to the event bus
+          message_rule: >
+            MESSAGE is omitted only for an exact tuple above and only while component and action remain visible.
+            Unknown, malformed, and near-match values remain visible exactly; no prose or substring heuristic is valid.
+          failure_rule: >
+            A present top-level LogEntry.failure is retained raw and strictly decoded through the canonical failure
+            owner. Human output renders class without the invariant platform. prefix plus detail code. A malformed
+            failure emits one warning containing compact raw evidence, then fails closed with exit 3; it is never
+            silently zeroed, guessed, or accepted.
+          follow_residual_details_rule: >
+            Follow starts from an unchanged copy of details and removes component, action, agent_id, run_id,
+            entity_id, session_id, or failure only when the same fact is present in an equivalent dedicated field.
+            Absent dedicated fields, type/value mismatches, malformed values, and additive keys remain visible in
+            residual details. This is a human projection only; API and machine fields remain unchanged.
+        snapshot_table: >
+          UTC audit-time table. TIME, LEVEL, COMPONENT, and SOURCE are always present. DATE is present when the page
+          crosses a UTC date. ACTION, RUN, ENTITY, SESSION, FAILURE, and MESSAGE are present only when at least one
+          returned row populates the column. TIME is HH:MM:SS.mmm; rows and order are unchanged; identifiers remain full.
+        snapshot_empty: >
+          With no match-affecting filters: `No runtime log entries have been recorded.` With filters: `No log entries
+          match <supplied filters in canonical flag order>. Remove filters or widen the time range.` Pagination and
+          order controls are not echoed.
+        snapshot_cursor: 'Next cursor: <cursor>'
+        follow_notification_line: log log_id=<id> ts=<HH:MM:SS.mmm> level=<level> component=<component> [action=<details.action>] source=<source> [run_id=<run>] [entity_id=<entity>] [session_id=<session>] [failure=<class-without-platform-prefix>/<detail>] [message=<message>] [details=<residual-compact-json>]
+        follow_date_context: Emit `--- YYYY-MM-DD UTC ---` before the first row and whenever the UTC date changes; follow remains line-oriented with no mutable table header.
       exit_codes:
         success: 0
         cli_validation: 2


### PR DESCRIPTION
## Summary

- add one raw-retaining `LogEntry` semantic projection owner for action, exact MESSAGE disposition, canonical failure class/detail, malformed failure evidence, and follow residual details
- move `swarm logs` snapshot, `swarm logs --follow`, and `swarm conversation turn` embedded runtime-log lines to that owner
- route snapshot tables through `writeCLITable`, add UTC date/time context, optional-column elision, truthful empty states, and human cursor prose
- lock the exact tuple registry and all three consumers in `platform-spec.yaml` and conformance tests

Closes #1819

## Governing references

Exact binding sections:

- `platform-spec.yaml#platform_tables.diagnostics_encoding.runtime_log_encoding`
- `platform-spec.yaml#engine.error_model.failure_taxonomy`
- `platform-spec.yaml#components.schemas.LogEntry`
- `platform-spec.yaml#api_specification.method_catalog.runtime.logs`
- `platform-spec.yaml#api_specification.method_catalog.runtime.subscribe_logs`
- `platform-spec.yaml#cli_specification.command_catalog.logs`
- `platform-spec.yaml#cli_specification.command_catalog.conversation_turn`
- `platform-spec.yaml#cli_specification.foundations.output_contract.shared_renderer_contract`
- `platform-spec.yaml#cli_specification.foundations.output_contract.command_support.output_conformance_registry`
- approved #1819 Pre-Implementation Coverage Audit and independent gate outcome

## Semantic migration

- **New canonical owner:** `cmd/swarm/runtime_log_projection.go` (`projectRuntimeLogEntry`), subordinate to persisted runtime-log facts, public `LogEntry`, and `internal/runtime/failures`.
- **Old paths now invalid:** command-local action/MESSAGE/failure interpretation in snapshot, follow, and conversation; literal-tab snapshot rendering; full follow `details=` replay after dedicated fields; `error_code` as human failure identity.
- **Production paths checked:** all `runtimeLogEntry`, `runtime_log_entries`, `OperatorRuntimeLogEntry`, `ListOperatorRuntimeLogs`, and runtime-log writer/renderer call sites. The only public CLI consumers are snapshot, follow, and conversation turn; all now consume the shared owner.
- **Migration complete:** yes for `public_cli_logentry_semantic_projection_drift`. Runtime/store/API facts and machine schemas are unchanged. Broader output-mode route-through remains #1712; broader conversation depth remains #1820.

## Proof

Passed:

- `go test ./cmd/swarm -run 'TestLogs|TestRuntimeLog|TestConversationTurn|TestCLIHumanCodePublicConsumersUseSharedProjector|TestCLIIdentifierDisplayColumnsUseFamilyAwareOwner|TestCLIOutputConformanceNoUnclassifiedLiteralTabTables' -count=1`
- `go test ./internal/apispec -count=1`
- SQLite/Postgres supported observability API surfaces, OpenRPC HTTP/WS runtime probes, conversation owner composition, and runtime-log subscription probes
- isolated rerun of `TestListPendingAgentDeliveryFacts_UsesFullPendingHorizon_V2`
- `git diff --check`

`go test ./...` was run twice with host Postgres. The first run passed `internal/store` and exposed two new static guard inventory entries in `cmd/swarm`; both were repaired. The second run passed `cmd/swarm` and every affected/runtime/API package, then `internal/store` hit its 10-minute package timeout blocked in `internal/testutil.StartPostgres -> CREATE DATABASE ... WITH TEMPLATE` while three other worktrees were running full suites on the same host Postgres. The timed-out test passes in isolation; no changed code is on that path.
