### PR TITLE
[agent-e][issue #1964] Preserve root-input rejection facts

### DIFF
--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimerunstart "github.com/division-sh/swarm/internal/runtime/runstart"
 )
 
 const (
@@ -117,6 +120,9 @@ func formatCLIAPIError(err error) string {
 	if diagnostic, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
 		return formatCLILoaderDiagnostic(diagnostic)
 	}
+	if diagnostic, ok := cliRootInputDiagnosticParts(err); ok {
+		return formatCLIRootInputDiagnostic(err, diagnostic)
+	}
 	if diagnostic, ok := cliAPITransportDiagnosticParts(err); ok {
 		lines := []string{"ERROR: " + cliAPIProblemWithWrapper(err, diagnostic.leaf, diagnostic.problem)}
 		lines = append(lines, diagnostic.evidence...)
@@ -124,6 +130,93 @@ func formatCLIAPIError(err error) string {
 		return strings.Join(lines, "\n")
 	}
 	return err.Error()
+}
+
+type cliRootInputDiagnostic struct {
+	leaf           *jsonRPCError
+	eventName      string
+	reason         runtimerunstart.RootInputValidationReason
+	declaredEvents []string
+	routableEvents []string
+}
+
+func cliRootInputDiagnosticParts(err error) (cliRootInputDiagnostic, bool) {
+	var rpcErr *jsonRPCError
+	if !errors.As(err, &rpcErr) || rpcErr == nil || applicationErrorCode(rpcErr.Data) != "EVENT_NOT_DECLARED" {
+		return cliRootInputDiagnostic{}, false
+	}
+	var data struct {
+		Details struct {
+			EventName      string    `json:"event_name"`
+			Reason         string    `json:"reason"`
+			DeclaredEvents *[]string `json:"declared_events"`
+			RoutableEvents *[]string `json:"routable_events"`
+		} `json:"details"`
+	}
+	if json.Unmarshal(rpcErr.Data, &data) != nil {
+		return cliRootInputDiagnostic{}, false
+	}
+	reason := runtimerunstart.RootInputValidationReason(strings.TrimSpace(data.Details.Reason))
+	if reason != runtimerunstart.RootInputNotDeclared && reason != runtimerunstart.RootInputNotRoutable {
+		return cliRootInputDiagnostic{}, false
+	}
+	eventName := strings.TrimSpace(data.Details.EventName)
+	if eventName == "" {
+		return cliRootInputDiagnostic{}, false
+	}
+	if data.Details.DeclaredEvents == nil || data.Details.RoutableEvents == nil {
+		return cliRootInputDiagnostic{}, false
+	}
+	return cliRootInputDiagnostic{
+		leaf:           rpcErr,
+		eventName:      eventName,
+		reason:         reason,
+		declaredEvents: normalizeCLIStringDomain(*data.Details.DeclaredEvents),
+		routableEvents: normalizeCLIStringDomain(*data.Details.RoutableEvents),
+	}, true
+}
+
+func formatCLIRootInputDiagnostic(err error, diagnostic cliRootInputDiagnostic) string {
+	problem := fmt.Sprintf("event %q is not a declared root input.", diagnostic.eventName)
+	remediation := fmt.Sprintf("Declare %q under `pins.inputs.events` and connect it to a runtime handler, or start the run with a declared routable input.", diagnostic.eventName)
+	if diagnostic.reason == runtimerunstart.RootInputNotRoutable {
+		problem = fmt.Sprintf("root input %q has no runtime route.", diagnostic.eventName)
+		remediation = fmt.Sprintf("Connect %q to a runtime handler, or start the run with a routable root input.", diagnostic.eventName)
+	}
+	return strings.Join([]string{
+		"ERROR: " + cliAPIProblemWithWrapper(err, diagnostic.leaf, problem),
+		"  A root input is an event declared in the root flow's `pins.inputs.events`.",
+		"  Declared root inputs: " + formatCLIStringDomain(diagnostic.declaredEvents) + ".",
+		"  Routable root inputs: " + formatCLIStringDomain(diagnostic.routableEvents) + ".",
+		"  Remediation: " + remediation,
+		"  Code: EVENT_NOT_DECLARED.",
+	}, "\n")
+}
+
+func normalizeCLIStringDomain(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatCLIStringDomain(values []string) string {
+	values = normalizeCLIStringDomain(values)
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
 }
 
 func formatCLILoaderDiagnostic(diagnostic *runtimecontracts.LoaderDiagnostic) string {

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -141,10 +141,11 @@ type cliRootInputDiagnostic struct {
 
 func cliRootInputDiagnosticParts(err error) (cliRootInputDiagnostic, bool) {
 	var rpcErr *jsonRPCError
-	if !errors.As(err, &rpcErr) || rpcErr == nil || applicationErrorCode(rpcErr.Data) != "EVENT_NOT_DECLARED" {
+	if !errors.As(err, &rpcErr) || rpcErr == nil {
 		return cliRootInputDiagnostic{}, false
 	}
 	var data struct {
+		Code    string `json:"code"`
 		Details struct {
 			EventName      string    `json:"event_name"`
 			Reason         string    `json:"reason"`
@@ -155,14 +156,14 @@ func cliRootInputDiagnosticParts(err error) (cliRootInputDiagnostic, bool) {
 	if json.Unmarshal(rpcErr.Data, &data) != nil {
 		return cliRootInputDiagnostic{}, false
 	}
-	reason := runtimerunstart.RootInputValidationReason(strings.TrimSpace(data.Details.Reason))
+	if data.Code != "EVENT_NOT_DECLARED" || !validCanonicalCLIScalar(data.Details.Reason) || !validCanonicalCLIScalar(data.Details.EventName) {
+		return cliRootInputDiagnostic{}, false
+	}
+	reason := runtimerunstart.RootInputValidationReason(data.Details.Reason)
 	if reason != runtimerunstart.RootInputNotDeclared && reason != runtimerunstart.RootInputNotRoutable {
 		return cliRootInputDiagnostic{}, false
 	}
-	eventName := strings.TrimSpace(data.Details.EventName)
-	if eventName == "" {
-		return cliRootInputDiagnostic{}, false
-	}
+	eventName := data.Details.EventName
 	if data.Details.DeclaredEvents == nil || data.Details.RoutableEvents == nil {
 		return cliRootInputDiagnostic{}, false
 	}
@@ -196,6 +197,10 @@ func formatCLIRootInputDiagnostic(err error, diagnostic cliRootInputDiagnostic) 
 		"  Remediation: " + remediation,
 		"  Code: EVENT_NOT_DECLARED.",
 	}, "\n")
+}
+
+func validCanonicalCLIScalar(value string) bool {
+	return value != "" && value == strings.TrimSpace(value)
 }
 
 func validCanonicalCLIStringDomain(values []string) bool {

--- a/cmd/swarm/cli_errors.go
+++ b/cmd/swarm/cli_errors.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -167,12 +166,18 @@ func cliRootInputDiagnosticParts(err error) (cliRootInputDiagnostic, bool) {
 	if data.Details.DeclaredEvents == nil || data.Details.RoutableEvents == nil {
 		return cliRootInputDiagnostic{}, false
 	}
+	declaredEvents := *data.Details.DeclaredEvents
+	routableEvents := *data.Details.RoutableEvents
+	if !validCanonicalCLIStringDomain(declaredEvents) || !validCanonicalCLIStringDomain(routableEvents) ||
+		!validCLIRootInputFacts(eventName, reason, declaredEvents, routableEvents) {
+		return cliRootInputDiagnostic{}, false
+	}
 	return cliRootInputDiagnostic{
 		leaf:           rpcErr,
 		eventName:      eventName,
 		reason:         reason,
-		declaredEvents: normalizeCLIStringDomain(*data.Details.DeclaredEvents),
-		routableEvents: normalizeCLIStringDomain(*data.Details.RoutableEvents),
+		declaredEvents: append([]string{}, declaredEvents...),
+		routableEvents: append([]string{}, routableEvents...),
 	}, true
 }
 
@@ -193,26 +198,41 @@ func formatCLIRootInputDiagnostic(err error, diagnostic cliRootInputDiagnostic) 
 	}, "\n")
 }
 
-func normalizeCLIStringDomain(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
+func validCanonicalCLIStringDomain(values []string) bool {
+	for i, value := range values {
+		if value == "" || value != strings.TrimSpace(value) {
+			return false
 		}
-		if _, ok := seen[value]; ok {
-			continue
+		if i > 0 && values[i-1] >= value {
+			return false
 		}
-		seen[value] = struct{}{}
-		out = append(out, value)
 	}
-	sort.Strings(out)
-	return out
+	return true
+}
+
+func validCLIRootInputFacts(eventName string, reason runtimerunstart.RootInputValidationReason, declaredEvents, routableEvents []string) bool {
+	declared := make(map[string]bool, len(declaredEvents))
+	for _, event := range declaredEvents {
+		declared[event] = true
+	}
+	routable := make(map[string]bool, len(routableEvents))
+	for _, event := range routableEvents {
+		if !declared[event] {
+			return false
+		}
+		routable[event] = true
+	}
+	switch reason {
+	case runtimerunstart.RootInputNotDeclared:
+		return !declared[eventName]
+	case runtimerunstart.RootInputNotRoutable:
+		return declared[eventName] && !routable[eventName]
+	default:
+		return false
+	}
 }
 
 func formatCLIStringDomain(values []string) string {
-	values = normalizeCLIStringDomain(values)
 	if len(values) == 0 {
 		return "none"
 	}

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -131,6 +131,118 @@ func TestCLIAPITransportDiagnosticPreservesWrapperContext(t *testing.T) {
 	}
 }
 
+func TestCLIRootInputDiagnosticRendersServerOwnedDomains(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		reason    string
+		declared  []string
+		routable  []string
+		want      []string
+		forbidden []string
+	}{
+		{
+			name:     "undeclared",
+			reason:   "not_declared_root_input",
+			declared: []string{"z.event", "a.event", "z.event"},
+			routable: []string{"z.event", "a.event"},
+			want: []string{
+				`ERROR: event "missing.event" is not a declared root input.`,
+				"A root input is an event declared in the root flow's `pins.inputs.events`.",
+				"Declared root inputs: a.event, z.event.",
+				"Routable root inputs: a.event, z.event.",
+				`Declare "missing.event" under ` + "`pins.inputs.events`",
+				"Code: EVENT_NOT_DECLARED",
+			},
+		},
+		{
+			name:     "declared but unroutable",
+			reason:   "declared_root_input_not_routable",
+			declared: []string{"waiting.event"},
+			routable: []string{},
+			want: []string{
+				`ERROR: root input "missing.event" has no runtime route.`,
+				"Declared root inputs: waiting.event.",
+				"Routable root inputs: none.",
+				`Connect "missing.event" to a runtime handler`,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(map[string]any{
+				"code": "EVENT_NOT_DECLARED",
+				"details": map[string]any{
+					"event_name":      "missing.event",
+					"reason":          tc.reason,
+					"declared_events": tc.declared,
+					"routable_events": tc.routable,
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal diagnostic: %v", err)
+			}
+			got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("diagnostic = %q, want substring %q", got, want)
+				}
+			}
+			for _, forbidden := range append(tc.forbidden, "details:") {
+				if strings.Contains(got, forbidden) {
+					t.Fatalf("diagnostic = %q, must not contain %q", got, forbidden)
+				}
+			}
+		})
+	}
+}
+
+func TestCLIRootInputDiagnosticRequiresCompleteServerOwnedDomains(t *testing.T) {
+	for _, details := range []map[string]any{
+		{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"routable_events": []string{},
+		},
+		{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{},
+			"routable_events": nil,
+		},
+	} {
+		data, err := json.Marshal(map[string]any{
+			"code":    "EVENT_NOT_DECLARED",
+			"details": details,
+		})
+		if err != nil {
+			t.Fatalf("marshal diagnostic: %v", err)
+		}
+		got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
+		if strings.Contains(got, "A root input is") || strings.Contains(got, "Routable root inputs: none") {
+			t.Fatalf("incomplete server facts entered root-input renderer: %q", got)
+		}
+	}
+}
+
+func TestCLIRootInputDiagnosticDoesNotCaptureOtherEventNotDeclaredReasons(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"code": "EVENT_NOT_DECLARED",
+		"details": map[string]any{
+			"event_name": "missing.event",
+			"reason":     "unknown_event",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal diagnostic: %v", err)
+	}
+	got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
+	if strings.Contains(got, "A root input is") {
+		t.Fatalf("event-catalog rejection entered root-input renderer: %q", got)
+	}
+	if !strings.Contains(got, "EVENT_NOT_DECLARED") || !strings.Contains(got, "reason=unknown_event") {
+		t.Fatalf("generic event-catalog diagnostic lost context: %q", got)
+	}
+}
+
 func TestCLIAPIErrorDoesNotClassifyGenericYAMLAsContractLoaderDiagnostic(t *testing.T) {
 	err := errors.New("load runtime config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `oops` into config.Config")
 

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -143,8 +143,8 @@ func TestCLIRootInputDiagnosticRendersServerOwnedDomains(t *testing.T) {
 		{
 			name:     "undeclared",
 			reason:   "not_declared_root_input",
-			declared: []string{"z.event", "a.event", "z.event"},
-			routable: []string{"z.event", "a.event"},
+			declared: []string{"a.event", "z.event"},
+			routable: []string{"a.event", "z.event"},
 			want: []string{
 				`ERROR: event "missing.event" is not a declared root input.`,
 				"A root input is an event declared in the root flow's `pins.inputs.events`.",
@@ -160,18 +160,22 @@ func TestCLIRootInputDiagnosticRendersServerOwnedDomains(t *testing.T) {
 			declared: []string{"waiting.event"},
 			routable: []string{},
 			want: []string{
-				`ERROR: root input "missing.event" has no runtime route.`,
+				`ERROR: root input "waiting.event" has no runtime route.`,
 				"Declared root inputs: waiting.event.",
 				"Routable root inputs: none.",
-				`Connect "missing.event" to a runtime handler`,
+				`Connect "waiting.event" to a runtime handler`,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			eventName := "missing.event"
+			if tc.reason == "declared_root_input_not_routable" {
+				eventName = "waiting.event"
+			}
 			data, err := json.Marshal(map[string]any{
 				"code": "EVENT_NOT_DECLARED",
 				"details": map[string]any{
-					"event_name":      "missing.event",
+					"event_name":      eventName,
 					"reason":          tc.reason,
 					"declared_events": tc.declared,
 					"routable_events": tc.routable,
@@ -196,30 +200,71 @@ func TestCLIRootInputDiagnosticRendersServerOwnedDomains(t *testing.T) {
 }
 
 func TestCLIRootInputDiagnosticRequiresCompleteServerOwnedDomains(t *testing.T) {
-	for _, details := range []map[string]any{
-		{
+	for _, tc := range []struct {
+		name    string
+		details map[string]any
+	}{
+		{name: "missing declared domain", details: map[string]any{
 			"event_name":      "missing.event",
 			"reason":          "not_declared_root_input",
 			"routable_events": []string{},
-		},
-		{
+		}},
+		{name: "null routable domain", details: map[string]any{
 			"event_name":      "missing.event",
 			"reason":          "not_declared_root_input",
 			"declared_events": []string{},
 			"routable_events": nil,
-		},
+		}},
+		{name: "blank domain entries", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{""},
+			"routable_events": []string{""},
+		}},
+		{name: "noncanonical whitespace", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{" declared.event "},
+			"routable_events": []string{},
+		}},
+		{name: "unsorted domain", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{"z.event", "a.event"},
+			"routable_events": []string{},
+		}},
+		{name: "duplicate domain entry", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{"a.event", "a.event"},
+			"routable_events": []string{},
+		}},
+		{name: "routable not declared", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{},
+			"routable_events": []string{"other.event"},
+		}},
+		{name: "reason contradicts domain", details: map[string]any{
+			"event_name":      "declared.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{"declared.event"},
+			"routable_events": []string{},
+		}},
 	} {
-		data, err := json.Marshal(map[string]any{
-			"code":    "EVENT_NOT_DECLARED",
-			"details": details,
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(map[string]any{
+				"code":    "EVENT_NOT_DECLARED",
+				"details": tc.details,
+			})
+			if err != nil {
+				t.Fatalf("marshal diagnostic: %v", err)
+			}
+			got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
+			if strings.Contains(got, "A root input is") || strings.Contains(got, "Routable root inputs: none") {
+				t.Fatalf("incomplete server facts entered root-input renderer: %q", got)
+			}
 		})
-		if err != nil {
-			t.Fatalf("marshal diagnostic: %v", err)
-		}
-		got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
-		if strings.Contains(got, "A root input is") || strings.Contains(got, "Routable root inputs: none") {
-			t.Fatalf("incomplete server facts entered root-input renderer: %q", got)
-		}
 	}
 }
 

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -224,22 +224,43 @@ func TestCLIRootInputDiagnosticRequiresCompleteServerOwnedDomains(t *testing.T) 
 }
 
 func TestCLIRootInputDiagnosticDoesNotCaptureOtherEventNotDeclaredReasons(t *testing.T) {
-	data, err := json.Marshal(map[string]any{
-		"code": "EVENT_NOT_DECLARED",
-		"details": map[string]any{
-			"event_name": "missing.event",
-			"reason":     "unknown_event",
-		},
-	})
-	if err != nil {
-		t.Fatalf("marshal diagnostic: %v", err)
+	reasons := []string{
+		"",
+		"unknown_event",
+		"unknown_flow_scoped_event",
+		"ambiguous_event_name",
+		"selected_run_entity_not_found",
+		"selected_target_entity_not_found",
+		"selected_target_flow_instance_mismatch",
+		"selected_run_target_not_routable",
+		"declared_event_has_no_selected_run_recipient",
+		"event_not_admitted_by_publisher",
 	}
-	got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
-	if strings.Contains(got, "A root input is") {
-		t.Fatalf("event-catalog rejection entered root-input renderer: %q", got)
-	}
-	if !strings.Contains(got, "EVENT_NOT_DECLARED") || !strings.Contains(got, "reason=unknown_event") {
-		t.Fatalf("generic event-catalog diagnostic lost context: %q", got)
+	for _, reason := range reasons {
+		t.Run(reason, func(t *testing.T) {
+			data, err := json.Marshal(map[string]any{
+				"code": "EVENT_NOT_DECLARED",
+				"details": map[string]any{
+					"event_name":      "missing.event",
+					"reason":          reason,
+					"declared_events": []string{"declared.event"},
+					"routable_events": []string{"declared.event"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal diagnostic: %v", err)
+			}
+			got := formatCLIAPIError(&jsonRPCError{Code: -32003, Message: "Application error: EVENT_NOT_DECLARED", Data: data})
+			if strings.Contains(got, "A root input is") {
+				t.Fatalf("non-root rejection %q entered root-input renderer: %q", reason, got)
+			}
+			if !strings.Contains(got, "EVENT_NOT_DECLARED") {
+				t.Fatalf("generic event diagnostic lost code for reason %q: %q", reason, got)
+			}
+			if reason != "" && !strings.Contains(got, "reason="+reason) {
+				t.Fatalf("generic event diagnostic lost reason %q: %q", reason, got)
+			}
+		})
 	}
 }
 

--- a/cmd/swarm/cli_errors_test.go
+++ b/cmd/swarm/cli_errors_test.go
@@ -202,6 +202,7 @@ func TestCLIRootInputDiagnosticRendersServerOwnedDomains(t *testing.T) {
 func TestCLIRootInputDiagnosticRequiresCompleteServerOwnedDomains(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
+		code    string
 		details map[string]any
 	}{
 		{name: "missing declared domain", details: map[string]any{
@@ -251,10 +252,32 @@ func TestCLIRootInputDiagnosticRequiresCompleteServerOwnedDomains(t *testing.T) 
 			"declared_events": []string{"declared.event"},
 			"routable_events": []string{},
 		}},
+		{name: "padded application code", code: " EVENT_NOT_DECLARED ", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{},
+			"routable_events": []string{},
+		}},
+		{name: "padded event name", details: map[string]any{
+			"event_name":      " missing.event ",
+			"reason":          "not_declared_root_input",
+			"declared_events": []string{},
+			"routable_events": []string{},
+		}},
+		{name: "padded reason", details: map[string]any{
+			"event_name":      "missing.event",
+			"reason":          " not_declared_root_input ",
+			"declared_events": []string{},
+			"routable_events": []string{},
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			code := tc.code
+			if code == "" {
+				code = "EVENT_NOT_DECLARED"
+			}
 			data, err := json.Marshal(map[string]any{
-				"code":    "EVENT_NOT_DECLARED",
+				"code":    code,
 				"details": tc.details,
 			})
 			if err != nil {

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -412,6 +412,75 @@ func TestRunCommandStartApplicationErrorsExitSixAndDoNotFollow(t *testing.T) {
 	}
 }
 
+func TestRunCommandStartRendersRootInputRejectionFromServerFacts(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})
+	var calls []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/ws" {
+			t.Fatal("run.subscribe_trace must not be opened after failed run.start")
+		}
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		calls = append(calls, req)
+		switch req.Method {
+		case "health.check":
+			writeJSONRPCResult(t, w, req.ID, runCommandHealthResult())
+		case "run.start":
+			w.Header().Set("content-type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]any{
+					"code":    -32003,
+					"message": "Application error: EVENT_NOT_DECLARED",
+					"data": map[string]any{
+						"code":      "EVENT_NOT_DECLARED",
+						"retryable": false,
+						"details": map[string]any{
+							"event_name":      "scan.missing",
+							"reason":          "not_declared_root_input",
+							"declared_events": []string{"scan.requested"},
+							"routable_events": []string{"scan.requested"},
+						},
+					},
+				},
+			}); err != nil {
+				t.Fatalf("encode response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected method = %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{
+		"run", "start", "--connect", server.URL, "--event", "scan.missing", "--payload", payloadPath, "--no-follow",
+	}, &stdout, &stderr, testRunCommandOptions(server))
+	if code != 6 {
+		t.Fatalf("code = %d, want 6 stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	assertRunCommandMethods(t, &calls, []string{"health.check", "run.start"})
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	for _, want := range []string{
+		`ERROR: event "scan.missing" is not a declared root input.`,
+		"A root input is an event declared in the root flow's `pins.inputs.events`.",
+		"Declared root inputs: scan.requested.",
+		"Routable root inputs: scan.requested.",
+		"Remediation:",
+		"Code: EVENT_NOT_DECLARED",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want substring %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestRunCommandBundleFingerprintSerializesLegacyBundleRef(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"ok": true})

--- a/internal/apispec/platform_spec_root_input_diagnostics_test.go
+++ b/internal/apispec/platform_spec_root_input_diagnostics_test.go
@@ -16,6 +16,7 @@ func TestPlatformSpecOwnsRootInputRejectionDiagnostics(t *testing.T) {
 		"none",
 		"MUST NOT reload contracts",
 		"non-canonical",
+		"exact scalar facts",
 		"reason-inconsistent",
 	} {
 		assertScalarContains(t, rendering, want)

--- a/internal/apispec/platform_spec_root_input_diagnostics_test.go
+++ b/internal/apispec/platform_spec_root_input_diagnostics_test.go
@@ -1,0 +1,33 @@
+package apispec
+
+import "testing"
+
+func TestPlatformSpecOwnsRootInputRejectionDiagnostics(t *testing.T) {
+	root := loadPlatformSpecYAMLNode(t)
+	outputContract := mustYAMLPath(t, root, "cli_specification", "foundations", "output_contract")
+	convention := mustMappingValue(t, outputContract, "diagnostic_convention")
+	contentRules := mustMappingValue(t, convention, "diagnostic_content_rules")
+	rendering := mustMappingValue(t, contentRules, "root_input_rejections")
+	for _, want := range []string{
+		"not_declared_root_input",
+		"declared_root_input_not_routable",
+		"server-owned root-input facts",
+		"pins.inputs.events",
+		"none",
+		"MUST NOT reload contracts",
+	} {
+		assertScalarContains(t, rendering, want)
+	}
+
+	contract := mustYAMLPath(t, root, "api_specification", "components", "error_catalog_metadata", "root_input_rejection_contract")
+	assertScalarContains(t, mustMappingValue(t, contract, "canonical_owner"), "RootInputValidationError")
+	reasons := mustMappingValue(t, contract, "reasons")
+	assertScalarContains(t, mustMappingValue(t, reasons, "not_declared_root_input"), "absent from the root flow")
+	assertScalarContains(t, mustMappingValue(t, reasons, "declared_root_input_not_routable"), "no derived runtime route")
+	assertScalarContains(t, mustMappingValue(t, contract, "rule"), "deterministically sorted declared_events")
+	assertScalarContains(t, mustMappingValue(t, contract, "rule"), "do not select the reason again")
+	assertScalarContains(t, mustMappingValue(t, contract, "absent_root_schema_rule"), "empty declared and routable root-input domain")
+	assertScalarContains(t, mustMappingValue(t, contract, "post_validation_rule"), "EVENT_PUBLISH_FAILED")
+	assertScalarContains(t, mustMappingValue(t, contract, "post_validation_rule"), "non-retryable publish contradiction")
+	assertScalarContains(t, mustMappingValue(t, contract, "post_validation_rule"), "separate event-catalog concept")
+}

--- a/internal/apispec/platform_spec_root_input_diagnostics_test.go
+++ b/internal/apispec/platform_spec_root_input_diagnostics_test.go
@@ -15,6 +15,8 @@ func TestPlatformSpecOwnsRootInputRejectionDiagnostics(t *testing.T) {
 		"pins.inputs.events",
 		"none",
 		"MUST NOT reload contracts",
+		"non-canonical",
+		"reason-inconsistent",
 	} {
 		assertScalarContains(t, rendering, want)
 	}

--- a/internal/apiv1/operator_event_publish.go
+++ b/internal/apiv1/operator_event_publish.go
@@ -218,7 +218,7 @@ func executeOperatorEventPublication(
 			if cfg.publishError != nil {
 				return store.APIIdempotencyCompletion{}, cfg.publishError(params, err)
 			}
-			return store.APIIdempotencyCompletion{}, runStartPublishError(params.EventName, err)
+			return store.APIIdempotencyCompletion{}, eventCatalogPublishError(params.EventName, err)
 		}
 		result, resourceID, err := cfg.buildCompletion(ctx, selectedOpts, params)
 		if err != nil {
@@ -433,9 +433,9 @@ func eventPublicationEvent(params eventPublicationParams, createdAt time.Time) e
 
 func validateEventPublication(ctx context.Context, opts OperatorReadOptions, params eventPublicationParams, cfg eventPublicationConfig) (eventPublicationParams, error) {
 	if cfg.rootInputOnly {
-		set, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
+		_, err := runtimerunstart.ValidateInputEvents(opts.Source, []string{params.EventName})
 		if err != nil {
-			return params, runStartRootInputError(params.EventName, set, err)
+			return params, rootInputApplicationError(err)
 		}
 		return params, nil
 	}
@@ -667,7 +667,7 @@ func validateExistingRunEventPublicationRecipientPlan(ctx context.Context, opts 
 		if cfg.publishError != nil {
 			return cfg.publishError(params, err)
 		}
-		return runStartPublishError(params.EventName, err)
+		return eventCatalogPublishError(params.EventName, err)
 	}
 	if strings.TrimSpace(plan.TargetFailure) != "" {
 		return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
@@ -719,31 +719,17 @@ func eventPublicationHasCreateEntityHandler(source semanticview.Source, eventNam
 	return false
 }
 
-func runStartRootInputError(eventName string, set runtimerunstart.RootInputSet, err error) error {
-	declared := append([]string{}, set.Declared...)
-	routable := append([]string{}, set.Routable...)
-	details := map[string]any{
-		"event_name":      eventName,
-		"declared_events": declared,
-		"routable_events": routable,
-		"reason":          strings.TrimSpace(err.Error()),
+func rootInputApplicationError(err error) error {
+	diagnostic, ok := runtimerunstart.AsRootInputValidationError(err)
+	if !ok {
+		return err
 	}
-	if !stringSliceContains(declared, eventName) {
-		details["reason"] = "not_declared_root_input"
-	} else if !stringSliceContains(routable, eventName) {
-		details["reason"] = "declared_root_input_not_routable"
-	}
-	return NewApplicationError(EventNotDeclaredCode, false, details)
-}
-
-func stringSliceContains(values []string, target string) bool {
-	target = strings.TrimSpace(target)
-	for _, value := range values {
-		if strings.TrimSpace(value) == target {
-			return true
-		}
-	}
-	return false
+	return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+		"event_name":      diagnostic.EventName,
+		"declared_events": append([]string{}, diagnostic.Inputs.Declared...),
+		"routable_events": append([]string{}, diagnostic.Inputs.Routable...),
+		"reason":          string(diagnostic.Reason),
+	})
 }
 
 func eventPublishSourceAgent(req Request) string {
@@ -755,12 +741,25 @@ func eventPublishSourceAgent(req Request) string {
 }
 
 func eventPublishPublishError(params eventPublicationParams, err error) error {
-	mapped := runStartPublishError(params.EventName, err)
+	mapped := eventCatalogPublishError(params.EventName, err)
 	var appErr *ApplicationError
 	if errors.As(mapped, &appErr) {
 		return mapped
 	}
-	return NewApplicationError(EventPublishFailedCode, true, map[string]any{
+	return eventPublishFailureError(params, err, true)
+}
+
+func runStartEventPublishError(params eventPublicationParams, err error) error {
+	mapped := publicationApplicationError(params.EventName, err)
+	var appErr *ApplicationError
+	if errors.As(mapped, &appErr) {
+		return mapped
+	}
+	return eventPublishFailureError(params, err, !errors.Is(err, runtimebus.ErrInvalidEventType))
+}
+
+func eventPublishFailureError(params eventPublicationParams, err error, retryable bool) error {
+	return NewApplicationError(EventPublishFailedCode, retryable, map[string]any{
 		"event_name": params.EventName,
 		"event_id":   params.EventID,
 		"run_id":     params.RunID,

--- a/internal/apiv1/operator_event_replay.go
+++ b/internal/apiv1/operator_event_replay.go
@@ -668,5 +668,5 @@ func eventReplayError(err error) error {
 }
 
 func eventReplayPublishError(eventName string, err error) error {
-	return runStartPublishError(eventName, err)
+	return eventCatalogPublishError(eventName, err)
 }

--- a/internal/apiv1/operator_run_start.go
+++ b/internal/apiv1/operator_run_start.go
@@ -61,7 +61,7 @@ func executeRunStart(ctx context.Context, req Request, opts OperatorReadOptions,
 		sourceAgent:                    func(Request) string { return "api.v1" },
 		rootInputOnly:                  true,
 		injectRunIDEntityIDWhenMissing: true,
-		publishError:                   eventPublishPublishError,
+		publishError:                   runStartEventPublishError,
 		buildCompletion: func(_ context.Context, _ OperatorReadOptions, params eventPublicationParams) (any, string, error) {
 			return runStartResult{RunID: params.RunID, Status: "running"}, params.RunID, nil
 		},
@@ -151,7 +151,7 @@ func runStartIdempotencyError(err error) error {
 	return err
 }
 
-func runStartPublishError(eventName string, err error) error {
+func publicationApplicationError(eventName string, err error) error {
 	var bundleUnavailable *storerunlifecycle.PersistedBundleUnavailableError
 	if errors.As(err, &bundleUnavailable) || errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
 		details := map[string]any{"event_name": eventName}
@@ -171,8 +171,20 @@ func runStartPublishError(eventName string, err error) error {
 			}},
 		})
 	}
-	if errors.Is(err, runtimebus.ErrInvalidEventType) {
-		return NewApplicationError(EventNotDeclaredCode, false, map[string]any{"event_name": eventName})
-	}
 	return err
+}
+
+func eventCatalogPublishError(eventName string, err error) error {
+	mapped := publicationApplicationError(eventName, err)
+	var appErr *ApplicationError
+	if errors.As(mapped, &appErr) {
+		return mapped
+	}
+	if errors.Is(err, runtimebus.ErrInvalidEventType) {
+		return NewApplicationError(EventNotDeclaredCode, false, map[string]any{
+			"event_name": eventName,
+			"reason":     "event_not_admitted_by_publisher",
+		})
+	}
+	return mapped
 }

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -15,6 +15,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	runtimerunstart "github.com/division-sh/swarm/internal/runtime/runstart"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -510,6 +511,66 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 		}
 		assertNoRunStartPersistence(t, db, runID)
 	})
+
+	t.Run("post-validation invalid event type is a publish contradiction", func(t *testing.T) {
+		_, db, _ := testutil.StartPostgres(t)
+		pg := &store.PostgresStore{DB: db}
+		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
+		handler := runStartTestHandler(t, pg, failingRunStartPublisher{err: runtimebus.ErrInvalidEventType}, source)
+		runID := uuid.NewString()
+
+		resp := rpcCall(t, handler, runStartBody(runID, runStartTestFingerprint, "scan.requested", `{"topic":"medicine"}`, "idem-invalid-event-after-validation"))
+		if resp.Error == nil {
+			t.Fatal("run.start post-validation invalid event error = nil")
+		}
+		data := asMap(t, resp.Error.Data)
+		if data["code"] != EventPublishFailedCode {
+			t.Fatalf("post-validation data = %#v, want %s", data, EventPublishFailedCode)
+		}
+		if data["retryable"] != false {
+			t.Fatalf("post-validation data = %#v, want non-retryable contradiction", data)
+		}
+		details := asMap(t, data["details"])
+		if details["event_name"] != "scan.requested" || details["run_id"] != runID || details["phase"] != "publish" {
+			t.Fatalf("post-validation details = %#v", details)
+		}
+		if details["reason"] != runtimebus.ErrInvalidEventType.Error() {
+			t.Fatalf("post-validation reason = %#v", details["reason"])
+		}
+		assertNoRunStartPersistence(t, db, runID)
+	})
+}
+
+func TestInvalidEventTypeMappersSeparateRootInputFromCatalogFailures(t *testing.T) {
+	params := eventPublicationParams{EventName: "scan.requested", EventID: "event-1", RunID: "run-1"}
+
+	runStartErr := runStartEventPublishError(params, runtimebus.ErrInvalidEventType)
+	var runStartAppErr *ApplicationError
+	if !errors.As(runStartErr, &runStartAppErr) || runStartAppErr.Code != EventPublishFailedCode {
+		t.Fatalf("run.start mapping = %#v, want %s", runStartErr, EventPublishFailedCode)
+	}
+	if runStartAppErr.Retryable {
+		t.Fatalf("run.start invalid-event contradiction = %#v, want non-retryable", runStartAppErr)
+	}
+
+	for name, mapped := range map[string]error{
+		"event publish": eventPublishPublishError(params, runtimebus.ErrInvalidEventType),
+		"event replay":  eventReplayPublishError(params.EventName, runtimebus.ErrInvalidEventType),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var appErr *ApplicationError
+			if !errors.As(mapped, &appErr) || appErr.Code != EventNotDeclaredCode {
+				t.Fatalf("mapping = %#v, want %s", mapped, EventNotDeclaredCode)
+			}
+			details, ok := appErr.Details.(map[string]any)
+			if !ok || details["reason"] != "event_not_admitted_by_publisher" {
+				t.Fatalf("details = %#v", appErr.Details)
+			}
+			if details["reason"] == string(runtimerunstart.RootInputNotDeclared) || details["reason"] == string(runtimerunstart.RootInputNotRoutable) {
+				t.Fatalf("catalog failure entered root-input reason: %#v", details)
+			}
+		})
+	}
 }
 
 func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.T) {

--- a/internal/builder/handler_rpc.go
+++ b/internal/builder/handler_rpc.go
@@ -98,6 +98,18 @@ func (h *handler) dispatchRPC(ctx context.Context, method string, params map[str
 				}
 			}
 			if _, err := runtimerunstart.ValidateInputEvents(source, inputEvents); err != nil {
+				if diagnostic, ok := runtimerunstart.AsRootInputValidationError(err); ok {
+					return nil, &RPCError{
+						Code:    -32602,
+						Message: "run.start input is not accepted by the root input contract",
+						Data: map[string]any{
+							"event_name":      diagnostic.EventName,
+							"reason":          string(diagnostic.Reason),
+							"declared_events": append([]string{}, diagnostic.Inputs.Declared...),
+							"routable_events": append([]string{}, diagnostic.Inputs.Routable...),
+						},
+					}
+				}
 				return nil, &RPCError{Code: -32602, Message: err.Error()}
 			}
 		}

--- a/internal/builder/handler_run_start_test.go
+++ b/internal/builder/handler_run_start_test.go
@@ -64,6 +64,7 @@ func TestHandlerRunStartRejectsUndeclaredInputBeforePublish(t *testing.T) {
 	if resp.Error == nil || resp.Error.Code != -32602 {
 		t.Fatalf("rpc error = %+v, want invalid params", resp.Error)
 	}
+	assertBuilderRootInputDiagnostic(t, resp.Error, "scan.requested", "not_declared_root_input", []string{"scan.corpus_file_requested"}, []string{"scan.corpus_file_requested"})
 	if len(store.appended) != 0 {
 		t.Fatalf("published events = %#v, want none before invalid input failure", store.appended)
 	}
@@ -106,8 +107,40 @@ func TestHandlerRunStartRejectsDeclaredUnroutableInputBeforePublish(t *testing.T
 	if resp.Error == nil || resp.Error.Code != -32602 {
 		t.Fatalf("rpc error = %+v, want invalid params", resp.Error)
 	}
+	assertBuilderRootInputDiagnostic(t, resp.Error, eventName, "declared_root_input_not_routable", []string{eventName}, nil)
 	if len(store.appended) != 0 {
 		t.Fatalf("published events = %#v, want none before invalid input failure", store.appended)
+	}
+}
+
+func assertBuilderRootInputDiagnostic(t *testing.T, rpcErr *RPCError, eventName, reason string, declared, routable []string) {
+	t.Helper()
+	data, ok := rpcErr.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("rpc error data = %T %#v, want structured map", rpcErr.Data, rpcErr.Data)
+	}
+	if data["event_name"] != eventName || data["reason"] != reason {
+		t.Fatalf("rpc error data = %#v", data)
+	}
+	assertStringSlice := func(field string, want []string) {
+		t.Helper()
+		got, ok := data[field].([]string)
+		if !ok {
+			t.Fatalf("%s = %T %#v, want []string", field, data[field], data[field])
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s = %#v, want %#v", field, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s = %#v, want %#v", field, got, want)
+			}
+		}
+	}
+	assertStringSlice("declared_events", declared)
+	assertStringSlice("routable_events", routable)
+	if rpcErr.Message == "" || rpcErr.Message == reason {
+		t.Fatalf("rpc error message = %q, want author-facing summary", rpcErr.Message)
 	}
 }
 

--- a/internal/runtime/runstart/root_input_consumer_guard_test.go
+++ b/internal/runtime/runstart/root_input_consumer_guard_test.go
@@ -1,0 +1,91 @@
+package runstart
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestValidateInputEventsConsumersAreExhaustivelyRegistered(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve current test file")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", ".."))
+	consumerCalls := make(map[string]map[string]bool)
+	err := filepath.WalkDir(filepath.Join(repoRoot, "internal"), func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			relative, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			functionName := filepath.ToSlash(relative) + ":" + function.Name.Name
+			calls := make(map[string]bool)
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				switch called := call.Fun.(type) {
+				case *ast.SelectorExpr:
+					calls[called.Sel.Name] = true
+				case *ast.Ident:
+					calls[called.Name] = true
+				}
+				return true
+			})
+			if calls["ValidateInputEvents"] || functionName == "internal/apiv1/operator_event_publish.go:rootInputApplicationError" {
+				consumerCalls[functionName] = calls
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan ValidateInputEvents consumers: %v", err)
+	}
+	consumers := make([]string, 0, len(consumerCalls))
+	for consumer := range consumerCalls {
+		if consumer != "internal/apiv1/operator_event_publish.go:rootInputApplicationError" {
+			consumers = append(consumers, consumer)
+		}
+	}
+	sort.Strings(consumers)
+	want := []string{
+		"internal/apiv1/operator_event_publish.go:validateEventPublication",
+		"internal/builder/handler_rpc.go:dispatchRPC",
+	}
+	if !reflect.DeepEqual(consumers, want) {
+		t.Fatalf("ValidateInputEvents consumers = %#v, want audited registry %#v; classify and preserve typed root-input facts before adding a consumer", consumers, want)
+	}
+	projectionRequirements := map[string]string{
+		"internal/apiv1/operator_event_publish.go:validateEventPublication":  "rootInputApplicationError",
+		"internal/apiv1/operator_event_publish.go:rootInputApplicationError": "AsRootInputValidationError",
+		"internal/builder/handler_rpc.go:dispatchRPC":                        "AsRootInputValidationError",
+	}
+	for consumer, requiredCall := range projectionRequirements {
+		if !consumerCalls[consumer][requiredCall] {
+			t.Errorf("%s must call %s so typed root-input facts cannot be flattened", consumer, requiredCall)
+		}
+	}
+}

--- a/internal/runtime/runstart/root_input_consumer_guard_test.go
+++ b/internal/runtime/runstart/root_input_consumer_guard_test.go
@@ -1,10 +1,12 @@
 package runstart
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -13,18 +15,89 @@ import (
 	"testing"
 )
 
+var auditedRootInputConsumers = []string{
+	"internal/apiv1/operator_event_publish.go:validateEventPublication",
+	"internal/builder/handler_rpc.go:dispatchRPC",
+}
+
+var rootInputProjectionRequirements = map[string]string{
+	"internal/apiv1/operator_event_publish.go:validateEventPublication":  "rootInputApplicationError",
+	"internal/apiv1/operator_event_publish.go:rootInputApplicationError": "AsRootInputValidationError",
+	"internal/builder/handler_rpc.go:dispatchRPC":                        "AsRootInputValidationError",
+}
+
 func TestValidateInputEventsConsumersAreExhaustivelyRegistered(t *testing.T) {
 	_, currentFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("resolve current test file")
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", ".."))
+	consumerCalls, err := scanRootInputConsumers(repoRoot)
+	if err != nil {
+		t.Fatalf("scan ValidateInputEvents consumers: %v", err)
+	}
+	if err := checkRootInputConsumerAudit(consumerCalls); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateInputEventsConsumerGuardRejectsCommandCaller(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeGuardFixture := func(relative, source string) {
+		t.Helper()
+		path := filepath.Join(repoRoot, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+	}
+	writeGuardFixture("internal/apiv1/operator_event_publish.go", `package apiv1
+func validateEventPublication() {
+	runstart.ValidateInputEvents()
+	rootInputApplicationError()
+}
+func rootInputApplicationError() { runstart.AsRootInputValidationError() }
+`)
+	writeGuardFixture("internal/builder/handler_rpc.go", `package builder
+func dispatchRPC() {
+	runstart.ValidateInputEvents()
+	runstart.AsRootInputValidationError()
+}
+`)
+	writeGuardFixture("cmd/swarm/synthetic.go", `package main
+func syntheticCommandConsumer() { runstart.ValidateInputEvents() }
+`)
+
+	consumerCalls, err := scanRootInputConsumers(repoRoot)
+	if err != nil {
+		t.Fatalf("scan fixture consumers: %v", err)
+	}
+	err = checkRootInputConsumerAudit(consumerCalls)
+	if err == nil || !strings.Contains(err.Error(), "cmd/swarm/synthetic.go:syntheticCommandConsumer") {
+		t.Fatalf("guard error = %v, want unregistered command consumer", err)
+	}
+}
+
+func scanRootInputConsumers(repoRoot string) (map[string]map[string]bool, error) {
 	consumerCalls := make(map[string]map[string]bool)
-	err := filepath.WalkDir(filepath.Join(repoRoot, "internal"), func(path string, entry fs.DirEntry, walkErr error) error {
+	excludedDirectories := map[string]bool{
+		".git":     true,
+		"testdata": true,
+		"vendor":   true,
+	}
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if entry.IsDir() {
+			if path != repoRoot && excludedDirectories[entry.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 		parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
@@ -62,8 +135,12 @@ func TestValidateInputEventsConsumersAreExhaustivelyRegistered(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("scan ValidateInputEvents consumers: %v", err)
+		return nil, err
 	}
+	return consumerCalls, nil
+}
+
+func checkRootInputConsumerAudit(consumerCalls map[string]map[string]bool) error {
 	consumers := make([]string, 0, len(consumerCalls))
 	for consumer := range consumerCalls {
 		if consumer != "internal/apiv1/operator_event_publish.go:rootInputApplicationError" {
@@ -71,21 +148,13 @@ func TestValidateInputEventsConsumersAreExhaustivelyRegistered(t *testing.T) {
 		}
 	}
 	sort.Strings(consumers)
-	want := []string{
-		"internal/apiv1/operator_event_publish.go:validateEventPublication",
-		"internal/builder/handler_rpc.go:dispatchRPC",
+	if !reflect.DeepEqual(consumers, auditedRootInputConsumers) {
+		return fmt.Errorf("ValidateInputEvents consumers = %#v, want audited registry %#v; classify and preserve typed root-input facts before adding a consumer", consumers, auditedRootInputConsumers)
 	}
-	if !reflect.DeepEqual(consumers, want) {
-		t.Fatalf("ValidateInputEvents consumers = %#v, want audited registry %#v; classify and preserve typed root-input facts before adding a consumer", consumers, want)
-	}
-	projectionRequirements := map[string]string{
-		"internal/apiv1/operator_event_publish.go:validateEventPublication":  "rootInputApplicationError",
-		"internal/apiv1/operator_event_publish.go:rootInputApplicationError": "AsRootInputValidationError",
-		"internal/builder/handler_rpc.go:dispatchRPC":                        "AsRootInputValidationError",
-	}
-	for consumer, requiredCall := range projectionRequirements {
+	for consumer, requiredCall := range rootInputProjectionRequirements {
 		if !consumerCalls[consumer][requiredCall] {
-			t.Errorf("%s must call %s so typed root-input facts cannot be flattened", consumer, requiredCall)
+			return fmt.Errorf("%s must call %s so typed root-input facts cannot be flattened", consumer, requiredCall)
 		}
 	}
+	return nil
 }

--- a/internal/runtime/runstart/root_inputs.go
+++ b/internal/runtime/runstart/root_inputs.go
@@ -1,6 +1,7 @@
 package runstart
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -15,13 +16,57 @@ type RootInputSet struct {
 	Routable []string
 }
 
+type RootInputValidationReason string
+
+const (
+	RootInputNotDeclared RootInputValidationReason = "not_declared_root_input"
+	RootInputNotRoutable RootInputValidationReason = "declared_root_input_not_routable"
+)
+
+type RootInputValidationError struct {
+	EventName string
+	Reason    RootInputValidationReason
+	Inputs    RootInputSet
+}
+
+func (e *RootInputValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	switch e.Reason {
+	case RootInputNotDeclared:
+		return fmt.Sprintf("run.start input %q is not declared in root input pins; declared root inputs: %s", e.EventName, formatRootInputDomain(e.Inputs.Declared))
+	case RootInputNotRoutable:
+		return fmt.Sprintf("run.start input %q is declared but has no runtime route; routable root inputs: %s", e.EventName, formatRootInputDomain(e.Inputs.Routable))
+	default:
+		return fmt.Sprintf("run.start input %q is invalid", e.EventName)
+	}
+}
+
+func AsRootInputValidationError(err error) (*RootInputValidationError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var validationErr *RootInputValidationError
+	if !errors.As(err, &validationErr) || validationErr == nil {
+		return nil, false
+	}
+	out := *validationErr
+	out.EventName = strings.TrimSpace(out.EventName)
+	out.Inputs = normalizeRootInputSet(out.Inputs)
+	return &out, true
+}
+
 func DeriveRootInputSet(source semanticview.Source) (RootInputSet, error) {
 	if source == nil {
 		return RootInputSet{}, fmt.Errorf("semantic source is required")
 	}
 	bundle, ok := semanticview.Bundle(source)
-	if !ok || bundle == nil || bundle.RootSchema == nil {
-		return RootInputSet{}, fmt.Errorf("root schema is required")
+	if !ok || bundle == nil {
+		return RootInputSet{}, fmt.Errorf("workflow contract bundle is required")
+	}
+	if bundle.RootSchema == nil {
+		return RootInputSet{Declared: []string{}, Routable: []string{}}, nil
 	}
 	declared := normalizeUnique(bundle.RootSchema.Pins.Inputs.Events)
 	routeTable, err := runtimebus.DeriveRouteTable(source)
@@ -51,13 +96,36 @@ func ValidateInputEvents(source semanticview.Source, inputEvents []string) (Root
 	routable := stringSet(set.Routable)
 	for _, eventType := range inputEvents {
 		if _, ok := declared[eventType]; !ok {
-			return set, fmt.Errorf("run.start input %q is not declared in root input pins; declared root inputs: %s", eventType, strings.Join(set.Declared, ", "))
+			return set, newRootInputValidationError(eventType, RootInputNotDeclared, set)
 		}
 		if _, ok := routable[eventType]; !ok {
-			return set, fmt.Errorf("run.start input %q is declared but has no runtime route; routable root inputs: %s", eventType, strings.Join(set.Routable, ", "))
+			return set, newRootInputValidationError(eventType, RootInputNotRoutable, set)
 		}
 	}
 	return set, nil
+}
+
+func newRootInputValidationError(eventName string, reason RootInputValidationReason, inputs RootInputSet) *RootInputValidationError {
+	return &RootInputValidationError{
+		EventName: strings.TrimSpace(eventName),
+		Reason:    reason,
+		Inputs:    normalizeRootInputSet(inputs),
+	}
+}
+
+func normalizeRootInputSet(inputs RootInputSet) RootInputSet {
+	return RootInputSet{
+		Declared: normalizeUnique(inputs.Declared),
+		Routable: normalizeUnique(inputs.Routable),
+	}
+}
+
+func formatRootInputDomain(values []string) string {
+	values = normalizeUnique(values)
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
 }
 
 func normalizeUnique(values []string) []string {

--- a/internal/runtime/runstart/root_inputs_test.go
+++ b/internal/runtime/runstart/root_inputs_test.go
@@ -1,6 +1,8 @@
 package runstart
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -20,8 +22,17 @@ func TestDeriveRootInputSetRequiresDeclaredAndRoutableRootInput(t *testing.T) {
 	if got, want := set.Routable, []string{"scan.corpus_file_requested"}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("routable = %#v, want %#v", got, want)
 	}
-	if _, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{"scan.requested"}); err == nil {
+	_, err = ValidateInputEvents(semanticview.Wrap(bundle), []string{"scan.requested"})
+	diagnostic, ok := AsRootInputValidationError(err)
+	if !ok {
 		t.Fatal("expected retired undeclared root input to fail")
+	}
+	if diagnostic.EventName != "scan.requested" || diagnostic.Reason != RootInputNotDeclared {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	if !reflect.DeepEqual(diagnostic.Inputs.Declared, []string{"scan.corpus_file_requested"}) ||
+		!reflect.DeepEqual(diagnostic.Inputs.Routable, []string{"scan.corpus_file_requested"}) {
+		t.Fatalf("diagnostic inputs = %#v", diagnostic.Inputs)
 	}
 }
 
@@ -34,8 +45,63 @@ func TestValidateInputEventsRejectsDeclaredUnroutableRootInput(t *testing.T) {
 	}
 	bundle.Nodes["scan-orchestrator"] = bundle.FlowTree.Root.Children[0].Nodes["scan-orchestrator"]
 
-	if _, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{eventName}); err == nil {
+	_, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{eventName})
+	diagnostic, ok := AsRootInputValidationError(err)
+	if !ok {
 		t.Fatal("expected declared but unroutable root input to fail")
+	}
+	if diagnostic.EventName != eventName || diagnostic.Reason != RootInputNotRoutable {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	if !reflect.DeepEqual(diagnostic.Inputs.Declared, []string{eventName}) || len(diagnostic.Inputs.Routable) != 0 {
+		t.Fatalf("diagnostic inputs = %#v", diagnostic.Inputs)
+	}
+	if !strings.Contains(diagnostic.Error(), "routable root inputs: none") {
+		t.Fatalf("diagnostic error = %q", diagnostic.Error())
+	}
+}
+
+func TestRootInputValidationErrorOwnsNormalizedSnapshot(t *testing.T) {
+	inputs := RootInputSet{
+		Declared: []string{"z.event", "a.event", "z.event"},
+		Routable: []string{"z.event"},
+	}
+	diagnostic := newRootInputValidationError(" missing.event ", RootInputNotDeclared, inputs)
+	inputs.Declared[0] = "changed.event"
+	inputs.Routable[0] = "changed.event"
+
+	if diagnostic.EventName != "missing.event" {
+		t.Fatalf("event name = %q", diagnostic.EventName)
+	}
+	if !reflect.DeepEqual(diagnostic.Inputs.Declared, []string{"a.event", "z.event"}) ||
+		!reflect.DeepEqual(diagnostic.Inputs.Routable, []string{"z.event"}) {
+		t.Fatalf("diagnostic inputs = %#v", diagnostic.Inputs)
+	}
+	copy, ok := AsRootInputValidationError(diagnostic)
+	if !ok {
+		t.Fatal("AsRootInputValidationError did not recognize typed error")
+	}
+	copy.Inputs.Declared[0] = "copy.changed"
+	if diagnostic.Inputs.Declared[0] != "a.event" {
+		t.Fatalf("typed extraction aliased original inputs: %#v", diagnostic.Inputs)
+	}
+}
+
+func TestValidateInputEventsTreatsAbsentRootSchemaAsEmptyDomain(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{}
+	set, err := ValidateInputEvents(semanticview.Wrap(bundle), []string{"flow/local.event"})
+	diagnostic, ok := AsRootInputValidationError(err)
+	if !ok {
+		t.Fatalf("ValidateInputEvents error = %v, want typed root-input rejection", err)
+	}
+	if diagnostic.EventName != "flow/local.event" || diagnostic.Reason != RootInputNotDeclared {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	if set.Declared == nil || set.Routable == nil || len(set.Declared) != 0 || len(set.Routable) != 0 {
+		t.Fatalf("root-input set = %#v, want explicit empty domains", set)
+	}
+	if diagnostic.Inputs.Declared == nil || diagnostic.Inputs.Routable == nil {
+		t.Fatalf("diagnostic inputs = %#v, want explicit empty domains", diagnostic.Inputs)
 	}
 }
 

--- a/openrpc.json
+++ b/openrpc.json
@@ -3793,8 +3793,10 @@
               },
               "details": {
                 "additionalProperties": false,
+                "description": "The requested event is not admitted by the selected event catalog, root-input contract, target, or recipient plan. Root-input reasons preserve the canonical declared and routable domains.",
                 "properties": {
                   "declared_events": {
+                    "description": "Deterministically sorted event domain from the owning server validator. For root-input reasons this is the root flow pins.inputs.events declaration.",
                     "items": {
                       "type": "string"
                     },
@@ -3804,9 +3806,11 @@
                     "type": "string"
                   },
                   "reason": {
+                    "description": "Named server rejection branch. Root-input values are not_declared_root_input and declared_root_input_not_routable.",
                     "type": "string"
                   },
                   "routable_events": {
+                    "description": "Deterministically sorted root inputs with a derived runtime route. Present for root-input reasons, including an empty array when none are routable.",
                     "items": {
                       "type": "string"
                     },
@@ -6715,8 +6719,10 @@
               },
               "details": {
                 "additionalProperties": false,
+                "description": "The requested event is not admitted by the selected event catalog, root-input contract, target, or recipient plan. Root-input reasons preserve the canonical declared and routable domains.",
                 "properties": {
                   "declared_events": {
+                    "description": "Deterministically sorted event domain from the owning server validator. For root-input reasons this is the root flow pins.inputs.events declaration.",
                     "items": {
                       "type": "string"
                     },
@@ -6726,9 +6732,11 @@
                     "type": "string"
                   },
                   "reason": {
+                    "description": "Named server rejection branch. Root-input values are not_declared_root_input and declared_root_input_not_routable.",
                     "type": "string"
                   },
                   "routable_events": {
+                    "description": "Deterministically sorted root inputs with a derived runtime route. Present for root-input reasons, including an empty array when none are routable.",
                     "items": {
                       "type": "string"
                     },
@@ -12892,8 +12900,10 @@
             },
             "details": {
               "additionalProperties": false,
+              "description": "The requested event is not admitted by the selected event catalog, root-input contract, target, or recipient plan. Root-input reasons preserve the canonical declared and routable domains.",
               "properties": {
                 "declared_events": {
+                  "description": "Deterministically sorted event domain from the owning server validator. For root-input reasons this is the root flow pins.inputs.events declaration.",
                   "items": {
                     "type": "string"
                   },
@@ -12903,9 +12913,11 @@
                   "type": "string"
                 },
                 "reason": {
+                  "description": "Named server rejection branch. Root-input values are not_declared_root_input and declared_root_input_not_routable.",
                   "type": "string"
                 },
                 "routable_events": {
+                  "description": "Deterministically sorted root inputs with a derived runtime route. Present for root-input reasons, including an empty array when none are routable.",
                   "items": {
                     "type": "string"
                   },

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16631,7 +16631,9 @@ cli_specification:
             `declared_root_input_not_routable` MUST consume the server-owned root-input facts. Human output defines a
             root input as an event declared in the root flow's `pins.inputs.events`, renders the declared and routable
             domains with `none` for an empty domain, and gives a contract-field remediation. CLI and Builder consumers
-            MUST NOT reload contracts, infer the domains independently, or flatten the structured facts to raw error text.
+            MUST NOT reload contracts, infer the domains independently, normalize malformed server facts, or flatten the
+            structured facts to raw error text. The CLI renders `none` only from an explicit canonical empty array; missing,
+            null, non-canonical, or reason-inconsistent domains fall back to the generic application-error rendering.
         exit_code_taxonomy:
           success: 0
           unexpected_or_internal_failure: 1

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16626,6 +16626,12 @@ cli_specification:
           evidence: >
             Evidence is optional and should appear only when it helps the user understand what was checked or why the
             diagnostic fired. Evidence must remain concise, stable, and user-facing.
+          root_input_rejections: >
+            A `run.start` EVENT_NOT_DECLARED rejection with reason `not_declared_root_input` or
+            `declared_root_input_not_routable` MUST consume the server-owned root-input facts. Human output defines a
+            root input as an event declared in the root flow's `pins.inputs.events`, renders the declared and routable
+            domains with `none` for an empty domain, and gives a contract-field remediation. CLI and Builder consumers
+            MUST NOT reload contracts, infer the domains independently, or flatten the structured facts to raw error text.
         exit_code_taxonomy:
           success: 0
           unexpected_or_internal_failure: 1
@@ -24530,6 +24536,24 @@ api_specification:
         correlation_id}) is constant; this section types `data.details`.
 
         '
+      root_input_rejection_contract:
+        canonical_owner: internal/runtime/runstart.RootInputSet, DeriveRootInputSet, ValidateInputEvents, and RootInputValidationError
+        reasons:
+          not_declared_root_input: The requested run-start event is absent from the root flow pins.inputs.events declaration.
+          declared_root_input_not_routable: The requested event is declared as a root input but has no derived runtime route.
+        absent_root_schema_rule: A workflow with no root schema has an empty declared and routable root-input domain; absence is not a validator failure.
+        lossless_consumers:
+        - internal/apiv1 run.start application-error adapter
+        - internal/builder run.start RPC adapter while that in-process consumer remains live
+        - swarm run start human diagnostic renderer
+        rule: >
+          Every consumer preserves the rejected event plus the deterministically sorted declared_events and
+          routable_events domains from the typed owner. Consumers do not select the reason again from string content.
+        post_validation_rule: >
+          If the publisher rejects an event type after run-start root-input validation succeeded, the failure is a
+          non-retryable publish contradiction and MUST use EVENT_PUBLISH_FAILED rather than emitting incomplete
+          root-input EVENT_NOT_DECLARED facts. Event-publish and replay invalid-event mapping remains a separate
+          event-catalog concept.
     errors:
       IDEMPOTENCY_CONFLICT:
         type: object
@@ -24774,6 +24798,7 @@ api_specification:
           reason:
             type: string
       EVENT_NOT_DECLARED:
+        description: The requested event is not admitted by the selected event catalog, root-input contract, target, or recipient plan. Root-input reasons preserve the canonical declared and routable domains.
         type: object
         additionalProperties: false
         required:
@@ -24782,14 +24807,17 @@ api_specification:
           event_name:
             type: string
           declared_events:
+            description: Deterministically sorted event domain from the owning server validator. For root-input reasons this is the root flow pins.inputs.events declaration.
             type: array
             items:
               type: string
           routable_events:
+            description: Deterministically sorted root inputs with a derived runtime route. Present for root-input reasons, including an empty array when none are routable.
             type: array
             items:
               type: string
           reason:
+            description: Named server rejection branch. Root-input values are not_declared_root_input and declared_root_input_not_routable.
             type: string
       EVENT_PUBLISH_FAILED:
         type: object

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16633,7 +16633,8 @@ cli_specification:
             domains with `none` for an empty domain, and gives a contract-field remediation. CLI and Builder consumers
             MUST NOT reload contracts, infer the domains independently, normalize malformed server facts, or flatten the
             structured facts to raw error text. The CLI renders `none` only from an explicit canonical empty array; missing,
-            null, non-canonical, or reason-inconsistent domains fall back to the generic application-error rendering.
+            null, non-canonical scalar or domain, or reason-inconsistent facts fall back to the generic application-error
+            rendering. The application code, reason, and rejected event name are exact scalar facts and are never trimmed.
         exit_code_taxonomy:
           success: 0
           unexpected_or_internal_failure: 1


### PR DESCRIPTION
## Summary

- promote root-input declaration/routability rejection facts into a typed `runstart.RootInputValidationError`
- preserve the typed reason and complete declared/routable domains through API, Builder, and `swarm run start`
- split run-start post-validation invalid-event contradictions from event-publish/replay catalog failures
- lock the semantics in `platform-spec.yaml`, regenerated OpenRPC, and structural consumer/projection guards

Part of #1964

## Approved boundary

This PR implements the independently approved first slice recorded in #1964: loss or flattening of canonical root-input declaration/routability facts across every live validator consumer and run-start renderer/fallback. It does not claim the broader diagnostic-teaching parent; that remains #1974. Workspace operational teaching remains under #1964/#1966.

`swarm test` is intentionally excluded because it calls `event.publish`, not `run.start`. Event publish and replay receive only separation regression coverage here.

## Governing contract

Exact authoritative references:

- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention.diagnostic_content_rules.root_input_rejections`
- `platform-spec.yaml#engine.input_pin_wiring.accepted_producer_sources.boundary_external_ingress`
- `platform-spec.yaml#api_specification.components.error_catalog_metadata.root_input_rejection_contract`
- `platform-spec.yaml#api_specification.components.errors.EVENT_NOT_DECLARED`
- `platform-spec.yaml#api_specification.components.errors.EVENT_PUBLISH_FAILED`

The PR updates the authoritative spec because it promotes typed runtime/API semantics and a user-facing rendering contract.

## Semantic migration

- **New canonical owner:** `internal/runtime/runstart.RootInputValidationError`, backed by `RootInputSet`, `DeriveRootInputSet`, and `ValidateInputEvents`.
- **Old paths now invalid:** string-only validation facts; API adapter-side reason selection; Builder raw-message-only root-input errors; generic CLI detail dumping for root-input reasons; shared invalid-event fallback semantics across run-start, event publish, and replay.
- **Production paths checked:** all `ValidateInputEvents` callers (apiv1 and Builder), API run-start validation, run-start post-validation publish fallback, event publish, event replay, CLI `swarm run start`, and incomplete application-error envelopes.
- **Migration completeness:** complete for the approved root-input fact-preservation child. A structural AST guard enumerates both validator consumers and requires their typed projection path.

## UX bar

- **U1:** both rejection branches provide field-level executable remediation and the available declared/routable domains.
- **U3:** empty domains render `none` only from an explicit server-owned empty array; missing/null facts fail closed to generic rendering.
- **U6:** the command defines “root input” at the failure point.
- **U11:** output names the rejected event and authored `pins.inputs.events` field, avoids the current internal-lexicon denylist, and stays at authoring altitude. Broader U11 registry enforcement is explicitly allocated to #1974.

Counter-example check: this PR removes the captured undefined-root-input/dead-end behavior and does not introduce source archaeology, inferred readback, or internal tracker references.

## Proof

Focused manifestation and ownership proof:

```text
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' \
  go test ./internal/runtime/runstart ./internal/builder ./internal/apiv1 ./cmd/swarm ./internal/apispec \
  -run 'Test(DeriveRootInputSetRequiresDeclaredAndRoutableRootInput|ValidateInputEventsRejectsDeclaredUnroutableRootInput|RootInputValidationErrorOwnsNormalizedSnapshot|ValidateInputEventsTreatsAbsentRootSchemaAsEmptyDomain|ValidateInputEventsConsumersAreExhaustivelyRegistered|HandlerRunStartRejects(Undeclared|DeclaredUnroutable)InputBeforePublish|OperatorRunStartRejectsFlowScopedEventName|OperatorRunStartHandlersFailClosedBeforePersistence|InvalidEventTypeMappersSeparateRootInputFromCatalogFailures|CLIRootInputDiagnostic|RunCommandStartRendersRootInputRejectionFromServerFacts|PlatformSpecOwnsRootInputRejectionDiagnostics|GeneratedOpenRPCArtifactMatchesPlatformSpec)$' \
  -count=1
```

Full suite:

```text
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=swarm_test password=swarm-test dbname=postgres sslmode=disable' go test ./...
```
