### PR TITLE
[agent-b][issue #1945] Canonicalize authoritative YAML parsing

### DIFF
--- a/cmd/swarm/authoritative_yaml_test.go
+++ b/cmd/swarm/authoritative_yaml_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/division-sh/swarm/internal/yamlsource"
+)
+
+func decodeAuthoritativeYAMLFileForTest(t testing.TB, path string, target any) {
+	t.Helper()
+	source, err := yamlsource.LoadFile(path)
+	if err != nil {
+		t.Fatalf("read authoritative YAML %s: %v", path, err)
+	}
+	if err := source.Decode(target); err != nil {
+		t.Fatalf("decode authoritative YAML %s: %v", path, err)
+	}
+}
+
+func decodeAuthoritativeYAMLBytesForTest(t testing.TB, raw []byte, target any) {
+	t.Helper()
+	source, err := yamlsource.Load(raw)
+	if err != nil {
+		t.Fatalf("parse authoritative YAML: %v", err)
+	}
+	if err := source.Decode(target); err != nil {
+		t.Fatalf("decode authoritative YAML: %v", err)
+	}
+}

--- a/cmd/swarm/cli_catalog_drift_test.go
+++ b/cmd/swarm/cli_catalog_drift_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/platform"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -39,14 +40,11 @@ func driftTestRepoRoot(t *testing.T) string {
 
 func loadCLISpecification(t *testing.T) *yaml.Node {
 	t.Helper()
-	raw, err := os.ReadFile(platform.DefaultPlatformSpecFile(driftTestRepoRoot(t)))
+	source, err := yamlsource.LoadFile(platform.DefaultPlatformSpecFile(driftTestRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	doc := source.NodeCopy()
 	root := doc.Content[0]
 	for i := 0; i+1 < len(root.Content); i += 2 {
 		if root.Content[i].Value == "cli_specification" {

--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/packs"
 	"github.com/division-sh/swarm/internal/userfacing"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -75,14 +76,11 @@ func TestProviderHumanCodeParityRejectsKnownCapabilitySpecDrift(t *testing.T) {
 
 func loadPlatformSpecRootForHumanProjection(t *testing.T) *yaml.Node {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(driftTestRepoRoot(t), "platform-spec.yaml"))
+	source, err := yamlsource.LoadFile(filepath.Join(driftTestRepoRoot(t), "platform-spec.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatal(err)
-	}
+	doc := source.NodeCopy()
 	if len(doc.Content) != 1 {
 		t.Fatalf("platform spec document content = %d, want 1", len(doc.Content))
 	}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -17,7 +17,6 @@ import (
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
-	"gopkg.in/yaml.v3"
 )
 
 func setDoctorProviderSecret(t *testing.T, key, value string) {
@@ -1190,13 +1189,7 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	preflight := spec.CLISpecification.Foundations.Preflight
 	if preflight.PromotedBy != "#1565" || preflight.ImplementationStatus != "implemented" || !strings.Contains(preflight.CanonicalOwner, "local_claude_cli_preflight_admission") {
 		t.Fatalf("preflight spec = %#v", preflight)
@@ -1278,13 +1271,7 @@ func TestPlatformSpecLocalTargetResolutionAuthorityPromoted(t *testing.T) {
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	target := spec.CLISpecification.Foundations.LocalTarget
 	if target.PromotedBy != "#1612" || target.ImplementationStatus != "implemented_first_slice" || target.CanonicalOwner != localTargetOwner {
 		t.Fatalf("local target owner = %#v", target)

--- a/cmd/swarm/env_authority_test.go
+++ b/cmd/swarm/env_authority_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/userfacing"
-	"gopkg.in/yaml.v3"
 )
 
 func TestServeCommandIgnoresMalformedRepoDotEnv(t *testing.T) {
@@ -218,13 +217,7 @@ func TestPlatformSpecIssue1640EnvClassificationCoversRetainedSlice(t *testing.T)
 			} `yaml:"workspace_monitor_artifact_debug_slice"`
 		} `yaml:"environment_source_authority"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 
 	authority := spec.EnvironmentSourceAuthority.WorkspaceMonitorArtifactDebugSlice
 	if authority.PromotedBy != "#1640" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "classification_updated_by_1843" {
@@ -332,13 +325,7 @@ func TestRepoWideSwarmEnvAcceptedSetMatchesSpec(t *testing.T) {
 			} `yaml:"repo_wide_swarm_env_accepted_set"`
 		} `yaml:"environment_source_authority"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 
 	authority := spec.EnvironmentSourceAuthority.RepoWideSwarmEnvAcceptedSet
 	if authority.PromotedBy != "#1731" || authority.ParentTracker != "#1600" || authority.ImplementationStatus != "implemented_first_slice" {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -57,9 +57,8 @@ import (
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"github.com/division-sh/swarm/internal/store/runbundle"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -2733,12 +2732,15 @@ func loadServePlatformSpecDocument(platformSpecPath string) (runtimecontracts.Pl
 	if platformSpecPath == "" {
 		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("platform spec path is required")
 	}
-	data, err := os.ReadFile(platformSpecPath)
+	source, err := yamlsource.LoadFile(platformSpecPath)
 	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", cause)
+		}
 		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("read platform spec: %w", err)
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(data, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", err)
 	}
 	return spec, nil

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/division-sh/swarm/internal/testpostgres"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 type delayedRunStatusAgent struct {
@@ -2171,13 +2170,7 @@ func TestPlatformSpecSecretsCLISurfacePromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	store := spec.ToolModel.CredentialStore
 	for _, want := range []string{"shadowed", "required_by"} {
 		if !strings.Contains(store.Interface.List, want) {
@@ -2275,13 +2268,7 @@ func TestPlatformSpecWorkspaceDataSourceAuthorityPromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	authority := spec.WorkspaceModel.DataSourceAuthority
 	if !strings.Contains(authority.PromotedBy, "#1139") || !strings.Contains(authority.PromotedBy, "#1223") || strings.TrimSpace(authority.ImplementationStatus) != "implemented" {
 		t.Fatalf("workspace data source authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
@@ -2373,13 +2360,7 @@ func TestPlatformSpecWorkspaceBackendSelectionPromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	authority := spec.WorkspaceModel.WorkspaceBackendSelection
 	if strings.TrimSpace(authority.PromotedBy) != "#1138" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_capability_driven_first_slice" {
 		t.Fatalf("workspace backend authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
@@ -2494,13 +2475,7 @@ func TestPlatformSpecWorkspaceExecutionTargetCapabilityPromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	authority := spec.WorkspaceModel.WorkspaceExecutionTargetCapability
 	if strings.TrimSpace(authority.PromotedBy) != "#1213/#1235/#1286/#1356" || strings.TrimSpace(authority.ImplementationStatus) != "implemented_host_file_relay_and_trusted_command_slice" {
 		t.Fatalf("workspace execution target authority status = promoted_by:%q implementation_status:%q", authority.PromotedBy, authority.ImplementationStatus)
@@ -2618,13 +2593,7 @@ func TestPlatformSpecInstalledBinaryPortabilityPromoted(t *testing.T) {
 			} `yaml:"runtime_image_packaging"`
 		} `yaml:"workspace_model"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	portability := spec.CLISpecification.Foundations.InstalledBinaryPortability
 	if strings.TrimSpace(portability.PromotedBy) != "#1002" {
 		t.Fatalf("installed binary portability promoted_by = %q, want #1002", portability.PromotedBy)
@@ -2706,13 +2675,7 @@ func TestPlatformSpecLocalCLITestGatewayStartupPromoted(t *testing.T) {
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	startup := spec.CLISpecification.Foundations.LocalCLITestGatewayStartup
 	if strings.TrimSpace(startup.PromotedBy) != "#997" {
 		t.Fatalf("local cli_test gateway startup promoted_by = %q, want #997", startup.PromotedBy)
@@ -2770,13 +2733,7 @@ func TestPlatformSpecLocalToolGatewayBindingPromoted(t *testing.T) {
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	binding := spec.CLISpecification.Foundations.LocalToolGatewayBinding
 	if strings.TrimSpace(binding.PromotedBy) != "#1568" {
 		t.Fatalf("local tool gateway binding promoted_by = %q, want #1568", binding.PromotedBy)
@@ -2845,13 +2802,7 @@ func TestPlatformSpecLocalCLITestWorkspaceCLIAvailabilityPromoted(t *testing.T) 
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	availability := spec.CLISpecification.Foundations.LocalCLITestWorkspaceCLIAvailability
 	if strings.TrimSpace(availability.PromotedBy) != "#997" {
 		t.Fatalf("local cli_test workspace cli availability promoted_by = %q, want #997", availability.PromotedBy)
@@ -3018,13 +2969,7 @@ func TestPlatformSpecLLMProviderModelSelectionSourceAuthorityPromoted(t *testing
 			} `yaml:"agent_session_management"`
 		} `yaml:"engine"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	authority := spec.Engine.AgentSessionManagement.Selection
 	if strings.TrimSpace(authority.PromotedBy) != "#1127" {
 		t.Fatalf("llm provider selection promoted_by = %q, want #1127", authority.PromotedBy)
@@ -15617,13 +15562,7 @@ func loadServeBootProgressSequenceFromSpec(t *testing.T) []serveBootProgressSpec
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	sequence := spec.CLISpecification.CommandCatalog.Serve.BootObservability.BootProgressSequence
 	if sequence.TotalSteps != runtimepkg.BootProgressTotalSteps {
 		t.Fatalf("platform spec total_steps = %d, want %d", sequence.TotalSteps, runtimepkg.BootProgressTotalSteps)
@@ -15653,13 +15592,7 @@ func loadServeDevModeSpec(t *testing.T) serveDevModeSpec {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	if strings.TrimSpace(spec.CLISpecification.CommandCatalog.Serve.DevMode.Flag) == "" {
 		t.Fatal("platform spec missing serve dev_mode_lifecycle_composition")
 	}
@@ -15677,13 +15610,7 @@ func loadServeUnifiedListenerSpec(t *testing.T) serveUnifiedListenerSpec {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	if strings.TrimSpace(spec.CLISpecification.CommandCatalog.Serve.Listener.Flag) == "" {
 		t.Fatal("platform spec missing serve unified_listener_bind_contract")
 	}
@@ -15701,13 +15628,7 @@ func loadServeListenerTopologySpec(t *testing.T) serveListenerTopologySpec {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	if strings.TrimSpace(spec.CLISpecification.CommandCatalog.Serve.ListenerTopology.CanonicalOwner) == "" {
 		t.Fatal("platform spec missing serve listener_topology_v2_1")
 	}
@@ -15723,13 +15644,7 @@ func loadCLIAPIConnectionAuthConfigSpec(t *testing.T) cliAPIConnectionAuthConfig
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	if strings.TrimSpace(spec.CLISpecification.Foundations.APIConnectionAuthConfig.CanonicalOwner) == "" {
 		t.Fatal("platform spec missing api_connection_auth_config_precedence")
 	}
@@ -15745,13 +15660,7 @@ func loadCLIContractPlatformSpecPathResolutionSpec(t *testing.T) cliContractPlat
 			} `yaml:"foundations"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	if strings.TrimSpace(spec.CLISpecification.Foundations.ContractPlatformSpecPathResolution.CanonicalOwner) == "" {
 		t.Fatal("platform spec missing contract_platform_spec_path_resolution")
 	}

--- a/cmd/swarm/provider_connector_tools_test.go
+++ b/cmd/swarm/provider_connector_tools_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/packs"
-	"gopkg.in/yaml.v3"
 )
 
 func TestProviderConnectorSurfaceMessageIncludesGeneratedReviewEvidence(t *testing.T) {
@@ -87,10 +86,6 @@ func TestProviderCapabilitySurfaceRetiresDuplicateOwnersAndTargetBindingGuess(t 
 }
 
 func TestProviderGuaranteeRegistryMatchesSpecAndNamesLiveProofs(t *testing.T) {
-	raw, err := os.ReadFile(filepath.Join(repoRoot(), "platform-spec.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
 	var spec struct {
 		ToolModel struct {
 			ProviderCapabilitySurface struct {
@@ -103,9 +98,7 @@ func TestProviderGuaranteeRegistryMatchesSpecAndNamesLiveProofs(t *testing.T) {
 			} `yaml:"provider_capability_surface"`
 		} `yaml:"tool_model"`
 	}
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatal(err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), "platform-spec.yaml"), &spec)
 	owners := map[string]string{}
 	for code, row := range spec.ToolModel.ProviderCapabilitySurface.Guarantees.Claims {
 		owners[code] = strings.TrimSpace(row.EnforcedBy)

--- a/cmd/swarm/provider_trigger_packs_test.go
+++ b/cmd/swarm/provider_trigger_packs_test.go
@@ -21,7 +21,6 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/store"
-	"gopkg.in/yaml.v3"
 )
 
 func TestProviderTriggerReleaseLayoutLoadsCompleteFilesystemInventory(t *testing.T) {
@@ -96,10 +95,6 @@ func TestProviderTriggerReleaseLayoutLoadsCompleteFilesystemInventory(t *testing
 }
 
 func TestPlatformSpecRequiredProviderTriggerInventoryMatchesRuntimeOwner(t *testing.T) {
-	body, err := os.ReadFile(filepath.Join(repoRoot(), "platform-spec.yaml"))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
 	var spec struct {
 		ToolModel struct {
 			ProviderTriggerAdapters struct {
@@ -112,9 +107,7 @@ func TestPlatformSpecRequiredProviderTriggerInventoryMatchesRuntimeOwner(t *test
 			} `yaml:"provider_trigger_adapters"`
 		} `yaml:"tool_model"`
 	}
-	if err := yaml.Unmarshal(body, &spec); err != nil {
-		t.Fatalf("parse platform spec provider trigger inventory: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), "platform-spec.yaml"), &spec)
 	declared := spec.ToolModel.ProviderTriggerAdapters.PackEnvelopeSourceAuthority.RequiredPlatformInventory
 	if declared.Owner != "internal/providertriggers.RequiredPlatformPackIdentities" {
 		t.Fatalf("required platform inventory owner = %q", declared.Owner)
@@ -131,10 +124,6 @@ func TestPlatformSpecRequiredProviderTriggerInventoryMatchesRuntimeOwner(t *test
 }
 
 func TestPlatformSpecProviderTriggerTargetAuthorityMatchesStandingIngress(t *testing.T) {
-	body, err := os.ReadFile(filepath.Join(repoRoot(), "platform-spec.yaml"))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
 	var spec struct {
 		ToolModel struct {
 			ProviderTriggerAdapters struct {
@@ -147,9 +136,7 @@ func TestPlatformSpecProviderTriggerTargetAuthorityMatchesStandingIngress(t *tes
 			} `yaml:"provider_trigger_adapters"`
 		} `yaml:"tool_model"`
 	}
-	if err := yaml.Unmarshal(body, &spec); err != nil {
-		t.Fatalf("parse platform spec provider trigger authority: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), "platform-spec.yaml"), &spec)
 	contract := spec.ToolModel.ProviderTriggerAdapters
 	routeAuthority := strings.Join(append(append([]string(nil), contract.Scope...), contract.ExistingGatewayOwner, contract.ManifestVocabulary.Provider), "\n")
 	for _, want := range []string{"/webhooks/{alias}/{provider}", "standing ingress target", "RuntimeContextManager"} {
@@ -310,9 +297,7 @@ func writeReleaseProviderTriggerConfig(t *testing.T, path, sqlitePath string) {
 func seedReleaseProviderTriggerStore(t *testing.T, platformSpecBody []byte, sqlitePath string) {
 	t.Helper()
 	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platformSpecBody, &platformSpec); err != nil {
-		t.Fatalf("parse release platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLBytesForTest(t, platformSpecBody, &platformSpec)
 	plans, err := store.GeneratePlatformTableDDLs(platformSpec)
 	if err != nil {
 		t.Fatalf("generate release platform tables: %v", err)

--- a/cmd/swarm/workspace_build_test.go
+++ b/cmd/swarm/workspace_build_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"gopkg.in/yaml.v3"
 )
 
 func TestWorkspaceBuildClaudeCLIUsesEmbeddedBuildPlanFromTempCWD(t *testing.T) {
@@ -244,13 +242,7 @@ func TestWorkspaceBuildSpecAuthorityPromoted(t *testing.T) {
 			} `yaml:"command_catalog"`
 		} `yaml:"cli_specification"`
 	}
-	data, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	if err := yaml.Unmarshal(data, &spec); err != nil {
-		t.Fatalf("parse platform spec: %v", err)
-	}
+	decodeAuthoritativeYAMLFileForTest(t, filepath.Join(repoRoot(), defaultPlatformSpecPath), &spec)
 	owner := spec.WorkspaceModel.BuildAuthority
 	if owner.PromotedBy != "#1566" || owner.ImplementationStatus != "implemented_first_slice" || owner.CanonicalOwner != "platform-spec.yaml#workspace_model.local_workspace_image_build_authority" {
 		t.Fatalf("workspace image build authority = %#v", owner)

--- a/internal/apispec/spec.go
+++ b/internal/apispec/spec.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 const (
@@ -163,12 +162,15 @@ type OpenRPCComponents struct {
 }
 
 func LoadPlatformSpec(path string) (*APISpecification, error) {
-	raw, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			return nil, fmt.Errorf("parse platform spec: %w", cause)
+		}
 		return nil, err
 	}
 	var spec PlatformSpec
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		return nil, fmt.Errorf("parse platform spec: %w", err)
 	}
 	if len(spec.APISpecification.MethodCatalog) == 0 {

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/platform"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1144,14 +1145,11 @@ func repoRoot(t *testing.T) string {
 
 func loadPlatformSpecYAMLNode(t *testing.T) *yaml.Node {
 	t.Helper()
-	raw, err := os.ReadFile(platform.DefaultPlatformSpecFile(repoRoot(t)))
+	source, err := yamlsource.LoadFile(platform.DefaultPlatformSpecFile(repoRoot(t)))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parse platform spec yaml: %v", err)
-	}
+	doc := source.NodeCopy()
 	if len(doc.Content) != 1 {
 		t.Fatalf("platform spec yaml document content count = %d, want 1", len(doc.Content))
 	}

--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/division-sh/swarm/internal/servedparity"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1410,21 +1411,17 @@ func publicSurfaceSpecRefExists(root, specRef string) error {
 	if filepath.IsAbs(path) || strings.HasPrefix(clean, "..") {
 		return fmt.Errorf("path must be repo-relative")
 	}
-	raw, err := os.ReadFile(filepath.Join(root, clean))
+	source, err := yamlsource.LoadFile(filepath.Join(root, clean))
 	if err != nil {
 		return err
 	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		return err
-	}
-	node := yamlDocumentRoot(&doc)
+	parts := make([]string, 0, 8)
 	for _, part := range strings.Split(strings.Trim(strings.TrimSpace(yamlPath), "."), ".") {
 		if part == "" {
 			continue
 		}
-		node = yamlMappingValue(node, part)
-		if node == nil {
+		parts = append(parts, part)
+		if _, found := source.LookupMapPath(parts...); !found {
 			return fmt.Errorf("anchor path component %q missing", part)
 		}
 	}
@@ -1796,22 +1793,18 @@ func validatePublicSurfaceProofRefs(root, rowID string, row publicSurfaceMatrixR
 
 func loadPublicSurfaceCLICommands(t *testing.T, root string) map[string]struct{} {
 	t.Helper()
-	raw, err := os.ReadFile(compliancePlatformSpecPath(root))
+	source, err := yamlsource.LoadFile(compliancePlatformSpecPath(root))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("parse platform spec yaml: %v", err)
-	}
-	rootNode := yamlDocumentRoot(&doc)
-	commandCatalog := yamlMappingValue(yamlMappingValue(rootNode, "cli_specification"), "command_catalog")
-	if commandCatalog == nil || commandCatalog.Kind != yaml.MappingNode {
+	commandCatalog, found := source.LookupMapPath("cli_specification", "command_catalog")
+	if !found || commandCatalog.Kind() != yamlsource.MappingNode {
 		t.Fatal("platform spec cli_specification.command_catalog missing")
 	}
 	out := map[string]struct{}{}
-	for i := 0; i+1 < len(commandCatalog.Content); i += 2 {
-		out[commandCatalog.Content[i].Value] = struct{}{}
+	for i := 0; i+1 < commandCatalog.Len(); i += 2 {
+		key, _ := commandCatalog.Child(i)
+		out[key.Value()] = struct{}{}
 	}
 	return out
 }
@@ -1854,28 +1847,6 @@ func loadPublicSurfaceGoTests(root string) (map[string]string, error) {
 		return nil, err
 	}
 	return out, nil
-}
-
-func yamlDocumentRoot(doc *yaml.Node) *yaml.Node {
-	if doc == nil {
-		return nil
-	}
-	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
-		return doc.Content[0]
-	}
-	return doc
-}
-
-func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return nil
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			return node.Content[i+1]
-		}
-	}
-	return nil
 }
 
 func publicSurfaceMatrixRowByID(t *testing.T, matrix *publicSurfaceBackendMatrix, id string) *publicSurfaceMatrixRow {

--- a/internal/platform/version.go
+++ b/internal/platform/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 type platformVersionDocument struct {
@@ -18,8 +18,12 @@ func PlatformVersion() (string, error) {
 }
 
 func PlatformVersionFromYAML(raw []byte) (string, error) {
+	source, err := yamlsource.Load(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse platform version: %w", err)
+	}
 	var doc platformVersionDocument
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
+	if err := source.Decode(&doc); err != nil {
 		return "", fmt.Errorf("parse platform version: %w", err)
 	}
 	version := strings.TrimSpace(doc.Platform.Version)

--- a/internal/promptcontracts/promptcontracts.go
+++ b/internal/promptcontracts/promptcontracts.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,9 +16,6 @@ var (
 	promptAgentIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 	promptModePattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 	promptTokenPattern   = regexp.MustCompile(`\{\{([a-zA-Z0-9_]+)\}\}`)
-
-	promptVariablesMu    sync.RWMutex
-	promptVariablesCache = map[string]map[string]any{}
 )
 
 // Load reads an agent prompt from the configured prompt directory with optional
@@ -88,38 +85,39 @@ func renderPromptTemplateForDir(promptsDir, promptText string) (string, error) {
 
 func loadPromptVariables(promptsDir string) (map[string]any, error) {
 	promptsDir = filepath.Clean(promptsDir)
-	promptVariablesMu.RLock()
-	if cached, ok := promptVariablesCache[promptsDir]; ok {
-		promptVariablesMu.RUnlock()
-		return cached, nil
-	}
-	promptVariablesMu.RUnlock()
-
 	sources := promptVariableSources(promptsDir)
 	if len(sources) == 0 {
 		return nil, fmt.Errorf("missing prompt variables source near %s", promptsDir)
 	}
 	vars := map[string]any{}
 	for _, source := range sources {
-		raw, err := os.ReadFile(source)
-		if err != nil {
-			return nil, fmt.Errorf("read prompt variable source %s: %w", source, err)
-		}
 		loaded := map[string]any{}
-		if err := yaml.Unmarshal(raw, &loaded); err != nil {
-			return nil, fmt.Errorf("parse prompt variables from %s: %w", source, err)
-		}
 		if isPolicyPromptVariableSource(source) {
+			snapshot, err := yamlsource.LoadFile(source)
+			if err != nil {
+				if cause, ok := yamlsource.ParseCause(err); ok {
+					return nil, fmt.Errorf("parse prompt variables from %s: %w", source, cause)
+				}
+				return nil, fmt.Errorf("read prompt variable source %s: %w", source, err)
+			}
+			if err := snapshot.Decode(&loaded); err != nil {
+				return nil, fmt.Errorf("parse prompt variables from %s: %w", source, err)
+			}
 			delete(loaded, "criteria")
+		} else {
+			raw, err := os.ReadFile(source)
+			if err != nil {
+				return nil, fmt.Errorf("read prompt variable source %s: %w", source, err)
+			}
+			if err := yaml.Unmarshal(raw, &loaded); err != nil {
+				return nil, fmt.Errorf("parse prompt variables from %s: %w", source, err)
+			}
 		}
 		for key, value := range loaded {
 			vars[key] = value
 		}
 	}
 
-	promptVariablesMu.Lock()
-	promptVariablesCache[promptsDir] = vars
-	promptVariablesMu.Unlock()
 	return vars, nil
 }
 

--- a/internal/promptcontracts/promptcontracts_test.go
+++ b/internal/promptcontracts/promptcontracts_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -179,14 +181,8 @@ criteria:
 	if err := os.Chdir(root); err != nil {
 		t.Fatalf("chdir %s: %v", root, err)
 	}
-	promptVariablesMu.Lock()
-	delete(promptVariablesCache, "prompts")
-	promptVariablesMu.Unlock()
 	t.Cleanup(func() {
 		_ = os.Chdir(cwd)
-		promptVariablesMu.Lock()
-		delete(promptVariablesCache, "prompts")
-		promptVariablesMu.Unlock()
 	})
 
 	if _, _, err := LoadFromDir("prompts", "analysis-agent", ""); err == nil {
@@ -203,6 +199,120 @@ criteria:
 	}
 	if _, ok := vars["criteria"]; ok {
 		t.Fatalf("criteria leaked into relative prompt variables: %#v", vars["criteria"])
+	}
+}
+
+func TestLoadFromDirReflectsPolicyRewriteAtSamePath(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "prompts")
+	writePromptContractTestFile(t, filepath.Join(dir, "agent.md"), "Value={{value}}")
+	policy := filepath.Join(root, "policy.yaml")
+	writePromptContractTestFile(t, policy, "value: first\n")
+
+	assertPromptContractRender(t, dir, "Value=first")
+	writePromptContractTestFile(t, policy, "value: second\n")
+	assertPromptContractRender(t, dir, "Value=second")
+}
+
+func TestLoadFromDirReflectsSourceAdditionRemovalAndPrecedence(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "prompts")
+	writePromptContractTestFile(t, filepath.Join(dir, "agent.md"), "Value={{value}}")
+	writePromptContractTestFile(t, filepath.Join(root, "prompt-variables.yaml"), "value: prompt-only\n")
+
+	assertPromptContractRender(t, dir, "Value=prompt-only")
+	policy := filepath.Join(root, "policy.yaml")
+	writePromptContractTestFile(t, policy, "value: policy\n")
+	assertPromptContractRender(t, dir, "Value=policy")
+	if err := os.Remove(policy); err != nil {
+		t.Fatal(err)
+	}
+	assertPromptContractRender(t, dir, "Value=prompt-only")
+}
+
+func TestLoadFromDirReflectsPromptOnlySourceRewriteRemovalAndAddition(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "prompts")
+	writePromptContractTestFile(t, filepath.Join(dir, "agent.md"), "Value={{value}}")
+	variables := filepath.Join(root, "prompt-variables.yaml")
+	writePromptContractTestFile(t, variables, "value: first\n")
+
+	assertPromptContractRender(t, dir, "Value=first")
+	writePromptContractTestFile(t, variables, "value: second\n")
+	assertPromptContractRender(t, dir, "Value=second")
+	if err := os.Remove(variables); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadFromDir(dir, "agent", ""); err == nil || !strings.Contains(err.Error(), "missing prompt variables source") {
+		t.Fatalf("LoadFromDir after source removal error = %v", err)
+	}
+	writePromptContractTestFile(t, variables, "value: third\n")
+	assertPromptContractRender(t, dir, "Value=third")
+}
+
+func TestLoadFromDirDoesNotMaskMalformedCurrentPolicy(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "prompts")
+	writePromptContractTestFile(t, filepath.Join(dir, "agent.md"), "Value={{value}}")
+	policy := filepath.Join(root, "policy.yaml")
+	writePromptContractTestFile(t, policy, "value: valid\n")
+	assertPromptContractRender(t, dir, "Value=valid")
+	writePromptContractTestFile(t, policy, "value: [\n")
+
+	if _, _, err := LoadFromDir(dir, "agent", ""); err == nil || !strings.Contains(err.Error(), policy) {
+		t.Fatalf("LoadFromDir error = %v, want current policy path", err)
+	}
+}
+
+func TestPromptVariableProjectionIsFreshAndConcurrent(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "prompts")
+	writePromptContractTestFile(t, filepath.Join(dir, "agent.md"), "Value={{value}}")
+	writePromptContractTestFile(t, filepath.Join(root, "policy.yaml"), "value: stable\n")
+
+	vars, err := loadPromptVariables(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vars["value"] = "mutated"
+	assertPromptContractRender(t, dir, "Value=stable")
+
+	const workers = 24
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			prompt, found, err := LoadFromDir(dir, "agent", "")
+			if err != nil || !found || prompt != "Value=stable" {
+				t.Errorf("LoadFromDir = %q, %v, %v", prompt, found, err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+func writePromptContractTestFile(t testing.TB, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertPromptContractRender(t testing.TB, dir, want string) {
+	t.Helper()
+	got, found, err := LoadFromDir(dir, "agent", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || got != want {
+		t.Fatalf("LoadFromDir = %q, %v; want %q, true", got, found, want)
 	}
 }
 
@@ -309,46 +419,38 @@ func loadPromptVarsForTest(t *testing.T, promptsDir string) map[string]any {
 
 	vars := map[string]any{}
 	for _, candidate := range promptVariableSources(promptsDir) {
-		raw, err := os.ReadFile(candidate)
-		if err != nil {
-			t.Fatalf("read %s: %v", candidate, err)
-		}
 		loaded := map[string]any{}
-		if err := yaml.Unmarshal(raw, &loaded); err != nil {
-			t.Fatalf("parse %s: %v", candidate, err)
+		if isPolicyPromptVariableSource(candidate) {
+			decodePromptContractSourceForTest(t, candidate, &loaded)
+		} else {
+			raw, err := os.ReadFile(candidate)
+			if err != nil {
+				t.Fatalf("read %s: %v", candidate, err)
+			}
+			if err := yaml.Unmarshal(raw, &loaded); err != nil {
+				t.Fatalf("parse %s: %v", candidate, err)
+			}
 		}
 		for key, value := range loaded {
 			vars[key] = value
 		}
 	}
 	for _, candidate := range promptSchemaSources(promptsDir) {
-		raw, err := os.ReadFile(candidate)
-		if err != nil {
-			t.Fatalf("read %s: %v", candidate, err)
-		}
 		var loaded struct {
 			InstanceVariables struct {
 				Variables map[string]any `yaml:"variables"`
 			} `yaml:"instance_variables"`
 		}
-		if err := yaml.Unmarshal(raw, &loaded); err != nil {
-			t.Fatalf("parse %s: %v", candidate, err)
-		}
+		decodePromptContractSourceForTest(t, candidate, &loaded)
 		for key := range loaded.InstanceVariables.Variables {
 			vars[key] = true
 		}
 	}
 	for _, candidate := range promptAgentInputSources(promptsDir) {
-		raw, err := os.ReadFile(candidate)
-		if err != nil {
-			t.Fatalf("read %s: %v", candidate, err)
-		}
 		loaded := map[string]struct {
 			PromptInputs []string `yaml:"prompt_inputs"`
 		}{}
-		if err := yaml.Unmarshal(raw, &loaded); err != nil {
-			t.Fatalf("parse %s: %v", candidate, err)
-		}
+		decodePromptContractSourceForTest(t, candidate, &loaded)
 		for _, entry := range loaded {
 			for _, key := range entry.PromptInputs {
 				key = strings.TrimSpace(key)
@@ -360,10 +462,6 @@ func loadPromptVarsForTest(t *testing.T, promptsDir string) map[string]any {
 		}
 	}
 	for _, candidate := range promptPackageSources(promptsDir) {
-		raw, err := os.ReadFile(candidate)
-		if err != nil {
-			t.Fatalf("read %s: %v", candidate, err)
-		}
 		var loaded struct {
 			EntitySchema struct {
 				Groups []struct {
@@ -373,9 +471,7 @@ func loadPromptVarsForTest(t *testing.T, promptsDir string) map[string]any {
 				} `yaml:"groups"`
 			} `yaml:"entity_schema"`
 		}
-		if err := yaml.Unmarshal(raw, &loaded); err != nil {
-			t.Fatalf("parse %s: %v", candidate, err)
-		}
+		decodePromptContractSourceForTest(t, candidate, &loaded)
 		for _, group := range loaded.EntitySchema.Groups {
 			for _, field := range group.Fields {
 				key := strings.TrimSpace(field.Name)
@@ -387,6 +483,20 @@ func loadPromptVarsForTest(t *testing.T, promptsDir string) map[string]any {
 		}
 	}
 	return vars
+}
+
+func decodePromptContractSourceForTest(t testing.TB, path string, target any) {
+	t.Helper()
+	source, err := yamlsource.LoadFile(path)
+	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			t.Fatalf("parse %s: %v", path, cause)
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := source.Decode(target); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
 }
 
 func promptContractAncestorDirs(promptsDir string) []string {

--- a/internal/runtime/agentcontrol/control_test.go
+++ b/internal/runtime/agentcontrol/control_test.go
@@ -9,7 +9,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 func TestNewDirectiveEventPayloadPreservesDirectiveMode(t *testing.T) {
@@ -59,12 +59,12 @@ func validateCurrentPlatformEventPayloadForAgentControlTest(t testing.TB, eventT
 		}
 		dir = parent
 	}
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(dir))
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(dir))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		t.Fatalf("unmarshal platform spec: %v", err)
 	}
 	registry := runtimecontracts.EventSchemaRegistryFromBundle(&runtimecontracts.WorkflowContractBundle{Platform: spec})

--- a/internal/runtime/bus/import_boundary_wildcard_routing_test.go
+++ b/internal/runtime/bus/import_boundary_wildcard_routing_test.go
@@ -757,7 +757,7 @@ func writeBusImportBoundaryWildcardFixture(t *testing.T, opts importBoundaryWild
 	if workerSubscription == "" {
 		workerSubscription = "**/task.done"
 	}
-	rootNode := ""
+	rootNode := "{}\n"
 	if opts.RootWildcard {
 		rootNode = `
 root-listener:

--- a/internal/runtime/cataloge2e/helpers_test.go
+++ b/internal/runtime/cataloge2e/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -57,6 +58,20 @@ func loadYAML(t testing.TB, path string, out any) {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	if err := yaml.Unmarshal(b, out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}
+
+func loadContractYAML(t testing.TB, path string, out any) {
+	t.Helper()
+	source, err := yamlsource.LoadFile(path)
+	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			t.Fatalf("unmarshal %s: %v", path, cause)
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := source.Decode(out); err != nil {
 		t.Fatalf("unmarshal %s: %v", path, err)
 	}
 }

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -159,7 +159,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 	var rootSchema struct {
 		InitialState string `yaml:"initial_state"`
 	}
-	loadYAML(t, filepath.Join(fixtureRoot, "schema.yaml"), &rootSchema)
+	loadContractYAML(t, filepath.Join(fixtureRoot, "schema.yaml"), &rootSchema)
 	module, err := newFixtureWorkflowModule(bundle)
 	if err != nil {
 		t.Fatalf("newFixtureWorkflowModule: %v", err)

--- a/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
+++ b/internal/runtime/conformance/deterministic_work_ladder_design_record_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -282,12 +283,12 @@ func TestDeterministicWorkLadderDesignRecordRejectsStaleOrRuntimeClaims(t *testi
 
 func TestDeterministicWorkLadderArtifactRepoDispositionPromotedToPlatformSpec(t *testing.T) {
 	root := conformanceRepoRoot(t)
-	raw, err := os.ReadFile(filepath.Join(root, "platform-spec.yaml"))
+	source, err := yamlsource.LoadFile(filepath.Join(root, "platform-spec.yaml"))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
 	var spec map[string]any
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		t.Fatalf("parse platform spec: %v", err)
 	}
 	artifact := yamlMapAt(t, spec,

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"io/fs"
 	"math"
 	"os"
@@ -18,8 +17,8 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"golang.org/x/text/unicode/norm"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -481,22 +480,15 @@ func canonicalBundleHashYAML(raw []byte) ([]byte, error) {
 	if !utf8.Valid(raw) {
 		return nil, fmt.Errorf("YAML input is not valid UTF-8")
 	}
-	dec := yaml.NewDecoder(bytes.NewReader(raw))
-	var doc yaml.Node
-	if err := dec.Decode(&doc); err != nil {
-		if err == io.EOF {
-			return nil, fmt.Errorf("YAML input has no document")
-		}
+	source, err := yamlsource.Load(raw)
+	if err != nil {
 		return nil, err
 	}
-	var second yaml.Node
-	if err := dec.Decode(&second); err != io.EOF {
-		if err == nil {
-			return nil, fmt.Errorf("YAML input has multiple documents")
-		}
-		return nil, err
-	}
-	value, err := canonicalBundleHashYAMLValue(&doc, map[*yaml.Node]bool{})
+	return canonicalBundleHashYAMLSnapshot(source)
+}
+
+func canonicalBundleHashYAMLSnapshot(source yamlsource.Snapshot) ([]byte, error) {
+	value, err := canonicalBundleHashYAMLValue(source.Root(), map[yamlsource.Node]bool{})
 	if err != nil {
 		return nil, err
 	}
@@ -508,26 +500,28 @@ func canonicalBundleHashYAML(raw []byte) ([]byte, error) {
 	return out, nil
 }
 
-func canonicalBundleHashYAMLValue(node *yaml.Node, stack map[*yaml.Node]bool) (any, error) {
-	if node == nil {
+func canonicalBundleHashYAMLValue(node yamlsource.Node, stack map[yamlsource.Node]bool) (any, error) {
+	if !node.Valid() {
 		return nil, fmt.Errorf("nil YAML node")
 	}
-	switch node.Kind {
-	case yaml.DocumentNode:
-		if len(node.Content) != 1 {
+	switch node.Kind() {
+	case yamlsource.DocumentNode:
+		if node.Len() != 1 {
 			return nil, fmt.Errorf("YAML document must contain exactly one root node")
 		}
-		return canonicalBundleHashYAMLValue(node.Content[0], stack)
-	case yaml.MappingNode:
-		if node.Tag != "" && node.Tag != "!!map" {
-			return nil, fmt.Errorf("unsupported YAML mapping tag %q", node.Tag)
+		child, _ := node.Child(0)
+		return canonicalBundleHashYAMLValue(child, stack)
+	case yamlsource.MappingNode:
+		if node.Tag() != "" && node.Tag() != "!!map" {
+			return nil, fmt.Errorf("unsupported YAML mapping tag %q", node.Tag())
 		}
-		if len(node.Content)%2 != 0 {
+		if node.Len()%2 != 0 {
 			return nil, fmt.Errorf("YAML mapping has an odd number of nodes")
 		}
-		out := make(map[string]any, len(node.Content)/2)
-		for i := 0; i < len(node.Content); i += 2 {
-			keyValue, err := canonicalBundleHashYAMLValue(node.Content[i], stack)
+		out := make(map[string]any, node.Len()/2)
+		for i := 0; i < node.Len(); i += 2 {
+			keyNode, _ := node.Child(i)
+			keyValue, err := canonicalBundleHashYAMLValue(keyNode, stack)
 			if err != nil {
 				return nil, err
 			}
@@ -538,19 +532,21 @@ func canonicalBundleHashYAMLValue(node *yaml.Node, stack map[*yaml.Node]bool) (a
 			if _, exists := out[key]; exists {
 				return nil, fmt.Errorf("duplicate YAML mapping key %q", key)
 			}
-			value, err := canonicalBundleHashYAMLValue(node.Content[i+1], stack)
+			valueNode, _ := node.Child(i + 1)
+			value, err := canonicalBundleHashYAMLValue(valueNode, stack)
 			if err != nil {
 				return nil, err
 			}
 			out[key] = value
 		}
 		return out, nil
-	case yaml.SequenceNode:
-		if node.Tag != "" && node.Tag != "!!seq" {
-			return nil, fmt.Errorf("unsupported YAML sequence tag %q", node.Tag)
+	case yamlsource.SequenceNode:
+		if node.Tag() != "" && node.Tag() != "!!seq" {
+			return nil, fmt.Errorf("unsupported YAML sequence tag %q", node.Tag())
 		}
-		out := make([]any, 0, len(node.Content))
-		for _, child := range node.Content {
+		out := make([]any, 0, node.Len())
+		for i := 0; i < node.Len(); i++ {
+			child, _ := node.Child(i)
 			value, err := canonicalBundleHashYAMLValue(child, stack)
 			if err != nil {
 				return nil, err
@@ -558,21 +554,22 @@ func canonicalBundleHashYAMLValue(node *yaml.Node, stack map[*yaml.Node]bool) (a
 			out = append(out, value)
 		}
 		return out, nil
-	case yaml.AliasNode:
-		if node.Alias == nil {
+	case yamlsource.AliasNode:
+		alias, ok := node.Alias()
+		if !ok {
 			return nil, fmt.Errorf("YAML alias has no target")
 		}
-		if stack[node.Alias] {
+		if stack[alias] {
 			return nil, fmt.Errorf("YAML alias cycle detected")
 		}
-		stack[node.Alias] = true
-		value, err := canonicalBundleHashYAMLValue(node.Alias, stack)
-		delete(stack, node.Alias)
+		stack[alias] = true
+		value, err := canonicalBundleHashYAMLValue(alias, stack)
+		delete(stack, alias)
 		return value, err
-	case yaml.ScalarNode:
+	case yamlsource.ScalarNode:
 		return canonicalBundleHashYAMLScalar(node)
 	default:
-		return nil, fmt.Errorf("unsupported YAML node kind %d", node.Kind)
+		return nil, fmt.Errorf("unsupported YAML node kind %d", node.Kind())
 	}
 }
 
@@ -585,47 +582,47 @@ const (
 	canonicalYAMLNumber
 )
 
-func canonicalBundleHashYAMLScalar(node *yaml.Node) (any, error) {
-	explicit := node.Style&yaml.TaggedStyle != 0
+func canonicalBundleHashYAMLScalar(node yamlsource.Node) (any, error) {
+	explicit := node.Style()&yamlsource.TaggedStyle != 0
 	if explicit {
-		if node.Tag != "!!str" && canonicalBundleHashYAMLQuotedScalar(node.Style) {
-			return nil, fmt.Errorf("explicit %s tag widens quoted scalar %q", node.Tag, node.Value)
+		if node.Tag() != "!!str" && canonicalBundleHashYAMLQuotedScalar(node.Style()) {
+			return nil, fmt.Errorf("explicit %s tag widens quoted scalar %q", node.Tag(), node.Value())
 		}
-		implicitValue, implicitKind, err := canonicalBundleHashImplicitScalar(node.Value)
+		implicitValue, implicitKind, err := canonicalBundleHashImplicitScalar(node.Value())
 		if err != nil {
 			return nil, err
 		}
-		switch node.Tag {
+		switch node.Tag() {
 		case "!!str":
-			return norm.NFC.String(node.Value), nil
+			return norm.NFC.String(node.Value()), nil
 		case "!!bool":
 			if implicitKind != canonicalYAMLBool {
-				return nil, fmt.Errorf("explicit bool tag widens scalar %q", node.Value)
+				return nil, fmt.Errorf("explicit bool tag widens scalar %q", node.Value())
 			}
 			return implicitValue, nil
 		case "!!int", "!!float":
 			if implicitKind != canonicalYAMLNumber {
-				return nil, fmt.Errorf("explicit numeric tag widens scalar %q", node.Value)
+				return nil, fmt.Errorf("explicit numeric tag widens scalar %q", node.Value())
 			}
 			return implicitValue, nil
 		case "!!null":
 			if implicitKind != canonicalYAMLNull {
-				return nil, fmt.Errorf("explicit null tag widens scalar %q", node.Value)
+				return nil, fmt.Errorf("explicit null tag widens scalar %q", node.Value())
 			}
 			return nil, nil
 		default:
-			return nil, fmt.Errorf("unsupported YAML scalar tag %q", node.Tag)
+			return nil, fmt.Errorf("unsupported YAML scalar tag %q", node.Tag())
 		}
 	}
-	if node.Tag == "!!str" {
-		return norm.NFC.String(node.Value), nil
+	if node.Tag() == "!!str" {
+		return norm.NFC.String(node.Value()), nil
 	}
-	value, _, err := canonicalBundleHashImplicitScalar(node.Value)
+	value, _, err := canonicalBundleHashImplicitScalar(node.Value())
 	return value, err
 }
 
-func canonicalBundleHashYAMLQuotedScalar(style yaml.Style) bool {
-	return style&yaml.DoubleQuotedStyle != 0 || style&yaml.SingleQuotedStyle != 0
+func canonicalBundleHashYAMLQuotedScalar(style yamlsource.Style) bool {
+	return style&yamlsource.DoubleQuotedStyle != 0 || style&yamlsource.SingleQuotedStyle != 0
 }
 
 func canonicalBundleHashImplicitScalar(raw string) (any, canonicalYAMLScalarKind, error) {

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -573,6 +573,7 @@ value: 1e0
 		{name: "non finite number", yaml: "a: .nan\n", contains: "non-finite"},
 		{name: "non string key", yaml: "true: value\n", contains: "not a string"},
 		{name: "multi document", yaml: "a: 1\n---\nb: 2\n", contains: "multiple documents"},
+		{name: "alias cycle", yaml: "a: &a [*a]\n", contains: "alias cycle"},
 		{name: "explicit bool quoted", yaml: `a: !!bool "true"` + "\n", contains: "widens quoted"},
 		{name: "explicit int quoted", yaml: `a: !!int "1"` + "\n", contains: "widens quoted"},
 		{name: "explicit null quoted", yaml: `a: !!null "null"` + "\n", contains: "widens quoted"},

--- a/internal/runtime/contracts/bundle_identity.go
+++ b/internal/runtime/contracts/bundle_identity.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 type BundleIdentity struct {
@@ -210,26 +210,34 @@ func sameFilePath(left, right string) bool {
 }
 
 func canonicalBundleIdentityContent(path string) ([]byte, error) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".yaml", ".yml":
-		var decoded any
-		if err := yaml.Unmarshal(raw, &decoded); err != nil {
-			return nil, err
-		}
-		normalized := normalizeYAMLForJSON(decoded)
-		out, err := json.Marshal(normalized)
+		snapshot, err := yamlsource.LoadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		return out, nil
+		return canonicalBundleIdentityYAMLSnapshot(snapshot)
 	default:
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
 		return []byte(normalizeTextContent(string(raw))), nil
 	}
+}
+
+func canonicalBundleIdentityYAMLSnapshot(snapshot yamlsource.Snapshot) ([]byte, error) {
+	var decoded any
+	if err := snapshot.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	normalized := normalizeYAMLForJSON(decoded)
+	out, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func normalizeYAMLForJSON(value any) any {

--- a/internal/runtime/contracts/bundle_yaml_source_test.go
+++ b/internal/runtime/contracts/bundle_yaml_source_test.go
@@ -1,52 +1,50 @@
 package contracts
 
 import (
-	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
-func TestAuthoritativeYAMLSourceServesTypedHashAndIdentityDerivationsOnce(t *testing.T) {
-	raw := []byte("name: example\nvalues: &values [one, two]\nalias: *values\n")
-	store := yamlsource.NewStore(yamlsource.Limits{MaxEntries: 8, MaxSourceBytes: 4096})
-	snapshot, err := store.Load(raw)
-	if err != nil {
+func TestProductionTypedHashAndIdentityEntrypointsShareAuthoritativeYAMLParse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "package.yaml")
+	raw := []byte(fmt.Sprintf("name: %q\nvalues: &values [one, two]\nalias: *values\n", path))
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
 		t.Fatal(err)
 	}
-
+	before := yamlsource.DefaultStats()
 	var typed map[string]any
-	if err := snapshot.Decode(&typed); err != nil {
+	if err := loadYAMLFile(path, &typed); err != nil {
 		t.Fatal(err)
 	}
-	hashProjection, err := canonicalBundleHashYAMLSnapshot(snapshot)
+	hashProjection, err := canonicalBundleHashContent(path, bundleHashYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
-	identityProjection, err := canonicalBundleIdentityYAMLSnapshot(snapshot)
+	identityProjection, err := canonicalBundleIdentityContent(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(hashProjection) == 0 || len(identityProjection) == 0 {
 		t.Fatalf("empty derivation: hash=%q identity=%q", hashProjection, identityProjection)
 	}
-	if stats := store.Stats(); stats.ParseCount != 1 {
-		t.Fatalf("parse count = %d, want 1", stats.ParseCount)
+	after := yamlsource.DefaultStats()
+	if delta := after.ParseCount - before.ParseCount; delta != 1 {
+		t.Fatalf("production parse count delta = %d, want 1", delta)
+	}
+	if delta := after.Hits - before.Hits; delta != 2 {
+		t.Fatalf("production owner hit delta = %d, want 2", delta)
 	}
 
 	typed["name"] = "mutated"
 	var fresh map[string]any
-	if err := snapshot.Decode(&fresh); err != nil {
+	if err := loadYAMLFile(path, &fresh); err != nil {
 		t.Fatal(err)
 	}
-	if fresh["name"] != "example" {
+	if fresh["name"] != path {
 		t.Fatalf("fresh decode contaminated: %#v", fresh)
-	}
-	wantHash, err := canonicalBundleHashYAML(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(hashProjection, wantHash) {
-		t.Fatalf("hash projection changed: got %q want %q", hashProjection, wantHash)
 	}
 }

--- a/internal/runtime/contracts/bundle_yaml_source_test.go
+++ b/internal/runtime/contracts/bundle_yaml_source_test.go
@@ -1,0 +1,52 @@
+package contracts
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/yamlsource"
+)
+
+func TestAuthoritativeYAMLSourceServesTypedHashAndIdentityDerivationsOnce(t *testing.T) {
+	raw := []byte("name: example\nvalues: &values [one, two]\nalias: *values\n")
+	store := yamlsource.NewStore(yamlsource.Limits{MaxEntries: 8, MaxSourceBytes: 4096})
+	snapshot, err := store.Load(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var typed map[string]any
+	if err := snapshot.Decode(&typed); err != nil {
+		t.Fatal(err)
+	}
+	hashProjection, err := canonicalBundleHashYAMLSnapshot(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identityProjection, err := canonicalBundleIdentityYAMLSnapshot(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hashProjection) == 0 || len(identityProjection) == 0 {
+		t.Fatalf("empty derivation: hash=%q identity=%q", hashProjection, identityProjection)
+	}
+	if stats := store.Stats(); stats.ParseCount != 1 {
+		t.Fatalf("parse count = %d, want 1", stats.ParseCount)
+	}
+
+	typed["name"] = "mutated"
+	var fresh map[string]any
+	if err := snapshot.Decode(&fresh); err != nil {
+		t.Fatal(err)
+	}
+	if fresh["name"] != "example" {
+		t.Fatalf("fresh decode contaminated: %#v", fresh)
+	}
+	wantHash, err := canonicalBundleHashYAML(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(hashProjection, wantHash) {
+		t.Fatalf("hash projection changed: got %q want %q", hashProjection, wantHash)
+	}
+}

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -592,13 +592,9 @@ func currentPlatformSpecForSchemaRegistryTest(t *testing.T) PlatformSpecDocument
 		}
 		dir = parent
 	}
-	raw, err := os.ReadFile(DefaultPlatformSpecFile(dir))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
 	var spec PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
+	if err := loadYAMLFile(DefaultPlatformSpecFile(dir), &spec); err != nil {
+		t.Fatalf("load platform spec: %v", err)
 	}
 	return spec
 }

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -2,7 +2,6 @@ package contracts
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/platform"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 const maxDiscoveredPackageDepth = 99
@@ -450,11 +450,14 @@ func sortedContractKeys[T any](m map[string]T) []string {
 	return keys
 }
 func loadYAMLFile(path string, target any) error {
-	raw, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			return wrapLoaderDiagnosticFile(cause, path)
+		}
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	if err := yaml.Unmarshal(raw, target); err != nil {
+	if err := source.Decode(target); err != nil {
 		return wrapLoaderDiagnosticFile(err, path)
 	}
 	return nil

--- a/internal/runtime/destructivereset/cleanup_catalog_test.go
+++ b/internal/runtime/destructivereset/cleanup_catalog_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 func TestDefaultPlatformCleanupCatalogClassifiesEveryPlatformTable(t *testing.T) {
@@ -104,7 +104,7 @@ func TestCleanupCatalogRetainsDirectiveOperationAuthority(t *testing.T) {
 func loadPlatformTableNamesForCleanupCatalogTest(t *testing.T) map[string]struct{} {
 	t.Helper()
 	repo := cleanupCatalogTestRepoRoot(t)
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repo))
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(repo))
 	if err != nil {
 		t.Fatalf("read platform-spec.yaml: %v", err)
 	}
@@ -115,7 +115,7 @@ func loadPlatformTableNamesForCleanupCatalogTest(t *testing.T) map[string]struct
 			} `yaml:"tables"`
 		} `yaml:"platform_tables"`
 	}
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
+	if err := source.Decode(&doc); err != nil {
 		t.Fatalf("parse platform-spec.yaml: %v", err)
 	}
 	if len(doc.PlatformTables.Tables) == 0 {
@@ -131,7 +131,7 @@ func loadPlatformTableNamesForCleanupCatalogTest(t *testing.T) map[string]struct
 func loadPlatformCleanupClassificationsForCleanupCatalogTest(t *testing.T) map[string]string {
 	t.Helper()
 	repo := cleanupCatalogTestRepoRoot(t)
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repo))
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(repo))
 	if err != nil {
 		t.Fatalf("read platform-spec.yaml: %v", err)
 	}
@@ -142,7 +142,7 @@ func loadPlatformCleanupClassificationsForCleanupCatalogTest(t *testing.T) map[s
 			} `yaml:"destructive_reset_cleanup_policy"`
 		} `yaml:"platform_tables"`
 	}
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
+	if err := source.Decode(&doc); err != nil {
 		t.Fatalf("parse platform-spec.yaml: %v", err)
 	}
 	if len(doc.PlatformTables.DestructiveResetCleanupPolicy.Classifications) == 0 {

--- a/internal/runtime/engine/compute_module_replay_test.go
+++ b/internal/runtime/engine/compute_module_replay_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 func TestExecuteWithPersistedComputeModuleReplayEvidenceLoadsAndFailsClosedOnStoredDivergence(t *testing.T) {
@@ -101,7 +101,11 @@ func persistComputeModuleReplayEvidenceForExecution(t *testing.T, ctx context.Co
 func newComputeModuleReplaySQLiteStore(t *testing.T) *store.SQLiteRuntimeStore {
 	t.Helper()
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &spec); err != nil {
+	source, err := yamlsource.Load(platform.PlatformSpecYAML())
+	if err != nil {
+		t.Fatalf("load platform spec: %v", err)
+	}
+	if err := source.Decode(&spec); err != nil {
 		t.Fatalf("decode platform spec: %v", err)
 	}
 	plans, err := store.GeneratePlatformTableDDLs(spec)

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -17,8 +16,8 @@ import (
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 type recordingReceiptBus struct {
@@ -286,12 +285,12 @@ func TestMaybeTripAuthCircuitBreaker_PreservesCanceledEventLineage(t *testing.T)
 
 func validateCurrentPlatformEventPayloadForManagerTest(t testing.TB, eventType string, payload []byte) {
 	t.Helper()
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		t.Fatalf("unmarshal platform spec: %v", err)
 	}
 	registry := runtimecontracts.EventSchemaRegistryFromBundle(&runtimecontracts.WorkflowContractBundle{Platform: spec})

--- a/internal/runtime/semanticview/endpoint_census.go
+++ b/internal/runtime/semanticview/endpoint_census.go
@@ -4,13 +4,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 type EventEndpointDirection string
@@ -773,7 +772,7 @@ func endpointAssociationResult(flowID, identity, nodeID string, candidates []Aut
 type endpointCensusBuilder struct {
 	source     Source
 	seen       map[string]struct{}
-	yamlFiles  map[string]*yaml.Node
+	yamlFiles  map[string]yamlsource.Node
 	producers  []AuthoredEventEndpoint
 	consumers  []AuthoredEventEndpoint
 	inputPins  []AuthoredEventEndpoint
@@ -1075,7 +1074,7 @@ func (b *endpointCensusBuilder) endpointSourceLine(endpoint AuthoredEventEndpoin
 		return 0
 	}
 	root := b.yamlFile(file)
-	if root == nil {
+	if !root.Valid() {
 		return 0
 	}
 	eventType := eventidentity.Normalize(endpoint.Event.Authored)
@@ -1093,48 +1092,47 @@ func (b *endpointCensusBuilder) endpointSourceLine(endpoint AuthoredEventEndpoin
 	}
 }
 
-func (b *endpointCensusBuilder) yamlFile(file string) *yaml.Node {
+func (b *endpointCensusBuilder) yamlFile(file string) yamlsource.Node {
 	if b.yamlFiles == nil {
-		b.yamlFiles = map[string]*yaml.Node{}
+		b.yamlFiles = map[string]yamlsource.Node{}
 	}
 	if root, ok := b.yamlFiles[file]; ok {
 		return root
 	}
-	b.yamlFiles[file] = nil
-	contents, err := os.ReadFile(file)
+	b.yamlFiles[file] = yamlsource.Node{}
+	source, err := yamlsource.LoadFile(file)
 	if err != nil {
-		return nil
+		return yamlsource.Node{}
 	}
-	var root yaml.Node
-	if err := yaml.Unmarshal(contents, &root); err != nil {
-		return nil
-	}
-	b.yamlFiles[file] = &root
-	return &root
+	root := source.Root()
+	b.yamlFiles[file] = root
+	return root
 }
 
-func yamlActorEventLine(root *yaml.Node, actorID string, fields []string, eventType string) int {
+func yamlActorEventLine(root yamlsource.Node, actorID string, fields []string, eventType string) int {
 	document := yamlDocumentMapping(root)
 	actor := yamlMappingValue(document, strings.TrimSpace(actorID))
-	if actor == nil || actor.Kind != yaml.MappingNode {
+	if actor.Kind() != yamlsource.MappingNode {
 		return 0
 	}
 	for _, field := range fields {
 		value := yamlMappingValue(actor, field)
-		if value == nil {
+		if !value.Valid() {
 			continue
 		}
-		switch value.Kind {
-		case yaml.MappingNode:
-			for i := 0; i+1 < len(value.Content); i += 2 {
-				if eventidentity.Normalize(value.Content[i].Value) == eventType {
-					return value.Content[i].Line
+		switch value.Kind() {
+		case yamlsource.MappingNode:
+			for i := 0; i+1 < value.Len(); i += 2 {
+				item, _ := value.Child(i)
+				if eventidentity.Normalize(item.Value()) == eventType {
+					return item.Line()
 				}
 			}
-		case yaml.SequenceNode:
-			for _, item := range value.Content {
-				if eventidentity.Normalize(item.Value) == eventType {
-					return item.Line
+		case yamlsource.SequenceNode:
+			for i := 0; i < value.Len(); i++ {
+				item, _ := value.Child(i)
+				if eventidentity.Normalize(item.Value()) == eventType {
+					return item.Line()
 				}
 			}
 		}
@@ -1142,26 +1140,26 @@ func yamlActorEventLine(root *yaml.Node, actorID string, fields []string, eventT
 	return 0
 }
 
-func yamlDocumentMapping(root *yaml.Node) *yaml.Node {
-	if root == nil {
-		return nil
-	}
-	if root.Kind == yaml.DocumentNode && len(root.Content) == 1 {
-		return root.Content[0]
+func yamlDocumentMapping(root yamlsource.Node) yamlsource.Node {
+	if root.Kind() == yamlsource.DocumentNode && root.Len() == 1 {
+		child, _ := root.Child(0)
+		return child
 	}
 	return root
 }
 
-func yamlMappingValue(mapping *yaml.Node, key string) *yaml.Node {
-	if mapping == nil || mapping.Kind != yaml.MappingNode {
-		return nil
+func yamlMappingValue(mapping yamlsource.Node, key string) yamlsource.Node {
+	if mapping.Kind() != yamlsource.MappingNode {
+		return yamlsource.Node{}
 	}
-	for i := 0; i+1 < len(mapping.Content); i += 2 {
-		if strings.TrimSpace(mapping.Content[i].Value) == key {
-			return mapping.Content[i+1]
+	for i := 0; i+1 < mapping.Len(); i += 2 {
+		candidate, _ := mapping.Child(i)
+		if strings.TrimSpace(candidate.Value()) == key {
+			value, _ := mapping.Child(i + 1)
+			return value
 		}
 	}
-	return nil
+	return yamlsource.Node{}
 }
 
 func (b *endpointCensusBuilder) build() AuthoredEventEndpointCensus {

--- a/internal/runtime/semanticview/endpoint_census_test.go
+++ b/internal/runtime/semanticview/endpoint_census_test.go
@@ -2,6 +2,8 @@ package semanticview
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -400,6 +402,37 @@ func TestEndpointCensusReusesBundleYAMLAndPreservesNodeAndAgentSourceLines(t *te
 	assertEndpointSourceLine(t, census.Consumers(), EventEndpointNodeHandler, "complete-node", "", "task.completed", filepath.Join(fixture, "nodes.yaml"), 14)
 	assertEndpointSourceLine(t, census.Consumers(), EventEndpointAgent, "", "test-agent", "task.assigned", filepath.Join(fixture, "agents.yaml"), 6)
 	assertEndpointSourceLine(t, census.Producers(), EventEndpointAgent, "", "test-agent", "task.completed", filepath.Join(fixture, "agents.yaml"), 8)
+}
+
+type endpointSourceFiles struct {
+	Source
+	nodes map[string]runtimecontracts.ContractItemSource
+}
+
+func (s endpointSourceFiles) NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool) {
+	source, ok := s.nodes[nodeID]
+	return source, ok
+}
+
+func TestEndpointCensusAcquiresUnprimedSourceThroughCanonicalOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nodes.yaml")
+	body := fmt.Sprintf("# unique source: %s\nworker-node:\n  event_handlers:\n    work.requested: {}\n", path)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	source := endpointSourceFiles{
+		Source: endpointCensusFixture(nil),
+		nodes: map[string]runtimecontracts.ContractItemSource{
+			"worker-node": {File: path},
+		},
+	}
+	before := yamlsource.DefaultStats()
+	census := BuildAuthoredEventEndpointCensus(source)
+	after := yamlsource.DefaultStats()
+	if delta := after.ParseCount - before.ParseCount; delta != 1 {
+		t.Fatalf("endpoint census canonical-owner parse delta = %d, want 1", delta)
+	}
+	assertEndpointSourceLine(t, census.Consumers(), EventEndpointNodeHandler, "worker-node", "", "work.requested", path, 4)
 }
 
 func assertEndpointSourceLine(t *testing.T, endpoints []AuthoredEventEndpoint, kind EventEndpointKind, nodeID, agentID, eventType, sourceFile string, sourceLine int) {

--- a/internal/runtime/semanticview/endpoint_census_test.go
+++ b/internal/runtime/semanticview/endpoint_census_test.go
@@ -7,6 +7,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 func TestAuthoredEventEndpointCensusEnumeratesExecutableFactsAndAssertions(t *testing.T) {
@@ -377,6 +378,41 @@ func TestLegacyQualifiedSubscriptionsUseDeclaredFlowIdentityAndExactSourceLine(t
 	if got.Consumer.SourceFile != filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-child-flow-absolute-path", "nodes.yaml") || got.Consumer.SourceLine != 13 {
 		t.Fatalf("legacy source = %s:%d, want nodes.yaml:13", got.Consumer.SourceFile, got.Consumer.SourceLine)
 	}
+}
+
+func TestEndpointCensusReusesBundleYAMLAndPreservesNodeAndAgentSourceLines(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	fixture := filepath.Join(repoRoot, "tests", "tier7-composition", "test-agent-emits-to-node")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(
+		repoRoot,
+		fixture,
+		runtimecontracts.DefaultPlatformSpecFile(repoRoot),
+	)
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	afterBundle := yamlsource.DefaultStats().ParseCount
+
+	census := BuildAuthoredEventEndpointCensus(Wrap(bundle))
+	if afterCensus := yamlsource.DefaultStats().ParseCount; afterCensus != afterBundle {
+		t.Fatalf("census reparsed authoritative YAML: parse count %d -> %d", afterBundle, afterCensus)
+	}
+	assertEndpointSourceLine(t, census.Consumers(), EventEndpointNodeHandler, "complete-node", "", "task.completed", filepath.Join(fixture, "nodes.yaml"), 14)
+	assertEndpointSourceLine(t, census.Consumers(), EventEndpointAgent, "", "test-agent", "task.assigned", filepath.Join(fixture, "agents.yaml"), 6)
+	assertEndpointSourceLine(t, census.Producers(), EventEndpointAgent, "", "test-agent", "task.completed", filepath.Join(fixture, "agents.yaml"), 8)
+}
+
+func assertEndpointSourceLine(t *testing.T, endpoints []AuthoredEventEndpoint, kind EventEndpointKind, nodeID, agentID, eventType, sourceFile string, sourceLine int) {
+	t.Helper()
+	for _, endpoint := range endpoints {
+		if endpoint.Kind == kind && endpoint.NodeID == nodeID && endpoint.AgentID == agentID && endpoint.Event.Authored == eventType {
+			if endpoint.SourceFile != sourceFile || endpoint.SourceLine != sourceLine {
+				t.Fatalf("endpoint source = %s:%d, want %s:%d", endpoint.SourceFile, endpoint.SourceLine, sourceFile, sourceLine)
+			}
+			return
+		}
+	}
+	t.Fatalf("endpoint kind=%s node=%q agent=%q event=%q not found: %#v", kind, nodeID, agentID, eventType, endpoints)
 }
 
 func TestLegacyQualifiedSubscriptionsExcludeConnectedInputDelivery(t *testing.T) {

--- a/internal/runtime/swarmflowtest/catalog_runner_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_test.go
@@ -21,6 +21,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimerequiredagents "github.com/division-sh/swarm/internal/runtime/requiredagents"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1408,18 +1409,18 @@ func catalogSemanticEventWarningIssues(source semanticview.Source) []catalogBoot
 
 func catalogLoadRawYAMLMap(t testing.TB, path string) map[string]any {
 	t.Helper()
-	data, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]any{}
 		}
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			t.Fatalf("decode raw YAML %s: %v", path, cause)
+		}
 		t.Fatalf("read raw YAML %s: %v", path, err)
 	}
-	if len(strings.TrimSpace(string(data))) == 0 {
-		return map[string]any{}
-	}
 	var raw map[string]any
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	if err := source.Decode(&raw); err != nil {
 		t.Fatalf("decode raw YAML %s: %v", path, err)
 	}
 	if raw == nil {
@@ -3591,11 +3592,14 @@ func toYAMLScalar(value any) string {
 
 func loadYAMLForCatalogTest(t testing.TB, path string, target any) {
 	t.Helper()
-	raw, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			t.Fatalf("parse %s: %v", path, cause)
+		}
 		t.Fatalf("read %s: %v", path, err)
 	}
-	if err := yaml.Unmarshal(raw, target); err != nil {
+	if err := source.Decode(target); err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 }

--- a/internal/runtime/swarmflowtest/catalog_runner_validation_test.go
+++ b/internal/runtime/swarmflowtest/catalog_runner_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -67,14 +68,11 @@ func TestCatalogFixtures_UseCanonicalCreateFlowInstanceAuthoring(t *testing.T) {
 	}
 	for _, path := range matches {
 		t.Run(strings.TrimPrefix(filepath.ToSlash(path), filepath.ToSlash(filepath.Join(repoRoot, "tests"))+"/"), func(t *testing.T) {
-			raw, err := os.ReadFile(path)
+			source, err := yamlsource.LoadFile(path)
 			if err != nil {
 				t.Fatalf("read %s: %v", path, err)
 			}
-			var root yaml.Node
-			if err := yaml.Unmarshal(raw, &root); err != nil {
-				t.Fatalf("parse %s: %v", path, err)
-			}
+			root := source.NodeCopy()
 			assertCanonicalCreateFlowInstanceAuthoring(t, path, &root)
 		})
 	}

--- a/internal/runtime/swarmflowtest/catalog_yaml_owner_guard_test.go
+++ b/internal/runtime/swarmflowtest/catalog_yaml_owner_guard_test.go
@@ -1,0 +1,96 @@
+package swarmflowtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+func TestCatalogCanonicalAuthoringGuardUsesCanonicalYAMLOwner(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "catalog_runner_validation_test.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var target *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "TestCatalogFixtures_UseCanonicalCreateFlowInstanceAuthoring" {
+			target = fn
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("catalog canonical-authoring guard function is missing")
+	}
+
+	imports := map[string]string{}
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := ""
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		if name == "" {
+			switch path {
+			case "os":
+				name = "os"
+			case "gopkg.in/yaml.v3":
+				name = "yaml"
+			case "github.com/division-sh/swarm/internal/yamlsource":
+				name = "yamlsource"
+			}
+		}
+		if name != "" {
+			imports[name] = path
+		}
+	}
+
+	foundOwner := false
+	ast.Inspect(target.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if imports[pkg.Name] == "github.com/division-sh/swarm/internal/yamlsource" && selector.Sel.Name == "LoadFile" {
+			foundOwner = true
+		}
+		return true
+	})
+	if !foundOwner {
+		t.Fatal("catalog canonical-authoring guard does not consume yamlsource.LoadFile")
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		path := imports[pkg.Name]
+		if (path == "os" && selector.Sel.Name == "ReadFile") ||
+			(path == "gopkg.in/yaml.v3" && (selector.Sel.Name == "Unmarshal" || selector.Sel.Name == "NewDecoder")) {
+			t.Errorf("catalog canonical-authoring file restored forbidden parser call %s.%s", pkg.Name, selector.Sel.Name)
+		}
+		return true
+	})
+}

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -3,7 +3,6 @@ package tools_test
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,8 +21,8 @@ import (
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 type humanTaskToolStore interface {
@@ -488,12 +487,12 @@ func newPostgresHumanTaskToolStoreForTest(t *testing.T) *store.PostgresStore {
 
 func newSQLiteRuntimeToolStoreForTest(t *testing.T) *store.SQLiteRuntimeStore {
 	t.Helper()
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
 	if err != nil {
 		t.Fatalf("read platform spec: %v", err)
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		t.Fatalf("unmarshal platform spec: %v", err)
 	}
 	plans, err := store.GeneratePlatformTableDDLs(spec)

--- a/internal/store/platform_spec_test.go
+++ b/internal/store/platform_spec_test.go
@@ -1,0 +1,21 @@
+package store
+
+import (
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/yamlsource"
+)
+
+func loadPlatformSpecDocumentForStoreTest(t testing.TB, path string) runtimecontracts.PlatformSpecDocument {
+	t.Helper()
+	source, err := yamlsource.LoadFile(path)
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := source.Decode(&spec); err != nil {
+		t.Fatalf("unmarshal platform spec: %v", err)
+	}
+	return spec
+}

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"os"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -29,7 +28,6 @@ import (
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 const specEntityStateRunID = "33333333-3333-3333-3333-333333333333"
@@ -1861,14 +1859,7 @@ func TestPostgresStore_RecordInboundEvent_PlatformCatalogSchemaMatchesProducerPa
 
 func currentPlatformPayloadValidatorForStoreTest(t testing.TB) EventPayloadValidator {
 	t.Helper()
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
+	spec := loadPlatformSpecDocumentForStoreTest(t, runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
 	registry := runtimecontracts.EventSchemaRegistryFromBundle(&runtimecontracts.WorkflowContractBundle{Platform: spec})
 	return func(eventType string, payload []byte) error {
 		schema, ok := registry[strings.TrimSpace(eventType)]

--- a/internal/store/schema_ddl_test.go
+++ b/internal/store/schema_ddl_test.go
@@ -2,14 +2,12 @@ package store
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	stdruntime "runtime"
 	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"gopkg.in/yaml.v3"
 )
 
 func TestSchemaFieldTypeToDDL(t *testing.T) {
@@ -138,14 +136,7 @@ func TestGeneratePlatformTableDDLs_ExtractsInlineUniquePartialIndex(t *testing.T
 func TestPlatformSpecEntityStateUsesRunScopedIdentity(t *testing.T) {
 	_, file, _, _ := stdruntime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
+	spec := loadPlatformSpecDocumentForStoreTest(t, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	plans, err := GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
@@ -180,14 +171,7 @@ func TestPlatformSpecEntityStateUsesRunScopedIdentity(t *testing.T) {
 func TestPlatformSpecOwnsMultiBundleSchemaFoundation(t *testing.T) {
 	_, file, _, _ := stdruntime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
+	spec := loadPlatformSpecDocumentForStoreTest(t, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	plans, err := GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
@@ -243,14 +227,7 @@ func TestPlatformSpecOwnsMultiBundleSchemaFoundation(t *testing.T) {
 func TestPlatformSpecEventReceiptsUsesTypedSubscriberIdentity(t *testing.T) {
 	_, file, _, _ := stdruntime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
+	spec := loadPlatformSpecDocumentForStoreTest(t, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	plans, err := GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"gopkg.in/yaml.v3"
 )
 
 func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
@@ -556,15 +555,7 @@ func loadPlatformSpecForSQLiteSchemaTest(t *testing.T) runtimecontracts.Platform
 	t.Helper()
 	_, file, _, _ := stdruntime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
-	raw, err := os.ReadFile(runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("read platform spec: %v", err)
-	}
-	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
-		t.Fatalf("unmarshal platform spec: %v", err)
-	}
-	return spec
+	return loadPlatformSpecDocumentForStoreTest(t, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 }
 
 func platformTableNamesForSQLiteSchemaTest() []string {

--- a/internal/store/storetest/sqlite.go
+++ b/internal/store/storetest/sqlite.go
@@ -9,7 +9,7 @@ import (
 	"github.com/division-sh/swarm/internal/platform"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/store"
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 // StartSQLiteRuntimeStore creates a file-backed SQLite runtime store with the
@@ -23,7 +23,11 @@ func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context) *stor
 	t.Helper()
 
 	var platformSpec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &platformSpec); err != nil {
+	source, err := yamlsource.Load(platform.PlatformSpecYAML())
+	if err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	if err := source.Decode(&platformSpec); err != nil {
 		t.Fatalf("unmarshal platform spec: %v", err)
 	}
 	plans, err := store.GeneratePlatformTableDDLs(platformSpec)

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -19,8 +18,8 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/store/platformschema"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -948,12 +947,15 @@ func loadPlatformSpec() (runtimecontracts.PlatformSpecDocument, error) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
 	path := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
-	raw, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
+		if cause, ok := yamlsource.ParseCause(err); ok {
+			return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", cause)
+		}
 		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("read platform spec: %w", err)
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &spec); err != nil {
+	if err := source.Decode(&spec); err != nil {
 		return runtimecontracts.PlatformSpecDocument{}, fmt.Errorf("unmarshal platform spec: %w", err)
 	}
 	return spec, nil

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/store/platformschema"
+	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -37,7 +38,11 @@ func TestTemplateDigestUsesCanonicalGeneratedSchema(t *testing.T) {
 	}
 	raw = append(raw, []byte("\n# unrelated non-schema spec comment\n")...)
 	var reparsed runtimecontracts.PlatformSpecDocument
-	if err := yaml.Unmarshal(raw, &reparsed); err != nil {
+	source, err := yamlsource.Load(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := source.Decode(&reparsed); err != nil {
 		t.Fatal(err)
 	}
 	reparsedPlans, err := platformschema.GeneratePlatformTableDDLs(reparsed)

--- a/internal/testutil/postgres_test.go
+++ b/internal/testutil/postgres_test.go
@@ -3,12 +3,11 @@ package testutil
 import (
 	"context"
 	"database/sql"
-	"os"
 	"testing"
 	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"gopkg.in/yaml.v3"
+	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 func TestStartPostgres_Smoke(t *testing.T) {
@@ -30,12 +29,12 @@ func loadPlatformSpec() (runtimecontracts.PlatformSpecDocument, error) {
 	if err != nil {
 		return runtimecontracts.PlatformSpecDocument{}, err
 	}
-	raw, err := os.ReadFile(path)
+	source, err := yamlsource.LoadFile(path)
 	if err != nil {
 		return runtimecontracts.PlatformSpecDocument{}, err
 	}
 	var spec runtimecontracts.PlatformSpecDocument
-	err = yaml.Unmarshal(raw, &spec)
+	err = source.Decode(&spec)
 	return spec, err
 }
 

--- a/internal/yamlsource/source.go
+++ b/internal/yamlsource/source.go
@@ -236,7 +236,7 @@ func (s Snapshot) Decode(target any) error {
 	if s.entry == nil {
 		return fmt.Errorf("empty YAML snapshot")
 	}
-	root := cloneNode(&s.entry.root, make(map[*yaml.Node]*yaml.Node))
+	root := cloneNode(&s.entry.root)
 	return root.Decode(target)
 }
 
@@ -251,25 +251,71 @@ func (s Snapshot) NodeCopy() yaml.Node {
 	if s.entry == nil {
 		return yaml.Node{}
 	}
-	return *cloneNode(&s.entry.root, make(map[*yaml.Node]*yaml.Node))
+	return *cloneNode(&s.entry.root)
 }
 
-func cloneNode(source *yaml.Node, seen map[*yaml.Node]*yaml.Node) *yaml.Node {
+func cloneNode(source *yaml.Node) *yaml.Node {
 	if source == nil {
 		return nil
 	}
-	if existing := seen[source]; existing != nil {
+	nodeCount, edgeCount := nodeTreeSize(source)
+	cloner := nodeGraphCloner{
+		nodes: make([]yaml.Node, nodeCount),
+		edges: make([]*yaml.Node, edgeCount),
+		seen:  make(map[*yaml.Node]*yaml.Node, nodeCount),
+	}
+	return cloner.clone(source)
+}
+
+func nodeTreeSize(source *yaml.Node) (nodes, edges int) {
+	if source == nil {
+		return 0, 0
+	}
+	nodes = 1
+	edges = len(source.Content)
+	for _, child := range source.Content {
+		childNodes, childEdges := nodeTreeSize(child)
+		nodes += childNodes
+		edges += childEdges
+	}
+	// yaml.v3 parser aliases point at anchored nodes already present in the
+	// document Content tree, so they do not require additional arena slots.
+	return nodes, edges
+}
+
+type nodeGraphCloner struct {
+	nodes    []yaml.Node
+	edges    []*yaml.Node
+	seen     map[*yaml.Node]*yaml.Node
+	nextNode int
+	nextEdge int
+}
+
+func (c *nodeGraphCloner) clone(source *yaml.Node) *yaml.Node {
+	if source == nil {
+		return nil
+	}
+	if existing := c.seen[source]; existing != nil {
 		return existing
 	}
-	clone := *source
+
+	clone := &c.nodes[c.nextNode]
+	c.nextNode++
+	*clone = *source
 	clone.Content = nil
 	clone.Alias = nil
-	seen[source] = &clone
-	for _, child := range source.Content {
-		clone.Content = append(clone.Content, cloneNode(child, seen))
+	c.seen[source] = clone
+
+	if len(source.Content) > 0 {
+		start := c.nextEdge
+		c.nextEdge += len(source.Content)
+		clone.Content = c.edges[start:c.nextEdge]
+		for i, child := range source.Content {
+			clone.Content[i] = c.clone(child)
+		}
 	}
-	clone.Alias = cloneNode(source.Alias, seen)
-	return &clone
+	clone.Alias = c.clone(source.Alias)
+	return clone
 }
 
 func (s Snapshot) LookupMapPath(parts ...string) (Node, bool) {

--- a/internal/yamlsource/source.go
+++ b/internal/yamlsource/source.go
@@ -33,6 +33,7 @@ type Store struct {
 	lru         *list.List
 	sourceBytes int64
 	parseCount  uint64
+	hits        uint64
 	coalesced   uint64
 	parse       func([]byte) (yaml.Node, error)
 }
@@ -70,6 +71,7 @@ type Stats struct {
 	Inflight    int
 	SourceBytes int64
 	ParseCount  uint64
+	Hits        uint64
 	Coalesced   uint64
 }
 
@@ -120,6 +122,7 @@ func (s *Store) Load(raw []byte) (Snapshot, error) {
 
 	s.mu.Lock()
 	if cached := s.entries[digest]; cached != nil {
+		s.hits++
 		s.lru.MoveToFront(cached.lru)
 		s.mu.Unlock()
 		return snapshotResult(cached)
@@ -164,6 +167,7 @@ func (s *Store) Stats() Stats {
 		Inflight:    len(s.inflight),
 		SourceBytes: s.sourceBytes,
 		ParseCount:  s.parseCount,
+		Hits:        s.hits,
 		Coalesced:   s.coalesced,
 	}
 }
@@ -232,7 +236,8 @@ func (s Snapshot) Decode(target any) error {
 	if s.entry == nil {
 		return fmt.Errorf("empty YAML snapshot")
 	}
-	return s.entry.root.Decode(target)
+	root := cloneNode(&s.entry.root, make(map[*yaml.Node]*yaml.Node))
+	return root.Decode(target)
 }
 
 func (s Snapshot) Root() Node {

--- a/internal/yamlsource/source.go
+++ b/internal/yamlsource/source.go
@@ -1,0 +1,376 @@
+package yamlsource
+
+import (
+	"bytes"
+	"container/list"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultMaxEntries     = 256
+	DefaultMaxSourceBytes = 64 << 20
+)
+
+type Digest [sha256.Size]byte
+
+type Limits struct {
+	MaxEntries     int
+	MaxSourceBytes int64
+}
+
+type Store struct {
+	mu          sync.Mutex
+	limits      Limits
+	entries     map[Digest]*entry
+	inflight    map[Digest]*entry
+	lru         *list.List
+	sourceBytes int64
+	parseCount  uint64
+	coalesced   uint64
+	parse       func([]byte) (yaml.Node, error)
+}
+
+type entry struct {
+	digest Digest
+	raw    []byte
+	root   yaml.Node
+	err    error
+	ready  chan struct{}
+	lru    *list.Element
+}
+
+type Snapshot struct {
+	entry *entry
+}
+
+type ParseError struct {
+	cause error
+}
+
+func (e *ParseError) Error() string { return e.cause.Error() }
+func (e *ParseError) Unwrap() error { return e.cause }
+
+func ParseCause(err error) (error, bool) {
+	var parseErr *ParseError
+	if !errors.As(err, &parseErr) {
+		return nil, false
+	}
+	return parseErr.cause, true
+}
+
+type Stats struct {
+	Entries     int
+	Inflight    int
+	SourceBytes int64
+	ParseCount  uint64
+	Coalesced   uint64
+}
+
+var defaultStore = NewStore(Limits{
+	MaxEntries:     DefaultMaxEntries,
+	MaxSourceBytes: DefaultMaxSourceBytes,
+})
+
+func NewStore(limits Limits) *Store {
+	if limits.MaxEntries < 0 {
+		limits.MaxEntries = 0
+	}
+	if limits.MaxSourceBytes < 0 {
+		limits.MaxSourceBytes = 0
+	}
+	return &Store{
+		limits:   limits,
+		entries:  make(map[Digest]*entry),
+		inflight: make(map[Digest]*entry),
+		lru:      list.New(),
+		parse:    parse,
+	}
+}
+
+func LoadFile(path string) (Snapshot, error) {
+	return defaultStore.LoadFile(path)
+}
+
+func Load(raw []byte) (Snapshot, error) {
+	return defaultStore.Load(raw)
+}
+
+func DefaultStats() Stats {
+	return defaultStore.Stats()
+}
+
+func (s *Store) LoadFile(path string) (Snapshot, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return s.Load(raw)
+}
+
+func (s *Store) Load(raw []byte) (Snapshot, error) {
+	owned := append([]byte(nil), raw...)
+	digest := sha256.Sum256(owned)
+
+	s.mu.Lock()
+	if cached := s.entries[digest]; cached != nil {
+		s.lru.MoveToFront(cached.lru)
+		s.mu.Unlock()
+		return snapshotResult(cached)
+	}
+	if pending := s.inflight[digest]; pending != nil {
+		ready := pending.ready
+		s.coalesced++
+		s.mu.Unlock()
+		<-ready
+		return snapshotResult(pending)
+	}
+
+	pending := &entry{digest: digest, raw: owned, ready: make(chan struct{})}
+	s.inflight[digest] = pending
+	s.mu.Unlock()
+
+	pending.root, pending.err = s.parse(owned)
+	if pending.err != nil {
+		pending.err = &ParseError{cause: pending.err}
+	}
+
+	s.mu.Lock()
+	s.parseCount++
+	delete(s.inflight, digest)
+	if s.retainable(pending) {
+		pending.lru = s.lru.PushFront(pending)
+		s.entries[digest] = pending
+		s.sourceBytes += int64(len(pending.raw))
+		s.evict()
+	}
+	close(pending.ready)
+	s.mu.Unlock()
+
+	return snapshotResult(pending)
+}
+
+func (s *Store) Stats() Stats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Stats{
+		Entries:     len(s.entries),
+		Inflight:    len(s.inflight),
+		SourceBytes: s.sourceBytes,
+		ParseCount:  s.parseCount,
+		Coalesced:   s.coalesced,
+	}
+}
+
+func (s *Store) retainable(candidate *entry) bool {
+	return s.limits.MaxEntries > 0 &&
+		s.limits.MaxSourceBytes > 0 &&
+		int64(len(candidate.raw)) <= s.limits.MaxSourceBytes
+}
+
+func (s *Store) evict() {
+	for len(s.entries) > s.limits.MaxEntries || s.sourceBytes > s.limits.MaxSourceBytes {
+		oldest := s.lru.Back()
+		if oldest == nil {
+			return
+		}
+		victim := oldest.Value.(*entry)
+		delete(s.entries, victim.digest)
+		s.sourceBytes -= int64(len(victim.raw))
+		s.lru.Remove(oldest)
+		victim.lru = nil
+	}
+}
+
+func snapshotResult(candidate *entry) (Snapshot, error) {
+	if candidate.err != nil {
+		return Snapshot{}, candidate.err
+	}
+	return Snapshot{entry: candidate}, nil
+}
+
+func parse(raw []byte) (yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	var root yaml.Node
+	if err := decoder.Decode(&root); err != nil {
+		if err == io.EOF {
+			return yaml.Node{}, fmt.Errorf("YAML input has no document")
+		}
+		return yaml.Node{}, err
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return yaml.Node{}, fmt.Errorf("YAML input has multiple documents")
+		}
+		return yaml.Node{}, err
+	}
+	return root, nil
+}
+
+func (s Snapshot) Digest() Digest {
+	if s.entry == nil {
+		return Digest{}
+	}
+	return s.entry.digest
+}
+
+func (s Snapshot) Bytes() []byte {
+	if s.entry == nil {
+		return nil
+	}
+	return append([]byte(nil), s.entry.raw...)
+}
+
+func (s Snapshot) Decode(target any) error {
+	if s.entry == nil {
+		return fmt.Errorf("empty YAML snapshot")
+	}
+	return s.entry.root.Decode(target)
+}
+
+func (s Snapshot) Root() Node {
+	if s.entry == nil {
+		return Node{}
+	}
+	return Node{node: &s.entry.root}
+}
+
+func (s Snapshot) NodeCopy() yaml.Node {
+	if s.entry == nil {
+		return yaml.Node{}
+	}
+	return *cloneNode(&s.entry.root, make(map[*yaml.Node]*yaml.Node))
+}
+
+func cloneNode(source *yaml.Node, seen map[*yaml.Node]*yaml.Node) *yaml.Node {
+	if source == nil {
+		return nil
+	}
+	if existing := seen[source]; existing != nil {
+		return existing
+	}
+	clone := *source
+	clone.Content = nil
+	clone.Alias = nil
+	seen[source] = &clone
+	for _, child := range source.Content {
+		clone.Content = append(clone.Content, cloneNode(child, seen))
+	}
+	clone.Alias = cloneNode(source.Alias, seen)
+	return &clone
+}
+
+func (s Snapshot) LookupMapPath(parts ...string) (Node, bool) {
+	node := s.Root()
+	if node.Kind() == DocumentNode {
+		if node.Len() != 1 {
+			return Node{}, false
+		}
+		node, _ = node.Child(0)
+	}
+	for _, part := range parts {
+		if node.Kind() != MappingNode {
+			return Node{}, false
+		}
+		found := false
+		for i := 0; i+1 < node.Len(); i += 2 {
+			key, _ := node.Child(i)
+			if key.Value() == part {
+				node, _ = node.Child(i + 1)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return Node{}, false
+		}
+	}
+	return node, true
+}
+
+type Kind uint32
+
+const (
+	DocumentNode Kind = Kind(yaml.DocumentNode)
+	SequenceNode Kind = Kind(yaml.SequenceNode)
+	MappingNode  Kind = Kind(yaml.MappingNode)
+	ScalarNode   Kind = Kind(yaml.ScalarNode)
+	AliasNode    Kind = Kind(yaml.AliasNode)
+)
+
+type Style uint32
+
+const (
+	TaggedStyle       Style = Style(yaml.TaggedStyle)
+	DoubleQuotedStyle Style = Style(yaml.DoubleQuotedStyle)
+	SingleQuotedStyle Style = Style(yaml.SingleQuotedStyle)
+)
+
+type Node struct {
+	node *yaml.Node
+}
+
+func (n Node) Valid() bool { return n.node != nil }
+
+func (n Node) Kind() Kind {
+	if n.node == nil {
+		return 0
+	}
+	return Kind(n.node.Kind)
+}
+
+func (n Node) Tag() string {
+	if n.node == nil {
+		return ""
+	}
+	return n.node.Tag
+}
+
+func (n Node) Value() string {
+	if n.node == nil {
+		return ""
+	}
+	return n.node.Value
+}
+
+func (n Node) Line() int {
+	if n.node == nil {
+		return 0
+	}
+	return n.node.Line
+}
+
+func (n Node) Style() Style {
+	if n.node == nil {
+		return 0
+	}
+	return Style(n.node.Style)
+}
+
+func (n Node) Len() int {
+	if n.node == nil {
+		return 0
+	}
+	return len(n.node.Content)
+}
+
+func (n Node) Child(index int) (Node, bool) {
+	if n.node == nil || index < 0 || index >= len(n.node.Content) {
+		return Node{}, false
+	}
+	return Node{node: n.node.Content[index]}, true
+}
+
+func (n Node) Alias() (Node, bool) {
+	if n.node == nil || n.node.Alias == nil {
+		return Node{}, false
+	}
+	return Node{node: n.node.Alias}, true
+}

--- a/internal/yamlsource/source_test.go
+++ b/internal/yamlsource/source_test.go
@@ -214,6 +214,52 @@ func TestSnapshotReadOnlyTraversalAndCopiedBytes(t *testing.T) {
 	}
 }
 
+type mutatingNodeTarget struct{}
+
+func (*mutatingNodeTarget) UnmarshalYAML(node *yaml.Node) error {
+	node.Value = "corrupted"
+	node.Tag = "!!str"
+	node.Content = nil
+	node.Alias = nil
+	return nil
+}
+
+func TestSnapshotDecodeDoesNotExposeRetainedNodeToUnmarshalers(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	snapshot, err := store.Load([]byte("root:\n  value: pristine\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 24
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			var target mutatingNodeTarget
+			if err := snapshot.Decode(&target); err != nil {
+				t.Errorf("Decode mutating target: %v", err)
+			}
+			if value, ok := snapshot.LookupMapPath("root", "value"); !ok || value.Value() != "pristine" {
+				t.Errorf("retained node changed: value=%q found=%v", value.Value(), ok)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var decoded map[string]map[string]string
+	if err := snapshot.Decode(&decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["root"]["value"] != "pristine" {
+		t.Fatalf("fresh decode = %#v", decoded)
+	}
+}
+
 func loadError(store *Store, raw []byte) error {
 	_, err := store.Load(raw)
 	return err

--- a/internal/yamlsource/source_test.go
+++ b/internal/yamlsource/source_test.go
@@ -1,0 +1,220 @@
+package yamlsource
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestStoreCoalescesConcurrentContent(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	raw := []byte("root:\n  value: one\n")
+	const workers = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			snapshot, err := store.Load(raw)
+			if err != nil {
+				t.Errorf("Load: %v", err)
+				return
+			}
+			var out map[string]any
+			if err := snapshot.Decode(&out); err != nil {
+				t.Errorf("Decode: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := store.Stats().ParseCount; got != 1 {
+		t.Fatalf("parse count = %d, want 1", got)
+	}
+}
+
+func TestStoreKeysByContentAndReturnsFreshValues(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	first, err := store.Load([]byte("items: [one]\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Load([]byte("items: [one]\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Digest() != second.Digest() || store.Stats().ParseCount != 1 {
+		t.Fatalf("same content did not reuse one parse: %+v", store.Stats())
+	}
+	var left, right map[string][]string
+	if err := first.Decode(&left); err != nil {
+		t.Fatal(err)
+	}
+	left["items"][0] = "mutated"
+	if err := second.Decode(&right); err != nil {
+		t.Fatal(err)
+	}
+	if right["items"][0] != "one" {
+		t.Fatalf("later decode contaminated: %#v", right)
+	}
+	changed, err := store.Load([]byte("items: [two]\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Digest() == first.Digest() || store.Stats().ParseCount != 2 {
+		t.Fatalf("changed content did not parse independently: %+v", store.Stats())
+	}
+}
+
+func TestStoreRetainsErrorsAndRejectsMultipleDocuments(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	bad := []byte("a: [\n")
+	firstErr := loadError(store, bad)
+	secondErr := loadError(store, append([]byte(nil), bad...))
+	if firstErr != secondErr {
+		t.Fatalf("retained error identity changed: %p != %p", firstErr, secondErr)
+	}
+	if store.Stats().ParseCount != 1 {
+		t.Fatalf("parse count = %d, want 1", store.Stats().ParseCount)
+	}
+	if _, err := store.Load([]byte("a: one\n---\nb: two\n")); err == nil || !bytes.Contains([]byte(err.Error()), []byte("multiple documents")) {
+		t.Fatalf("multi-document error = %v", err)
+	}
+}
+
+func TestStoreBoundsEvictionAndOversizedEntries(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 2, MaxSourceBytes: 32})
+	a := []byte("a: one\n")
+	b := []byte("b: two\n")
+	c := []byte("c: three\n")
+	for _, raw := range [][]byte{a, b} {
+		if _, err := store.Load(raw); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.Load(a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load(c); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.Stats().ParseCount; got != 3 {
+		t.Fatalf("parse count after LRU touch = %d, want 3", got)
+	}
+	if _, err := store.Load(b); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.Stats().ParseCount; got != 4 {
+		t.Fatalf("least-recently-used entry was retained: parse count = %d, want 4", got)
+	}
+	stats := store.Stats()
+	if stats.Entries > 2 || stats.SourceBytes > 32 {
+		t.Fatalf("cache bounds exceeded: %+v", stats)
+	}
+	oversized := bytes.Repeat([]byte("x"), 64)
+	if _, err := store.Load(append([]byte("value: "), oversized...)); err != nil {
+		t.Fatal(err)
+	}
+	if after := store.Stats(); after.Entries != stats.Entries {
+		t.Fatalf("oversized entry retained: before=%+v after=%+v", stats, after)
+	}
+}
+
+func TestStoreCoalescesOversizedInflightEntryWithoutRetainingIt(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 1, MaxSourceBytes: 8})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	parseSource := store.parse
+	store.parse = func(raw []byte) (yaml.Node, error) {
+		close(entered)
+		<-release
+		return parseSource(raw)
+	}
+	raw := []byte("value: oversized\n")
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := store.Load(raw)
+		firstDone <- err
+	}()
+	<-entered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := store.Load(raw)
+		secondDone <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for store.Stats().Coalesced == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if store.Stats().Coalesced != 1 {
+		close(release)
+		t.Fatal("second load did not join the in-flight parse")
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+	if stats := store.Stats(); stats.ParseCount != 1 || stats.Entries != 0 || stats.Inflight != 0 {
+		t.Fatalf("oversized in-flight stats = %+v", stats)
+	}
+}
+
+func TestStoreRejectsMissingDocument(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	if _, err := store.Load([]byte("# comments only\n")); err == nil || !bytes.Contains([]byte(err.Error()), []byte("no document")) {
+		t.Fatalf("missing-document error = %v", err)
+	}
+}
+
+func TestSnapshotReadOnlyTraversalAndCopiedBytes(t *testing.T) {
+	store := NewStore(Limits{MaxEntries: 8, MaxSourceBytes: 1024})
+	input := []byte("root:\n  value: &v tagged\n  alias: *v\n")
+	snapshot, err := store.Load(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input[0] = 'X'
+	if snapshot.Bytes()[0] != 'r' {
+		t.Fatal("snapshot retained caller-owned input bytes")
+	}
+	value, ok := snapshot.LookupMapPath("root", "value")
+	if !ok || value.Kind() != ScalarNode || value.Value() != "tagged" {
+		t.Fatalf("lookup = %#v, %v", value, ok)
+	}
+	alias, ok := snapshot.LookupMapPath("root", "alias")
+	if !ok || alias.Kind() != AliasNode {
+		t.Fatalf("alias lookup = %#v, %v", alias, ok)
+	}
+	target, ok := alias.Alias()
+	if !ok || target != value {
+		t.Fatalf("alias target = %#v, %v; want %#v", target, ok, value)
+	}
+	raw := snapshot.Bytes()
+	raw[0] = 'X'
+	if snapshot.Bytes()[0] != 'r' {
+		t.Fatal("snapshot bytes were not copied")
+	}
+	copyRoot := snapshot.NodeCopy()
+	copyRoot.Content[0].Content[1].Content[1].Value = "mutated"
+	copyAlias := copyRoot.Content[0].Content[1].Content[3]
+	if copyAlias.Alias != copyRoot.Content[0].Content[1].Content[1] {
+		t.Fatal("node copy did not remap alias within copied tree")
+	}
+	if got, _ := snapshot.LookupMapPath("root", "value"); got.Value() != "tagged" {
+		t.Fatalf("node copy mutation contaminated snapshot: %q", got.Value())
+	}
+}
+
+func loadError(store *Store, raw []byte) error {
+	_, err := store.Load(raw)
+	return err
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -156,6 +156,39 @@ vocabulary:
     - description
 contract_formats:
   description: Canonical format for all flow contract files.
+  authoritative_yaml_source:
+    canonical_owner: platform-spec.yaml#contract_formats.authoritative_yaml_source
+    implementation_owner: internal/yamlsource
+    scope:
+    - platform-spec.yaml
+    - package.yaml
+    - schema.yaml
+    - nodes.yaml
+    - events.yaml
+    - entities.yaml
+    - types.yaml
+    - agents.yaml
+    - tools.yaml
+    - policy.yaml
+    document_grammar: |
+      Every present authoritative YAML source MUST contain exactly one YAML
+      document. Empty and comment-only files contain no document and fail
+      closed. Multi-document streams fail closed. An authored empty mapping is
+      written explicitly as {}. File omission remains governed by
+      contract_formats.minimum_flow_package and is not equivalent to a present
+      empty document.
+    lexical_ownership: |
+      The process acquires authoritative YAML lexical state through one
+      content-addressed immutable owner keyed by SHA-256 of copied source bytes,
+      never by path or mtime. The owner retains parsed success or failure under
+      bounded process-local LRU limits, coalesces concurrent acquisition, keeps
+      retained yaml.Node pointers private, and exposes only read-only traversal,
+      caller-owned node copies, copied bytes, or fresh caller-owned decoded
+      values. Domain projections such as workflow bundles, API specifications,
+      bundle hashes, bundle identities, prompt variables, and source-line views
+      remain in their existing semantic owners and MUST NOT become shared
+      mutable cache values.
+    diagnostics: Read failures and parse/decode failures preserve the current source path and fail closed.
   loader_defaults:
     description: Fields and identifiers that the loader derives from context. Entries marked non-authorable are not accepted
       as public YAML fields.


### PR DESCRIPTION
## Summary

- add one process-local, content-addressed immutable owner for authoritative platform/workflow-contract YAML
- migrate production, proof, catalog, hash/identity, prompt-policy, and endpoint-census consumers
- remove the stale path-keyed mutable prompt-variable projection cache
- enforce one YAML document, fresh caller-owned decode, bounded weighted LRU retention, retained errors, and concurrent parse coalescing
- keep retained YAML nodes private even from custom node unmarshallers, using allocation-bounded arena copies

Closes #1945

## Governing context

Exact governing specification: `platform-spec.yaml#contract_formats.authoritative_yaml_source`.

That section now owns the authoritative source scope, exact-one-document grammar, content-addressed lexical ownership, private retained-node contract, fresh caller-owned projections, and diagnostic requirements. Binding review context remains issue #1945, its Pre-Implementation Coverage Audit revisions and independent Gate B outcomes. Parent context is #1196 and `maintenance-and-cleanup.yaml#harness_reliability_and_local_smoke`.

## Semantic migration

- **New canonical owner:** `internal/yamlsource`, keyed by SHA-256 of copied content bytes and governed by `platform-spec.yaml#contract_formats.authoritative_yaml_source`.
- **Invalid old paths:** direct authoritative `os.ReadFile + yaml.Unmarshal/NewDecoder` consumers; canonical hash and legacy identity reparsing; catalog/cataloge2e direct reparsing; endpoint-census mutable node path cache; `promptcontracts.promptVariablesCache`; retained-node exposure through `Snapshot.Decode`.
- **Production paths checked:** API spec loading, serve boot, platform version, test Postgres/store schema setup, central workflow bundle loading, prompt policy projection, canonical hash/identity, and semantic endpoint census.
- **Proof paths checked:** CLI/platform raw queries, API public-surface proofs, store/schema proofs, catalog harnesses, cataloge2e, contract helpers, production typed/hash/identity entrypoints, unprimed endpoint acquisition, and catalog parser-recurrence guard.
- **Migration status:** complete for the approved authoritative platform/workflow-contract lexical class. Config/scenario/payload/proof-matrix/archive/`expected.yaml`/prompt-only parsers remain distinct classified artifacts.

## Verification

- `go test -race ./internal/yamlsource ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/swarmflowtest ./internal/promptcontracts -count=1`
- malicious `UnmarshalYAML(*yaml.Node)` mutation/concurrency regression: pass
- production typed/hash/identity proof: one parse and two owner hits
- unprimed unique endpoint source acquisition plus exact node/agent source-line parity: pass
- catalog canonical-authoring AST recurrence guard: pass
- named API manifestations on the copy-safe arena implementation: package 9.671s, wall 17.87s; audited baseline package 38.535s, wall 42.91s
- exact managed-Postgres `go test ./... -count=1` run completed in 339.60s. The known `TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer` failure reproduces identically on detached current `origin/master` `97df429c`; no fork-semantic code changes here.
- the concurrent-run `internal/testpostgres` handoff-mode collision from that full run passed immediately in isolated rerun: `TestServiceRegistryConcurrentLiveRunnersRemainUntouched` in 8.085s
- PR CI is the final isolated supported-environment proof
