### PR TITLE
[agent-b][issue #1902] Cache fail-closed conformance snapshots

### DIFF
--- a/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
+++ b/internal/runtime/conformance/final_flow_instance_authoring_conformance_test.go
@@ -292,7 +292,7 @@ func TestFinalFlowInstanceAuthoringFixture_RouteAuthorityBypassInventoryStaysCla
 			t.Fatalf("seam_family %s invalid_authority missing", id)
 		}
 	}
-	if problems := validateRouteAuthorityDriftInventory(root, inventory); len(problems) != 0 {
+	if problems := validateRouteAuthorityDriftInventory(t, root, inventory); len(problems) != 0 {
 		t.Fatalf("route authority inventory validation failed:\n- %s", strings.Join(problems, "\n- "))
 	}
 }

--- a/internal/runtime/conformance/fork_replay_resume_design_record_test.go
+++ b/internal/runtime/conformance/fork_replay_resume_design_record_test.go
@@ -87,7 +87,7 @@ func TestForkReplayResumeDesignRecordCoversBoundedModel(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	record := loadForkReplayResumeDesignRecord(t, root)
 	ctx := forkReplayResumeValidationContext{
-		goTests: collectGoTestNames(t, root),
+		goTests: conformanceGoTestNames(t, root),
 	}
 	if problems := validateForkReplayResumeDesignRecord(root, record, ctx); len(problems) > 0 {
 		t.Fatalf("fork replay/resume design record validation failed:\n- %s", strings.Join(problems, "\n- "))
@@ -98,7 +98,7 @@ func TestForkReplayResumeDesignRecordRejectsStaleOrUnmappedClaims(t *testing.T) 
 	root := conformanceRepoRoot(t)
 	base := loadForkReplayResumeDesignRecord(t, root)
 	ctx := forkReplayResumeValidationContext{
-		goTests: collectGoTestNames(t, root),
+		goTests: conformanceGoTestNames(t, root),
 	}
 	tests := []struct {
 		name   string
@@ -154,8 +154,7 @@ func TestForkReplayResumeDesignRecordRejectsStaleOrUnmappedClaims(t *testing.T) 
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			record := base
-			record.Rows = append([]forkReplayResumeDesignRow(nil), base.Rows...)
+			record := cloneForkReplayResumeDesignRecord(base)
 			tc.mutate(&record)
 			problems := validateForkReplayResumeDesignRecord(root, record, ctx)
 			if !routeAuthorityProblemsContain(problems, tc.want) {
@@ -180,6 +179,20 @@ func loadForkReplayResumeDesignRecord(t *testing.T, root string) forkReplayResum
 		t.Fatalf("parse fork replay/resume design record: %v", err)
 	}
 	return record
+}
+
+func cloneForkReplayResumeDesignRecord(in forkReplayResumeDesignRecord) forkReplayResumeDesignRecord {
+	out := in
+	out.StaleLanguagePolicy.ForbiddenPhrases = append([]string(nil), in.StaleLanguagePolicy.ForbiddenPhrases...)
+	out.StaleLanguagePolicy.ForbiddenPublicReadbackKeys = append([]string(nil), in.StaleLanguagePolicy.ForbiddenPublicReadbackKeys...)
+	out.StaleLanguagePolicy.LegacyIdentifierSentinels = append([]forkReplayResumeLegacyIdentifier(nil), in.StaleLanguagePolicy.LegacyIdentifierSentinels...)
+	out.Successors = append([]forkReplayResumeSuccessor(nil), in.Successors...)
+	out.Rows = append([]forkReplayResumeDesignRow(nil), in.Rows...)
+	for i := range out.Rows {
+		out.Rows[i].BlockerCodes = append([]string(nil), in.Rows[i].BlockerCodes...)
+		out.Rows[i].ProofRefs = append([]forkReplayResumeProofRef(nil), in.Rows[i].ProofRefs...)
+	}
+	return out
 }
 
 func validateForkReplayResumeDesignRecord(root string, record forkReplayResumeDesignRecord, ctx forkReplayResumeValidationContext) []string {

--- a/internal/runtime/conformance/multi_bundle_option_a_matrix_test.go
+++ b/internal/runtime/conformance/multi_bundle_option_a_matrix_test.go
@@ -2,10 +2,6 @@ package conformance
 
 import (
 	"encoding/json"
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"os"
 	"path/filepath"
 	"sort"
@@ -86,7 +82,7 @@ func TestMultiBundleOptionAMatrixProofReferencesResolve(t *testing.T) {
 	matrix := loadMultiBundleOptionAMatrix(t, root)
 	openRPCMethods := loadMatrixOpenRPCMethods(t, filepath.Join(root, matrix.Source.OpenRPCArtifact))
 	apiMatrixMethods := loadMatrixAPIMethods(t, filepath.Join(root, matrix.Source.APIComplianceMatrix))
-	goTests := collectGoTestNames(t, root)
+	goTests := conformanceGoTestNames(t, root)
 
 	allowedClassifications := map[string]bool{}
 	for _, classification := range matrix.Classifications {
@@ -311,43 +307,6 @@ func loadMatrixAPIMethods(t *testing.T, path string) map[string]bool {
 			t.Fatal("api compliance matrix method missing name")
 		}
 		out[name] = true
-	}
-	return out
-}
-
-func collectGoTestNames(t *testing.T, root string) map[string]bool {
-	t.Helper()
-	out := map[string]bool{}
-	fset := token.NewFileSet()
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "vendor", "node_modules":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			return fmt.Errorf("parse %s: %w", path, err)
-		}
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") {
-				continue
-			}
-			out[fn.Name.Name] = true
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("collect go tests: %v", err)
 	}
 	return out
 }

--- a/internal/runtime/conformance/repo_validation_snapshot_test.go
+++ b/internal/runtime/conformance/repo_validation_snapshot_test.go
@@ -18,9 +18,8 @@ import (
 )
 
 type conformanceRepoSnapshotFile struct {
-	Path      string
-	Raw       []byte
-	Scannable bool
+	Path string
+	Raw  []byte
 }
 
 type conformanceRepoSnapshotIO struct {
@@ -123,9 +122,12 @@ func buildConformanceRepoSnapshot(root string, source conformanceRepoSnapshotIO)
 		}
 		if entry.IsDir() {
 			switch entry.Name() {
-			case ".git", "vendor", "node_modules", "tmp", "test-results":
+			case ".git", "vendor", "node_modules":
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		if !conformanceRepoSnapshotScannableFile(path) {
 			return nil
 		}
 		rel, err := source.relPath(root, path)
@@ -133,20 +135,14 @@ func buildConformanceRepoSnapshot(root string, source conformanceRepoSnapshotIO)
 			return fmt.Errorf("derive repository-relative path for %s: %w", path, err)
 		}
 		rel = filepath.ToSlash(filepath.Clean(rel))
-		scannable := conformanceRepoSnapshotScannableFile(path)
 		raw, err := source.readFile(path)
 		if err != nil {
-			kind := "repository file"
-			if scannable {
-				kind = "scannable repository file"
-			}
-			return fmt.Errorf("read %s %s: %w", kind, rel, err)
+			return fmt.Errorf("read scannable repository file %s: %w", rel, err)
 		}
 		raw = append([]byte(nil), raw...)
 		files = append(files, conformanceRepoSnapshotFile{
-			Path:      rel,
-			Raw:       raw,
-			Scannable: scannable,
+			Path: rel,
+			Raw:  raw,
 		})
 		filesByPath[rel] = raw
 
@@ -210,7 +206,7 @@ func (s *conformanceRepoSnapshot) file(path string) ([]byte, error) {
 func (s *conformanceRepoSnapshot) fileList() []conformanceRepoSnapshotFile {
 	out := make([]conformanceRepoSnapshotFile, len(s.files))
 	for i, file := range s.files {
-		out[i] = conformanceRepoSnapshotFile{Path: file.Path, Raw: append([]byte(nil), file.Raw...), Scannable: file.Scannable}
+		out[i] = conformanceRepoSnapshotFile{Path: file.Path, Raw: append([]byte(nil), file.Raw...)}
 	}
 	return out
 }
@@ -220,7 +216,7 @@ func (s *conformanceRepoSnapshot) matchingFiles(pattern string, re *regexp.Regex
 	entry := loaded.(*conformanceRepoSnapshotMatch)
 	entry.once.Do(func() {
 		for _, file := range s.files {
-			if file.Scannable && re.Match(file.Raw) {
+			if re.Match(file.Raw) {
 				entry.matches = append(entry.matches, file.Path)
 			}
 		}
@@ -324,6 +320,72 @@ func TestBuildConformanceRepoSnapshotRejectsInvalidGoTest(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "parse Go test file broken_test.go") {
 		t.Fatalf("error = %v, want fail-closed Go parse diagnostic", err)
+	}
+}
+
+func TestBuildConformanceRepoSnapshotReadsOnlyScannableInputs(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "fixture.go", "package fixture\n")
+	writeConformanceSnapshotFixture(t, root, "artifact.zip", "not a semantic input")
+
+	source := defaultConformanceRepoSnapshotIO()
+	readFile := source.readFile
+	relPath := source.relPath
+	nonScannableReads := 0
+	nonScannableRelPaths := 0
+	source.relPath = func(root, path string) (string, error) {
+		if filepath.Ext(path) == ".zip" {
+			nonScannableRelPaths++
+			return "", errors.New("irrelevant path must not be derived")
+		}
+		return relPath(root, path)
+	}
+	source.readFile = func(path string) ([]byte, error) {
+		if filepath.Ext(path) == ".zip" {
+			nonScannableReads++
+			return nil, errors.New("irrelevant file must not be read")
+		}
+		return readFile(path)
+	}
+	snapshot, err := buildConformanceRepoSnapshot(root, source)
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	if nonScannableReads != 0 {
+		t.Fatalf("non-scannable reads = %d, want 0", nonScannableReads)
+	}
+	if nonScannableRelPaths != 0 {
+		t.Fatalf("non-scannable relative-path derivations = %d, want 0", nonScannableRelPaths)
+	}
+	if _, err := snapshot.file("artifact.zip"); err == nil {
+		t.Fatal("non-scannable artifact unexpectedly became a semantic snapshot input")
+	}
+	if _, err := snapshot.file("fixture.go"); err != nil {
+		t.Fatalf("scannable fixture unavailable: %v", err)
+	}
+}
+
+func TestConformanceRepoSnapshotSeparatesCanonicalAndRouteExclusions(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "tmp/hidden_test.go", "package fixture\n// route-needle\nfunc TestHiddenInTmp(t *testing.T) {}\n")
+	writeConformanceSnapshotFixture(t, root, "test-results/hidden_test.go", "package fixture\n// route-needle\nfunc TestHiddenInResults(t *testing.T) {}\n")
+	writeConformanceSnapshotFixture(t, root, "visible.go", "package fixture\n// route-needle\n")
+
+	snapshot, err := buildConformanceRepoSnapshot(root, defaultConformanceRepoSnapshotIO())
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	names := snapshot.goTestNames()
+	for _, name := range []string{"TestHiddenInTmp", "TestHiddenInResults"} {
+		if !names[name] {
+			t.Fatalf("canonical Go-test index omitted %s", name)
+		}
+	}
+
+	corpus := &routeAuthorityDriftValidationCorpus{snapshot: snapshot, overlays: map[string][]byte{}}
+	matches := routeAuthorityDriftMatchingFiles(corpus, "route-needle", regexp.MustCompile("route-needle"))
+	if len(matches) != 1 || matches[0] != "visible.go" {
+		t.Fatalf("route matches = %#v, want only visible.go", matches)
 	}
 }
 

--- a/internal/runtime/conformance/repo_validation_snapshot_test.go
+++ b/internal/runtime/conformance/repo_validation_snapshot_test.go
@@ -1,0 +1,526 @@
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type conformanceRepoSnapshotFile struct {
+	Path      string
+	Raw       []byte
+	Scannable bool
+}
+
+type conformanceRepoSnapshotIO struct {
+	walkDir  func(string, fs.WalkDirFunc) error
+	readFile func(string) ([]byte, error)
+	relPath  func(string, string) (string, error)
+}
+
+type conformanceRepoSnapshot struct {
+	files          []conformanceRepoSnapshotFile
+	filesByPath    map[string][]byte
+	goTests        map[string]bool
+	matches        sync.Map
+	pathMatchCache sync.Map
+}
+
+type conformanceRepoSnapshotMatch struct {
+	once    sync.Once
+	matches []string
+}
+
+type conformanceRepoSnapshotPathMatch struct {
+	once    sync.Once
+	matches bool
+}
+
+type conformanceRepoSnapshotCacheEntry struct {
+	once     sync.Once
+	snapshot *conformanceRepoSnapshot
+	err      error
+}
+
+type conformanceRepoSnapshotCache struct {
+	mu      sync.Mutex
+	entries map[string]*conformanceRepoSnapshotCacheEntry
+	build   func(string) (*conformanceRepoSnapshot, error)
+}
+
+var conformanceRepoSnapshotBuilds atomic.Int64
+
+var canonicalConformanceRepoSnapshots = newConformanceRepoSnapshotCache(func(root string) (*conformanceRepoSnapshot, error) {
+	conformanceRepoSnapshotBuilds.Add(1)
+	return buildConformanceRepoSnapshot(root, defaultConformanceRepoSnapshotIO())
+})
+
+func newConformanceRepoSnapshotCache(build func(string) (*conformanceRepoSnapshot, error)) *conformanceRepoSnapshotCache {
+	return &conformanceRepoSnapshotCache{
+		entries: map[string]*conformanceRepoSnapshotCacheEntry{},
+		build:   build,
+	}
+}
+
+func (c *conformanceRepoSnapshotCache) load(root string) (*conformanceRepoSnapshot, error) {
+	key, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository snapshot root %q: %w", root, err)
+	}
+
+	c.mu.Lock()
+	entry := c.entries[key]
+	if entry == nil {
+		entry = &conformanceRepoSnapshotCacheEntry{}
+		c.entries[key] = entry
+	}
+	c.mu.Unlock()
+
+	entry.once.Do(func() {
+		entry.snapshot, entry.err = c.build(key)
+		if entry.err == nil && entry.snapshot == nil {
+			entry.err = fmt.Errorf("repository snapshot builder returned nil without an error")
+		}
+	})
+	return entry.snapshot, entry.err
+}
+
+func defaultConformanceRepoSnapshotIO() conformanceRepoSnapshotIO {
+	return conformanceRepoSnapshotIO{
+		walkDir:  filepath.WalkDir,
+		readFile: os.ReadFile,
+		relPath:  filepath.Rel,
+	}
+}
+
+func buildConformanceRepoSnapshot(root string, source conformanceRepoSnapshotIO) (*conformanceRepoSnapshot, error) {
+	if source.walkDir == nil || source.readFile == nil || source.relPath == nil {
+		return nil, fmt.Errorf("repository snapshot source is incomplete")
+	}
+
+	files := make([]conformanceRepoSnapshotFile, 0)
+	filesByPath := map[string][]byte{}
+	goTests := map[string]bool{}
+	fset := token.NewFileSet()
+
+	err := source.walkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("traverse %s: %w", path, walkErr)
+		}
+		if entry == nil {
+			return fmt.Errorf("traverse %s: missing directory entry", path)
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "node_modules", "tmp", "test-results":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := source.relPath(root, path)
+		if err != nil {
+			return fmt.Errorf("derive repository-relative path for %s: %w", path, err)
+		}
+		rel = filepath.ToSlash(filepath.Clean(rel))
+		scannable := conformanceRepoSnapshotScannableFile(path)
+		raw, err := source.readFile(path)
+		if err != nil {
+			kind := "repository file"
+			if scannable {
+				kind = "scannable repository file"
+			}
+			return fmt.Errorf("read %s %s: %w", kind, rel, err)
+		}
+		raw = append([]byte(nil), raw...)
+		files = append(files, conformanceRepoSnapshotFile{
+			Path:      rel,
+			Raw:       raw,
+			Scannable: scannable,
+		})
+		filesByPath[rel] = raw
+
+		if strings.HasSuffix(rel, "_test.go") {
+			file, err := parser.ParseFile(fset, path, raw, 0)
+			if err != nil {
+				return fmt.Errorf("parse Go test file %s: %w", rel, err)
+			}
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if ok && fn.Recv == nil && strings.HasPrefix(fn.Name.Name, "Test") {
+					goTests[fn.Name.Name] = true
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("acquire complete repository snapshot rooted at %s: %w", root, err)
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return &conformanceRepoSnapshot{
+		files:       files,
+		filesByPath: filesByPath,
+		goTests:     goTests,
+	}, nil
+}
+
+func mustConformanceRepoSnapshot(t *testing.T, root string) *conformanceRepoSnapshot {
+	t.Helper()
+	snapshot, err := canonicalConformanceRepoSnapshots.load(root)
+	if err != nil {
+		t.Fatalf("acquire conformance repository snapshot: %v", err)
+	}
+	return snapshot
+}
+
+func conformanceGoTestNames(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	return mustConformanceRepoSnapshot(t, root).goTestNames()
+}
+
+func (s *conformanceRepoSnapshot) goTestNames() map[string]bool {
+	out := make(map[string]bool, len(s.goTests))
+	for name, present := range s.goTests {
+		out[name] = present
+	}
+	return out
+}
+
+func (s *conformanceRepoSnapshot) file(path string) ([]byte, error) {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	raw, ok := s.filesByPath[cleaned]
+	if !ok {
+		return nil, fmt.Errorf("required path %s is unavailable in the complete repository snapshot", cleaned)
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+func (s *conformanceRepoSnapshot) fileList() []conformanceRepoSnapshotFile {
+	out := make([]conformanceRepoSnapshotFile, len(s.files))
+	for i, file := range s.files {
+		out[i] = conformanceRepoSnapshotFile{Path: file.Path, Raw: append([]byte(nil), file.Raw...), Scannable: file.Scannable}
+	}
+	return out
+}
+
+func (s *conformanceRepoSnapshot) matchingFiles(pattern string, re *regexp.Regexp) []string {
+	loaded, _ := s.matches.LoadOrStore(pattern, &conformanceRepoSnapshotMatch{})
+	entry := loaded.(*conformanceRepoSnapshotMatch)
+	entry.once.Do(func() {
+		for _, file := range s.files {
+			if file.Scannable && re.Match(file.Raw) {
+				entry.matches = append(entry.matches, file.Path)
+			}
+		}
+		sort.Strings(entry.matches)
+	})
+	return append([]string(nil), entry.matches...)
+}
+
+func (s *conformanceRepoSnapshot) pathMatches(path, pattern string, re *regexp.Regexp) (bool, error) {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	raw, ok := s.filesByPath[cleaned]
+	if !ok {
+		return false, fmt.Errorf("required path %s is unavailable in the complete repository snapshot", cleaned)
+	}
+	key := pattern + "\x00" + cleaned
+	loaded, _ := s.pathMatchCache.LoadOrStore(key, &conformanceRepoSnapshotPathMatch{})
+	entry := loaded.(*conformanceRepoSnapshotPathMatch)
+	entry.once.Do(func() { entry.matches = re.Match(raw) })
+	return entry.matches, nil
+}
+
+func conformanceRepoSnapshotScannableFile(path string) bool {
+	switch filepath.Ext(path) {
+	case ".go", ".yaml", ".yml", ".json", ".md":
+		return true
+	default:
+		return false
+	}
+}
+
+func TestBuildConformanceRepoSnapshotFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "fixture_test.go", "package fixture\nfunc TestFixture(t *testing.T) {}\n")
+
+	tests := []struct {
+		name   string
+		source func(error) conformanceRepoSnapshotIO
+		want   string
+	}{
+		{
+			name: "root walk failure",
+			source: func(sentinel error) conformanceRepoSnapshotIO {
+				source := defaultConformanceRepoSnapshotIO()
+				source.walkDir = func(string, fs.WalkDirFunc) error { return sentinel }
+				return source
+			},
+			want: "root walk failed",
+		},
+		{
+			name: "callback traversal failure",
+			source: func(sentinel error) conformanceRepoSnapshotIO {
+				source := defaultConformanceRepoSnapshotIO()
+				source.walkDir = func(root string, callback fs.WalkDirFunc) error {
+					return callback(filepath.Join(root, "broken.go"), nil, sentinel)
+				}
+				return source
+			},
+			want: "traverse",
+		},
+		{
+			name: "relative path failure",
+			source: func(sentinel error) conformanceRepoSnapshotIO {
+				source := defaultConformanceRepoSnapshotIO()
+				source.relPath = func(string, string) (string, error) { return "", sentinel }
+				return source
+			},
+			want: "derive repository-relative path",
+		},
+		{
+			name: "scannable file read failure",
+			source: func(sentinel error) conformanceRepoSnapshotIO {
+				source := defaultConformanceRepoSnapshotIO()
+				source.readFile = func(string) ([]byte, error) { return nil, sentinel }
+				return source
+			},
+			want: "read scannable repository file fixture_test.go",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sentinel := fmt.Errorf("%s", tc.want)
+			snapshot, err := buildConformanceRepoSnapshot(root, tc.source(sentinel))
+			if snapshot != nil {
+				t.Fatalf("snapshot = %#v, want nil after acquisition failure", snapshot)
+			}
+			if err == nil || !errors.Is(err, sentinel) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want wrapped sentinel containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildConformanceRepoSnapshotRejectsInvalidGoTest(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "broken_test.go", "package fixture\nfunc TestBroken(")
+
+	snapshot, err := buildConformanceRepoSnapshot(root, defaultConformanceRepoSnapshotIO())
+	if snapshot != nil {
+		t.Fatalf("snapshot = %#v, want nil after Go parse failure", snapshot)
+	}
+	if err == nil || !strings.Contains(err.Error(), "parse Go test file broken_test.go") {
+		t.Fatalf("error = %v, want fail-closed Go parse diagnostic", err)
+	}
+}
+
+func TestConformanceRepoSnapshotCacheRetainsBuildError(t *testing.T) {
+	sentinel := errors.New("snapshot unavailable")
+	builds := 0
+	cache := newConformanceRepoSnapshotCache(func(string) (*conformanceRepoSnapshot, error) {
+		builds++
+		return nil, sentinel
+	})
+
+	for i := 0; i < 3; i++ {
+		snapshot, err := cache.load(t.TempDir())
+		if snapshot != nil || !errors.Is(err, sentinel) {
+			t.Fatalf("load %d = (%#v, %v), want retained sentinel error", i, snapshot, err)
+		}
+	}
+	if builds != 3 {
+		t.Fatalf("builds = %d, want one retained build error per distinct root", builds)
+	}
+
+	root := t.TempDir()
+	builds = 0
+	cache = newConformanceRepoSnapshotCache(func(string) (*conformanceRepoSnapshot, error) {
+		builds++
+		return nil, sentinel
+	})
+	var first error
+	for i := 0; i < 3; i++ {
+		snapshot, err := cache.load(root)
+		if snapshot != nil || !errors.Is(err, sentinel) {
+			t.Fatalf("same-root load %d = (%#v, %v), want retained sentinel error", i, snapshot, err)
+		}
+		if i == 0 {
+			first = err
+		} else if err != first {
+			t.Fatalf("same-root load %d returned a different retained error", i)
+		}
+	}
+	if builds != 1 {
+		t.Fatalf("same-root builds = %d, want 1", builds)
+	}
+}
+
+func TestConformanceRepoSnapshotViewsAreImmutable(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "fixture_test.go", "package fixture\n// needle\nfunc TestFixture(t *testing.T) {}\n")
+	writeConformanceSnapshotFixture(t, root, "notes.md", "needle\n")
+	snapshot, err := buildConformanceRepoSnapshot(root, defaultConformanceRepoSnapshotIO())
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+
+	files := snapshot.fileList()
+	files[0].Path = "mutated"
+	files[0].Raw[0] = 'X'
+	if got := snapshot.fileList()[0]; got.Path == "mutated" || got.Raw[0] == 'X' {
+		t.Fatalf("file list mutation leaked into snapshot: %#v", got)
+	}
+
+	raw, err := snapshot.file("notes.md")
+	if err != nil {
+		t.Fatalf("lookup notes.md: %v", err)
+	}
+	raw[0] = 'X'
+	pristine, err := snapshot.file("notes.md")
+	if err != nil || pristine[0] == 'X' {
+		t.Fatalf("file byte mutation leaked into snapshot: %q, %v", pristine, err)
+	}
+
+	names := snapshot.goTestNames()
+	delete(names, "TestFixture")
+	names["TestInjected"] = true
+	pristineNames := snapshot.goTestNames()
+	if !pristineNames["TestFixture"] || pristineNames["TestInjected"] {
+		t.Fatalf("Go test map mutation leaked into snapshot: %#v", pristineNames)
+	}
+
+	re := regexp.MustCompile("needle")
+	matches := snapshot.matchingFiles("needle", re)
+	matches[0] = "mutated"
+	if got := snapshot.matchingFiles("needle", re); got[0] == "mutated" {
+		t.Fatalf("match-list mutation leaked into snapshot: %#v", got)
+	}
+
+	baseMatches := snapshot.matchingFiles("synthetic", regexp.MustCompile("synthetic"))
+	corpus := (&routeAuthorityDriftValidationCorpus{snapshot: snapshot, overlays: map[string][]byte{}}).withFile(routeAuthorityDriftRepoFile{
+		Path: "synthetic.go",
+		Raw:  []byte("synthetic"),
+	})
+	overlayMatches := routeAuthorityDriftMatchingFiles(corpus, "synthetic", regexp.MustCompile("synthetic"))
+	if len(baseMatches) != 0 || len(overlayMatches) != 1 || overlayMatches[0] != "synthetic.go" {
+		t.Fatalf("base/overlay matches = %#v/%#v, want isolated synthetic overlay", baseMatches, overlayMatches)
+	}
+	corpus.overlays["synthetic.go"][0] = 'X'
+	if got := snapshot.matchingFiles("synthetic", regexp.MustCompile("synthetic")); len(got) != 0 {
+		t.Fatalf("overlay byte mutation changed base matches: %#v", got)
+	}
+}
+
+func TestRouteAuthorityRequiredPathLookupDistinguishesUnavailableFromNonMatch(t *testing.T) {
+	root := t.TempDir()
+	writeConformanceSnapshotFixture(t, root, "present.go", "package fixture\n")
+	snapshot, err := buildConformanceRepoSnapshot(root, defaultConformanceRepoSnapshotIO())
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	corpus := &routeAuthorityDriftValidationCorpus{snapshot: snapshot, overlays: map[string][]byte{}}
+	re := regexp.MustCompile("ConnectRoutePlan")
+
+	matched, err := routeAuthorityDriftPathMatches(corpus, "missing.go", re)
+	if matched || err == nil || !strings.Contains(err.Error(), "required path missing.go is unavailable") {
+		t.Fatalf("missing lookup = (%t, %v), want explicit unavailable-path error", matched, err)
+	}
+	matched, err = routeAuthorityDriftPathMatches(corpus, "present.go", re)
+	if matched || err != nil {
+		t.Fatalf("valid non-match = (%t, %v), want false without error", matched, err)
+	}
+
+	unavailable := validateRouteAuthorityDriftSearchDimension(corpus, routeAuthorityDriftSearchDimension{
+		ID:             "lookup",
+		Pattern:        "ConnectRoutePlan",
+		RequiredPaths:  []string{"missing.go"},
+		CanonicalLayer: "spec_authority",
+	})
+	if !routeAuthorityProblemsContain(unavailable, "lookup required_path missing.go unavailable:") {
+		t.Fatalf("unavailable-path problems = %#v, want explicit unavailable diagnostic", unavailable)
+	}
+	nonMatch := validateRouteAuthorityDriftSearchDimension(corpus, routeAuthorityDriftSearchDimension{
+		ID:             "lookup",
+		Pattern:        "ConnectRoutePlan",
+		RequiredPaths:  []string{"present.go"},
+		CanonicalLayer: "spec_authority",
+	})
+	if !routeAuthorityProblemsContain(nonMatch, "lookup required_path present.go does not match pattern") {
+		t.Fatalf("valid non-match problems = %#v, want pattern-mismatch diagnostic", nonMatch)
+	}
+}
+
+func TestCanonicalConformanceRepoSnapshotBuildsOnce(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	first := mustConformanceRepoSnapshot(t, root)
+	second := routeAuthorityDriftNewValidationCorpus(t, root).snapshot
+	names := conformanceGoTestNames(t, root)
+	if first != second {
+		t.Fatal("canonical snapshot consumers received different owners")
+	}
+	for _, name := range []string{
+		"TestCanonicalConformanceRepoSnapshotBuildsOnce",
+		"TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions",
+	} {
+		if !names[name] {
+			t.Fatalf("shared Go-test index omitted route-view self-audit test %s", name)
+		}
+	}
+	if got := conformanceRepoSnapshotBuilds.Load(); got != 1 {
+		t.Fatalf("canonical snapshot builds = %d, want 1", got)
+	}
+}
+
+func TestConformanceMutableValidationInputsAreDeepCloned(t *testing.T) {
+	root := conformanceRepoRoot(t)
+
+	inventory := loadRouteAuthorityDriftInventory(t, root)
+	inventoryClone := cloneRouteAuthorityDriftInventory(inventory)
+	inventoryClone.SearchDimensions[0].RequiredPaths[0] = "mutated"
+	inventoryClone.SeamFamilies[0].Paths[0] = "mutated"
+	inventoryClone.GuardrailProposals[0].Prevents[0] = "mutated"
+	if inventory.SearchDimensions[0].RequiredPaths[0] == "mutated" || inventory.SeamFamilies[0].Paths[0] == "mutated" || inventory.GuardrailProposals[0].Prevents[0] == "mutated" {
+		t.Fatal("route inventory nested mutation leaked into source")
+	}
+
+	matrix := loadRouteAuthorityMatrix(t, root)
+	matrixClone := cloneRouteAuthorityMatrix(matrix)
+	matrixClone.Rows[0].ProofDimensions[0] = "mutated"
+	matrixClone.Rows[0].OwnerRefs[0].Kind = "mutated"
+	matrixClone.Rows[0].ProofRefs[0].Kind = "mutated"
+	if matrix.Rows[0].ProofDimensions[0] == "mutated" || matrix.Rows[0].OwnerRefs[0].Kind == "mutated" || matrix.Rows[0].ProofRefs[0].Kind == "mutated" {
+		t.Fatal("route matrix nested mutation leaked into source")
+	}
+
+	record := loadForkReplayResumeDesignRecord(t, root)
+	recordClone := cloneForkReplayResumeDesignRecord(record)
+	recordClone.Rows[0].BlockerCodes[0] = "mutated"
+	recordClone.Rows[0].ProofRefs[0].Kind = "mutated"
+	if record.Rows[0].BlockerCodes[0] == "mutated" || record.Rows[0].ProofRefs[0].Kind == "mutated" {
+		t.Fatal("fork replay record nested mutation leaked into source")
+	}
+}
+
+func writeConformanceSnapshotFixture(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -575,7 +575,7 @@ func (c *routeAuthorityDriftValidationCorpus) withFile(file routeAuthorityDriftR
 func routeAuthorityDriftMatchingFiles(corpus *routeAuthorityDriftValidationCorpus, pattern string, re *regexp.Regexp) []string {
 	var matches []string
 	for _, path := range corpus.snapshot.matchingFiles(pattern, re) {
-		if routeAuthorityDriftSelfAuditFile(path) {
+		if routeAuthorityDriftExcludedFile(path) {
 			continue
 		}
 		if _, replaced := corpus.overlays[path]; !replaced {
@@ -583,12 +583,21 @@ func routeAuthorityDriftMatchingFiles(corpus *routeAuthorityDriftValidationCorpu
 		}
 	}
 	for path, raw := range corpus.overlays {
-		if !routeAuthorityDriftSelfAuditFile(path) && re.Match(raw) {
+		if !routeAuthorityDriftExcludedFile(path) && re.Match(raw) {
 			matches = append(matches, path)
 		}
 	}
 	sort.Strings(matches)
 	return matches
+}
+
+func routeAuthorityDriftExcludedFile(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(filepath.Clean(path)), "/") {
+		if part == "tmp" || part == "test-results" {
+			return true
+		}
+	}
+	return routeAuthorityDriftSelfAuditFile(path)
 }
 
 func routeAuthorityDriftSelfAuditFile(path string) bool {

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -84,14 +84,14 @@ type routeAuthorityDriftRepoFile struct {
 }
 
 type routeAuthorityDriftValidationCorpus struct {
-	Files         []routeAuthorityDriftRepoFile
-	MatchesByExpr map[string][]string
+	snapshot *conformanceRepoSnapshot
+	overlays map[string][]byte
 }
 
 func TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	inventory := loadRouteAuthorityDriftInventory(t, root)
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root)
 	if problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory); len(problems) > 0 {
 		t.Fatalf("route authority drift inventory validation failed:\n- %s", strings.Join(problems, "\n- "))
 	}
@@ -100,7 +100,7 @@ func TestRouteAuthorityDriftInventoryCoversRepoWideSearchDimensions(t *testing.T
 func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	base := loadRouteAuthorityDriftInventory(t, root)
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root)
 
 	tests := []struct {
 		name   string
@@ -170,10 +170,7 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			inventory := base
-			inventory.SearchDimensions = append([]routeAuthorityDriftSearchDimension(nil), base.SearchDimensions...)
-			inventory.SeamFamilies = append([]routeAuthorityDriftSeamFamily(nil), base.SeamFamilies...)
-			inventory.GuardrailProposals = append([]routeAuthorityDriftGuardrail(nil), base.GuardrailProposals...)
+			inventory := cloneRouteAuthorityDriftInventory(base)
 			tc.mutate(&inventory)
 			problems := validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
 			if !routeAuthorityProblemsContain(problems, tc.want) {
@@ -186,8 +183,7 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 func TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	inventory := loadRouteAuthorityDriftInventory(t, root)
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
-	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root).withFile(routeAuthorityDriftRepoFile{
 		Path: "internal/runtime/bus/untracked_route_authority.go",
 		Raw:  []byte("package bus\n\nfunc untracked(plan ConnectRoutePlan) { _ = plan }\n"),
 	})
@@ -202,9 +198,8 @@ func TestRouteAuthorityDriftInventoryRejectsUnclassifiedRouteLikeProducer(t *tes
 func TestRouteAuthorityDriftInventoryRejectsDimensionMismatchClassification(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	inventory := loadRouteAuthorityDriftInventory(t, root)
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
 	const path = "internal/runtime/bus/misclassified_route_authority.go"
-	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root).withFile(routeAuthorityDriftRepoFile{
 		Path: path,
 		Raw:  []byte("package bus\n\nfunc misclassified(plan ConnectRoutePlan) { _ = plan }\n"),
 	})
@@ -221,8 +216,7 @@ func TestRouteAuthorityDriftInventoryRejectsDimensionMismatchClassification(t *t
 func TestRouteAuthorityDriftInventoryRejectsUnclassifiedDirectDeliveryPath(t *testing.T) {
 	root := conformanceRepoRoot(t)
 	inventory := loadRouteAuthorityDriftInventory(t, root)
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
-	corpus.Files = append(corpus.Files, routeAuthorityDriftRepoFile{
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root).withFile(routeAuthorityDriftRepoFile{
 		Path: "internal/runtime/bus/untracked_direct_delivery.go",
 		Raw:  []byte("package bus\n\nfunc (b *bus) PublishDirect(ctx context.Context, evt events.Event, recipients []string) error { return nil }\n"),
 	})
@@ -247,8 +241,30 @@ func loadRouteAuthorityDriftInventory(t *testing.T, root string) routeAuthorityD
 	return inventory
 }
 
-func validateRouteAuthorityDriftInventory(root string, inventory routeAuthorityDriftInventory) []string {
-	corpus := routeAuthorityDriftNewValidationCorpus(root)
+func cloneRouteAuthorityDriftInventory(in routeAuthorityDriftInventory) routeAuthorityDriftInventory {
+	out := in
+	out.ImplementationIssues = append([]int(nil), in.ImplementationIssues...)
+	out.ParentIssues = append([]int(nil), in.ParentIssues...)
+	out.SearchDimensions = append([]routeAuthorityDriftSearchDimension(nil), in.SearchDimensions...)
+	for i := range out.SearchDimensions {
+		out.SearchDimensions[i].RequiredPaths = append([]string(nil), in.SearchDimensions[i].RequiredPaths...)
+	}
+	out.SeamFamilies = append([]routeAuthorityDriftSeamFamily(nil), in.SeamFamilies...)
+	for i := range out.SeamFamilies {
+		out.SeamFamilies[i].Paths = append([]string(nil), in.SeamFamilies[i].Paths...)
+		out.SeamFamilies[i].SearchDimensions = append([]string(nil), in.SeamFamilies[i].SearchDimensions...)
+		out.SeamFamilies[i].InvalidAuthority = append([]string(nil), in.SeamFamilies[i].InvalidAuthority...)
+	}
+	out.GuardrailProposals = append([]routeAuthorityDriftGuardrail(nil), in.GuardrailProposals...)
+	for i := range out.GuardrailProposals {
+		out.GuardrailProposals[i].Prevents = append([]string(nil), in.GuardrailProposals[i].Prevents...)
+	}
+	return out
+}
+
+func validateRouteAuthorityDriftInventory(t *testing.T, root string, inventory routeAuthorityDriftInventory) []string {
+	t.Helper()
+	corpus := routeAuthorityDriftNewValidationCorpus(t, root)
 	return validateRouteAuthorityDriftInventoryWithCorpus(root, corpus, inventory)
 }
 
@@ -290,7 +306,7 @@ func validateRouteAuthorityDriftInventoryWithCorpus(root string, corpus *routeAu
 			problems = append(problems, fmt.Sprintf("search_dimension %s appears more than once", id))
 		}
 		dimensionsByID[id] = dimension
-		problems = append(problems, validateRouteAuthorityDriftSearchDimension(root, corpus, dimension)...)
+		problems = append(problems, validateRouteAuthorityDriftSearchDimension(corpus, dimension)...)
 	}
 	for _, id := range requiredRouteAuthorityDriftSearchDimensions() {
 		if _, ok := dimensionsByID[id]; !ok {
@@ -428,7 +444,7 @@ func validateRouteAuthorityDriftSources(root string, source routeAuthorityDriftI
 	return problems
 }
 
-func validateRouteAuthorityDriftSearchDimension(root string, corpus *routeAuthorityDriftValidationCorpus, dimension routeAuthorityDriftSearchDimension) []string {
+func validateRouteAuthorityDriftSearchDimension(corpus *routeAuthorityDriftValidationCorpus, dimension routeAuthorityDriftSearchDimension) []string {
 	var problems []string
 	id := strings.TrimSpace(dimension.ID)
 	pattern := strings.TrimSpace(dimension.Pattern)
@@ -451,7 +467,12 @@ func validateRouteAuthorityDriftSearchDimension(root string, corpus *routeAuthor
 			problems = append(problems, fmt.Sprintf("%s required_path missing", id))
 			continue
 		}
-		if !routeAuthorityDriftPathMatches(root, path, re) {
+		matches, err := routeAuthorityDriftPathMatches(corpus, path, re)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s required_path %s unavailable: %v", id, path, err))
+			continue
+		}
+		if !matches {
 			problems = append(problems, fmt.Sprintf("%s required_path %s does not match pattern", id, path))
 		}
 	}
@@ -534,87 +555,59 @@ func validateRouteAuthorityDriftGuardrails(root string, guardrails []routeAuthor
 	return problems
 }
 
-func routeAuthorityDriftNewValidationCorpus(root string) *routeAuthorityDriftValidationCorpus {
+func routeAuthorityDriftNewValidationCorpus(t *testing.T, root string) *routeAuthorityDriftValidationCorpus {
+	t.Helper()
 	return &routeAuthorityDriftValidationCorpus{
-		Files:         routeAuthorityDriftRepoFiles(root),
-		MatchesByExpr: map[string][]string{},
+		snapshot: mustConformanceRepoSnapshot(t, root),
+		overlays: map[string][]byte{},
 	}
 }
 
-func routeAuthorityDriftRepoFiles(root string) []routeAuthorityDriftRepoFile {
-	var files []routeAuthorityDriftRepoFile
-	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if entry.IsDir() {
-			switch entry.Name() {
-			case ".git", "vendor", "node_modules", "tmp", "test-results":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !routeAuthorityDriftScannableFile(path) {
-			return nil
-		}
-		if rel, err := filepath.Rel(root, path); err == nil {
-			relPath := filepath.ToSlash(rel)
-			if routeAuthorityDriftSelfAuditFile(relPath) {
-				return nil
-			}
-			raw, err := os.ReadFile(path)
-			if err != nil {
-				return nil
-			}
-			files = append(files, routeAuthorityDriftRepoFile{Path: relPath, Raw: raw})
-		}
-		return nil
-	})
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Path < files[j].Path
-	})
-	return files
+func (c *routeAuthorityDriftValidationCorpus) withFile(file routeAuthorityDriftRepoFile) *routeAuthorityDriftValidationCorpus {
+	overlays := make(map[string][]byte, len(c.overlays)+1)
+	for path, raw := range c.overlays {
+		overlays[path] = append([]byte(nil), raw...)
+	}
+	overlays[filepath.ToSlash(filepath.Clean(file.Path))] = append([]byte(nil), file.Raw...)
+	return &routeAuthorityDriftValidationCorpus{snapshot: c.snapshot, overlays: overlays}
 }
 
 func routeAuthorityDriftMatchingFiles(corpus *routeAuthorityDriftValidationCorpus, pattern string, re *regexp.Regexp) []string {
-	if matches, ok := corpus.MatchesByExpr[pattern]; ok {
-		return matches
-	}
 	var matches []string
-	for _, file := range corpus.Files {
-		if re.Match(file.Raw) {
-			matches = append(matches, file.Path)
+	for _, path := range corpus.snapshot.matchingFiles(pattern, re) {
+		if routeAuthorityDriftSelfAuditFile(path) {
+			continue
+		}
+		if _, replaced := corpus.overlays[path]; !replaced {
+			matches = append(matches, path)
+		}
+	}
+	for path, raw := range corpus.overlays {
+		if !routeAuthorityDriftSelfAuditFile(path) && re.Match(raw) {
+			matches = append(matches, path)
 		}
 	}
 	sort.Strings(matches)
-	corpus.MatchesByExpr[pattern] = matches
 	return matches
 }
 
 func routeAuthorityDriftSelfAuditFile(path string) bool {
 	switch path {
-	case routeAuthorityDriftInventoryPath, "internal/runtime/conformance/route_authority_drift_inventory_test.go":
+	case routeAuthorityDriftInventoryPath,
+		"internal/runtime/conformance/repo_validation_snapshot_test.go",
+		"internal/runtime/conformance/route_authority_drift_inventory_test.go":
 		return true
 	default:
 		return false
 	}
 }
 
-func routeAuthorityDriftPathMatches(root, path string, re *regexp.Regexp) bool {
-	raw, err := os.ReadFile(filepath.Join(root, filepath.Clean(path)))
-	if err != nil {
-		return false
+func routeAuthorityDriftPathMatches(corpus *routeAuthorityDriftValidationCorpus, path string, re *regexp.Regexp) (bool, error) {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if raw, ok := corpus.overlays[cleaned]; ok {
+		return re.Match(raw), nil
 	}
-	return re.Match(raw)
-}
-
-func routeAuthorityDriftScannableFile(path string) bool {
-	switch filepath.Ext(path) {
-	case ".go", ".yaml", ".yml", ".json", ".md":
-		return true
-	default:
-		return false
-	}
+	return corpus.snapshot.pathMatches(cleaned, re.String(), re)
 }
 
 func routeAuthorityDriftSearchDimensionByID(t *testing.T, inventory *routeAuthorityDriftInventory, id string) *routeAuthorityDriftSearchDimension {

--- a/internal/runtime/conformance/route_authority_drift_inventory_test.go
+++ b/internal/runtime/conformance/route_authority_drift_inventory_test.go
@@ -118,9 +118,9 @@ func TestRouteAuthorityDriftInventoryRejectsNarrowOrStaleAudit(t *testing.T) {
 			name: "required path must match the audited pattern",
 			mutate: func(inventory *routeAuthorityDriftInventory) {
 				dim := routeAuthorityDriftSearchDimensionByID(t, inventory, "event_deliveries")
-				dim.RequiredPaths = []string{"go.mod"}
+				dim.RequiredPaths = []string{"README.md"}
 			},
-			want: "event_deliveries required_path go.mod does not match pattern",
+			want: "event_deliveries required_path README.md does not match pattern",
 		},
 		{
 			name: "no implemented guardrail is not enough",

--- a/internal/runtime/conformance/route_authority_matrix_test.go
+++ b/internal/runtime/conformance/route_authority_matrix_test.go
@@ -151,8 +151,7 @@ func TestRouteAuthorityMatrixRejectsStaleReferences(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			matrix := base
-			matrix.Rows = append([]routeAuthorityMatrixRow(nil), base.Rows...)
+			matrix := cloneRouteAuthorityMatrix(base)
 			tc.mutate(&matrix)
 			problems := validateRouteAuthorityMatrix(root, matrix, ctx)
 			if !routeAuthorityProblemsContain(problems, tc.want) {
@@ -175,11 +174,24 @@ func loadRouteAuthorityMatrix(t *testing.T, root string) routeAuthorityMatrix {
 	return matrix
 }
 
+func cloneRouteAuthorityMatrix(in routeAuthorityMatrix) routeAuthorityMatrix {
+	out := in
+	out.ActiveTrackers = append([]routeAuthorityActiveTracker(nil), in.ActiveTrackers...)
+	out.Rows = append([]routeAuthorityMatrixRow(nil), in.Rows...)
+	for i := range out.Rows {
+		out.Rows[i].ProofDimensions = append([]string(nil), in.Rows[i].ProofDimensions...)
+		out.Rows[i].InvalidAuthority = append([]string(nil), in.Rows[i].InvalidAuthority...)
+		out.Rows[i].OwnerRefs = append([]routeAuthorityProofRef(nil), in.Rows[i].OwnerRefs...)
+		out.Rows[i].ProofRefs = append([]routeAuthorityProofRef(nil), in.Rows[i].ProofRefs...)
+	}
+	return out
+}
+
 func newRouteAuthorityValidationContext(t *testing.T, root string, matrix routeAuthorityMatrix) routeAuthorityValidationContext {
 	t.Helper()
 	return routeAuthorityValidationContext{
 		openRPCMethods: loadMatrixOpenRPCMethods(t, filepath.Join(root, matrix.Source.OpenRPCArtifact)),
-		goTests:        collectGoTestNames(t, root),
+		goTests:        conformanceGoTestNames(t, root),
 	}
 }
 


### PR DESCRIPTION
## Summary

- add one root-keyed, process-local, complete-or-error repository snapshot owner for conformance tests
- reuse immutable checkout facts, Go test names, route regex matches, and required-path matches across all audited consumers
- replace mutable corpus sharing with typed overlays and deep-clone route/fork validation inputs
- fail closed on root traversal, callback, relative-path, file-read, Go-parse, and required-path acquisition failures

## Governing context

No exact `platform-spec.yaml` section governs this test-harness performance/integrity class. Binding context is #1902's approved Pre-Implementation Coverage Audit and Gate B re-review, parent #1196, the route-authority inventory/matrix conformance artifacts, and `maintenance-and-cleanup.yaml#harness_reliability_and_local_smoke`.

No production architecture or runtime semantics change; `platform-spec.yaml` is intentionally unchanged.

## Semantic/test-owner migration

- New canonical owner: `internal/runtime/conformance/repo_validation_snapshot_test.go`, a test-only root-keyed complete-or-error checkout snapshot with immutable accessors and retained per-root errors.
- Old paths now invalid: per-consumer `routeAuthorityDriftRepoFiles`, repeated `collectGoTestNames` AST walks, direct required-path reads, ignored walk/read errors, direct mutable corpus file appends, and shallow nested matrix/inventory copies.
- Checked consumers: all six route-corpus construction paths, all five Go-test-name consumers, the hidden final-flow validator path, and the direct required-path reader.
- Migration complete: repo-wide recurrence scans find no surviving old builder, AST collector, direct content reader, or boolean-on-read-error path inside the approved package boundary.

## Performance

Exact focused JSON command:

`go test ./internal/runtime/conformance -run 'RouteAuthority|FinalFlowInstanceAuthoringFixture_RouteAuthorityBypassInventoryStaysClassified|MultiBundleOptionAMatrixProofReferencesResolve|ForkReplayResumeDesignRecord' -count=1 -json`

- before: 232.934s package time
- after: 13.927s package time
- reduction: approximately 94%

## Proof

- injected fail-closed acquisition, retained-error, immutability, overlay, required-path, build-count, and deep-clone tests
- exact focused command: pass
- full conformance package with host PostgreSQL: pass
- selected surface `-count=10`: pass in 18.112s
- selected surface `-race -count=10 -timeout=15m`: pass in 328.574s
- `go vet ./internal/runtime/conformance`: pass
- `SWARM_TEST_POSTGRES_DSN='postgres://…@127.0.0.1:55432/postgres?sslmode=disable' go test ./...`: pass

Closes #1902
