### PR TITLE
[agent-e][issue #1955] Accept relative CLI read windows

### DIFF
--- a/cmd/swarm/cli_api.go
+++ b/cmd/swarm/cli_api.go
@@ -52,6 +52,7 @@ type rootCommandOptions struct {
 	runReadyTimeout        time.Duration
 	runReadyPoll           time.Duration
 	runStatusPoll          time.Duration
+	now                    func() time.Time
 }
 
 func defaultRootCommandOptions() rootCommandOptions {
@@ -63,6 +64,7 @@ func defaultRootCommandOptions() rootCommandOptions {
 		runReadyTimeout: 30 * time.Second,
 		runReadyPoll:    250 * time.Millisecond,
 		runStatusPoll:   time.Second,
+		now:             time.Now,
 	}
 }
 

--- a/cmd/swarm/cli_read_window.go
+++ b/cmd/swarm/cli_read_window.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type cliReadWindowBoundInput struct {
+	Value string
+	Set   bool
+}
+
+type cliReadWindowInput struct {
+	Since        cliReadWindowBoundInput
+	Until        cliReadWindowBoundInput
+	ReferenceUTC time.Time
+}
+
+type cliReadWindow struct {
+	Since *time.Time
+	Until *time.Time
+}
+
+func captureCLIReadWindowReference(opts rootCommandOptions) time.Time {
+	now := time.Now
+	if opts.now != nil {
+		now = opts.now
+	}
+	return now().UTC()
+}
+
+func resolveCLIReadWindow(input cliReadWindowInput) (cliReadWindow, error) {
+	if input.ReferenceUTC.IsZero() {
+		return cliReadWindow{}, fmt.Errorf("read-window reference time is required")
+	}
+	reference := input.ReferenceUTC.UTC()
+	window := cliReadWindow{}
+	if input.Since.Set {
+		since, err := resolveCLIReadWindowBound("--since", input.Since.Value, reference)
+		if err != nil {
+			return cliReadWindow{}, err
+		}
+		window.Since = &since
+	}
+	if input.Until.Set {
+		until, err := resolveCLIReadWindowBound("--until", input.Until.Value, reference)
+		if err != nil {
+			return cliReadWindow{}, err
+		}
+		window.Until = &until
+	}
+	if window.Since != nil && window.Until != nil && window.Since.After(*window.Until) {
+		return cliReadWindow{}, fmt.Errorf("--until must be greater than or equal to --since")
+	}
+	return window, nil
+}
+
+func resolveCLIReadWindowBound(name, raw string, reference time.Time) (time.Time, error) {
+	if raw == "" || strings.TrimSpace(raw) != raw {
+		return time.Time{}, fmt.Errorf("%s must not be empty or contain surrounding whitespace", name)
+	}
+	if absolute, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return absolute.UTC(), nil
+	}
+	duration, ok := parseCLIReadWindowDuration(raw)
+	if !ok {
+		return time.Time{}, fmt.Errorf("%s must be an RFC3339 timestamp or a positive relative duration using lowercase h, m, s, or ms", name)
+	}
+	return reference.Add(-duration).UTC(), nil
+}
+
+func parseCLIReadWindowDuration(raw string) (time.Duration, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	var total time.Duration
+	for offset := 0; offset < len(raw); {
+		digitStart := offset
+		for offset < len(raw) && raw[offset] >= '0' && raw[offset] <= '9' {
+			offset++
+		}
+		if digitStart == offset {
+			return 0, false
+		}
+		amount, err := strconv.ParseUint(raw[digitStart:offset], 10, 64)
+		if err != nil || amount == 0 {
+			return 0, false
+		}
+
+		unit := time.Duration(0)
+		switch {
+		case strings.HasPrefix(raw[offset:], "ms"):
+			unit = time.Millisecond
+			offset += 2
+		case offset < len(raw) && raw[offset] == 's':
+			unit = time.Second
+			offset++
+		case offset < len(raw) && raw[offset] == 'm':
+			unit = time.Minute
+			offset++
+		case offset < len(raw) && raw[offset] == 'h':
+			unit = time.Hour
+			offset++
+		default:
+			return 0, false
+		}
+
+		if amount > uint64(math.MaxInt64)/uint64(unit) {
+			return 0, false
+		}
+		component := time.Duration(amount) * unit
+		if total > time.Duration(math.MaxInt64)-component {
+			return 0, false
+		}
+		total += component
+	}
+	return total, total > 0
+}
+
+func (window cliReadWindow) addParams(params map[string]any) {
+	if window.Since != nil {
+		params["since"] = window.Since.UTC().Format(time.RFC3339Nano)
+	}
+	if window.Until != nil {
+		params["until"] = window.Until.UTC().Format(time.RFC3339Nano)
+	}
+}

