### PR TITLE
[agent-e][issue #1964] Teach workspace operational recovery

### DIFF
--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -121,6 +121,64 @@ func TestBootFloorConformanceVerifyDescribeReportNativeBashWorkspaceRequirement(
 	})
 }
 
+func TestBootFloorExplicitHostRefusalAcrossServeVerifyDescribe(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	configPath := writeDoctorClaudeHostConfig(t, "")
+	contractsPath := doctorAgentContractsPath
+
+	t.Run("serve", func(t *testing.T) {
+		var out lockedBuffer
+		code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+			ConfigPath:           configPath,
+			ContractsPath:        contractsPath,
+			DataSource:           t.TempDir(),
+			PlatformSpecPath:     defaultPlatformSpecPath,
+			StoreMode:            storebackend.ActiveDefaultBackend().String(),
+			APIListenAddr:        "127.0.0.1:0",
+			MCPListenAddr:        "127.0.0.1:0",
+			SelfCheck:            true,
+			RequireBundleMatch:   false,
+			NoRequireBundleMatch: true,
+			Output:               &out,
+		})
+		if code != cliExitRuntime {
+			t.Fatalf("serve code = %d, want %d\n%s", code, cliExitRuntime, out.String())
+		}
+		assertClaudeHostRefusal(t, out.String())
+	})
+
+	t.Run("verify", func(t *testing.T) {
+		opts := defaultVerifyCommandOptions()
+		opts.configPath = configPath
+		opts.contractsPath = contractsPath
+		var stdout, stderr bytes.Buffer
+		if code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr); code == 0 {
+			t.Fatalf("verify unexpectedly succeeded stdout=%s stderr=%s", stdout.String(), stderr.String())
+		}
+		assertClaudeHostRefusal(t, stderr.String())
+	})
+
+	t.Run("describe", func(t *testing.T) {
+		opts := defaultDescribeCommandOptions()
+		opts.configPath = configPath
+		opts.contractsPath = contractsPath
+		var stdout, stderr bytes.Buffer
+		if code := runDescribeCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr); code == 0 {
+			t.Fatalf("describe unexpectedly succeeded stdout=%s stderr=%s", stdout.String(), stderr.String())
+		}
+		assertClaudeHostRefusal(t, stderr.String())
+	})
+}
+
+func assertClaudeHostRefusal(t *testing.T, output string) {
+	t.Helper()
+	for _, want := range []string{"uses claude_cli backend", "Use Docker", "llm.backend: anthropic", "Docker-free local run"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("explicit-host refusal missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func assertBootFloorWorkspaceRequirementOutput(t *testing.T, output string) {
 	t.Helper()
 	for _, want := range []string{"workspace backend: docker", "agent native-bash-worker", "native_tools.bash"} {

--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -53,7 +53,7 @@ func TestBootFloorConformanceNativeBashHostOptOutIsLoudUnsafe(t *testing.T) {
 			t.Fatalf("serve output missing %q:\n%s", want, output)
 		}
 	}
-	if strings.Contains(strings.ToLower(output), "docker is not available") {
+	if strings.Contains(strings.ToLower(output), "docker is not reachable") {
 		t.Fatalf("host opt-out serve output shows Docker dependency despite explicit host backend:\n%s", output)
 	}
 }

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -1232,9 +1232,12 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailure
 			wantErr:   "workspace validation failed: workspace image is required",
 		},
 		{
-			name:      "ensure prereqs",
-			lifecycle: stubWorkspaceLifecycle{prereqErr: errors.New("docker unavailable")},
-			wantErr:   "docker unavailable",
+			name: "ensure prereqs preserves typed recovery",
+			lifecycle: stubWorkspaceLifecycle{prereqErr: &workspace.PrerequisiteError{
+				Problem:     `Docker is not reachable via "/opt/docker"`,
+				Remediation: "Start the Docker daemon, then verify with `/opt/docker info`",
+			}},
+			wantErr: "/opt/docker info",
 		},
 		{
 			name:      "ensure system workspaces",

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -24,6 +24,7 @@ import (
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -1264,6 +1265,46 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailure
 				t.Fatalf("CurrentRuntime = %p after %s failure, want nil", supervisor.CurrentRuntime(), tc.name)
 			}
 		})
+	}
+}
+
+func TestRuntimeProjectSupervisorOpenProjectExecutesExplicitHostRefusal(t *testing.T) {
+	projectRoot := writeProjectRoot(t)
+	bundle := testBuilderSupervisorBundle(t)
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
+		"worker": {ID: "worker"},
+	}
+	source := semanticview.Wrap(bundle)
+	module := stubWorkflowModule{source: source}
+	cfg := testWorkspaceBackendConfig(llmselection.BackendClaudeCLI)
+	supervisor := newRuntimeProjectSupervisor(
+		"", "", cfg, storeBundle{}, new(atomic.Bool), workspaceMountSources{},
+		workspaceBackendSelection{Backend: workspace.BackendHost, Source: "workspace.backend", PreferenceExplicit: true},
+		nil, nil, nil, "", nil, nil, nil,
+	)
+	supervisor.dev = true
+	supervisor.loadWorkflow = func(_, contractsRoot, _ string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
+		if strings.TrimSpace(contractsRoot) != strings.TrimSpace(projectRoot) {
+			return nil, nil, fmt.Errorf("contracts root = %q, want %q", contractsRoot, projectRoot)
+		}
+		return module, bundle, nil
+	}
+	supervisor.validateSource = func(context.Context, semanticview.Source) error { return nil }
+	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
+		return "store wiring ready", nil
+	}
+	supervisor.createRuntime = func(context.Context, runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
+		t.Fatal("createRuntime must not run after workspace backend refusal")
+		return nil, nil
+	}
+
+	_, err := supervisor.OpenProject(context.Background(), projectRoot)
+	if err == nil {
+		t.Fatal("OpenProject unexpectedly accepted claude_cli host execution")
+	}
+	assertClaudeHostRefusal(t, err.Error())
+	if supervisor.CurrentProject().Loaded || supervisor.CurrentRuntime() != nil {
+		t.Fatalf("failed replacement changed authority: project=%#v runtime=%p", supervisor.CurrentProject(), supervisor.CurrentRuntime())
 	}
 }
 

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -191,7 +191,7 @@ func runDescribeCommandWithOutput(ctx context.Context, repo string, opts describ
 		return cliExitValidation
 	}
 	source := semanticview.Wrap(bundle)
-	workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, source)
+	workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, opts.configPath, source)
 	if err != nil {
 		if errOut != nil {
 			fmt.Fprintf(errOut, "describe failed: resolve workspace backend: %v\n", err)

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -79,7 +79,7 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 		"backend_prerequisite/missing_backend_credential",
 		"workspace_prerequisite/workspace_image_unavailable",
 		"swarm secrets set CLAUDE_CODE_OAUTH_TOKEN",
-		"set workspace.image",
+		"swarm workspace build --backend claude_cli",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
@@ -105,12 +105,141 @@ func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 	}
 	for _, want := range []string{
 		"workspace_prerequisite/docker_unavailable",
-		"docker is not available",
-		"start Docker, set workspace.docker_bin",
+		"Docker is not reachable",
+		"Start the Docker daemon, then verify with",
+		dockerBin + " info",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestDoctorClaudeCLIPreflightSkipsDependentChecksAfterDockerFailure(t *testing.T) {
+	dockerBin := configureDoctorDockerStub(t)
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TEST_DOCKER_UNAVAILABLE", "1")
+	dockerLog := filepath.Join(t.TempDir(), "docker-calls.log")
+	t.Setenv("SWARM_TEST_DOCKER_LOG", dockerLog)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), true), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	assertLocalPreflightFindingState(t, report, "docker_unavailable", localPreflightStatusFailed, localPreflightSeverityBlocker)
+	assertLocalPreflightFindingState(t, report, "workspace_image_unavailable", localPreflightStatusSkipped, localPreflightSeverityInfo)
+	assertLocalPreflightFindingState(t, report, "workspace_claude_cli_unavailable", localPreflightStatusSkipped, localPreflightSeverityInfo)
+	dockerFinding, _ := localPreflightReportFinding(report, "docker_unavailable")
+	if !strings.Contains(dockerFinding.Remediation, dockerBin+" info") {
+		t.Fatalf("Docker remediation = %q, want configured binary verification command", dockerFinding.Remediation)
+	}
+	assertDoctorDockerCalls(t, dockerLog, []string{"version --format {{.Server.Version}}"}, []string{"image inspect", "run --rm"})
+}
+
+func TestDoctorClaudeCLIPreflightSkipsCLIProofAfterImageFailure(t *testing.T) {
+	dockerBin := configureDoctorDockerStub(t)
+	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+	t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
+	dockerLog := filepath.Join(t.TempDir(), "docker-calls.log")
+	t.Setenv("SWARM_TEST_DOCKER_LOG", dockerLog)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), doctorClaudeArgs(t, writeDoctorClaudeConfig(t, dockerBin), true), &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+	}
+	assertLocalPreflightFindingState(t, report, "docker_available", localPreflightStatusOK, localPreflightSeverityInfo)
+	assertLocalPreflightFindingState(t, report, "workspace_image_unavailable", localPreflightStatusFailed, localPreflightSeverityBlocker)
+	assertLocalPreflightFindingState(t, report, "workspace_claude_cli_unavailable", localPreflightStatusSkipped, localPreflightSeverityInfo)
+	imageFinding, _ := localPreflightReportFinding(report, "workspace_image_unavailable")
+	if !strings.Contains(imageFinding.Remediation, "swarm workspace build --backend claude_cli") || strings.Contains(imageFinding.Remediation, "pull") {
+		t.Fatalf("image remediation = %q, want exact local build command without pull", imageFinding.Remediation)
+	}
+	assertDoctorDockerCalls(t, dockerLog, []string{"version --format {{.Server.Version}}", "image inspect"}, []string{"run --rm"})
+}
+
+func TestDoctorWorkspaceBackendHostRefusalRendersTypedCapabilityRemediation(t *testing.T) {
+	tests := []struct {
+		name              string
+		contractsPath     func(*testing.T) string
+		wantMessage       []string
+		wantRemediation   []string
+		forbidRemediation string
+	}{
+		{
+			name:          "claude only",
+			contractsPath: func(*testing.T) string { return doctorAgentContractsPath },
+			wantMessage:   []string{"uses claude_cli backend"},
+			wantRemediation: []string{
+				"Use Docker",
+				"llm.backend: anthropic",
+				"host execution is refused only for exec-capable agents",
+			},
+		},
+		{
+			name:          "claude plus native bash",
+			contractsPath: writeServeRuntimeNativeBashFixture,
+			wantMessage:   []string{"uses claude_cli backend", "native_tools.bash"},
+			wantRemediation: []string{
+				"Use Docker",
+				"llm.backend: anthropic",
+				"workspace.allow_exec_on_host: true",
+			},
+			forbidRemediation: "or switch to an API backend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := writeDoctorClaudeConfig(t, "")
+			raw, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("read doctor config: %v", err)
+			}
+			writeRuntimeConfigText(t, configPath, strings.Replace(string(raw), "workspace:\n", "workspace:\n  backend: host\n", 1))
+			args := doctorClaudeArgs(t, configPath, true)
+			for i := range args {
+				if args[i] == "--contracts" && i+1 < len(args) {
+					args[i+1] = tt.contractsPath(t)
+				}
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), args, &stdout, &stderr, defaultRootCommandOptions())
+			if code != cliExitRuntime {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+			}
+			var report localPreflightReport
+			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+				t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+			}
+			finding, ok := localPreflightReportFinding(report, "workspace_backend_decision_failed")
+			if !ok || finding.Status != localPreflightStatusFailed || finding.Severity != localPreflightSeverityBlocker {
+				t.Fatalf("workspace backend finding = %#v, want failed blocker", finding)
+			}
+			for _, want := range tt.wantMessage {
+				if !strings.Contains(finding.Message, want) {
+					t.Fatalf("message = %q, want %q", finding.Message, want)
+				}
+			}
+			for _, want := range tt.wantRemediation {
+				if !strings.Contains(finding.Remediation, want) {
+					t.Fatalf("remediation = %q, want %q", finding.Remediation, want)
+				}
+			}
+			if tt.forbidRemediation != "" && strings.Contains(finding.Remediation, tt.forbidRemediation) {
+				t.Fatalf("remediation = %q, must not present API switch as complete", finding.Remediation)
+			}
+		})
 	}
 }
 
