### PR TITLE
[agent-f][issue #1936] Compile inbound admission authority

### DIFF
--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -65,6 +65,7 @@ func TestBootFloorConformanceVerifyDescribeReportNativeBashWorkspaceRequirement(
 	t.Run("verify text", func(t *testing.T) {
 		opts := defaultVerifyCommandOptions()
 		opts.contractsPath = contractsRoot
+		opts.configPath = writeTestVerifyRuntimeConfig(t)
 
 		var stdout, stderr bytes.Buffer
 		code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &stdout, &stderr)
@@ -77,6 +78,7 @@ func TestBootFloorConformanceVerifyDescribeReportNativeBashWorkspaceRequirement(
 	t.Run("verify json", func(t *testing.T) {
 		opts := defaultVerifyCommandOptions()
 		opts.contractsPath = contractsRoot
+		opts.configPath = writeTestVerifyRuntimeConfig(t)
 		opts.output.asJSON = true
 
 		var stdout, stderr bytes.Buffer

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -36,12 +36,13 @@ type runtimeProjectSupervisor struct {
 	workspaceBackend    workspaceBackendSelection
 	credentials         runtimecredentials.Store
 	providerCredentials runtimecredentials.Store
-	providerTriggers    *providertriggers.Registry
+	providerTriggers    *providertriggers.CatalogSnapshot
+	loadProviderCatalog func() (*providertriggers.CatalogSnapshot, error)
 	startRuntime        func(context.Context, *runtime.Runtime) error
 	quiesceRuntime      func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	shutdownRuntime     func(context.Context, *runtime.Runtime, runtime.ShutdownOptions) error
 	loadWorkflow        func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error)
-	validateSource      func(context.Context, semanticview.Source) error
+	validateSource      func(context.Context, semanticview.Source, *providertriggers.CatalogSnapshot) error
 	initStateStores     func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error)
 	newWorkspaces       func(storeBundle, string, semanticview.Source, workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error)
 	createRuntime       func(context.Context, runtime.RuntimeDeps) (*runtime.Runtime, error)
@@ -82,7 +83,7 @@ func newRuntimeProjectSupervisor(
 	workspaceBackend workspaceBackendSelection,
 	credentials runtimecredentials.Store,
 	providerCredentials runtimecredentials.Store,
-	providerTriggers *providertriggers.Registry,
+	providerTriggers *providertriggers.CatalogSnapshot,
 	initialRoot string,
 	initialBundle *runtimecontracts.WorkflowContractBundle,
 	initialSource semanticview.Source,
@@ -117,13 +118,13 @@ func newRuntimeProjectSupervisor(
 		loadWorkflow: func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 			return newSwarmWorkflowModule(repoRoot, contractsRoot, platformSpecPath)
 		},
-		validateSource: func(ctx context.Context, source semanticview.Source) error {
+		validateSource: func(ctx context.Context, source semanticview.Source, catalog *providertriggers.CatalogSnapshot) error {
 			credentialStore, err := buildCredentialStore()
 			if err != nil {
 				return err
 			}
 			opts := runtime.DefaultWorkflowContractValidationOptions(credentialStore)
-			opts.ProviderTriggerRegistry = providerTriggers
+			opts.ProviderTriggerCatalog = catalog
 			_, err = runtime.ValidateWorkflowContractSurface(ctx, source, opts)
 			return err
 		},
@@ -189,7 +190,11 @@ func (s *runtimeProjectSupervisor) ReloadProject(ctx context.Context, projectDir
 	if projectDir == "" {
 		return builderpkg.ProjectStatus{}, fmt.Errorf("project is not loaded")
 	}
-	return s.loadProject(ctx, projectDir)
+	status, err := s.loadProject(ctx, projectDir)
+	if err != nil {
+		return s.CurrentProject(), fmt.Errorf("reload rejected: %w; previous runtime contexts and provider-trigger catalog generation remain loaded and serving", err)
+	}
+	return status, nil
 }
 
 func (s *runtimeProjectSupervisor) DisableSourceReplacement(reason string) {
@@ -240,7 +245,21 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return builderpkg.ProjectStatus{}, fmt.Errorf("load project: %w", err)
 	}
 	source := semanticview.Wrap(bundle)
-	if err := s.validateSource(ctx, source); err != nil {
+	candidateCatalog := s.providerTriggers
+	if s.loadProviderCatalog != nil {
+		candidateCatalog, err = s.loadProviderCatalog()
+		if err != nil {
+			return builderpkg.ProjectStatus{}, fmt.Errorf("load candidate provider-trigger catalog: %w", err)
+		}
+	}
+	if candidateCatalog == nil {
+		return builderpkg.ProjectStatus{}, fmt.Errorf("candidate provider-trigger catalog is required")
+	}
+	if err := s.validateSource(ctx, source, candidateCatalog); err != nil {
+		return builderpkg.ProjectStatus{}, err
+	}
+	admissionCandidate, err := s.compileProcessAdmissionCandidate(ctx, candidateCatalog)
+	if err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
 	candidateHash, err := runtimecontracts.BundleHash(bundle)
@@ -289,15 +308,15 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		Config: s.cfg,
 		Stores: s.stores.runtimeStores(),
 		Options: runtime.RuntimeOptions{
-			SelfCheck:               false,
-			WorkflowModule:          module,
-			WorkspaceLifecycle:      workspaces,
-			BundleFingerprint:       bundleIdentity.Fingerprint,
-			BundleSourceFact:        bundleSourceFact,
-			Credentials:             s.credentials,
-			ManagedCredentials:      managedCredentialStore,
-			ProviderCredentials:     s.providerCredentials,
-			ProviderTriggerRegistry: s.providerTriggers,
+			SelfCheck:              false,
+			WorkflowModule:         module,
+			WorkspaceLifecycle:     workspaces,
+			BundleFingerprint:      bundleIdentity.Fingerprint,
+			BundleSourceFact:       bundleSourceFact,
+			Credentials:            s.credentials,
+			ManagedCredentials:     managedCredentialStore,
+			ProviderCredentials:    s.providerCredentials,
+			ProviderTriggerCatalog: candidateCatalog,
 		},
 	})
 	if err != nil {
@@ -307,12 +326,51 @@ func (s *runtimeProjectSupervisor) loadProject(ctx context.Context, projectDir s
 		return s.CurrentProject(), err
 	}
 
-	status, err := s.replaceCurrentRuntimeWithSource(ctx, resolvedRoot, source, bundle, bundleSourceFact, bundleIdentity, newRT)
+	admissionCandidate.catalog = candidateCatalog
+	status, err := s.replaceCurrentRuntimeWithSourceAndAdmission(ctx, resolvedRoot, source, bundle, bundleSourceFact, bundleIdentity, newRT, &admissionCandidate)
 	if err != nil {
 		return builderpkg.ProjectStatus{}, err
 	}
 	slog.Info("builder project loaded", "project_dir", filepath.Clean(resolvedRoot), "workflow", strings.TrimSpace(status.WorkflowName))
 	return status, nil
+}
+
+type processAdmissionCandidate struct {
+	catalog          *providertriggers.CatalogSnapshot
+	state            runtime.ProcessAdmissionState
+	survivingTargets map[string][]runtime.StandingTarget
+}
+
+func (s *runtimeProjectSupervisor) compileProcessAdmissionCandidate(ctx context.Context, catalog *providertriggers.CatalogSnapshot) (processAdmissionCandidate, error) {
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		return processAdmissionCandidate{}, err
+	}
+	candidate := processAdmissionCandidate{
+		state:            runtime.ProcessAdmissionState{GenerationID: catalog.GenerationID(), InstalledSubjects: installed},
+		survivingTargets: map[string][]runtime.StandingTarget{},
+	}
+	s.mu.RLock()
+	manager := s.runtimeContexts
+	currentHash := strings.TrimSpace(s.currentBundleSourceFact.BundleHash)
+	s.mu.RUnlock()
+	if manager == nil {
+		return candidate, nil
+	}
+	for _, loaded := range manager.LoadedContexts() {
+		if loaded.BundleHash == currentHash {
+			continue
+		}
+		if err := s.validateSource(ctx, loaded.Source, catalog); err != nil {
+			return processAdmissionCandidate{}, fmt.Errorf("candidate provider-trigger catalog rejected loaded runtime context %s: %w", loaded.BundleHash, err)
+		}
+		targets, err := runtime.RecompileStandingTargetAdmissions(loaded.Source, catalog, loaded.StandingTargets)
+		if err != nil {
+			return processAdmissionCandidate{}, fmt.Errorf("candidate provider-trigger catalog cannot recompile loaded runtime context %s: %w", loaded.BundleHash, err)
+		}
+		candidate.survivingTargets[loaded.BundleHash] = targets
+	}
+	return candidate, nil
 }
 
 func (s *runtimeProjectSupervisor) validatePersistedStandingOwnership(ctx context.Context, candidate *runtime.Runtime, candidateFact runtimecorrelation.BundleSourceFact) error {
@@ -382,6 +440,19 @@ func (s *runtimeProjectSupervisor) replaceCurrentRuntimeWithSource(
 	identity runtimecontracts.BundleIdentity,
 	newRT *runtime.Runtime,
 ) (builderpkg.ProjectStatus, error) {
+	return s.replaceCurrentRuntimeWithSourceAndAdmission(ctx, resolvedRoot, source, bundle, fact, identity, newRT, nil)
+}
+
+func (s *runtimeProjectSupervisor) replaceCurrentRuntimeWithSourceAndAdmission(
+	ctx context.Context,
+	resolvedRoot string,
+	source semanticview.Source,
+	bundle *runtimecontracts.WorkflowContractBundle,
+	fact runtimecorrelation.BundleSourceFact,
+	identity runtimecontracts.BundleIdentity,
+	newRT *runtime.Runtime,
+	admissionCandidate *processAdmissionCandidate,
+) (builderpkg.ProjectStatus, error) {
 	s.mu.RLock()
 	manager := s.runtimeContexts
 	oldHash := strings.TrimSpace(s.currentBundleSourceFact.BundleHash)
@@ -401,6 +472,11 @@ func (s *runtimeProjectSupervisor) replaceCurrentRuntimeWithSource(
 		}
 		if err := manager.ValidateReplacement(oldHash, contextDef); err != nil {
 			return builderpkg.ProjectStatus{}, err
+		}
+		if admissionCandidate != nil {
+			if err := manager.ValidateProcessAdmissionReplacement(oldHash, contextDef, admissionCandidate.survivingTargets, admissionCandidate.state); err != nil {
+				return builderpkg.ProjectStatus{}, err
+			}
 		}
 		oldContext, ok := manager.LookupBundleHash(oldHash)
 		if !ok || oldContext == nil {
@@ -446,10 +522,21 @@ func (s *runtimeProjectSupervisor) replaceCurrentRuntimeWithSource(
 			rollbackErr := handoff.Rollback()
 			return s.CurrentProject(), errors.Join(err, rollbackErr, s.restoreQuiescedPredecessor(ctx, manager, oldContextDef, oldRT))
 		}
-		if err := manager.PublishBundleHashReplacement(oldHash, contextDef); err != nil {
+		publish := func() error { return manager.PublishBundleHashReplacement(oldHash, contextDef) }
+		if admissionCandidate != nil {
+			publish = func() error {
+				return manager.PublishBundleHashReplacementWithAdmission(oldHash, contextDef, admissionCandidate.survivingTargets, admissionCandidate.state)
+			}
+		}
+		if err := publish(); err != nil {
 			quiesceErr := s.quiesceCurrentRuntimeWithOptions(context.Background(), newRT, s.replacementShutdown)
 			rollbackErr := handoff.Rollback()
 			return s.CurrentProject(), errors.Join(err, quiesceErr, rollbackErr, s.restoreQuiescedPredecessor(ctx, manager, oldContextDef, oldRT))
+		}
+		if admissionCandidate != nil {
+			s.mu.Lock()
+			s.providerTriggers = admissionCandidate.catalog
+			s.mu.Unlock()
 		}
 		oldRT = s.swapCurrentRuntime(resolvedRoot, source, bundle, fact, identity, newRT)
 		handoff.Finalize()
@@ -465,6 +552,11 @@ func (s *runtimeProjectSupervisor) replaceCurrentRuntimeWithSource(
 	if err := s.startCurrentRuntime(ctx, newRT); err != nil {
 		_ = s.shutdownCurrentRuntime(context.Background(), newRT)
 		return builderpkg.ProjectStatus{}, err
+	}
+	if admissionCandidate != nil {
+		s.mu.Lock()
+		s.providerTriggers = admissionCandidate.catalog
+		s.mu.Unlock()
 	}
 	return s.attachCurrentRuntime(resolvedRoot, source, bundle, fact, identity, newRT), nil
 }
@@ -600,7 +692,7 @@ func (s *runtimeProjectSupervisor) restoreQuiescedPredecessor(ctx context.Contex
 	}
 	predecessorContext.Runtime = restored
 	predecessorContext.StandingTargets = targets
-	if err := manager.PublishBundleHashReplacement(predecessorContext.BundleHash, predecessorContext); err != nil {
+	if err := manager.PublishRestoredBundleHashReplacement(predecessorContext.BundleHash, predecessorContext); err != nil {
 		quiesceErr := s.quiesceCurrentRuntimeWithOptions(context.Background(), restored, s.replacementShutdown)
 		rollbackErr := handoff.Rollback()
 		return errors.Join(fmt.Errorf("restore predecessor runtime context: %w", err), quiesceErr, rollbackErr)
@@ -681,7 +773,7 @@ func (h runtimeProcessInboundHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	lookup.Context.Runtime.InboundGateway.HandleResolvedWebhook(w, r, runtime.InboundTarget{
 		BundleHash: target.BundleHash, FlowID: target.FlowID, RunID: target.RunID,
 		FlowInstance: target.FlowInstance, EntityID: target.EntityID, EntitySlug: target.Alias,
-		Alias: target.Alias, Provider: target.Provider, SigningSecret: target.SigningSecret,
+		Alias: target.Alias, Provider: target.Provider, SigningSecret: target.SigningSecret, AdmissionPlan: target.AdmissionPlan,
 	}, lookup.Context.Source)
 }
 

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -221,7 +221,7 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 		t.Fatalf("load standing fixture: %v", err)
 	}
 	source := semanticview.Wrap(bundle)
-	registry := testProviderTriggerRegistry(t)
+	catalog := testProviderTriggerCatalog(t)
 	makeContext := func(hash, alias, runID, entityID string) (runtimepkg.BundleContext, *processIngressProofStore, *processIngressEventStore) {
 		persistence := &processIngressProofStore{}
 		eventsStore := &processIngressEventStore{}
@@ -229,14 +229,18 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewEventBus(%s): %v", alias, err)
 		}
-		gateway := runtimepkg.NewInboundGatewayWithProviderRegistry(bus, nil, nil, registry, persistence)
+		gateway := runtimepkg.NewInboundGateway(bus, nil, nil, persistence)
 		gateway.SetCredentialStore(processIngressCredentialStore{"webhook_signing.telegram": "telegram-secret"})
+		plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: alias, Provider: "telegram", SigningSecret: "webhook_signing.telegram"})
+		if err != nil {
+			t.Fatalf("CompileAdmission(%s): %v", alias, err)
+		}
 		return runtimepkg.BundleContext{
 			BundleHash: hash, Source: source, Runtime: &runtimepkg.Runtime{Bus: bus, InboundGateway: gateway},
 			StandingTargets: []runtimepkg.StandingTarget{{
 				BundleHash: hash, FlowID: "telegram-chat", Alias: alias, Provider: "telegram",
 				RunID: runID, FlowInstance: "telegram-chat/" + strings.TrimPrefix(alias, "chat-"),
-				EntityID: entityID, SigningSecret: "webhook_signing.telegram",
+				EntityID: entityID, SigningSecret: "webhook_signing.telegram", AdmissionPlan: plan,
 			}},
 		}, persistence, eventsStore
 	}
@@ -244,7 +248,11 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 	hashB := "bundle-v1:sha256:" + strings.Repeat("b", 64)
 	contextA, persistenceA, eventsA := makeContext(hashA, "chat-a", "41000000-0000-0000-0000-000000000001", "41000000-0000-0000-0000-000000000002")
 	contextB, persistenceB, eventsB := makeContext(hashB, "chat-b", "42000000-0000-0000-0000-000000000001", "42000000-0000-0000-0000-000000000002")
-	manager, err := runtimepkg.NewRuntimeContextManager(nil, contextA, contextB)
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := runtimepkg.NewRuntimeContextManagerWithAdmission(nil, runtimepkg.ProcessAdmissionState{GenerationID: catalog.GenerationID(), InstalledSubjects: installed}, contextA, contextB)
 	if err != nil {
 		t.Fatalf("NewRuntimeContextManager: %v", err)
 	}
@@ -286,7 +294,16 @@ func TestRuntimeProjectSupervisorRejectsChangedStandingBundleWithoutMutation(t *
 		RunID: "41000000-0000-0000-0000-000000000001", FlowInstance: "service/a",
 		EntityID: "41000000-0000-0000-0000-000000000002", SigningSecret: "webhook_signing.telegram",
 	}
-	manager, err := runtimepkg.NewRuntimeContextManager(nil, runtimepkg.BundleContext{
+	catalog := testProviderTriggerCatalog(t)
+	oldTarget.AdmissionPlan, err = catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: "chat", Provider: "telegram", SigningSecret: "webhook_signing.telegram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := runtimepkg.NewRuntimeContextManagerWithAdmission(nil, runtimepkg.ProcessAdmissionState{GenerationID: catalog.GenerationID(), InstalledSubjects: installed}, runtimepkg.BundleContext{
 		BundleHash: oldHash, Source: source, Runtime: oldRT, StandingTargets: []runtimepkg.StandingTarget{oldTarget},
 	})
 	if err != nil {
@@ -596,7 +613,7 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 					}
 					source := semanticview.Wrap(bundle)
 					module := stubWorkflowModule{source: source}
-					providerRegistry := testProviderTriggerRegistry(t)
+					providerRegistry := testProviderTriggerCatalog(t)
 					oldHash := runtimeContextTestHash("a")
 					newHash := oldHash
 					if changedHash {
@@ -611,7 +628,7 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 								WorkflowModule:                   module,
 								LLMRuntime:                       runtimellm.NoopRuntime{},
 								DisablePersistentStartupRecovery: true,
-								ProviderTriggerRegistry:          providerRegistry,
+								ProviderTriggerCatalog:           providerRegistry,
 								BundleSourceFact: runtimecorrelation.BundleSourceFact{
 									BundleHash:   hash,
 									BundleSource: storerunlifecycle.BundleSourceEphemeral,
@@ -792,13 +809,13 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 				t.Fatalf("initializeStateStores: %v", err)
 			}
 			source := semanticview.Wrap(bundle)
-			providerRegistry := testProviderTriggerRegistry(t)
+			providerRegistry := testProviderTriggerCatalog(t)
 			hash := runtimeContextTestHash("f")
 			fact := runtimecorrelation.BundleSourceFact{BundleHash: hash, BundleSource: storerunlifecycle.BundleSourceEphemeral}
 			newRuntime := func() *runtimepkg.Runtime {
 				rt, err := runtimepkg.NewRuntime(context.Background(), runtimepkg.RuntimeDeps{
 					Config: &config.Config{}, Stores: stores.runtimeStores(),
-					Options: runtimepkg.RuntimeOptions{SelfCheck: false, WorkflowModule: stubWorkflowModule{source: source}, LLMRuntime: runtimellm.NoopRuntime{}, DisablePersistentStartupRecovery: true, ProviderTriggerRegistry: providerRegistry, BundleSourceFact: fact},
+					Options: runtimepkg.RuntimeOptions{SelfCheck: false, WorkflowModule: stubWorkflowModule{source: source}, LLMRuntime: runtimellm.NoopRuntime{}, DisablePersistentStartupRecovery: true, ProviderTriggerCatalog: providerRegistry, BundleSourceFact: fact},
 				})
 				if err != nil {
 					t.Fatalf("NewRuntime: %v", err)
@@ -1152,6 +1169,9 @@ func newSupervisorForLoadProjectFailureTest(
 	source := semanticview.Wrap(bundle)
 	module := stubWorkflowModule{source: source}
 	supervisor := newRuntimeProjectSupervisor("", "", nil, storeBundle{}, new(atomic.Bool), workspaceMountSources{}, workspaceBackendSelection{Backend: workspace.BackendDocker, Source: "test"}, nil, nil, nil, "", nil, nil, nil)
+	catalog := testProviderTriggerCatalog(t)
+	supervisor.providerTriggers = catalog
+	supervisor.loadProviderCatalog = func() (*providertriggers.CatalogSnapshot, error) { return catalog, nil }
 	supervisor.dev = true
 	supervisor.loadWorkflow = func(repoRoot, contractsRoot, platformSpecPath string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if got := strings.TrimSpace(contractsRoot); got != strings.TrimSpace(projectRoot) {
@@ -1159,7 +1179,7 @@ func newSupervisorForLoadProjectFailureTest(
 		}
 		return module, bundle, nil
 	}
-	supervisor.validateSource = func(context.Context, semanticview.Source) error { return nil }
+	supervisor.validateSource = func(context.Context, semanticview.Source, *providertriggers.CatalogSnapshot) error { return nil }
 	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
 		return "store wiring ready", nil
 	}
@@ -1200,23 +1220,25 @@ func TestRuntimeProjectSupervisorLoadProjectUsesResolvedWorkspaceMountSources(t 
 	}
 }
 
-func TestRuntimeProjectSupervisorCarriesBootAdmittedProviderRegistryIntoReplacement(t *testing.T) {
+func TestRuntimeProjectSupervisorReverifiesProviderCatalogForReplacement(t *testing.T) {
 	projectRoot := writeProjectRoot(t)
-	wantRegistry := testProviderTriggerRegistry(t)
-	var gotRegistry *providertriggers.Registry
+	bootCatalog := testProviderTriggerCatalog(t)
+	candidateCatalog := testProviderTriggerCatalog(t)
+	var gotCatalog *providertriggers.CatalogSnapshot
 	supervisor := newSupervisorForLoadProjectFailureTest(t, projectRoot, stubWorkspaceLifecycle{}, func(_ context.Context, deps runtimepkg.RuntimeDeps) (*runtimepkg.Runtime, error) {
-		gotRegistry = deps.Options.ProviderTriggerRegistry
+		gotCatalog = deps.Options.ProviderTriggerCatalog
 		return &runtimepkg.Runtime{}, nil
 	})
-	supervisor.providerTriggers = wantRegistry
+	supervisor.providerTriggers = bootCatalog
+	supervisor.loadProviderCatalog = func() (*providertriggers.CatalogSnapshot, error) { return candidateCatalog, nil }
 	supervisor.startRuntime = func(context.Context, *runtimepkg.Runtime) error { return nil }
 	supervisor.shutdownRuntime = func(context.Context, *runtimepkg.Runtime, runtimepkg.ShutdownOptions) error { return nil }
 
 	if _, err := supervisor.OpenProject(context.Background(), projectRoot); err != nil {
 		t.Fatalf("OpenProject: %v", err)
 	}
-	if gotRegistry != wantRegistry {
-		t.Fatalf("replacement provider registry = %p, want boot-admitted %p", gotRegistry, wantRegistry)
+	if gotCatalog != candidateCatalog {
+		t.Fatalf("replacement provider catalog = %p, want reverified candidate %p (boot=%p)", gotCatalog, candidateCatalog, bootCatalog)
 	}
 }
 

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -1311,7 +1311,7 @@ func TestRuntimeProjectSupervisorOpenProjectExecutesExplicitHostRefusal(t *testi
 		}
 		return module, bundle, nil
 	}
-	supervisor.validateSource = func(context.Context, semanticview.Source) error { return nil }
+	supervisor.validateSource = func(context.Context, semanticview.Source, *providertriggers.CatalogSnapshot) error { return nil }
 	supervisor.initStateStores = func(context.Context, storeBundle, *runtimecontracts.WorkflowContractBundle) (string, error) {
 		return "store wiring ready", nil
 	}

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -1305,6 +1305,9 @@ func TestRuntimeProjectSupervisorOpenProjectExecutesExplicitHostRefusal(t *testi
 		nil, nil, nil, "", nil, nil, nil,
 	)
 	supervisor.dev = true
+	catalog := emptyProviderTriggerCatalog(t)
+	supervisor.providerTriggers = catalog
+	supervisor.loadProviderCatalog = func() (*providertriggers.CatalogSnapshot, error) { return catalog, nil }
 	supervisor.loadWorkflow = func(_, contractsRoot, _ string) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle, error) {
 		if strings.TrimSpace(contractsRoot) != strings.TrimSpace(projectRoot) {
 			return nil, nil, fmt.Errorf("contracts root = %q, want %q", contractsRoot, projectRoot)

--- a/cmd/swarm/cli_logging_test.go
+++ b/cmd/swarm/cli_logging_test.go
@@ -57,7 +57,7 @@ func TestCLILoggingForSharedOutputConsumers(t *testing.T) {
 		{
 			name: "verify",
 			args: func(t *testing.T) []string {
-				return []string{"verify", "--contracts", outputModeVerifyFixture(t)}
+				return []string{"verify", "--contracts", outputModeVerifyFixture(t), "--config", writeTestVerifyRuntimeConfig(t)}
 			},
 			repo: func(*testing.T) string { return repoRoot() },
 		},

--- a/cmd/swarm/cli_output_test.go
+++ b/cmd/swarm/cli_output_test.go
@@ -75,10 +75,11 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 	}
 
 	verifyFixture := outputModeVerifyFixture(t)
+	verifyConfig := writeTestVerifyRuntimeConfig(t)
 
 	stdout.Reset()
 	stderr.Reset()
-	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--json"}, &stdout, &stderr)
+	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--config", verifyConfig, "--json"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("verify --json code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -92,7 +93,7 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--quiet"}, &stdout, &stderr)
+	code = executeRootCommand(context.Background(), repoRoot(), []string{"verify", "--contracts", verifyFixture, "--config", verifyConfig, "--quiet"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("verify --quiet code = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -438,7 +439,7 @@ func TestCLIOutputNoColorForSharedRendererConsumers(t *testing.T) {
 		{
 			name: "verify",
 			args: func(t *testing.T) []string {
-				return []string{"verify", "--contracts", outputModeVerifyFixture(t)}
+				return []string{"verify", "--contracts", outputModeVerifyFixture(t), "--config", writeTestVerifyRuntimeConfig(t)}
 			},
 			repo: func(*testing.T) string { return repoRoot() },
 		},

--- a/cmd/swarm/describe.go
+++ b/cmd/swarm/describe.go
@@ -248,7 +248,20 @@ func writeDescribeText(out io.Writer, view authoringview.View, workspaceBackendD
 			if flow.Ingress != nil {
 				fmt.Fprintf(out, "    ingress: alias=%s\n", flow.Ingress.Alias)
 				for _, provider := range flow.Ingress.Providers {
-					fmt.Fprintf(out, "      - provider=%s signing_secret=%s\n", provider.Provider, provider.SigningSecret)
+					fmt.Fprintf(out, "      - provider=%s admission=%s", provider.Provider, provider.AdmissionKind)
+					if provider.PackID != "" {
+						fmt.Fprintf(out, " pack_id=%s", provider.PackID)
+					}
+					if provider.RequestAuthentication != "" {
+						fmt.Fprintf(out, " authentication=%s", provider.RequestAuthentication)
+					}
+					if provider.Event != "" {
+						fmt.Fprintf(out, " event=%s", provider.Event)
+					}
+					if provider.SigningSecret != "" {
+						fmt.Fprintf(out, " signing_secret=%s", provider.SigningSecret)
+					}
+					fmt.Fprintln(out)
 				}
 			}
 			if flow.PrimaryEntity != nil {
@@ -413,7 +426,17 @@ func writeRoutingTopologyText(out io.Writer, topology routingtopology.Topology) 
 		fmt.Fprintln(out, "  root input sources:")
 		for _, source := range topology.RootInputSources {
 			target := firstNonEmpty(source.Target.FlowPath, source.Target.FlowID)
-			fmt.Fprintf(out, "    - [%s] %s/%s -> flow %s (%s)\n", source.Kind, source.Alias, source.Provider, target, source.AuthoredLocation)
+			fmt.Fprintf(out, "    - [%s] %s/%s -> flow %s admission=%s", source.Kind, source.Alias, source.Provider, target, source.Admission.Kind)
+			if source.Admission.PackID != "" {
+				fmt.Fprintf(out, " pack_id=%s", source.Admission.PackID)
+			}
+			if source.Admission.DeclaredAuthentication != "" {
+				fmt.Fprintf(out, " authentication=%s", source.Admission.DeclaredAuthentication)
+			}
+			if source.Admission.Event != "" {
+				fmt.Fprintf(out, " event=%s", source.Admission.Event)
+			}
+			fmt.Fprintf(out, " (%s)\n", source.AuthoredLocation)
 		}
 	}
 	pubsub, inter := 0, 0

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -74,14 +74,14 @@ func TestDescribeCommandRendersStandingIngressDeclaration(t *testing.T) {
 		t.Fatalf("standing describe flow = %#v", flow)
 	}
 	provider := flow.Ingress.Providers[0]
-	if provider.Provider != "telegram" || provider.SigningSecret != "webhook_signing.telegram" {
+	if provider.Provider != "telegram" || provider.SigningSecret != "webhook_signing.telegram" || provider.AdmissionKind != "pack-required" || provider.PackID != "" || provider.RequestAuthentication != "" {
 		t.Fatalf("standing describe provider = %#v", provider)
 	}
 	if len(view.RoutingTopology.RootInputSources) != 1 {
 		t.Fatalf("standing root input sources = %#v", view.RoutingTopology.RootInputSources)
 	}
 	source := view.RoutingTopology.RootInputSources[0]
-	if source.Kind != routingtopology.RootInputSourceStandingIngress || source.Alias != "chat" || source.Provider != "telegram" || source.Target.FlowID != "telegram-chat" || source.Target.FlowPath != "telegram-chat" {
+	if source.Kind != routingtopology.RootInputSourceStandingIngress || source.Alias != "chat" || source.Provider != "telegram" || source.Target.FlowID != "telegram-chat" || source.Target.FlowPath != "telegram-chat" || source.Admission.Kind != "pack-required" || source.Admission.PackID != "" {
 		t.Fatalf("standing root input source = %#v", source)
 	}
 	for _, edge := range view.RoutingTopology.Edges {
@@ -109,7 +109,7 @@ func TestDescribeRoutesProjectsStandingIngressAsRootInputAdmission(t *testing.T)
 	if code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"describe", "routes", "--contracts", contractsRoot}, &humanOut, &humanErr, defaultRootCommandOptions()); code != 0 {
 		t.Fatalf("describe routes code=%d stdout=%s stderr=%s", code, humanOut.String(), humanErr.String())
 	}
-	for _, want := range []string{"root input sources:", "[standing_ingress] chat/telegram -> flow telegram-chat"} {
+	for _, want := range []string{"root input sources:", "[standing_ingress] chat/telegram -> flow telegram-chat admission=pack-required"} {
 		if !strings.Contains(humanOut.String(), want) {
 			t.Fatalf("standing routes human output missing %q:\n%s", want, humanOut.String())
 		}

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -523,6 +523,7 @@ func TestVerifyCommandAcceptsJoinTransitionCarrierFixture(t *testing.T) {
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
 		"verify",
 		"--contracts", contractsRoot,
+		"--config", writeTestVerifyRuntimeConfig(t),
 		"--json",
 	}, &stdout, &stderr, defaultRootCommandOptions())
 	if code != 0 {
@@ -559,6 +560,7 @@ func TestVerifyCommandRejectsTypeInvalidJoinCompletion(t *testing.T) {
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
 		"verify",
 		"--contracts", contractsRoot,
+		"--config", writeTestVerifyRuntimeConfig(t),
 		"--json",
 	}, &stdout, &stderr, defaultRootCommandOptions())
 	if code == 0 {
@@ -609,7 +611,7 @@ types:
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{
-		"verify", "--contracts", contractsRoot, "--json",
+		"verify", "--contracts", contractsRoot, "--config", writeTestVerifyRuntimeConfig(t), "--json",
 	}, &stdout, &stderr, defaultRootCommandOptions())
 	if code == 0 {
 		t.Fatalf("verify --json code = 0 stdout=%s stderr=%s", stdout.String(), stderr.String())

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -196,6 +196,7 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		CheckContractSecrets:   cmd.Flags().Changed("contracts"),
 		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets("doctor"),
 		ProviderTriggerPacks:   providerPackLoad.Loaded,
+		ProviderTriggerCatalog: providerPackLoad.Catalog,
 	})
 	addUnifiedConfigDiagnosticsToReport(&report, cfgResult.Diagnostics)
 	addSwarmEnvFindingsToLocalPreflightReport(&report, envFindings)

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -1,0 +1,560 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providertriggers"
+	"github.com/division-sh/swarm/internal/runtime"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestInboundAdmissionSupportedSurfacePolicyMatrixSQLiteAndPostgres(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			runInboundAdmissionSupportedSurfacePolicyMatrix(t, backend)
+		})
+	}
+}
+
+func TestVerifyProjectsInstalledTriggersWithoutStandingIngress(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	root := writeVerifyLintEvidenceFixture(t)
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	var textOut, textErr bytes.Buffer
+	if code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &textOut, &textErr); code != 0 {
+		t.Fatalf("verify text exit=%d stdout=%s stderr=%s", code, textOut.String(), textErr.String())
+	}
+	for _, provider := range []string{"github", "intercom", "shopify", "slack", "stripe", "telegram", "twilio", "typeform"} {
+		if !strings.Contains(textOut.String(), "provider trigger pack provider."+provider+" AVAILABLE") {
+			t.Fatalf("verify text omitted installed %s trigger:\n%s", provider, textOut.String())
+		}
+	}
+	opts.output.asJSON = true
+	var jsonOut, jsonErr bytes.Buffer
+	if code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &jsonOut, &jsonErr); code != 0 {
+		t.Fatalf("verify JSON exit=%d stdout=%s stderr=%s", code, jsonOut.String(), jsonErr.String())
+	}
+	result := decodeOutputJSON[verifyCommandResult](t, jsonOut.String())
+	installed := 0
+	for _, subject := range result.CapabilitySubjects {
+		if subject.Kind == packs.SubjectProviderTrigger && subject.Applicability == "installed" {
+			installed++
+		}
+	}
+	if installed != 8 {
+		t.Fatalf("verify installed trigger subjects=%d, want 8: %#v", installed, result.CapabilitySubjects)
+	}
+}
+
+func TestProviderTriggerCapabilitySubjectsPreserveInstalledEffectiveMultiplicityAndRendering(t *testing.T) {
+	platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
+	catalog, _, err := providertriggers.NewCatalogSnapshotFromRequiredPlatformPackDirs("0.7.0", platformDirs, externalDirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractsRoot := writeInboundAdmissionPolicyMatrixFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot(), contractsRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects, err := runtime.ProviderTriggerCapabilitySubjects(semanticview.Wrap(bundle), catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, effective, raw := 0, 0, 0
+	textProjection := ""
+	for _, subject := range subjects {
+		textProjection += packs.RenderSubject(subject, false) + "\n"
+		switch subject.Applicability {
+		case "installed":
+			installed++
+		case "effective":
+			effective++
+			if subject.TriggerAdmission != nil && subject.TriggerAdmission.PolicySource == "raw_declaration" {
+				raw++
+			}
+		}
+	}
+	if installed != 9 || effective != 6 || raw != 3 {
+		t.Fatalf("subject multiplicity installed=%d effective=%d raw=%d", installed, effective, raw)
+	}
+	body, err := json.Marshal(verifyCommandResult{OK: true, CapabilitySubjects: subjects})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projected verifyCommandResult
+	if err := json.Unmarshal(body, &projected); err != nil {
+		t.Fatal(err)
+	}
+	if len(projected.CapabilitySubjects) != len(subjects) {
+		t.Fatalf("JSON subjects=%d, want %d", len(projected.CapabilitySubjects), len(subjects))
+	}
+	for _, subject := range projected.CapabilitySubjects {
+		if !strings.Contains(textProjection, subject.ID) {
+			t.Fatalf("text projection omitted JSON subject %q", subject.ID)
+		}
+	}
+}
+
+func TestInboundAdmissionSupportedSurfaceStartupFailuresSQLiteAndPostgres(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			isolateCLIAPIConfigEnv(t)
+			var postgresStore *store.PostgresStore
+			var postgresDSN string
+			if backend == "postgres" {
+				dsn, _, cleanup := testutil.StartPostgres(t)
+				postgresDSN = dsn
+				t.Cleanup(cleanup)
+				oldBuildStores := buildStoresForServe
+				oldWorkspace := configuredWorkspaceLifecycleForServe
+				buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+					if _, err := postgresStore.BindSchemaCapabilities(ctx); err != nil {
+						return storeBundle{}, err
+					}
+					return selectedPostgresStoreBundle(postgresStore, cfg), nil
+				}
+				configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+					return serveRuntimeWorkspaceStub{}, nil
+				}
+				t.Cleanup(func() {
+					buildStoresForServe = oldBuildStores
+					configuredWorkspaceLifecycleForServe = oldWorkspace
+				})
+			}
+
+			for _, tc := range []struct {
+				name           string
+				mutatePackage  func(string) string
+				removeExternal bool
+				want           string
+			}{
+				{
+					name: "missing pinned pack",
+					mutatePackage: func(body string) string {
+						return strings.Replace(body, "pack: {id: provider.telegram}", "pack: {id: provider.telegram_missing}", 1)
+					},
+					want: `verified pack for "telegram" is "provider.telegram"`,
+				},
+				{
+					name: "provider pack mismatch",
+					mutatePackage: func(body string) string {
+						return strings.Replace(body, "pack: {id: provider.telegram}", "pack: {id: provider.slack}", 1)
+					},
+					want: `which provides "slack"`,
+				},
+				{
+					name:          "removed external pack",
+					mutatePackage: func(body string) string { return body }, removeExternal: true,
+					want: `pins pack "provider.acme_public", but that id is not loaded`,
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
+					if tc.removeExternal {
+						externalDirs = nil
+					}
+					contractsRoot := writeInboundAdmissionPolicyMatrixFixture(t)
+					packagePath := filepath.Join(contractsRoot, "package.yaml")
+					body, err := os.ReadFile(packagePath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(packagePath, []byte(tc.mutatePackage(string(body))), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if backend == "postgres" {
+						postgresStore, err = store.NewPostgresStore(postgresDSN)
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					configPath := writeInboundAdmissionRuntimeConfig(t, backend, filepath.Join(t.TempDir(), "failure.sqlite"), platformDirs, externalDirs)
+					process := startServeRuntimeTestProcess(t, serveOptions{
+						ConfigPath: configPath, ContractsPath: contractsRoot, PlatformSpecPath: defaultPlatformSpecPath,
+						StoreMode: backend, APIListenAddr: "127.0.0.1:0", MCPListenAddr: "127.0.0.1:0",
+						SelfCheck: true, RequireBundleMatch: false, Dev: true, Verbose: true,
+					})
+					code, exited := process.waitForExit(15 * time.Second)
+					if !exited {
+						process.cleanup()
+						t.Fatal("invalid admission candidate reached a live served runtime")
+					}
+					process.recordStopped(code)
+					output := process.outputString()
+					if code == 0 || strings.Contains(output, "swarm runtime ready") || !strings.Contains(output, tc.want) {
+						t.Fatalf("exit=%d want=%q\n%s", code, tc.want, output)
+					}
+				})
+			}
+		})
+	}
+}
+
+func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend string) {
+	t.Helper()
+	isolateCLIAPIConfigEnv(t)
+	platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
+	contractsRoot := writeInboundAdmissionPolicyMatrixFixture(t)
+	dataRoot := t.TempDir()
+	credentialPath := filepath.Join(dataRoot, "credentials.json")
+	t.Setenv("SWARM_CREDENTIALS_FILE", credentialPath)
+	credentialStore, err := runtimecredentials.NewFileStore(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, value := range map[string]string{
+		"webhook_signing.telegram": "telegram-secret",
+		"webhook_signing.partner":  "partner-secret",
+	} {
+		if err := credentialStore.Set(context.Background(), key, value); err != nil {
+			t.Fatalf("set credential %s: %v", key, err)
+		}
+	}
+
+	var sqliteStore *store.SQLiteRuntimeStore
+	var postgresStore *store.PostgresStore
+	var postgresDSN string
+	configPath := ""
+	if backend == "sqlite" {
+		sqlitePath := filepath.Join(dataRoot, "admission.sqlite")
+		configPath = writeInboundAdmissionRuntimeConfig(t, backend, sqlitePath, platformDirs, externalDirs)
+	} else {
+		dsn, _, cleanup := testutil.StartPostgres(t)
+		postgresDSN = dsn
+		t.Cleanup(cleanup)
+		postgresStore, err = store.NewPostgresStore(dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldBuildStores := buildStoresForServe
+		oldWorkspace := configuredWorkspaceLifecycleForServe
+		buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
+			if _, err := postgresStore.BindSchemaCapabilities(ctx); err != nil {
+				return storeBundle{}, err
+			}
+			return selectedPostgresStoreBundle(postgresStore, cfg), nil
+		}
+		configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
+			return serveRuntimeWorkspaceStub{}, nil
+		}
+		t.Cleanup(func() {
+			buildStoresForServe = oldBuildStores
+			configuredWorkspaceLifecycleForServe = oldWorkspace
+		})
+		configPath = writeInboundAdmissionRuntimeConfig(t, backend, "", platformDirs, externalDirs)
+	}
+
+	opts := serveOptions{
+		ConfigPath: configPath, ContractsPath: contractsRoot, PlatformSpecPath: defaultPlatformSpecPath,
+		StoreMode: backend, APIListenAddr: "127.0.0.1:0", MCPListenAddr: "127.0.0.1:0",
+		SelfCheck: true, RequireBundleMatch: false, Dev: true, Verbose: true,
+		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+	}
+	process := startServeRuntimeTestProcess(t, opts)
+	process.waitForReadyLine()
+	baseURL := "http://" + serveRuntimeAPIListenerFromOutput(t, process.outputString())
+
+	tests := []struct {
+		provider string
+		body     []byte
+		headers  map[string]string
+		event    string
+	}{
+		{provider: "telegram", body: []byte(`{"update_id":901,"message":{"chat":{"id":42}}}`), headers: map[string]string{"X-Telegram-Bot-Api-Secret-Token": "telegram-secret"}, event: "inbound.telegram"},
+		{provider: "intercom", body: []byte(`{"id":"platform-unsigned-1","topic":"contact.created"}`), event: "inbound.intercom"},
+		{provider: "acme_public", body: []byte(`{"id":"external-unsigned-1"}`), event: "inbound.acme_public"},
+		{provider: "partner_auth", body: []byte(`{"value":1}`), headers: map[string]string{"X-Partner-Delivery": "partner-auth-1"}, event: "inbound.partner_auth"},
+		{provider: "partner_open", body: []byte(`{"delivery":{"id":"partner-open-1"},"value":2}`), event: "inbound.partner_open"},
+		{provider: "partner_ack", body: []byte("raw-open-body"), event: "inbound.partner_ack"},
+	}
+	for i := range tests {
+		test := &tests[i]
+		if test.provider == "partner_auth" {
+			mac := hmac.New(sha256.New, []byte("partner-secret"))
+			_, _ = mac.Write(test.body)
+			test.headers["X-Partner-Signature"] = hex.EncodeToString(mac.Sum(nil))
+		}
+		status, response := sendInboundAdmissionSupportedRequest(t, baseURL, test.provider, test.body, test.headers)
+		if status != http.StatusAccepted {
+			t.Fatalf("%s status=%d response=%s\nserve output:\n%s", test.provider, status, response, process.outputString())
+		}
+	}
+	status, _ := sendInboundAdmissionSupportedRequest(t, baseURL, "partner_auth", []byte(`{"value":1}`), map[string]string{
+		"X-Partner-Delivery":  "partner-auth-invalid",
+		"X-Partner-Signature": "invalid",
+	})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("invalid authenticated raw status=%d, want 401", status)
+	}
+	if code := process.stop(); code != 0 {
+		t.Fatalf("serve exit=%d\n%s", code, process.outputString())
+	}
+
+	if backend == "sqlite" {
+		sqlitePath := inboundAdmissionSQLitePathFromConfig(t, configPath)
+		sqliteStore, err = store.NewSQLiteRuntimeStore(sqlitePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sqliteStore.Close()
+	} else {
+		postgresStore, err = store.NewPostgresStore(postgresDSN)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, test := range tests {
+		var count int
+		if backend == "sqlite" {
+			err = sqliteStore.DB.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = ?`, test.event).Scan(&count)
+		} else {
+			err = postgresStore.DB.QueryRow(`SELECT COUNT(*) FROM events WHERE event_name = $1`, test.event).Scan(&count)
+		}
+		if err != nil || count != 1 {
+			t.Fatalf("%s persisted count=%d err=%v, want 1", test.event, count, err)
+		}
+	}
+}
+
+func sendInboundAdmissionSupportedRequest(t testing.TB, baseURL, provider string, body []byte, headers map[string]string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(baseURL, "/")+"/webhooks/matrix/"+provider, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	response := new(bytes.Buffer)
+	_, _ = response.ReadFrom(resp.Body)
+	return resp.StatusCode, response.String()
+}
+
+func writeInboundAdmissionPolicyMatrixFixture(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"package.yaml": `name: inbound-admission-policy-matrix
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: matrix
+    flow: matrix
+    mode: singleton
+    activation: standing
+    ingress:
+      alias: matrix
+      providers:
+        - provider: telegram
+          signing_secret: webhook_signing.telegram
+          admission:
+            pack: {id: provider.telegram}
+        - provider: intercom
+          admission:
+            pack: {id: provider.intercom}
+            acknowledge: unsigned_webhook
+        - provider: acme_public
+          admission:
+            pack: {id: provider.acme_public}
+            acknowledge: unsigned_webhook
+        - provider: partner_auth
+          signing_secret: webhook_signing.partner
+          admission:
+            kind: raw
+            authentication: {kind: hmac_sha256, header: X-Partner-Signature, encoding: hex}
+            event: inbound.partner_auth
+            delivery_id: {source: header, header: X-Partner-Delivery}
+            payload: json
+        - provider: partner_open
+          admission:
+            kind: raw
+            authentication: {kind: none}
+            event: inbound.partner_open
+            delivery_id: {source: json_path, json_path: $.delivery.id}
+            payload: raw
+        - provider: partner_ack
+          admission:
+            kind: raw
+            acknowledge: unsigned_webhook
+            authentication: {kind: none}
+            event: inbound.partner_ack
+            delivery_id: {source: body_sha256}
+            payload: raw
+`,
+		"schema.yaml": "name: inbound-admission-policy-matrix\n",
+		"policy.yaml": "{}\n", "tools.yaml": "{}\n", "agents.yaml": "{}\n", "events.yaml": "{}\n", "nodes.yaml": "{}\n",
+		"flows/matrix/schema.yaml": `name: matrix
+mode: singleton
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - {name: telegram, event: inbound.telegram, source: external}
+      - {name: intercom, event: inbound.intercom, source: external}
+      - {name: acme_public, event: inbound.acme_public, source: external}
+      - {name: partner_auth, event: inbound.partner_auth, source: external}
+      - {name: partner_open, event: inbound.partner_open, source: external}
+      - {name: partner_ack, event: inbound.partner_ack, source: external}
+  outputs: {events: []}
+`,
+		"flows/matrix/entities.yaml": "matrix_service:\n  service_id:\n    type: text\n    initial: standing\n  records:\n    type: map[text]json\n    initial: {}\n",
+		"flows/matrix/types.yaml":    "{}\n", "flows/matrix/policy.yaml": "{}\n", "flows/matrix/tools.yaml": "{}\n", "flows/matrix/agents.yaml": "{}\n",
+		"flows/matrix/events.yaml": inboundAdmissionMatrixEventsYAML(),
+		"flows/matrix/nodes.yaml":  inboundAdmissionMatrixNodesYAML(),
+	}
+	for name, body := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func inboundAdmissionMatrixEventsYAML() string {
+	var out strings.Builder
+	for _, event := range []string{"inbound.telegram", "inbound.intercom", "inbound.acme_public", "inbound.partner_auth", "inbound.partner_open", "inbound.partner_ack"} {
+		fmt.Fprintf(&out, "%s:\n  entity_id: text\n  provider: text\n  event_type: text\n  provider_event_type: text\n  provider_event_id: text\n  provider_delivery_id: text\n  headers: json\n  received_at: text\n", event)
+	}
+	return out.String()
+}
+
+func inboundAdmissionMatrixNodesYAML() string {
+	events := []string{"inbound.telegram", "inbound.intercom", "inbound.acme_public", "inbound.partner_auth", "inbound.partner_open", "inbound.partner_ack"}
+	var out strings.Builder
+	out.WriteString("matrix-sink:\n  id: matrix-sink\n  execution_type: system_node\n  subscribes_to: [" + strings.Join(events, ", ") + "]\n  event_handlers:\n")
+	for _, event := range events {
+		fmt.Fprintf(&out, `    %s:
+      data_accumulation:
+        writes:
+          - op: set
+            target: entity.records
+            key: {ref: payload.provider_event_id}
+            value: {ref: payload.provider_event_id}
+`, event)
+	}
+	return out.String()
+}
+
+func writeInboundAdmissionPackInventory(t *testing.T) ([]string, []string) {
+	t.Helper()
+	platformRoot := t.TempDir()
+	platformDirs := make([]string, 0, len(providertriggers.RequiredPlatformPackIdentities()))
+	for _, identity := range providertriggers.RequiredPlatformPackIdentities() {
+		dir := filepath.Join(platformRoot, identity.Provider)
+		copyProviderTriggerPackFixture(t, identity.Provider, dir, false)
+		platformDirs = append(platformDirs, dir)
+	}
+	writeUnsignedProviderTriggerPack(t, filepath.Join(platformRoot, "intercom"), "provider.intercom", "intercom", "platform", "inbound.intercom")
+	externalDir := filepath.Join(t.TempDir(), "acme_public")
+	writeUnsignedProviderTriggerPack(t, externalDir, "provider.acme_public", "acme_public", "external", "inbound.acme_public")
+	return platformDirs, []string{externalDir}
+}
+
+func writeUnsignedProviderTriggerPack(t testing.TB, dir, id, provider, provenance, event string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(fmt.Sprintf(`provider: %s
+payload_object_required: true
+secret: {required: false}
+delivery_id: {json_path: $.id, required: true}
+event_type: {literal: event, required: true}
+event_name: {literal: %s}
+ack: {mode: durable_before_dispatch}
+`, provider, event))
+	envelope := []byte(fmt.Sprintf(`id: %s
+version: 0.1.0
+platform_version: '>=0.7.0 <0.8.0'
+type: trigger
+manifest_hash: sha256:%s
+provenance: {source: %s}
+capabilities:
+  can:
+    receive_https_route: /webhooks/{alias}/%s
+    emit_events: [%s]
+    persist_dedupe_markers: true
+  cannot: [emit_undeclared_events, run_code_before_admission, touch_unbound_resources]
+requires: {}
+tests: [providertriggers/%s]
+`, id, strings.Repeat("0", 64), provenance, provider, event, provider))
+	_, stamped, err := providertriggers.StampPackEnvelope(envelope, manifest)
+	if err != nil {
+		t.Fatalf("stamp %s: %v", id, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trigger.yaml"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pack.yaml"), stamped, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeInboundAdmissionRuntimeConfig(t testing.TB, backend, sqlitePath string, platformDirs, externalDirs []string) string {
+	t.Helper()
+	lines := []string{"runtime:", "  recovery_on_startup: false", "workspace:", "  data_source: " + t.TempDir()}
+	if backend == "sqlite" {
+		lines = append(lines, "store:", "  backend: sqlite", "  sqlite:", "    path: "+sqlitePath)
+	}
+	lines = append(lines, "llm:", "  backend: anthropic", "provider_triggers:", "  packs:", "    platform_dirs:")
+	for _, dir := range platformDirs {
+		lines = append(lines, fmt.Sprintf("      - %q", dir))
+	}
+	lines = append(lines, "    external_dirs:")
+	for _, dir := range externalDirs {
+		lines = append(lines, fmt.Sprintf("      - %q", dir))
+	}
+	path := filepath.Join(t.TempDir(), "swarm.yaml")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func inboundAdmissionSQLitePathFromConfig(t testing.TB, configPath string) string {
+	t.Helper()
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "path: ") {
+			return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "path: "))
+		}
+	}
+	t.Fatal("SQLite path missing from test config")
+	return ""
+}

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -36,23 +36,52 @@ func TestInboundAdmissionSupportedSurfacePolicyMatrixSQLiteAndPostgres(t *testin
 	}
 }
 
-func TestVerifyProjectsInstalledTriggersWithoutStandingIngress(t *testing.T) {
+func TestVerifyRejectsAmbientCheckoutProviderTriggerInventory(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	root := writeVerifyLintEvidenceFixture(t)
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = root
+	opts.platformSpecPath = filepath.Join(repoRoot(), defaultPlatformSpecPath)
+	var errors []string
+	for _, repo := range []string{repoRoot(), t.TempDir()} {
+		var out, errOut bytes.Buffer
+		if code := runVerifyCommandWithOutput(context.Background(), repo, opts, &out, &errOut); code == 0 {
+			t.Fatalf("verify unexpectedly admitted ambient inventory for repo %q:\n%s", repo, out.String())
+		}
+		if out.Len() != 0 {
+			t.Fatalf("verify repo %q projected capabilities without configured inventory:\n%s", repo, out.String())
+		}
+		if !strings.Contains(errOut.String(), "provider_triggers.packs.platform_dirs is required") {
+			t.Fatalf("verify repo %q error omitted configured inventory requirement:\n%s", repo, errOut.String())
+		}
+		errors = append(errors, errOut.String())
+	}
+	if errors[0] != errors[1] {
+		t.Fatalf("identical configuration changed meaning by checkout presence:\ncheckout: %s\nempty repo: %s", errors[0], errors[1])
+	}
+}
+
+func TestVerifyProjectsExplicitConfiguredInventoryWithoutStandingIngress(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
+	root := writeVerifyLintEvidenceFixture(t)
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	opts.platformSpecPath = filepath.Join(repoRoot(), defaultPlatformSpecPath)
+	opts.configPath = writeInboundAdmissionRuntimeConfig(t, "sqlite", filepath.Join(t.TempDir(), "verify.sqlite"), platformDirs, externalDirs)
+	emptyRepo := t.TempDir()
 	var textOut, textErr bytes.Buffer
-	if code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &textOut, &textErr); code != 0 {
+	if code := runVerifyCommandWithOutput(context.Background(), emptyRepo, opts, &textOut, &textErr); code != 0 {
 		t.Fatalf("verify text exit=%d stdout=%s stderr=%s", code, textOut.String(), textErr.String())
 	}
-	for _, provider := range []string{"github", "intercom", "shopify", "slack", "stripe", "telegram", "twilio", "typeform"} {
+	for _, provider := range []string{"acme_public", "github", "intercom", "shopify", "slack", "stripe", "telegram", "twilio", "typeform"} {
 		if !strings.Contains(textOut.String(), "provider trigger pack provider."+provider+" AVAILABLE") {
 			t.Fatalf("verify text omitted installed %s trigger:\n%s", provider, textOut.String())
 		}
 	}
 	opts.output.asJSON = true
 	var jsonOut, jsonErr bytes.Buffer
-	if code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &jsonOut, &jsonErr); code != 0 {
+	if code := runVerifyCommandWithOutput(context.Background(), emptyRepo, opts, &jsonOut, &jsonErr); code != 0 {
 		t.Fatalf("verify JSON exit=%d stdout=%s stderr=%s", code, jsonOut.String(), jsonErr.String())
 	}
 	result := decodeOutputJSON[verifyCommandResult](t, jsonOut.String())
@@ -62,8 +91,81 @@ func TestVerifyProjectsInstalledTriggersWithoutStandingIngress(t *testing.T) {
 			installed++
 		}
 	}
-	if installed != 8 {
-		t.Fatalf("verify installed trigger subjects=%d, want 8: %#v", installed, result.CapabilitySubjects)
+	if installed != 9 {
+		t.Fatalf("verify installed trigger subjects=%d, want 9: %#v", installed, result.CapabilitySubjects)
+	}
+}
+
+func TestVerifyConfiguredInventoryProjectsUnsignedWarningAndReadback(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = writeInboundAdmissionPolicyMatrixFixture(t)
+	opts.platformSpecPath = filepath.Join(repoRoot(), defaultPlatformSpecPath)
+	opts.configPath = writeInboundAdmissionRuntimeConfig(t, "sqlite", filepath.Join(t.TempDir(), "verify.sqlite"), platformDirs, externalDirs)
+	emptyRepo := t.TempDir()
+
+	var textOut, textErr bytes.Buffer
+	if code := runVerifyCommandWithOutput(context.Background(), emptyRepo, opts, &textOut, &textErr); code != 0 {
+		t.Fatalf("verify text exit=%d stdout=%s stderr=%s", code, textOut.String(), textErr.String())
+	}
+	if got := strings.Count(textErr.String(), "inbound_unsigned_webhook"); got != 1 {
+		t.Fatalf("verify text unsigned warning count=%d, want 1:\n%s", got, textErr.String())
+	}
+	for _, want := range []string{`provider "partner_open" accepts unsigned webhooks`, "add admission.acknowledge: unsigned_webhook"} {
+		if !strings.Contains(textErr.String(), want) {
+			t.Fatalf("verify text warning omitted %q:\n%s", want, textErr.String())
+		}
+	}
+	if strings.Contains(textErr.String(), `provider "partner_ack" accepts unsigned webhooks`) {
+		t.Fatalf("verify text did not suppress acknowledged warning:\n%s", textErr.String())
+	}
+
+	opts.output.asJSON = true
+	var jsonOut, jsonErr bytes.Buffer
+	if code := runVerifyCommandWithOutput(context.Background(), emptyRepo, opts, &jsonOut, &jsonErr); code != 0 {
+		t.Fatalf("verify JSON exit=%d stdout=%s stderr=%s", code, jsonOut.String(), jsonErr.String())
+	}
+	if jsonErr.Len() != 0 {
+		t.Fatalf("verify JSON stderr=%s, want empty", jsonErr.String())
+	}
+	result := decodeOutputJSON[verifyCommandResult](t, jsonOut.String())
+	unsignedWarnings := 0
+	for _, warning := range result.Warnings {
+		if warning.CheckID != "inbound_unsigned_webhook" {
+			continue
+		}
+		unsignedWarnings++
+		if !strings.Contains(warning.Message, `provider "partner_open" accepts unsigned webhooks`) || warning.Remediation != "add admission.acknowledge: unsigned_webhook to confirm this intentional public endpoint" {
+			t.Fatalf("verify JSON unsigned warning=%#v", warning)
+		}
+	}
+	if unsignedWarnings != 1 {
+		t.Fatalf("verify JSON unsigned warnings=%d, want 1: %#v", unsignedWarnings, result.Warnings)
+	}
+
+	readback := map[string]packs.Subject{}
+	installed, effective := 0, 0
+	for _, subject := range result.CapabilitySubjects {
+		switch subject.Applicability {
+		case "installed":
+			installed++
+		case "effective":
+			effective++
+			readback[subject.Provider] = subject
+		}
+	}
+	if installed != 9 || effective != 6 {
+		t.Fatalf("verify subject multiplicity installed=%d effective=%d", installed, effective)
+	}
+	for _, provider := range []string{"partner_open", "partner_ack"} {
+		subject, ok := readback[provider]
+		if !ok || subject.TriggerAdmission == nil || subject.TriggerAdmission.PolicySource != "raw_declaration" || subject.TriggerAdmission.RequestAuthentication != "UNAUTHENTICATED" {
+			t.Fatalf("verify %s readback=%#v", provider, subject)
+		}
+		if rendered := packs.RenderSubject(subject, false); !strings.Contains(textOut.String(), rendered) {
+			t.Fatalf("verify text/JSON readback diverged for %s:\nwant %s\ntext:\n%s", provider, rendered, textOut.String())
+		}
 	}
 }
 
@@ -274,6 +376,31 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 	}
 	process := startServeRuntimeTestProcess(t, opts)
 	process.waitForReadyLine()
+	serveOutput := process.outputString()
+	var unsignedWarningLine string
+	for _, line := range strings.Split(serveOutput, "\n") {
+		if strings.Contains(line, "[WARN] inbound_unsigned_webhook") {
+			if unsignedWarningLine != "" {
+				t.Fatalf("serve emitted duplicate unsigned warning:\n%s", serveOutput)
+			}
+			unsignedWarningLine = line
+		}
+	}
+	if unsignedWarningLine == "" || !strings.Contains(unsignedWarningLine, `provider "partner_open" accepts unsigned webhooks`) || strings.Contains(unsignedWarningLine, "partner_ack") || !strings.Contains(serveOutput, "remediation: add admission.acknowledge: unsigned_webhook") {
+		t.Fatalf("serve unsigned warning line=%q\noutput:\n%s", unsignedWarningLine, serveOutput)
+	}
+	for _, provider := range []string{"partner_open", "partner_ack"} {
+		found := false
+		for _, line := range strings.Split(serveOutput, "\n") {
+			if strings.Contains(line, "standing ingress admitted:") && strings.Contains(line, ":matrix:"+provider+" ") && strings.Contains(line, "request_authentication=UNAUTHENTICATED") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("serve readback omitted %s UNAUTHENTICATED truth:\n%s", provider, serveOutput)
+		}
+	}
 	baseURL := "http://" + serveRuntimeAPIListenerFromOutput(t, process.outputString())
 
 	tests := []struct {

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -89,6 +89,7 @@ type localPreflightRequest struct {
 	CheckContractSecrets   bool
 	ContractSecretSeverity localPreflightSeverity
 	ProviderTriggerPacks   []providertriggers.LoadedPack
+	ProviderTriggerCatalog *providertriggers.CatalogSnapshot
 }
 
 func runLocalClaudeCLIPreflight(ctx context.Context, req localPreflightRequest) localPreflightReport {
@@ -246,6 +247,7 @@ func loadLocalPreflightCapabilitySource(ctx context.Context, req localPreflightR
 		return nil, "", false
 	}
 	appendProviderConnectorCapabilitySubjects(ctx, report, source)
+	appendEffectiveProviderTriggerCapabilitySubjects(report, source, req.ProviderTriggerCatalog)
 	return source, contractsRoot, true
 }
 
@@ -587,7 +589,7 @@ func serveLocalPreflightMode(opts serveOptions) string {
 	return "serve"
 }
 
-func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serveOptions, cfg *config.Config, resolvedPaths cliContractPlatformSpecPaths, workspaceBackend workspaceBackendSelection, mountSources workspaceMountSources, providerTriggerPacks []providertriggers.LoadedPack) localPreflightReport {
+func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serveOptions, cfg *config.Config, resolvedPaths cliContractPlatformSpecPaths, workspaceBackend workspaceBackendSelection, mountSources workspaceMountSources, providerTriggerPacks []providertriggers.LoadedPack, providerTriggerCatalog *providertriggers.CatalogSnapshot) localPreflightReport {
 	mode := serveLocalPreflightMode(opts)
 	return runLocalClaudeCLIPreflight(ctx, localPreflightRequest{
 		Mode:                   mode,
@@ -604,5 +606,6 @@ func runServeLocalClaudeCLIPreflight(ctx context.Context, repo string, opts serv
 		CheckContractSecrets:   true,
 		ContractSecretSeverity: localPreflightCommandSeverityForContractSecrets(mode),
 		ProviderTriggerPacks:   providerTriggerPacks,
+		ProviderTriggerCatalog: providerTriggerCatalog,
 	})
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2241,13 +2241,11 @@ func verifyWorkflowContractValidationOptions(repo string, source semanticview.So
 	opts.ValidateLLMModelResolution = true
 	opts.LLMProfile = profile
 	opts.ModelAliases = configResult.Config.LLM.Models
-	if sourceHasStandingIngress(source) {
-		providerPacks, err := loadConfiguredProviderTriggerPacks(repo, configResult)
-		if err != nil {
-			return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load provider trigger packs: %w", err)
-		}
-		opts.ProviderTriggerCatalog = providerPacks.Catalog
+	providerPacks, err := loadVerifyProviderTriggerPacks(repo, configResult, sourceHasStandingIngress(source))
+	if err != nil {
+		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load provider trigger packs: %w", err)
 	}
+	opts.ProviderTriggerCatalog = providerPacks.Catalog
 	return opts, nil
 }
 

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -24,6 +24,7 @@ import (
 
 	apiv1 "github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
+	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/platform"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	"github.com/division-sh/swarm/internal/runtime"
@@ -407,25 +408,25 @@ type serveRuntimeBundleContext struct {
 }
 
 type serveRuntimeBundleContextRequest struct {
-	Ctx                     context.Context
-	Stores                  storeBundle
-	Config                  *config.Config
-	Loaded                  serveRuntimeBundle
-	StateStoreSummary       string
-	Options                 serveOptions
-	MountSources            workspaceMountSources
-	WorkspaceBackend        workspaceBackendSelection
-	Credentials             runtimecredentials.Store
-	ManagedCredentials      runtimemanagedcredentials.Store
-	ProviderCredentials     runtimecredentials.Store
-	ProviderTriggerRegistry *providertriggers.Registry
-	BootStartedAt           time.Time
-	BootProgress            func(runtime.BootProgressEvent)
-	EnableToolGateway       bool
-	ToolGatewayBinding      toolgateway.Binding
-	UseStartupOwnership     bool
-	UseStartupRecovery      bool
-	RequireBundleScopeName  bool
+	Ctx                    context.Context
+	Stores                 storeBundle
+	Config                 *config.Config
+	Loaded                 serveRuntimeBundle
+	StateStoreSummary      string
+	Options                serveOptions
+	MountSources           workspaceMountSources
+	WorkspaceBackend       workspaceBackendSelection
+	Credentials            runtimecredentials.Store
+	ManagedCredentials     runtimemanagedcredentials.Store
+	ProviderCredentials    runtimecredentials.Store
+	ProviderTriggerCatalog *providertriggers.CatalogSnapshot
+	BootStartedAt          time.Time
+	BootProgress           func(runtime.BootProgressEvent)
+	EnableToolGateway      bool
+	ToolGatewayBinding     toolgateway.Binding
+	UseStartupOwnership    bool
+	UseStartupRecovery     bool
+	RequireBundleScopeName bool
 }
 
 func defaultServeOptions() serveOptions {
@@ -739,7 +740,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	}
 	validationOpts := runtime.DefaultWorkflowContractValidationOptions(req.Credentials)
 	validationOpts.ManagedCredentials = req.ManagedCredentials
-	validationOpts.ProviderTriggerRegistry = req.ProviderTriggerRegistry
+	validationOpts.ProviderTriggerCatalog = req.ProviderTriggerCatalog
 	validation, err := runtime.ValidateWorkflowContractSurface(req.Ctx, loaded.source, validationOpts)
 	if err != nil {
 		return serveRuntimeBundleContext{}, err
@@ -767,7 +768,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 			Credentials:                      req.Credentials,
 			ManagedCredentials:               req.ManagedCredentials,
 			ProviderCredentials:              req.ProviderCredentials,
-			ProviderTriggerRegistry:          req.ProviderTriggerRegistry,
+			ProviderTriggerCatalog:           req.ProviderTriggerCatalog,
 			BootStartedAt:                    req.BootStartedAt,
 			BootProgress:                     req.BootProgress,
 			SystemContainers:                 systemWorkspaceContainers(workspaces),
@@ -960,7 +961,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	logWorkspaceBackendDecision(opts.Output, primaryWorkspaceBackend)
 	if shouldRunServeLocalClaudeCLIPreflight(opts) {
-		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources, providerPackLoad.Loaded)
+		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources, providerPackLoad.Loaded, providerPackLoad.Catalog)
 		if preflight.HasBlockers() {
 			detail := preflight.BlockerSummary()
 			reporter.emit(5, "local_preflight", "FAILED", detail)
@@ -1102,25 +1103,25 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			logWorkspaceBackendDecision(opts.Output, workspaceBackend)
 		}
 		contextDef, err := buildServeRuntimeBundleContext(serveRuntimeBundleContextRequest{
-			Ctx:                     ctx,
-			Stores:                  stores,
-			Config:                  cfg,
-			Loaded:                  loaded,
-			StateStoreSummary:       serveStateStoreSummaryAt(stateStoreSummaries, i),
-			Options:                 opts,
-			MountSources:            mountSources,
-			WorkspaceBackend:        workspaceBackend,
-			Credentials:             credentialStore,
-			ManagedCredentials:      managedCredentialStore,
-			ProviderCredentials:     providerCredentialStore,
-			ProviderTriggerRegistry: providerPackLoad.Registry,
-			BootStartedAt:           bootStartedAt,
-			BootProgress:            reporter.runtimeSink(),
-			EnableToolGateway:       i == 0,
-			ToolGatewayBinding:      contextToolGatewayBinding,
-			UseStartupOwnership:     len(loadedBundles) == 1 && i == 0,
-			UseStartupRecovery:      len(loadedBundles) == 1,
-			RequireBundleScopeName:  len(loadedBundles) > 1,
+			Ctx:                    ctx,
+			Stores:                 stores,
+			Config:                 cfg,
+			Loaded:                 loaded,
+			StateStoreSummary:      serveStateStoreSummaryAt(stateStoreSummaries, i),
+			Options:                opts,
+			MountSources:           mountSources,
+			WorkspaceBackend:       workspaceBackend,
+			Credentials:            credentialStore,
+			ManagedCredentials:     managedCredentialStore,
+			ProviderCredentials:    providerCredentialStore,
+			ProviderTriggerCatalog: providerPackLoad.Catalog,
+			BootStartedAt:          bootStartedAt,
+			BootProgress:           reporter.runtimeSink(),
+			EnableToolGateway:      i == 0,
+			ToolGatewayBinding:     contextToolGatewayBinding,
+			UseStartupOwnership:    len(loadedBundles) == 1 && i == 0,
+			UseStartupRecovery:     len(loadedBundles) == 1,
+			RequireBundleScopeName: len(loadedBundles) > 1,
 		})
 		if err != nil {
 			reporter.emit(5, "runtime_context", "FAILED", err.Error())
@@ -1146,12 +1147,19 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		log.Printf("plan runtime contexts: %v", err)
 		return 1
 	}
-	if err := runtime.ValidateRuntimeContextSet(preflightContexts...); err != nil {
+	installedTriggerSubjects, err := providerPackLoad.Catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		reporter.emit(5, "runtime_context", "FAILED", err.Error())
+		log.Printf("derive provider trigger capability subjects: %v", err)
+		return 1
+	}
+	admissionState := runtime.ProcessAdmissionState{GenerationID: providerPackLoad.Catalog.GenerationID(), InstalledSubjects: installedTriggerSubjects}
+	if err := runtime.ValidateRuntimeContextSetWithAdmission(admissionState, preflightContexts...); err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
 		log.Printf("validate runtime contexts: %v", err)
 		return 1
 	}
-	runtimeContextManager, err := runtime.NewRuntimeContextManager(runtimeContextAvailabilityReader(stores))
+	runtimeContextManager, err := runtime.NewRuntimeContextManagerWithAdmission(runtimeContextAvailabilityReader(stores), admissionState)
 	if err != nil {
 		reporter.emit(5, "runtime_context", "FAILED", err.Error())
 		log.Printf("init runtime context manager: %v", err)
@@ -1165,7 +1173,10 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	var ready atomic.Bool
-	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackendPreference, credentialStore, providerCredentialStore, providerPackLoad.Registry, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor := newRuntimeProjectSupervisor(repo, resolvedPlatformSpecPath, cfg, stores, &ready, mountSources, workspaceBackendPreference, credentialStore, providerCredentialStore, providerPackLoad.Catalog, contractsRoot, bundle, source, rt, opts.Dev)
+	supervisor.loadProviderCatalog = func() (*providertriggers.CatalogSnapshot, error) {
+		return providerPackLoad.Reload()
+	}
 	supervisor.replacementShutdown = runtime.ShutdownOptions{Grace: opts.ShutdownGrace}
 	supervisor.runtimeLifetime = ctx
 	supervisor.SetRuntimeContextManager(runtimeContextManager, primaryContext.bundleSourceFact, primaryContext.bootIdentity)
@@ -1294,7 +1305,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	reporter.emit(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
 	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	logReadySummary(source, contractsRoot, apiListener.Addr(), mcpListener.Addr())
-	logReadyStandingIngress(ctx, runtimeContextManager, providerCredentialStore, apiListener.Addr())
+	logReadyStandingIngress(runtimeContextManager, apiListener.Addr())
 
 	<-ctx.Done()
 	ready.Store(false)
@@ -1335,20 +1346,15 @@ func plannedServeRuntimeContexts(contexts []serveRuntimeBundleContext) ([]runtim
 	return planned, nil
 }
 
-func logReadyStandingIngress(ctx context.Context, manager *runtime.RuntimeContextManager, credentials runtimecredentials.Store, apiAddr net.Addr) {
+func logReadyStandingIngress(manager *runtime.RuntimeContextManager, apiAddr net.Addr) {
 	if manager == nil || apiAddr == nil {
 		return
 	}
-	for _, contextDef := range manager.LoadedContexts() {
-		for _, target := range contextDef.StandingTargets {
-			state := "UNBOUND"
-			if credentials != nil {
-				if value, ok, err := credentials.Get(ctx, target.SigningSecret); err == nil && ok && strings.TrimSpace(value) != "" {
-					state = "BOUND"
-				}
-			}
-			log.Printf("standing ingress ready: provider=%s url=http://%s/webhooks/%s/%s signing_secret=%s %s bundle_hash=%s", target.Provider, apiAddr.String(), target.Alias, target.Provider, target.SigningSecret, state, target.BundleHash)
+	for _, subject := range manager.CapabilitySubjects() {
+		if subject.Kind != packs.SubjectProviderTrigger || subject.Applicability != "effective" {
+			continue
 		}
+		log.Printf("standing ingress admitted: api_base_url=http://%s %s", apiAddr.String(), packs.RenderSubject(subject, false))
 	}
 }
 
@@ -1487,12 +1493,13 @@ func closeAdditionalServeRuntimeContexts(ctx context.Context, contexts []serveRu
 }
 
 type verifyCommandResult struct {
-	OK               bool                  `json:"ok"`
-	Contracts        string                `json:"contracts"`
-	WorkspaceBackend string                `json:"workspace_backend"`
-	Errors           []verifyFindingOutput `json:"errors"`
-	Warnings         []verifyFindingOutput `json:"warnings"`
-	LintEvidence     []verifyFindingOutput `json:"lint_evidence"`
+	OK                 bool                  `json:"ok"`
+	Contracts          string                `json:"contracts"`
+	WorkspaceBackend   string                `json:"workspace_backend"`
+	Errors             []verifyFindingOutput `json:"errors"`
+	Warnings           []verifyFindingOutput `json:"warnings"`
+	LintEvidence       []verifyFindingOutput `json:"lint_evidence"`
+	CapabilitySubjects []packs.Subject       `json:"capability_subjects"`
 }
 
 type verifyFindingOutput struct {
@@ -1594,6 +1601,9 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 			if out != nil {
 				fmt.Fprintf(out, "verify ok: contracts=%s\n", contractsRoot)
 				fmt.Fprintf(out, "%s\n", workspaceBackendDetail)
+				for _, subject := range result.CapabilitySubjects {
+					fmt.Fprintln(out, packs.RenderSubject(subject, false))
+				}
 			}
 		}, func() ([]string, error) {
 			return []string{"ok"}, nil
@@ -1606,12 +1616,13 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 
 func verifyCommandOutput(ok bool, contractsRoot string, workspaceBackend string, result runtime.WorkflowContractValidationResult) verifyCommandResult {
 	return verifyCommandResult{
-		OK:               ok,
-		Contracts:        contractsRoot,
-		WorkspaceBackend: workspaceBackend,
-		Errors:           verifyFindingOutputs(result.BootReport.Errors()),
-		Warnings:         verifyFindingOutputs(result.BootReport.Warnings()),
-		LintEvidence:     verifyFindingOutputs(result.BootReport.LintEvidence()),
+		OK:                 ok,
+		Contracts:          contractsRoot,
+		WorkspaceBackend:   workspaceBackend,
+		Errors:             verifyFindingOutputs(result.BootReport.Errors()),
+		Warnings:           verifyFindingOutputs(result.BootReport.Warnings()),
+		LintEvidence:       verifyFindingOutputs(result.BootReport.LintEvidence()),
+		CapabilitySubjects: append([]packs.Subject(nil), result.CapabilitySubjects...),
 	}
 }
 
@@ -2235,7 +2246,7 @@ func verifyWorkflowContractValidationOptions(repo string, source semanticview.So
 		if err != nil {
 			return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load provider trigger packs: %w", err)
 		}
-		opts.ProviderTriggerRegistry = providerPacks.Registry
+		opts.ProviderTriggerCatalog = providerPacks.Catalog
 	}
 	return opts, nil
 }

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1285,7 +1285,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	go serveHTTPServer("mcp", mcpServer, mcpListener)
 	defer shutdownHTTPServer("mcp", mcpServer)
 	defer shutdownHTTPServer("api", apiServer)
-	logBootWarnings(bootReport)
+	logBootWarnings(bootReport, opts.Output)
 	if err := startServeRuntimeContexts(ctx, runtimeContexts, runtimeContextManager); err != nil {
 		reporter.emit(22, "ready", "FAILED", err.Error())
 		log.Printf("start runtime: %v", err)
@@ -1305,7 +1305,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	reporter.emit(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
 	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	logReadySummary(source, contractsRoot, apiListener.Addr(), mcpListener.Addr())
-	logReadyStandingIngress(runtimeContextManager, apiListener.Addr())
+	logReadyStandingIngress(runtimeContextManager, apiListener.Addr(), opts.Output)
 
 	<-ctx.Done()
 	ready.Store(false)
@@ -1346,7 +1346,7 @@ func plannedServeRuntimeContexts(contexts []serveRuntimeBundleContext) ([]runtim
 	return planned, nil
 }
 
-func logReadyStandingIngress(manager *runtime.RuntimeContextManager, apiAddr net.Addr) {
+func logReadyStandingIngress(manager *runtime.RuntimeContextManager, apiAddr net.Addr, out io.Writer) {
 	if manager == nil || apiAddr == nil {
 		return
 	}
@@ -1354,7 +1354,11 @@ func logReadyStandingIngress(manager *runtime.RuntimeContextManager, apiAddr net
 		if subject.Kind != packs.SubjectProviderTrigger || subject.Applicability != "effective" {
 			continue
 		}
-		log.Printf("standing ingress admitted: api_base_url=http://%s %s", apiAddr.String(), packs.RenderSubject(subject, false))
+		message := fmt.Sprintf("standing ingress admitted: api_base_url=http://%s %s", apiAddr.String(), packs.RenderSubject(subject, false))
+		log.Print(message)
+		if out != nil {
+			fmt.Fprintln(out, message)
+		}
 	}
 }
 
@@ -1565,7 +1569,7 @@ func runVerifyCommandWithOutput(ctx context.Context, repo string, opts verifyCom
 		return cliExitValidation
 	} else {
 		source := semanticview.Wrap(bundle)
-		validationOpts, err := verifyWorkflowContractValidationOptions(repo, source)
+		validationOpts, err := verifyWorkflowContractValidationOptions(repo, opts.configPath, source)
 		if err != nil {
 			if errOut != nil {
 				fmt.Fprintf(errOut, "verify failed: configure validation: %v\n", err)
@@ -2219,7 +2223,7 @@ func verifyBundleResultWithOptions(ctx context.Context, source semanticview.Sour
 	return runtime.ValidateWorkflowContractSurface(ctx, source, opts)
 }
 
-func verifyWorkflowContractValidationOptions(repo string, source semanticview.Source) (runtime.WorkflowContractValidationOptions, error) {
+func verifyWorkflowContractValidationOptions(repo, configPath string, source semanticview.Source) (runtime.WorkflowContractValidationOptions, error) {
 	credentialStore, err := buildCredentialStore()
 	if err != nil {
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("configure credentials: %w", err)
@@ -2230,7 +2234,7 @@ func verifyWorkflowContractValidationOptions(repo string, source semanticview.So
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("configure managed credentials: %w", err)
 	}
 	opts.ManagedCredentials = managedCredentialStore
-	configResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo})
+	configResult, err := loadRuntimeConfigWithOptions(runtimeConfigLoadOptions{RepoRoot: repo, ExplicitPath: configPath})
 	if err != nil {
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load runtime config: %w", err)
 	}
@@ -2241,23 +2245,12 @@ func verifyWorkflowContractValidationOptions(repo string, source semanticview.So
 	opts.ValidateLLMModelResolution = true
 	opts.LLMProfile = profile
 	opts.ModelAliases = configResult.Config.LLM.Models
-	providerPacks, err := loadVerifyProviderTriggerPacks(repo, configResult, sourceHasStandingIngress(source))
+	providerPacks, err := loadConfiguredProviderTriggerPacks(repo, configResult)
 	if err != nil {
 		return runtime.WorkflowContractValidationOptions{}, fmt.Errorf("load provider trigger packs: %w", err)
 	}
 	opts.ProviderTriggerCatalog = providerPacks.Catalog
 	return opts, nil
-}
-
-func sourceHasStandingIngress(source semanticview.Source) bool {
-	for _, scope := range semanticview.ProjectScopes(source) {
-		for _, ref := range scope.Manifest.Flows {
-			if ref.HasStandingActivation() && ref.Ingress != nil {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func writeVerifyFindings(out io.Writer, findings []runtimebootverify.Finding, blocking bool) {
@@ -2902,7 +2895,7 @@ func serveBootBundleLoadDetail(fingerprint string, source semanticview.Source) s
 	return fmt.Sprintf("%s, %s", fingerprint, serveBootRegistryDetail(source))
 }
 
-func logBootWarnings(report runtimebootverify.Report) {
+func logBootWarnings(report runtimebootverify.Report, out io.Writer) {
 	warningCounts := make(map[string]int, len(report.Findings))
 	for _, finding := range report.Warnings() {
 		warningCounts[strings.TrimSpace(finding.CheckID)]++
@@ -2915,6 +2908,9 @@ func logBootWarnings(report runtimebootverify.Report) {
 	}
 	for _, finding := range report.Warnings() {
 		slog.Warn("swarm boot validation warning", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
+		if out != nil {
+			fmt.Fprintln(out, runtimebootverify.FormatSurfaceFinding(finding, false))
+		}
 	}
 }
 

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -15130,7 +15130,7 @@ func assertServePreflightStaleGatewayWarning(t *testing.T, opts serveOptions, wa
 	if err != nil {
 		t.Fatalf("load provider packs for preflight proof: %v", err)
 	}
-	report := runServeLocalClaudeCLIPreflight(context.Background(), repoRoot(), opts, cfgResult.Config, resolvedPaths, workspaceBackend, workspaceMountSources{DataSource: t.TempDir(), DataSourceSource: "test"}, providerPacks.Loaded)
+	report := runServeLocalClaudeCLIPreflight(context.Background(), repoRoot(), opts, cfgResult.Config, resolvedPaths, workspaceBackend, workspaceMountSources{DataSource: t.TempDir(), DataSourceSource: "test"}, providerPacks.Loaded, providerPacks.Catalog)
 	if report.Mode != wantMode {
 		t.Fatalf("preflight mode = %q, want %q", report.Mode, wantMode)
 	}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -1605,11 +1605,12 @@ func TestVerifyCommandIgnoresRepoDotEnvAfterLazyRepoDiscovery(t *testing.T) {
 	repo := t.TempDir()
 	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, "go.mod"), "module testrepo\n")
 	contractsRoot := writeEnvAuthorityContractsFixture(t, "dot-env-contracts")
+	configPath := writeTestVerifyRuntimeConfig(t)
 	writeWorkflowValidationFixtureFile(t, filepath.Join(repo, ".env"), "SWARM_CONTRACTS_PATH="+contractsRoot+"\nBROKEN\n")
 	chdirForTest(t, repo)
 
 	var stdout, stderr bytes.Buffer
-	code := executeRootCommand(context.Background(), "", []string{"verify"}, &stdout, &stderr)
+	code := executeRootCommand(context.Background(), "", []string{"verify", "--config", configPath}, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("verify unexpectedly consumed contracts path from repo .env: stdout=%s stderr=%s", stdout.String(), stderr.String())
 	}
@@ -1619,7 +1620,7 @@ func TestVerifyCommandIgnoresRepoDotEnvAfterLazyRepoDiscovery(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = executeRootCommand(context.Background(), "", []string{"verify", "--contracts", contractsRoot}, &stdout, &stderr)
+	code = executeRootCommand(context.Background(), "", []string{"verify", "--contracts", contractsRoot, "--config", configPath}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("verify with explicit contracts code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
@@ -1680,7 +1681,7 @@ platform_version: ">=0.7.0 <0.8.0"
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), "", root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), "", root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -1706,7 +1707,7 @@ platform_version: ">=0.8.0"
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), "", root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), "", root, &buf)
 	if code == 0 {
 		t.Fatalf("runVerifyCommand exit code = 0, output = %q", buf.String())
 	}
@@ -1743,7 +1744,7 @@ extra:
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), "", root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), "", root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -1770,7 +1771,7 @@ homepage: https://division.sh
 	writeWorkflowValidationFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), "", root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), "", root, &buf)
 	if code == 0 {
 		t.Fatalf("runVerifyCommand exit code = 0, output = %q", buf.String())
 	}
@@ -12623,13 +12624,16 @@ func TestRunState_PreservesRunningTruthWhileManagerWorkIsActive(t *testing.T) {
 	}
 }
 
-func runVerifyCommandWithContractsForTest(ctx context.Context, repo, contractsPath string, out *bytes.Buffer) int {
-	return runVerifyCommandWithContractsOutputForTest(ctx, repo, contractsPath, out, out)
+func runVerifyCommandWithContractsForTest(t *testing.T, ctx context.Context, repo, contractsPath string, out *bytes.Buffer) int {
+	t.Helper()
+	return runVerifyCommandWithContractsOutputForTest(t, ctx, repo, contractsPath, out, out)
 }
 
-func runVerifyCommandWithContractsOutputForTest(ctx context.Context, repo, contractsPath string, out, errOut *bytes.Buffer) int {
+func runVerifyCommandWithContractsOutputForTest(t *testing.T, ctx context.Context, repo, contractsPath string, out, errOut *bytes.Buffer) int {
+	t.Helper()
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = contractsPath
+	opts.configPath = writeTestVerifyRuntimeConfig(t)
 	return runVerifyCommandWithOutput(ctx, repo, opts, out, errOut)
 }
 
@@ -12644,7 +12648,7 @@ func TestRunVerifyCommand_BadContractsPath(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), tc.path, &buf)
+			code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), tc.path, &buf)
 			if code == 0 {
 				t.Fatal("expected non-zero exit code")
 			}
@@ -13021,7 +13025,7 @@ pins:
 			root := t.TempDir()
 			tt.write(t, root)
 			var buf bytes.Buffer
-			code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+			code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 			if code != cliExitValidation {
 				t.Fatalf("code = %d, want %d output=%s", code, cliExitValidation, buf.String())
 			}
@@ -13072,7 +13076,7 @@ func TestRunVerifyCommand_SurfacesLintEvidence(t *testing.T) {
 	root := writeVerifyLintEvidenceFixture(t)
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
 	}
@@ -13091,6 +13095,7 @@ func TestRunVerifyCommand_SurfacesLintEvidence(t *testing.T) {
 
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = root
+	opts.configPath = writeTestVerifyRuntimeConfig(t)
 	opts.output.asJSON = true
 	stdout.Reset()
 	stderr.Reset()
@@ -13114,6 +13119,7 @@ func TestRunVerifyCommand_JSONDoesNotHideLaterValidationErrorBehindAdvisoryBootF
 	root := writeVerifyLintEvidenceWithMissingEmitSchemaFixture(t)
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = root
+	opts.configPath = writeTestVerifyRuntimeConfig(t)
 	opts.output.asJSON = true
 
 	var stdout, stderr bytes.Buffer
@@ -13219,7 +13225,7 @@ func TestRunVerifyCommand_AllowsBootTimerWithoutCancelOn(t *testing.T) {
 	root := writeVerifyBootTimerCommandFixture(t, "")
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
 	}
@@ -13232,7 +13238,7 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 	root := writeVerifyBootTimerCommandFixture(t, "state:done")
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("runVerifyCommand exit code = 0, stdout = %q stderr = %q", stdout.String(), stderr.String())
 	}
@@ -13253,6 +13259,7 @@ func TestRunVerifyCommand_RejectsBootTimerWithCancelOn(t *testing.T) {
 
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = root
+	opts.configPath = writeTestVerifyRuntimeConfig(t)
 	opts.output.asJSON = true
 	stdout.Reset()
 	stderr.Reset()
@@ -13289,7 +13296,7 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 
 	root := filepath.Join(repoRoot(), "tests", "tier8-boot-verification", "test-boot-state-machine-unreachable")
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(
+	code := runVerifyCommandWithContractsOutputForTest(t,
 		context.Background(),
 		repoRoot(),
 		root,
@@ -13318,6 +13325,7 @@ func TestRunVerifyCommand_EscalatedWarningUsesBlockingAnalyzerOutput(t *testing.
 
 	opts := defaultVerifyCommandOptions()
 	opts.contractsPath = root
+	opts.configPath = writeTestVerifyRuntimeConfig(t)
 	opts.output.asJSON = true
 	stdout.Reset()
 	stderr.Reset()
@@ -13478,7 +13486,7 @@ assignee:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -13499,7 +13507,7 @@ func TestRunVerifyCommand_FailsForUndefinedSelectedBackendModelAlias(t *testing.
 	writeVerifyModelAliasFixture(t, root, "not_configured")
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
 	}
@@ -13516,7 +13524,7 @@ func TestRunVerifyCommand_UsesUnifiedRuntimeConfigModelAliases(t *testing.T) {
 	writeVerifyModelAliasFixture(t, root, "audit.custom")
 
 	configPath := filepath.Join(t.TempDir(), "swarm.yaml")
-	writeRuntimeConfigText(t, configPath, strings.Join([]string{
+	writeRuntimeConfigText(t, configPath, withTestProviderTriggerPlatformInventory(t, strings.Join([]string{
 		"llm:",
 		"  backend: anthropic",
 		"  models:",
@@ -13526,11 +13534,13 @@ func TestRunVerifyCommand_UsesUnifiedRuntimeConfigModelAliases(t *testing.T) {
 		"    lock_ttl: 10s",
 		"    rotate_after_turns: 40",
 		"    rotate_on_parse_failures: 3",
-	}, "\n")+"\n")
+	}, "\n")+"\n"))
 	t.Setenv("SWARM_CONFIG", configPath)
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	opts := defaultVerifyCommandOptions()
+	opts.contractsPath = root
+	code := runVerifyCommandWithOutput(context.Background(), repoRoot(), opts, &buf, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -13600,7 +13610,7 @@ Use save_entity_field for `+"`business_brief`"+`.
 `)
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
 	}
@@ -13641,7 +13651,7 @@ accumulator:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, output = %q", buf.String())
 	}
@@ -13696,7 +13706,7 @@ accumulator:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -13781,7 +13791,7 @@ scorer:
 `)
 
 	var buf bytes.Buffer
-	code := runVerifyCommandWithContractsForTest(context.Background(), repoRoot(), root, &buf)
+	code := runVerifyCommandWithContractsForTest(t, context.Background(), repoRoot(), root, &buf)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, output = %q", code, buf.String())
 	}
@@ -13799,7 +13809,7 @@ func TestRunVerifyCommand_WarnsForAccumulateAllWithoutBoundedEscape(t *testing.T
 	})
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("runVerifyCommand exit code = %d, stdout = %q stderr = %q", code, stdout.String(), stderr.String())
 	}
@@ -13823,7 +13833,7 @@ func TestRunVerifyCommand_FailsForAccumulateTimeoutWithoutTimeoutMS(t *testing.T
 	})
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
 	}
@@ -13853,7 +13863,7 @@ func TestRunVerifyCommand_FailsForAccumulatorInputWithoutProducerPath(t *testing
 	})
 
 	var stdout, stderr bytes.Buffer
-	code := runVerifyCommandWithContractsOutputForTest(context.Background(), repoRoot(), root, &stdout, &stderr)
+	code := runVerifyCommandWithContractsOutputForTest(t, context.Background(), repoRoot(), root, &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code, stdout = %q stderr = %q", stdout.String(), stderr.String())
 	}

--- a/cmd/swarm/provider_connector_tools_test.go
+++ b/cmd/swarm/provider_connector_tools_test.go
@@ -115,8 +115,7 @@ func TestProviderGuaranteeRegistryMatchesSpecAndNamesLiveProofs(t *testing.T) {
 		t.Fatalf("guarantee registry differs from authoritative platform spec:\ngot:  %#v\nwant: %#v", got, owners)
 	}
 	ownerFiles := map[string]string{
-		"internal/providertriggers.Manifest.resolveEventName":                                     "internal/providertriggers/providertriggers.go",
-		"internal/providertriggers.Manifest.Accept":                                               "internal/providertriggers/providertriggers.go",
+		"internal/providertriggers.InboundAdmissionPlan.Accept":                                   "internal/providertriggers/admission.go",
 		"internal/runtime.InboundGateway.HandleResolvedWebhook":                                   "internal/runtime/inbound.go",
 		"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent": "internal/runtime/pipeline/activity_engine.go",
 		"internal/runtime/pipeline.executePreparedActivityHTTPTool":                               "internal/runtime/pipeline/activity_engine.go",

--- a/cmd/swarm/provider_trigger_packs.go
+++ b/cmd/swarm/provider_trigger_packs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -54,49 +53,6 @@ func loadConfiguredProviderTriggerPacks(repo string, cfgResult runtimeConfigLoad
 		ExternalDirs: externalDirs,
 	}, nil
 }
-
-// loadVerifyProviderTriggerPacks keeps offline verification self-contained by
-// using the fixed release inventory when no elevated platform override exists.
-// Both sources pass through the identical required-inventory verifier.
-func loadVerifyProviderTriggerPacks(repo string, cfgResult runtimeConfigLoadResult, requireCatalog bool) (providerTriggerPackLoad, error) {
-	if cfgResult.Config == nil {
-		return providerTriggerPackLoad{}, fmt.Errorf("runtime config is required")
-	}
-	if len(cfgResult.Config.ProviderTriggers.Packs.PlatformDirs) > 0 {
-		return loadConfiguredProviderTriggerPacks(repo, cfgResult)
-	}
-	runningVersion, err := platform.PlatformVersion()
-	if err != nil {
-		return providerTriggerPackLoad{}, err
-	}
-	platformDirs := make([]string, 0, len(providertriggers.RequiredPlatformPackIdentities()))
-	present := 0
-	for _, identity := range providertriggers.RequiredPlatformPackIdentities() {
-		dir := filepath.Join(repo, "packs", "provider-triggers", identity.Provider)
-		platformDirs = append(platformDirs, dir)
-		if _, err := os.Stat(filepath.Join(dir, packs.EnvelopeFileName)); err == nil {
-			present++
-		} else if !os.IsNotExist(err) {
-			return providerTriggerPackLoad{}, fmt.Errorf("inspect default provider trigger pack %q: %w", dir, err)
-		}
-	}
-	externalDirs := resolveProviderTriggerPackDirs(repo, providerTriggerPackConfigOrigin(cfgResult, "provider_triggers.packs.external_dirs"), cfgResult.Config.ProviderTriggers.Packs.ExternalDirs)
-	if present == 0 && len(externalDirs) == 0 && !requireCatalog {
-		catalog, err := providertriggers.NewCatalogSnapshot()
-		if err != nil {
-			return providerTriggerPackLoad{}, err
-		}
-		return providerTriggerPackLoad{Catalog: catalog}, nil
-	}
-	catalog, loaded, err := providertriggers.NewCatalogSnapshotFromRequiredPlatformPackDirs(runningVersion, platformDirs, externalDirs)
-	if err != nil {
-		return providerTriggerPackLoad{}, err
-	}
-	return providerTriggerPackLoad{
-		Catalog: catalog, Loaded: loaded, PlatformDirs: platformDirs, ExternalDirs: externalDirs,
-	}, nil
-}
-
 func requiredProviderTriggerPlatformPackIDs() string {
 	identities := providertriggers.RequiredPlatformPackIdentities()
 	ids := make([]string, 0, len(identities))

--- a/cmd/swarm/provider_trigger_packs.go
+++ b/cmd/swarm/provider_trigger_packs.go
@@ -8,13 +8,24 @@ import (
 	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/platform"
 	"github.com/division-sh/swarm/internal/providertriggers"
+	"github.com/division-sh/swarm/internal/runtime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 type providerTriggerPackLoad struct {
-	Registry     *providertriggers.Registry
+	Catalog      *providertriggers.CatalogSnapshot
 	Loaded       []providertriggers.LoadedPack
 	PlatformDirs []string
 	ExternalDirs []string
+}
+
+func (l providerTriggerPackLoad) Reload() (*providertriggers.CatalogSnapshot, error) {
+	runningVersion, err := platform.PlatformVersion()
+	if err != nil {
+		return nil, err
+	}
+	catalog, _, err := providertriggers.NewCatalogSnapshotFromRequiredPlatformPackDirs(runningVersion, l.PlatformDirs, l.ExternalDirs)
+	return catalog, err
 }
 
 func loadConfiguredProviderTriggerPacks(repo string, cfgResult runtimeConfigLoadResult) (providerTriggerPackLoad, error) {
@@ -31,12 +42,12 @@ func loadConfiguredProviderTriggerPacks(repo string, cfgResult runtimeConfigLoad
 	}
 	platformDirs := resolveProviderTriggerPackDirs(repo, providerTriggerPackConfigOrigin(cfgResult, "provider_triggers.packs.platform_dirs"), configuredPlatformDirs)
 	externalDirs := resolveProviderTriggerPackDirs(repo, providerTriggerPackConfigOrigin(cfgResult, "provider_triggers.packs.external_dirs"), cfgResult.Config.ProviderTriggers.Packs.ExternalDirs)
-	registry, loaded, err := providertriggers.NewRegistryFromRequiredPlatformPackDirs(runningVersion, platformDirs, externalDirs)
+	catalog, loaded, err := providertriggers.NewCatalogSnapshotFromRequiredPlatformPackDirs(runningVersion, platformDirs, externalDirs)
 	if err != nil {
 		return providerTriggerPackLoad{}, err
 	}
 	return providerTriggerPackLoad{
-		Registry:     registry,
+		Catalog:      catalog,
 		Loaded:       loaded,
 		PlatformDirs: platformDirs,
 		ExternalDirs: externalDirs,
@@ -91,6 +102,18 @@ func appendProviderTriggerCapabilitySubjects(report *localPreflightReport, loade
 			return
 		}
 		subjects = append(subjects, subject)
+	}
+	report.addCapabilitySubjects(subjects)
+}
+
+func appendEffectiveProviderTriggerCapabilitySubjects(report *localPreflightReport, source semanticview.Source, catalog *providertriggers.CatalogSnapshot) {
+	if report == nil || source == nil || catalog == nil {
+		return
+	}
+	subjects, err := runtime.EffectiveStandingIngressCapabilitySubjects(source, catalog)
+	if err != nil {
+		report.add(localPreflightProviderPackPrerequisite, "provider_trigger_target_admission_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix the standing ingress provider admission declaration or configured trigger packs")
+		return
 	}
 	report.addCapabilitySubjects(subjects)
 }

--- a/cmd/swarm/provider_trigger_packs.go
+++ b/cmd/swarm/provider_trigger_packs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +52,48 @@ func loadConfiguredProviderTriggerPacks(repo string, cfgResult runtimeConfigLoad
 		Loaded:       loaded,
 		PlatformDirs: platformDirs,
 		ExternalDirs: externalDirs,
+	}, nil
+}
+
+// loadVerifyProviderTriggerPacks keeps offline verification self-contained by
+// using the fixed release inventory when no elevated platform override exists.
+// Both sources pass through the identical required-inventory verifier.
+func loadVerifyProviderTriggerPacks(repo string, cfgResult runtimeConfigLoadResult, requireCatalog bool) (providerTriggerPackLoad, error) {
+	if cfgResult.Config == nil {
+		return providerTriggerPackLoad{}, fmt.Errorf("runtime config is required")
+	}
+	if len(cfgResult.Config.ProviderTriggers.Packs.PlatformDirs) > 0 {
+		return loadConfiguredProviderTriggerPacks(repo, cfgResult)
+	}
+	runningVersion, err := platform.PlatformVersion()
+	if err != nil {
+		return providerTriggerPackLoad{}, err
+	}
+	platformDirs := make([]string, 0, len(providertriggers.RequiredPlatformPackIdentities()))
+	present := 0
+	for _, identity := range providertriggers.RequiredPlatformPackIdentities() {
+		dir := filepath.Join(repo, "packs", "provider-triggers", identity.Provider)
+		platformDirs = append(platformDirs, dir)
+		if _, err := os.Stat(filepath.Join(dir, packs.EnvelopeFileName)); err == nil {
+			present++
+		} else if !os.IsNotExist(err) {
+			return providerTriggerPackLoad{}, fmt.Errorf("inspect default provider trigger pack %q: %w", dir, err)
+		}
+	}
+	externalDirs := resolveProviderTriggerPackDirs(repo, providerTriggerPackConfigOrigin(cfgResult, "provider_triggers.packs.external_dirs"), cfgResult.Config.ProviderTriggers.Packs.ExternalDirs)
+	if present == 0 && len(externalDirs) == 0 && !requireCatalog {
+		catalog, err := providertriggers.NewCatalogSnapshot()
+		if err != nil {
+			return providerTriggerPackLoad{}, err
+		}
+		return providerTriggerPackLoad{Catalog: catalog}, nil
+	}
+	catalog, loaded, err := providertriggers.NewCatalogSnapshotFromRequiredPlatformPackDirs(runningVersion, platformDirs, externalDirs)
+	if err != nil {
+		return providerTriggerPackLoad{}, err
+	}
+	return providerTriggerPackLoad{
+		Catalog: catalog, Loaded: loaded, PlatformDirs: platformDirs, ExternalDirs: externalDirs,
 	}, nil
 }
 

--- a/cmd/swarm/provider_trigger_smoke_helpers_test.go
+++ b/cmd/swarm/provider_trigger_smoke_helpers_test.go
@@ -105,7 +105,7 @@ func startProviderTriggerSmokeServer(
 	if strings.TrimSpace(listenAddr) == "" {
 		listenAddr = "localhost:0"
 	}
-	gateway := runtimepkg.NewInboundGatewayWithProviderRegistry(bus, nil, nil, testProviderTriggerRegistry(t), sqliteStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
 	gateway.SetCredentialStore(providerTriggerSmokeCredentialStore{target.SigningSecret: signingSecret})
 	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec := &providerTriggerSmokeCaptureWriter{ResponseWriter: w, status: http.StatusOK}

--- a/cmd/swarm/provider_trigger_test_registry_test.go
+++ b/cmd/swarm/provider_trigger_test_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -23,11 +24,11 @@ func testProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot 
 
 func testProviderTriggerPackDirs(t *testing.T) []string {
 	t.Helper()
-	root := filepath.Join("..", "..", "packs", "provider-triggers")
-	root, err := filepath.Abs(root)
-	if err != nil {
-		t.Fatalf("resolve provider trigger pack root: %v", err)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve provider trigger test fixture source path")
 	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "packs", "provider-triggers"))
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		t.Fatalf("read provider trigger pack root: %v", err)
@@ -61,4 +62,11 @@ func withTestProviderTriggerPlatformInventory(t *testing.T, configText string) s
 		lines = append(lines, fmt.Sprintf("      - %q", dir))
 	}
 	return strings.TrimRight(configText, "\n") + "\n" + strings.Join(lines, "\n") + "\n"
+}
+
+func writeTestVerifyRuntimeConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "verify-runtime.yaml")
+	writeRuntimeConfigText(t, path, withTestProviderTriggerPlatformInventory(t, "llm:\n  backend: anthropic\n"))
+	return path
 }

--- a/cmd/swarm/provider_trigger_test_registry_test.go
+++ b/cmd/swarm/provider_trigger_test_registry_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/division-sh/swarm/internal/providertriggers"
 )
 
-func testProviderTriggerRegistry(t *testing.T) *providertriggers.Registry {
+func testProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot {
 	t.Helper()
 	dirs := testProviderTriggerPackDirs(t)
-	registry, _, err := providertriggers.NewRegistryFromPackDirs("0.7.0", dirs, nil)
+	registry, _, err := providertriggers.NewCatalogSnapshotFromPackDirs("0.7.0", dirs, nil)
 	if err != nil {
 		t.Fatalf("load provider trigger registry: %v", err)
 	}
@@ -42,9 +42,9 @@ func testProviderTriggerPackDirs(t *testing.T) []string {
 	return dirs
 }
 
-func emptyProviderTriggerRegistry(t *testing.T) *providertriggers.Registry {
+func emptyProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot {
 	t.Helper()
-	registry, err := providertriggers.NewRegistry()
+	registry, err := providertriggers.NewCatalogSnapshot()
 	if err != nil {
 		t.Fatalf("create empty provider trigger registry: %v", err)
 	}

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -671,7 +671,7 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwne
 			SelfCheck:               true,
 			WorkflowModule:          stubWorkflowModule{source: semanticview.Wrap(bundle)},
 			LLMRuntime:              storeBackendSelectionNoopLLMRuntime{},
-			ProviderTriggerRegistry: testProviderTriggerRegistry(t),
+			ProviderTriggerCatalog: testProviderTriggerCatalog(t),
 		},
 	})
 	if err != nil {

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -668,9 +668,9 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwne
 		Config: &config.Config{},
 		Stores: runtimeStores,
 		Options: runtime.RuntimeOptions{
-			SelfCheck:               true,
-			WorkflowModule:          stubWorkflowModule{source: semanticview.Wrap(bundle)},
-			LLMRuntime:              storeBackendSelectionNoopLLMRuntime{},
+			SelfCheck:              true,
+			WorkflowModule:         stubWorkflowModule{source: semanticview.Wrap(bundle)},
+			LLMRuntime:             storeBackendSelectionNoopLLMRuntime{},
 			ProviderTriggerCatalog: testProviderTriggerCatalog(t),
 		},
 	})

--- a/internal/packs/capability_surface.go
+++ b/internal/packs/capability_surface.go
@@ -61,19 +61,39 @@ const (
 )
 
 type Subject struct {
-	ID            string        `json:"id"`
-	Kind          SubjectKind   `json:"kind"`
-	Provider      string        `json:"provider"`
-	Action        string        `json:"action,omitempty"`
-	Source        string        `json:"source"`
-	Provenance    string        `json:"provenance,omitempty"`
-	SourcePath    string        `json:"source_path,omitempty"`
-	Applicability string        `json:"applicability"`
-	Status        SubjectStatus `json:"status"`
-	Capabilities  []Capability  `json:"capabilities,omitempty"`
-	Guarantees    []Guarantee   `json:"guarantees,omitempty"`
-	Requirements  []Requirement `json:"requirements,omitempty"`
-	Evidence      []Evidence    `json:"evidence,omitempty"`
+	ID               string            `json:"id"`
+	Kind             SubjectKind       `json:"kind"`
+	Provider         string            `json:"provider"`
+	Action           string            `json:"action,omitempty"`
+	Source           string            `json:"source"`
+	Provenance       string            `json:"provenance,omitempty"`
+	SourcePath       string            `json:"source_path,omitempty"`
+	Applicability    string            `json:"applicability"`
+	Status           SubjectStatus     `json:"status"`
+	Capabilities     []Capability      `json:"capabilities,omitempty"`
+	Guarantees       []Guarantee       `json:"guarantees,omitempty"`
+	Requirements     []Requirement     `json:"requirements,omitempty"`
+	Evidence         []Evidence        `json:"evidence,omitempty"`
+	TriggerAdmission *TriggerAdmission `json:"trigger_admission,omitempty"`
+}
+
+type TriggerAdmission struct {
+	BundleHash            string               `json:"bundle_hash"`
+	Alias                 string               `json:"alias"`
+	CatalogGeneration     string               `json:"catalog_generation"`
+	PolicySource          string               `json:"policy_source"`
+	RequestAuthentication string               `json:"request_authentication"`
+	Event                 string               `json:"event"`
+	SignedPayload         string               `json:"signed_payload,omitempty"`
+	DigestEncoding        string               `json:"digest_encoding,omitempty"`
+	Pack                  *TriggerPackIdentity `json:"pack,omitempty"`
+}
+
+type TriggerPackIdentity struct {
+	ID           string `json:"id"`
+	Version      string `json:"version"`
+	ManifestHash string `json:"manifest_hash"`
+	Provenance   string `json:"provenance"`
 }
 
 type Capability struct {
@@ -115,8 +135,8 @@ type Evidence struct {
 var guaranteeRegistry = map[string]struct {
 	enforcedBy string
 }{
-	GuaranteeEmitDeclaredEventsOnly: {"internal/providertriggers.Manifest.resolveEventName"},
-	GuaranteeAdmissionBeforeCode:    {"internal/providertriggers.Manifest.Accept"},
+	GuaranteeEmitDeclaredEventsOnly: {"internal/providertriggers.InboundAdmissionPlan.Accept"},
+	GuaranteeAdmissionBeforeCode:    {"internal/providertriggers.InboundAdmissionPlan.Accept"},
 	GuaranteeBoundResourcesOnly:     {"internal/runtime.InboundGateway.HandleResolvedWebhook"},
 	GuaranteeActivityJournal:        {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
 	GuaranteeNoAutomaticWriteRetry:  {"internal/runtime/pipeline.pipelineActivityDispatcher.executeNonIdempotentActivityIntent"},
@@ -237,7 +257,7 @@ func requirementRemediation(kind, name, status string) string {
 }
 
 func NormalizeSubjects(subjects []Subject) ([]Subject, error) {
-	out := append([]Subject(nil), subjects...)
+	out := CloneSubjects(subjects)
 	for i := range out {
 		if err := normalizeSubject(&out[i]); err != nil {
 			return nil, err
@@ -255,6 +275,54 @@ func NormalizeSubjects(subjects []Subject) ([]Subject, error) {
 		}
 	}
 	return out, nil
+}
+
+func CloneSubjects(subjects []Subject) []Subject {
+	out := make([]Subject, len(subjects))
+	for i, subject := range subjects {
+		out[i] = subject
+		out[i].Capabilities = append([]Capability(nil), subject.Capabilities...)
+		out[i].Guarantees = append([]Guarantee(nil), subject.Guarantees...)
+		out[i].Requirements = make([]Requirement, len(subject.Requirements))
+		for j, requirement := range subject.Requirements {
+			out[i].Requirements[j] = requirement
+			out[i].Requirements[j].Scopes = append([]string(nil), requirement.Scopes...)
+			if requirement.Satisfied != nil {
+				value := *requirement.Satisfied
+				out[i].Requirements[j].Satisfied = &value
+			}
+			if requirement.TokenRequest != nil {
+				profile := *requirement.TokenRequest
+				profile.StaticHeaders = cloneStringMap(requirement.TokenRequest.StaticHeaders)
+				out[i].Requirements[j].TokenRequest = &profile
+			}
+		}
+		out[i].Evidence = make([]Evidence, len(subject.Evidence))
+		for j, evidence := range subject.Evidence {
+			out[i].Evidence[j] = evidence
+			out[i].Evidence[j].Fields = cloneStringMap(evidence.Fields)
+		}
+		if subject.TriggerAdmission != nil {
+			admission := *subject.TriggerAdmission
+			if subject.TriggerAdmission.Pack != nil {
+				identity := *subject.TriggerAdmission.Pack
+				admission.Pack = &identity
+			}
+			out[i].TriggerAdmission = &admission
+		}
+	}
+	return out
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func normalizeSubject(subject *Subject) error {
@@ -284,15 +352,10 @@ func normalizeSubject(subject *Subject) error {
 	var derivedStatus SubjectStatus
 	switch subject.Kind {
 	case SubjectProviderTrigger:
-		if subject.Source != "trigger_pack" || subject.Applicability != "installed" {
-			return fmt.Errorf("provider trigger subject %q must use trigger_pack/installed applicability", subject.ID)
+		if err := normalizeProviderTriggerSubject(subject); err != nil {
+			return err
 		}
 		derivedStatus = StatusAvailable
-		for _, requirement := range subject.Requirements {
-			if requirement.Scope != RequirementScopeTarget || requirement.Satisfied != nil || requirement.Status != "" || requirement.Remediation != "" {
-				return fmt.Errorf("provider trigger subject %q requirement %q must remain target-scoped and unevaluated", subject.ID, requirement.Name)
-			}
-		}
 	case SubjectProviderConnector:
 		switch subject.Applicability {
 		case "installed":
@@ -368,6 +431,77 @@ func normalizeSubject(subject *Subject) error {
 	return nil
 }
 
+func normalizeProviderTriggerSubject(subject *Subject) error {
+	switch subject.Applicability {
+	case "installed":
+		if subject.Source != "trigger_pack" || subject.TriggerAdmission != nil {
+			return fmt.Errorf("installed provider trigger subject %q must use trigger_pack source and must not carry target admission", subject.ID)
+		}
+	case "effective":
+		if subject.Source != "trigger_pack_binding" && subject.Source != "raw_declaration" {
+			return fmt.Errorf("effective provider trigger subject %q has invalid source %q", subject.ID, subject.Source)
+		}
+		if subject.TriggerAdmission == nil {
+			return fmt.Errorf("effective provider trigger subject %q requires typed trigger_admission", subject.ID)
+		}
+		admission := subject.TriggerAdmission
+		admission.BundleHash = strings.TrimSpace(admission.BundleHash)
+		admission.Alias = strings.Trim(strings.TrimSpace(admission.Alias), "/")
+		admission.CatalogGeneration = strings.TrimSpace(admission.CatalogGeneration)
+		admission.PolicySource = strings.TrimSpace(admission.PolicySource)
+		admission.RequestAuthentication = strings.TrimSpace(admission.RequestAuthentication)
+		admission.Event = strings.TrimSpace(admission.Event)
+		admission.SignedPayload = strings.TrimSpace(admission.SignedPayload)
+		admission.DigestEncoding = strings.TrimSpace(admission.DigestEncoding)
+		if admission.BundleHash == "" || admission.Alias == "" || admission.CatalogGeneration == "" || admission.Event == "" {
+			return fmt.Errorf("effective provider trigger subject %q requires bundle_hash, alias, catalog_generation, and event", subject.ID)
+		}
+		wantID := "ingress:" + admission.BundleHash + ":" + admission.Alias + ":" + subject.Provider
+		if subject.ID != wantID {
+			return fmt.Errorf("effective provider trigger subject %q must use stable target id %q", subject.ID, wantID)
+		}
+		if admission.PolicySource != "verified_pack" && admission.PolicySource != "raw_declaration" {
+			return fmt.Errorf("effective provider trigger subject %q has invalid policy_source %q", subject.ID, admission.PolicySource)
+		}
+		allowedAuth := map[string]bool{"TOKEN_EQUALITY": true, "TOKEN": true, "HMAC_SHA256": true, "HMAC_SHA1": true, "UNAUTHENTICATED": true}
+		if !allowedAuth[admission.RequestAuthentication] {
+			return fmt.Errorf("effective provider trigger subject %q has invalid request_authentication %q", subject.ID, admission.RequestAuthentication)
+		}
+		if admission.PolicySource == "verified_pack" {
+			if subject.Source != "trigger_pack_binding" || admission.Pack == nil {
+				return fmt.Errorf("effective verified-pack trigger subject %q requires trigger_pack_binding source and pack identity", subject.ID)
+			}
+			pack := admission.Pack
+			pack.ID = strings.TrimSpace(pack.ID)
+			pack.Version = strings.TrimSpace(pack.Version)
+			pack.ManifestHash = strings.TrimSpace(pack.ManifestHash)
+			pack.Provenance = strings.TrimSpace(pack.Provenance)
+			if pack.ID == "" || pack.Version == "" || pack.ManifestHash == "" || pack.Provenance == "" {
+				return fmt.Errorf("effective verified-pack trigger subject %q has incomplete pack identity", subject.ID)
+			}
+		} else if subject.Source != "raw_declaration" || admission.Pack != nil {
+			return fmt.Errorf("effective raw trigger subject %q must use raw_declaration source without pack identity", subject.ID)
+		}
+	default:
+		return fmt.Errorf("provider trigger subject %q has invalid applicability %q", subject.ID, subject.Applicability)
+	}
+	for _, requirement := range subject.Requirements {
+		if requirement.Scope != RequirementScopeTarget || requirement.Satisfied != nil || requirement.Status != "" || requirement.Remediation != "" {
+			return fmt.Errorf("provider trigger subject %q requirement %q must remain target-scoped and unevaluated", subject.ID, requirement.Name)
+		}
+	}
+	if subject.Applicability == "effective" {
+		unauthenticated := subject.TriggerAdmission.RequestAuthentication == "UNAUTHENTICATED"
+		if unauthenticated && len(subject.Requirements) != 0 {
+			return fmt.Errorf("effective unauthenticated provider trigger subject %q must not carry secret requirements", subject.ID)
+		}
+		if !unauthenticated && len(subject.Requirements) != 1 {
+			return fmt.Errorf("effective authenticated provider trigger subject %q must carry exactly one unevaluated secret requirement", subject.ID)
+		}
+	}
+	return nil
+}
+
 func validateConnectorRequirement(subjectID string, requirement Requirement) error {
 	if requirement.Satisfied == nil || requirement.Status == "" {
 		return fmt.Errorf("provider connector subject %q requirement %q must be evaluated", subjectID, requirement.Name)
@@ -406,6 +540,19 @@ func RenderSubject(subject Subject, verbose bool) string {
 	}
 	if subject.SourcePath != "" {
 		parts = append(parts, "source_path="+subject.SourcePath)
+	}
+	if subject.TriggerAdmission != nil {
+		admission := subject.TriggerAdmission
+		parts = append(parts,
+			"alias="+admission.Alias,
+			"policy_source="+admission.PolicySource,
+			"request_authentication="+admission.RequestAuthentication,
+			"event="+admission.Event,
+			"catalog_generation="+admission.CatalogGeneration,
+		)
+		if admission.Pack != nil {
+			parts = append(parts, "pack="+admission.Pack.ID+"@"+admission.Pack.Version+" manifest_hash="+admission.Pack.ManifestHash)
+		}
 	}
 	for _, requirement := range subject.Requirements {
 		parts = append(parts, renderRequirement(requirement))

--- a/internal/packs/capability_surface_test.go
+++ b/internal/packs/capability_surface_test.go
@@ -1,6 +1,7 @@
 package packs
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -18,6 +19,51 @@ func TestNormalizeSubjectsRejectsGlobalTriggerReadiness(t *testing.T) {
 	subject.Requirements = []Requirement{RequirementWithStatus(RequirementSecret, "webhook_signing.stripe", RequirementScopeTarget, "BOUND", "credential_store")}
 	if _, err := NormalizeSubjects([]Subject{subject}); err == nil || !strings.Contains(err.Error(), "target-scoped and unevaluated") {
 		t.Fatalf("NormalizeSubjects error = %v, want evaluated trigger requirement rejection", err)
+	}
+}
+
+func TestNormalizeSubjectsOwnsEffectiveTriggerAdmissionShape(t *testing.T) {
+	bundleHash := "bundle-v1:sha256:" + strings.Repeat("a", 64)
+	base := Subject{
+		ID: "ingress:" + bundleHash + ":chat:acme", Kind: SubjectProviderTrigger, Provider: "acme",
+		Source: "trigger_pack_binding", Provenance: "external", Applicability: "effective",
+		TriggerAdmission: &TriggerAdmission{
+			BundleHash: bundleHash, Alias: "chat", CatalogGeneration: strings.Repeat("b", 64),
+			PolicySource: "verified_pack", RequestAuthentication: "TOKEN_EQUALITY", Event: "inbound.acme",
+			Pack: &TriggerPackIdentity{ID: "provider.acme", Version: "1.0.0", ManifestHash: "sha256:" + strings.Repeat("c", 64), Provenance: "external"},
+		},
+		Requirements: []Requirement{TargetScopedRequirement(RequirementSecret, "webhook_signing.acme")},
+	}
+	normalized, err := NormalizeSubjects([]Subject{base})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized[0].Status != StatusAvailable {
+		t.Fatalf("effective trigger status = %q, want AVAILABLE until target binding readback", normalized[0].Status)
+	}
+
+	invalid := base
+	invalid.Source = "raw_declaration"
+	if _, err := NormalizeSubjects([]Subject{invalid}); err == nil || !strings.Contains(err.Error(), "trigger_pack_binding source") {
+		t.Fatalf("pack/source mismatch error = %v", err)
+	}
+	invalid = base
+	invalid.TriggerAdmission = &TriggerAdmission{
+		BundleHash: bundleHash, Alias: "chat", CatalogGeneration: strings.Repeat("b", 64),
+		PolicySource: "raw_declaration", RequestAuthentication: "UNAUTHENTICATED", Event: "inbound.acme",
+	}
+	invalid.Source = "raw_declaration"
+	invalid.Requirements = base.Requirements
+	if _, err := NormalizeSubjects([]Subject{invalid}); err == nil || !strings.Contains(err.Error(), "must not carry secret requirements") {
+		t.Fatalf("unsigned requirement error = %v", err)
+	}
+	invalid.Requirements = nil
+	normalized, err = NormalizeSubjects([]Subject{invalid})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rendered := RenderSubject(normalized[0], false); !strings.Contains(rendered, "request_authentication=UNAUTHENTICATED") || !strings.Contains(rendered, "policy_source=raw_declaration") {
+		t.Fatalf("unauthenticated trigger readback = %q", rendered)
 	}
 }
 
@@ -135,5 +181,54 @@ func TestNormalizeSubjectsOrdersDeterministicallyAndRejectsDuplicates(t *testing
 	}
 	if _, err := NormalizeSubjects(append(items, items[0])); err == nil || !strings.Contains(err.Error(), "duplicate capability subject") {
 		t.Fatalf("duplicate error = %v", err)
+	}
+}
+
+func TestCloneSubjectsDoesNotExposeNestedCapabilityState(t *testing.T) {
+	satisfied := true
+	original := []Subject{{
+		ID: "ingress:bundle:chat:acme", Kind: SubjectProviderTrigger, Provider: "acme",
+		Source: "trigger_pack_binding", Applicability: "effective",
+		TriggerAdmission: &TriggerAdmission{Pack: &TriggerPackIdentity{ID: "provider.acme"}},
+		Requirements:     []Requirement{{Satisfied: &satisfied, Scopes: []string{"write"}, TokenRequest: &TokenRequestProfile{StaticHeaders: map[string]string{"Version": "1"}}}},
+		Evidence:         []Evidence{{Fields: map[string]string{"generation": "old"}}},
+	}}
+	cloned := CloneSubjects(original)
+	cloned[0].TriggerAdmission.Pack.ID = "mutated"
+	cloned[0].Requirements[0].Scopes[0] = "mutated"
+	cloned[0].Requirements[0].TokenRequest.StaticHeaders["Version"] = "2"
+	cloned[0].Evidence[0].Fields["generation"] = "new"
+	*cloned[0].Requirements[0].Satisfied = false
+	if original[0].TriggerAdmission.Pack.ID != "provider.acme" || original[0].Requirements[0].Scopes[0] != "write" || original[0].Requirements[0].TokenRequest.StaticHeaders["Version"] != "1" || original[0].Evidence[0].Fields["generation"] != "old" || !*original[0].Requirements[0].Satisfied {
+		t.Fatalf("CloneSubjects exposed nested state: %#v", original[0])
+	}
+}
+
+func TestEffectiveTriggerTextAndJSONProjectTheSameTypedFacts(t *testing.T) {
+	bundleHash := "bundle-v1:sha256:" + strings.Repeat("d", 64)
+	subject := Subject{
+		ID: "ingress:" + bundleHash + ":chat:acme", Kind: SubjectProviderTrigger, Provider: "acme",
+		Source: "trigger_pack_binding", Provenance: "external", Applicability: "effective",
+		TriggerAdmission: &TriggerAdmission{
+			BundleHash: bundleHash, Alias: "chat", CatalogGeneration: strings.Repeat("e", 64),
+			PolicySource: "verified_pack", RequestAuthentication: "HMAC_SHA256", Event: "inbound.acme",
+			SignedPayload: "raw_body", DigestEncoding: "base64",
+			Pack: &TriggerPackIdentity{ID: "provider.acme", Version: "1.2.3", ManifestHash: "sha256:" + strings.Repeat("f", 64), Provenance: "external"},
+		},
+		Requirements: []Requirement{TargetScopedRequirement(RequirementSecret, "webhook_signing.acme")},
+	}
+	normalized, err := NormalizeSubjects([]Subject{subject})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(normalized[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := RenderSubject(normalized[0], false)
+	for _, value := range []string{"chat", "verified_pack", "HMAC_SHA256", "inbound.acme", strings.Repeat("e", 64), "provider.acme", "1.2.3", "webhook_signing.acme"} {
+		if !strings.Contains(string(body), value) || !strings.Contains(text, value) {
+			t.Fatalf("typed fact %q missing from JSON or text\njson=%s\ntext=%s", value, body, text)
+		}
 	}
 }

--- a/internal/providertriggers/admission.go
+++ b/internal/providertriggers/admission.go
@@ -453,7 +453,13 @@ func (p InboundAdmissionPlan) acceptExplicitRaw(req Request) (Delivery, error) {
 	} else {
 		parsed = string(req.Body)
 	}
-	deliveryID, err := rawDeliveryID(policy.DeliveryID, req.Headers, parsed, req.Body)
+	deliverySource := parsed
+	if policy.DeliveryID.Source == "json_path" && policy.Payload == "raw" {
+		if err := json.Unmarshal(req.Body, &deliverySource); err != nil {
+			return Delivery{}, badRequest("raw webhook delivery id JSON path requires a valid JSON request body")
+		}
+	}
+	deliveryID, err := rawDeliveryID(policy.DeliveryID, req.Headers, deliverySource, req.Body)
 	if err != nil {
 		return Delivery{}, err
 	}

--- a/internal/providertriggers/admission.go
+++ b/internal/providertriggers/admission.go
@@ -1,0 +1,532 @@
+package providertriggers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/packs"
+)
+
+type AdmissionKind string
+
+const (
+	AdmissionKindPack AdmissionKind = "pack"
+	AdmissionKindRaw  AdmissionKind = "raw"
+)
+
+type PolicySource string
+
+const (
+	PolicySourceVerifiedPack   PolicySource = "verified_pack"
+	PolicySourceRawDeclaration PolicySource = "raw_declaration"
+)
+
+type RequestAuthentication string
+
+const (
+	RequestAuthenticationTokenEquality RequestAuthentication = "TOKEN_EQUALITY"
+	RequestAuthenticationToken         RequestAuthentication = "TOKEN"
+	RequestAuthenticationHMACSHA256    RequestAuthentication = "HMAC_SHA256"
+	RequestAuthenticationHMACSHA1      RequestAuthentication = "HMAC_SHA1"
+	RequestAuthenticationNone          RequestAuthentication = "UNAUTHENTICATED"
+)
+
+const UnsignedWebhookAcknowledgement = "unsigned_webhook"
+
+type AdmissionDeclaration struct {
+	Kind           string
+	PackID         string
+	Acknowledge    string
+	Authentication RawAuthenticationDeclaration
+	Event          string
+	DeliveryID     RawDeliveryIDDeclaration
+	Payload        string
+}
+
+type RawAuthenticationDeclaration struct {
+	Kind     string
+	Header   string
+	Prefix   string
+	Encoding string
+}
+
+type RawDeliveryIDDeclaration struct {
+	Source   string
+	Header   string
+	JSONPath string
+}
+
+type CompileAdmissionRequest struct {
+	Alias         string
+	Provider      string
+	SigningSecret string
+	Declaration   AdmissionDeclaration
+}
+
+type RawAdmissionPolicy struct {
+	Authentication RawAuthenticationDeclaration
+	Event          string
+	DeliveryID     RawDeliveryIDDeclaration
+	Payload        string
+}
+
+type InboundAdmissionPlan struct {
+	generationID          string
+	provider              string
+	policySource          PolicySource
+	requestAuthentication RequestAuthentication
+	packIdentity          *PackIdentity
+	manifest              *Manifest
+	raw                   *RawAdmissionPolicy
+	requiresSecret        bool
+	eventNames            EventNameManifest
+	acknowledgedUnsigned  bool
+}
+
+func (s *CatalogSnapshot) CompileAdmission(req CompileAdmissionRequest) (InboundAdmissionPlan, error) {
+	alias := strings.Trim(strings.TrimSpace(req.Alias), "/")
+	provider := NormalizeProviderName(req.Provider)
+	if alias == "" || provider == "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress admission requires alias and provider")
+	}
+	if s == nil {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q cannot compile admission: provider trigger catalog snapshot is required", alias, provider)
+	}
+	kind := strings.ToLower(strings.TrimSpace(req.Declaration.Kind))
+	if kind == "" {
+		kind = string(AdmissionKindPack)
+	}
+	switch AdmissionKind(kind) {
+	case AdmissionKindPack:
+		return s.compilePackAdmission(alias, provider, strings.TrimSpace(req.SigningSecret), req.Declaration)
+	case AdmissionKindRaw:
+		return s.compileRawAdmission(alias, provider, strings.TrimSpace(req.SigningSecret), req.Declaration)
+	default:
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q admission.kind must be pack or raw; got %q", alias, provider, req.Declaration.Kind)
+	}
+}
+
+func (s *CatalogSnapshot) compilePackAdmission(alias, provider, signingSecret string, declaration AdmissionDeclaration) (InboundAdmissionPlan, error) {
+	if s == nil {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q cannot compile pack-required admission: provider trigger catalog snapshot is required", alias, provider)
+	}
+	if hasRawFields(declaration) {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q uses pack admission and must not declare authentication, event, delivery_id, or payload; remove raw-only fields", alias, provider)
+	}
+	var (
+		entry CatalogEntry
+		ok    bool
+	)
+	if pin := strings.TrimSpace(declaration.PackID); pin != "" {
+		entry, ok = s.EntryByID(pin)
+		if !ok {
+			if installed, exists := s.EntryByProvider(provider); exists {
+				return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q pins pack %q, but that id is not loaded; verified pack for %q is %q; fix admission.pack.id or provider_triggers.packs.*", alias, provider, pin, provider, installed.Identity.ID)
+			}
+			return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q pins pack %q, but that id is not loaded; fix admission.pack.id or provider_triggers.packs.*", alias, provider, pin)
+		}
+		entryProvider := NormalizeProviderName(entry.Manifest.Provider)
+		if entryProvider != provider {
+			return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q pins pack %q, which provides %q; use a pack for %q or change provider to %q", alias, provider, pin, entryProvider, provider, entryProvider)
+		}
+	} else {
+		entry, ok = s.EntryByProvider(provider)
+		if !ok {
+			return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q is pack-required, but no verified trigger pack provides %q; configure that pack in provider_triggers.packs.external_dirs, or declare admission.kind: raw with an explicit raw policy", alias, provider, provider)
+		}
+	}
+	auth, err := manifestRequestAuthentication(entry.Manifest)
+	if err != nil {
+		return InboundAdmissionPlan{}, err
+	}
+	ack := strings.TrimSpace(declaration.Acknowledge)
+	if err := validateAcknowledgement(alias, provider, auth, ack, true); err != nil {
+		return InboundAdmissionPlan{}, err
+	}
+	requiresSecret := auth != RequestAuthenticationNone
+	if requiresSecret && signingSecret == "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q requires signing_secret for %s request authentication", alias, provider, auth)
+	}
+	if !requiresSecret && signingSecret != "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q is UNAUTHENTICATED and must not declare signing_secret; remove signing_secret", alias, provider)
+	}
+	manifest := entry.Manifest
+	identity := entry.Identity
+	return InboundAdmissionPlan{
+		generationID: s.GenerationID(), provider: provider, policySource: PolicySourceVerifiedPack,
+		requestAuthentication: auth, packIdentity: &identity, manifest: &manifest,
+		requiresSecret: requiresSecret, eventNames: manifest.EventName,
+		acknowledgedUnsigned: ack == UnsignedWebhookAcknowledgement,
+	}, nil
+}
+
+func (s *CatalogSnapshot) compileRawAdmission(alias, provider, signingSecret string, declaration AdmissionDeclaration) (InboundAdmissionPlan, error) {
+	if strings.TrimSpace(declaration.PackID) != "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("raw ingress alias %q provider %q must not pin a pack; remove admission.pack", alias, provider)
+	}
+	if s != nil {
+		if entry, exists := s.EntryByProvider(provider); exists {
+			return InboundAdmissionPlan{}, fmt.Errorf("raw ingress alias %q provider %q conflicts with installed pack %q; use pack admission or rename the intentional raw namespace to %q", alias, provider, entry.Identity.ID, provider+"-raw")
+		}
+	}
+	policy, auth, err := compileRawPolicy(alias, provider, declaration)
+	if err != nil {
+		return InboundAdmissionPlan{}, err
+	}
+	ack := strings.TrimSpace(declaration.Acknowledge)
+	if err := validateAcknowledgement(alias, provider, auth, ack, false); err != nil {
+		return InboundAdmissionPlan{}, err
+	}
+	requiresSecret := auth != RequestAuthenticationNone
+	if requiresSecret && signingSecret == "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q requires signing_secret for %s request authentication", alias, provider, auth)
+	}
+	if !requiresSecret && signingSecret != "" {
+		return InboundAdmissionPlan{}, fmt.Errorf("ingress alias %q provider %q is UNAUTHENTICATED and must not declare signing_secret; remove signing_secret", alias, provider)
+	}
+	generationID := ""
+	if s != nil {
+		generationID = s.GenerationID()
+	}
+	return InboundAdmissionPlan{
+		generationID: generationID, provider: provider, policySource: PolicySourceRawDeclaration,
+		requestAuthentication: auth, raw: &policy, requiresSecret: requiresSecret,
+		eventNames: EventNameManifest{Literal: policy.Event}, acknowledgedUnsigned: ack == UnsignedWebhookAcknowledgement,
+	}, nil
+}
+
+func hasRawFields(declaration AdmissionDeclaration) bool {
+	return strings.TrimSpace(declaration.Authentication.Kind) != "" || strings.TrimSpace(declaration.Authentication.Header) != "" ||
+		strings.TrimSpace(declaration.Authentication.Prefix) != "" || strings.TrimSpace(declaration.Authentication.Encoding) != "" ||
+		strings.TrimSpace(declaration.Event) != "" || strings.TrimSpace(declaration.DeliveryID.Source) != "" ||
+		strings.TrimSpace(declaration.DeliveryID.Header) != "" || strings.TrimSpace(declaration.DeliveryID.JSONPath) != "" ||
+		strings.TrimSpace(declaration.Payload) != ""
+}
+
+func manifestRequestAuthentication(manifest Manifest) (RequestAuthentication, error) {
+	switch strings.TrimSpace(manifest.Signature.Type) {
+	case signatureTypeTokenEquality:
+		return RequestAuthenticationTokenEquality, nil
+	case signatureTypeHMACSHA256:
+		return RequestAuthenticationHMACSHA256, nil
+	case signatureTypeHMACSHA1:
+		return RequestAuthenticationHMACSHA1, nil
+	case "":
+		return RequestAuthenticationNone, nil
+	default:
+		return "", fmt.Errorf("provider trigger manifest %q has unsupported request authentication %q", NormalizeProviderName(manifest.Provider), manifest.Signature.Type)
+	}
+}
+
+func validateAcknowledgement(alias, provider string, auth RequestAuthentication, acknowledge string, pack bool) error {
+	if acknowledge != "" && acknowledge != UnsignedWebhookAcknowledgement {
+		return fmt.Errorf("ingress alias %q provider %q admission.acknowledge must be %q when present; remove it or use the canonical token", alias, provider, UnsignedWebhookAcknowledgement)
+	}
+	if auth != RequestAuthenticationNone && acknowledge != "" {
+		return fmt.Errorf("ingress alias %q provider %q acknowledges unsigned_webhook, but the compiled admission uses %s; remove admission.acknowledge", alias, provider, auth)
+	}
+	if pack && auth == RequestAuthenticationNone && acknowledge == "" {
+		return fmt.Errorf("ingress alias %q provider %q resolves an unauthenticated verified pack; add admission.acknowledge: unsigned_webhook to authorize this public endpoint, or install an authenticated pack", alias, provider)
+	}
+	return nil
+}
+
+func compileRawPolicy(alias, provider string, declaration AdmissionDeclaration) (RawAdmissionPolicy, RequestAuthentication, error) {
+	auth := declaration.Authentication
+	auth.Kind = strings.ToLower(strings.TrimSpace(auth.Kind))
+	auth.Header = http.CanonicalHeaderKey(strings.TrimSpace(auth.Header))
+	auth.Encoding = strings.ToLower(strings.TrimSpace(auth.Encoding))
+	var projected RequestAuthentication
+	switch auth.Kind {
+	case "none":
+		projected = RequestAuthenticationNone
+		if auth.Header != "" || auth.Prefix != "" || auth.Encoding != "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q authentication.kind none must not declare header, prefix, or encoding", alias, provider)
+		}
+	case "token":
+		projected = RequestAuthenticationToken
+		if auth.Header == "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.authentication.header for token authentication", alias, provider)
+		}
+		if auth.Encoding != "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q token authentication must not declare encoding", alias, provider)
+		}
+	case "hmac_sha256":
+		projected = RequestAuthenticationHMACSHA256
+		if auth.Header == "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.authentication.header for hmac_sha256 authentication", alias, provider)
+		}
+		if auth.Encoding == "" {
+			auth.Encoding = "hex"
+		}
+		if auth.Encoding != "hex" && auth.Encoding != "base64" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q admission.authentication.encoding must be hex or base64", alias, provider)
+		}
+	default:
+		return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.authentication.kind: none, token, or hmac_sha256", alias, provider)
+	}
+	event := strings.TrimSpace(declaration.Event)
+	if event == "" {
+		return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.event; add the exact literal event name", alias, provider)
+	}
+	delivery := declaration.DeliveryID
+	delivery.Source = strings.ToLower(strings.TrimSpace(delivery.Source))
+	delivery.Header = http.CanonicalHeaderKey(strings.TrimSpace(delivery.Header))
+	switch delivery.Source {
+	case "header":
+		if delivery.Header == "" || strings.TrimSpace(delivery.JSONPath) != "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q delivery_id source header requires header and forbids json_path", alias, provider)
+		}
+	case "json_path":
+		if strings.TrimSpace(delivery.JSONPath) == "" || delivery.Header != "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q delivery_id source json_path requires json_path and forbids header", alias, provider)
+		}
+		if err := validateJSONPath(provider, "raw delivery_id.json_path", delivery.JSONPath); err != nil {
+			return RawAdmissionPolicy{}, "", err
+		}
+	case "body_sha256":
+		if delivery.Header != "" || strings.TrimSpace(delivery.JSONPath) != "" {
+			return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q delivery_id source body_sha256 forbids header and json_path", alias, provider)
+		}
+	default:
+		return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.delivery_id.source: header, json_path, or body_sha256", alias, provider)
+	}
+	payload := strings.ToLower(strings.TrimSpace(declaration.Payload))
+	if payload != "json" && payload != "raw" {
+		return RawAdmissionPolicy{}, "", fmt.Errorf("raw ingress alias %q provider %q requires admission.payload: json or raw", alias, provider)
+	}
+	return RawAdmissionPolicy{Authentication: auth, Event: event, DeliveryID: delivery, Payload: payload}, projected, nil
+}
+
+func (p InboundAdmissionPlan) Valid() bool {
+	return p.provider != "" && p.generationID != "" && (p.manifest != nil || p.raw != nil)
+}
+
+func (p InboundAdmissionPlan) GenerationID() string       { return p.generationID }
+func (p InboundAdmissionPlan) Provider() string           { return p.provider }
+func (p InboundAdmissionPlan) PolicySource() PolicySource { return p.policySource }
+func (p InboundAdmissionPlan) RequestAuthentication() RequestAuthentication {
+	return p.requestAuthentication
+}
+func (p InboundAdmissionPlan) RequiresSecret() bool          { return p.requiresSecret }
+func (p InboundAdmissionPlan) EventNames() EventNameManifest { return p.eventNames }
+func (p InboundAdmissionPlan) PackIdentity() (PackIdentity, bool) {
+	if p.packIdentity == nil {
+		return PackIdentity{}, false
+	}
+	return *p.packIdentity, true
+}
+func (p InboundAdmissionPlan) AcknowledgedUnsigned() bool { return p.acknowledgedUnsigned }
+
+type EffectiveSubjectRequest struct {
+	BundleHash    string
+	Alias         string
+	SigningSecret string
+	SourcePath    string
+}
+
+func (s *CatalogSnapshot) InstalledCapabilitySubjects() ([]packs.Subject, error) {
+	entries := s.Entries()
+	subjects := make([]packs.Subject, 0, len(entries))
+	for _, entry := range entries {
+		loaded := LoadedPack{
+			Envelope: packs.Envelope{
+				ID: entry.Identity.ID, Version: entry.Identity.Version, ManifestHash: entry.Identity.ManifestHash,
+				Provenance: packs.Provenance{Source: entry.Identity.Provenance},
+			},
+			Manifest: entry.Manifest, SourcePath: entry.SourcePath, Source: entry.Source,
+		}
+		subject, err := loaded.CapabilitySubject()
+		if err != nil {
+			return nil, err
+		}
+		subjects = append(subjects, subject)
+	}
+	return packs.NormalizeSubjects(subjects)
+}
+
+func (p InboundAdmissionPlan) EffectiveCapabilitySubject(req EffectiveSubjectRequest) (packs.Subject, error) {
+	if !p.Valid() {
+		return packs.Subject{}, fmt.Errorf("compiled inbound admission plan is required")
+	}
+	bundleHash := strings.TrimSpace(req.BundleHash)
+	alias := strings.Trim(strings.TrimSpace(req.Alias), "/")
+	if bundleHash == "" || alias == "" {
+		return packs.Subject{}, fmt.Errorf("effective inbound admission subject requires bundle_hash and alias")
+	}
+	eventName := strings.TrimSpace(p.eventNames.Literal)
+	if eventName == "" {
+		eventName = strings.TrimSpace(p.eventNames.Template)
+	}
+	source := "raw_declaration"
+	provenance := "project"
+	admission := &packs.TriggerAdmission{
+		BundleHash: bundleHash, Alias: alias, CatalogGeneration: p.generationID,
+		PolicySource: string(p.policySource), RequestAuthentication: string(p.requestAuthentication), Event: eventName,
+	}
+	if p.manifest != nil {
+		source = "trigger_pack_binding"
+		provenance = p.packIdentity.Provenance
+		admission.SignedPayload = strings.TrimSpace(p.manifest.Signature.SignedPayload)
+		admission.DigestEncoding = strings.TrimSpace(p.manifest.Signature.digestEncoding())
+		if strings.TrimSpace(p.manifest.Signature.Type) == signatureTypeTokenEquality || p.requestAuthentication == RequestAuthenticationNone {
+			admission.DigestEncoding = ""
+		}
+		admission.Pack = &packs.TriggerPackIdentity{
+			ID: p.packIdentity.ID, Version: p.packIdentity.Version,
+			ManifestHash: p.packIdentity.ManifestHash, Provenance: p.packIdentity.Provenance,
+		}
+	} else if p.raw != nil && p.requestAuthentication == RequestAuthenticationHMACSHA256 {
+		admission.SignedPayload = "raw_body"
+		admission.DigestEncoding = p.raw.Authentication.Encoding
+	}
+	subject := packs.Subject{
+		ID:   "ingress:" + bundleHash + ":" + alias + ":" + p.provider,
+		Kind: packs.SubjectProviderTrigger, Provider: p.provider, Source: source,
+		Provenance: provenance, SourcePath: strings.TrimSpace(req.SourcePath), Applicability: "effective",
+		TriggerAdmission: admission,
+		Capabilities: []packs.Capability{
+			{Code: packs.CapabilityReceiveHTTPSRoute, Target: "/webhooks/" + alias + "/" + p.provider},
+			{Code: packs.CapabilityEmitEvent, Target: eventName},
+			{Code: packs.CapabilityPersistDedupeMarkers},
+		},
+	}
+	if p.requiresSecret {
+		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityVerifySecret, Target: strings.TrimSpace(req.SigningSecret)})
+		subject.Requirements = append(subject.Requirements, packs.TargetScopedRequirement(packs.RequirementSecret, strings.TrimSpace(req.SigningSecret)))
+	}
+	for _, code := range []string{cannotEmitUndeclaredEvents, cannotRunCodeBeforeAdmission, cannotTouchUnboundResources} {
+		guarantee, err := packs.NewGuarantee(code)
+		if err != nil {
+			return packs.Subject{}, err
+		}
+		subject.Guarantees = append(subject.Guarantees, guarantee)
+	}
+	normalized, err := packs.NormalizeSubjects([]packs.Subject{subject})
+	if err != nil {
+		return packs.Subject{}, err
+	}
+	return normalized[0], nil
+}
+
+func (p InboundAdmissionPlan) Accept(req Request) (Delivery, error) {
+	if !p.Valid() {
+		return Delivery{}, badRequest("compiled inbound admission plan is required")
+	}
+	provider := NormalizeProviderName(req.Provider)
+	if provider == "" {
+		provider = p.provider
+	}
+	if provider != p.provider {
+		return Delivery{}, badRequest(fmt.Sprintf("compiled inbound admission plan provider %q does not match request provider %q", p.provider, provider))
+	}
+	req = req.withProvider(provider)
+	if p.requiresSecret && strings.TrimSpace(req.Target.WebhookSecret) == "" {
+		return Delivery{}, unauthorized(provider + " webhook signing secret is required")
+	}
+	if p.manifest != nil {
+		return p.manifest.Accept(req)
+	}
+	return p.acceptExplicitRaw(req)
+}
+
+func (p InboundAdmissionPlan) acceptExplicitRaw(req Request) (Delivery, error) {
+	policy := p.raw
+	if policy == nil {
+		return Delivery{}, badRequest("compiled raw admission policy is required")
+	}
+	if err := verifyRawAuthentication(policy.Authentication, req.Target.WebhookSecret, req.Headers, req.Body); err != nil {
+		return Delivery{}, err
+	}
+	var parsed any
+	if policy.Payload == "json" {
+		if err := json.Unmarshal(req.Body, &parsed); err != nil {
+			return Delivery{}, badRequest("raw webhook payload must be valid JSON")
+		}
+	} else {
+		parsed = string(req.Body)
+	}
+	deliveryID, err := rawDeliveryID(policy.DeliveryID, req.Headers, parsed, req.Body)
+	if err != nil {
+		return Delivery{}, err
+	}
+	payload := map[string]any{
+		"provider": p.provider, "provider_event_id": deliveryID,
+		"provider_event_type": NormalizeEventToken(policy.Event), "data": parsed,
+	}
+	return Delivery{
+		ProviderEventID: deliveryID, ProviderEventType: NormalizeEventToken(policy.Event),
+		EventName: events.EventType(policy.Event), Payload: payload,
+	}, nil
+}
+
+func verifyRawAuthentication(auth RawAuthenticationDeclaration, secret string, headers http.Header, body []byte) error {
+	if auth.Kind == "none" {
+		return nil
+	}
+	if strings.TrimSpace(secret) == "" {
+		return unauthorized("webhook signing secret is required")
+	}
+	values := headers.Values(auth.Header)
+	if len(values) != 1 || strings.TrimSpace(values[0]) == "" {
+		return unauthorized("invalid webhook authentication header")
+	}
+	candidate := strings.TrimSpace(values[0])
+	if auth.Prefix != "" {
+		if !strings.HasPrefix(candidate, auth.Prefix) {
+			return unauthorized("invalid webhook authentication header")
+		}
+		candidate = strings.TrimSpace(strings.TrimPrefix(candidate, auth.Prefix))
+	}
+	switch auth.Kind {
+	case "token":
+		if hmac.Equal([]byte(candidate), []byte(strings.TrimSpace(secret))) {
+			return nil
+		}
+	case "hmac_sha256":
+		mac := hmac.New(sha256.New, []byte(strings.TrimSpace(secret)))
+		_, _ = mac.Write(body)
+		digest := mac.Sum(nil)
+		expected := hex.EncodeToString(digest)
+		if auth.Encoding == "base64" {
+			expected = base64.StdEncoding.EncodeToString(digest)
+		}
+		if auth.Encoding == "hex" {
+			candidate = strings.ToLower(candidate)
+			expected = strings.ToLower(expected)
+		}
+		if hmac.Equal([]byte(candidate), []byte(expected)) {
+			return nil
+		}
+	}
+	return unauthorized("invalid webhook authentication")
+}
+
+func rawDeliveryID(policy RawDeliveryIDDeclaration, headers http.Header, payload any, body []byte) (string, error) {
+	switch policy.Source {
+	case "header":
+		values := headers.Values(policy.Header)
+		if len(values) != 1 || strings.TrimSpace(values[0]) == "" {
+			return "", badRequest("raw webhook delivery id header is required and must occur exactly once")
+		}
+		return strings.TrimSpace(values[0]), nil
+	case "json_path":
+		value, ok := stringFromJSONPath(payload, policy.JSONPath)
+		if !ok || strings.TrimSpace(value) == "" {
+			return "", badRequest("raw webhook delivery id JSON path is required")
+		}
+		return strings.TrimSpace(value), nil
+	case "body_sha256":
+		sum := sha256.Sum256(body)
+		return hex.EncodeToString(sum[:]), nil
+	default:
+		return "", badRequest("compiled raw webhook delivery id policy is invalid")
+	}
+}

--- a/internal/providertriggers/admission_test.go
+++ b/internal/providertriggers/admission_test.go
@@ -1,0 +1,315 @@
+package providertriggers
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestManifestRejectsSignedOptionalSecretAndEmptyKeyExecution(t *testing.T) {
+	for _, signatureType := range []string{signatureTypeHMACSHA256, signatureTypeHMACSHA1, signatureTypeTokenEquality} {
+		t.Run(signatureType, func(t *testing.T) {
+			manifest := admissionTestManifest("acme", signatureType, false)
+			if err := manifest.Validate(); err == nil || !strings.Contains(err.Error(), "signed request authentication requires secret.required true") {
+				t.Fatalf("Validate error = %v", err)
+			}
+			_, err := manifest.Accept(Request{Provider: "acme", Headers: http.Header{"X-Signature": []string{"value"}}, Body: []byte(`{}`), Payload: map[string]any{}})
+			requireProviderTriggerError(t, err, http.StatusUnauthorized)
+		})
+	}
+}
+
+func TestCatalogGenerationIsSemanticAndOrderIndependent(t *testing.T) {
+	a := admissionTestEntry(admissionTestManifest("a", signatureTypeTokenEquality, true), "provider.a")
+	b := admissionTestEntry(admissionTestManifest("b", signatureTypeHMACSHA256, true), "provider.b")
+	first, err := NewCatalogSnapshot(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewCatalogSnapshot(b, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GenerationID() == "" || first.GenerationID() != second.GenerationID() {
+		t.Fatalf("generation ids = %q %q", first.GenerationID(), second.GenerationID())
+	}
+	b.Identity.ManifestHash = strings.Repeat("b", 64)
+	changed, err := NewCatalogSnapshot(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.GenerationID() == first.GenerationID() {
+		t.Fatal("manifest identity change did not change catalog generation")
+	}
+}
+
+func TestCatalogSnapshotDoesNotExposeMutableManifestState(t *testing.T) {
+	manifest := admissionTestManifest("acme", signatureTypeHMACSHA256, true)
+	manifest.Metadata = map[string]string{"delivery": "delivery_id"}
+	entry := admissionTestEntry(manifest, "provider.acme")
+	catalog, err := NewCatalogSnapshot(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manifest.Metadata["delivery"] = "event_type"
+	returned, ok := catalog.EntryByProvider("acme")
+	if !ok {
+		t.Fatal("catalog entry missing")
+	}
+	returned.Manifest.Metadata["delivery"] = "user_agent"
+	again, _ := catalog.EntryByProvider("acme")
+	if got := again.Manifest.Metadata["delivery"]; got != "delivery_id" {
+		t.Fatalf("catalog manifest metadata = %q, want immutable delivery_id", got)
+	}
+	entries := catalog.Entries()
+	entries[0].Manifest.Metadata["delivery"] = "event_type"
+	again, _ = catalog.EntryByID("provider.acme")
+	if got := again.Manifest.Metadata["delivery"]; got != "delivery_id" {
+		t.Fatalf("catalog Entries exposed mutable state: %q", got)
+	}
+}
+
+func TestCompileAdmissionRequiresExplicitUnsignedPackAcknowledgement(t *testing.T) {
+	for _, provenance := range []string{"platform", "external"} {
+		t.Run(provenance, func(t *testing.T) {
+			manifest := admissionTestManifest("acme", "", false)
+			entry := admissionTestEntry(manifest, "provider.acme")
+			entry.Identity.Provenance = provenance
+			catalog, err := NewCatalogSnapshot(entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = catalog.CompileAdmission(CompileAdmissionRequest{Alias: "chat", Provider: "acme"})
+			if err == nil || !strings.Contains(err.Error(), "admission.acknowledge: unsigned_webhook") {
+				t.Fatalf("CompileAdmission error = %v", err)
+			}
+			plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+				Alias: "chat", Provider: "acme",
+				Declaration: AdmissionDeclaration{Acknowledge: UnsignedWebhookAcknowledgement},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity, ok := plan.PackIdentity()
+			if plan.PolicySource() != PolicySourceVerifiedPack || plan.RequestAuthentication() != RequestAuthenticationNone || !plan.AcknowledgedUnsigned() || !ok || identity.Provenance != provenance {
+				t.Fatalf("plan = %+v identity=%+v/%t", plan, identity, ok)
+			}
+			if _, err := catalog.CompileAdmission(CompileAdmissionRequest{Alias: "chat", Provider: "acme", SigningSecret: "unexpected", Declaration: AdmissionDeclaration{Acknowledge: UnsignedWebhookAcknowledgement}}); err == nil || !strings.Contains(err.Error(), "must not declare signing_secret") {
+				t.Fatalf("unsigned signing-secret error = %v", err)
+			}
+		})
+	}
+}
+
+func TestPackAuthenticationTransitionRequiresNewExplicitTargetContract(t *testing.T) {
+	signedEntry := admissionTestEntry(admissionTestManifest("acme", signatureTypeTokenEquality, true), "provider.acme")
+	signed, err := NewCatalogSnapshot(signedEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedPlan, err := signed.CompileAdmission(CompileAdmissionRequest{Alias: "chat", Provider: "acme", SigningSecret: "webhook_signing.acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsignedEntry := admissionTestEntry(admissionTestManifest("acme", "", false), "provider.acme")
+	unsignedEntry.Identity.ManifestHash = strings.Repeat("b", 64)
+	unsigned, err := NewCatalogSnapshot(unsignedEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if signed.GenerationID() == unsigned.GenerationID() {
+		t.Fatal("signed-to-unsigned pack transition retained catalog generation")
+	}
+	_, err = unsigned.CompileAdmission(CompileAdmissionRequest{Alias: "chat", Provider: "acme", SigningSecret: "webhook_signing.acme"})
+	if err == nil || !strings.Contains(err.Error(), "admission.acknowledge: unsigned_webhook") {
+		t.Fatalf("unsigned transition error = %v", err)
+	}
+	unsignedPlan, err := unsigned.CompileAdmission(CompileAdmissionRequest{
+		Alias: "chat", Provider: "acme", Declaration: AdmissionDeclaration{Acknowledge: UnsignedWebhookAcknowledgement},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if signedPlan.RequestAuthentication() != RequestAuthenticationTokenEquality || unsignedPlan.RequestAuthentication() != RequestAuthenticationNone {
+		t.Fatalf("transition plans = %s -> %s", signedPlan.RequestAuthentication(), unsignedPlan.RequestAuthentication())
+	}
+}
+
+func TestCompileAdmissionProjectsExactPackAuthentication(t *testing.T) {
+	for _, tc := range []struct {
+		signature string
+		want      RequestAuthentication
+	}{
+		{signatureTypeTokenEquality, RequestAuthenticationTokenEquality},
+		{signatureTypeHMACSHA256, RequestAuthenticationHMACSHA256},
+		{signatureTypeHMACSHA1, RequestAuthenticationHMACSHA1},
+	} {
+		t.Run(tc.signature, func(t *testing.T) {
+			catalog, err := NewCatalogSnapshot(admissionTestEntry(admissionTestManifest("acme", tc.signature, true), "provider.acme"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := catalog.CompileAdmission(CompileAdmissionRequest{Alias: "chat", Provider: "acme", SigningSecret: "webhook_signing.acme"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.RequestAuthentication() != tc.want || !plan.RequiresSecret() {
+				t.Fatalf("authentication = %s requires=%t", plan.RequestAuthentication(), plan.RequiresSecret())
+			}
+			subject, err := plan.EffectiveCapabilitySubject(EffectiveSubjectRequest{BundleHash: strings.Repeat("a", 64), Alias: "chat", SigningSecret: "webhook_signing.acme"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if subject.TriggerAdmission == nil || subject.TriggerAdmission.RequestAuthentication != string(tc.want) || subject.TriggerAdmission.PolicySource != string(PolicySourceVerifiedPack) || len(subject.Requirements) != 1 {
+				t.Fatalf("subject = %#v", subject)
+			}
+		})
+	}
+}
+
+func TestRawAdmissionConsumesOnlyDeclaredAuthenticationAndDeliverySources(t *testing.T) {
+	catalog, err := NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "partner", Provider: "partner-events", SigningSecret: "webhook_signing.partner",
+		Declaration: AdmissionDeclaration{
+			Kind: "raw", Event: "inbound.partner", Payload: "json",
+			Authentication: RawAuthenticationDeclaration{Kind: "hmac_sha256", Header: "X-Partner-Signature", Encoding: "hex"},
+			DeliveryID:     RawDeliveryIDDeclaration{Source: "header", Header: "X-Partner-Delivery"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"id":"payload-must-not-own-id","value":1}`)
+	mac := hmac.New(sha256.New, []byte("secret"))
+	_, _ = mac.Write(body)
+	headers := http.Header{
+		"X-Partner-Signature": []string{hex.EncodeToString(mac.Sum(nil))},
+		"X-Partner-Delivery":  []string{"declared-id"},
+		"Stripe-Signature":    []string{"ignored"},
+		"X-Github-Event":      []string{"ignored"},
+	}
+	delivery, err := plan.Accept(Request{Provider: "partner-events", Target: Target{WebhookSecret: "secret"}, Headers: headers, Body: body})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivery.ProviderEventID != "declared-id" || delivery.EventName != "inbound.partner" {
+		t.Fatalf("delivery = %+v", delivery)
+	}
+	headers["X-Partner-Delivery"] = []string{"one", "two"}
+	if _, err := plan.Accept(Request{Provider: "partner-events", Target: Target{WebhookSecret: "secret"}, Headers: headers, Body: body}); err == nil {
+		t.Fatal("duplicate declared delivery header accepted")
+	}
+}
+
+func TestRawProviderCannotShadowInstalledPack(t *testing.T) {
+	catalog, err := NewCatalogSnapshot(admissionTestEntry(admissionTestManifest("acme", signatureTypeTokenEquality, true), "provider.acme"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "chat", Provider: "acme",
+		Declaration: AdmissionDeclaration{Kind: "raw", Event: "inbound.acme", Payload: "raw", Authentication: RawAuthenticationDeclaration{Kind: "none"}, DeliveryID: RawDeliveryIDDeclaration{Source: "body_sha256"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), `rename the intentional raw namespace to "acme-raw"`) {
+		t.Fatalf("CompileAdmission error = %v", err)
+	}
+}
+
+func TestRawAdmissionBase64SignatureComparisonIsCaseSensitive(t *testing.T) {
+	catalog, err := NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "partner", Provider: "partner-events", SigningSecret: "webhook_signing.partner",
+		Declaration: AdmissionDeclaration{
+			Kind: "raw", Event: "inbound.partner", Payload: "raw",
+			Authentication: RawAuthenticationDeclaration{Kind: "hmac_sha256", Header: "X-Signature", Encoding: "base64"},
+			DeliveryID:     RawDeliveryIDDeclaration{Source: "body_sha256"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("case-sensitive")
+	mac := hmac.New(sha256.New, []byte("secret"))
+	_, _ = mac.Write(body)
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	mutated := strings.ToLower(signature)
+	if mutated == signature {
+		t.Fatal("test vector unexpectedly has no uppercase Base64 characters")
+	}
+	_, err = plan.Accept(Request{
+		Provider: "partner-events", Target: Target{WebhookSecret: "secret"}, Body: body,
+		Headers: http.Header{"X-Signature": []string{mutated}},
+	})
+	requireProviderTriggerError(t, err, http.StatusUnauthorized)
+}
+
+func TestCompileAdmissionTeachingFailures(t *testing.T) {
+	catalog, err := NewCatalogSnapshot(admissionTestEntry(admissionTestManifest("acme", signatureTypeTokenEquality, true), "provider.acme"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		req  CompileAdmissionRequest
+		want string
+	}{
+		{name: "missing pack", req: CompileAdmissionRequest{Alias: "chat", Provider: "missing"}, want: "pack-required"},
+		{name: "wrong id", req: CompileAdmissionRequest{Alias: "chat", Provider: "acme", Declaration: AdmissionDeclaration{PackID: "provider.acmee"}}, want: `verified pack for "acme" is "provider.acme"`},
+		{name: "provider mismatch", req: CompileAdmissionRequest{Alias: "chat", Provider: "other", Declaration: AdmissionDeclaration{PackID: "provider.acme"}}, want: `which provides "acme"`},
+		{name: "raw fields in pack", req: CompileAdmissionRequest{Alias: "chat", Provider: "acme", Declaration: AdmissionDeclaration{Event: "inbound.acme"}}, want: "remove raw-only fields"},
+		{name: "invalid acknowledgement", req: CompileAdmissionRequest{Alias: "chat", Provider: "acme", SigningSecret: "secret", Declaration: AdmissionDeclaration{Acknowledge: "yes"}}, want: "canonical token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := catalog.CompileAdmission(tc.req)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CompileAdmission error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func admissionTestEntry(manifest Manifest, id string) CatalogEntry {
+	return CatalogEntry{
+		Identity: PackIdentity{ID: id, Version: "1.0.0", ManifestHash: strings.Repeat("a", 64), Provenance: "external"},
+		Manifest: manifest, Source: "test", SourcePath: "/tmp/" + id,
+	}
+}
+
+func admissionTestManifest(provider, signatureType string, secretRequired bool) Manifest {
+	signature := SignatureManifest{Type: signatureType, Header: "X-Signature"}
+	switch signatureType {
+	case signatureTypeHMACSHA256:
+		signature.Encoding = "hex"
+		signature.SignedPayload = "raw_body"
+	case signatureTypeHMACSHA1:
+		signature.Encoding = "hex"
+		signature.SignedPayload = "raw_body"
+	case signatureTypeTokenEquality:
+	default:
+		signature = SignatureManifest{}
+	}
+	return Manifest{
+		Provider: provider, Secret: SecretManifest{Required: secretRequired}, Signature: signature,
+		DeliveryID: ValueSource{Header: "X-Delivery", Required: true}, EventType: ValueSource{Literal: "event", Required: true},
+		EventName: EventNameManifest{Literal: "inbound." + provider}, Ack: AckManifest{Mode: "after_publish"},
+	}
+}
+
+func signAdmissionTestHMACSHA1(secret string, body []byte) string {
+	mac := hmac.New(sha1.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/providertriggers/admission_test.go
+++ b/internal/providertriggers/admission_test.go
@@ -256,6 +256,40 @@ func TestRawAdmissionBase64SignatureComparisonIsCaseSensitive(t *testing.T) {
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
 }
 
+func TestRawAdmissionPreservesRawPayloadWhileResolvingJSONPathDeliveryID(t *testing.T) {
+	catalog, err := NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "partner", Provider: "partner-events",
+		Declaration: AdmissionDeclaration{
+			Kind: "raw", Acknowledge: UnsignedWebhookAcknowledgement,
+			Event: "inbound.partner", Payload: "raw",
+			Authentication: RawAuthenticationDeclaration{Kind: "none"},
+			DeliveryID:     RawDeliveryIDDeclaration{Source: "json_path", JSONPath: "$.delivery.id"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"delivery":{"id":"evt-raw-json-path"},"value":1}`)
+	delivery, err := plan.Accept(Request{Provider: "partner-events", Body: body})
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if delivery.ProviderEventID != "evt-raw-json-path" {
+		t.Fatalf("delivery id = %q", delivery.ProviderEventID)
+	}
+	data, ok := delivery.Payload["data"].(string)
+	if !ok || data != string(body) {
+		t.Fatalf("raw emitted payload = %#v, want exact body string", delivery.Payload["data"])
+	}
+	if _, err := plan.Accept(Request{Provider: "partner-events", Body: []byte("not-json")}); err == nil || !strings.Contains(err.Error(), "requires a valid JSON request body") {
+		t.Fatalf("invalid JSON error = %v", err)
+	}
+}
+
 func TestCompileAdmissionTeachingFailures(t *testing.T) {
 	catalog, err := NewCatalogSnapshot(admissionTestEntry(admissionTestManifest("acme", signatureTypeTokenEquality, true), "provider.acme"))
 	if err != nil {

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -87,14 +87,24 @@ func (e Error) Error() string {
 	return e.Message
 }
 
-type Registry struct {
-	manifests map[string]Manifest
-	sources   map[string]string
+type PackIdentity struct {
+	ID           string `json:"id"`
+	Version      string `json:"version"`
+	ManifestHash string `json:"manifest_hash"`
+	Provenance   string `json:"provenance"`
 }
 
-type ManifestSource struct {
-	Manifest Manifest
-	Source   string
+type CatalogEntry struct {
+	Identity   PackIdentity
+	Manifest   Manifest
+	SourcePath string
+	Source     string
+}
+
+type CatalogSnapshot struct {
+	generationID string
+	byProvider   map[string]CatalogEntry
+	byID         map[string]CatalogEntry
 }
 
 type LoadedPack struct {
@@ -126,33 +136,49 @@ func RequiredPlatformPackIdentities() []PlatformPackIdentity {
 	return append([]PlatformPackIdentity(nil), requiredPlatformPackIdentities...)
 }
 
-func NewRegistry(manifests ...Manifest) (*Registry, error) {
-	sources := make([]ManifestSource, 0, len(manifests))
-	for _, manifest := range manifests {
-		sources = append(sources, ManifestSource{Manifest: manifest, Source: "direct"})
+func NewCatalogSnapshot(entries ...CatalogEntry) (*CatalogSnapshot, error) {
+	snapshot := &CatalogSnapshot{
+		byProvider: make(map[string]CatalogEntry, len(entries)),
+		byID:       make(map[string]CatalogEntry, len(entries)),
 	}
-	return NewRegistryFromSources(sources...)
-}
-
-func NewRegistryFromSources(sources ...ManifestSource) (*Registry, error) {
-	r := &Registry{
-		manifests: make(map[string]Manifest, len(sources)),
-		sources:   make(map[string]string, len(sources)),
-	}
-	for _, source := range sources {
-		manifest := source.Manifest
+	normalizedEntries := make([]CatalogEntry, 0, len(entries))
+	for _, entry := range entries {
+		manifest := entry.Manifest
 		if err := manifest.Validate(); err != nil {
 			return nil, err
 		}
 		provider := NormalizeProviderName(manifest.Provider)
-		if existingSource, exists := r.sources[provider]; exists {
-			return nil, fmt.Errorf("duplicate provider trigger manifest for %q from %s and %s", provider, existingSource, firstNonEmpty(source.Source, "unknown"))
+		entry.Manifest.Provider = provider
+		entry.Identity.ID = strings.TrimSpace(entry.Identity.ID)
+		entry.Identity.Version = strings.TrimSpace(entry.Identity.Version)
+		entry.Identity.ManifestHash = strings.TrimSpace(entry.Identity.ManifestHash)
+		entry.Identity.Provenance = strings.TrimSpace(entry.Identity.Provenance)
+		entry.SourcePath = strings.TrimSpace(entry.SourcePath)
+		entry.Source = firstNonEmpty(entry.Source, "unknown")
+		clonedManifest, err := cloneManifest(entry.Manifest)
+		if err != nil {
+			return nil, fmt.Errorf("clone provider trigger manifest %q: %w", provider, err)
 		}
-		manifest.Provider = provider
-		r.manifests[provider] = manifest
-		r.sources[provider] = firstNonEmpty(source.Source, "unknown")
+		entry.Manifest = clonedManifest
+		if entry.Identity.ID == "" || entry.Identity.Version == "" || entry.Identity.ManifestHash == "" || entry.Identity.Provenance == "" {
+			return nil, fmt.Errorf("provider trigger catalog entry for %q requires pack id, version, manifest_hash, and provenance", provider)
+		}
+		if existing, exists := snapshot.byProvider[provider]; exists {
+			return nil, fmt.Errorf("duplicate provider trigger manifest for %q from %s and %s", provider, existing.Source, entry.Source)
+		}
+		if existing, exists := snapshot.byID[entry.Identity.ID]; exists {
+			return nil, fmt.Errorf("duplicate provider trigger pack id %q from %s and %s", entry.Identity.ID, existing.Source, entry.Source)
+		}
+		snapshot.byProvider[provider] = entry
+		snapshot.byID[entry.Identity.ID] = entry
+		normalizedEntries = append(normalizedEntries, entry)
 	}
-	return r, nil
+	generationID, err := catalogGenerationID(normalizedEntries)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.generationID = generationID
+	return snapshot, nil
 }
 
 func LoadPlatformPackDirs(runningPlatformVersion string, dirs ...string) ([]LoadedPack, error) {
@@ -185,15 +211,15 @@ func loadPackDirs(runningPlatformVersion, expectedProvenance string, dirs ...str
 	return loaded, nil
 }
 
-func NewRegistryFromPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string) (*Registry, []LoadedPack, error) {
-	return newRegistryFromPackDirs(runningPlatformVersion, platformDirs, externalDirs, false)
+func NewCatalogSnapshotFromPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string) (*CatalogSnapshot, []LoadedPack, error) {
+	return newCatalogSnapshotFromPackDirs(runningPlatformVersion, platformDirs, externalDirs, false)
 }
 
-func NewRegistryFromRequiredPlatformPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string) (*Registry, []LoadedPack, error) {
-	return newRegistryFromPackDirs(runningPlatformVersion, platformDirs, externalDirs, true)
+func NewCatalogSnapshotFromRequiredPlatformPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string) (*CatalogSnapshot, []LoadedPack, error) {
+	return newCatalogSnapshotFromPackDirs(runningPlatformVersion, platformDirs, externalDirs, true)
 }
 
-func newRegistryFromPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string, requireCompletePlatformInventory bool) (*Registry, []LoadedPack, error) {
+func newCatalogSnapshotFromPackDirs(runningPlatformVersion string, platformDirs, externalDirs []string, requireCompletePlatformInventory bool) (*CatalogSnapshot, []LoadedPack, error) {
 	if err := rejectDuplicatePackDirectories(platformDirs, externalDirs); err != nil {
 		return nil, nil, err
 	}
@@ -219,11 +245,11 @@ func newRegistryFromPackDirs(runningPlatformVersion string, platformDirs, extern
 	if err := validateLoadedPackIdentities(loaded); err != nil {
 		return nil, nil, err
 	}
-	registry, err := NewRegistryFromSources(SourcesFromLoadedPacks(loaded...)...)
+	snapshot, err := NewCatalogSnapshot(CatalogEntriesFromLoadedPacks(loaded...)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	return registry, loaded, nil
+	return snapshot, loaded, nil
 }
 
 func validateRequiredPlatformPackInventory(loaded []LoadedPack) error {
@@ -334,15 +360,19 @@ func loadedPackSource(pack LoadedPack) string {
 	return fmt.Sprintf("provenance=%s path=%q pack=%q", provenance, sourcePath, strings.TrimSpace(pack.Envelope.ID))
 }
 
-func SourcesFromLoadedPacks(loaded ...LoadedPack) []ManifestSource {
-	sources := make([]ManifestSource, 0, len(loaded))
+func CatalogEntriesFromLoadedPacks(loaded ...LoadedPack) []CatalogEntry {
+	entries := make([]CatalogEntry, 0, len(loaded))
 	for _, pack := range loaded {
-		sources = append(sources, ManifestSource{
-			Manifest: pack.Manifest,
-			Source:   firstNonEmpty(pack.Source, loadedPackSource(pack)),
+		entries = append(entries, CatalogEntry{
+			Identity: PackIdentity{
+				ID: strings.TrimSpace(pack.Envelope.ID), Version: strings.TrimSpace(pack.Envelope.Version),
+				ManifestHash: strings.TrimSpace(pack.Envelope.ManifestHash), Provenance: strings.TrimSpace(pack.Envelope.Provenance.Source),
+			},
+			Manifest: pack.Manifest, SourcePath: strings.TrimSpace(pack.SourcePath),
+			Source: firstNonEmpty(pack.Source, loadedPackSource(pack)),
 		})
 	}
-	return sources
+	return entries
 }
 
 func LoadPackFS(fsys fs.FS, dir, runningPlatformVersion string) (LoadedPack, error) {
@@ -448,32 +478,83 @@ func (p LoadedPack) CapabilitySubject() (packs.Subject, error) {
 	return normalized[0], nil
 }
 
-func (r *Registry) Accept(req Request) (Delivery, error) {
-	provider := NormalizeProviderName(req.Provider)
-	if provider == "" {
-		return Delivery{}, badRequest("provider is required")
-	}
-	if r != nil {
-		if manifest, ok := r.manifests[provider]; ok {
-			return manifest.Accept(req.withProvider(provider))
-		}
-	}
-	return acceptRaw(req.withProvider(provider))
-}
-
-func (r *Registry) Manifest(provider string) (Manifest, bool) {
-	if r == nil {
-		return Manifest{}, false
-	}
-	manifest, ok := r.manifests[NormalizeProviderName(provider)]
-	return manifest, ok
-}
-
-func (r *Registry) Source(provider string) string {
-	if r == nil {
+func (s *CatalogSnapshot) GenerationID() string {
+	if s == nil {
 		return ""
 	}
-	return strings.TrimSpace(r.sources[NormalizeProviderName(provider)])
+	return s.generationID
+}
+
+func (s *CatalogSnapshot) EntryByProvider(provider string) (CatalogEntry, bool) {
+	if s == nil {
+		return CatalogEntry{}, false
+	}
+	entry, ok := s.byProvider[NormalizeProviderName(provider)]
+	if !ok {
+		return CatalogEntry{}, false
+	}
+	return cloneCatalogEntry(entry), true
+}
+
+func (s *CatalogSnapshot) EntryByID(id string) (CatalogEntry, bool) {
+	if s == nil {
+		return CatalogEntry{}, false
+	}
+	entry, ok := s.byID[strings.TrimSpace(id)]
+	if !ok {
+		return CatalogEntry{}, false
+	}
+	return cloneCatalogEntry(entry), true
+}
+
+func (s *CatalogSnapshot) Entries() []CatalogEntry {
+	if s == nil {
+		return nil
+	}
+	out := make([]CatalogEntry, 0, len(s.byID))
+	for _, entry := range s.byID {
+		out = append(out, cloneCatalogEntry(entry))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Identity.ID < out[j].Identity.ID })
+	return out
+}
+
+func cloneCatalogEntry(entry CatalogEntry) CatalogEntry {
+	manifest, err := cloneManifest(entry.Manifest)
+	if err != nil {
+		panic("provider trigger catalog contains an invalid manifest clone: " + err.Error())
+	}
+	entry.Manifest = manifest
+	return entry
+}
+
+func cloneManifest(manifest Manifest) (Manifest, error) {
+	body, err := yaml.Marshal(manifest)
+	if err != nil {
+		return Manifest{}, err
+	}
+	return parseManifestStrict(body)
+}
+
+func catalogGenerationID(entries []CatalogEntry) (string, error) {
+	type tuple struct {
+		ID, Provider, Version, ManifestHash, Provenance string
+	}
+	tuples := make([]tuple, 0, len(entries))
+	for _, entry := range entries {
+		tuples = append(tuples, tuple{
+			ID: strings.TrimSpace(entry.Identity.ID), Provider: NormalizeProviderName(entry.Manifest.Provider),
+			Version: strings.TrimSpace(entry.Identity.Version), ManifestHash: strings.TrimSpace(entry.Identity.ManifestHash),
+			Provenance: strings.TrimSpace(entry.Identity.Provenance),
+		})
+	}
+	sort.Slice(tuples, func(i, j int) bool { return tuples[i].ID < tuples[j].ID })
+	body, err := json.Marshal(tuples)
+	if err != nil {
+		return "", fmt.Errorf("encode provider trigger catalog generation: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func (req Request) withProvider(provider string) Request {
@@ -608,6 +689,9 @@ func (m Manifest) Validate() error {
 	signatureType := strings.TrimSpace(m.Signature.Type)
 	if m.Secret.Required && signatureType == "" {
 		return fmt.Errorf("%s manifest requires signature when secret is required", provider)
+	}
+	if signatureType != "" && !m.Secret.Required {
+		return fmt.Errorf("provider trigger manifest %q declares signature.type %q with secret.required false; signed request authentication requires secret.required true", provider, signatureType)
 	}
 	switch strings.TrimSpace(m.PayloadSource) {
 	case "", "payload", "form":
@@ -786,6 +870,9 @@ func (m Manifest) Accept(req Request) (Delivery, error) {
 }
 
 func (m Manifest) verifySignature(secret string, req Request) error {
+	if strings.TrimSpace(secret) == "" {
+		return unauthorized(NormalizeProviderName(m.Provider) + " webhook signing secret is required")
+	}
 	if strings.TrimSpace(m.Signature.Type) == signatureTypeTokenEquality {
 		return m.verifyTokenEquality(secret, req)
 	}
@@ -1086,96 +1173,6 @@ func formValuesPayload(values url.Values) map[string]any {
 		payload[key] = copied
 	}
 	return payload
-}
-
-func acceptRaw(req Request) (Delivery, error) {
-	provider := NormalizeProviderName(req.Provider)
-	if provider == "" {
-		return Delivery{}, badRequest("provider is required")
-	}
-	if !verifyRawWebhookSignature(req.Target.WebhookSecret, req.Body, req.Headers) {
-		return Delivery{}, unauthorized("invalid signature")
-	}
-	entityID := req.Target.EffectiveEntityID()
-	deliveryID := firstNonEmpty(
-		req.Headers.Get("X-Provider-Event-ID"),
-		req.Headers.Get("X-Request-ID"),
-		extractProviderEventID(req.Payload),
-		fingerprintInbound(entityID, provider, req.Body),
-	)
-	eventType := resolveProviderEventType(req.Payload)
-	payload := map[string]any{
-		"entity_id":            strings.TrimSpace(entityID),
-		"provider":             provider,
-		"event_type":           eventType,
-		"provider_event_type":  eventType,
-		"provider_event_id":    deliveryID,
-		"provider_delivery_id": deliveryID,
-		"payload":              req.Payload,
-		"headers":              map[string]any{"user_agent": req.UserAgent},
-		"received_at":          req.Received.UTC().Format(time.RFC3339),
-	}
-	return Delivery{
-		ProviderEventID:   deliveryID,
-		ProviderEventType: eventType,
-		EventName:         events.EventType("inbound." + provider),
-		Payload:           payload,
-	}, nil
-}
-
-func verifyRawWebhookSignature(secret string, body []byte, headers http.Header) bool {
-	secret = strings.TrimSpace(secret)
-	if secret == "" {
-		return true
-	}
-	if sig := strings.TrimSpace(headers.Get("X-Hub-Signature-256")); strings.HasPrefix(strings.ToLower(sig), "sha256=") {
-		given := strings.TrimSpace(sig[len("sha256="):])
-		mac := hmac.New(sha256.New, []byte(secret))
-		_, _ = mac.Write(body)
-		expected := hex.EncodeToString(mac.Sum(nil))
-		return hmac.Equal([]byte(strings.ToLower(given)), []byte(strings.ToLower(expected)))
-	}
-	token := strings.TrimSpace(headers.Get("X-Webhook-Token"))
-	if token == "" {
-		auth := strings.TrimSpace(headers.Get("Authorization"))
-		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
-			token = strings.TrimSpace(auth[7:])
-		}
-	}
-	return hmac.Equal([]byte(token), []byte(secret))
-}
-
-func extractProviderEventID(payload any) string {
-	m, ok := payload.(map[string]any)
-	if !ok {
-		return ""
-	}
-	for _, key := range []string{"id", "event_id", "message_id"} {
-		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
-			return strings.TrimSpace(v)
-		}
-	}
-	return ""
-}
-
-func fingerprintInbound(entityID, provider string, body []byte) string {
-	h := sha1.New()
-	_, _ = h.Write([]byte(entityID))
-	_, _ = h.Write([]byte("|"))
-	_, _ = h.Write([]byte(provider))
-	_, _ = h.Write([]byte("|"))
-	_, _ = h.Write(body)
-	return "fp:" + hex.EncodeToString(h.Sum(nil))
-}
-
-func resolveProviderEventType(payload any) string {
-	m, _ := payload.(map[string]any)
-	for _, key := range []string{"event_type", "type", "status", "kind", "action"} {
-		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
-			return NormalizeEventToken(v)
-		}
-	}
-	return "event"
 }
 
 func stringFromJSONPath(payload any, path string) (string, bool) {

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -24,7 +24,8 @@ import (
 func TestFilesystemRegistryLoadsFirstPartyProvidersFromVerifiedPlatformPacks(t *testing.T) {
 	registry := testPlatformRegistry(t)
 	for _, provider := range []string{"github", "intercom", "shopify", "slack", "stripe", "telegram", "twilio", "typeform"} {
-		got := registry.sources[provider]
+		entry, _ := registry.EntryByProvider(provider)
+		got := entry.Source
 		for _, want := range []string{"provenance=platform", "provider." + provider, filepath.Join("packs", "provider-triggers", provider)} {
 			if !strings.Contains(got, want) {
 				t.Fatalf("%s source = %q, want containing %q", provider, got, want)
@@ -97,7 +98,7 @@ func TestPlatformPackInventoryIsCompleteFilesystemOnlyAndFreshlyStamped(t *testi
 
 func TestRequiredPlatformPackInventoryAdmission(t *testing.T) {
 	dirs := testPlatformPackDirs(t)
-	registry, loaded, err := NewRegistryFromRequiredPlatformPackDirs("0.7.0", dirs, nil)
+	registry, loaded, err := NewCatalogSnapshotFromRequiredPlatformPackDirs("0.7.0", dirs, nil)
 	if err != nil {
 		t.Fatalf("load complete required platform inventory: %v", err)
 	}
@@ -111,7 +112,7 @@ func TestRequiredPlatformPackInventoryAdmission(t *testing.T) {
 			omitted = append(omitted, dir)
 		}
 	}
-	_, _, err = NewRegistryFromRequiredPlatformPackDirs("0.7.0", omitted, []string{"/external/must-not-be-read-before-platform-completeness"})
+	_, _, err = NewCatalogSnapshotFromRequiredPlatformPackDirs("0.7.0", omitted, []string{"/external/must-not-be-read-before-platform-completeness"})
 	if err == nil {
 		t.Fatal("required platform inventory accepted omitted Stripe pack")
 	}
@@ -263,10 +264,9 @@ func TestProviderTriggerPackRejectsShadowingAndNamesSources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadPackFS: %v", err)
 	}
-	_, err = NewRegistryFromSources(
-		ManifestSource{Manifest: pack.Manifest, Source: "external:/tmp/github"},
-		SourcesFromLoadedPacks(pack)[0],
-	)
+	duplicate := CatalogEntriesFromLoadedPacks(pack)[0]
+	duplicate.Source = "external:/tmp/github"
+	_, err = NewCatalogSnapshot(duplicate, CatalogEntriesFromLoadedPacks(pack)[0])
 	if err == nil {
 		t.Fatal("NewRegistryFromSources succeeded, want duplicate provider failure")
 	}
@@ -277,7 +277,7 @@ func TestProviderTriggerPackRejectsShadowingAndNamesSources(t *testing.T) {
 	}
 }
 
-func TestProviderTriggerRegistryLoadsExternalPackDirs(t *testing.T) {
+func TestProviderTriggerCatalogLoadsExternalPackDirs(t *testing.T) {
 	dir := copyBuiltinPackToTemp(t, "stripe")
 	replaceInFile(t, filepath.Join(dir, "trigger.yaml"), "provider: stripe", "provider: acme")
 	replaceInFile(t, filepath.Join(dir, "trigger.yaml"), "literal: inbound.stripe", "literal: inbound.acme")
@@ -290,14 +290,16 @@ func TestProviderTriggerRegistryLoadsExternalPackDirs(t *testing.T) {
 	replaceInFile(t, filepath.Join(dir, "pack.yaml"), "providertriggers/stripe", "providertriggers/acme")
 	rewritePackHash(t, dir)
 
-	registry, loaded, err := NewRegistryFromPackDirs("0.7.0", testPlatformPackDirs(t), []string{dir})
+	registry, loaded, err := NewCatalogSnapshotFromPackDirs("0.7.0", testPlatformPackDirs(t), []string{dir})
 	if err != nil {
-		t.Fatalf("NewRegistryFromPackDirs: %v", err)
+		t.Fatalf("NewCatalogSnapshotFromPackDirs: %v", err)
 	}
-	if got := registry.sources["acme"]; !strings.Contains(got, "provenance=external") || !strings.Contains(got, dir) {
+	acme, _ := registry.EntryByProvider("acme")
+	if got := acme.Source; !strings.Contains(got, "provenance=external") || !strings.Contains(got, dir) {
 		t.Fatalf("acme source = %q, want external dir source %q", got, dir)
 	}
-	if got := registry.sources["stripe"]; !strings.Contains(got, "provenance=platform") || !strings.Contains(got, "provider.stripe") {
+	stripe, _ := registry.EntryByProvider("stripe")
+	if got := stripe.Source; !strings.Contains(got, "provenance=platform") || !strings.Contains(got, "provider.stripe") {
 		t.Fatalf("stripe source = %q, want platform pack source", got)
 	}
 	foundExternal := false
@@ -312,14 +314,14 @@ func TestProviderTriggerRegistryLoadsExternalPackDirs(t *testing.T) {
 	}
 }
 
-func TestProviderTriggerRegistryRejectsExternalShadowingAgainstPlatformPack(t *testing.T) {
+func TestProviderTriggerCatalogRejectsExternalShadowingAgainstPlatformPack(t *testing.T) {
 	dir := copyBuiltinPackToTemp(t, "github")
 	replaceInFile(t, filepath.Join(dir, "pack.yaml"), "source: platform", "source: external")
 	replaceInFile(t, filepath.Join(dir, "pack.yaml"), "id: provider.github", "id: provider.github.external")
 
-	_, _, err := NewRegistryFromPackDirs("0.7.0", testPlatformPackDirs(t), []string{dir})
+	_, _, err := NewCatalogSnapshotFromPackDirs("0.7.0", testPlatformPackDirs(t), []string{dir})
 	if err == nil {
-		t.Fatal("NewRegistryFromPackDirs succeeded, want duplicate provider failure")
+		t.Fatal("NewCatalogSnapshotFromPackDirs succeeded, want duplicate provider failure")
 	}
 	for _, want := range []string{`duplicate provider trigger manifest for "github"`, "provenance=platform", "provenance=external", dir} {
 		if !strings.Contains(err.Error(), want) {
@@ -349,11 +351,11 @@ func TestProviderTriggerPackRequiresReadbackDoesNotRequireBoundSecretAtLoad(t *t
 	if strings.Contains(renderedCan, "stripe-secret") {
 		t.Fatal("capability surface leaked a concrete secret value")
 	}
-	registry, err := NewRegistryFromSources(SourcesFromLoadedPacks(pack)...)
+	registry, err := NewCatalogSnapshot(CatalogEntriesFromLoadedPacks(pack)...)
 	if err != nil {
 		t.Fatalf("NewRegistryFromSources: %v", err)
 	}
-	_, err = registry.Accept(Request{
+	_, err = acceptInstalled(registry, Request{
 		Provider: "stripe",
 		Target:   Target{EntitySlug: "customer-a"},
 	})
@@ -390,13 +392,13 @@ func TestExternalTelegramProviderTriggerPackUsesSameTokenEqualityVerifier(t *tes
 	if err != nil {
 		t.Fatalf("LoadExternalPackDirs: %v", err)
 	}
-	registry, err := NewRegistryFromSources(SourcesFromLoadedPacks(loaded...)...)
+	registry, err := NewCatalogSnapshot(CatalogEntriesFromLoadedPacks(loaded...)...)
 	if err != nil {
 		t.Fatalf("NewRegistryFromSources: %v", err)
 	}
 
 	body := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
-	delivery, err := registry.Accept(telegramRequest("telegram-secret", body, map[string]any{
+	delivery, err := acceptInstalled(registry, telegramRequest("telegram-secret", body, map[string]any{
 		"update_id": float64(123456789),
 		"message":   map[string]any{"message_id": float64(7), "chat": map[string]any{"id": float64(42)}, "text": "hello"},
 	}))
@@ -419,7 +421,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
 		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
 
-		delivery, err := registry.Accept(req)
+		delivery, err := acceptInstalled(registry, req)
 		if err != nil {
 			t.Fatalf("Accept hostile valid request: %v", err)
 		}
@@ -440,7 +442,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
 		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
 		req.Headers.Set("X-Other-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), body))
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusUnauthorized)
 	})
 
@@ -451,7 +453,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
 		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(old))
 		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(old), body))
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusUnauthorized)
 	})
 
@@ -462,7 +464,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Headers.Set("X-Hostile-Delivery", "delivery-header")
 		req.Headers.Set("X-Hostile-Timestamp", strconvFormatUnix(now))
 		req.Headers.Set("X-Hostile-Signature", hostileSignature("hostile-secret", strconvFormatUnix(now), signedBody))
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusUnauthorized)
 	})
 
@@ -475,7 +477,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Payload = map[string]any{
 			"event_type": map[string]any{"nested": "safe.event"},
 		}
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 
@@ -488,7 +490,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Payload = map[string]any{
 			"event_type": []any{"safe.event"},
 		}
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 
@@ -501,7 +503,7 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		req.Payload = map[string]any{
 			"event_type": true,
 		}
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 }
@@ -520,7 +522,7 @@ func TestManifestInterpreterRejectsMalformedJSONPathIdentityPayloads(t *testing.
 			"event_type": "safe.event",
 		}
 
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 
@@ -534,7 +536,7 @@ func TestManifestInterpreterRejectsMalformedJSONPathIdentityPayloads(t *testing.
 			"event_type": "safe.event",
 		}
 
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 
@@ -548,7 +550,7 @@ func TestManifestInterpreterRejectsMalformedJSONPathIdentityPayloads(t *testing.
 			"event_type": true,
 		}
 
-		_, err := registry.Accept(req)
+		_, err := acceptInstalled(registry, req)
 		requireProviderTriggerError(t, err, http.StatusBadRequest)
 	})
 }
@@ -569,15 +571,15 @@ func TestStripeManifestRejectsMalformedSignatureParams(t *testing.T) {
 	}
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",v0="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
 
-	_, err := testPlatformRegistry(t).Accept(req)
+	_, err := acceptInstalled(testPlatformRegistry(t), req)
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
 
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",broken,v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
-	_, err = testPlatformRegistry(t).Accept(req)
+	_, err = acceptInstalled(testPlatformRegistry(t), req)
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
 
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",t="+strconvFormatUnix(now)+",v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
-	_, err = testPlatformRegistry(t).Accept(req)
+	_, err = acceptInstalled(testPlatformRegistry(t), req)
 	requireProviderTriggerError(t, err, http.StatusUnauthorized)
 }
 
@@ -597,7 +599,7 @@ func TestStripeManifestAcceptsLiteralEventType(t *testing.T) {
 	}
 	req.Headers.Set("Stripe-Signature", "t="+strconvFormatUnix(now)+",v1="+stripeSignatureHex("stripe-secret", strconvFormatUnix(now), body))
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Stripe literal event type: %v", err)
 	}
@@ -639,7 +641,7 @@ func TestTwilioManifestAcceptsSignedFormWebhook(t *testing.T) {
 	}
 	req.Headers.Set("X-Twilio-Signature", twilioSignatureBase64("twilio-secret", requestURL, form))
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Twilio form webhook: %v", err)
 	}
@@ -772,7 +774,7 @@ func TestTwilioManifestRejectsAmbiguousOrUnsupportedCallbacks(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := testPlatformRegistry(t).Accept(tc.configure(validRequest()))
+			_, err := acceptInstalled(testPlatformRegistry(t), tc.configure(validRequest()))
 			requireProviderTriggerError(t, err, tc.wantStatus)
 		})
 	}
@@ -797,7 +799,7 @@ func TestShopifyManifestAcceptsRawBodyBase64Signature(t *testing.T) {
 	req.Headers.Set("X-Shopify-Webhook-Id", "webhook-123")
 	req.Headers.Set("X-Shopify-Topic", "orders/create")
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Shopify webhook: %v", err)
 	}
@@ -904,7 +906,7 @@ func TestShopifyManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := testPlatformRegistry(t).Accept(tc.configure(validRequest()))
+			_, err := acceptInstalled(testPlatformRegistry(t), tc.configure(validRequest()))
 			requireProviderTriggerError(t, err, tc.wantStatus)
 		})
 	}
@@ -927,7 +929,7 @@ func TestTypeformManifestAcceptsRawBodyBase64Signature(t *testing.T) {
 	}
 	req.Headers.Set("Typeform-Signature", typeformSignatureBase64("typeform-secret", body))
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Typeform webhook: %v", err)
 	}
@@ -1037,7 +1039,7 @@ func TestTypeformManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := testPlatformRegistry(t).Accept(tc.configure(validRequest()))
+			_, err := acceptInstalled(testPlatformRegistry(t), tc.configure(validRequest()))
 			requireProviderTriggerError(t, err, tc.wantStatus)
 		})
 	}
@@ -1060,7 +1062,7 @@ func TestIntercomManifestAcceptsRawBodySHA1Signature(t *testing.T) {
 	}
 	req.Headers.Set("X-Hub-Signature", intercomSignatureHex("intercom-secret", body))
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Intercom webhook: %v", err)
 	}
@@ -1170,7 +1172,7 @@ func TestIntercomManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := testPlatformRegistry(t).Accept(tc.configure(validRequest()))
+			_, err := acceptInstalled(testPlatformRegistry(t), tc.configure(validRequest()))
 			requireProviderTriggerError(t, err, tc.wantStatus)
 		})
 	}
@@ -1183,7 +1185,7 @@ func TestTelegramManifestAcceptsHeaderTokenUpdate(t *testing.T) {
 		"message":   map[string]any{"message_id": float64(7), "chat": map[string]any{"id": float64(42)}, "text": "hello"},
 	})
 
-	delivery, err := testPlatformRegistry(t).Accept(req)
+	delivery, err := acceptInstalled(testPlatformRegistry(t), req)
 	if err != nil {
 		t.Fatalf("Accept Telegram webhook: %v", err)
 	}
@@ -1278,7 +1280,7 @@ func TestTelegramManifestRejectsInvalidInputsBeforeDelivery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := testPlatformRegistry(t).Accept(tc.configure(validRequest()))
+			_, err := acceptInstalled(testPlatformRegistry(t), tc.configure(validRequest()))
 			requireProviderTriggerError(t, err, tc.wantStatus)
 		})
 	}
@@ -1412,15 +1414,15 @@ func TestManifestValidationRejectsAuthoringErrors(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := NewRegistry(tc.manifest); err == nil {
-				t.Fatal("NewRegistry succeeded, want validation error")
+			if _, err := newTestCatalogSnapshot(tc.manifest); err == nil {
+				t.Fatal("newTestCatalogSnapshot succeeded, want validation error")
 			}
 		})
 	}
 }
 
 func TestRegistryRejectsEmptyProvider(t *testing.T) {
-	_, err := testPlatformRegistry(t).Accept(Request{
+	_, err := acceptInstalled(testPlatformRegistry(t), Request{
 		Target:  Target{EntityID: "entity-1"},
 		Body:    []byte(`{}`),
 		Headers: make(http.Header),
@@ -1476,7 +1478,7 @@ func tokenEqualityValidationManifest(provider string, mutate func(*SignatureMani
 	}
 }
 
-func newHostileRegistry(t *testing.T) *Registry {
+func newHostileRegistry(t *testing.T) *CatalogSnapshot {
 	t.Helper()
 	manifest := Manifest{
 		Provider:              "hostile",
@@ -1515,14 +1517,14 @@ func newHostileRegistry(t *testing.T) *Registry {
 			"hostile_event":    "event_type",
 		},
 	}
-	registry, err := NewRegistry(manifest)
+	registry, err := newTestCatalogSnapshot(manifest)
 	if err != nil {
 		t.Fatalf("NewRegistry hostile: %v", err)
 	}
 	return registry
 }
 
-func newHostilePayloadIdentityRegistry(t *testing.T) *Registry {
+func newHostilePayloadIdentityRegistry(t *testing.T) *CatalogSnapshot {
 	t.Helper()
 	manifest := Manifest{
 		Provider:              "hostile",
@@ -1557,7 +1559,7 @@ func newHostilePayloadIdentityRegistry(t *testing.T) *Registry {
 		EventName: EventNameManifest{Literal: "inbound.hostile"},
 		Ack:       AckManifest{Mode: "durable_before_dispatch"},
 	}
-	registry, err := NewRegistry(manifest)
+	registry, err := newTestCatalogSnapshot(manifest)
 	if err != nil {
 		t.Fatalf("NewRegistry hostile payload identity: %v", err)
 	}
@@ -1693,13 +1695,39 @@ func copyBuiltinPackToTemp(t *testing.T, provider string) string {
 	return dir
 }
 
-func testPlatformRegistry(t *testing.T) *Registry {
+func testPlatformRegistry(t *testing.T) *CatalogSnapshot {
 	t.Helper()
-	registry, _, err := NewRegistryFromPackDirs("0.7.0", testPlatformPackDirs(t), nil)
+	registry, _, err := NewCatalogSnapshotFromPackDirs("0.7.0", testPlatformPackDirs(t), nil)
 	if err != nil {
 		t.Fatalf("load filesystem provider trigger registry: %v", err)
 	}
 	return registry
+}
+
+func newTestCatalogSnapshot(manifests ...Manifest) (*CatalogSnapshot, error) {
+	entries := make([]CatalogEntry, 0, len(manifests))
+	for _, manifest := range manifests {
+		body, _ := json.Marshal(manifest)
+		sum := sha256.Sum256(body)
+		provider := NormalizeProviderName(manifest.Provider)
+		entries = append(entries, CatalogEntry{
+			Identity: PackIdentity{ID: "test." + provider, Version: "0.0.0", ManifestHash: hex.EncodeToString(sum[:]), Provenance: "test"},
+			Manifest: manifest, Source: "test",
+		})
+	}
+	return NewCatalogSnapshot(entries...)
+}
+
+func acceptInstalled(snapshot *CatalogSnapshot, req Request) (Delivery, error) {
+	provider := NormalizeProviderName(req.Provider)
+	if provider == "" {
+		return Delivery{}, badRequest("provider is required")
+	}
+	entry, ok := snapshot.EntryByProvider(provider)
+	if !ok {
+		return Delivery{}, badRequest("provider trigger pack is not installed")
+	}
+	return entry.Manifest.Accept(req.withProvider(provider))
 }
 
 func testPlatformPackDirs(t *testing.T) []string {

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -74,8 +74,13 @@ type StandingIngressView struct {
 }
 
 type StandingIngressProviderView struct {
-	Provider      string `json:"provider"`
-	SigningSecret string `json:"signing_secret"`
+	Provider              string `json:"provider"`
+	SigningSecret         string `json:"signing_secret,omitempty"`
+	AdmissionKind         string `json:"admission_kind"`
+	PackID                string `json:"pack_id,omitempty"`
+	RequestAuthentication string `json:"request_authentication,omitempty"`
+	Event                 string `json:"event,omitempty"`
+	Acknowledgement       string `json:"acknowledgement,omitempty"`
 }
 
 type FlowSourceFiles struct {
@@ -370,7 +375,7 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 				}
 				ingress := &StandingIngressView{Alias: alias}
 				for _, provider := range ref.Ingress.Providers {
-					ingress.Providers = append(ingress.Providers, StandingIngressProviderView{Provider: strings.TrimSpace(provider.Provider), SigningSecret: strings.TrimSpace(provider.SigningSecret)})
+					ingress.Providers = append(ingress.Providers, standingIngressProviderView(provider))
 				}
 				item.Ingress = ingress
 			}
@@ -404,6 +409,28 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 		out = append(out, item)
 	}
 	return out
+}
+
+func standingIngressProviderView(provider runtimecontracts.ProjectFlowIngressProvider) StandingIngressProviderView {
+	kind := strings.ToLower(strings.TrimSpace(provider.Admission.Kind))
+	if kind == "" {
+		kind = "pack-required"
+	}
+	view := StandingIngressProviderView{
+		Provider: strings.TrimSpace(provider.Provider), SigningSecret: strings.TrimSpace(provider.SigningSecret),
+		AdmissionKind: kind, Event: strings.TrimSpace(provider.Admission.Event),
+		Acknowledgement: strings.TrimSpace(provider.Admission.Acknowledge),
+	}
+	if provider.Admission.Pack != nil {
+		view.PackID = strings.TrimSpace(provider.Admission.Pack.ID)
+	}
+	if provider.Admission.Authentication != nil {
+		view.RequestAuthentication = strings.ToUpper(strings.TrimSpace(provider.Admission.Authentication.Kind))
+		if view.RequestAuthentication == "NONE" {
+			view.RequestAuthentication = "UNAUTHENTICATED"
+		}
+	}
+	return view
 }
 
 func packageFlowRefsByID(bundle *runtimecontracts.WorkflowContractBundle) map[string]runtimecontracts.ProjectFlowRef {

--- a/internal/runtime/context_manager.go
+++ b/internal/runtime/context_manager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/division-sh/swarm/internal/packs"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -108,21 +109,46 @@ type RuntimeContextDeactivationResult struct {
 }
 
 type RuntimeContextManager struct {
-	mu           sync.RWMutex
-	availability RunBundleAvailabilityReader
-	contexts     map[string]*runtimeContextEntry
-	order        []string
+	mu                       sync.RWMutex
+	availability             RunBundleAvailabilityReader
+	contexts                 map[string]*runtimeContextEntry
+	order                    []string
+	admissionGeneration      string
+	installedTriggerSubjects []packs.Subject
+	capabilitySubjects       []packs.Subject
+}
+
+type ProcessAdmissionState struct {
+	GenerationID      string
+	InstalledSubjects []packs.Subject
 }
 
 func NewRuntimeContextManager(availability RunBundleAvailabilityReader, contexts ...BundleContext) (*RuntimeContextManager, error) {
+	return newRuntimeContextManager(availability, ProcessAdmissionState{}, contexts...)
+}
+
+func NewRuntimeContextManagerWithAdmission(availability RunBundleAvailabilityReader, state ProcessAdmissionState, contexts ...BundleContext) (*RuntimeContextManager, error) {
+	return newRuntimeContextManager(availability, state, contexts...)
+}
+
+func newRuntimeContextManager(availability RunBundleAvailabilityReader, state ProcessAdmissionState, contexts ...BundleContext) (*RuntimeContextManager, error) {
+	installed, err := packs.NormalizeSubjects(state.InstalledSubjects)
+	if err != nil {
+		return nil, fmt.Errorf("normalize installed provider trigger subjects: %w", err)
+	}
 	manager := &RuntimeContextManager{
-		availability: availability,
-		contexts:     map[string]*runtimeContextEntry{},
+		availability:             availability,
+		contexts:                 map[string]*runtimeContextEntry{},
+		admissionGeneration:      strings.TrimSpace(state.GenerationID),
+		installedTriggerSubjects: installed,
 	}
 	for _, contextDef := range contexts {
 		if err := manager.Register(contextDef); err != nil {
 			return nil, err
 		}
+	}
+	if err := manager.refreshCapabilitySubjectsLocked(); err != nil {
+		return nil, err
 	}
 	return manager, nil
 }
@@ -131,6 +157,11 @@ func NewRuntimeContextManager(availability RunBundleAvailabilityReader, contexts
 // rules without publishing any context as loaded.
 func ValidateRuntimeContextSet(contexts ...BundleContext) error {
 	_, err := NewRuntimeContextManager(nil, contexts...)
+	return err
+}
+
+func ValidateRuntimeContextSetWithAdmission(state ProcessAdmissionState, contexts ...BundleContext) error {
+	_, err := NewRuntimeContextManagerWithAdmission(nil, state, contexts...)
 	return err
 }
 
@@ -145,6 +176,9 @@ func (m *RuntimeContextManager) Register(contextDef BundleContext) error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if err := m.validateAdmissionGenerationLocked(contextDef); err != nil {
+		return err
+	}
 	if m.contexts == nil {
 		m.contexts = map[string]*runtimeContextEntry{}
 	}
@@ -169,6 +203,16 @@ func (m *RuntimeContextManager) Register(contextDef BundleContext) error {
 	}
 	m.order = append(m.order, contextDef.BundleHash)
 	sort.Strings(m.order)
+	if err := m.refreshCapabilitySubjectsLocked(); err != nil {
+		delete(m.contexts, contextDef.BundleHash)
+		for i, bundleHash := range m.order {
+			if bundleHash == contextDef.BundleHash {
+				m.order = append(m.order[:i], m.order[i+1:]...)
+				break
+			}
+		}
+		return err
+	}
 	return nil
 }
 
@@ -206,8 +250,11 @@ func validateRuntimeContextStandingTargets(contextDef BundleContext) error {
 		if target.BundleHash != contextDef.BundleHash {
 			return fmt.Errorf("runtime context %s standing target %q/%q bundle_hash %q does not match context", contextDef.BundleHash, target.Alias, target.Provider, target.BundleHash)
 		}
-		if target.Alias == "" || target.Provider == "" || target.RunID == "" || target.FlowID == "" || target.FlowInstance == "" || target.EntityID == "" || target.SigningSecret == "" {
-			return fmt.Errorf("runtime context %s standing target requires alias, provider, run_id, flow_id, flow_instance, entity_id, and signing_secret", contextDef.BundleHash)
+		if target.Alias == "" || target.Provider == "" || target.RunID == "" || target.FlowID == "" || target.FlowInstance == "" || target.EntityID == "" || !target.AdmissionPlan.Valid() {
+			return fmt.Errorf("runtime context %s standing target requires alias, provider, run_id, flow_id, flow_instance, entity_id, and compiled admission plan", contextDef.BundleHash)
+		}
+		if target.AdmissionPlan.RequiresSecret() != (target.SigningSecret != "") {
+			return fmt.Errorf("runtime context %s standing target %q/%q signing_secret presence contradicts compiled %s request authentication", contextDef.BundleHash, target.Alias, target.Provider, target.AdmissionPlan.RequestAuthentication())
 		}
 		key := target.Alias + "\x00" + target.Provider
 		if previous, ok := seen[key]; ok {
@@ -216,6 +263,60 @@ func validateRuntimeContextStandingTargets(contextDef BundleContext) error {
 		seen[key] = target.SourcePath
 	}
 	return nil
+}
+
+func (m *RuntimeContextManager) validateAdmissionGenerationLocked(contextDef BundleContext) error {
+	for _, target := range contextDef.StandingTargets {
+		generation := target.AdmissionPlan.GenerationID()
+		if m.admissionGeneration == "" {
+			return fmt.Errorf("runtime context %s standing target %q/%q requires process admission catalog generation", contextDef.BundleHash, target.Alias, target.Provider)
+		}
+		if generation != m.admissionGeneration {
+			return fmt.Errorf("runtime context %s standing target %q/%q admission generation %q does not match process generation %q", contextDef.BundleHash, target.Alias, target.Provider, generation, m.admissionGeneration)
+		}
+	}
+	return nil
+}
+
+func (m *RuntimeContextManager) refreshCapabilitySubjectsLocked() error {
+	subjects := append([]packs.Subject(nil), m.installedTriggerSubjects...)
+	for _, bundleHash := range m.order {
+		entry := m.contexts[bundleHash]
+		if !runtimeContextEntryLoaded(entry) {
+			continue
+		}
+		for _, target := range entry.context.StandingTargets {
+			subject, err := target.CapabilitySubject()
+			if err != nil {
+				return fmt.Errorf("derive standing ingress capability subject: %w", err)
+			}
+			subjects = append(subjects, subject)
+		}
+	}
+	normalized, err := packs.NormalizeSubjects(subjects)
+	if err != nil {
+		return fmt.Errorf("normalize process provider capability subjects: %w", err)
+	}
+	m.capabilitySubjects = normalized
+	return nil
+}
+
+func (m *RuntimeContextManager) AdmissionState() ProcessAdmissionState {
+	if m == nil {
+		return ProcessAdmissionState{}
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return ProcessAdmissionState{GenerationID: m.admissionGeneration, InstalledSubjects: packs.CloneSubjects(m.installedTriggerSubjects)}
+}
+
+func (m *RuntimeContextManager) CapabilitySubjects() []packs.Subject {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return packs.CloneSubjects(m.capabilitySubjects)
 }
 
 func (m *RuntimeContextManager) duplicateLoadedIngressAliasLocked(incoming BundleContext) (BundleContext, BundleContext, string, bool) {
@@ -509,8 +610,8 @@ func (m *RuntimeContextManager) BeginBundleHashReplacement(existingHash string, 
 	return predecessor, nil
 }
 
-// PublishBundleHashReplacement is the only transition from replacement
-// unavailability back to loaded process authority.
+// PublishBundleHashReplacement publishes a replacement that carries no
+// admission targets. Admission-bearing reloads use the process-wide API.
 func (m *RuntimeContextManager) PublishBundleHashReplacement(existingHash string, contextDef BundleContext) error {
 	if m == nil {
 		return fmt.Errorf("runtime context manager is required")
@@ -526,6 +627,47 @@ func (m *RuntimeContextManager) PublishBundleHashReplacement(existingHash string
 	if entry == nil || entry.state != RuntimeContextStateUnloaded || entry.cause != RuntimeContextCauseReplacing {
 		return fmt.Errorf("runtime context %s is not unavailable for replacement", existingHash)
 	}
+	if m.admissionGeneration != "" && (len(entry.context.StandingTargets) > 0 || len(contextDef.StandingTargets) > 0) {
+		return fmt.Errorf("runtime context %s carries compiled admission targets; publish through PublishBundleHashReplacementWithAdmission", existingHash)
+	}
+	return m.publishBundleHashReplacementLocked(existingHash, contextDef, entry)
+}
+
+// PublishRestoredBundleHashReplacement restores the withdrawn predecessor
+// against the already-published catalog generation after candidate failure.
+func (m *RuntimeContextManager) PublishRestoredBundleHashReplacement(existingHash string, contextDef BundleContext) error {
+	if m == nil {
+		return fmt.Errorf("runtime context manager is required")
+	}
+	contextDef, err := validateRuntimeContextDefinition(contextDef)
+	if err != nil {
+		return err
+	}
+	existingHash = strings.TrimSpace(existingHash)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.contexts[existingHash]
+	if entry == nil || entry.state != RuntimeContextStateUnloaded || entry.cause != RuntimeContextCauseReplacing || entry.context == nil {
+		return fmt.Errorf("runtime context %s is not unavailable for predecessor restoration", existingHash)
+	}
+	if err := validateTargetsGeneration(contextDef, m.admissionGeneration); err != nil {
+		return err
+	}
+	if err := validateRestoredAdmissionAuthority(*entry.context, contextDef); err != nil {
+		return err
+	}
+	subjects, err := m.replacementCapabilitySubjectsLocked(existingHash, contextDef)
+	if err != nil {
+		return err
+	}
+	if err := m.publishBundleHashReplacementLocked(existingHash, contextDef, entry); err != nil {
+		return err
+	}
+	m.capabilitySubjects = subjects
+	return nil
+}
+
+func (m *RuntimeContextManager) publishBundleHashReplacementLocked(existingHash string, contextDef BundleContext, entry *runtimeContextEntry) error {
 	if existingHash != contextDef.BundleHash {
 		if _, exists := m.contexts[contextDef.BundleHash]; exists {
 			return fmt.Errorf("replacement runtime context bundle_hash %s is already registered", contextDef.BundleHash)
@@ -557,6 +699,216 @@ func (m *RuntimeContextManager) PublishBundleHashReplacement(existingHash string
 	return nil
 }
 
+func validateRestoredAdmissionAuthority(predecessor, restored BundleContext) error {
+	if len(predecessor.StandingTargets) != len(restored.StandingTargets) {
+		return fmt.Errorf("restored runtime context %s changed standing admission target count from %d to %d", predecessor.BundleHash, len(predecessor.StandingTargets), len(restored.StandingTargets))
+	}
+	want := map[string]StandingTarget{}
+	for _, target := range predecessor.StandingTargets {
+		target = target.normalized()
+		want[target.Alias+"\x00"+target.Provider] = target
+	}
+	for _, target := range restored.StandingTargets {
+		target = target.normalized()
+		previous, ok := want[target.Alias+"\x00"+target.Provider]
+		if !ok || previous.SigningSecret != target.SigningSecret ||
+			previous.AdmissionPlan.GenerationID() != target.AdmissionPlan.GenerationID() ||
+			previous.AdmissionPlan.PolicySource() != target.AdmissionPlan.PolicySource() ||
+			previous.AdmissionPlan.RequestAuthentication() != target.AdmissionPlan.RequestAuthentication() {
+			return fmt.Errorf("restored runtime context %s changed standing admission authority for %q/%q", predecessor.BundleHash, target.Alias, target.Provider)
+		}
+		delete(want, target.Alias+"\x00"+target.Provider)
+	}
+	if len(want) != 0 {
+		return fmt.Errorf("restored runtime context %s omitted predecessor standing admission targets", predecessor.BundleHash)
+	}
+	return nil
+}
+
+func (m *RuntimeContextManager) replacementCapabilitySubjectsLocked(existingHash string, contextDef BundleContext) ([]packs.Subject, error) {
+	subjects := packs.CloneSubjects(m.installedTriggerSubjects)
+	for _, bundleHash := range m.order {
+		if bundleHash == existingHash {
+			continue
+		}
+		entry := m.contexts[bundleHash]
+		if !runtimeContextEntryLoaded(entry) {
+			continue
+		}
+		for _, target := range entry.context.StandingTargets {
+			subject, err := target.CapabilitySubject()
+			if err != nil {
+				return nil, err
+			}
+			subjects = append(subjects, subject)
+		}
+	}
+	for _, target := range contextDef.StandingTargets {
+		subject, err := target.CapabilitySubject()
+		if err != nil {
+			return nil, err
+		}
+		subjects = append(subjects, subject)
+	}
+	return packs.NormalizeSubjects(subjects)
+}
+
+func (m *RuntimeContextManager) ValidateProcessAdmissionReplacement(existingHash string, contextDef BundleContext, survivingTargets map[string][]StandingTarget, state ProcessAdmissionState) error {
+	if m == nil {
+		return fmt.Errorf("runtime context manager is required")
+	}
+	contextDef, err := validateRuntimeContextDefinition(contextDef)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.validateReplacementLocked(strings.TrimSpace(existingHash), contextDef); err != nil {
+		return err
+	}
+	_, _, err = m.validateProcessAdmissionCandidateLocked(strings.TrimSpace(existingHash), contextDef, survivingTargets, state)
+	return err
+}
+
+// PublishBundleHashReplacementWithAdmission is the sole authority transition
+// for a runtime replacement and its process-global provider-trigger catalog.
+func (m *RuntimeContextManager) PublishBundleHashReplacementWithAdmission(existingHash string, contextDef BundleContext, survivingTargets map[string][]StandingTarget, state ProcessAdmissionState) error {
+	if m == nil {
+		return fmt.Errorf("runtime context manager is required")
+	}
+	contextDef, err := validateRuntimeContextDefinition(contextDef)
+	if err != nil {
+		return err
+	}
+	existingHash = strings.TrimSpace(existingHash)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.contexts[existingHash]
+	if entry == nil || entry.state != RuntimeContextStateUnloaded || entry.cause != RuntimeContextCauseReplacing {
+		return fmt.Errorf("runtime context %s is not unavailable for replacement", existingHash)
+	}
+	installed, subjects, err := m.validateProcessAdmissionCandidateLocked(existingHash, contextDef, survivingTargets, state)
+	if err != nil {
+		return err
+	}
+	if existingHash != contextDef.BundleHash {
+		if _, exists := m.contexts[contextDef.BundleHash]; exists {
+			return fmt.Errorf("replacement runtime context bundle_hash %s is already registered", contextDef.BundleHash)
+		}
+		delete(m.contexts, existingHash)
+		for i, bundleHash := range m.order {
+			if bundleHash == existingHash {
+				m.order = append(m.order[:i], m.order[i+1:]...)
+				break
+			}
+		}
+		entry = &runtimeContextEntry{}
+		m.contexts[contextDef.BundleHash] = entry
+		m.order = append(m.order, contextDef.BundleHash)
+		sort.Strings(m.order)
+	}
+	for bundleHash, targets := range survivingTargets {
+		if surviving := m.contexts[strings.TrimSpace(bundleHash)]; surviving != nil && runtimeContextEntryLoaded(surviving) {
+			copied := *surviving.context
+			copied.StandingTargets = append([]StandingTarget(nil), targets...)
+			surviving.context = &copied
+		}
+	}
+	copied := contextDef
+	entry.context = &copied
+	entry.state = RuntimeContextStateLoaded
+	entry.cause = ""
+	m.admissionGeneration = strings.TrimSpace(state.GenerationID)
+	m.installedTriggerSubjects = installed
+	m.capabilitySubjects = subjects
+	return nil
+}
+
+func (m *RuntimeContextManager) validateProcessAdmissionCandidateLocked(existingHash string, contextDef BundleContext, survivingTargets map[string][]StandingTarget, state ProcessAdmissionState) ([]packs.Subject, []packs.Subject, error) {
+	generation := strings.TrimSpace(state.GenerationID)
+	if generation == "" {
+		return nil, nil, fmt.Errorf("candidate provider-trigger catalog generation is required")
+	}
+	installed, err := packs.NormalizeSubjects(state.InstalledSubjects)
+	if err != nil {
+		return nil, nil, fmt.Errorf("normalize candidate installed provider trigger subjects: %w", err)
+	}
+	contexts := make([]BundleContext, 0, len(m.contexts))
+	seenUpdates := map[string]struct{}{}
+	for _, bundleHash := range m.order {
+		if bundleHash == existingHash {
+			continue
+		}
+		entry := m.contexts[bundleHash]
+		if !runtimeContextEntryLoaded(entry) {
+			continue
+		}
+		targets, ok := survivingTargets[bundleHash]
+		if !ok {
+			return nil, nil, fmt.Errorf("candidate provider-trigger catalog generation %q did not recompile loaded runtime context %s", generation, bundleHash)
+		}
+		seenUpdates[bundleHash] = struct{}{}
+		copied := *entry.context
+		copied.StandingTargets = append([]StandingTarget(nil), targets...)
+		if err := validateRuntimeContextStandingTargets(copied); err != nil {
+			return nil, nil, err
+		}
+		if err := validateTargetsGeneration(copied, generation); err != nil {
+			return nil, nil, err
+		}
+		contexts = append(contexts, copied)
+	}
+	for bundleHash := range survivingTargets {
+		if _, ok := seenUpdates[strings.TrimSpace(bundleHash)]; !ok {
+			return nil, nil, fmt.Errorf("candidate provider-trigger target update names non-surviving runtime context %s", bundleHash)
+		}
+	}
+	if err := validateTargetsGeneration(contextDef, generation); err != nil {
+		return nil, nil, err
+	}
+	contexts = append(contexts, contextDef)
+	if err := validateContextSetCollisions(contexts); err != nil {
+		return nil, nil, err
+	}
+	subjects := append([]packs.Subject(nil), installed...)
+	for _, candidateContext := range contexts {
+		for _, target := range candidateContext.StandingTargets {
+			subject, err := target.CapabilitySubject()
+			if err != nil {
+				return nil, nil, fmt.Errorf("derive candidate standing ingress capability subject: %w", err)
+			}
+			subjects = append(subjects, subject)
+		}
+	}
+	normalized, err := packs.NormalizeSubjects(subjects)
+	if err != nil {
+		return nil, nil, fmt.Errorf("normalize candidate process provider capability subjects: %w", err)
+	}
+	return installed, normalized, nil
+}
+
+func validateTargetsGeneration(contextDef BundleContext, generation string) error {
+	for _, target := range contextDef.StandingTargets {
+		if target.AdmissionPlan.GenerationID() != generation {
+			return fmt.Errorf("runtime context %s standing target %q/%q admission generation %q does not match candidate process generation %q", contextDef.BundleHash, target.Alias, target.Provider, target.AdmissionPlan.GenerationID(), generation)
+		}
+	}
+	return nil
+}
+
+func validateContextSetCollisions(contexts []BundleContext) error {
+	seenAlias := map[string]string{}
+	for _, contextDef := range contexts {
+		for _, target := range contextDef.StandingTargets {
+			if previous, ok := seenAlias[target.Alias]; ok {
+				return fmt.Errorf("duplicate standing ingress alias %q across loaded BundleContexts: existing %s; incoming %s; rename one package flow ingress alias", target.Alias, previous, contextDef.BundleHash)
+			}
+			seenAlias[target.Alias] = contextDef.BundleHash
+		}
+	}
+	return nil
+}
+
 func (m *RuntimeContextManager) ReplaceBundleHash(existingHash string, contextDef BundleContext) error {
 	if m == nil {
 		return fmt.Errorf("runtime context manager is required")
@@ -572,6 +924,9 @@ func (m *RuntimeContextManager) ReplaceBundleHash(existingHash string, contextDe
 		return err
 	}
 	entry := m.contexts[existingHash]
+	if m.admissionGeneration != "" && (len(entry.context.StandingTargets) > 0 || len(contextDef.StandingTargets) > 0) {
+		return fmt.Errorf("runtime context %s carries compiled admission targets; replace through the process admission replacement transaction", existingHash)
+	}
 	if entry.context != nil && entry.context.Runtime != nil {
 		entry.context.Runtime.CloseAdmission()
 	}

--- a/internal/runtime/context_manager_admission_test.go
+++ b/internal/runtime/context_manager_admission_test.go
@@ -1,0 +1,267 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/providertriggers"
+)
+
+func TestRuntimeContextManagerPublishesOneAdmissionGenerationAcrossAllContexts(t *testing.T) {
+	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	newCatalog := runtimeAdmissionTestCatalog(t, "b")
+	oldState := runtimeAdmissionTestState(t, oldCatalog)
+	newState := runtimeAdmissionTestState(t, newCatalog)
+
+	primary := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", oldCatalog)
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, oldState, primary, survivor)
+	if err != nil {
+		t.Fatalf("NewRuntimeContextManagerWithAdmission: %v", err)
+	}
+	candidate := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", newCatalog)
+	survivingTargets := map[string][]StandingTarget{
+		runtimeContextTestHashB: runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", newCatalog).StandingTargets,
+	}
+	if err := manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidate, survivingTargets, newState); err != nil {
+		t.Fatalf("ValidateProcessAdmissionReplacement: %v", err)
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 1)
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			subjects := manager.CapabilitySubjects()
+			generation := ""
+			for _, subject := range subjects {
+				if subject.TriggerAdmission == nil {
+					continue
+				}
+				got := subject.TriggerAdmission.CatalogGeneration
+				if generation == "" {
+					generation = got
+				}
+				if got != generation {
+					select {
+					case errCh <- &mixedAdmissionGenerationError{first: generation, second: got}:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	if _, err := manager.BeginBundleHashReplacement(runtimeContextTestHashA, candidate); err != nil {
+		t.Fatalf("BeginBundleHashReplacement: %v", err)
+	}
+	if err := manager.PublishBundleHashReplacementWithAdmission(runtimeContextTestHashA, candidate, survivingTargets, newState); err != nil {
+		t.Fatalf("PublishBundleHashReplacementWithAdmission: %v", err)
+	}
+	close(stop)
+	readers.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+
+	if got := manager.AdmissionState().GenerationID; got != newCatalog.GenerationID() {
+		t.Fatalf("process generation = %q, want %q", got, newCatalog.GenerationID())
+	}
+	for _, alias := range []string{"primary", "survivor"} {
+		lookup := manager.LookupIngress(alias, "acme")
+		if !lookup.Loaded() || lookup.Target.AdmissionPlan.GenerationID() != newCatalog.GenerationID() {
+			t.Fatalf("lookup %q = %#v, want loaded new generation", alias, lookup)
+		}
+	}
+	assertRuntimeAdmissionSubjectGeneration(t, manager.CapabilitySubjects(), newCatalog.GenerationID(), 2)
+}
+
+func TestRuntimeContextManagerRejectsIncompleteAdmissionGenerationWithoutMutation(t *testing.T) {
+	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	newCatalog := runtimeAdmissionTestCatalog(t, "b")
+	primary := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", oldCatalog)
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, oldCatalog), primary, survivor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", newCatalog)
+	err = manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidate, nil, runtimeAdmissionTestState(t, newCatalog))
+	if err == nil || !strings.Contains(err.Error(), "did not recompile loaded runtime context") {
+		t.Fatalf("validation error = %v", err)
+	}
+	if got := manager.AdmissionState().GenerationID; got != oldCatalog.GenerationID() {
+		t.Fatalf("failed candidate changed generation to %q", got)
+	}
+	for _, alias := range []string{"primary", "survivor"} {
+		lookup := manager.LookupIngress(alias, "acme")
+		if !lookup.Loaded() || lookup.Target.AdmissionPlan.GenerationID() != oldCatalog.GenerationID() {
+			t.Fatalf("failed candidate changed lookup %q: %#v", alias, lookup)
+		}
+	}
+	assertRuntimeAdmissionSubjectGeneration(t, manager.CapabilitySubjects(), oldCatalog.GenerationID(), 2)
+}
+
+func TestRuntimeContextManagerAdmissionGenerationDoesNotDependOnPrimaryPackUse(t *testing.T) {
+	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	newCatalog := runtimeAdmissionTestCatalog(t, "b")
+	primary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, oldCatalog), primary, survivor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePrimary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	newSurvivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", newCatalog)
+	updates := map[string][]StandingTarget{runtimeContextTestHashB: newSurvivor.StandingTargets}
+	state := runtimeAdmissionTestState(t, newCatalog)
+	if err := manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidatePrimary, updates, state); err != nil {
+		t.Fatalf("primary-without-pack validation: %v", err)
+	}
+	if _, err := manager.BeginBundleHashReplacement(runtimeContextTestHashA, candidatePrimary); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.PublishBundleHashReplacementWithAdmission(runtimeContextTestHashA, candidatePrimary, updates, state); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.LookupIngress("survivor", "acme"); !got.Loaded() || got.Target.AdmissionPlan.GenerationID() != newCatalog.GenerationID() {
+		t.Fatalf("surviving pack target = %#v", got)
+	}
+	if primary, ok := manager.LookupBundleHash(runtimeContextTestHashA); !ok || len(primary.StandingTargets) != 0 {
+		t.Fatalf("primary context unexpectedly acquired pack target: %#v/%t", primary, ok)
+	}
+}
+
+func TestRuntimeContextManagerRejectsCandidatePackRemovalAcrossContexts(t *testing.T) {
+	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	emptyCatalog, err := providertriggers.NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	primary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, oldCatalog), primary, survivor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidatePrimary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	err = manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidatePrimary, map[string][]StandingTarget{
+		runtimeContextTestHashB: survivor.StandingTargets,
+	}, runtimeAdmissionTestState(t, emptyCatalog))
+	if err == nil || !strings.Contains(err.Error(), "does not match candidate process generation") {
+		t.Fatalf("pack removal validation error = %v", err)
+	}
+	if got := manager.AdmissionState().GenerationID; got != oldCatalog.GenerationID() {
+		t.Fatalf("pack removal changed process generation to %q", got)
+	}
+	if got := manager.LookupIngress("survivor", "acme"); !got.Loaded() || got.Target.AdmissionPlan.GenerationID() != oldCatalog.GenerationID() {
+		t.Fatalf("pack removal changed survivor: %#v", got)
+	}
+}
+
+func TestRuntimeContextManagerRejectsAdmissionTargetsOnLegacyPublishAndRestoresPredecessor(t *testing.T) {
+	catalog := runtimeAdmissionTestCatalog(t, "a")
+	predecessor := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", catalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, catalog), predecessor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", catalog)
+	if _, err := manager.BeginBundleHashReplacement(runtimeContextTestHashA, restored); err != nil {
+		t.Fatal(err)
+	}
+	err = manager.PublishBundleHashReplacement(runtimeContextTestHashA, restored)
+	if err == nil || !strings.Contains(err.Error(), "PublishBundleHashReplacementWithAdmission") {
+		t.Fatalf("legacy publish error = %v", err)
+	}
+	if err := manager.PublishRestoredBundleHashReplacement(runtimeContextTestHashA, restored); err != nil {
+		t.Fatalf("PublishRestoredBundleHashReplacement: %v", err)
+	}
+	lookup := manager.LookupIngress("primary", "acme")
+	if !lookup.Loaded() || lookup.Target.AdmissionPlan.GenerationID() != catalog.GenerationID() {
+		t.Fatalf("restored lookup = %#v", lookup)
+	}
+	assertRuntimeAdmissionSubjectGeneration(t, manager.CapabilitySubjects(), catalog.GenerationID(), 1)
+}
+
+type mixedAdmissionGenerationError struct{ first, second string }
+
+func (e *mixedAdmissionGenerationError) Error() string {
+	return "capability snapshot mixed admission generations " + e.first + " and " + e.second
+}
+
+func runtimeAdmissionTestCatalog(t *testing.T, hashToken string) *providertriggers.CatalogSnapshot {
+	t.Helper()
+	manifest := providertriggers.Manifest{
+		Provider: "acme", Secret: providertriggers.SecretManifest{Required: true},
+		Signature:  providertriggers.SignatureManifest{Type: "token_equality", Header: "X-Acme-Token"},
+		DeliveryID: providertriggers.ValueSource{Header: "X-Acme-Delivery", Required: true},
+		EventType:  providertriggers.ValueSource{Literal: "event", Required: true},
+		EventName:  providertriggers.EventNameManifest{Literal: "inbound.acme"},
+		Ack:        providertriggers.AckManifest{Mode: "after_publish"},
+	}
+	catalog, err := providertriggers.NewCatalogSnapshot(providertriggers.CatalogEntry{
+		Identity: providertriggers.PackIdentity{
+			ID: "provider.acme", Version: "1.0.0", ManifestHash: strings.Repeat(hashToken, 64), Provenance: packs.ProvenanceExternal,
+		},
+		Manifest: manifest, Source: "test", SourcePath: "/packs/acme",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return catalog
+}
+
+func runtimeAdmissionTestState(t *testing.T, catalog *providertriggers.CatalogSnapshot) ProcessAdmissionState {
+	t.Helper()
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ProcessAdmissionState{GenerationID: catalog.GenerationID(), InstalledSubjects: installed}
+}
+
+func runtimeAdmissionTestContext(t *testing.T, hash, alias string, catalog *providertriggers.CatalogSnapshot) BundleContext {
+	t.Helper()
+	contextDef := testBundleContext(t, hash, "inbound.acme")
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: alias, Provider: "acme", SigningSecret: "webhook_signing.acme",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextDef.StandingTargets = []StandingTarget{{
+		BundleHash: hash, FlowID: "acme-flow", Alias: alias, Provider: "acme", RunID: "run-" + alias,
+		FlowInstance: "acme-flow/" + alias, EntityID: "entity-" + alias, SigningSecret: "webhook_signing.acme", AdmissionPlan: plan,
+	}}
+	return contextDef
+}
+
+func assertRuntimeAdmissionSubjectGeneration(t *testing.T, subjects []packs.Subject, generation string, wantEffective int) {
+	t.Helper()
+	effective := 0
+	for _, subject := range subjects {
+		if subject.TriggerAdmission == nil {
+			continue
+		}
+		effective++
+		if subject.TriggerAdmission.CatalogGeneration != generation {
+			t.Fatalf("subject %q generation = %q, want %q", subject.ID, subject.TriggerAdmission.CatalogGeneration, generation)
+		}
+	}
+	if effective != wantEffective {
+		t.Fatalf("effective trigger subjects = %d, want %d", effective, wantEffective)
+	}
+}

--- a/internal/runtime/context_manager_admission_test.go
+++ b/internal/runtime/context_manager_admission_test.go
@@ -101,7 +101,16 @@ func TestRuntimeContextManagerPublishesOneAdmissionGenerationAcrossAllContexts(t
 			t.Fatalf("lookup %q = %#v, want loaded new generation", alias, lookup)
 		}
 	}
-	assertRuntimeAdmissionSubjectGeneration(t, manager.CapabilitySubjects(), newCatalog.GenerationID(), 2)
+	subjects := manager.CapabilitySubjects()
+	assertRuntimeAdmissionSubjectGeneration(t, subjects, newCatalog.GenerationID(), 2)
+	for _, subject := range subjects {
+		if subject.Applicability != "effective" || subject.TriggerAdmission == nil {
+			continue
+		}
+		if subject.TriggerAdmission.Pack == nil || subject.TriggerAdmission.Pack.ManifestHash != strings.Repeat("b", 64) {
+			t.Fatalf("effective subject retained stale pack identity: %#v", subject)
+		}
+	}
 }
 
 func TestRuntimeContextManagerRejectsIncompleteAdmissionGenerationWithoutMutation(t *testing.T) {

--- a/internal/runtime/context_manager_admission_test.go
+++ b/internal/runtime/context_manager_admission_test.go
@@ -42,6 +42,22 @@ func TestRuntimeContextManagerPublishesOneAdmissionGenerationAcrossAllContexts(t
 			default:
 			}
 			subjects := manager.CapabilitySubjects()
+			lookup := manager.LookupIngress("survivor", "acme")
+			if !lookup.Loaded() {
+				select {
+				case errCh <- &mixedAdmissionGenerationError{first: "loaded", second: "missing lookup"}:
+				default:
+				}
+				return
+			}
+			lookupGeneration := lookup.Target.AdmissionPlan.GenerationID()
+			if lookupGeneration != oldCatalog.GenerationID() && lookupGeneration != newCatalog.GenerationID() {
+				select {
+				case errCh <- &mixedAdmissionGenerationError{first: oldCatalog.GenerationID() + " or " + newCatalog.GenerationID(), second: lookupGeneration}:
+				default:
+				}
+				return
+			}
 			generation := ""
 			for _, subject := range subjects {
 				if subject.TriggerAdmission == nil {
@@ -145,29 +161,119 @@ func TestRuntimeContextManagerAdmissionGenerationDoesNotDependOnPrimaryPackUse(t
 }
 
 func TestRuntimeContextManagerRejectsCandidatePackRemovalAcrossContexts(t *testing.T) {
-	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	source, oldCatalog := standingTelegramDeclarationSource(t, "inbound.telegram")
 	emptyCatalog, err := providertriggers.NewCatalogSnapshot()
 	if err != nil {
 		t.Fatal(err)
 	}
 	primary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
-	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	survivor := testBundleContext(t, runtimeContextTestHashB, "inbound.telegram")
+	survivor.Source = source
+	plan, err := oldCatalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "chat", Provider: "telegram", SigningSecret: "webhook_signing.telegram",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	survivor.StandingTargets = []StandingTarget{{
+		BundleHash: runtimeContextTestHashB, FlowID: "coordinator", Alias: "chat", Provider: "telegram",
+		RunID: "run-chat", FlowInstance: "coordinator/chat", EntityID: "entity-chat",
+		SigningSecret: "webhook_signing.telegram", AdmissionPlan: plan,
+	}}
 	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, oldCatalog), primary, survivor)
 	if err != nil {
 		t.Fatal(err)
 	}
 	candidatePrimary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
-	err = manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidatePrimary, map[string][]StandingTarget{
-		runtimeContextTestHashB: survivor.StandingTargets,
-	}, runtimeAdmissionTestState(t, emptyCatalog))
-	if err == nil || !strings.Contains(err.Error(), "does not match candidate process generation") {
-		t.Fatalf("pack removal validation error = %v", err)
+	if _, err = RecompileStandingTargetAdmissions(survivor.Source, emptyCatalog, survivor.StandingTargets); err == nil || !strings.Contains(err.Error(), `provider "telegram" is pack-required`) {
+		t.Fatalf("actual pack removal recompile error = %v", err)
 	}
 	if got := manager.AdmissionState().GenerationID; got != oldCatalog.GenerationID() {
 		t.Fatalf("pack removal changed process generation to %q", got)
 	}
-	if got := manager.LookupIngress("survivor", "acme"); !got.Loaded() || got.Target.AdmissionPlan.GenerationID() != oldCatalog.GenerationID() {
+	if got := manager.LookupIngress("chat", "telegram"); !got.Loaded() || got.Target.AdmissionPlan.GenerationID() != oldCatalog.GenerationID() {
 		t.Fatalf("pack removal changed survivor: %#v", got)
+	}
+	if _, ok := manager.LookupBundleHash(candidatePrimary.BundleHash); !ok {
+		t.Fatal("pack removal failure withdrew unchanged primary context")
+	}
+}
+
+func TestRuntimeContextManagerRejectsTwoContextIngressCollisionWithoutMutation(t *testing.T) {
+	oldCatalog := runtimeAdmissionTestCatalog(t, "a")
+	newCatalog := runtimeAdmissionTestCatalog(t, "b")
+	primary := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "primary", oldCatalog)
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", oldCatalog)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, oldCatalog), primary, survivor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := runtimeAdmissionTestContext(t, runtimeContextTestHashA, "survivor", newCatalog)
+	updates := map[string][]StandingTarget{
+		runtimeContextTestHashB: runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", newCatalog).StandingTargets,
+	}
+	err = manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidate, updates, runtimeAdmissionTestState(t, newCatalog))
+	if err == nil || !strings.Contains(err.Error(), `duplicate standing ingress alias "survivor"`) {
+		t.Fatalf("collision validation error = %v", err)
+	}
+	if got := manager.AdmissionState().GenerationID; got != oldCatalog.GenerationID() {
+		t.Fatalf("collision changed generation to %q", got)
+	}
+	for alias, hash := range map[string]string{"primary": runtimeContextTestHashA, "survivor": runtimeContextTestHashB} {
+		lookup := manager.LookupIngress(alias, "acme")
+		if !lookup.Loaded() || lookup.Context.BundleHash != hash || lookup.Target.AdmissionPlan.GenerationID() != oldCatalog.GenerationID() {
+			t.Fatalf("collision changed %s lookup: %#v", alias, lookup)
+		}
+	}
+}
+
+func TestRuntimeContextManagerSignedToUnsignedTransitionRequiresAcknowledgedRecompileAcrossContexts(t *testing.T) {
+	signed := runtimeAdmissionTestCatalog(t, "a")
+	unsigned := runtimeAdmissionUnsignedTestCatalog(t, "b")
+	primary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	survivor := runtimeAdmissionTestContext(t, runtimeContextTestHashB, "survivor", signed)
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, runtimeAdmissionTestState(t, signed), primary, survivor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := unsigned.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: "survivor", Provider: "acme"}); err == nil || !strings.Contains(err.Error(), "admission.acknowledge: unsigned_webhook") {
+		t.Fatalf("unacknowledged transition compile error = %v", err)
+	}
+	if got := manager.LookupIngress("survivor", "acme"); !got.Loaded() || got.Target.AdmissionPlan.RequestAuthentication() != providertriggers.RequestAuthenticationTokenEquality {
+		t.Fatalf("failed transition changed predecessor: %#v", got)
+	}
+
+	unsignedPlan, err := unsigned.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "survivor", Provider: "acme",
+		Declaration: providertriggers.AdmissionDeclaration{Acknowledge: providertriggers.UnsignedWebhookAcknowledgement},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSurvivor := survivor
+	newSurvivor.StandingTargets = append([]StandingTarget(nil), survivor.StandingTargets...)
+	newSurvivor.StandingTargets[0].SigningSecret = ""
+	newSurvivor.StandingTargets[0].AdmissionPlan = unsignedPlan
+	candidatePrimary := testBundleContext(t, runtimeContextTestHashA, "primary.event")
+	updates := map[string][]StandingTarget{runtimeContextTestHashB: newSurvivor.StandingTargets}
+	state := runtimeAdmissionTestState(t, unsigned)
+	if err := manager.ValidateProcessAdmissionReplacement(runtimeContextTestHashA, candidatePrimary, updates, state); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.BeginBundleHashReplacement(runtimeContextTestHashA, candidatePrimary); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.PublishBundleHashReplacementWithAdmission(runtimeContextTestHashA, candidatePrimary, updates, state); err != nil {
+		t.Fatal(err)
+	}
+	lookup := manager.LookupIngress("survivor", "acme")
+	if !lookup.Loaded() || lookup.Target.AdmissionPlan.RequestAuthentication() != providertriggers.RequestAuthenticationNone || lookup.Target.AdmissionPlan.GenerationID() != unsigned.GenerationID() {
+		t.Fatalf("acknowledged transition lookup = %#v", lookup)
+	}
+	for _, subject := range manager.CapabilitySubjects() {
+		if subject.TriggerAdmission != nil && subject.Applicability == "effective" && subject.TriggerAdmission.RequestAuthentication != "UNAUTHENTICATED" {
+			t.Fatalf("transition readback retained stale authentication: %#v", subject)
+		}
 	}
 }
 
@@ -207,6 +313,27 @@ func runtimeAdmissionTestCatalog(t *testing.T, hashToken string) *providertrigge
 	manifest := providertriggers.Manifest{
 		Provider: "acme", Secret: providertriggers.SecretManifest{Required: true},
 		Signature:  providertriggers.SignatureManifest{Type: "token_equality", Header: "X-Acme-Token"},
+		DeliveryID: providertriggers.ValueSource{Header: "X-Acme-Delivery", Required: true},
+		EventType:  providertriggers.ValueSource{Literal: "event", Required: true},
+		EventName:  providertriggers.EventNameManifest{Literal: "inbound.acme"},
+		Ack:        providertriggers.AckManifest{Mode: "after_publish"},
+	}
+	catalog, err := providertriggers.NewCatalogSnapshot(providertriggers.CatalogEntry{
+		Identity: providertriggers.PackIdentity{
+			ID: "provider.acme", Version: "1.0.0", ManifestHash: strings.Repeat(hashToken, 64), Provenance: packs.ProvenanceExternal,
+		},
+		Manifest: manifest, Source: "test", SourcePath: "/packs/acme",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return catalog
+}
+
+func runtimeAdmissionUnsignedTestCatalog(t *testing.T, hashToken string) *providertriggers.CatalogSnapshot {
+	t.Helper()
+	manifest := providertriggers.Manifest{
+		Provider: "acme", Secret: providertriggers.SecretManifest{Required: false},
 		DeliveryID: providertriggers.ValueSource{Header: "X-Acme-Delivery", Required: true},
 		EventType:  providertriggers.ValueSource{Literal: "event", Required: true},
 		EventName:  providertriggers.EventNameManifest{Literal: "inbound.acme"},

--- a/internal/runtime/contracts/workflow_contract_standing_activation_test.go
+++ b/internal/runtime/contracts/workflow_contract_standing_activation_test.go
@@ -74,3 +74,55 @@ flows:
 		})
 	}
 }
+
+func TestProjectPackageDocumentInboundAdmissionStrictDecode(t *testing.T) {
+	var doc ProjectPackageDocument
+	if err := yaml.Unmarshal([]byte(`
+name: demo
+flows:
+  - id: events
+    flow: events
+    mode: singleton
+    activation: standing
+    ingress:
+      providers:
+        - provider: partner-events
+          signing_secret: webhook_signing.partner
+          admission:
+            kind: raw
+            authentication:
+              kind: hmac_sha256
+              header: X-Partner-Signature
+              prefix: sha256=
+              encoding: hex
+            event: inbound.partner
+            delivery_id:
+              source: json_path
+              json_path: $.event_id
+            payload: json
+`), &doc); err != nil {
+		t.Fatalf("Unmarshal raw admission: %v", err)
+	}
+	provider := doc.Flows[0].Ingress.Providers[0]
+	if provider.Admission.Kind != "raw" || provider.Admission.Authentication == nil || provider.Admission.Authentication.Header != "X-Partner-Signature" || provider.Admission.DeliveryID == nil || provider.Admission.DeliveryID.JSONPath != "$.event_id" {
+		t.Fatalf("raw admission = %#v", provider.Admission)
+	}
+
+	for _, tc := range []struct {
+		name, block, field string
+	}{
+		{name: "admission", field: "fallback", block: "admission:\n            fallback: raw"},
+		{name: "pack", field: "version", block: "admission:\n            pack:\n              id: provider.telegram\n              version: latest"},
+		{name: "authentication", field: "algorithm", block: "admission:\n            kind: raw\n            authentication:\n              kind: token\n              algorithm: constant_time"},
+		{name: "delivery_id", field: "query", block: "admission:\n            kind: raw\n            delivery_id:\n              source: header\n              query: id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "name: demo\nflows:\n  - id: chat\n    flow: chat\n    mode: singleton\n    activation: standing\n    ingress:\n      providers:\n        - provider: telegram\n          " + tc.block + "\n"
+			var invalid ProjectPackageDocument
+			err := yaml.Unmarshal([]byte(body), &invalid)
+			if err == nil || !strings.Contains(err.Error(), tc.field) || !strings.Contains(err.Error(), "not supported") {
+				t.Fatalf("strict decode error = %v, want unsupported field %q", err, tc.field)
+			}
+		})
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1218,8 +1218,36 @@ type ProjectFlowIngress struct {
 }
 
 type ProjectFlowIngressProvider struct {
-	Provider      string `yaml:"provider"`
-	SigningSecret string `yaml:"signing_secret"`
+	Provider      string                      `yaml:"provider"`
+	SigningSecret string                      `yaml:"signing_secret"`
+	Admission     ProjectFlowIngressAdmission `yaml:"admission"`
+}
+
+type ProjectFlowIngressAdmission struct {
+	Kind           string                            `yaml:"kind"`
+	Pack           *ProjectFlowIngressAdmissionPack  `yaml:"pack"`
+	Acknowledge    string                            `yaml:"acknowledge"`
+	Authentication *ProjectFlowIngressAuthentication `yaml:"authentication"`
+	Event          string                            `yaml:"event"`
+	DeliveryID     *ProjectFlowIngressDeliveryID     `yaml:"delivery_id"`
+	Payload        string                            `yaml:"payload"`
+}
+
+type ProjectFlowIngressAdmissionPack struct {
+	ID string `yaml:"id"`
+}
+
+type ProjectFlowIngressAuthentication struct {
+	Kind     string `yaml:"kind"`
+	Header   string `yaml:"header"`
+	Prefix   string `yaml:"prefix"`
+	Encoding string `yaml:"encoding"`
+}
+
+type ProjectFlowIngressDeliveryID struct {
+	Source   string `yaml:"source"`
+	Header   string `yaml:"header"`
+	JSONPath string `yaml:"json_path"`
 }
 type FlowPackageRequires struct {
 	Inputs          []string               `yaml:"inputs"`

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -55,6 +55,27 @@ var projectFlowIngressFields = map[string]struct{}{
 var projectFlowIngressProviderFields = map[string]struct{}{
 	"provider":       {},
 	"signing_secret": {},
+	"admission":      {},
+}
+
+var projectFlowIngressAdmissionFields = map[string]struct{}{
+	"kind":           {},
+	"pack":           {},
+	"acknowledge":    {},
+	"authentication": {},
+	"event":          {},
+	"delivery_id":    {},
+	"payload":        {},
+}
+
+var projectFlowIngressAdmissionPackFields = map[string]struct{}{"id": {}}
+
+var projectFlowIngressAuthenticationFields = map[string]struct{}{
+	"kind": {}, "header": {}, "prefix": {}, "encoding": {},
+}
+
+var projectFlowIngressDeliveryIDFields = map[string]struct{}{
+	"source": {}, "header": {}, "json_path": {},
 }
 
 func (p *ProjectPackageDocument) UnmarshalYAML(node *yaml.Node) error {
@@ -187,6 +208,70 @@ func (p *ProjectFlowIngressProvider) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	*p = ProjectFlowIngressProvider(out)
+	return nil
+}
+
+func (a *ProjectFlowIngressAdmission) UnmarshalYAML(node *yaml.Node) error {
+	if a == nil {
+		return nil
+	}
+	if err := validateKnownMappingFields(node, "package flow ingress admission", projectFlowIngressAdmissionFields); err != nil {
+		return err
+	}
+	type raw ProjectFlowIngressAdmission
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*a = ProjectFlowIngressAdmission(out)
+	return nil
+}
+
+func (p *ProjectFlowIngressAdmissionPack) UnmarshalYAML(node *yaml.Node) error {
+	if p == nil {
+		return nil
+	}
+	if err := validateKnownMappingFields(node, "package flow ingress admission pack", projectFlowIngressAdmissionPackFields); err != nil {
+		return err
+	}
+	type raw ProjectFlowIngressAdmissionPack
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*p = ProjectFlowIngressAdmissionPack(out)
+	return nil
+}
+
+func (a *ProjectFlowIngressAuthentication) UnmarshalYAML(node *yaml.Node) error {
+	if a == nil {
+		return nil
+	}
+	if err := validateKnownMappingFields(node, "package flow ingress admission authentication", projectFlowIngressAuthenticationFields); err != nil {
+		return err
+	}
+	type raw ProjectFlowIngressAuthentication
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*a = ProjectFlowIngressAuthentication(out)
+	return nil
+}
+
+func (d *ProjectFlowIngressDeliveryID) UnmarshalYAML(node *yaml.Node) error {
+	if d == nil {
+		return nil
+	}
+	if err := validateKnownMappingFields(node, "package flow ingress admission delivery_id", projectFlowIngressDeliveryIDFields); err != nil {
+		return err
+	}
+	type raw ProjectFlowIngressDeliveryID
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*d = ProjectFlowIngressDeliveryID(out)
 	return nil
 }
 

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -159,9 +159,6 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 		http.Error(w, "webhook body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
-	if len(body) == 0 {
-		body = []byte("{}")
-	}
 	requestURL := inboundRequestURL(r)
 	queryValues, queryParseError := inboundQueryValues(r)
 	formValues, formParsed, formParseError := inboundFormValues(r.Header.Get("Content-Type"), body)

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -42,6 +42,7 @@ type InboundTarget struct {
 	Alias         string
 	Provider      string
 	SigningSecret string
+	AdmissionPlan providertriggers.InboundAdmissionPlan
 }
 
 func (t InboundTarget) EffectiveEntityID() string {
@@ -69,7 +70,6 @@ type InboundGateway struct {
 	shutdownAdmissionClosed func() bool
 	beginAdmission          func(context.Context) (context.Context, func(), bool)
 	runtimeIngress          *runtimeingress.Controller
-	providers               *providertriggers.Registry
 	credentials             runtimecredentials.Store
 }
 
@@ -79,20 +79,16 @@ func (g *InboundGateway) SetAdmissionGuard(begin func(context.Context) (context.
 	}
 }
 
-func NewInboundGatewayWithProviderRegistry(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, providers *providertriggers.Registry, stores ...InboundPersistence) *InboundGateway {
+func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
 	var store InboundPersistence
 	if len(stores) > 0 {
 		store = stores[0]
-	}
-	if providers == nil {
-		panic("provider trigger registry is required")
 	}
 	g := &InboundGateway{
 		bus:                     bus,
 		store:                   store,
 		logger:                  logger,
 		shutdownAdmissionClosed: shutdownAdmissionClosed,
-		providers:               providers,
 	}
 	return g
 }
@@ -149,6 +145,10 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 		http.Error(w, "provider is required", http.StatusBadRequest)
 		return
 	}
+	if !target.AdmissionPlan.Valid() {
+		http.Error(w, fmt.Sprintf("ingress target %q provider %q has no compiled admission plan; request rejected before provider admission", target.Alias, provider), http.StatusServiceUnavailable)
+		return
+	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, inboundWebhookMaxBodyBytes+1))
 	if err != nil {
@@ -167,7 +167,11 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 	formValues, formParsed, formParseError := inboundFormValues(r.Header.Get("Content-Type"), body)
 
 	signingValue := ""
-	if target.SigningSecret != "" {
+	if target.AdmissionPlan.RequiresSecret() {
+		if target.SigningSecret == "" {
+			http.Error(w, fmt.Sprintf("ingress alias %q provider %q requires a signing secret for %s request authentication", target.Alias, provider, target.AdmissionPlan.RequestAuthentication()), http.StatusServiceUnavailable)
+			return
+		}
 		if g.credentials == nil {
 			http.Error(w, fmt.Sprintf("signing secret %s is UNBOUND; run `swarm secrets set %s`", target.SigningSecret, target.SigningSecret), http.StatusServiceUnavailable)
 			return
@@ -191,7 +195,7 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 	entityID := target.EffectiveEntityID()
 	entitySlug := target.EffectiveEntitySlug()
 	now := time.Now().UTC()
-	delivery, err := g.providers.Accept(providertriggers.Request{
+	delivery, err := target.AdmissionPlan.Accept(providertriggers.Request{
 		Provider: provider,
 		Target: providertriggers.Target{
 			EntityID:      target.EntityID,

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -2252,6 +2252,80 @@ func TestInboundGateway_ExecutesOnlyCompiledRawAdmissionPolicy(t *testing.T) {
 	}
 }
 
+func TestInboundGateway_PreservesExactEmptyBodyForCompiledAdmission(t *testing.T) {
+	catalog, err := providertriggers.NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "partner", Provider: "partner-events", SigningSecret: "partner-secret",
+		Declaration: providertriggers.AdmissionDeclaration{
+			Kind: "raw", Event: "inbound.partner", Payload: "raw",
+			Authentication: providertriggers.RawAuthenticationDeclaration{Kind: "hmac_sha256", Header: "X-Partner-Signature", Encoding: "hex"},
+			DeliveryID:     providertriggers.RawDeliveryIDDeclaration{Source: "body_sha256"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mac := hmac.New(sha256.New, []byte("partner-secret"))
+	signature := hex.EncodeToString(mac.Sum(nil))
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &recordingInboundStore{inserted: true}
+	gateway := NewInboundGateway(bus, nil, nil, store)
+	gateway.SetCredentialStore(identityInboundCredentialStore{})
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/partner/partner-events", nil)
+	req.Header.Set("X-Partner-Signature", signature)
+	rec := httptest.NewRecorder()
+	gateway.HandleResolvedWebhook(rec, req, InboundTarget{
+		BundleHash: "bundle-v1:sha256:" + strings.Repeat("e", 64), FlowID: "partner-flow", RunID: "run-partner",
+		FlowInstance: "partner-flow/standing", EntityID: "entity-partner", Alias: "partner", Provider: "partner-events",
+		SigningSecret: "partner-secret", AdmissionPlan: plan,
+	}, nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	wantID := hex.EncodeToString(sha256.New().Sum(nil))
+	if store.providerEventID != wantID {
+		t.Fatalf("body_sha256 delivery id = %q, want exact empty-body hash %q", store.providerEventID, wantID)
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(eventStore.events))
+	}
+
+	jsonPlan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "json", Provider: "json-events",
+		Declaration: providertriggers.AdmissionDeclaration{
+			Kind: "raw", Acknowledge: providertriggers.UnsignedWebhookAcknowledgement,
+			Event: "inbound.json", Payload: "json",
+			Authentication: providertriggers.RawAuthenticationDeclaration{Kind: "none"},
+			DeliveryID:     providertriggers.RawDeliveryIDDeclaration{Source: "body_sha256"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonStore := &recordingInboundStore{inserted: true}
+	jsonGateway := NewInboundGateway(bus, nil, nil, jsonStore)
+	jsonReq := httptest.NewRequest(http.MethodPost, "/webhooks/json/json-events", nil)
+	jsonRec := httptest.NewRecorder()
+	jsonGateway.HandleResolvedWebhook(jsonRec, jsonReq, InboundTarget{
+		BundleHash: "bundle-v1:sha256:" + strings.Repeat("f", 64), FlowID: "json-flow", RunID: "run-json",
+		FlowInstance: "json-flow/standing", EntityID: "entity-json", Alias: "json", Provider: "json-events",
+		AdmissionPlan: jsonPlan,
+	}, nil)
+	if jsonRec.Code != http.StatusBadRequest || !strings.Contains(jsonRec.Body.String(), "must be valid JSON") {
+		t.Fatalf("empty JSON body response = %d %q", jsonRec.Code, jsonRec.Body.String())
+	}
+	if jsonStore.recorded {
+		t.Fatal("empty JSON body reached marker persistence")
+	}
+}
+
 func TestInboundGateway_RejectsOversizedBodyBeforeMarkerAndPublish(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 type testInboundTargetResolver interface {
@@ -36,6 +37,37 @@ type testInboundTargetResolver interface {
 type testInboundGateway struct {
 	*InboundGateway
 	resolver testInboundTargetResolver
+	catalog  *providertriggers.CatalogSnapshot
+}
+
+func (g *testInboundGateway) HandleResolvedWebhook(w http.ResponseWriter, r *http.Request, target InboundTarget, source semanticview.Source) {
+	if target.Provider == "" || target.Alias == "" {
+		alias, provider, _ := parseWebhookPath(r.URL.Path)
+		if target.Alias == "" {
+			target.Alias = alias
+		}
+		if target.Provider == "" {
+			target.Provider = provider
+		}
+	}
+	if !target.AdmissionPlan.Valid() && g.catalog != nil {
+		declaration := providertriggers.AdmissionDeclaration{}
+		if _, installed := g.catalog.EntryByProvider(target.Provider); !installed && target.SigningSecret == "" {
+			declaration = providertriggers.AdmissionDeclaration{
+				Kind: "raw", Acknowledge: providertriggers.UnsignedWebhookAcknowledgement,
+				Authentication: providertriggers.RawAuthenticationDeclaration{Kind: "none"},
+				Event:          "inbound." + providertriggers.NormalizeProviderName(target.Provider),
+				DeliveryID:     providertriggers.RawDeliveryIDDeclaration{Source: "json_path", JSONPath: "$.id"}, Payload: "json",
+			}
+		}
+		plan, err := g.catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+			Alias: target.Alias, Provider: target.Provider, SigningSecret: target.SigningSecret, Declaration: declaration,
+		})
+		if err == nil {
+			target.AdmissionPlan = plan
+		}
+	}
+	g.InboundGateway.HandleResolvedWebhook(w, r, target, source)
 }
 
 func (g *testInboundGateway) Handler() http.Handler {
@@ -72,17 +104,17 @@ func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *Runti
 		}
 	}
 	sort.Strings(dirs)
-	registry, _, err := providertriggers.NewRegistryFromPackDirs("0.7.0", dirs, nil)
+	registry, _, err := providertriggers.NewCatalogSnapshotFromPackDirs("0.7.0", dirs, nil)
 	if err != nil {
 		t.Fatalf("load provider trigger registry: %v", err)
 	}
-	gateway := NewInboundGatewayWithProviderRegistry(bus, logger, shutdownAdmissionClosed, registry, stores...)
+	gateway := NewInboundGateway(bus, logger, shutdownAdmissionClosed, stores...)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	var resolver testInboundTargetResolver
 	if len(stores) > 0 {
 		resolver, _ = any(stores[0]).(testInboundTargetResolver)
 	}
-	return &testInboundGateway{InboundGateway: gateway, resolver: resolver}
+	return &testInboundGateway{InboundGateway: gateway, resolver: resolver, catalog: registry}
 }
 
 type identityInboundCredentialStore struct{}
@@ -561,8 +593,8 @@ func TestInboundGateway_SlackRejectsMissingSecretBeforeMarkerAndPublish(t *testi
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 body=%s", rec.Code, rec.Body.String())
 	}
 	if store.recorded {
 		t.Fatal("Slack request without configured signing secret recorded inbound marker")
@@ -1891,7 +1923,7 @@ func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *te
 			body:       []byte(`{"update_id":123456789,"message":{"message_id":7,"text":"hello"}}`),
 			target:     InboundTarget{EntityID: "3fd8fc37-6d02-4d50-8bb7-14c6cb0fed0a", EntitySlug: "customer-a"},
 			configure:  func(*http.Request, []byte) {},
-			wantStatus: http.StatusUnauthorized,
+			wantStatus: http.StatusServiceUnavailable,
 		},
 		{
 			name:       "missing token header",
@@ -1998,7 +2030,7 @@ func TestInboundGateway_TelegramDuplicateDeliveryDoesNotPublishAgain(t *testing.
 	}
 }
 
-func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(t *testing.T) {
+func TestInboundGateway_NoPlanDoesNotInterpretTypeformOrIntercomSignatures(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		body      []byte
@@ -2040,11 +2072,11 @@ func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(
 			rec := httptest.NewRecorder()
 			g.Handler().ServeHTTP(rec, req)
 
-			if rec.Code != http.StatusUnauthorized {
-				t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503 body=%s", rec.Code, rec.Body.String())
 			}
 			if store.recorded {
-				t.Fatalf("raw fallback accepted %s signature and recorded inbound marker", tc.name)
+				t.Fatalf("missing compiled plan accepted %s signature and recorded inbound marker", tc.name)
 			}
 			if len(eventStore.events) != 0 {
 				t.Fatalf("published events = %d, want 0", len(eventStore.events))
@@ -2053,7 +2085,7 @@ func TestInboundGateway_RawFallbackDoesNotInterpretTypeformOrIntercomSignatures(
 	}
 }
 
-func TestInboundGateway_RawFallbackDoesNotInterpretTelegramSecretToken(t *testing.T) {
+func TestInboundGateway_NoPlanDoesNotInterpretTelegramSecretToken(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
@@ -2075,18 +2107,18 @@ func TestInboundGateway_RawFallbackDoesNotInterpretTelegramSecretToken(t *testin
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 body=%s", rec.Code, rec.Body.String())
 	}
 	if store.recorded {
-		t.Fatal("raw fallback accepted Telegram secret token and recorded inbound marker")
+		t.Fatal("missing compiled plan accepted Telegram secret token and recorded inbound marker")
 	}
 	if len(eventStore.events) != 0 {
 		t.Fatalf("published events = %d, want 0", len(eventStore.events))
 	}
 }
 
-func TestInboundGateway_RawFallbackDoesNotInterpretShopifySignature(t *testing.T) {
+func TestInboundGateway_NoPlanDoesNotInterpretShopifySignature(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
@@ -2108,18 +2140,18 @@ func TestInboundGateway_RawFallbackDoesNotInterpretShopifySignature(t *testing.T
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 body=%s", rec.Code, rec.Body.String())
 	}
 	if store.recorded {
-		t.Fatal("raw fallback accepted Shopify signature and recorded inbound marker")
+		t.Fatal("missing compiled plan accepted Shopify signature and recorded inbound marker")
 	}
 	if len(eventStore.events) != 0 {
 		t.Fatalf("published events = %d, want 0", len(eventStore.events))
 	}
 }
 
-func TestInboundGateway_RawFallbackDoesNotInterpretStripeSignature(t *testing.T) {
+func TestInboundGateway_NoPlanDoesNotInterpretStripeSignature(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
@@ -2142,14 +2174,81 @@ func TestInboundGateway_RawFallbackDoesNotInterpretStripeSignature(t *testing.T)
 	rec := httptest.NewRecorder()
 	g.Handler().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 body=%s", rec.Code, rec.Body.String())
 	}
 	if store.recorded {
-		t.Fatal("raw fallback accepted Stripe-Signature and recorded inbound marker")
+		t.Fatal("missing compiled plan accepted Stripe-Signature and recorded inbound marker")
 	}
 	if len(eventStore.events) != 0 {
 		t.Fatalf("published events = %d, want 0", len(eventStore.events))
+	}
+}
+
+func TestInboundGateway_ExecutesOnlyCompiledRawAdmissionPolicy(t *testing.T) {
+	catalog, err := providertriggers.NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "partner", Provider: "partner-events", SigningSecret: "partner-secret",
+		Declaration: providertriggers.AdmissionDeclaration{
+			Kind: "raw", Event: "inbound.partner", Payload: "json",
+			Authentication: providertriggers.RawAuthenticationDeclaration{Kind: "hmac_sha256", Header: "X-Partner-Signature", Prefix: "sha256=", Encoding: "hex"},
+			DeliveryID:     providertriggers.RawDeliveryIDDeclaration{Source: "header", Header: "X-Partner-Delivery"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"id":"payload-id-is-not-authority","value":1}`)
+	mac := hmac.New(sha256.New, []byte("partner-secret"))
+	_, _ = mac.Write(body)
+	signature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	for _, tc := range []struct {
+		name, signature string
+		wantStatus      int
+		wantRecorded    bool
+	}{
+		{name: "declared signature and delivery header", signature: signature, wantStatus: http.StatusAccepted, wantRecorded: true},
+		{name: "provider-shaped but undeclared signature is rejected", signature: shopifyWebhookSignature("partner-secret", body), wantStatus: http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eventStore := &capturingInboundEventStore{}
+			bus, err := runtimebus.NewEventBus(eventStore)
+			if err != nil {
+				t.Fatal(err)
+			}
+			store := &recordingInboundStore{inserted: true}
+			gateway := NewInboundGateway(bus, nil, nil, store)
+			gateway.SetCredentialStore(identityInboundCredentialStore{})
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/partner/partner-events", strings.NewReader(string(body)))
+			req.Header.Set("X-Partner-Signature", tc.signature)
+			req.Header.Set("X-Partner-Delivery", "declared-delivery")
+			// These old heuristic candidates are deliberately irrelevant.
+			req.Header.Set("Stripe-Signature", signature)
+			req.Header.Set("X-GitHub-Event", "push")
+			rec := httptest.NewRecorder()
+			gateway.HandleResolvedWebhook(rec, req, InboundTarget{
+				BundleHash: "bundle-v1:sha256:" + strings.Repeat("d", 64), FlowID: "partner-flow", RunID: "run-partner",
+				FlowInstance: "partner-flow/standing", EntityID: "entity-partner", Alias: "partner", Provider: "partner-events",
+				SigningSecret: "partner-secret", AdmissionPlan: plan,
+			}, nil)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if store.recorded != tc.wantRecorded {
+				t.Fatalf("marker recorded=%t, want %t", store.recorded, tc.wantRecorded)
+			}
+			if tc.wantRecorded {
+				if store.providerEventID != "declared-delivery" || len(eventStore.events) != 1 || eventStore.events[0].Type() != "inbound.partner" {
+					t.Fatalf("accepted raw delivery marker=%q events=%#v", store.providerEventID, eventStore.events)
+				}
+			} else if len(eventStore.events) != 0 {
+				t.Fatalf("rejected raw delivery published %d events", len(eventStore.events))
+			}
+		})
 	}
 }
 

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -1338,11 +1338,17 @@ func acceptedTelegramInboundDeliveryEvent(t *testing.T, entityID, runID string) 
 		UserAgent: "telegram-test",
 	}
 	req.Headers.Set("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
-	registry, _, err := providertriggers.NewRegistryFromPackDirs("0.7.0", []string{filepath.Join("..", "..", "..", "packs", "provider-triggers", "telegram")}, nil)
+	catalog, _, err := providertriggers.NewCatalogSnapshotFromPackDirs("0.7.0", []string{filepath.Join("..", "..", "..", "packs", "provider-triggers", "telegram")}, nil)
 	if err != nil {
 		t.Fatalf("load Telegram provider trigger pack: %v", err)
 	}
-	delivery, err := registry.Accept(req)
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: "telegram-chat", Provider: "telegram", SigningSecret: "webhook_signing.telegram",
+	})
+	if err != nil {
+		t.Fatalf("compile Telegram inbound admission: %v", err)
+	}
+	delivery, err := plan.Accept(req)
 	if err != nil {
 		t.Fatalf("Accept Telegram inbound delivery: %v", err)
 	}

--- a/internal/runtime/provider_trigger_registry_external_test.go
+++ b/internal/runtime/provider_trigger_registry_external_test.go
@@ -29,7 +29,7 @@ func (boundedProviderCredentialStore) Set(context.Context, string, string) error
 func (boundedProviderCredentialStore) List(context.Context) ([]string, error)    { return nil, nil }
 func (boundedProviderCredentialStore) Delete(context.Context, string) error      { return nil }
 
-func testProviderTriggerRegistry(t *testing.T) *providertriggers.Registry {
+func testProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot {
 	t.Helper()
 	root := filepath.Join("..", "..", "packs", "provider-triggers")
 	entries, err := os.ReadDir(root)
@@ -43,7 +43,7 @@ func testProviderTriggerRegistry(t *testing.T) *providertriggers.Registry {
 		}
 	}
 	sort.Strings(dirs)
-	registry, _, err := providertriggers.NewRegistryFromPackDirs("0.7.0", dirs, nil)
+	registry, _, err := providertriggers.NewCatalogSnapshotFromPackDirs("0.7.0", dirs, nil)
 	if err != nil {
 		t.Fatalf("load provider trigger registry: %v", err)
 	}
@@ -52,7 +52,7 @@ func testProviderTriggerRegistry(t *testing.T) *providertriggers.Registry {
 
 func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *runtimepkg.RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...runtimepkg.InboundPersistence) *runtimepkg.InboundGateway {
 	t.Helper()
-	gateway := runtimepkg.NewInboundGatewayWithProviderRegistry(bus, logger, shutdownAdmissionClosed, testProviderTriggerRegistry(t), stores...)
+	gateway := runtimepkg.NewInboundGateway(bus, logger, shutdownAdmissionClosed, stores...)
 	gateway.SetCredentialStore(boundedProviderCredentialStore{})
 	return gateway
 }
@@ -79,7 +79,13 @@ func handleBoundedProviderDelivery(t *testing.T, gateway *runtimepkg.InboundGate
 			formParsed = true
 		}
 	}
-	delivery, err := testProviderTriggerRegistry(t).Accept(providertriggers.Request{
+	plan, err := testProviderTriggerCatalog(t).CompileAdmission(providertriggers.CompileAdmissionRequest{
+		Alias: entityID, Provider: provider, SigningSecret: "test.signing_secret",
+	})
+	if err != nil {
+		t.Fatalf("compile provider admission: %v", err)
+	}
+	delivery, err := plan.Accept(providertriggers.Request{
 		Provider: provider,
 		Target:   providertriggers.Target{EntityID: entityID, EntitySlug: entityID, WebhookSecret: signingSecret},
 		Method:   r.Method, URL: r.URL.String(), Body: body, Headers: r.Header, Payload: payload,

--- a/internal/runtime/routingtopology/topology.go
+++ b/internal/runtime/routingtopology/topology.go
@@ -77,12 +77,21 @@ type BoundaryExposure struct {
 }
 
 type RootInputSource struct {
-	ID               string          `json:"id"`
-	Kind             string          `json:"kind"`
-	Alias            string          `json:"alias"`
-	Provider         string          `json:"provider"`
-	Target           RootInputTarget `json:"target"`
-	AuthoredLocation string          `json:"authored_location,omitempty"`
+	ID               string             `json:"id"`
+	Kind             string             `json:"kind"`
+	Alias            string             `json:"alias"`
+	Provider         string             `json:"provider"`
+	Target           RootInputTarget    `json:"target"`
+	AuthoredLocation string             `json:"authored_location,omitempty"`
+	Admission        RootInputAdmission `json:"admission"`
+}
+
+type RootInputAdmission struct {
+	Kind                   string `json:"kind"`
+	PackID                 string `json:"pack_id,omitempty"`
+	DeclaredAuthentication string `json:"declared_authentication,omitempty"`
+	Event                  string `json:"event,omitempty"`
+	Acknowledgement        string `json:"acknowledgement,omitempty"`
 }
 
 type RootInputTarget struct {
@@ -272,12 +281,26 @@ func rootInputSourceViews(source semanticview.Source) []RootInputSource {
 				sourceFile = "package.yaml"
 			}
 			for providerIndex, binding := range ref.Ingress.Providers {
+				admissionKind := strings.ToLower(strings.TrimSpace(binding.Admission.Kind))
+				if admissionKind == "" {
+					admissionKind = "pack-required"
+				}
 				item := RootInputSource{
 					Kind:             RootInputSourceStandingIngress,
 					Alias:            alias,
 					Provider:         strings.TrimSpace(binding.Provider),
 					Target:           target,
 					AuthoredLocation: sourceFile + ":flows[" + strconv.Itoa(flowIndex) + "].ingress.providers[" + strconv.Itoa(providerIndex) + "]",
+					Admission:        RootInputAdmission{Kind: admissionKind, Event: strings.TrimSpace(binding.Admission.Event), Acknowledgement: strings.TrimSpace(binding.Admission.Acknowledge)},
+				}
+				if binding.Admission.Pack != nil {
+					item.Admission.PackID = strings.TrimSpace(binding.Admission.Pack.ID)
+				}
+				if binding.Admission.Authentication != nil {
+					item.Admission.DeclaredAuthentication = strings.ToUpper(strings.TrimSpace(binding.Admission.Authentication.Kind))
+					if item.Admission.DeclaredAuthentication == "NONE" {
+						item.Admission.DeclaredAuthentication = "UNAUTHENTICATED"
+					}
 				}
 				item.ID = rootInputSourceID(item)
 				out = append(out, item)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -84,7 +84,7 @@ type RuntimeOptions struct {
 	Credentials                      runtimecredentials.Store
 	ManagedCredentials               runtimemanagedcredentials.Store
 	ProviderCredentials              runtimecredentials.Store
-	ProviderTriggerRegistry          *providertriggers.Registry
+	ProviderTriggerCatalog           *providertriggers.CatalogSnapshot
 	BootStartedAt                    time.Time
 	BootProgress                     func(BootProgressEvent)
 	SystemContainers                 []string
@@ -391,7 +391,7 @@ func ensureWorkflowBootWiring(opts RuntimeOptions) error {
 	}
 	validationOpts := DefaultWorkflowContractValidationOptions(opts.Credentials)
 	validationOpts.ManagedCredentials = opts.ManagedCredentials
-	validationOpts.ProviderTriggerRegistry = opts.ProviderTriggerRegistry
+	validationOpts.ProviderTriggerCatalog = opts.ProviderTriggerCatalog
 	result, err := ValidateWorkflowContractSurface(context.Background(), source, validationOpts)
 	if err != nil {
 		return err
@@ -468,8 +468,8 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 	if blocker := strings.TrimSpace(stores.ConstructionBlocker); blocker != "" {
 		return validatedRuntimeDeps{}, fmt.Errorf("runtime store boundary is not construction-ready: %s", blocker)
 	}
-	if stores.InboundStore != nil && opts.ProviderTriggerRegistry == nil {
-		return validatedRuntimeDeps{}, fmt.Errorf("provider trigger registry is required when inbound store is configured")
+	if stores.InboundStore != nil && opts.ProviderTriggerCatalog == nil {
+		return validatedRuntimeDeps{}, fmt.Errorf("provider trigger catalog snapshot is required when inbound store is configured")
 	}
 	var source semanticview.Source
 	if opts.WorkflowModule != nil {
@@ -819,7 +819,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	managerRef = rt.Manager
 
 	if stores.InboundStore != nil {
-		rt.InboundGateway = NewInboundGatewayWithProviderRegistry(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed, opts.ProviderTriggerRegistry, stores.InboundStore)
+		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed, stores.InboundStore)
 		rt.InboundGateway.SetAdmissionGuard(rt.shutdownGate.BeginContext)
 		rt.InboundGateway.SetRuntimeIngress(rt.RuntimeIngress)
 		rt.InboundGateway.SetCredentialStore(opts.ProviderCredentials)

--- a/internal/runtime/standing_targets.go
+++ b/internal/runtime/standing_targets.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -19,6 +20,7 @@ type StandingIngressBinding struct {
 	SigningSecret string
 	EventLiteral  string
 	EventTemplate string
+	AdmissionPlan providertriggers.InboundAdmissionPlan
 }
 
 type StandingTargetDeclaration struct {
@@ -42,6 +44,7 @@ type StandingTarget struct {
 	FlowInstance  string
 	EntityID      string
 	SigningSecret string
+	AdmissionPlan providertriggers.InboundAdmissionPlan
 }
 
 type StandingActivation struct {
@@ -76,6 +79,13 @@ func (t StandingTarget) normalized() StandingTarget {
 	return t
 }
 
+func (t StandingTarget) CapabilitySubject() (packs.Subject, error) {
+	t = t.normalized()
+	return t.AdmissionPlan.EffectiveCapabilitySubject(providertriggers.EffectiveSubjectRequest{
+		BundleHash: t.BundleHash, Alias: t.Alias, SigningSecret: t.SigningSecret, SourcePath: t.SourcePath,
+	})
+}
+
 func NormalizeStandingIngressAlias(alias string) (string, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
@@ -92,7 +102,7 @@ func NormalizeStandingIngressAlias(alias string) (string, error) {
 	return alias, nil
 }
 
-func ResolveStandingTargetDeclarations(source semanticview.Source, providers *providertriggers.Registry) ([]StandingTargetDeclaration, error) {
+func ResolveStandingTargetDeclarations(source semanticview.Source, catalog *providertriggers.CatalogSnapshot) ([]StandingTargetDeclaration, error) {
 	bundle, ok := semanticview.Bundle(source)
 	if !ok || bundle == nil {
 		return nil, fmt.Errorf("standing target declarations require a bundle-backed semantic source")
@@ -156,23 +166,21 @@ func ResolveStandingTargetDeclarations(source semanticview.Source, providers *pr
 					}
 					seenProviders[provider] = struct{}{}
 					secret := strings.TrimSpace(binding.SigningSecret)
-					if secret == "" {
-						return nil, fmt.Errorf("%s ingress provider %q requires signing_secret", location, provider)
+					plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+						Alias: decl.Alias, Provider: provider, SigningSecret: secret,
+						Declaration: providerAdmissionDeclaration(binding.Admission),
+					})
+					if err != nil {
+						return nil, fmt.Errorf("%s: %w", location, err)
 					}
-					if providers == nil {
-						return nil, fmt.Errorf("%s ingress provider %q cannot be verified: provider trigger registry is required", location, provider)
-					}
-					manifest, exists := providers.Manifest(provider)
-					if !exists {
-						return nil, fmt.Errorf("%s ingress provider %q is not installed", location, provider)
-					}
-					literal := strings.TrimSpace(manifest.EventName.Literal)
-					template := strings.TrimSpace(manifest.EventName.Template)
-					if err := validateStandingIngressPins(source, flowID, provider, manifest.EventName); err != nil {
+					eventNames := plan.EventNames()
+					literal := strings.TrimSpace(eventNames.Literal)
+					template := strings.TrimSpace(eventNames.Template)
+					if err := validateStandingIngressPins(source, flowID, provider, eventNames); err != nil {
 						return nil, fmt.Errorf("%s: %w", location, err)
 					}
 					decl.Ingress = append(decl.Ingress, StandingIngressBinding{
-						Provider: provider, SigningSecret: secret, EventLiteral: literal, EventTemplate: template,
+						Provider: provider, SigningSecret: secret, EventLiteral: literal, EventTemplate: template, AdmissionPlan: plan,
 					})
 				}
 			}
@@ -192,6 +200,90 @@ func ResolveStandingTargetDeclarations(source semanticview.Source, providers *pr
 		return declarations[i].PackageKey < declarations[j].PackageKey
 	})
 	return declarations, nil
+}
+
+func providerAdmissionDeclaration(admission runtimecontracts.ProjectFlowIngressAdmission) providertriggers.AdmissionDeclaration {
+	declaration := providertriggers.AdmissionDeclaration{
+		Kind: admission.Kind, Acknowledge: admission.Acknowledge, Event: admission.Event, Payload: admission.Payload,
+	}
+	if admission.Pack != nil {
+		declaration.PackID = admission.Pack.ID
+	}
+	if admission.Authentication != nil {
+		declaration.Authentication = providertriggers.RawAuthenticationDeclaration{
+			Kind: admission.Authentication.Kind, Header: admission.Authentication.Header,
+			Prefix: admission.Authentication.Prefix, Encoding: admission.Authentication.Encoding,
+		}
+	}
+	if admission.DeliveryID != nil {
+		declaration.DeliveryID = providertriggers.RawDeliveryIDDeclaration{
+			Source: admission.DeliveryID.Source, Header: admission.DeliveryID.Header, JSONPath: admission.DeliveryID.JSONPath,
+		}
+	}
+	return declaration
+}
+
+func RecompileStandingTargetAdmissions(source semanticview.Source, catalog *providertriggers.CatalogSnapshot, existing []StandingTarget) ([]StandingTarget, error) {
+	declarations, err := ResolveStandingTargetDeclarations(source, catalog)
+	if err != nil {
+		return nil, err
+	}
+	bindings := map[string]StandingIngressBinding{}
+	for _, declaration := range declarations {
+		for _, binding := range declaration.Ingress {
+			bindings[declaration.Alias+"\x00"+binding.Provider] = binding
+		}
+	}
+	if len(bindings) != len(existing) {
+		return nil, fmt.Errorf("candidate provider-trigger catalog recompile found %d declared standing ingress targets, but loaded context carries %d", len(bindings), len(existing))
+	}
+	out := make([]StandingTarget, 0, len(existing))
+	for _, target := range existing {
+		target = target.normalized()
+		binding, ok := bindings[target.Alias+"\x00"+target.Provider]
+		if !ok {
+			return nil, fmt.Errorf("candidate provider-trigger catalog recompile cannot resolve loaded standing target %q/%q", target.Alias, target.Provider)
+		}
+		target.SigningSecret = binding.SigningSecret
+		target.AdmissionPlan = binding.AdmissionPlan
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+func EffectiveStandingIngressCapabilitySubjects(source semanticview.Source, catalog *providertriggers.CatalogSnapshot) ([]packs.Subject, error) {
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return nil, fmt.Errorf("effective standing ingress capability subjects require a bundle-backed semantic source")
+	}
+	declarations, err := ResolveStandingTargetDeclarations(source, catalog)
+	if err != nil {
+		return nil, err
+	}
+	ingressCount := 0
+	for _, declaration := range declarations {
+		ingressCount += len(declaration.Ingress)
+	}
+	if ingressCount == 0 {
+		return nil, nil
+	}
+	bundleHash, err := runtimecontracts.BundleHash(bundle)
+	if err != nil {
+		return nil, err
+	}
+	subjects := make([]packs.Subject, 0, ingressCount)
+	for _, declaration := range declarations {
+		for _, binding := range declaration.Ingress {
+			subject, err := binding.AdmissionPlan.EffectiveCapabilitySubject(providertriggers.EffectiveSubjectRequest{
+				BundleHash: bundleHash, Alias: declaration.Alias, SigningSecret: binding.SigningSecret, SourcePath: declaration.SourcePath,
+			})
+			if err != nil {
+				return nil, err
+			}
+			subjects = append(subjects, subject)
+		}
+	}
+	return packs.NormalizeSubjects(subjects)
 }
 
 func standingDeclarationLocation(pkg runtimecontracts.LoadedProjectPackage, flowID string) string {
@@ -337,7 +429,7 @@ func (rt *Runtime) standingTargetPlans() ([]standingTargetPlan, error) {
 		return nil, fmt.Errorf("runtime workflow module is required")
 	}
 	source := rt.Options.WorkflowModule.SemanticSource()
-	declarations, err := ResolveStandingTargetDeclarations(source, rt.Options.ProviderTriggerRegistry)
+	declarations, err := ResolveStandingTargetDeclarations(source, rt.Options.ProviderTriggerCatalog)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +450,7 @@ func (rt *Runtime) standingTargetPlans() ([]standingTargetPlan, error) {
 				BundleHash: fact.BundleHash, PackageKey: declaration.PackageKey, SourcePath: declaration.SourcePath,
 				FlowID: declaration.FlowID, FlowPath: declaration.FlowPath, Alias: declaration.Alias,
 				Provider: binding.Provider, RunID: runID, FlowInstance: instance.InstancePath,
-				EntityID: instance.EntityID, SigningSecret: binding.SigningSecret,
+				EntityID: instance.EntityID, SigningSecret: binding.SigningSecret, AdmissionPlan: binding.AdmissionPlan,
 			}.normalized())
 		}
 		plans = append(plans, plan)

--- a/internal/runtime/standing_targets.go
+++ b/internal/runtime/standing_targets.go
@@ -286,6 +286,25 @@ func EffectiveStandingIngressCapabilitySubjects(source semanticview.Source, cata
 	return packs.NormalizeSubjects(subjects)
 }
 
+// ProviderTriggerCapabilitySubjects is the canonical installed-plus-effective
+// trigger projection for contract verification surfaces.
+func ProviderTriggerCapabilitySubjects(source semanticview.Source, catalog *providertriggers.CatalogSnapshot) ([]packs.Subject, error) {
+	var subjects []packs.Subject
+	if catalog != nil {
+		installed, err := catalog.InstalledCapabilitySubjects()
+		if err != nil {
+			return nil, err
+		}
+		subjects = append(subjects, installed...)
+	}
+	effective, err := EffectiveStandingIngressCapabilitySubjects(source, catalog)
+	if err != nil {
+		return nil, err
+	}
+	subjects = append(subjects, effective...)
+	return packs.NormalizeSubjects(subjects)
+}
+
 func standingDeclarationLocation(pkg runtimecontracts.LoadedProjectPackage, flowID string) string {
 	path := strings.TrimSpace(pkg.Paths.PackageFile)
 	if path == "" {

--- a/internal/runtime/standing_targets_test.go
+++ b/internal/runtime/standing_targets_test.go
@@ -89,20 +89,100 @@ func TestResolveStandingTargetDeclarationsRejectsUnreachableIngressAlias(t *test
 	}
 }
 
+func TestStandingIngressAdmissionOmissionIsPackRequired(t *testing.T) {
+	source, _ := standingTelegramDeclarationSource(t, "inbound.partner")
+	bundle, _ := semanticview.Bundle(source)
+	binding := &bundle.PackageTree[0].Manifest.Flows[0].Ingress.Providers[0]
+	binding.Provider = "partner"
+	binding.SigningSecret = ""
+	binding.Admission = runtimecontracts.ProjectFlowIngressAdmission{}
+	emptyCatalog, err := providertriggers.NewCatalogSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ResolveStandingTargetDeclarations(source, emptyCatalog)
+	if err == nil || !strings.Contains(err.Error(), `provider "partner" is pack-required`) || !strings.Contains(err.Error(), "admission.kind: raw") {
+		t.Fatalf("omitted admission error = %v", err)
+	}
+}
+
+func TestValidateWorkflowContractSurfaceWarnsForUnacknowledgedUnsignedRawAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		acknowledge string
+		wantWarning bool
+	}{
+		{name: "warning teaches acknowledgement", wantWarning: true},
+		{name: "structured acknowledgement suppresses warning", acknowledge: providertriggers.UnsignedWebhookAcknowledgement},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source, _ := standingTelegramDeclarationSource(t, "inbound.partner")
+			bundle, _ := semanticview.Bundle(source)
+			binding := &bundle.PackageTree[0].Manifest.Flows[0].Ingress.Providers[0]
+			binding.Provider = "partner"
+			binding.SigningSecret = ""
+			binding.Admission = runtimecontracts.ProjectFlowIngressAdmission{
+				Kind: "raw", Acknowledge: tc.acknowledge, Event: "inbound.partner", Payload: "json",
+				Authentication: &runtimecontracts.ProjectFlowIngressAuthentication{Kind: "none"},
+				DeliveryID:     &runtimecontracts.ProjectFlowIngressDeliveryID{Source: "json_path", JSONPath: "$.id"},
+			}
+			emptyCatalog, err := providertriggers.NewCatalogSnapshot()
+			if err != nil {
+				t.Fatal(err)
+			}
+			declarations, err := ResolveStandingTargetDeclarations(source, emptyCatalog)
+			if err != nil {
+				t.Fatalf("ResolveStandingTargetDeclarations: %v", err)
+			}
+			warnings := unsignedRawAdmissionFindings(declarations)
+			found := false
+			for _, warning := range warnings {
+				if warning.CheckID != "inbound_unsigned_webhook" {
+					continue
+				}
+				found = true
+				if !strings.Contains(warning.Message, "anyone who learns") || !strings.Contains(warning.Remediation, "admission.acknowledge: unsigned_webhook") {
+					t.Fatalf("unsigned warning = %#v", warning)
+				}
+			}
+			if found != tc.wantWarning {
+				t.Fatalf("unsigned warning found=%t, want %t: %#v", found, tc.wantWarning, warnings)
+			}
+			bundleHash := "bundle-v1:sha256:" + strings.Repeat("c", 64)
+			subject, err := declarations[0].Ingress[0].AdmissionPlan.EffectiveCapabilitySubject(providertriggers.EffectiveSubjectRequest{BundleHash: bundleHash, Alias: declarations[0].Alias})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if subject.TriggerAdmission == nil || subject.TriggerAdmission.RequestAuthentication != "UNAUTHENTICATED" || len(subject.Requirements) != 0 {
+				t.Fatalf("effective unsigned subject = %#v", subject)
+			}
+		})
+	}
+}
+
 func TestRuntimeContextManagerLookupIngressDistinguishesAliasAndProvider(t *testing.T) {
-	source, _ := standingTelegramDeclarationSource(t, "inbound.telegram")
+	source, catalog := standingTelegramDeclarationSource(t, "inbound.telegram")
 	bus, err := runtimebus.NewEventBus(nil)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	hash := "bundle-v1:sha256:" + strings.Repeat("a", 64)
-	manager, err := NewRuntimeContextManager(nil, BundleContext{
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: "chat", Provider: "telegram", SigningSecret: "webhook_signing.telegram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := NewRuntimeContextManagerWithAdmission(nil, ProcessAdmissionState{GenerationID: catalog.GenerationID(), InstalledSubjects: installed}, BundleContext{
 		BundleHash: hash,
 		Source:     source,
 		Runtime:    &Runtime{Bus: bus},
 		StandingTargets: []StandingTarget{{
 			BundleHash: hash, FlowID: "coordinator", Alias: "chat", Provider: "telegram",
 			RunID: "run", FlowInstance: "coordinator/a", EntityID: "entity", SigningSecret: "webhook_signing.telegram",
+			AdmissionPlan: plan,
 		}},
 	})
 	if err != nil {
@@ -117,7 +197,7 @@ func TestRuntimeContextManagerLookupIngressDistinguishesAliasAndProvider(t *test
 }
 
 func TestInboundGatewayRejectsMappedEventBeforeMarkerOrPublish(t *testing.T) {
-	source, _ := standingTelegramDeclarationSource(t, "lead.observed")
+	source, catalog := standingTelegramDeclarationSource(t, "lead.observed")
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
@@ -128,11 +208,16 @@ func TestInboundGatewayRejectsMappedEventBeforeMarkerOrPublish(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/chat/telegram", strings.NewReader(`{"update_id":124,"message":{"chat":{"id":42}}}`))
 	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
 	rec := httptest.NewRecorder()
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: "chat", Provider: "telegram", SigningSecret: "telegram-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	gateway.HandleResolvedWebhook(rec, req, InboundTarget{
 		BundleHash: "bundle-v1:sha256:" + strings.Repeat("a", 64), FlowID: "coordinator",
 		RunID: "41000000-0000-0000-0000-000000000001", FlowInstance: "coordinator/a",
 		EntityID: "41000000-0000-0000-0000-000000000002", Alias: "chat", Provider: "telegram",
 		SigningSecret: "telegram-secret",
+		AdmissionPlan: plan,
 	}, source)
 	if rec.Code != http.StatusUnprocessableEntity || !strings.Contains(rec.Body.String(), "no exact external input pin") {
 		t.Fatalf("response = %d %q, want exact-pin rejection", rec.Code, rec.Body.String())
@@ -143,14 +228,14 @@ func TestInboundGatewayRejectsMappedEventBeforeMarkerOrPublish(t *testing.T) {
 }
 
 func TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish(t *testing.T) {
-	source, registry := standingProviderDeclarationSource(t, "github", "inbound.github.issues")
+	source, catalog := standingProviderDeclarationSource(t, "github", "inbound.github.issues")
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	store := &recordingInboundStore{inserted: true}
-	gateway := NewInboundGatewayWithProviderRegistry(bus, nil, nil, registry, store)
+	gateway := NewInboundGateway(bus, nil, nil, store)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	body := []byte(`{"action":"created","issue":{"number":7}}`)
 	mac := hmac.New(sha256.New, []byte("github-secret"))
@@ -160,11 +245,16 @@ func TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish(t *
 	req.Header.Set("X-GitHub-Delivery", "delivery-comment-1")
 	req.Header.Set("X-GitHub-Event", "issue_comment")
 	rec := httptest.NewRecorder()
+	plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: "issues", Provider: "github", SigningSecret: "github-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	gateway.HandleResolvedWebhook(rec, req, InboundTarget{
 		BundleHash: "bundle-v1:sha256:" + strings.Repeat("b", 64), FlowID: "coordinator",
 		RunID: "42000000-0000-0000-0000-000000000001", FlowInstance: "coordinator/b",
 		EntityID: "42000000-0000-0000-0000-000000000002", Alias: "issues", Provider: "github",
 		SigningSecret: "github-secret",
+		AdmissionPlan: plan,
 	}, source)
 	if rec.Code != http.StatusUnprocessableEntity || !strings.Contains(rec.Body.String(), `resolved event "inbound.github.issue_comment"`) || !strings.Contains(rec.Body.String(), "has no exact external input pin") {
 		t.Fatalf("response = %d %q, want exact mapped dynamic-event rejection", rec.Code, rec.Body.String())
@@ -174,11 +264,11 @@ func TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish(t *
 	}
 }
 
-func standingTelegramDeclarationSource(t testing.TB, inputEvent string) (semanticview.Source, *providertriggers.Registry) {
+func standingTelegramDeclarationSource(t testing.TB, inputEvent string) (semanticview.Source, *providertriggers.CatalogSnapshot) {
 	return standingProviderDeclarationSource(t, "telegram", inputEvent)
 }
 
-func standingProviderDeclarationSource(t testing.TB, provider, inputEvent string) (semanticview.Source, *providertriggers.Registry) {
+func standingProviderDeclarationSource(t testing.TB, provider, inputEvent string) (semanticview.Source, *providertriggers.CatalogSnapshot) {
 	t.Helper()
 	alias := provider
 	if provider == "telegram" {
@@ -209,7 +299,7 @@ func standingProviderDeclarationSource(t testing.TB, provider, inputEvent string
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
-	registry, _, err := providertriggers.NewRegistryFromPackDirs("0.7.0", []string{filepath.Join(repoRoot, "packs", "provider-triggers", provider)}, nil)
+	registry, _, err := providertriggers.NewCatalogSnapshotFromPackDirs("0.7.0", []string{filepath.Join(repoRoot, "packs", "provider-triggers", provider)}, nil)
 	if err != nil {
 		t.Fatalf("load %s pack: %v", provider, err)
 	}

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/providerconnectors"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
@@ -29,7 +30,7 @@ type WorkflowContractValidationOptions struct {
 	LLMProfile                     llmselection.Profile
 	ModelAliases                   llmselection.ModelAliases
 	HarnessInjections              []runtimecontracts.FlowInputProducerInjection
-	ProviderTriggerRegistry        *providertriggers.Registry
+	ProviderTriggerCatalog         *providertriggers.CatalogSnapshot
 }
 
 type WorkflowContractValidationResult struct {
@@ -38,6 +39,7 @@ type WorkflowContractValidationResult struct {
 	MissingEmitSchemaEventTypes      []string
 	GeneratedEmitSchemaErrors        []error
 	GeneratedToolSchemaClosureErrors []error
+	CapabilitySubjects               []packs.Subject
 }
 
 func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Store) WorkflowContractValidationOptions {
@@ -47,7 +49,7 @@ func DefaultWorkflowContractValidationOptions(credentials runtimecredentials.Sto
 		StrictEmitSchemas:              runtimeEnvBool("SWARM_EMIT_SCHEMA_STRICT", true),
 		FatalToolImplementationWarning: bootWarningsFatal(),
 		FatalBootWarnings:              bootWarningsFatal(),
-		ExcludedFatalBootWarningChecks: []string{"tool_resolution"},
+		ExcludedFatalBootWarningChecks: []string{"tool_resolution", "inbound_unsigned_webhook"},
 	}
 }
 
@@ -117,11 +119,40 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	if len(connectorErrors) > 0 {
 		return result, fmt.Errorf("provider connector validation failed:\n%s", formatValidationErrors(connectorErrors))
 	}
-	if _, err := ResolveStandingTargetDeclarations(source, opts.ProviderTriggerRegistry); err != nil {
+	declarations, err := ResolveStandingTargetDeclarations(source, opts.ProviderTriggerCatalog)
+	if err != nil {
 		return result, fmt.Errorf("standing ingress validation failed: %w", err)
+	}
+	for _, finding := range unsignedRawAdmissionFindings(declarations) {
+		result.BootReport.Add(finding)
+	}
+	result.BootReport.Sort()
+	result.CapabilitySubjects, err = EffectiveStandingIngressCapabilitySubjects(source, opts.ProviderTriggerCatalog)
+	if err != nil {
+		return result, fmt.Errorf("standing ingress capability projection failed: %w", err)
 	}
 
 	return result, nil
+}
+
+func unsignedRawAdmissionFindings(declarations []StandingTargetDeclaration) []runtimebootverify.Finding {
+	var findings []runtimebootverify.Finding
+	for _, declaration := range declarations {
+		for _, binding := range declaration.Ingress {
+			if binding.AdmissionPlan.PolicySource() != providertriggers.PolicySourceRawDeclaration ||
+				binding.AdmissionPlan.RequestAuthentication() != providertriggers.RequestAuthenticationNone ||
+				binding.AdmissionPlan.AcknowledgedUnsigned() {
+				continue
+			}
+			findings = append(findings, runtimebootverify.Finding{
+				CheckID: "inbound_unsigned_webhook", Severity: runtimebootverify.SeveritySemanticDriftWarn,
+				Location:    declaration.SourcePath,
+				Message:     fmt.Sprintf("ingress alias %q provider %q accepts unsigned webhooks; anyone who learns /webhooks/%s/%s can POST events into this flow", declaration.Alias, binding.Provider, declaration.Alias, binding.Provider),
+				Remediation: "add admission.acknowledge: unsigned_webhook to confirm this intentional public endpoint",
+			})
+		}
+	}
+	return findings
 }
 
 func formatWorkflowValidationFindings(findings []runtimebootverify.Finding, blocking bool) string {

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -127,9 +127,9 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 		result.BootReport.Add(finding)
 	}
 	result.BootReport.Sort()
-	result.CapabilitySubjects, err = EffectiveStandingIngressCapabilitySubjects(source, opts.ProviderTriggerCatalog)
+	result.CapabilitySubjects, err = ProviderTriggerCapabilitySubjects(source, opts.ProviderTriggerCatalog)
 	if err != nil {
-		return result, fmt.Errorf("standing ingress capability projection failed: %w", err)
+		return result, fmt.Errorf("provider trigger capability projection failed: %w", err)
 	}
 
 	return result, nil

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -711,7 +711,7 @@ func TestRuntimeDepsValidateOwnsRequiredBootInputs(t *testing.T) {
 				Stores:  Stores{InboundStore: &recordingInboundStore{}},
 				Options: RuntimeOptions{WorkflowModule: validModule},
 			},
-			errContains: "provider trigger registry is required when inbound store is configured",
+			errContains: "provider trigger catalog snapshot is required when inbound store is configured",
 		},
 	}
 

--- a/internal/testpostgres/creator_process_other.go
+++ b/internal/testpostgres/creator_process_other.go
@@ -11,6 +11,8 @@ func validateCreatorProcessSupport() error {
 	return fmt.Errorf("Postgres test service creator handoff is unsupported on this platform")
 }
 
+func restrictCreatorProcessFileMode() {}
+
 func creatorProcessCommand(string, string, string, *fileLock) (*exec.Cmd, error) {
 	return nil, validateCreatorProcessSupport()
 }

--- a/internal/testpostgres/creator_process_unix.go
+++ b/internal/testpostgres/creator_process_unix.go
@@ -6,9 +6,15 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 func validateCreatorProcessSupport() error { return nil }
+
+func restrictCreatorProcessFileMode() {
+	// The creator is a dedicated subprocess, so its umask cannot affect the runner.
+	syscall.Umask(0o077)
+}
 
 func creatorProcessCommand(executable, stateRoot, leaseID string, creator *fileLock) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(context.Background(), executable, "--internal-create", "--state-root", stateRoot, "--lease-id", leaseID, "--creator-fd", "3")

--- a/internal/testpostgres/creator_process_windows.go
+++ b/internal/testpostgres/creator_process_windows.go
@@ -14,6 +14,8 @@ import (
 
 func validateCreatorProcessSupport() error { return nil }
 
+func restrictCreatorProcessFileMode() {}
+
 func creatorProcessCommand(executable, stateRoot, leaseID string, creator *fileLock) (*exec.Cmd, error) {
 	handle := windows.Handle(creator.File().Fd())
 	if err := windows.SetHandleInformation(handle, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT); err != nil {

--- a/internal/testpostgres/service_registry.go
+++ b/internal/testpostgres/service_registry.go
@@ -316,6 +316,7 @@ func (s *Service) Close(ctx context.Context) error {
 }
 
 func (r *ServiceRegistry) RunCreator(ctx context.Context, leaseID string, creatorFD uintptr) error {
+	restrictCreatorProcessFileMode()
 	if err := r.initialize(); err != nil {
 		return err
 	}

--- a/internal/testpostgres/service_registry_process_test.go
+++ b/internal/testpostgres/service_registry_process_test.go
@@ -322,17 +322,17 @@ if args[0] == "ps":
         else: print(value["Id"])
     sys.exit(0)
 if args[0] == "create":
+    cidfile = args[args.index("--cidfile") + 1]
+    with open(cidfile, "w") as f: f.write("container-id\n")
     with open(path("create-count"), "a") as f: f.write("1\n")
     open(path("create-started"), "w").close()
     while not os.path.exists(path("release-create")): time.sleep(.02)
-    cidfile = args[args.index("--cidfile") + 1]
     name = args[args.index("--name") + 1]
     labels = {}
     for i, value in enumerate(args):
         if value == "--label":
             key, label_value = args[i + 1].split("=", 1); labels[key] = label_value
     value = {"Id":"container-id", "Name":"/" + name, "Image":"image-id", "Config":{"Labels":labels}, "State":{"Running":False}}
-    with open(cidfile, "w") as f: f.write("container-id\n")
     with open(path("inspect.json"), "w") as f: json.dump([value], f)
     print("container-id"); sys.exit(0)
 if args[0] == "inspect":

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7241,8 +7241,9 @@ tool_model:
     promoted_by: '#1929'
     owner: internal/packs typed capability-surface model and deterministic renderer consuming internal/userfacing human-code projection
     description: >
-      Provider trigger packs and provider connector declarations expose one typed proof-ready model to local preflight and
-      doctor. Body-specific owners derive capability and guarantee facts from accepted manifests or ToolSchemaEntry values;
+      Provider trigger packs, effective compiled ingress targets, and provider connector declarations expose one typed
+      proof-ready model to verify, local preflight, serve readiness, and doctor. Body-specific owners derive capability and
+      guarantee facts from accepted manifests, compiled inbound admission plans, or ToolSchemaEntry values;
       credential owners derive connector requirement state. The common owner normalizes subject identity, applicability,
       status, requirements, enforcement evidence, ordering, and text/JSON projections. Pack envelope capabilities and
       requires remain import-time derive-and-compare integrity assertions and MUST NOT be read as runtime surface truth.
@@ -7259,19 +7260,22 @@ tool_model:
         provider_connector: effective ToolSchemaEntry or installed connector-pack action
       source_values:
         trigger_pack: verified platform or external trigger pack
+        trigger_pack_binding: effective standing ingress target compiled from one exact verified trigger pack identity
+        raw_declaration: effective standing ingress target compiled from an explicit closed raw admission declaration
         connector_pack_import: explicitly imported connector action
         connector_pack: installed but not imported connector action
         flow_local: flow-local ToolSchemaEntry with category provider_connector
       applicability_values:
-        effective: callable connector declaration selected by the contract
+        effective: compiled ingress target or callable connector declaration selected by the contract
         installed: verified pack inventory that is not an effective callable connector
     status:
       READY: effective connector whose every static or managed credential requirement is satisfied
       NOT_READY: effective connector with at least one unsatisfied static or managed credential requirement
       AVAILABLE: >
-        Installed capability that is not effective in the current contract. All provider-trigger pack subjects are
-        AVAILABLE until #1944 contributes a selected-target readiness subject. Unimported connector actions are AVAILABLE
-        and carry import remediation but MUST remain absent from ToolEntries, agent surfaces, validation, and execution.
+        Installed capability that is not effective in the current contract, or an effective provider-trigger target whose
+        target-scoped secret binding is intentionally unevaluated until #1944 contributes BOUND/UNBOUND readiness. Unimported
+        connector actions are AVAILABLE and carry import remediation but MUST remain absent from ToolEntries, agent
+        surfaces, validation, and execution.
       rollup_rule: >
         `internal/packs NormalizeSubjects` derives status from kind, applicability, and validated requirement state.
         Body adapters MUST NOT compute status. A supplied status that contradicts the derived tuple, an installed connector
@@ -7295,10 +7299,10 @@ tool_model:
     guarantee_enforcement_registry:
       claims:
         emit_undeclared_events:
-          enforced_by: internal/providertriggers.Manifest.resolveEventName
+          enforced_by: internal/providertriggers.InboundAdmissionPlan.Accept
           execution_proof: internal/providertriggers TestStripeManifestAcceptsLiteralEventType
         run_code_before_admission:
-          enforced_by: internal/providertriggers.Manifest.Accept
+          enforced_by: internal/providertriggers.InboundAdmissionPlan.Accept
           execution_proof: internal/runtime TestInboundGateway_GitHubAdapterRejectsInvalidSignatureBeforeMarkerAndPublish
         touch_unbound_resources:
           enforced_by: internal/runtime.InboundGateway.HandleResolvedWebhook
@@ -7339,9 +7343,13 @@ tool_model:
         REFRESH_FAILED: swarm connections disconnect <resolved-deployment-key> && swarm connections connect <resolved-deployment-key>
         SCOPE_INSUFFICIENT: swarm connections connect <resolved-deployment-key>
       trigger_rule: >
+        Installed trigger-pack subjects render inventory facts with no target admission. Every declared standing ingress
+        provider also renders one effective typed subject with stable id `ingress:<bundle_hash>:<alias>:<provider>`, exact
+        catalog generation, policy_source, request_authentication, event policy, and resolved pack identity when applicable.
         Trigger signing requirements render with `scope: target` and no status, satisfied value, binding remediation,
-        READY/NOT_READY claim, selected-store query, or inferred global binding. #1944 owns target selection, enablement,
-        redacted SQLite/Postgres signing-binding readback, ambiguity, and mutation/remediation.
+        READY/NOT_READY claim, selected-store query, or inferred global binding. #1944 owns redacted SQLite/Postgres
+        signing-binding readback and mutation/remediation; it consumes this target identity and MUST NOT reconstruct another
+        admission model.
     projection:
       structured_owner: local preflight report capability_subjects
       human_phrase_owner: platform-spec.yaml#cli_specification.foundations.output_contract.shared_renderer_contract.human_code_projection
@@ -7720,16 +7728,89 @@ tool_model:
     existing_gateway_owner: >
       `cmd/swarm.runtimeProcessInboundHandler` owns the supported `/webhooks/{alias}/{provider}` route and resolves alias plus
       provider through the loaded `RuntimeContextManager` standing-target registry. `internal/runtime/inbound.go` remains the
-      generic HTTP ingress executor only after that exact target is resolved. It consumes
-      `runtime_ingress.queueable_ingress.inbound.webhook`, delegates configured-provider interpretation to the
-      provider-trigger manifest interpreter, persists the inbound dedupe marker before publish for delivery callbacks, and
-      publishes the normalized root ingress event returned by the manifest interpreter. Provider manifests may also return
-      an authenticated response-only result when the provider protocol requires a challenge response that is not a delivery.
+      generic HTTP ingress executor only after that exact target and its immutable InboundAdmissionPlan are resolved. It
+      consumes `runtime_ingress.queueable_ingress.inbound.webhook`, executes only that plan, persists the inbound dedupe
+      marker before publish for delivery callbacks, and publishes the normalized root ingress event returned by the plan.
+      Provider manifests may also return an authenticated response-only result when the provider protocol requires a
+      challenge response that is not a delivery. The gateway MUST NOT inspect catalog presence, provider-specific headers,
+      or payload shape to select an interpreter at request time.
     manifest_interpreter_owner: >
       `internal/providertriggers` is the configured-provider manifest interpreter and canonical owner for first-class
       provider trigger admission. Runtime-local Go implementations for selected configured providers are non-authoritative.
       A selected configured provider must consume a provider-trigger manifest for signing, replay checks, delivery-id
       extraction, event-type extraction, event naming, acknowledgement timing, and redaction.
+    compiled_admission_authority:
+      owner: internal/providertriggers.CatalogSnapshot and InboundAdmissionPlan
+      issue: '#1936'
+      declaration_owner: package.yaml flows[].ingress.providers[].admission
+      omission_rule: >
+        Omitted `admission` or omitted `admission.kind` always means `pack`, independent of environment. Pack mode must
+        resolve exactly one verified provider-trigger pack from the current immutable CatalogSnapshot or verification fails.
+        Missing packs never select raw mode. Platform and external packs resolve through the identical rule and verifier.
+      pack_grammar:
+        minimal: '{provider: telegram, signing_secret: webhook_signing.telegram}'
+        optional_pin: 'admission: {kind: pack, pack: {id: provider.telegram}}'
+        rules:
+        - '`kind` may be omitted or exactly `pack`'
+        - '`pack.id` is optional and pins one exact loaded pack id; wrong, missing, or provider-mismatched ids fail with loaded-pack remediation'
+        - authentication, event, delivery_id, and payload are raw-only and forbidden
+        - signed pack plans require one non-empty signing_secret reference; unauthenticated pack plans forbid it
+        - an unauthenticated pack plan requires `acknowledge: unsigned_webhook`; authenticated plans forbid acknowledgement
+      raw_grammar:
+        required:
+        - 'kind: raw'
+        - 'authentication.kind: none | token | hmac_sha256'
+        - exact literal event
+        - 'delivery_id.source: header | json_path | body_sha256'
+        - 'payload: json | raw'
+        conditional:
+        - token requires one explicit header, permits an optional prefix, and forbids encoding
+        - hmac_sha256 requires one explicit header, permits an optional prefix, signs exact raw body bytes, and uses encoding hex or base64
+        - none forbids header, prefix, encoding, and signing_secret
+        - header delivery identity requires exactly one value from the named header
+        - json_path delivery identity requires one syntactically valid declared JSONPath and a non-empty resolved value
+        - body_sha256 derives identity only from exact body bytes
+        rules:
+        - raw is legal only through explicit `kind: raw`; there is no raw default, fallback, or compatibility path
+        - raw provider names cannot equal a provider owned by any installed pack; intentional raw use must choose a distinct namespace such as `<provider>-raw`
+        - provider-specific signature headers, delivery fields, event fields, or payload heuristics not named by the declaration are ignored
+        - duplicate declared authentication or delivery-id header values fail closed
+        - authenticated raw plans require signing_secret; unauthenticated raw plans forbid it
+      unsigned_acknowledgement: >
+        `acknowledge: unsigned_webhook` is the only accepted acknowledgement token. For explicit unauthenticated raw
+        admission, absence emits the non-blocking `inbound_unsigned_webhook` verify warning with remediation naming the
+        token; presence suppresses that warning. Effective readback always renders request_authentication=UNAUTHENTICATED
+        regardless of acknowledgement. Comments and booleans are not controls.
+      exact_request_authentication:
+        TOKEN_EQUALITY: pack manifest token_equality
+        TOKEN: explicit raw token equality
+        HMAC_SHA256: pack or raw HMAC-SHA256
+        HMAC_SHA1: pack HMAC-SHA1
+        UNAUTHENTICATED: pack with no signature or explicit raw none
+      catalog_snapshot: >
+        Each successful configured pack load produces one immutable CatalogSnapshot. Its deterministic generation id is
+        SHA-256 over sorted semantic tuples `(pack id, normalized provider, version, exact manifest_hash, provenance)`.
+        Entries and capability projections return deep copies; consumers cannot mutate published catalog state. Signed
+        manifests with `secret.required: false` are invalid at load, and every signed execution rejects an empty runtime key.
+      plan: >
+        Verification compiles every standing ingress binding into one immutable InboundAdmissionPlan containing the exact
+        catalog generation, normalized provider, policy_source (`verified_pack` or `raw_declaration`), exact
+        request_authentication, resolved pack id/version/manifest_hash/provenance when applicable, copied executable policy,
+        secret requirement, event-name policy, and unsigned acknowledgement fact. Runtime targets and effective capability
+        subjects carry this plan; a target without a valid plan is unavailable and the gateway fails before credential
+        lookup, body interpretation, marker persistence, or publish.
+      process_generation: >
+        Boot compiles primary and every additional loaded BundleContext against one CatalogSnapshot generation before any
+        runtime is published. Reload re-reads and re-verifies configured pack directories into a candidate snapshot, then
+        recompiles the candidate context and every surviving loaded context. RuntimeContextManager validates and atomically
+        publishes the candidate primary context, all surviving target plans, catalog generation, installed subjects, and
+        effective subjects. Missing/remapped/tampered packs, incomplete surviving-context recompilation, generation mismatch,
+        target collision, or projection failure rejects reload while the predecessor contexts and generation remain loaded.
+      projections: >
+        Verify, local preflight, serve readiness, and doctor consume `tool_model.provider_capability_surface` installed and
+        effective subjects from the compiled owner. Basic describe and routing topology remain declaration-only and show
+        authored admission kind/pin/auth/event/acknowledgement facts without claiming resolved pack identity, generation,
+        request authentication, or readiness.
     pack_envelope_source_authority:
       owner: internal/packs universal envelope plus body-specific verifiers such as internal/providertriggers and internal/providerconnectors
       status: >
@@ -7742,9 +7823,10 @@ tool_model:
         platform-authored capability source. Runtime config declares external provider-trigger packs separately at
         `provider_triggers.packs.external_dirs`. Relative paths in both lists resolve against the config layer that declares
         the effective key. `swarm serve` verifies the complete declared set before runtime construction and injects one
-        registry into every runtime and Builder replacement runtime. Missing, malformed, incompatible, tampered, or
+        immutable catalog snapshot generation into every runtime and Builder replacement runtime. Missing, malformed,
+        incompatible, tampered, or
         colliding declared packs fail boot; no executable-relative, current-directory, source-checkout, embedded, package-
-        global default, or nil-registry discovery fallback exists. Connector packs in this first slice are platform packs
+        global default, or nil-catalog discovery fallback exists. Connector packs in this first slice are platform packs
         explicitly imported by package.yaml `connector_packs.imports[]`; external connector-pack directories require a later
         gated surface.
       required_platform_inventory:
@@ -7820,7 +7902,7 @@ tool_model:
       - reject competing immutable identities and duplicate universal pack ids across the composed set
       - require the exact current-platform first-party `(pack id, provider)` inventory from `required_platform_inventory`
       - reject provider-name/tool-name collisions independently according to the body-specific collision rule
-      - register/import only verified body manifests
+      - construct one immutable CatalogSnapshot and compile every effective ingress plan only from that snapshot
       trust_tiers: >
         Trust tiers differ by provenance value and by readback/operational policy only. First-party bundled packs and
         future external packs use the identical verifier path. No pack is trusted merely because the platform ships it.
@@ -7845,7 +7927,7 @@ tool_model:
         GitHub, Slack, Stripe, Twilio, Shopify, Typeform, Intercom, and Telegram provider-trigger manifests are first-party
         platform packs distributed as filesystem inventory and loaded through this envelope path. Their trigger bodies are
         absent from binary embed inputs. There is no permanent built-in-control exemption, package-global default registry,
-        nil-registry reconstruction path, or partial platform-inventory mode for configured-provider manifests. Envelope
+        nil-catalog reconstruction path, or partial platform-inventory mode for configured-provider manifests. Envelope
         `manifest_hash`, `capabilities`, and `requires` are deterministic build-stamped summaries; import verifies exact-byte
         body hash and body-derived equality.
       non_goals:
@@ -8072,12 +8154,10 @@ tool_model:
         event name is literal `inbound.telegram`, not a dynamic template. Granular Telegram update classification from fields
         such as `message`, `edited_message`, or `callback_query` is a later gated semantic concept.
     raw_webhook_mode: >
-      Unknown providers may continue through the raw generic webhook mode, but that path is a different semantic concept and
-      does not prove provider-trigger adapter closure. Configured providers MUST consume their manifest interpreter owner
-      rather than generic signature, delivery-id, event-type, acknowledgement, or `inbound.{provider}` mapping fallbacks.
-      Raw webhook mode MUST NOT interpret configured-provider signatures such as `Stripe-Signature` or
-      `X-Twilio-Signature`; configured-provider signature semantics belong only to the corresponding configured-provider
-      manifest.
+      Raw webhook admission exists only as the explicit closed declaration in `compiled_admission_authority.raw_grammar`.
+      The former unknown-provider acceptRaw fallback, generic signature-header search, payload id/type guessing,
+      acknowledgement guessing, and automatic `inbound.{provider}` event mapping are retired with zero compatibility path.
+      An unplanned target or pack-required declaration without a verified pack fails closed; neither condition may invoke raw.
   custom_tool_schema:
     description: Accepted fields for tool definitions in tools.yaml. This is the union of fields across all implementation
       classes.
@@ -8594,6 +8674,8 @@ flow_model:
       canonical_owners:
         declaration: internal/runtime/contracts.ProjectFlowRef
         verification: internal/runtime.ResolveStandingTargetDeclarations
+        provider_catalog: internal/providertriggers.CatalogSnapshot
+        admission_plan: internal/providertriggers.InboundAdmissionPlan
         lifecycle: internal/runtime.Runtime.EnsureStandingTargets
         process_registry: internal/runtime.RuntimeContextManager
         ingress_dispatch: internal/runtime.InboundGateway.HandleResolvedWebhook
@@ -8617,8 +8699,9 @@ flow_model:
         - ingress requires activation: standing and defaults alias to the package flow id
         - 'ingress alias is exactly one URL path segment matching [A-Za-z0-9][A-Za-z0-9._-]* so every verified alias is addressable as /webhooks/{alias}/{provider}'
         - ingress providers are a list so duplicate provider declarations remain visible to strict verification
-        - signing_secret is an explicit deployment credential reference; package data never carries the value
-        - every provider binding requires an exact compatible external input pin under the provider manifest event-name policy
+        - admission omission is always pack-required; raw admission requires explicit kind plus its complete closed policy
+        - signing_secret is an explicit deployment credential reference required only by the compiled authentication policy; package data never carries the value
+        - every provider binding requires an exact compatible external input pin under its compiled event-name policy
       lifecycle_authority: >
         Before readiness, package activation atomically and idempotently creates or resumes one deterministic durable run,
         one singleton flow instance, and that instance's primary entity. First activation consumes the full canonical
@@ -8634,8 +8717,9 @@ flow_model:
       process_routing: >
         One process RuntimeContextManager owns primary, additional, SQLite, Postgres, API, ingress, replacement, and
         deactivation visibility. It resolves alias/provider to exactly one loaded BundleContext and context-complete target.
-        Dispatch MUST use that selected context's source, provider registry, credential store, ingress controller, store,
-        EventBus, and runtime. Primary-runtime fallback and parallel alias registries are forbidden. Replacement and
+        Dispatch MUST use that selected context's source, immutable admission plan, credential store, ingress controller,
+        store, EventBus, and runtime. Primary-runtime fallback, request-time provider catalog lookup, and parallel alias
+        registries are forbidden. Replacement and
         deactivation atomically reject new predecessor admission while manager visibility is serialized. Before replacement
         quiescence begins, the RuntimeContextManager marks the predecessor unavailable and process readiness becomes false;
         `/readyz`, `/v1/rpc`, `/v1/ws`, and `/webhooks/...` fail with service-unavailable semantics until one loaded runtime
@@ -8649,7 +8733,11 @@ flow_model:
         and entity_id before persistence and publish; root-ingress admission MUST preserve that run and MUST NOT mint a run
         per webhook.
       replacement_policy: >
-        Same-bundle-hash restart resumes the standing identity. Same-hash live replacement may publish new runtime objects
+        Same-bundle-hash restart resumes the standing identity. Provider-trigger pack directories are re-read and re-verified
+        for every reload. One candidate catalog generation must successfully recompile every surviving loaded context and the
+        replacement context before readiness changes; RuntimeContextManager publishes the context set, target plans,
+        generation, and installed/effective capability subjects as one authority transition. Any failure leaves the previous
+        generation and contexts serving. Same-hash live replacement may publish new runtime objects
         only after they are ready and then atomically replaces process visibility. Replacement first rejects new predecessor
         admission and quiesces all predecessor shared-store/background consumers under the configured grace while retaining
         the one exclusive store lease. Only after quiescence may lease authority transfer and candidate activation begin.
@@ -8672,16 +8760,22 @@ flow_model:
       - duplicate aliases within a bundle or across loaded runtime contexts
       - duplicate providers within one alias
       - ingress on a non-standing or non-singleton flow
-      - missing provider, signing-secret reference, provider manifest, or compatible external event pin
+      - missing provider, required signing-secret reference, verified pack for pack-required admission, valid compiled admission plan, or compatible external event pin
+      - raw admission selected by omission, fallback, provider-pack collision, partial policy, or heuristic request interpretation
+      - unsigned pack without `acknowledge: unsigned_webhook`, invalid acknowledgement token, or acknowledgement on authenticated admission
+      - catalog-generation mismatch or incomplete all-context recompilation during boot/reload
       - unknown or unloaded alias/provider target
       - unbound signing-secret value at request time
       - standing run source or canonical bundle_hash mismatch
       readback: >
-        Basic describe projects activation, alias, providers, and signing-secret references from package declarations. Serve
-        readiness projects the exact POST URL and BOUND/UNBOUND state from the loaded RuntimeContextManager plus deployment
-        credential store. `routing-topology/v1.root_input_sources` projects each alias/provider binding and its target flow as
-        admission provenance; it is not a producer, edge, or third delivery scope. Neither surface exposes secret values or
-        creates a second target model.
+        Basic describe projects activation, alias, providers, signing-secret references, and authored admission kind, pack
+        pin, raw authentication/event policy, and acknowledgement from package declarations only. It never claims a resolved
+        pack identity, catalog generation, effective request authentication, or readiness. Verify, local preflight, serve,
+        and doctor project installed and effective trigger subjects from the process admission authority; effective rows name
+        the exact POST URL, policy_source, request_authentication, event, generation, and resolved pack identity when present.
+        #1944 adds BOUND/UNBOUND state from the deployment credential store. `routing-topology/v1.root_input_sources`
+        projects each authored alias/provider/admission binding and target flow as admission provenance; it is not a producer,
+        edge, or third delivery scope. No surface exposes secret values or creates a second target model.
       legacy_paths_removed:
       - scanning entity_state by route alias as ingress target authority
       - reading webhook signing values from flow-instance config
@@ -8815,8 +8909,10 @@ flow_model:
           - inter_flow_connect delivery between authored producers and consumers, lowered from declared output pin through parent connect to declared input pin
           root_input_source_rule: >
             `root_input_sources` is the deterministic admission-provenance projection for declared standing ingress. Each
-            entry names the authored alias, provider, package/flow target, and authored package location. It does not create a
-            producer endpoint or route edge, does not participate in delivery-scope counts, and does not authorize delivery.
+            entry names the authored alias, provider, admission kind/pin/authentication/event/acknowledgement facts,
+            package/flow target, and authored package location. It does not claim compiled pack identity, catalog generation,
+            or effective request authentication; create a producer endpoint or route edge; participate in delivery-scope
+            counts; or authorize delivery.
             After admission, the canonical declared-input association and typed pub/sub relation owners govern the event's
             ordinary delivery. Flow-entry ingress declarations remain the semantic source; the projection is read-only.
           typed_pubsub_rule: >


### PR DESCRIPTION
## Summary

- compile every standing ingress provider binding into an immutable `InboundAdmissionPlan` from one immutable `CatalogSnapshot` generation
- make omission permanently pack-required, add a closed explicit raw admission grammar, and retire request-time raw/provider heuristics
- publish catalog generation, all loaded target plans, and installed/effective capability subjects atomically through `RuntimeContextManager`
- expose declaration-only admission facts through describe/topology and effective typed admission facts through verify, preflight, serve, and doctor
- reject signed optional-secret manifests and empty runtime signing keys fail closed

Closes #1936

## Governing contract

This PR updates and implements the authoritative contracts at:

- `platform-spec.yaml#tool_model.provider_trigger_adapters.compiled_admission_authority`
- `platform-spec.yaml#tool_model.provider_trigger_adapters.raw_webhook_mode`
- `platform-spec.yaml#tool_model.provider_trigger_adapters.pack_envelope_source_authority`
- `platform-spec.yaml#tool_model.provider_capability_surface`
- `platform-spec.yaml#flow_model.flow_package.standing_activation_model`

The approved pre-implementation gate and repaired audit on #1936 are binding context, including the independent final gate at https://github.com/division-sh/swarm/issues/1936#issuecomment-4951727043.

## Semantic migration

**New canonical owners**

- verified process inventory and generation: `internal/providertriggers.CatalogSnapshot`
- target policy and executable request admission: `internal/providertriggers.InboundAdmissionPlan`
- process-wide context/plan/generation/subject publication: `internal/runtime.RuntimeContextManager`
- installed and effective provider readback: `internal/packs.Subject` with typed `TriggerAdmission`

**Old paths now invalid and removed**

- mutable `providertriggers.Registry` and `Registry.Accept`
- absence-selected `acceptRaw`
- multi-provider signature-header probing
- payload/event/delivery-id guessing and automatic `inbound.{provider}` fallback
- request-time catalog lookup by the gateway
- reload reuse of the boot catalog without re-verification/all-context recompilation
- installed-only trigger capability projection

Production paths checked for surviving old behavior: primary and additional boot contexts, Builder reload and rollback, process ingress routing, direct gateway execution, standing target compilation/recompilation, verify/local preflight/serve/doctor readback, describe/topology projection, and SQLite/Postgres served ingress. The chosen migration is complete; no compatibility interpreter remains.

## Validation

```text
SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...
```

Focused supported-surface proofs included in that run:

- `TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplies`
- `TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndReplies`
- `TestRuntimeContextManagerPublishesOneAdmissionGenerationAcrossAllContexts`
- `TestRuntimeContextManagerRejectsCandidatePackRemovalAcrossContexts`
- `TestInboundGateway_ExecutesOnlyCompiledRawAdmissionPolicy`