--- a/cmd/swarm/cli_read_window_conformance_test.go
+++ b/cmd/swarm/cli_read_window_conformance_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCLIReadWindowRegistryCoversEveryPublicSinceUntilFlag(t *testing.T) {
+	want := map[string]string{
+		"swarm run list":      "read_window",
+		"swarm run trace":     "read_window",
+		"swarm event list":    "read_window",
+		"swarm logs":          "read_window",
+		"swarm mailbox defer": "future_deadline",
+	}
+	got := map[string]string{}
+	for path, cmd := range visibleCLICommandPaths(t) {
+		if cmd.Flags().Lookup("since") == nil && cmd.Flags().Lookup("until") == nil {
+			continue
+		}
+		classification, ok := want[path]
+		if !ok {
+			t.Errorf("public command %q exposes --since/--until without a read-window classification", path)
+			continue
+		}
+		got[path] = classification
+	}
+	for path, classification := range want {
+		if got[path] != classification {
+			t.Errorf("classified command %q = %q, want %q", path, got[path], classification)
+		}
+	}
+}
+
+func TestCLIReadWindowConsumersRouteThroughCanonicalOwner(t *testing.T) {
+	want := map[string]bool{
+		"diagnosticRunListOptions.params":         false,
+		"diagnosticTraceOptions.snapshotParams":   false,
+		"eventListCommandOptions.params":          false,
+		"runtimeLogCommandOptions.snapshotParams": false,
+	}
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, declaration := range parsed.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 || fn.Body == nil {
+				continue
+			}
+			receiver := cliReadWindowReceiverName(fn.Recv.List[0].Type)
+			key := receiver + "." + fn.Name.Name
+			if _, ok := want[key]; !ok {
+				continue
+			}
+			ownerCalls := 0
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if ident, ok := call.Fun.(*ast.Ident); ok {
+					switch ident.Name {
+					case "resolveCLIReadWindow":
+						ownerCalls++
+					case "validateRFC3339Flag", "parseRFC3339Flag":
+						t.Errorf("%s still calls legacy %s", key, ident.Name)
+					}
+				}
+				return true
+			})
+			if ownerCalls != 1 {
+				t.Errorf("%s canonical owner calls = %d, want 1", key, ownerCalls)
+			}
+			want[key] = true
+		}
+	}
+	for key, found := range want {
+		if !found {
+			t.Errorf("canonical read-window consumer %s not found", key)
+		}
+	}
+}
+
+func TestCLIReadWindowSpecOwnerAndConsumersStayCanonical(t *testing.T) {
+	spec := loadCLISpecification(t)
+	foundations := driftMappingValue(spec, "foundations")
+	owner := driftMappingValue(foundations, "read_window_input")
+	if owner == nil {
+		t.Fatal("cli_specification.foundations.read_window_input not found")
+	}
+	if got := cliReadWindowSpecScalar(owner, "canonical_owner"); got != "platform-spec.yaml#cli_specification.foundations.read_window_input" {
+		t.Fatalf("read-window canonical_owner = %q", got)
+	}
+	accepted := driftMappingValue(owner, "accepted_input")
+	relative := cliReadWindowSpecScalar(accepted, "relative")
+	for _, required := range []string{"lowercase `h`, `m`, `s`, or `ms`", "Every component and the total MUST be positive", "duration overflow"} {
+		if !strings.Contains(relative, required) {
+			t.Errorf("relative grammar missing %q: %s", required, relative)
+		}
+	}
+
+	catalog := driftMappingValue(spec, "command_catalog")
+	for _, command := range []string{"runs", "events_list", "logs"} {
+		row := driftMappingValue(catalog, command)
+		if got := cliReadWindowSpecScalar(row, "read_window_input_contract"); got != "cli_specification.foundations.read_window_input" {
+			t.Errorf("command_catalog.%s read-window owner = %q", command, got)
+		}
+	}
+	trace := driftMappingValue(catalog, "trace")
+	traceFilter := driftMappingValue(trace, "promoted_trace_filter_contract")
+	if got := cliReadWindowSpecScalar(traceFilter, "cli_read_window_input_contract"); got != "cli_specification.foundations.read_window_input" {
+		t.Errorf("command_catalog.trace read-window owner = %q", got)
+	}
+}
+
+func cliReadWindowSpecScalar(node *yaml.Node, key string) string {
+	if node == nil {
+		return ""
+	}
+	value := driftMappingValue(node, key)
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(value.Value)
+}
+
+func cliReadWindowReceiverName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.StarExpr:
+		return cliReadWindowReceiverName(value.X)
+	default:
+		return ""
+	}
+}