@@ -1043,15 +1172,16 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 		CLISpecification struct {
 			Foundations struct {
 				Preflight struct {
-					PromotedBy           string   `yaml:"promoted_by"`
-					ImplementationStatus string   `yaml:"implementation_status"`
-					CanonicalOwner       string   `yaml:"canonical_owner"`
-					ImplementationOwner  string   `yaml:"implementation_owner"`
-					Scope                string   `yaml:"scope"`
-					FindingCategories    []string `yaml:"finding_categories"`
-					CommandModeRule      string   `yaml:"command_mode_rule"`
-					OwnerConsumptionRule string   `yaml:"owner_consumption_rule"`
-					SplitTail            []string `yaml:"split_tail"`
+					PromotedBy              string   `yaml:"promoted_by"`
+					ImplementationStatus    string   `yaml:"implementation_status"`
+					CanonicalOwner          string   `yaml:"canonical_owner"`
+					ImplementationOwner     string   `yaml:"implementation_owner"`
+					Scope                   string   `yaml:"scope"`
+					FindingCategories       []string `yaml:"finding_categories"`
+					CommandModeRule         string   `yaml:"command_mode_rule"`
+					OwnerConsumptionRule    string   `yaml:"owner_consumption_rule"`
+					DependencyReportingRule string   `yaml:"dependency_reporting_rule"`
+					SplitTail               []string `yaml:"split_tail"`
 				} `yaml:"local_claude_cli_preflight_admission"`
 			} `yaml:"foundations"`
 			CommandCatalog struct {
@@ -1089,6 +1219,11 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 	for _, want := range []string{"llm_provider_selection_config_authority", "tool_model.credential_store", "workspace lifecycle", "serve startup/listener"} {
 		if !strings.Contains(preflight.OwnerConsumptionRule, want) {
 			t.Fatalf("owner consumption rule missing %q:\n%s", want, preflight.OwnerConsumptionRule)
+		}
+	}
+	for _, want := range []string{"Docker daemon probe fails", "`skipped`/not measured", "MUST NOT emit derivative blockers", "configured-image probe", "Text and JSON"} {
+		if !strings.Contains(preflight.DependencyReportingRule, want) {
+			t.Fatalf("dependency reporting rule missing %q:\n%s", want, preflight.DependencyReportingRule)
 		}
 	}
 	doctor := spec.CLISpecification.CommandCatalog.Doctor
@@ -1371,6 +1506,9 @@ func configureDoctorDockerStub(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "docker")
 	script := `#!/bin/sh
+if [ -n "${SWARM_TEST_DOCKER_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "${SWARM_TEST_DOCKER_LOG}"
+fi
 case "$1:$2" in
   version:--format)
     if [ "${SWARM_TEST_DOCKER_UNAVAILABLE:-}" = "1" ]; then
@@ -1410,6 +1548,36 @@ esac
 		t.Fatalf("write docker stub: %v", err)
 	}
 	return path
+}
+
+func assertLocalPreflightFindingState(t *testing.T, report localPreflightReport, code string, status localPreflightFindingStatus, severity localPreflightSeverity) {
+	t.Helper()
+	finding, ok := localPreflightReportFinding(report, code)
+	if !ok {
+		t.Fatalf("report missing finding %q: %#v", code, report.Findings)
+	}
+	if finding.Status != status || finding.Severity != severity {
+		t.Fatalf("finding %q = %#v, want status=%s severity=%s", code, finding, status, severity)
+	}
+}
+
+func assertDoctorDockerCalls(t *testing.T, path string, required, forbidden []string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Docker call log: %v", err)
+	}
+	calls := string(raw)
+	for _, want := range required {
+		if !strings.Contains(calls, want) {
+			t.Fatalf("Docker calls missing %q:\n%s", want, calls)
+		}
+	}
+	for _, forbiddenCall := range forbidden {
+		if strings.Contains(calls, forbiddenCall) {
+			t.Fatalf("Docker calls include dependent probe %q after upstream failure:\n%s", forbiddenCall, calls)
+		}
+	}
 }
 
 func freeDoctorTCPPort(t *testing.T) string {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -200,12 +200,7 @@ func TestDoctorWorkspaceBackendHostRefusalRendersTypedCapabilityRemediation(t *t
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configPath := writeDoctorClaudeConfig(t, "")
-			raw, err := os.ReadFile(configPath)
-			if err != nil {
-				t.Fatalf("read doctor config: %v", err)
-			}
-			writeRuntimeConfigText(t, configPath, strings.Replace(string(raw), "workspace:\n", "workspace:\n  backend: host\n", 1))
+			configPath := writeDoctorClaudeHostConfig(t, "")
 			args := doctorClaudeArgs(t, configPath, true)
 			for i := range args {
 				if args[i] == "--contracts" && i+1 < len(args) {
@@ -1216,6 +1211,11 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 			t.Fatalf("preflight spec missing consumer %q:\n%#v", want, preflight)
 		}
 	}
+	for _, want := range []string{"complete typed blocking finding", "including remediation", "error output", "Direct non-dev serve", "log-only cause is not a substitute"} {
+		if !strings.Contains(preflight.CommandModeRule, want) {
+			t.Fatalf("preflight command-mode rule missing %q:\n%s", want, preflight.CommandModeRule)
+		}
+	}
 	for _, want := range []string{"llm_provider_selection_config_authority", "tool_model.credential_store", "workspace lifecycle", "serve startup/listener"} {
 		if !strings.Contains(preflight.OwnerConsumptionRule, want) {
 			t.Fatalf("owner consumption rule missing %q:\n%s", want, preflight.OwnerConsumptionRule)
@@ -1395,6 +1395,17 @@ func writeDoctorClaudeConfig(t *testing.T, dockerBin string) string {
 		strings.Join(providerPacks, "\n"),
 	}, "\n")+"\n")
 	return path
+}
+
+func writeDoctorClaudeHostConfig(t *testing.T, dockerBin string) string {
+	t.Helper()
+	configPath := writeDoctorClaudeConfig(t, dockerBin)
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read doctor config: %v", err)
+	}
+	writeRuntimeConfigText(t, configPath, strings.Replace(string(raw), "workspace:\n", "workspace:\n  backend: host\n", 1))
+	return configPath
 }
 
 func writeDoctorTargetRepo(t *testing.T) string {

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -130,7 +131,14 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 	}
 	workspaceBackend, err := decideWorkspaceBackend(req.WorkspaceBackend, req.Config, source)
 	if err != nil {
-		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities")
+		message := err.Error()
+		remediation := "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities"
+		var decisionErr *workspaceBackendDecisionError
+		if errors.As(err, &decisionErr) {
+			message = decisionErr.Problem
+			remediation = decisionErr.Remediation
+		}
+		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
 		return report.finalize()
 	}
 	status := localPreflightStatusOK
@@ -388,12 +396,19 @@ func (r *localPreflightReport) checkWorkspace(ctx context.Context, cfg *config.C
 		return
 	}
 	if err := dockerManager.CheckDockerAvailable(ctx); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "docker_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "start Docker, set workspace.docker_bin in swarm.yaml, or pass --docker-bin to `swarm workspace build`")
+		message, remediation := workspacePrerequisiteDiagnostic(err, fmt.Sprintf("Start the Docker daemon, then verify with `%s`", workspace.DockerInfoCommand(dockerManager.DockerBin())))
+		r.add(localPreflightWorkspacePrerequisite, "docker_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityInfo, localPreflightStatusSkipped, "workspace image was not checked because Docker is unreachable", remediation)
+		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_unavailable", localPreflightSeverityInfo, localPreflightStatusSkipped, "configured Claude CLI command was not checked because the workspace image was not measured", remediation)
+		return
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "docker_available", localPreflightSeverityInfo, localPreflightStatusOK, "Docker is reachable", "")
 	}
 	if err := dockerManager.CheckWorkspaceImageAvailable(ctx); err != nil {
-		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "run `swarm workspace build --backend claude_cli`, pull the configured workspace image, or set workspace.image")
+		message, remediation := workspacePrerequisiteDiagnostic(err, "Run `swarm workspace build --backend claude_cli` before startup")
+		r.add(localPreflightWorkspacePrerequisite, "workspace_image_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
+		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_unavailable", localPreflightSeverityInfo, localPreflightStatusSkipped, "configured Claude CLI command was not checked because the workspace image is unavailable", remediation)
+		return
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_image_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image is available", "")
 	}
@@ -402,6 +417,19 @@ func (r *localPreflightReport) checkWorkspace(ctx context.Context, cfg *config.C
 	} else {
 		r.add(localPreflightWorkspacePrerequisite, "workspace_claude_cli_available", localPreflightSeverityInfo, localPreflightStatusOK, "workspace image can execute the configured Claude CLI command", "")
 	}
+}
+
+func workspacePrerequisiteDiagnostic(err error, fallbackRemediation string) (string, string) {
+	message := err.Error()
+	remediation := strings.TrimSpace(fallbackRemediation)
+	var prerequisiteErr *workspace.PrerequisiteError
+	if errors.As(err, &prerequisiteErr) {
+		message = prerequisiteErr.Problem
+		if strings.TrimSpace(prerequisiteErr.Remediation) != "" {
+			remediation = prerequisiteErr.Remediation
+		}
+	}
+	return message, remediation
 }
 
 func loadLocalPreflightSource(repo string, paths cliContractPlatformSpecPaths) (semanticview.Source, string, error) {

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -131,13 +131,7 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 	}
 	workspaceBackend, err := decideWorkspaceBackend(req.WorkspaceBackend, req.Config, source)
 	if err != nil {
-		message := err.Error()
-		remediation := "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities"
-		var decisionErr *workspaceBackendDecisionError
-		if errors.As(err, &decisionErr) {
-			message = decisionErr.Problem
-			remediation = decisionErr.Remediation
-		}
+		message, remediation := workspaceBackendDecisionDiagnostic(err)
 		report.add(localPreflightWorkspacePrerequisite, "workspace_backend_decision_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, message, remediation)
 		return report.finalize()
 	}
@@ -187,6 +181,53 @@ func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) 
 	}
 	report.checkWorkspace(ctx, req.Config, source, contractsRoot, req.MountSources, workspaceBackend, req.Config.LLM.ClaudeCLI.Command)
 	return report.finalize()
+}
+
+func workspaceBackendDecisionDiagnostic(err error) (string, string) {
+	message := err.Error()
+	remediation := "fix workspace.backend, workspace.allow_exec_on_host, or the selected contract capabilities"
+	var decisionErr *workspaceBackendDecisionError
+	if errors.As(err, &decisionErr) {
+		message = decisionErr.Problem
+		remediation = decisionErr.Remediation
+	}
+	return message, remediation
+}
+
+func writeWorkspaceBackendDecisionFailure(out io.Writer, location string, err error) {
+	if out == nil || err == nil {
+		return
+	}
+	message, remediation := workspaceBackendDecisionDiagnostic(err)
+	fmt.Fprintln(out, formatLocalPreflightFinding(location, localPreflightFinding{
+		Category:    localPreflightWorkspacePrerequisite,
+		Code:        "workspace_backend_decision_failed",
+		Status:      localPreflightStatusFailed,
+		Severity:    localPreflightSeverityBlocker,
+		Message:     message,
+		Remediation: remediation,
+		Owner:       localPreflightOwner,
+	}))
+}
+
+func writeWorkspacePrerequisiteFailure(out io.Writer, location string, err error) bool {
+	if out == nil || err == nil {
+		return false
+	}
+	var prerequisiteErr *workspace.PrerequisiteError
+	if !errors.As(err, &prerequisiteErr) {
+		return false
+	}
+	fmt.Fprintln(out, formatLocalPreflightFinding(location, localPreflightFinding{
+		Category:    localPreflightWorkspacePrerequisite,
+		Code:        "workspace_prerequisite_failed",
+		Status:      localPreflightStatusFailed,
+		Severity:    localPreflightSeverityBlocker,
+		Message:     prerequisiteErr.Problem,
+		Remediation: prerequisiteErr.Remediation,
+		Owner:       localPreflightOwner,
+	}))
+	return true
 }
 
 func loadLocalPreflightCapabilitySource(ctx context.Context, req localPreflightRequest, report *localPreflightReport) (semanticview.Source, string, bool) {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -955,6 +955,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	primaryWorkspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, source)
 	if err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
+		writeWorkspaceBackendDecisionFailure(opts.Output, "serve", err)
 		log.Printf("resolve workspace backend decision: %v", err)
 		return 3
 	}
@@ -1094,6 +1095,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		workspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, loaded.source)
 		if err != nil {
 			reporter.emit(5, "runtime_context", "FAILED", err.Error())
+			writeWorkspaceBackendDecisionFailure(opts.Output, "serve", err)
 			slog.Error("resolve workspace backend decision", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
 			return 3
 		}
@@ -1123,6 +1125,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		})
 		if err != nil {
 			reporter.emit(5, "runtime_context", "FAILED", err.Error())
+			writeWorkspacePrerequisiteFailure(opts.Output, "serve", err)
 			slog.Error("build runtime context", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
 			return 1
 		}
@@ -1563,7 +1566,7 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 			}
 			return 1
 		}
-		workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, source)
+		workspaceBackend, err := resolveWorkspaceBackendDiagnostic(repo, opts.configPath, source)
 		if err != nil {
 			if errOut != nil {
 				fmt.Fprintf(errOut, "verify failed: resolve workspace backend: %v\n", err)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -2338,6 +2338,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 				RetiredEnvVar        string   `yaml:"retired_env_var"`
 				SourceOrder          []string `yaml:"source_order"`
 				DefaultBackend       string   `yaml:"default_backend"`
+				CapabilityReasonRule string   `yaml:"capability_reason_rule"`
 				CapabilityClasses    map[string]struct {
 					Rule string `yaml:"rule"`
 				} `yaml:"capability_classes"`
@@ -2395,6 +2396,11 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 	}
 	if authority.DefaultBackend != "capability-derived" {
 		t.Fatalf("workspace backend default = %q, want capability-derived", authority.DefaultBackend)
+	}
+	for _, want := range []string{"typed capability reasons", "MUST NOT parse", "llm.backend: anthropic", "every remaining exec reason", "workspace.allow_exec_on_host"} {
+		if !strings.Contains(authority.CapabilityReasonRule, want) {
+			t.Fatalf("workspace backend capability reason rule missing %q:\n%s", want, authority.CapabilityReasonRule)
+		}
 	}
 	for _, want := range []string{"none", "workspace_write", "exec"} {
 		if _, ok := authority.CapabilityClasses[want]; !ok {
@@ -2601,12 +2607,13 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 		} `yaml:"cli_specification"`
 		WorkspaceModel struct {
 			RuntimeImagePackaging struct {
-				PromotedBy           string `yaml:"promoted_by"`
-				ImplementationStatus string `yaml:"implementation_status"`
-				CanonicalOwner       string `yaml:"canonical_owner"`
-				Rule                 string `yaml:"rule"`
-				MountSourceRule      string `yaml:"mount_source_rule"`
-				SplitScope           string `yaml:"split_scope"`
+				PromotedBy           string            `yaml:"promoted_by"`
+				ImplementationStatus string            `yaml:"implementation_status"`
+				CanonicalOwner       string            `yaml:"canonical_owner"`
+				Rule                 string            `yaml:"rule"`
+				MountSourceRule      string            `yaml:"mount_source_rule"`
+				SplitScope           string            `yaml:"split_scope"`
+				RecoveryDiagnostics  map[string]string `yaml:"recovery_diagnostics"`
 			} `yaml:"runtime_image_packaging"`
 		} `yaml:"workspace_model"`
 	}
@@ -2670,6 +2677,9 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 		if !strings.Contains(packaging.MountSourceRule, want) {
 			t.Fatalf("runtime image packaging mount source rule missing %q:\n%s", want, packaging.MountSourceRule)
 		}
+	}
+	if !strings.Contains(packaging.RecoveryDiagnostics["docker_daemon"], "<configured-docker-bin> info") || !strings.Contains(packaging.RecoveryDiagnostics["workspace_image"], "swarm workspace build --backend claude_cli") || !strings.Contains(packaging.RecoveryDiagnostics["workspace_image"], "MUST NOT advertise pulling") {
+		t.Fatalf("runtime image recovery diagnostics incomplete: %#v", packaging.RecoveryDiagnostics)
 	}
 	for _, want := range []string{"#996", "#997"} {
 		if !strings.Contains(packaging.SplitScope, want) {
@@ -9593,7 +9603,7 @@ func TestRunServeRuntimeHostWorkspaceBackendBootsWithoutDockerForSystemOnlyFlow(
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
-	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "docker is not available") {
+	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "Docker is not reachable") {
 		t.Fatalf("host workspace serve output shows Docker dependency despite host backend:\n%s", serve.outputString())
 	}
 }
@@ -9624,7 +9634,7 @@ func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 	if !strings.Contains(serve.outputString(), "workspace backend: none") {
 		t.Fatalf("serve output missing no-workspace decision:\n%s", serve.outputString())
 	}
-	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "docker is not available") {
+	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "Docker is not reachable") {
 		t.Fatalf("no-agent serve output shows Docker dependency despite no-workspace decision:\n%s", serve.outputString())
 	}
 }
@@ -9659,7 +9669,7 @@ func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
 	if !strings.Contains(output, "workspace backend: host") {
 		t.Fatalf("serve output missing host workspace decision for API-backed agent:\n%s", output)
 	}
-	if strings.Contains(strings.ToLower(output), "docker is not available") {
+	if strings.Contains(strings.ToLower(output), "docker is not reachable") {
 		t.Fatalf("API-backed agent serve output shows Docker dependency despite host decision:\n%s", output)
 	}
 }
@@ -9690,7 +9700,7 @@ func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) 
 		t.Fatalf("runServeRuntime code = 0, want Docker prerequisite failure\noutput:\n%s", out.String())
 	}
 	output := out.String()
-	for _, want := range []string{"[5/22] runtime_context", "workspace backend: docker", "native_tools.bash", "docker is not available"} {
+	for _, want := range []string{"[5/22] runtime_context", "workspace backend: docker", "native_tools.bash", "Docker is not reachable", missingDocker + " info"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("serve output missing %q:\n%s", want, output)
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -3673,6 +3674,78 @@ func TestRunServeRuntimeDBLoadedUsesEmbeddedSpecBeforeCatalogRead(t *testing.T) 
 	}
 	if strings.Contains(serve.outputString(), "missing-platform-spec.yaml") || strings.Contains(serve.outputString(), "read platform spec") {
 		t.Fatalf("DB-loaded serve used missing local platform spec before catalog read:\n%s", serve.outputString())
+	}
+}
+
+func TestRunServeRuntimeDBLoadedExecutesExplicitHostRefusal(t *testing.T) {
+	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
+		return serveRuntimeWorkspaceStub{}
+	})
+	ctx := context.Background()
+	bundleHash := seedServeRuntimeBundleCatalog(t, ctx, pg, doctorAgentContractsPath)
+	var out lockedBuffer
+	code := runServeRuntime(ctx, repoRoot(), serveOptions{
+		ConfigPath:         writeDoctorClaudeHostConfig(t, ""),
+		BundleHash:         bundleHash,
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: true,
+		Output:             &out,
+	})
+	if code != cliExitRuntime {
+		t.Fatalf("DB-loaded serve code = %d, want %d\n%s", code, cliExitRuntime, out.String())
+	}
+	assertClaudeHostRefusal(t, out.String())
+}
+
+func TestRunServeRuntimeDBLoadedExecutesDockerManagerRecovery(t *testing.T) {
+	const dockerBin = "/opt/db-loaded-docker"
+	var daemonProbes atomic.Int32
+	contractsRoot := writeServeRuntimeNativeBashFixture(t)
+	_, _, pg := installServeRuntimePostgresTestStoresWithWorkspaceFactory(t, func(mountSources workspaceMountSources) serveWorkspaceLifecycle {
+		manager := workspace.NewDockerManager(nil)
+		cfg := workspace.DefaultDockerConfig()
+		cfg.DockerBin = dockerBin
+		cfg.WorkspaceImage = "db-loaded-workspace:test"
+		cfg.SharedDataSource = mountSources.DataSource
+		cfg.ContractsSource = contractsRoot
+		manager.SetConfig(cfg)
+		manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+			if len(args) > 0 && args[0] == "version" {
+				daemonProbes.Add(1)
+				return "", fmt.Errorf("daemon offline")
+			}
+			return "", nil
+		})
+		return manager
+	})
+	ctx := context.Background()
+	bundleHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, contractsRoot)
+	var out lockedBuffer
+	code := runServeRuntime(ctx, repoRoot(), serveOptions{
+		ConfigPath:         writeServeRuntimeTestConfig(t),
+		BundleHash:         bundleHash,
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "postgres",
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		SelfCheck:          true,
+		RequireBundleMatch: true,
+		Output:             &out,
+	})
+	if code == 0 {
+		t.Fatalf("DB-loaded serve code = 0, want Docker prerequisite failure\n%s", out.String())
+	}
+	if daemonProbes.Load() == 0 {
+		t.Fatal("DB-loaded runtime did not execute DockerManager daemon probe")
+	}
+	for _, want := range []string{dockerBin, "Start the Docker daemon, then verify with `" + dockerBin + " info`"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("DB-loaded runtime output missing %q:\n%s", want, out.String())
+		}
 	}
 }
 
@@ -11293,6 +11366,29 @@ flows: []
 	}
 }
 
+func TestRunForkRuntimeOwnerHarness_SelectedContractsExecutesExplicitHostRefusal(t *testing.T) {
+	dsn, _, _ := testutil.StartPostgres(t)
+	setPostgresEnvFromDSN(t, dsn)
+	configPath := os.Getenv("SWARM_CONFIG")
+	rawConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read run-fork config: %v", err)
+	}
+	writeRuntimeConfigText(t, configPath, string(rawConfig)+fmt.Sprintf("workspace:\n  backend: host\n  data_source: %q\n", t.TempDir()))
+	var out bytes.Buffer
+	code := runForkRuntimeOwnerHarness(context.Background(), repoRoot(), []string{
+		"--store", "postgres",
+		"--config", configPath,
+		"--contracts", doctorAgentContractsPath,
+		"--run", uuid.NewString(),
+		"--at", uuid.NewString(),
+	}, &out)
+	if code != 1 {
+		t.Fatalf("selected-contract run-fork code = %d, want 1\n%s", code, out.String())
+	}
+	assertClaudeHostRefusal(t, out.String())
+}
+
 func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)
@@ -14924,7 +15020,7 @@ func TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T
 		dataSource:       t.TempDir(),
 		platformSpecPath: defaultPlatformSpecPath,
 		apiPort:          apiPort,
-	})
+	}, io.Discard)
 	if err != nil {
 		t.Fatalf("startLocalRunServe: %v", err)
 	}

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -167,7 +169,7 @@ func runRunCommand(ctx context.Context, repo string, out, errOut io.Writer, opts
 			writeCLIAPIError(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
 		}
-		stopLocal, err = startLocalRunServe(ctx, repo, opts)
+		stopLocal, err = startLocalRunServe(ctx, repo, opts, errOut)
 		if err != nil {
 			writeCLIAPIError(errOut, err)
 			return commandExitError{code: runCommandErrorExitCode(err)}
@@ -374,7 +376,31 @@ func loadRunCommandPayload(path string) (map[string]any, error) {
 	return payload, nil
 }
 
-func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions) (func(), error) {
+type runStartupOutput struct {
+	mu      sync.Mutex
+	buffer  bytes.Buffer
+	discard bool
+}
+
+func (o *runStartupOutput) Write(p []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.discard {
+		return len(p), nil
+	}
+	return o.buffer.Write(p)
+}
+
+func (o *runStartupOutput) finish() []byte {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.discard = true
+	output := append([]byte(nil), o.buffer.Bytes()...)
+	o.buffer.Reset()
+	return output
+}
+
+func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions, startupErrOut io.Writer) (func(), error) {
 	runServe := opts.apiOptions.runServe
 	if runServe == nil {
 		runServe = runServeRuntime
@@ -401,6 +427,8 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	serveOpts.DataSource = opts.dataSource
 	serveOpts.PlatformSpecPath = resolvedPaths.PlatformSpecPath
 	serveOpts.LocalRun = true
+	var startupOutput runStartupOutput
+	serveOpts.Output = &startupOutput
 	if opts.apiPort > 0 {
 		serveOpts.APIListenAddr = net.JoinHostPort("127.0.0.1", strconv.Itoa(opts.apiPort))
 	}
@@ -408,6 +436,7 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	done := make(chan int, 1)
 	go func() {
 		done <- runServe(serveCtx, repo, serveOpts)
+		close(done)
 	}()
 	stop := func() {
 		cancel()
@@ -422,8 +451,12 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	}
 	if err := waitForRunCommandReady(ctx, opts, done); err != nil {
 		stop()
+		if output := startupOutput.finish(); startupErrOut != nil && len(output) > 0 {
+			_, _ = startupErrOut.Write(output)
+		}
 		return nil, err
 	}
+	startupOutput.finish()
 	return stop, nil
 }
 

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -147,7 +147,7 @@ func TestRunCommandLocalForegroundRendersRealWorkspaceStartupDiagnostics(t *test
 			payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
 			apiPort := freeDoctorTCPPort(t)
 			opts := defaultRootCommandOptions()
-			opts.runReadyTimeout = 5 * time.Second
+			opts.runReadyTimeout = 20 * time.Second
 			opts.runReadyPoll = 10 * time.Millisecond
 
 			var stdout, stderr bytes.Buffer
@@ -186,7 +186,7 @@ func TestRunCommandLocalForegroundRendersRealExplicitHostRefusal(t *testing.T) {
 	configPath := writeDoctorClaudeHostConfig(t, "")
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
 	opts := defaultRootCommandOptions()
-	opts.runReadyTimeout = 5 * time.Second
+	opts.runReadyTimeout = 20 * time.Second
 	opts.runReadyPoll = 10 * time.Millisecond
 
 	var stdout, stderr bytes.Buffer

--- a/cmd/swarm/run_command_test.go
+++ b/cmd/swarm/run_command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -109,6 +110,104 @@ func TestRunCommandLocalForegroundConsumesServeOwnerAndV1API(t *testing.T) {
 	}
 }
 
+func TestRunCommandLocalForegroundRendersRealWorkspaceStartupDiagnostics(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*testing.T) (string, string)
+		want      []string
+	}{
+		{
+			name: "Docker daemon unavailable",
+			configure: func(t *testing.T) (string, string) {
+				dockerBin := configureDoctorDockerStub(t)
+				t.Setenv("SWARM_TEST_DOCKER_UNAVAILABLE", "1")
+				return writeDoctorClaudeConfig(t, dockerBin), dockerBin + " info"
+			},
+			want: []string{"workspace_prerequisite/docker_unavailable", "Start the Docker daemon, then verify with", " info`"},
+		},
+		{
+			name: "workspace image unavailable",
+			configure: func(t *testing.T) (string, string) {
+				dockerBin := configureDoctorDockerStub(t)
+				t.Setenv("SWARM_TEST_DOCKER_IMAGE_MISSING", "1")
+				return writeDoctorClaudeConfig(t, dockerBin), ""
+			},
+			want: []string{"workspace_prerequisite/workspace_image_unavailable", "swarm workspace build --backend claude_cli"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
+			t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+			t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+			t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+			configPath, exactRecovery := tt.configure(t)
+			payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
+			apiPort := freeDoctorTCPPort(t)
+			opts := defaultRootCommandOptions()
+			opts.runReadyTimeout = 5 * time.Second
+			opts.runReadyPoll = 10 * time.Millisecond
+
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+				"--swarm-dir", t.TempDir(),
+				"run", "start",
+				"--event", "task.requested",
+				"--payload", payloadPath,
+				"--config", configPath,
+				"--backend", "claude_cli",
+				"--contracts", doctorAgentContractsPath,
+				"--data", t.TempDir(),
+				"--platform-spec", defaultPlatformSpecPath,
+				"--api-port", apiPort,
+			}, &stdout, &stderr, opts)
+			if code != cliExitRuntime {
+				t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("local run stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+			if exactRecovery != "" && !strings.Contains(stderr.String(), exactRecovery) {
+				t.Fatalf("local run stderr missing exact configured recovery %q:\n%s", exactRecovery, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "local serve exited before readiness") {
+				t.Fatalf("local run stderr missing startup failure boundary:\n%s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunCommandLocalForegroundRendersRealExplicitHostRefusal(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	configPath := writeDoctorClaudeHostConfig(t, "")
+	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
+	opts := defaultRootCommandOptions()
+	opts.runReadyTimeout = 5 * time.Second
+	opts.runReadyPoll = 10 * time.Millisecond
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
+		"--swarm-dir", t.TempDir(),
+		"run", "start",
+		"--event", "task.requested",
+		"--payload", payloadPath,
+		"--config", configPath,
+		"--backend", "claude_cli",
+		"--contracts", doctorAgentContractsPath,
+		"--data", t.TempDir(),
+		"--platform-spec", defaultPlatformSpecPath,
+		"--api-port", freeDoctorTCPPort(t),
+	}, &stdout, &stderr, opts)
+	if code != cliExitRuntime {
+		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
+	}
+	assertClaudeHostRefusal(t, stderr.String())
+}
+
 func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	tokenFile := writeCLIAPITokenFile(t, "serve-token")
@@ -190,7 +289,7 @@ func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {
 		return 0
 	}
 
-	stop, err := startLocalRunServe(context.Background(), repo, opts)
+	stop, err := startLocalRunServe(context.Background(), repo, opts, io.Discard)
 	if err != nil {
 		t.Fatalf("startLocalRunServe: %v", err)
 	}

--- a/cmd/swarm/workspace_backend.go
+++ b/cmd/swarm/workspace_backend.go
@@ -21,6 +21,68 @@ const (
 	workspaceCapabilityExec           workspaceCapabilityClass = "exec"
 )
 
+type workspaceCapabilityReasonKind string
+
+const (
+	workspaceReasonNoAgents     workspaceCapabilityReasonKind = "no_agents"
+	workspaceReasonLifecycle    workspaceCapabilityReasonKind = "workspace_lifecycle"
+	workspaceReasonClaudeCLI    workspaceCapabilityReasonKind = "claude_cli"
+	workspaceReasonNativeBash   workspaceCapabilityReasonKind = "native_bash"
+	workspaceReasonExecTool     workspaceCapabilityReasonKind = "exec_tool"
+	workspaceReasonNativeFileIO workspaceCapabilityReasonKind = "native_file_io"
+)
+
+type workspaceCapabilityReason struct {
+	Kind    workspaceCapabilityReasonKind
+	AgentID string
+	Tool    string
+}
+
+func (r workspaceCapabilityReason) String() string {
+	switch r.Kind {
+	case workspaceReasonNoAgents:
+		return "selected contract source declares no agents"
+	case workspaceReasonLifecycle:
+		return "declared agents use runtime-mediated workspace lifecycle"
+	case workspaceReasonClaudeCLI:
+		return fmt.Sprintf("agent %s uses claude_cli backend", workspaceBackendAgentLabel(r.AgentID))
+	case workspaceReasonNativeBash:
+		return fmt.Sprintf("agent %s has native_tools.bash", workspaceBackendAgentLabel(r.AgentID))
+	case workspaceReasonExecTool:
+		return fmt.Sprintf("agent %s has exec-class tool %s", workspaceBackendAgentLabel(r.AgentID), strings.TrimSpace(r.Tool))
+	case workspaceReasonNativeFileIO:
+		return fmt.Sprintf("agent %s has native_tools.file_io", workspaceBackendAgentLabel(r.AgentID))
+	default:
+		return "the selected contract"
+	}
+}
+
+func (r workspaceCapabilityReason) isExec() bool {
+	switch r.Kind {
+	case workspaceReasonClaudeCLI, workspaceReasonNativeBash, workspaceReasonExecTool:
+		return true
+	default:
+		return false
+	}
+}
+
+type workspaceBackendDecisionError struct {
+	Problem     string
+	Remediation string
+}
+
+func (e *workspaceBackendDecisionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	problem := strings.TrimSpace(e.Problem)
+	remediation := strings.TrimSpace(e.Remediation)
+	if remediation == "" {
+		return problem
+	}
+	return problem + ". " + remediation
+}
+
 type workspaceBackendSelection struct {
 	Backend string
 	Source  string
@@ -31,8 +93,7 @@ type workspaceBackendSelection struct {
 	UnsafeHost         bool
 
 	CapabilityClass workspaceCapabilityClass
-	Reasons         []string
-	HostUnsupported []string
+	Reasons         []workspaceCapabilityReason
 }
 
 type workspaceBackendInput struct {
@@ -120,14 +181,13 @@ func normalizeWorkspaceBackend(raw string, source string) (string, error) {
 }
 
 func decideWorkspaceBackend(preference workspaceBackendSelection, cfg *config.Config, source semanticview.Source) (workspaceBackendSelection, error) {
-	class, reasons, hostUnsupported, err := classifyWorkspaceBackendRequirement(cfg, source)
+	class, reasons, err := classifyWorkspaceBackendRequirement(cfg, source)
 	if err != nil {
 		return preference, err
 	}
 	decision := preference
 	decision.CapabilityClass = class
 	decision.Reasons = reasons
-	decision.HostUnsupported = hostUnsupported
 
 	switch class {
 	case workspaceCapabilityNone:
@@ -148,17 +208,30 @@ func decideWorkspaceBackend(preference workspaceBackendSelection, cfg *config.Co
 			break
 		}
 		if decision.Backend == workspace.BackendHost {
-			if len(hostUnsupported) > 0 {
-				return decision, fmt.Errorf("workspace backend host is unsupported for this exec-capable contract: %s; use Docker", strings.Join(hostUnsupported, "; "))
+			if workspaceBackendHasReason(reasons, workspaceReasonClaudeCLI) {
+				problem := fmt.Sprintf("workspace backend host is unsupported for this exec-capable contract: %s", workspaceBackendExecReasonSummary(reasons))
+				remediation := "Use Docker"
+				if workspaceBackendExecReasonsAreClaudeOnly(reasons) {
+					remediation += ", or switch to an API backend (`llm.backend: anthropic`) for a Docker-free local run; host execution is refused only for exec-capable agents"
+				} else {
+					remediation += ". For a Docker-free local run, switch to an API backend (`llm.backend: anthropic`) and explicitly authorize the remaining host execution with `workspace.allow_exec_on_host: true`"
+				}
+				return decision, &workspaceBackendDecisionError{Problem: problem, Remediation: remediation}
 			}
 			if !decision.AllowExecOnHost {
 				switch decision.Source {
 				case "--workspace-backend":
 					decision.AllowExecOnHost = true
 				case "workspace.backend":
-					return decision, fmt.Errorf("workspace.backend: host grants agent execution on this machine for %s; set workspace.allow_exec_on_host: true or use Docker", workspaceBackendReasonSummary(reasons))
+					return decision, &workspaceBackendDecisionError{
+						Problem:     fmt.Sprintf("workspace.backend: host grants agent execution on this machine for %s", workspaceBackendReasonSummary(reasons)),
+						Remediation: "Set `workspace.allow_exec_on_host: true` or use Docker",
+					}
 				default:
-					return decision, fmt.Errorf("workspace backend host cannot authorize unsafe host execution for %s; use --workspace-backend host for one command or workspace.backend: host with workspace.allow_exec_on_host: true", workspaceBackendReasonSummary(reasons))
+					return decision, &workspaceBackendDecisionError{
+						Problem:     fmt.Sprintf("workspace backend host cannot authorize unsafe host execution for %s", workspaceBackendReasonSummary(reasons)),
+						Remediation: "Use `--workspace-backend host` for one command, or set `workspace.backend: host` with `workspace.allow_exec_on_host: true`",
+					}
 				}
 			}
 			decision.UnsafeHost = true
@@ -167,20 +240,20 @@ func decideWorkspaceBackend(preference workspaceBackendSelection, cfg *config.Co
 	return decision, nil
 }
 
-func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview.Source) (workspaceCapabilityClass, []string, []string, error) {
+func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview.Source) (workspaceCapabilityClass, []workspaceCapabilityReason, error) {
 	if cfg == nil {
-		return "", nil, nil, fmt.Errorf("runtime config is required")
+		return "", nil, fmt.Errorf("runtime config is required")
 	}
 	if source == nil {
-		return "", nil, nil, fmt.Errorf("semantic source is required")
+		return "", nil, fmt.Errorf("semantic source is required")
 	}
 	profile, err := cfg.LLMBackendProfile()
 	if err != nil {
-		return "", nil, nil, err
+		return "", nil, err
 	}
 	entries := source.AgentEntries()
 	if len(entries) == 0 {
-		return workspaceCapabilityNone, []string{"selected contract source declares no agents"}, nil, nil
+		return workspaceCapabilityNone, []workspaceCapabilityReason{{Kind: workspaceReasonNoAgents}}, nil
 	}
 
 	agentIDs := make([]string, 0, len(entries))
@@ -190,31 +263,29 @@ func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview
 	sort.Strings(agentIDs)
 
 	class := workspaceCapabilityWorkspaceWrite
-	reasons := []string{"declared agents use runtime-mediated workspace lifecycle"}
-	hostUnsupported := []string{}
+	reasons := []workspaceCapabilityReason{{Kind: workspaceReasonLifecycle}}
 	for _, agentID := range agentIDs {
 		entry := entries[agentID]
 		label := workspaceBackendAgentLabel(agentID, entry.ID, entry.Role)
 		if profile.ID == llmselection.BackendClaudeCLI {
 			class = workspaceCapabilityExec
-			reasons = append(reasons, fmt.Sprintf("agent %s uses claude_cli backend", label))
-			hostUnsupported = append(hostUnsupported, fmt.Sprintf("agent %s uses claude_cli backend", label))
+			reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonClaudeCLI, AgentID: label})
 		}
 		if nativeToolEnabled(entry.NativeTools, "bash") {
 			class = workspaceCapabilityExec
-			reasons = append(reasons, fmt.Sprintf("agent %s has native_tools.bash", label))
+			reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonNativeBash, AgentID: label})
 		}
 		for _, tool := range entry.ConfiguredTools() {
 			if workspaceExecClassTool(tool) {
 				class = workspaceCapabilityExec
-				reasons = append(reasons, fmt.Sprintf("agent %s has exec-class tool %s", label, strings.TrimSpace(tool)))
+				reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonExecTool, AgentID: label, Tool: strings.TrimSpace(tool)})
 			}
 		}
 		if class != workspaceCapabilityExec && nativeToolEnabled(entry.NativeTools, "file_io") {
-			reasons = append(reasons, fmt.Sprintf("agent %s has native_tools.file_io", label))
+			reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonNativeFileIO, AgentID: label})
 		}
 	}