--- a/cmd/swarm/cli_read_window_test.go
+++ b/cmd/swarm/cli_read_window_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+var cliReadWindowSupportedCommands = []struct {
+	name       string
+	args       []string
+	wantMethod string
+}{
+	{name: "run list", args: []string{"run", "list"}, wantMethod: "run.list"},
+	{name: "run trace", args: []string{"run", "trace", "run-1"}, wantMethod: "run.trace"},
+	{name: "event list", args: []string{"event", "list"}, wantMethod: "event.list"},
+	{name: "logs", args: []string{"logs"}, wantMethod: "runtime.logs"},
+}
+
+func TestParseCLIReadWindowDuration(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  time.Duration
+	}{
+		{input: "250ms", want: 250 * time.Millisecond},
+		{input: "45s", want: 45 * time.Second},
+		{input: "90m", want: 90 * time.Minute},
+		{input: "2h", want: 2 * time.Hour},
+		{input: "1h30m15s250ms", want: time.Hour + 30*time.Minute + 15*time.Second + 250*time.Millisecond},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			got, ok := parseCLIReadWindowDuration(tc.input)
+			if !ok || got != tc.want {
+				t.Fatalf("parseCLIReadWindowDuration(%q) = %s, %t; want %s, true", tc.input, got, ok, tc.want)
+			}
+		})
+	}
+
+	for _, input := range []string{
+		"", " ", "0h", "1h0m", "0h1m", "-1h", "+1h", "1.5h", "1", "1H", "1M",
+		"1d", "1w", "1us", "1ns", "1hm", "1ms2", "ms", "999999999999999999999999999999h",
+		"2562047788015216h",
+	} {
+		t.Run("reject_"+strings.ReplaceAll(input, " ", "space"), func(t *testing.T) {
+			if got, ok := parseCLIReadWindowDuration(input); ok {
+				t.Fatalf("parseCLIReadWindowDuration(%q) = %s, true; want rejection", input, got)
+			}
+		})
+	}
+}
+
+func TestCLIReadWindowEveryPublicBoundAcceptsRelativeInput(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 123456789, time.UTC)
+	for _, command := range cliReadWindowSupportedCommands {
+		for _, bound := range []struct {
+			flag string
+			raw  string
+			want string
+		}{
+			{flag: "--since", raw: "2h", want: "2026-07-11T11:00:00.123456789Z"},
+			{flag: "--until", raw: "30m", want: "2026-07-11T12:30:00.123456789Z"},
+		} {
+			t.Run(command.name+"_"+bound.flag, func(t *testing.T) {
+				request, calls, code, stderr := executeCLIReadWindowCommand(t, append(append([]string{}, command.args...), bound.flag, bound.raw), reference)
+				if code != 0 {
+					t.Fatalf("code = %d stderr=%s", code, stderr)
+				}
+				if calls != 1 || request.Method != command.wantMethod {
+					t.Fatalf("calls/method = %d/%q, want 1/%q", calls, request.Method, command.wantMethod)
+				}
+				key := strings.TrimPrefix(bound.flag, "--")
+				if got := request.Params[key]; got != bound.want {
+					t.Fatalf("%s = %#v, want %q", key, got, bound.want)
+				}
+				other := "since"
+				if key == "since" {
+					other = "until"
+				}
+				if _, ok := request.Params[other]; ok {
+					t.Fatalf("params = %#v, want %s omitted", request.Params, other)
+				}
+			})
+		}
+	}
+}
+
+func TestCLIReadWindowSupportedSurfacesCanonicalizeMixedBounds(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	for _, command := range cliReadWindowSupportedCommands {
+		t.Run(command.name, func(t *testing.T) {
+			args := append(append([]string{}, command.args...),
+				"--since", "2026-07-11T08:00:00-04:00",
+				"--until", "30m",
+			)
+			request, calls, code, stderr := executeCLIReadWindowCommand(t, args, reference)
+			if code != 0 || calls != 1 {
+				t.Fatalf("code/calls = %d/%d stderr=%s", code, calls, stderr)
+			}
+			if got := request.Params["since"]; got != "2026-07-11T12:00:00Z" {
+				t.Fatalf("since = %#v, want canonical UTC", got)
+			}
+			if got := request.Params["until"]; got != "2026-07-11T12:30:00Z" {
+				t.Fatalf("until = %#v, want relative UTC", got)
+			}
+		})
+	}
+}
+
+func TestCLIReadWindowSupportedSurfacesAcceptEqualBounds(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	for _, command := range cliReadWindowSupportedCommands {
+		t.Run(command.name, func(t *testing.T) {
+			args := append(append([]string{}, command.args...),
+				"--since", "2026-07-11T12:00:00Z",
+				"--until", "1h",
+			)
+			request, calls, code, stderr := executeCLIReadWindowCommand(t, args, reference)
+			if code != 0 || calls != 1 {
+				t.Fatalf("code/calls = %d/%d stderr=%s", code, calls, stderr)
+			}
+			if request.Params["since"] != request.Params["until"] {
+				t.Fatalf("params = %#v, want equal canonical bounds", request.Params)
+			}
+		})
+	}
+}
+
+func TestCLIReadWindowSupportedSurfacesRejectReversedBoundsWithoutRequest(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	for _, command := range cliReadWindowSupportedCommands {
+		t.Run(command.name, func(t *testing.T) {
+			args := append(append([]string{}, command.args...), "--since", "30m", "--until", "2h")
+			_, calls, code, stderr := executeCLIReadWindowCommand(t, args, reference)
+			if code != 2 || calls != 0 {
+				t.Fatalf("code/calls = %d/%d, want 2/0 stderr=%s", code, calls, stderr)
+			}
+			if !strings.Contains(stderr, "--until must be greater than or equal to --since") {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func TestCLIReadWindowEveryPublicBoundRejectsExplicitBlankWithoutRequest(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	for _, command := range cliReadWindowSupportedCommands {
+		for _, flag := range []string{"--since", "--until"} {
+			t.Run(command.name+"_"+flag, func(t *testing.T) {
+				args := append(append([]string{}, command.args...), flag, " ")
+				_, calls, code, stderr := executeCLIReadWindowCommand(t, args, reference)
+				if code != 2 || calls != 0 {
+					t.Fatalf("code/calls = %d/%d, want 2/0 stderr=%s", code, calls, stderr)
+				}
+				if !strings.Contains(stderr, flag+" must not be empty") {
+					t.Fatalf("stderr = %q", stderr)
+				}
+			})
+		}
+	}
+}
+
+func TestCLIReadWindowMalformedClassesFailBeforeRequest(t *testing.T) {
+	reference := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	cases := []struct {
+		command int
+		flag    string
+		value   string
+	}{
+		{command: 0, flag: "--since", value: "0h"},
+		{command: 0, flag: "--until", value: "-1h"},
+		{command: 1, flag: "--since", value: "+1h"},
+		{command: 1, flag: "--until", value: "1.5h"},
+		{command: 2, flag: "--since", value: "1d"},
+		{command: 2, flag: "--until", value: "1H"},
+		{command: 3, flag: "--since", value: "1hm"},
+		{command: 3, flag: "--until", value: "999999999999999999999999999999h"},
+	}
+	for _, tc := range cases {
+		command := cliReadWindowSupportedCommands[tc.command]
+		t.Run(command.name+"_"+tc.flag+"_"+tc.value, func(t *testing.T) {
+			args := append(append([]string{}, command.args...), tc.flag, tc.value)
+			_, calls, code, stderr := executeCLIReadWindowCommand(t, args, reference)
+			if code != 2 || calls != 0 {
+				t.Fatalf("code/calls = %d/%d, want 2/0 stderr=%s", code, calls, stderr)
+			}
+			if !strings.Contains(stderr, "positive relative duration") {
+				t.Fatalf("stderr = %q", stderr)
+			}
+		})
+	}
+}
+
+func executeCLIReadWindowCommand(t *testing.T, args []string, reference time.Time) (jsonRPCRequest, int, int, string) {
+	t.Helper()
+	setCLIAPITestToken(t, "test-token")
+	var request jsonRPCRequest
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		result := map[string]any{}
+		switch request.Method {
+		case "run.list":
+			result["runs"] = []any{}
+		case "run.trace":
+			result["trace"] = []any{}
+		case "event.list":
+			result["events"] = []any{}
+		case "runtime.logs":
+			result["logs"] = []any{}
+		default:
+			t.Errorf("unexpected method %q", request.Method)
+		}
+		writeJSONRPCResult(t, w, request.ID, result)
+	}))
+	defer server.Close()
+
+	nowCalls := 0
+	opts := testRootCommandOptions(server)
+	opts.now = func() time.Time {
+		nowCalls++
+		return reference
+	}
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, opts)
+	if nowCalls != 1 {
+		t.Fatalf("invocation clock calls = %d, want 1", nowCalls)
+	}
+	return request, calls, code, stderr.String()
+}

--- a/cmd/swarm/diagnostics.go
+++ b/cmd/swarm/diagnostics.go
@@ -28,6 +28,9 @@ type diagnosticRunListOptions struct {
 	status     string
 	since      string
 	until      string
+	sinceSet   bool
+	untilSet   bool
+	reference  time.Time
 	limit      int
 	cursor     string
 }
@@ -50,6 +53,7 @@ type diagnosticTraceOptions struct {
 	subscriberTypes  []string
 	sinceSet         bool
 	untilSet         bool
+	reference        time.Time
 	limitSet         bool
 	cursorSet        bool
 }
@@ -221,6 +225,9 @@ func newRunsCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "List runs.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			runOpts.sinceSet = cmd.Flags().Changed("since")
+			runOpts.untilSet = cmd.Flags().Changed("until")
+			runOpts.reference = captureCLIReadWindowReference(runOpts.apiOptions)
 			if cmd.Flags().Changed("limit") && runOpts.limit == 0 {
 				return fmt.Errorf("--limit must be between 1 and 500")
 			}
@@ -303,6 +310,7 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			traceOpts.sinceSet = cmd.Flags().Changed("since")
 			traceOpts.untilSet = cmd.Flags().Changed("until")
+			traceOpts.reference = captureCLIReadWindowReference(traceOpts.apiOptions)
 			traceOpts.limitSet = cmd.Flags().Changed("limit")
 			traceOpts.cursorSet = cmd.Flags().Changed("cursor")
 			runID := ""
@@ -318,8 +326,8 @@ func newTraceCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&traceOpts.noRetry, "no-retry", false, "Disable trace follow reconnect/recovery retries")
 	cmd.Flags().BoolVar(&traceOpts.deliveryDetail, "delivery-detail", false, "Show snapshot delivery lifecycle fields from RunTraceRow")
 	cmd.Flags().BoolVar(&traceOpts.deliverySummary, "delivery-summary", false, "Summarize snapshot delivery lifecycle fields from all RunTraceRow pages")
-	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 trace materialization watermark")
-	cmd.Flags().StringVar(&traceOpts.until, "until", "", "Snapshot-only inclusive RFC3339 trace materialization upper bound")
+	cmd.Flags().StringVar(&traceOpts.since, "since", "", "Snapshot-only RFC3339 or relative trace materialization watermark")
+	cmd.Flags().StringVar(&traceOpts.until, "until", "", "Snapshot-only inclusive RFC3339 or relative trace materialization upper bound")
 	cmd.Flags().IntVar(&traceOpts.limit, "limit", 0, "Snapshot-only page size, 1-2000")
 	cmd.Flags().StringVar(&traceOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
 	cmd.Flags().StringArrayVar(&traceOpts.eventNames, "event-name", nil, "Event name filter; repeat to match any")
@@ -450,8 +458,8 @@ func writeInvestigateTraceRetiredMessage(w io.Writer) {
 
 func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptions) {
 	cmd.Flags().StringVar(&opts.status, "status", "", "Optional run status filter")
-	cmd.Flags().StringVar(&opts.since, "since", "", "Optional RFC3339 lower started_at bound")
-	cmd.Flags().StringVar(&opts.until, "until", "", "Optional RFC3339 upper started_at bound")
+	cmd.Flags().StringVar(&opts.since, "since", "", "Optional RFC3339 or relative lower started_at bound")
+	cmd.Flags().StringVar(&opts.until, "until", "", "Optional RFC3339 or relative upper started_at bound")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "Optional pagination cursor")
 }