-	return class, uniqueNonEmptyStrings(reasons), uniqueNonEmptyStrings(hostUnsupported), nil
+	return class, uniqueWorkspaceCapabilityReasons(reasons), nil
 }
 
 func nativeToolEnabled(raw map[string]any, name string) bool {
@@ -244,11 +315,48 @@ func workspaceBackendAgentLabel(parts ...string) string {
 	return "<unknown>"
 }
 
-func workspaceBackendReasonSummary(reasons []string) string {
+func workspaceBackendReasonSummary(reasons []workspaceCapabilityReason) string {
 	if len(reasons) == 0 {
 		return "the selected contract"
 	}
-	return strings.Join(reasons, "; ")
+	formatted := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		formatted = append(formatted, reason.String())
+	}
+	return strings.Join(formatted, "; ")
+}
+
+func workspaceBackendExecReasonSummary(reasons []workspaceCapabilityReason) string {
+	execReasons := make([]workspaceCapabilityReason, 0, len(reasons))
+	for _, reason := range reasons {
+		if reason.isExec() {
+			execReasons = append(execReasons, reason)
+		}
+	}
+	return workspaceBackendReasonSummary(execReasons)
+}
+
+func workspaceBackendHasReason(reasons []workspaceCapabilityReason, kind workspaceCapabilityReasonKind) bool {
+	for _, reason := range reasons {
+		if reason.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func workspaceBackendExecReasonsAreClaudeOnly(reasons []workspaceCapabilityReason) bool {
+	found := false
+	for _, reason := range reasons {
+		if !reason.isExec() {
+			continue
+		}
+		found = true
+		if reason.Kind != workspaceReasonClaudeCLI {
+			return false
+		}
+	}
+	return found
 }
 
 func workspaceBackendDecisionDetail(decision workspaceBackendSelection) string {
@@ -273,14 +381,12 @@ func workspaceBackendUnsafeWarning(decision workspaceBackendSelection) string {
 	return fmt.Sprintf("UNSAFE: grants the agent execution on this machine via workspace backend host (%s)", workspaceBackendReasonSummary(decision.Reasons))
 }
 
-func uniqueNonEmptyStrings(values []string) []string {
-	seen := map[string]struct{}{}
-	out := make([]string, 0, len(values))
+func uniqueWorkspaceCapabilityReasons(values []workspaceCapabilityReason) []workspaceCapabilityReason {
+	seen := map[workspaceCapabilityReason]struct{}{}
+	out := make([]workspaceCapabilityReason, 0, len(values))
 	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
+		value.AgentID = strings.TrimSpace(value.AgentID)
+		value.Tool = strings.TrimSpace(value.Tool)
 		if _, ok := seen[value]; ok {
 			continue
 		}

--- a/cmd/swarm/workspace_backend.go
+++ b/cmd/swarm/workspace_backend.go
@@ -125,8 +125,8 @@ func resolveWorkspaceBackendDecision(flagBackend string, flagSet bool, cfg *conf
 	return decideWorkspaceBackend(preference, cfg, source)
 }
 
-func resolveWorkspaceBackendDiagnostic(repo string, source semanticview.Source) (workspaceBackendSelection, error) {
-	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo})
+func resolveWorkspaceBackendDiagnostic(repo, configPath string, source semanticview.Source) (workspaceBackendSelection, error) {
+	cfgResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo, ExplicitPath: configPath})
 	if err != nil {
 		return workspaceBackendSelection{}, err
 	}
@@ -281,7 +281,7 @@ func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview
 				reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonExecTool, AgentID: label, Tool: strings.TrimSpace(tool)})
 			}
 		}
-		if class != workspaceCapabilityExec && nativeToolEnabled(entry.NativeTools, "file_io") {
+		if nativeToolEnabled(entry.NativeTools, "file_io") {
 			reasons = append(reasons, workspaceCapabilityReason{Kind: workspaceReasonNativeFileIO, AgentID: label})
 		}
 	}

--- a/cmd/swarm/workspace_backend_decision_test.go
+++ b/cmd/swarm/workspace_backend_decision_test.go
@@ -209,6 +209,52 @@ func TestWorkspaceBackendHostRemediationUsesTypedExecReasons(t *testing.T) {
 	}
 }
 
+func TestWorkspaceBackendReasonsPreserveEveryAgentCapabilityAcrossAggregateClass(t *testing.T) {
+	tests := []struct {
+		name   string
+		agents map[string]runtimecontracts.AgentRegistryEntry
+	}{
+		{
+			name: "exec agent sorts first",
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"a-exec":  {ID: "a-exec", NativeTools: map[string]any{"bash": true}},
+				"z-files": {ID: "z-files", NativeTools: map[string]any{"file_io": true}},
+			},
+		},
+		{
+			name: "file agent sorts first",
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"a-files": {ID: "a-files", NativeTools: map[string]any{"file_io": true}},
+				"z-exec":  {ID: "z-exec", NativeTools: map[string]any{"bash": true}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := decideWorkspaceBackend(workspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Agents: tt.agents}))
+			if err != nil {
+				t.Fatalf("decideWorkspaceBackend: %v", err)
+			}
+			if decision.CapabilityClass != workspaceCapabilityExec || decision.Backend != workspace.BackendDocker {
+				t.Fatalf("decision = %#v, want aggregate exec/Docker", decision)
+			}
+			var bashAgents, fileAgents []string
+			for _, reason := range decision.Reasons {
+				switch reason.Kind {
+				case workspaceReasonNativeBash:
+					bashAgents = append(bashAgents, reason.AgentID)
+				case workspaceReasonNativeFileIO:
+					fileAgents = append(fileAgents, reason.AgentID)
+				}
+			}
+			if len(bashAgents) != 1 || len(fileAgents) != 1 {
+				t.Fatalf("typed reasons = %#v, want one bash and one file_io fact independent of aggregate class", decision.Reasons)
+			}
+		})
+	}
+}
+
 func TestConfiguredWorkspaceLifecycleForBackendNoWorkspace(t *testing.T) {
 	lifecycle, err := configuredWorkspaceLifecycleForBackend(nil, nil, "", semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), workspaceMountSources{}, workspaceBackendSelection{Backend: workspaceBackendNone, Source: "capability-derived", NoWorkspace: true})
 	if err != nil {

--- a/cmd/swarm/workspace_backend_decision_test.go
+++ b/cmd/swarm/workspace_backend_decision_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -15,16 +16,16 @@ import (
 
 func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 	tests := []struct {
-		name          string
-		cfg           *config.Config
-		agents        map[string]runtimecontracts.AgentRegistryEntry
-		preference    workspaceBackendSelection
-		wantBackend   string
-		wantClass     workspaceCapabilityClass
-		wantNo        bool
-		wantUnsafe    bool
-		wantErr       string
-		wantHostBlock string
+		name        string
+		cfg         *config.Config
+		agents      map[string]runtimecontracts.AgentRegistryEntry
+		preference  workspaceBackendSelection
+		wantBackend string
+		wantClass   workspaceCapabilityClass
+		wantNo      bool
+		wantUnsafe  bool
+		wantErr     string
+		wantReason  workspaceCapabilityReasonKind
 	}{
 		{
 			name:        "no agents defaults to no workspace lifecycle",
@@ -66,9 +67,9 @@ func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 			agents: map[string]runtimecontracts.AgentRegistryEntry{
 				"worker": {ID: "worker"},
 			},
-			wantBackend:   workspace.BackendDocker,
-			wantClass:     workspaceCapabilityExec,
-			wantHostBlock: "claude_cli",
+			wantBackend: workspace.BackendDocker,
+			wantClass:   workspaceCapabilityExec,
+			wantReason:  workspaceReasonClaudeCLI,
 		},
 		{
 			name: "flag host is loud unsafe opt out for host supported exec",
@@ -136,8 +137,73 @@ func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 			if decision.Backend != tt.wantBackend || decision.CapabilityClass != tt.wantClass || decision.NoWorkspace != tt.wantNo || decision.UnsafeHost != tt.wantUnsafe {
 				t.Fatalf("decision = %#v, want backend=%s class=%s no=%v unsafe=%v", decision, tt.wantBackend, tt.wantClass, tt.wantNo, tt.wantUnsafe)
 			}
-			if tt.wantHostBlock != "" && !joinedContains(decision.HostUnsupported, tt.wantHostBlock) {
-				t.Fatalf("host unsupported = %#v, want %q", decision.HostUnsupported, tt.wantHostBlock)
+			if tt.wantReason != "" && !workspaceBackendHasReason(decision.Reasons, tt.wantReason) {
+				t.Fatalf("reasons = %#v, want kind %q", decision.Reasons, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestWorkspaceBackendHostRemediationUsesTypedExecReasons(t *testing.T) {
+	tests := []struct {
+		name              string
+		agent             runtimecontracts.AgentRegistryEntry
+		wantProblem       []string
+		wantRemediation   []string
+		forbidRemediation string
+		wantClaudeOnly    bool
+	}{
+		{
+			name:            "claude only offers API backend as complete alternative",
+			agent:           runtimecontracts.AgentRegistryEntry{ID: "worker"},
+			wantProblem:     []string{"agent worker uses claude_cli backend"},
+			wantRemediation: []string{"Use Docker", "llm.backend: anthropic", "Docker-free local run"},
+			wantClaudeOnly:  true,
+		},
+		{
+			name:              "mixed native bash names every blocker and requires host authorization",
+			agent:             runtimecontracts.AgentRegistryEntry{ID: "worker", NativeTools: map[string]any{"bash": true}},
+			wantProblem:       []string{"agent worker uses claude_cli backend", "agent worker has native_tools.bash"},
+			wantRemediation:   []string{"Use Docker", "llm.backend: anthropic", "workspace.allow_exec_on_host: true"},
+			forbidRemediation: "or switch to an API backend",
+		},
+		{
+			name:              "mixed exec tool names every blocker and requires host authorization",
+			agent:             runtimecontracts.AgentRegistryEntry{ID: "worker", Tools: []string{"shell"}},
+			wantProblem:       []string{"agent worker uses claude_cli backend", "agent worker has exec-class tool shell"},
+			wantRemediation:   []string{"Use Docker", "llm.backend: anthropic", "workspace.allow_exec_on_host: true"},
+			forbidRemediation: "or switch to an API backend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preference := workspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend", PreferenceExplicit: true, AllowExecOnHost: true}
+			decision, err := decideWorkspaceBackend(preference, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": tt.agent},
+			}))
+			if err == nil {
+				t.Fatal("decideWorkspaceBackend unexpectedly accepted claude_cli host execution")
+			}
+			var decisionErr *workspaceBackendDecisionError
+			if !errors.As(err, &decisionErr) {
+				t.Fatalf("error type = %T, want *workspaceBackendDecisionError", err)
+			}
+			for _, want := range tt.wantProblem {
+				if !strings.Contains(decisionErr.Problem, want) {
+					t.Fatalf("problem = %q, want %q", decisionErr.Problem, want)
+				}
+			}
+			for _, want := range tt.wantRemediation {
+				if !strings.Contains(decisionErr.Remediation, want) {
+					t.Fatalf("remediation = %q, want %q", decisionErr.Remediation, want)
+				}
+			}
+			if tt.forbidRemediation != "" && strings.Contains(decisionErr.Remediation, tt.forbidRemediation) {
+				t.Fatalf("remediation = %q, must not present API switch as a complete exit", decisionErr.Remediation)
+			}
+			if got := workspaceBackendExecReasonsAreClaudeOnly(decision.Reasons); got != tt.wantClaudeOnly {
+				t.Fatalf("typed Claude-only discrimination = %v, want %v; reasons=%#v", got, tt.wantClaudeOnly, decision.Reasons)
 			}
 		})
 	}

--- a/cmd/swarm/workspace_build.go
+++ b/cmd/swarm/workspace_build.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/platform"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -126,7 +127,7 @@ func runWorkspaceBuildCommand(ctx context.Context, out io.Writer, opts workspace
 		}
 	}
 	if _, err := runWorkspaceBuildDocker(ctx, dockerBin, "version", "--format", "{{.Server.Version}}"); err != nil {
-		return fmt.Errorf("workspace image build failed: Docker is not available via %q; start Docker, set workspace.docker_bin, or pass --docker-bin: %w", dockerBin, err)
+		return fmt.Errorf("workspace image build failed: Docker is not reachable via %q. Start the Docker daemon, then verify with `%s`: %w", dockerBin, workspace.DockerInfoCommand(dockerBin), err)
 	}
 
 	if out != nil {

--- a/cmd/swarm/workspace_build_test.go
+++ b/cmd/swarm/workspace_build_test.go
@@ -185,7 +185,7 @@ func TestWorkspaceBuildClaudeCLIFailsOnUnavailableDocker(t *testing.T) {
 	if code != cliExitRuntime {
 		t.Fatalf("code = %d, want %d stdout=%s stderr=%s", code, cliExitRuntime, stdout.String(), stderr.String())
 	}
-	for _, want := range []string{"Docker is not available", "--docker-bin"} {
+	for _, want := range []string{"Docker is not reachable", missingDocker + " info"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
 		}
@@ -227,6 +227,7 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 				BuildPlanRule        string         `yaml:"build_plan_rule"`
 				BuildProfile         map[string]any `yaml:"claude_cli_build_profile"`
 				ImageTargetRule      string         `yaml:"image_target_rule"`
+				DockerBinRule        string         `yaml:"docker_bin_rule"`
 				ValidationRule       string         `yaml:"validation_rule"`
 				ConsumerBoundaries   []string       `yaml:"consumer_boundaries"`
 			} `yaml:"local_workspace_image_build_authority"`
@@ -262,6 +263,11 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 	for _, want := range []string{"workspace.image", "swarm-workspace:latest", "--image"} {
 		if !strings.Contains(owner.ImageTargetRule, want) {
 			t.Fatalf("image target rule missing %q:\n%s", want, owner.ImageTargetRule)
+		}
+	}
+	for _, want := range []string{"workspace.docker_bin", "<configured-docker-bin> info", "MUST NOT substitute"} {
+		if !strings.Contains(owner.DockerBinRule, want) {
+			t.Fatalf("Docker binary rule missing %q:\n%s", want, owner.DockerBinRule)
 		}
 	}
 	for _, want := range []string{"temporary image tag", "command -v", "--version", "lookup alone are insufficient"} {

--- a/internal/runtime/workspace/manager.go
+++ b/internal/runtime/workspace/manager.go
@@ -135,6 +135,33 @@ type DockerManager struct {
 	RunDockerFn func(ctx context.Context, args ...string) (string, error) // test seam
 }
 
+type PrerequisiteError struct {
+	Problem     string
+	Remediation string
+	Cause       error
+}
+
+func (e *PrerequisiteError) Error() string {
+	if e == nil {
+		return ""
+	}
+	message := "workspace prerequisite failed: " + strings.TrimSpace(e.Problem)
+	if remediation := strings.TrimSpace(e.Remediation); remediation != "" {
+		message += "; " + remediation
+	}
+	if e.Cause != nil {
+		message += ": " + e.Cause.Error()
+	}
+	return message
+}
+
+func (e *PrerequisiteError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
 const workspaceOrphanKillScript = `if command -v pkill >/dev/null 2>&1; then
   pkill -KILL -f '(^|/)(claude|codex)( |$)' >/dev/null 2>&1 || true
 else
@@ -165,6 +192,31 @@ func (m *DockerManager) SetConfig(cfg DockerConfig) {
 		return
 	}
 	m.cfg = cfg
+}
+
+func (m *DockerManager) DockerBin() string {
+	if m == nil {
+		return defaultDockerBin
+	}
+	if dockerBin := strings.TrimSpace(m.cfg.DockerBin); dockerBin != "" {
+		return dockerBin
+	}
+	return defaultDockerBin
+}
+
+func DockerInfoCommand(dockerBin string) string {
+	dockerBin = strings.TrimSpace(dockerBin)
+	if dockerBin == "" {
+		dockerBin = defaultDockerBin
+	}
+	return shellCommandToken(dockerBin) + " info"
+}
+
+func shellCommandToken(value string) string {
+	if !strings.ContainsAny(value, " \t\n'\"\\$`!&|;()<>*?[]{}") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func (m *DockerManager) SetSemanticSource(source semanticview.Source) {
@@ -769,7 +821,11 @@ func (m *DockerManager) standardMountArgs() []string {
 
 func (m *DockerManager) ensureDockerAvailable(ctx context.Context) error {
 	if _, err := m.RunDocker(ctx, "version", "--format", "{{.Server.Version}}"); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: docker is not available: %w", err)
+		return &PrerequisiteError{
+			Problem:     fmt.Sprintf("Docker is not reachable via %q", m.DockerBin()),
+			Remediation: fmt.Sprintf("Start the Docker daemon, then verify with `%s`", DockerInfoCommand(m.DockerBin())),
+			Cause:       err,
+		}
 	}
 	return nil
 }
@@ -791,10 +847,17 @@ func (m *DockerManager) ensureWorkspaceNetwork(ctx context.Context) error {
 func (m *DockerManager) ensureWorkspaceImage(ctx context.Context) error {
 	image := strings.TrimSpace(m.cfg.WorkspaceImage)
 	if image == "" {
-		return fmt.Errorf("workspace prerequisite failed: workspace image is required")
+		return &PrerequisiteError{
+			Problem:     "workspace image is required",
+			Remediation: "Set `workspace.image`, then run `swarm workspace build --backend claude_cli` before startup",
+		}
 	}
 	if _, err := m.RunDocker(ctx, "image", "inspect", image); err != nil {
-		return fmt.Errorf("workspace prerequisite failed: workspace image %s is not available; build or pull the image before startup, or set workspace.image to an available image: %w", image, err)
+		return &PrerequisiteError{
+			Problem:     fmt.Sprintf("workspace image %q is not available", image),
+			Remediation: "Run `swarm workspace build --backend claude_cli` before startup",
+			Cause:       err,
+		}
 	}
 	return nil
 }

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,41 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 )
+
+func TestWorkspacePrerequisiteRecoveryUsesConfiguredDockerBinaryAndLocalBuild(t *testing.T) {
+	manager := NewDockerManager(nil)
+	cfg := DefaultDockerConfig()
+	cfg.DockerBin = "/opt/docker cli"
+	cfg.WorkspaceImage = "custom-workspace:test"
+	manager.SetConfig(cfg)
+
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		return "", fmt.Errorf("daemon offline")
+	})
+	err := manager.CheckDockerAvailable(context.Background())
+	var prerequisiteErr *PrerequisiteError
+	if !errors.As(err, &prerequisiteErr) {
+		t.Fatalf("CheckDockerAvailable error type = %T, want *PrerequisiteError", err)
+	}
+	if !strings.Contains(prerequisiteErr.Problem, cfg.DockerBin) || prerequisiteErr.Remediation != "Start the Docker daemon, then verify with `'/opt/docker cli' info`" {
+		t.Fatalf("Docker diagnostic = %#v, want configured binary recovery", prerequisiteErr)
+	}
+
+	manager.SetRunDockerFnForTest(func(_ context.Context, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "image" && args[1] == "inspect" {
+			return "", fmt.Errorf("image absent")
+		}
+		return "", nil
+	})
+	err = manager.CheckWorkspaceImageAvailable(context.Background())
+	prerequisiteErr = nil
+	if !errors.As(err, &prerequisiteErr) {
+		t.Fatalf("CheckWorkspaceImageAvailable error type = %T, want *PrerequisiteError", err)
+	}
+	if !strings.Contains(prerequisiteErr.Problem, cfg.WorkspaceImage) || prerequisiteErr.Remediation != "Run `swarm workspace build --backend claude_cli` before startup" || strings.Contains(prerequisiteErr.Error(), "pull") {
+		t.Fatalf("image diagnostic = %#v, want exact local build recovery without pull", prerequisiteErr)
+	}
+}
 
 func TestWorkspaceClassesForSource(t *testing.T) {
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
@@ -418,11 +454,11 @@ func TestEnsurePrereqs_CreatesMissingNetworkAndFailsClosedForMissingImage(t *tes
 	if err == nil {
 		t.Fatal("EnsurePrereqs unexpectedly succeeded with missing workspace image")
 	}
-	if !strings.Contains(err.Error(), "workspace image test-image:latest is not available") {
+	if !strings.Contains(err.Error(), `workspace image "test-image:latest" is not available`) {
 		t.Fatalf("EnsurePrereqs error = %v, want missing image diagnostic", err)
 	}
-	if !strings.Contains(err.Error(), "set workspace.image") {
-		t.Fatalf("EnsurePrereqs error = %v, want configured image remediation", err)
+	if !strings.Contains(err.Error(), "swarm workspace build --backend claude_cli") || strings.Contains(err.Error(), "pull") {
+		t.Fatalf("EnsurePrereqs error = %v, want exact local build remediation without pull", err)
 	}
 
 	joined := flattenDockerCalls(calls)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -14491,6 +14491,14 @@ workspace_model:
       the resolved workspace image before creating workspaces and fail closed with an actionable diagnostic when the image is
       absent. Production runtime code MUST NOT build a missing workspace image from source-checkout `Dockerfile.workspace`, use
       `runtime.Caller` / Go source paths as a runtime asset root, or walk for `go.mod` to recover build material.
+    recovery_diagnostics:
+      docker_daemon: >
+        A failed Docker daemon probe MUST name the configured Docker binary and prescribe the portable verification command
+        `<configured-docker-bin> info`. It MUST NOT guess an environment-specific daemon launcher.
+      workspace_image: >
+        A missing configured workspace image MUST prescribe the exact local recovery command
+        `swarm workspace build --backend claude_cli`. It MUST NOT advertise pulling a release image until the release-image
+        authority publishes one.
     mount_source_rule: >
       Host sources for `/data` and `/opt/swarm/contracts` MUST come from `workspace_model.data_source_authority`,
       explicit deployment configuration, config/CLI path resolution, or an already selected workflow/project
@@ -14533,6 +14541,8 @@ workspace_model:
     docker_bin_rule: >
       The command MUST use `--docker-bin` when provided, otherwise `workspace.docker_bin` from an explicit config when
       provided, otherwise the built-in `docker` default. `SWARM_DOCKER_BIN` is retired and MUST NOT be read as a fallback.
+      When the daemon probe fails, the diagnostic MUST name the selected binary and prescribe
+      `<configured-docker-bin> info`; it MUST NOT substitute a default binary or guess a daemon launcher.
     validation_rule: >
       The command MUST build into a temporary image tag first and MUST NOT publish/replace the configured runtime image
       tag until validation passes. After build, the command MUST validate the temporary image by running a harmless
@@ -14634,6 +14644,12 @@ workspace_model:
           Any agent whose effective backend spawns a local process (`claude_cli`) or that is granted an exec-class capability
           such as `native_tools.bash` requires Docker by default. The first slice is coarse any-exec => Docker; per-agent
           backend selection remains split.
+    capability_reason_rule: >
+      Backend selection MUST retain typed capability reasons for each relevant agent and capability. Rendering those facts as
+      text is a projection; remediation logic MUST NOT parse rendered reason strings. A Claude-only host refusal may offer
+      `llm.backend: anthropic` as a complete Docker-free alternative. If native bash or another exec-class tool remains, the
+      diagnostic MUST name every remaining exec reason and MUST NOT present an API-backend switch alone as sufficient; host
+      execution also requires the explicit unsafe authorization `workspace.allow_exec_on_host: true`.
     decision_table:
       - contents: no declared agents
         backend: none
@@ -16618,6 +16634,11 @@ cli_specification:
         contract-required secrets consume `tool_model.credential_store` / `swarm secrets check`; Docker/image/workspace CLI
         capability consumes the workspace lifecycle owner; listener and gateway validation consume the serve startup/listener
         owners. Doctor-only or run-only duplicate interpreters are non-authoritative.
+      dependency_reporting_rule: >
+        Workspace prerequisite findings MUST preserve dependency truth. If the Docker daemon probe fails, configured-image and
+        CLI-in-image findings are `skipped`/not measured and MUST NOT emit derivative blockers. If the configured-image probe
+        fails, the CLI-in-image finding is `skipped`/not measured. Text and JSON render the same finding statuses and the
+        upstream blocker carries the exact recovery command from `workspace_model.runtime_image_packaging`.
       split_tail:
       - '#1566 workspace image build/validation path remains split; this owner may report a missing/unusable image but must not build one.'
       - '#1567 API connection discovery and .swarm/connection.* remain split.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16626,7 +16626,11 @@ cli_specification:
         --backend claude_cli` and local foreground `swarm run start --backend claude_cli` consume the same owner as admission
         evidence and fail closed before readiness when a blocking prerequisite is missing. Non-dev `swarm serve
         --backend claude_cli` consumes the runtime-safety subset where the selected disk-contract startup path needs the same
-        prerequisites; dev-only conveniences must not leak into deployment-mode serve.
+        prerequisites; dev-only conveniences must not leak into deployment-mode serve. When local foreground `swarm run start`
+        starts the serve owner and startup fails, it MUST render the complete typed blocking finding, including remediation, on
+        the run command's error output. Direct non-dev serve startup failures carrying a typed workspace prerequisite MUST render
+        that complete blocking finding on command output as well. A generic exit code or log-only cause is not a substitute for
+        the startup diagnostic.
       owner_consumption_rule: >
         The preflight owner MUST delegate subordinate facts to existing owners: backend profile/credential and retired
         selector checks consume `llm_provider_selection_config_authority`; the selected backend credential is required only


### PR DESCRIPTION
## Summary

- replace rendered workspace capability strings as semantic input with typed per-agent capability reasons
- make Claude-only host refusal offer the API-backend exit while mixed exec contracts name every blocker and require explicit host authorization
- carry typed workspace prerequisite problem/remediation facts through direct runtime, Builder, serve/run, doctor text/JSON, and workspace-build surfaces
- stop dependent image/CLI probes after Docker or image failure and report them as `skipped` / not measured
- lock the promoted behavior in `platform-spec.yaml`

## Failure class and closure

This closes the approved #1964 workspace-operational first slice: explicit-host backend decision remediation, daemon/configured-image recovery, and truthful dependency reporting for the enumerated consumers.

The broader workspace-prerequisite parent remains open under #1966 for network, mount/source, container lifecycle/network attachment, image-content/status, release-image, and probe-consolidation work. This PR does not claim those owners are consolidated.

Closes #1964

## Governing references

- `platform-spec.yaml#workspace_model.workspace_backend_selection`
- `platform-spec.yaml#workspace_model.runtime_image_packaging`
- `platform-spec.yaml#workspace_model.local_workspace_image_build_authority`
- `platform-spec.yaml#cli_specification.foundations.local_claude_cli_preflight_admission`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- approved pre-audit and independent gate on #1964

## Semantic migration

**New canonical facts**

- `workspaceCapabilityReason` / `workspaceCapabilityReasonKind` own backend capability discrimination; rendered reason text is projection only
- `workspace.PrerequisiteError` owns structured workspace prerequisite problem/remediation/cause facts
- `workspace.DockerInfoCommand` derives the exact configured-binary verification command

**Invalid old paths**

- `Reasons []string` and `HostUnsupported []string` are removed as semantic inputs
- remediation no longer infers Claude-only vs mixed exec from display text
- local preflight no longer probes image/CLI after an upstream failure
- daemon/image messages no longer advertise guessed daemon launchers or an unpublished image pull

**Production paths checked**

- primary and per-bundle serve runtime contexts, including DB-loaded startup
- local foreground `swarm run start` through the serve owner
- Builder reload/replacement
- selected-contract run-fork
- verify, describe, doctor text/JSON
- direct `DockerManager` / `EnsurePrereqs`
- `swarm workspace build`
- no-agent, API-host, loud unsafe-host, and later forkchat execution-admission negatives

The selected semantic migration is complete. The #1966 parent architecture remains intentionally separate.

## Validation

- focused backend decision, doctor text/JSON, serve/run, verify/describe, Builder, workspace build, and manager tests
- `go test ./...` on the rebased final commit using a fresh disposable Postgres cluster
- `git diff --check`