@@ -459,7 +467,7 @@ func bindDiagnosticRunListFlags(cmd *cobra.Command, opts *diagnosticRunListOptio
 func runDiagnosticRunListCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticRunListOptions) error {
 	params, err := opts.params()
 	if err != nil {
-		return err
+		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
@@ -519,7 +527,7 @@ func runDiagnosticRunCommand(ctx context.Context, out, errOut io.Writer, opts di
 func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts diagnosticTraceOptions, runID string) error {
 	traceParams, err := opts.traceParams()
 	if err != nil {
-		return err
+		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
@@ -538,7 +546,7 @@ func runDiagnosticTraceCommand(ctx context.Context, out, errOut io.Writer, opts 
 	traceParams["run_id"] = runID
 	if opts.deliverySummary {
 		if !opts.untilSet {
-			traceParams["until"] = time.Now().UTC().Format(time.RFC3339Nano)
+			traceParams["until"] = opts.reference.UTC().Format(time.RFC3339Nano)
 		}
 		result, err := fetchDiagnosticRunTraceSummary(ctx, client, traceParams)
 		if err != nil {
@@ -586,29 +594,15 @@ func (o diagnosticTraceOptions) snapshotParams() (map[string]any, error) {
 		}
 		params["cursor"] = cursor
 	}
-	var sinceTime *time.Time
-	if o.sinceSet {
-		since := strings.TrimSpace(o.since)
-		parsed, err := parseRFC3339Flag("--since", since)
-		if err != nil {
-			return nil, err
-		}
-		sinceTime = &parsed
-		params["since"] = since
+	window, err := resolveCLIReadWindow(cliReadWindowInput{
+		Since:        cliReadWindowBoundInput{Value: o.since, Set: o.sinceSet},
+		Until:        cliReadWindowBoundInput{Value: o.until, Set: o.untilSet},
+		ReferenceUTC: o.reference,
+	})
+	if err != nil {
+		return nil, err
 	}
-	var untilTime *time.Time
-	if o.untilSet {
-		until := strings.TrimSpace(o.until)
-		parsed, err := parseRFC3339Flag("--until", until)
-		if err != nil {
-			return nil, err
-		}
-		untilTime = &parsed
-		params["until"] = until
-	}
-	if sinceTime != nil && untilTime != nil && sinceTime.After(*untilTime) {
-		return nil, fmt.Errorf("--until must be at or after --since")
-	}
+	window.addParams(params)
 	filter, err := o.traceFilter()
 	if err != nil {
 		return nil, err
@@ -1120,18 +1114,15 @@ func (o diagnosticRunListOptions) params() (map[string]any, error) {
 		}
 		params["limit"] = o.limit
 	}
-	if since := strings.TrimSpace(o.since); since != "" {
-		if err := validateRFC3339Flag("--since", since); err != nil {
-			return nil, err
-		}
-		params["since"] = since
+	window, err := resolveCLIReadWindow(cliReadWindowInput{
+		Since:        cliReadWindowBoundInput{Value: o.since, Set: o.sinceSet},
+		Until:        cliReadWindowBoundInput{Value: o.until, Set: o.untilSet},
+		ReferenceUTC: o.reference,
+	})
+	if err != nil {
+		return nil, err
 	}
-	if until := strings.TrimSpace(o.until); until != "" {
-		if err := validateRFC3339Flag("--until", until); err != nil {
-			return nil, err
-		}
-		params["until"] = until
-	}
+	window.addParams(params)
 	return params, nil
 }
 

--- a/cmd/swarm/diagnostics_test.go
+++ b/cmd/swarm/diagnostics_test.go
@@ -679,6 +679,7 @@ func TestTraceDeliverySummaryExhaustsRunTracePages(t *testing.T) {
 
 func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
+	wantReference := time.Date(2026, 5, 13, 10, 30, 0, 123456789, time.UTC)
 	var capturedUntil string
 	server, requests := newDiagnosticSuccessServer(t, func(req jsonRPCRequest, callIndex int) map[string]any {
 		switch callIndex {
@@ -732,13 +733,25 @@ func TestTraceDeliverySummaryUsesOmittedRunResolver(t *testing.T) {
 	})
 	defer server.Close()
 
+	nowCalls := 0
+	opts := testRootCommandOptions(server)
+	opts.now = func() time.Time {
+		nowCalls++
+		return wantReference
+	}
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "trace", "--delivery-summary"}, &stdout, &stderr, testRootCommandOptions(server))
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"run", "trace", "--delivery-summary"}, &stdout, &stderr, opts)
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 	if len(*requests) != 3 {
 		t.Fatalf("requests = %d, want run.list then two run.trace pages", len(*requests))
+	}
+	if nowCalls != 1 {
+		t.Fatalf("invocation clock calls = %d, want 1", nowCalls)
+	}
+	if capturedUntil != wantReference.Format(time.RFC3339Nano) {
+		t.Fatalf("captured until = %q, want %q", capturedUntil, wantReference.Format(time.RFC3339Nano))
 	}
 	if !strings.Contains(stdout.String(), "run trace delivery summary: run_id=active-run snapshot=point-in-time") {
 		t.Fatalf("stdout = %q, want resolved active-run summary", stdout.String())
@@ -1316,13 +1329,13 @@ func TestDiagnosticsRejectInvalidInputBeforeRequest(t *testing.T) {
 		wantStderr string
 	}{
 		{name: "runs invalid limit", args: []string{"run", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 500"},
-		{name: "runs invalid since", args: []string{"run", "list", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "runs invalid since", args: []string{"run", "list", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp or a positive relative duration"},
 		{name: "trace extra arg", args: []string{"run", "trace", "run-1", "extra"}, wantStderr: "accepts at most one argument"},
 		{name: "trace invalid limit low", args: []string{"run", "trace", "run-1", "--limit", "0"}, wantStderr: "--limit must be between 1 and 2000"},
 		{name: "trace invalid limit high", args: []string{"run", "trace", "run-1", "--limit", "2001"}, wantStderr: "--limit must be between 1 and 2000"},
-		{name: "trace invalid since", args: []string{"run", "trace", "run-1", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp"},
-		{name: "trace invalid until", args: []string{"run", "trace", "run-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp"},
-		{name: "trace since after until", args: []string{"run", "trace", "run-1", "--since", "2026-05-13T10:05:00Z", "--until", "2026-05-13T10:00:00Z"}, wantStderr: "--until must be at or after --since"},
+		{name: "trace invalid since", args: []string{"run", "trace", "run-1", "--since", "yesterday"}, wantStderr: "--since must be an RFC3339 timestamp or a positive relative duration"},
+		{name: "trace invalid until", args: []string{"run", "trace", "run-1", "--until", "tomorrow"}, wantStderr: "--until must be an RFC3339 timestamp or a positive relative duration"},
+		{name: "trace since after until", args: []string{"run", "trace", "run-1", "--since", "2026-05-13T10:05:00Z", "--until", "2026-05-13T10:00:00Z"}, wantStderr: "--until must be greater than or equal to --since"},
 		{name: "trace blank cursor", args: []string{"run", "trace", "run-1", "--cursor", " "}, wantStderr: "--cursor must not be empty"},
 		{name: "trace no retry requires follow", args: []string{"run", "trace", "run-1", "--no-retry"}, wantStderr: "--no-retry requires --follow"},
 		{name: "trace delivery detail and summary are mutually exclusive", args: []string{"run", "trace", "run-1", "--delivery-detail", "--delivery-summary"}, wantStderr: "--delivery-detail and --delivery-summary are mutually exclusive"},

--- a/cmd/swarm/events.go
+++ b/cmd/swarm/events.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/gorilla/websocket"
@@ -46,6 +47,9 @@ type eventListCommandOptions struct {
 	filter     eventFilterOptions
 	since      string
 	until      string
+	sinceSet   bool
+	untilSet   bool
+	reference  time.Time
 	limit      int
 	limitSet   bool
 	cursor     string
@@ -212,12 +216,15 @@ func newEventsListCommand(opts rootCommandOptions) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts.filter.hasDeadLetterSet = cmd.Flags().Changed("has-dead-letter")
 			listOpts.limitSet = cmd.Flags().Changed("limit")
+			listOpts.sinceSet = cmd.Flags().Changed("since")
+			listOpts.untilSet = cmd.Flags().Changed("until")
+			listOpts.reference = captureCLIReadWindowReference(listOpts.apiOptions)
 			return runEventListCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), listOpts)
 		},
 	}
 	bindEventFilterFlags(cmd, &listOpts.filter)
-	cmd.Flags().StringVar(&listOpts.since, "since", "", "Optional RFC3339 lower created_at bound")
-	cmd.Flags().StringVar(&listOpts.until, "until", "", "Optional RFC3339 upper created_at bound")
+	cmd.Flags().StringVar(&listOpts.since, "since", "", "Optional RFC3339 or relative lower created_at bound")
+	cmd.Flags().StringVar(&listOpts.until, "until", "", "Optional RFC3339 or relative upper created_at bound")
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-1000")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Optional pagination cursor")
 	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
@@ -290,8 +297,7 @@ func bindEventFilterFlags(cmd *cobra.Command, opts *eventFilterOptions) {
 func runEventListCommand(ctx context.Context, out, errOut io.Writer, opts eventListCommandOptions) error {
 	params, err := opts.params()
 	if err != nil {
-		writeCLIAPIError(errOut, err)
-		return commandExitError{code: eventObservationExitValidation}
+		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
 	if err != nil {
@@ -426,18 +432,15 @@ func (opts eventListCommandOptions) params() (map[string]any, error) {
 		}
 		params["limit"] = opts.limit
 	}
-	if since := strings.TrimSpace(opts.since); since != "" {
-		if err := validateRFC3339Flag("--since", since); err != nil {
-			return nil, err
-		}
-		params["since"] = since
+	window, err := resolveCLIReadWindow(cliReadWindowInput{
+		Since:        cliReadWindowBoundInput{Value: opts.since, Set: opts.sinceSet},
+		Until:        cliReadWindowBoundInput{Value: opts.until, Set: opts.untilSet},
+		ReferenceUTC: opts.reference,
+	})
+	if err != nil {
+		return nil, err
 	}
-	if until := strings.TrimSpace(opts.until); until != "" {
-		if err := validateRFC3339Flag("--until", until); err != nil {
-			return nil, err
-		}
-		params["until"] = until
-	}
+	window.addParams(params)
 	return params, nil
 }
 

--- a/cmd/swarm/events_test.go
+++ b/cmd/swarm/events_test.go
@@ -304,7 +304,7 @@ func TestEventsRejectInvalidInputBeforeRequest(t *testing.T) {
 		wantStderr string
 	}{
 		{name: "list invalid limit", args: []string{"event", "list", "--limit", "0"}, wantStderr: "--limit must be between 1 and 1000"},
-		{name: "list invalid since", args: []string{"event", "list", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "list invalid since", args: []string{"event", "list", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp or a positive relative duration"},
 		{name: "list invalid delivery status", args: []string{"event", "list", "--delivery-status", "done"}, wantStderr: "--delivery-status must be one of"},
 		{name: "view blank event id", args: []string{"event", "view", "  "}, wantStderr: "event id is required"},
 		{name: "replay missing event id", args: []string{"event", "replay"}, wantStderr: "requires <event-id>"},

--- a/cmd/swarm/logs.go
+++ b/cmd/swarm/logs.go
@@ -43,6 +43,7 @@ type runtimeLogCommandOptions struct {
 	orderSet  bool
 	sinceSet  bool
 	untilSet  bool
+	reference time.Time
 }
 
 type runtimeLogListResult struct {
@@ -95,6 +96,7 @@ func newLogsCommand(opts rootCommandOptions) *cobra.Command {
 			logOpts.orderSet = cmd.Flags().Changed("order")
 			logOpts.sinceSet = cmd.Flags().Changed("since")
 			logOpts.untilSet = cmd.Flags().Changed("until")
+			logOpts.reference = captureCLIReadWindowReference(logOpts.apiOptions)
 			return runLogsCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), logOpts)
 		},
 	}
@@ -107,8 +109,8 @@ func newLogsCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&logOpts.source, "source", "", "Filter by log source")
 	cmd.Flags().BoolVar(&logOpts.follow, "follow", false, "Follow matching runtime logs as they stream")
 	cmd.Flags().StringVar(&logOpts.replaySince, "replay-since", "", "With --follow, optional RFC3339 catch-up window start")
-	cmd.Flags().StringVar(&logOpts.since, "since", "", "Snapshot-only RFC3339 lower timestamp bound")
-	cmd.Flags().StringVar(&logOpts.until, "until", "", "Snapshot-only RFC3339 upper timestamp bound")
+	cmd.Flags().StringVar(&logOpts.since, "since", "", "Snapshot-only RFC3339 or relative lower timestamp bound")
+	cmd.Flags().StringVar(&logOpts.until, "until", "", "Snapshot-only RFC3339 or relative upper timestamp bound")
 	cmd.Flags().IntVar(&logOpts.limit, "limit", 0, "Snapshot-only page size, 1-1000")
 	cmd.Flags().StringVar(&logOpts.cursor, "cursor", "", "Snapshot-only pagination cursor")
 	cmd.Flags().StringVar(&logOpts.order, "order", "", "Snapshot-only sort order: asc or desc")
@@ -216,27 +218,15 @@ func (opts runtimeLogCommandOptions) snapshotParams() (map[string]any, error) {
 		}
 		params["order"] = order
 	}
-	since := strings.TrimSpace(opts.since)
-	until := strings.TrimSpace(opts.until)
-	if since != "" {
-		if err := validateRFC3339Flag("--since", since); err != nil {
-			return nil, err
-		}
-		params["since"] = since
+	window, err := resolveCLIReadWindow(cliReadWindowInput{
+		Since:        cliReadWindowBoundInput{Value: opts.since, Set: opts.sinceSet},
+		Until:        cliReadWindowBoundInput{Value: opts.until, Set: opts.untilSet},
+		ReferenceUTC: opts.reference,
+	})
+	if err != nil {
+		return nil, err
 	}
-	if until != "" {
-		if err := validateRFC3339Flag("--until", until); err != nil {
-			return nil, err
-		}
-		params["until"] = until
-	}
-	if since != "" && until != "" {
-		sinceTime, _ := time.Parse(time.RFC3339Nano, since)
-		untilTime, _ := time.Parse(time.RFC3339Nano, until)
-		if untilTime.Before(sinceTime) {
-			return nil, fmt.Errorf("--until must be greater than or equal to --since")
-		}
-	}
+	window.addParams(params)
 	return params, nil
 }
 

--- a/cmd/swarm/logs_test.go
+++ b/cmd/swarm/logs_test.go
@@ -202,7 +202,7 @@ func TestLogsRejectInvalidInputBeforeRequest(t *testing.T) {
 		{name: "invalid level", args: []string{"logs", "--level", "fatal"}, wantStderr: "--level must be one of"},
 		{name: "invalid order", args: []string{"logs", "--order", "sideways"}, wantStderr: "--order must be one of"},
 		{name: "invalid limit", args: []string{"logs", "--limit", "0"}, wantStderr: "--limit must be between 1 and 1000"},
-		{name: "invalid since", args: []string{"logs", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp"},
+		{name: "invalid since", args: []string{"logs", "--since", "not-time"}, wantStderr: "--since must be an RFC3339 timestamp or a positive relative duration"},
 		{name: "invalid window", args: []string{"logs", "--since", "2026-05-19T11:00:00Z", "--until", "2026-05-19T10:00:00Z"}, wantStderr: "--until must be greater than or equal to --since"},
 		{name: "replay without follow", args: []string{"logs", "--replay-since", "2026-05-19T10:00:00Z"}, wantStderr: "--replay-since requires --follow"},
 		{name: "follow rejects limit", args: []string{"logs", "--follow", "--limit", "10"}, wantStderr: "--limit is not supported with --follow"},

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -15869,6 +15869,52 @@ cli_specification:
           Cobra unknown-command behavior until a later tracked row promotes hidden fail-closed
           stubs with exact migration text and proof.
   foundations:
+    read_window_input:
+      promoted_by: '#1955'
+      implementation_status: implemented
+      canonical_owner: platform-spec.yaml#cli_specification.foundations.read_window_input
+      scope: >
+        Shared public CLI input authority for optional lower/upper read-window bounds. It applies exactly to
+        `swarm run list`, snapshot `swarm run trace`, `swarm event list`, and snapshot `swarm logs`. It owns CLI
+        flag presence, accepted input grammar, invocation-clock capture, absolute UTC projection, and resolved
+        window ordering before those commands call their existing API owners.
+      accepted_input:
+        absolute: RFC3339 or RFC3339Nano timestamp.
+        relative: >
+          One or more additive unsigned whole-number components using lowercase `h`, `m`, `s`, or `ms` only.
+          Examples are `2h`, `90m`, `1h30m`, and `250ms`. Every component and the total MUST be positive.
+          Signs, surrounding whitespace, decimals, bare numbers, uppercase units, `d`/`w`/other units, zero
+          components, malformed sequences, and duration overflow are invalid.
+      presence_rule: >
+        Omitted bounds remain optional. An explicitly supplied empty or whitespace value is invalid and MUST NOT be
+        collapsed into omission.
+      resolution_rule: >
+        Each command invocation captures one UTC reference time before resolving either bound. Both relative
+        `--since` and relative `--until` mean the captured reference time minus the supplied elapsed duration.
+        Mixed absolute/relative bounds consume the same captured reference. `swarm run trace --delivery-summary`
+        also uses that reference as its fixed omitted `until` and reuses the resulting value across every page.
+      wire_rule: >
+        Every accepted bound is projected to an absolute UTC RFC3339Nano string before the existing API request.
+        The API/OpenRPC timestamp grammar, filtering, ordering, pagination, storage, and runtime semantics do not
+        accept relative syntax and are unchanged.
+      ordering_rule: >
+        A resolved `since` after `until` is a CLI validation failure before any request. Equal bounds are valid for
+        these four selected read API contracts.
+      diagnostic_rule: >
+        Invalid, blank, zero, signed, malformed, unsupported-unit, overflow, and reversed-window input consumes
+        cli_specification.foundations.output_contract.diagnostic_convention and exits 2 before any API or WebSocket
+        request.
+      consumers:
+      - swarm run list --since/--until
+      - swarm run trace --since/--until in snapshot mode
+      - swarm event list --since/--until
+      - swarm logs --since/--until in snapshot mode
+      excluded_different_concepts:
+      - run/event/log follow recovery replay_since watermarks
+      - mailbox and scenario future deadlines
+      - forkchat historical point selectors
+      - incident aggregation horizons
+      - API-only usage windows
     command_router:
       canonical_owner: cmd/swarm Cobra command tree
       implementation_framework: github.com/spf13/cobra
@@ -18945,6 +18991,10 @@ cli_specification:
       implementation_status: implemented
       owner: /v1/rpc run.list
       behavior: List runs through the canonical run.list read owner; no direct DB/store/runtime-state reads.
+      read_window_input_contract: cli_specification.foundations.read_window_input
+      flags:
+      - --since <RFC3339-or-relative-duration>
+      - --until <RFC3339-or-relative-duration>
     status:
       command: swarm run status [<run-id>]
       group: run_operate
@@ -18959,7 +19009,7 @@ cli_specification:
         present. Test/internal labels such as test_quiescence_ready, heuristics, blocking_layer, and blocking_reason
         never appear in human output. JSON preserves the exact run.diagnose or run.get result shape.
     trace:
-      command: swarm run trace [<run-id>] [--verbose] [--delivery-detail|--delivery-summary] [--since <timestamp>] [--until <timestamp>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
+      command: swarm run trace [<run-id>] [--verbose] [--delivery-detail|--delivery-summary] [--since <RFC3339-or-relative-duration>] [--until <RFC3339-or-relative-duration>] [--limit <n>] [--cursor <cursor>] [--event-name <name> ...] [--entity-id <entity-id> ...] [--delivery-status <pending|in_progress|delivered|failed|dead_letter> ...] [--subscriber-id <id> ...] [--subscriber-type <node|agent> ...] [--follow|-f] [--no-retry]
       group: run_operate
       tier: must_have
       implementation_status: implemented
@@ -18978,6 +19028,7 @@ cli_specification:
         - until
         - filter
         - include_internal
+        cli_read_window_input_contract: cli_specification.foundations.read_window_input
         filter_schema: RunTraceFilter
         filter_fields:
           event_name: Repeatable event-name predicate. The CLI sends an array of non-empty names as `filter.event_name` and the server matches any value against RunTraceRow.event_name.
@@ -18986,11 +19037,15 @@ cli_specification:
           subscriber_id: Repeatable subscriber identity predicate. The CLI sends an array of non-empty subscriber ids as `filter.subscriber_id` and the server matches any value against RunTraceRow.subscriber_id.
           subscriber_type: Repeatable subscriber type predicate. The CLI sends an array of SubscriberType enum values as `filter.subscriber_type` and the server matches any value against RunTraceRow.subscriber_type.
         since_semantics: >
-          `since` is an RFC3339/RFC3339Nano timestamp watermark. The server returns trace rows whose canonical
+          The API `since` parameter is an absolute RFC3339/RFC3339Nano timestamp watermark. Snapshot CLI input
+          additionally consumes cli_specification.foundations.read_window_input and sends its resolved UTC value.
+          The server returns trace rows whose canonical
           materialization watermark is strictly after `since`, where that watermark is the greatest available
           timestamp across the joined event, delivery, session, and turn fields owned by RunTraceRow.
         until_semantics: >
-          `until` is a snapshot-only RFC3339/RFC3339Nano timestamp upper bound. The server returns trace rows whose
+          The API `until` parameter is a snapshot-only absolute RFC3339/RFC3339Nano timestamp upper bound. Snapshot
+          CLI input additionally consumes cli_specification.foundations.read_window_input and sends its resolved UTC
+          value. The server returns trace rows whose
           canonical materialization watermark is less than or equal to `until`, using the same greatest-available
           event, delivery, session, and turn timestamp owner as `since`. Combined `since` and `until` define the
           half-open window `(since, until]`; `since` after `until` is invalid, while equal timestamps are allowed and
@@ -19596,6 +19651,7 @@ cli_specification:
       implementation_status: implemented
       owner: /v1/rpc event.list
       behavior: Read-only event observation CLI consumer. The CLI sends only EventListFilter fields plus list-only limit/cursor/since/until params to /v1/rpc event.list through the shared v1 API client, renders server-owned EventFull summaries, and never reconstructs event, delivery, or dead-letter truth locally.
+      read_window_input_contract: cli_specification.foundations.read_window_input
       flags:
       - --run-id <run-id>
       - --entity-id <entity-id>
@@ -19605,8 +19661,8 @@ cli_specification:
       - --subscriber-type <node|agent>
       - --reason-code <code>
       - --has-dead-letter[=true|false]
-      - --since <RFC3339>
-      - --until <RFC3339>
+      - --since <RFC3339-or-relative-duration>
+      - --until <RFC3339-or-relative-duration>
       - --limit <1-1000>
       - --cursor <cursor>
       output:
@@ -20203,6 +20259,7 @@ cli_specification:
         params through the shared v1 API client. Follow mode sends only runtime-log identity/content filters plus optional
         replay_since through /v1/ws runtime.subscribe_logs. The CLI renders server-owned LogEntry rows and never reads
         runtime logs directly from DB/store/runtime/EventBus/dashboard/process logs/container logs.
+      read_window_input_contract: cli_specification.foundations.read_window_input
       flags:
         shared_filters:
         - --run-id <run-id>
@@ -20213,8 +20270,8 @@ cli_specification:
         - --error-code <code>
         - --source <source>
         snapshot_only:
-        - --since <RFC3339>
-        - --until <RFC3339>
+        - --since <RFC3339-or-relative-duration>
+        - --until <RFC3339-or-relative-duration>
         - --limit <1-1000>
         - --cursor <cursor>
         - --order <asc|desc>


### PR DESCRIPTION
## Summary

- add one typed CLI read-window owner for RFC3339 and relative `h/m/s/ms` input
- migrate `run list`, snapshot `run trace`, `event list`, and snapshot `logs`
- preserve explicit flag presence, one invocation clock, UTC RFC3339Nano wire values, and complete ordering validation
- promote the authoritative common contract in `platform-spec.yaml`
- add supported Cobra and structural conformance proof for all eight flags

Closes #1955.

## Governing authority

Exact merge-bearing references:

- `platform-spec.yaml#cli_specification.foundations.read_window_input` (introduced here)
- `platform-spec.yaml#cli_specification.command_catalog.runs`
- `platform-spec.yaml#cli_specification.command_catalog.trace.promoted_trace_filter_contract.since_semantics`
- `platform-spec.yaml#cli_specification.command_catalog.trace.promoted_trace_filter_contract.until_semantics`
- `platform-spec.yaml#cli_specification.command_catalog.events_list.flags`
- `platform-spec.yaml#cli_specification.command_catalog.logs.flags.snapshot_only`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- approved Pre-Implementation Coverage Audit and independent gate on #1955

## Semantic migration

**New canonical owner:** `cmd/swarm/cli_read_window.go` plus `cli_specification.foundations.read_window_input`.

**Old paths now invalid:** command-local read-window calls to `validateRFC3339Flag` / `parseRFC3339Flag`, trace/log-local ordering, missing run/event ordering, and the second `time.Now()` used by trace delivery-summary.

**Production paths checked:** every visible Cobra `--since`/`--until` flag; the four selected API parameter builders; trace delivery-summary pagination; replay watermarks; mailbox deadlines; forkchat historical selection; incident horizons; API/OpenRPC absolute timestamp owners.

**Migration status:** complete for `public_cli_read_window_time_bound_input_semantics_drift`. Replay/deadline/history/horizon selectors remain intentionally separate concepts.

## Proof

- `go test ./cmd/swarm -run 'Test(ParseCLIReadWindowDuration|CLIReadWindow|TraceDeliverySummaryUsesOmittedRunResolver|DiagnosticsRejectInvalidInputBeforeRequest|EventsRejectInvalidInputBeforeRequest|LogsRejectInvalidInputBeforeRequest)' -count=1`
- `go test ./internal/apispec -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' PGPASSWORD=swarm-test go test ./cmd/swarm -count=1`
- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' PGPASSWORD=swarm-test go test ./...`
- `git diff --check`

All passed.