### PR TITLE
[agent-g][issue #2003] Fail closed on incompatible runtime stores

### DIFF
--- a/cmd/swarm/claude_attempt_identity_test.go
+++ b/cmd/swarm/claude_attempt_identity_test.go
@@ -411,9 +411,7 @@ func newClaudeAttemptProofBackend(t *testing.T, name string) claudeAttemptProofB
 			t.Fatalf("new SQLite runtime store: %v", err)
 		}
 		t.Cleanup(func() { _ = sqliteStore.Close() })
-		if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
-			t.Fatalf("ensure SQLite runtime schema: %v", err)
-		}
+		bootstrapSQLiteSchemaForTest(t, context.Background(), sqliteStore, plans)
 		return claudeAttemptProofBackend{name: name, store: sqliteStore, db: sqliteStore.DB, sessions: sqliteStore}
 	case "postgres":
 		_, db, _ := testutil.StartPostgres(t)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -2665,11 +2665,14 @@ func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runt
 	if err != nil {
 		return "", fmt.Errorf("state_schema tables: %w", err)
 	}
-	plans := append([]store.SchemaTableDDL{}, platformPlans...)
-	plans = append(plans, statePlans...)
-	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
+	request, err := schemaBootstrapRequest(bundle.Platform, platformPlans, statePlans)
+	if err != nil {
 		return "", err
 	}
+	if err := ensureServeSchemaTables(ctx, stores, request); err != nil {
+		return "", err
+	}
+	plans := append(append([]store.SchemaTableDDL{}, platformPlans...), statePlans...)
 	return summarizeServeSchemaPlans(plans, verbose), nil
 }
 
@@ -2685,7 +2688,11 @@ func initializeServePlatformStateStores(ctx context.Context, stores storeBundle,
 	if err != nil {
 		return "", fmt.Errorf("platform-owned tables: %w", err)
 	}
-	if err := ensureServeSchemaTables(ctx, stores, plans); err != nil {
+	request, err := schemaBootstrapRequest(spec, plans, nil)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureServeSchemaTables(ctx, stores, request); err != nil {
 		return "", err
 	}
 	return summarizeServeSchemaPlans(plans, verbose), nil
@@ -2703,11 +2710,27 @@ func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBu
 	return summaries, nil
 }
 
-func ensureServeSchemaTables(ctx context.Context, stores storeBundle, plans []store.SchemaTableDDL) error {
+func schemaBootstrapRequest(spec runtimecontracts.PlatformSpecDocument, platformPlans, statePlans []store.SchemaTableDDL) (store.SchemaBootstrapRequest, error) {
+	metadata, err := resolveLocalVersionMetadata()
+	if err != nil {
+		return store.SchemaBootstrapRequest{}, fmt.Errorf("resolve schema bootstrap build identity: %w", err)
+	}
+	return store.SchemaBootstrapRequest{
+		PlatformPlans: platformPlans,
+		StatePlans:    statePlans,
+		Origin: store.RuntimeStoreOrigin{
+			SwarmVersion:    metadata.BinaryVersion,
+			PlatformVersion: strings.TrimSpace(spec.Platform.Version),
+			CreatedAt:       time.Now().UTC(),
+		},
+	}, nil
+}
+
+func ensureServeSchemaTables(ctx context.Context, stores storeBundle, request store.SchemaBootstrapRequest) error {
 	if stores.SchemaBootstrapper == nil {
 		return nil
 	}
-	if err := stores.SchemaBootstrapper.EnsureSchemaTables(ctx, plans); err != nil {
+	if err := stores.SchemaBootstrapper.BootstrapSchema(ctx, request); err != nil {
 		return err
 	}
 	if err := rebindServePostgresSchemaCapabilities(ctx, stores); err != nil {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10297,6 +10297,7 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryFailsPersistedMissingBef
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
+		StoreModeSet:       true,
 		APIListenAddr:      "127.0.0.1:0",
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
@@ -10327,8 +10328,8 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 	})
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO agents (agent_id, role, model, conversation_mode)
-		VALUES ('agent-a', 'operator', 'default', 'task')
+		INSERT INTO agents (agent_id, role, model, conversation_mode, runtime_descriptor)
+		VALUES ('agent-a', 'operator', 'default', 'task', '{"type":"default"}'::jsonb)
 	`); err != nil {
 		t.Fatalf("seed agent: %v", err)
 	}
@@ -10378,6 +10379,7 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
+		StoreModeSet:       true,
 		APIListenAddr:      "127.0.0.1:0",
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
@@ -10428,10 +10430,7 @@ func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string,
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}
-	if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
-		_ = sqliteStore.Close()
-		t.Fatalf("EnsureSchemaTables: %v", err)
-	}
+	bootstrapSQLiteSchemaForTest(t, context.Background(), sqliteStore, plans)
 	ctx := context.Background()
 	now := time.Date(2026, 5, 18, 4, 30, 0, 0, time.UTC)
 	runID := uuid.NewString()
@@ -14589,7 +14588,7 @@ func captureServeSchemaPlanSummary(t *testing.T, plans []store.SchemaTableDDL, v
 
 type recordingSchemaBootstrapper struct{}
 
-func (recordingSchemaBootstrapper) EnsureSchemaTables(context.Context, []store.SchemaTableDDL) error {
+func (recordingSchemaBootstrapper) BootstrapSchema(context.Context, store.SchemaBootstrapRequest) error {
 	return nil
 }
 
@@ -14601,8 +14600,9 @@ type capturingSchemaBootstrapper struct {
 	plans []store.SchemaTableDDL
 }
 
-func (c *capturingSchemaBootstrapper) EnsureSchemaTables(_ context.Context, plans []store.SchemaTableDDL) error {
-	c.plans = append([]store.SchemaTableDDL{}, plans...)
+func (c *capturingSchemaBootstrapper) BootstrapSchema(_ context.Context, request store.SchemaBootstrapRequest) error {
+	c.plans = append([]store.SchemaTableDDL{}, request.PlatformPlans...)
+	c.plans = append(c.plans, request.StatePlans...)
 	return nil
 }
 

--- a/cmd/swarm/provider_trigger_packs_test.go
+++ b/cmd/swarm/provider_trigger_packs_test.go
@@ -307,10 +307,7 @@ func seedReleaseProviderTriggerStore(t *testing.T, platformSpecBody []byte, sqli
 		t.Fatalf("create release SQLite store: %v", err)
 	}
 	ctx := context.Background()
-	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
-		_ = sqliteStore.Close()
-		t.Fatalf("initialize release SQLite store: %v", err)
-	}
+	bootstrapSQLiteSchemaForTest(t, ctx, sqliteStore, plans)
 	seedProviderTriggerSmokeRuntime(t, runtimecorrelation.WithRunID(ctx, "76000000-0000-0000-0000-000000000001"), sqliteStore,
 		"76000000-0000-0000-0000-000000000001", "76000000-0000-0000-0000-000000000002", "release-stripe", "stripe-customer", "stripe", "stripe-release-secret", "release-stripe-agent")
 	seedProviderTriggerSmokeRuntime(t, runtimecorrelation.WithRunID(ctx, "76000000-0000-0000-0000-000000000003"), sqliteStore,

--- a/cmd/swarm/schema_bootstrap_test.go
+++ b/cmd/swarm/schema_bootstrap_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/store"
+)
+
+func bootstrapSQLiteSchemaForTest(t testing.TB, ctx context.Context, sqliteStore *store.SQLiteRuntimeStore, plans []store.SchemaTableDDL) {
+	t.Helper()
+	if err := sqliteStore.BootstrapSchema(ctx, store.SchemaBootstrapRequest{
+		PlatformPlans: plans,
+		Origin: store.RuntimeStoreOrigin{
+			SwarmVersion:    "cmd-test",
+			PlatformVersion: "test",
+			CreatedAt:       time.Now().UTC(),
+		},
+	}); err != nil {
+		t.Fatalf("BootstrapSchema: %v", err)
+	}
+}

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -49,7 +49,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "reply_contexts", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "reply_contexts.run_id", DeleteOrderGroup: 4},
 		{Table: "events", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "events.run_id", DeleteOrderGroup: 5},
 		{Table: "runs", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteAll, PredicateOwner: "runs.run_id cleanup set", DeleteOrderGroup: 6},
-		{Table: "schema_version", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "schema/migration state", PreservationProof: "must survive destructive runtime cleanup"},
+		{Table: "runtime_store_metadata", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "immutable runtime store creation origin", PreservationProof: "must survive destructive runtime cleanup unchanged"},
 		{Table: "api_idempotency", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "API idempotency/auth-like state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "runtime_ingress_state", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "singleton runtime ingress owner", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "agents", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "agent registry/config state", PreservationProof: "must survive destructive runtime cleanup"},

--- a/internal/runtime/engine/compute_module_replay_test.go
+++ b/internal/runtime/engine/compute_module_replay_test.go
@@ -122,8 +122,11 @@ func newComputeModuleReplaySQLiteStore(t *testing.T) *store.SQLiteRuntimeStore {
 			t.Fatalf("close sqlite runtime store: %v", err)
 		}
 	})
-	if err := sqliteStore.EnsureSchemaTables(context.Background(), plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
+	if err := sqliteStore.BootstrapSchema(context.Background(), store.SchemaBootstrapRequest{
+		PlatformPlans: plans,
+		Origin:        store.RuntimeStoreOrigin{SwarmVersion: "engine-test", PlatformVersion: spec.Platform.Version, CreatedAt: time.Now().UTC()},
+	}); err != nil {
+		t.Fatalf("BootstrapSchema: %v", err)
 	}
 	return sqliteStore
 }

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -508,8 +508,11 @@ func newSQLiteRuntimeToolStoreForTest(t *testing.T) *store.SQLiteRuntimeStore {
 			t.Fatalf("close sqlite runtime store: %v", err)
 		}
 	})
-	if err := sqliteStore.EnsureSchemaTables(unmanagedToolTestContext(), plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
+	if err := sqliteStore.BootstrapSchema(unmanagedToolTestContext(), store.SchemaBootstrapRequest{
+		PlatformPlans: plans,
+		Origin:        store.RuntimeStoreOrigin{SwarmVersion: "tools-test", PlatformVersion: spec.Platform.Version, CreatedAt: time.Now().UTC()},
+	}); err != nil {
+		t.Fatalf("BootstrapSchema: %v", err)
 	}
 	return sqliteStore
 }

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -87,7 +87,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesRunScopedRowsAndPrese
 		}
 	}
 	for _, table := range []string{
-		"schema_version",
+		"runtime_store_metadata",
 		"api_idempotency",
 		"runtime_ingress_state",
 		"agents",
@@ -1246,9 +1246,6 @@ func seedDestructiveResetCleanupRows(t *testing.T, ctx context.Context, pg *Post
 	}
 	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO run_control_state (run_id, control_status, controlled_by) VALUES ($1::uuid, 'stopped', 'test')`, runA); err != nil {
 		t.Fatalf("seed run control: %v", err)
-	}
-	if _, err := pg.DB.ExecContext(ctx, `INSERT INTO schema_version (platform_version) VALUES ('test') ON CONFLICT (id) DO UPDATE SET platform_version = EXCLUDED.platform_version`); err != nil {
-		t.Fatalf("seed schema version: %v", err)
 	}
 	if _, err := pg.DB.ExecContext(ctx, `
 		INSERT INTO api_idempotency (method, actor_token_id, idempotency_key, request_hash, resource_id, response, expires_at)

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -7,9 +7,30 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
+
+func BootstrapFreshPostgres(ctx context.Context, tx *sql.Tx, plans []TableDDL, swarmVersion, platformVersion string, createdAt time.Time) error {
+	if tx == nil {
+		return fmt.Errorf("postgres bootstrap transaction is required")
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
+		return fmt.Errorf("create pgcrypto for fresh postgres store: %w", err)
+	}
+	for _, plan := range plans {
+		for _, statement := range plan.Statements {
+			if _, err := tx.ExecContext(ctx, strings.TrimSpace(statement)); err != nil {
+				return fmt.Errorf("create postgres %s table %s: %w", plan.SchemaKind, plan.TableName, err)
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO runtime_store_metadata (id, swarm_version, platform_version, created_at) VALUES (1, $1, $2, $3)`, swarmVersion, platformVersion, createdAt.UTC()); err != nil {
+		return fmt.Errorf("stamp fresh postgres store origin: %w", err)
+	}
+	return nil
+}
 
 type TableDDL struct {
 	TableName   string
@@ -94,49 +115,6 @@ func IncludesPlatformTables(plans []TableDDL) bool {
 	return false
 }
 
-func EnsurePostgresTables(ctx context.Context, db *sql.DB, plans []TableDDL, mapStatementError func(TableDDL, error) error) error {
-	if db == nil {
-		return fmt.Errorf("postgres store is required for schema ddl")
-	}
-	if len(plans) == 0 {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
-		return fmt.Errorf("ensure pgcrypto extension: %w", err)
-	}
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("begin schema ddl tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	for _, plan := range plans {
-		for _, statement := range plan.Statements {
-			statement = strings.TrimSpace(statement)
-			if statement == "" {
-				continue
-			}
-			if _, err := tx.ExecContext(ctx, statement); err != nil {
-				if mapStatementError != nil {
-					if mapped := mapStatementError(plan, err); mapped != nil {
-						return mapped
-					}
-				}
-				return fmt.Errorf("ensure %s table %s: %w", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName), err)
-			}
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit schema ddl tx: %w", err)
-	}
-	committed = true
-	return nil
-}
-
 func ExtractTableName(statement string) string {
 	statement = strings.TrimSpace(statement)
 	matches := createTableName.FindStringSubmatch(statement)
@@ -158,7 +136,7 @@ func PlanColumnNames(plan TableDDL) []string {
 
 func platformTableOrder(name string) int {
 	switch strings.TrimSpace(name) {
-	case "schema_version":
+	case "runtime_store_metadata":
 		return 0
 	case "bundles":
 		return 3

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/config"
-	"github.com/division-sh/swarm/internal/store/platformschema"
 	_ "github.com/lib/pq"
 )
 
@@ -97,74 +96,6 @@ func (s *PostgresStore) Ping(ctx context.Context) error {
 }
 
 func (*PostgresStore) SupportsPersistedReplay() bool { return true }
-
-func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
-	if s == nil || s.DB == nil {
-		return fmt.Errorf("postgres store is required for schema ddl")
-	}
-	if len(plans) == 0 {
-		return nil
-	}
-	if schemaDDLIncludesPlatformTables(plans) {
-		if err := ensurePostgresCanonicalFailureSchema(ctx, s.DB); err != nil {
-			return fmt.Errorf("migrate canonical runtime failures: %w", err)
-		}
-		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
-			return fmt.Errorf("ensure platform-table compatibility prerequisites: %w", err)
-		}
-	}
-	if err := platformschema.EnsurePostgresTables(ctx, s.DB, plans, func(plan SchemaTableDDL, cause error) error {
-		return s.outdatedSchemaErrorForPlan(ctx, plan, cause)
-	}); err != nil {
-		return err
-	}
-	if schemaDDLIncludesPlatformTables(plans) {
-		if err := ensurePostgresCanonicalFailureSchema(ctx, s.DB); err != nil {
-			return fmt.Errorf("validate canonical runtime failures: %w", err)
-		}
-		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
-			return fmt.Errorf("ensure platform-table compatibility aftermath: %w", err)
-		}
-	}
-	return nil
-}
-
-func (s *PostgresStore) outdatedSchemaErrorForPlan(ctx context.Context, plan SchemaTableDDL, cause error) error {
-	if s == nil || s.DB == nil {
-		return nil
-	}
-	tableName := strings.TrimSpace(plan.TableName)
-	if tableName == "" {
-		return nil
-	}
-	expectedColumns := schemaDDLPlanColumnNames(plan)
-	if len(expectedColumns) == 0 {
-		return nil
-	}
-	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
-	if err != nil || !catalog.hasTable(tableName) {
-		return nil
-	}
-	missingColumns := make([]string, 0)
-	for _, columnName := range expectedColumns {
-		if !catalog.hasColumns(tableName, columnName) {
-			missingColumns = append(missingColumns, columnName)
-		}
-	}
-	if len(missingColumns) == 0 {
-		return nil
-	}
-	return &OutdatedSchemaError{
-		SchemaKind:     strings.TrimSpace(plan.SchemaKind),
-		TableName:      tableName,
-		MissingColumns: missingColumns,
-		Cause:          cause,
-	}
-}
-
-func schemaDDLIncludesPlatformTables(plans []SchemaTableDDL) bool {
-	return platformschema.IncludesPlatformTables(plans)
-}
 
 func (s *PostgresStore) ensureSchemaCompatibilityColumns(ctx context.Context) error {
 	if err := s.ensurePostgresAgentLifecycleColumns(ctx); err != nil {

--- a/internal/store/postgres_schema_bootstrap.go
+++ b/internal/store/postgres_schema_bootstrap.go
@@ -47,6 +47,7 @@ func (s *PostgresStore) BootstrapSchema(ctx context.Context, request SchemaBoots
 		return err
 	}
 	report.Target = target
+	diagnostic := schemaCompatibilityDiagnostic{Backend: SchemaDialectPostgres, Target: target, Current: request.Origin, Origin: report.Origin}
 	switch report.State {
 	case schemaStateFresh:
 		if err := platformschema.BootstrapFreshPostgres(ctx, tx, request.PlatformPlans, request.Origin.SwarmVersion, request.Origin.PlatformVersion, request.Origin.CreatedAt); err != nil {
@@ -54,11 +55,11 @@ func (s *PostgresStore) BootstrapSchema(ctx context.Context, request SchemaBoots
 		}
 	case schemaStateCompatible:
 	case schemaStateIncompatible:
-		return &SchemaCompatibilityError{Backend: SchemaDialectPostgres, Target: target, Current: request.Origin, Origin: report.Origin, Drift: report.Drift}
+		return diagnostic.failure(report.Drift)
 	default:
 		return fmt.Errorf("unknown postgres schema compatibility state %q", report.State)
 	}
-	if err := ensurePostgresStatePlans(ctx, tx, request.StatePlans); err != nil {
+	if err := ensurePostgresStatePlans(ctx, tx, request.StatePlans, diagnostic); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -244,7 +245,7 @@ func executePostgresPlans(ctx context.Context, tx *sql.Tx, plans []SchemaTableDD
 	return nil
 }
 
-func ensurePostgresStatePlans(ctx context.Context, tx *sql.Tx, plans []SchemaTableDDL) error {
+func ensurePostgresStatePlans(ctx context.Context, tx *sql.Tx, plans []SchemaTableDDL, diagnostic schemaCompatibilityDiagnostic) error {
 	for _, plan := range plans {
 		expected, err := expectedSchemaShape([]SchemaTableDDL{plan}, SchemaDialectPostgres)
 		if err != nil {
@@ -265,7 +266,7 @@ func ensurePostgresStatePlans(ctx context.Context, tx *sql.Tx, plans []SchemaTab
 			return err
 		}
 		if drift := compareSchemaShapes(expected, actual); len(drift) > 0 {
-			return fmt.Errorf("generated state table %s is incompatible: %s", plan.TableName, strings.Join(drift, "; "))
+			return diagnostic.failure(generatedStateDrift(plan.TableName, drift))
 		}
 	}
 	return nil

--- a/internal/store/postgres_schema_bootstrap.go
+++ b/internal/store/postgres_schema_bootstrap.go
@@ -1,0 +1,272 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/store/platformschema"
+)
+
+const postgresSchemaBootstrapLock int64 = 0x535741524d534348
+
+type schemaQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func (s *PostgresStore) BootstrapSchema(ctx context.Context, request SchemaBootstrapRequest) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("postgres store is required for schema bootstrap")
+	}
+	if err := request.validate(); err != nil {
+		return err
+	}
+	expected, err := expectedSchemaShape(request.PlatformPlans, SchemaDialectPostgres)
+	if err != nil {
+		return err
+	}
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin postgres schema bootstrap: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, postgresSchemaBootstrapLock); err != nil {
+		return fmt.Errorf("serialize postgres schema bootstrap: %w", err)
+	}
+	target, report, err := inspectPostgresCompatibility(ctx, tx, expected)
+	if err != nil {
+		return err
+	}
+	report.Target = target
+	switch report.State {
+	case schemaStateFresh:
+		if err := platformschema.BootstrapFreshPostgres(ctx, tx, request.PlatformPlans, request.Origin.SwarmVersion, request.Origin.PlatformVersion, request.Origin.CreatedAt); err != nil {
+			return err
+		}
+	case schemaStateCompatible:
+	case schemaStateIncompatible:
+		return &SchemaCompatibilityError{Backend: SchemaDialectPostgres, Target: target, Current: request.Origin, Origin: report.Origin, Drift: report.Drift}
+	default:
+		return fmt.Errorf("unknown postgres schema compatibility state %q", report.State)
+	}
+	if err := ensurePostgresStatePlans(ctx, tx, request.StatePlans); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit postgres schema bootstrap: %w", err)
+	}
+	committed = true
+	_, err = s.BindSchemaCapabilities(ctx)
+	return err
+}
+
+func inspectPostgresCompatibility(ctx context.Context, q schemaQueryer, expected schemaShape) (string, schemaCompatibilityReport, error) {
+	var target string
+	if err := q.QueryRowContext(ctx, `SELECT current_database()`).Scan(&target); err != nil {
+		return "", schemaCompatibilityReport{}, fmt.Errorf("read postgres database identity: %w", err)
+	}
+	tables, err := postgresPublicTables(ctx, q)
+	if err != nil {
+		return target, schemaCompatibilityReport{}, err
+	}
+	if len(tables) == 0 {
+		return target, schemaCompatibilityReport{State: schemaStateFresh}, nil
+	}
+	var origin *RuntimeStoreOrigin
+	var drift []string
+	if _, ok := tables[RuntimeStoreMetadataTable]; !ok {
+		drift = append(drift, "non-empty public schema has no runtime_store_metadata origin stamp")
+	} else {
+		origin, err = readRuntimeStoreOrigin(ctx, q)
+		if err != nil {
+			drift = append(drift, "runtime_store_metadata origin row is malformed: "+err.Error())
+		} else if origin == nil {
+			drift = append(drift, "runtime_store_metadata does not contain the required id=1 origin row")
+		}
+	}
+	actual, err := loadPostgresSchemaShape(ctx, q, expected)
+	if err != nil {
+		return target, schemaCompatibilityReport{}, err
+	}
+	drift = append(drift, compareSchemaShapes(expected, actual)...)
+	state := schemaStateCompatible
+	if len(drift) > 0 {
+		state = schemaStateIncompatible
+	}
+	return target, schemaCompatibilityReport{State: state, Origin: origin, Drift: drift}, nil
+}
+
+func postgresPublicTables(ctx context.Context, q schemaQueryer) (map[string]struct{}, error) {
+	rows, err := q.QueryContext(ctx, `
+		SELECT c.relname
+		FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect postgres public tables: %w", err)
+	}
+	defer rows.Close()
+	tables := map[string]struct{}{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		tables[strings.TrimSpace(name)] = struct{}{}
+	}
+	return tables, rows.Err()
+}
+
+func loadPostgresSchemaShape(ctx context.Context, q schemaQueryer, expected schemaShape) (schemaShape, error) {
+	actual := schemaShape{Tables: map[string]schemaTableShape{}}
+	rows, err := q.QueryContext(ctx, `
+		SELECT c.relname, a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod), a.attnotnull,
+		       COALESCE(pg_get_expr(d.adbin, d.adrelid), '')
+		FROM pg_catalog.pg_class c
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+		LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+		WHERE n.nspname = 'public' AND c.relkind = 'r'
+	`)
+	if err != nil {
+		return schemaShape{}, fmt.Errorf("inspect postgres columns: %w", err)
+	}
+	for rows.Next() {
+		var tableName, columnName, typeName, defaultValue string
+		var notNull bool
+		if err := rows.Scan(&tableName, &columnName, &typeName, &notNull, &defaultValue); err != nil {
+			rows.Close()
+			return schemaShape{}, err
+		}
+		if _, required := expected.Tables[tableName]; !required {
+			continue
+		}
+		table, ok := actual.Tables[tableName]
+		if !ok {
+			table = schemaTableShape{Columns: map[string]schemaColumnShape{}, Indexes: map[string]string{}}
+		}
+		table.Columns[columnName] = schemaColumnShape{Type: normalizeSchemaType(typeName), NotNull: notNull, Default: normalizeDefault(defaultValue)}
+		actual.Tables[tableName] = table
+	}
+	if err := rows.Close(); err != nil {
+		return schemaShape{}, err
+	}
+	rows, err = q.QueryContext(ctx, `
+		SELECT c.relname, pg_get_constraintdef(con.oid, true)
+		FROM pg_catalog.pg_constraint con
+		JOIN pg_catalog.pg_class c ON c.oid = con.conrelid
+		JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+	`)
+	if err != nil {
+		return schemaShape{}, fmt.Errorf("inspect postgres constraints: %w", err)
+	}
+	for rows.Next() {
+		var tableName, definition string
+		if err := rows.Scan(&tableName, &definition); err != nil {
+			rows.Close()
+			return schemaShape{}, err
+		}
+		table, ok := actual.Tables[tableName]
+		if !ok {
+			continue
+		}
+		table.Constraints = append(table.Constraints, normalizeConstraint(definition))
+		actual.Tables[tableName] = table
+	}
+	if err := rows.Close(); err != nil {
+		return schemaShape{}, err
+	}
+	rows, err = q.QueryContext(ctx, `
+		SELECT t.relname, i.relname, ix.indisunique, pg_get_indexdef(ix.indexrelid, 0, true)
+		FROM pg_catalog.pg_index ix
+		JOIN pg_catalog.pg_class t ON t.oid = ix.indrelid
+		JOIN pg_catalog.pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+		LEFT JOIN pg_catalog.pg_constraint con ON con.conindid = ix.indexrelid
+		WHERE n.nspname = 'public' AND con.oid IS NULL
+	`)
+	if err != nil {
+		return schemaShape{}, fmt.Errorf("inspect postgres indexes: %w", err)
+	}
+	for rows.Next() {
+		var tableName, indexName, definition string
+		var unique bool
+		if err := rows.Scan(&tableName, &indexName, &unique, &definition); err != nil {
+			rows.Close()
+			return schemaShape{}, err
+		}
+		table, ok := actual.Tables[tableName]
+		if !ok {
+			continue
+		}
+		table.Indexes[indexName] = normalizePostgresIndexDefinition(unique, tableName, definition)
+		actual.Tables[tableName] = table
+	}
+	if err := rows.Close(); err != nil {
+		return schemaShape{}, err
+	}
+	for name, table := range actual.Tables {
+		sort.Strings(table.Constraints)
+		actual.Tables[name] = table
+	}
+	return actual, nil
+}
+
+var postgresIndexBodyPattern = regexp.MustCompile(`(?is)^create\s+(?:unique\s+)?index\s+\S+\s+on\s+(?:public\.)?\S+\s+(?:using\s+btree\s+)?\((.*)\)\s*(where\s+.+)?$`)
+
+func normalizePostgresIndexDefinition(unique bool, tableName, definition string) string {
+	matches := postgresIndexBodyPattern.FindStringSubmatch(strings.TrimSpace(definition))
+	if len(matches) != 3 {
+		return normalizeConstraint(definition)
+	}
+	return normalizeIndexDefinition(unique, tableName, matches[1], matches[2])
+}
+
+func executePostgresPlans(ctx context.Context, tx *sql.Tx, plans []SchemaTableDDL) error {
+	for _, plan := range plans {
+		for _, statement := range plan.Statements {
+			if _, err := tx.ExecContext(ctx, strings.TrimSpace(statement)); err != nil {
+				return fmt.Errorf("create postgres %s table %s: %w", plan.SchemaKind, plan.TableName, err)
+			}
+		}
+	}
+	return nil
+}
+
+func ensurePostgresStatePlans(ctx context.Context, tx *sql.Tx, plans []SchemaTableDDL) error {
+	for _, plan := range plans {
+		expected, err := expectedSchemaShape([]SchemaTableDDL{plan}, SchemaDialectPostgres)
+		if err != nil {
+			return err
+		}
+		tables, err := postgresPublicTables(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if _, exists := tables[plan.TableName]; !exists {
+			if err := executePostgresPlans(ctx, tx, []SchemaTableDDL{plan}); err != nil {
+				return err
+			}
+			continue
+		}
+		actual, err := loadPostgresSchemaShape(ctx, tx, expected)
+		if err != nil {
+			return err
+		}
+		if drift := compareSchemaShapes(expected, actual); len(drift) > 0 {
+			return fmt.Errorf("generated state table %s is incompatible: %s", plan.TableName, strings.Join(drift, "; "))
+		}
+	}
+	return nil
+}

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -885,7 +885,7 @@ func runtimeWriterRules() []runtimeWriterRule {
 		},
 		{
 			name:           "sqlite schema bootstrap",
-			path:           rx(`^internal/store/(sqlite_schema|agent_lifecycle_schema|platformschema/platformschema)\.go$`),
+			path:           rx(`^internal/store/(sqlite_schema|sqlite_schema_bootstrap|agent_lifecycle_schema|platformschema/platformschema)\.go$`),
 			kinds:          allPrimitiveKinds(),
 			classification: classDifferentConcept,
 			reason:         "schema/bootstrap owns dialect DDL and PRAGMA behavior, split from selected runtime mutation writers",

--- a/internal/store/schema_bootstrap.go
+++ b/internal/store/schema_bootstrap.go
@@ -1,6 +1,11 @@
 package store
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
 
 type SchemaDialect string
 
@@ -9,7 +14,54 @@ const (
 	SchemaDialectSQLite   SchemaDialect = "sqlite"
 )
 
+const RuntimeStoreMetadataTable = "runtime_store_metadata"
+
+type RuntimeStoreOrigin struct {
+	SwarmVersion    string
+	PlatformVersion string
+	CreatedAt       time.Time
+}
+
+func (o RuntimeStoreOrigin) validate() error {
+	if strings.TrimSpace(o.SwarmVersion) == "" {
+		return fmt.Errorf("running Swarm version is required for schema bootstrap")
+	}
+	if strings.TrimSpace(o.PlatformVersion) == "" {
+		return fmt.Errorf("running platform version is required for schema bootstrap")
+	}
+	if o.CreatedAt.IsZero() {
+		return fmt.Errorf("store creation time is required for schema bootstrap")
+	}
+	return nil
+}
+
+type SchemaBootstrapRequest struct {
+	PlatformPlans []SchemaTableDDL
+	StatePlans    []SchemaTableDDL
+	Origin        RuntimeStoreOrigin
+}
+
+func (r SchemaBootstrapRequest) validate() error {
+	if len(r.PlatformPlans) == 0 {
+		return fmt.Errorf("platform schema plans are required")
+	}
+	if err := r.Origin.validate(); err != nil {
+		return err
+	}
+	for _, plan := range r.PlatformPlans {
+		if strings.TrimSpace(plan.SchemaKind) != "platform_spec" {
+			return fmt.Errorf("platform schema request contains %s table %s", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName))
+		}
+	}
+	for _, plan := range r.StatePlans {
+		if strings.TrimSpace(plan.SchemaKind) != "state_schema" {
+			return fmt.Errorf("generated state schema request contains %s table %s", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName))
+		}
+	}
+	return nil
+}
+
 type SchemaBootstrapper interface {
-	EnsureSchemaTables(context.Context, []SchemaTableDDL) error
+	BootstrapSchema(context.Context, SchemaBootstrapRequest) error
 	ResolveSchemaCapabilities(context.Context) (StoreSchemaCapabilities, error)
 }

--- a/internal/store/schema_bootstrap.go
+++ b/internal/store/schema_bootstrap.go
@@ -35,6 +35,19 @@ func (o RuntimeStoreOrigin) validate() error {
 	return nil
 }
 
+func (o RuntimeStoreOrigin) validateStored() error {
+	if strings.TrimSpace(o.SwarmVersion) == "" {
+		return fmt.Errorf("stored Swarm version is required")
+	}
+	if strings.TrimSpace(o.PlatformVersion) == "" {
+		return fmt.Errorf("stored platform version is required")
+	}
+	if o.CreatedAt.IsZero() {
+		return fmt.Errorf("stored creation time must be non-zero")
+	}
+	return nil
+}
+
 type SchemaBootstrapRequest struct {
 	PlatformPlans []SchemaTableDDL
 	StatePlans    []SchemaTableDDL

--- a/internal/store/schema_bootstrap_legacy_test.go
+++ b/internal/store/schema_bootstrap_legacy_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EnsureSchemaTables exists only in the store package test binary so legacy
+// fixture tests can be migrated independently without restoring the production
+// schema API.
+func (s *PostgresStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
+	if schemaPlansIncludePlatform(plans) {
+		if err := ensurePostgresCanonicalFailureSchema(ctx, s.DB); err != nil {
+			return err
+		}
+		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+			return err
+		}
+	}
+	if _, err := s.DB.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
+		return err
+	}
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, plan := range plans {
+		for _, statement := range plan.Statements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				if mapped := s.outdatedSchemaErrorForLegacyTest(ctx, plan, err); mapped != nil {
+					return mapped
+				}
+				return err
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if schemaPlansIncludePlatform(plans) {
+		if err := ensurePostgresCanonicalFailureSchema(ctx, s.DB); err != nil {
+			return err
+		}
+		if err := s.ensureSchemaCompatibilityColumns(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteSchemaStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
+	if schemaPlansIncludePlatform(plans) {
+		if err := ensureSQLiteCanonicalFailureSchema(ctx, s.DB); err != nil {
+			return err
+		}
+	}
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var agentStatements []string
+	for _, plan := range plans {
+		statements, err := SQLiteStatementsForPlan(plan)
+		if err != nil {
+			return err
+		}
+		if plan.TableName == "agents" {
+			agentStatements = append(agentStatements, statements...)
+		}
+		for _, statement := range statements {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return err
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if schemaPlansIncludePlatform(plans) {
+		if err := ensureSQLiteCanonicalFailureSchema(ctx, s.DB); err != nil {
+			return err
+		}
+	}
+	if len(agentStatements) > 0 {
+		if err := s.ensureSQLiteAgentLLMBackendProfiles(ctx, agentStatements); err != nil {
+			return err
+		}
+		if err := s.ensureSQLiteAgentModelAliases(ctx); err != nil {
+			return err
+		}
+		if err := s.ensureSQLiteAgentLifecycleColumns(ctx); err != nil {
+			return err
+		}
+	}
+	if err := s.ensureSQLiteMailboxDeferredUntil(ctx); err != nil {
+		return err
+	}
+	return s.ensureSQLiteReplyContextColumns(ctx)
+}
+
+func (s *SQLiteRuntimeStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
+	return s.SQLiteSchemaStore.EnsureSchemaTables(ctx, plans)
+}
+
+func schemaPlansIncludePlatform(plans []SchemaTableDDL) bool {
+	for _, plan := range plans {
+		if plan.SchemaKind == "platform_spec" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *PostgresStore) outdatedSchemaErrorForLegacyTest(ctx context.Context, plan SchemaTableDDL, cause error) error {
+	tableName := strings.TrimSpace(plan.TableName)
+	expectedColumns := schemaDDLPlanColumnNames(plan)
+	if tableName == "" || len(expectedColumns) == 0 {
+		return nil
+	}
+	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	if err != nil || !catalog.hasTable(tableName) {
+		return nil
+	}
+	var missing []string
+	for _, column := range expectedColumns {
+		if !catalog.hasColumns(tableName, column) {
+			missing = append(missing, column)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return &OutdatedSchemaError{SchemaKind: plan.SchemaKind, TableName: tableName, MissingColumns: missing, Cause: fmt.Errorf("%w", cause)}
+}
+
+func testSchemaBootstrapRequest(plans []SchemaTableDDL) SchemaBootstrapRequest {
+	request := SchemaBootstrapRequest{Origin: RuntimeStoreOrigin{SwarmVersion: "test", PlatformVersion: "test", CreatedAt: time.Now().UTC()}}
+	for _, plan := range plans {
+		if plan.SchemaKind == "platform_spec" {
+			request.PlatformPlans = append(request.PlatformPlans, plan)
+		} else if plan.SchemaKind == "state_schema" {
+			request.StatePlans = append(request.StatePlans, plan)
+		}
+	}
+	return request
+}

--- a/internal/store/schema_compatibility.go
+++ b/internal/store/schema_compatibility.go
@@ -1,0 +1,462 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type schemaCompatibilityState string
+
+const (
+	schemaStateFresh        schemaCompatibilityState = "fresh"
+	schemaStateCompatible   schemaCompatibilityState = "compatible"
+	schemaStateIncompatible schemaCompatibilityState = "incompatible"
+)
+
+type schemaCompatibilityReport struct {
+	State  schemaCompatibilityState
+	Origin *RuntimeStoreOrigin
+	Drift  []string
+	Target string
+}
+
+type SchemaCompatibilityError struct {
+	Backend SchemaDialect
+	Target  string
+	Current RuntimeStoreOrigin
+	Origin  *RuntimeStoreOrigin
+	Drift   []string
+}
+
+func (e *SchemaCompatibilityError) Error() string {
+	target := strings.TrimSpace(e.Target)
+	if target == "" {
+		target = "selected store"
+	}
+	origin := "unknown (the store is not stamped)"
+	if e.Origin != nil {
+		origin = fmt.Sprintf("Swarm %s / platform %s created %s", e.Origin.SwarmVersion, e.Origin.PlatformVersion, e.Origin.CreatedAt.UTC().Format(time.RFC3339))
+	}
+	drift := strings.Join(e.Drift, "; ")
+	if drift == "" {
+		drift = "the selected namespace is not a compatible Swarm runtime store"
+	}
+	remediation := "create and select a fresh PostgreSQL database (for example: createdb swarm_fresh, then set database.name to swarm_fresh)"
+	if e.Backend == SchemaDialectSQLite {
+		remediation = fmt.Sprintf("stop Swarm and remove the incompatible local store with: rm -f -- %s %s %s", shellQuote(target), shellQuote(target+"-wal"), shellQuote(target+"-shm"))
+	}
+	return fmt.Sprintf("%s %s is incompatible with Swarm %s / platform %s: %s; stored origin: %s; remediation: %s", e.Backend, target, e.Current.SwarmVersion, e.Current.PlatformVersion, drift, origin, remediation)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+type schemaShape struct {
+	Tables map[string]schemaTableShape
+}
+
+type schemaTableShape struct {
+	Columns     map[string]schemaColumnShape
+	Constraints []string
+	Indexes     map[string]string
+}
+
+type schemaColumnShape struct {
+	Type       string
+	NotNull    bool
+	Default    string
+	PrimaryKey bool
+	Unique     bool
+	Reference  string
+	Checks     []string
+}
+
+var (
+	compatCreateTablePattern = regexp.MustCompile(`(?is)^create\s+table(?:\s+if\s+not\s+exists)?\s+("?[a-z_][a-z0-9_]*"?)\s*\((.*)\)\s*$`)
+	compatCreateIndexPattern = regexp.MustCompile(`(?is)^create\s+(unique\s+)?index(?:\s+if\s+not\s+exists)?\s+("?[a-z_][a-z0-9_]*"?)\s+on\s+("?[a-z_][a-z0-9_]*"?)\s*\((.*)\)\s*(where\s+.+)?$`)
+	compatSQLSpacePattern    = regexp.MustCompile(`\s+`)
+	compatSQLCastPattern     = regexp.MustCompile(`::[a-z_][a-z0-9_]*(?:\[\])?`)
+)
+
+func expectedSchemaShape(plans []SchemaTableDDL, dialect SchemaDialect) (schemaShape, error) {
+	shape := schemaShape{Tables: make(map[string]schemaTableShape, len(plans))}
+	for _, plan := range plans {
+		statements, err := StatementsForSchemaDialect(plan, dialect)
+		if err != nil {
+			return schemaShape{}, err
+		}
+		for _, statement := range statements {
+			if err := addStatementToShape(&shape, statement); err != nil {
+				return schemaShape{}, fmt.Errorf("derive expected %s shape for %s: %w", dialect, plan.TableName, err)
+			}
+		}
+	}
+	return shape, nil
+}
+
+func addStatementToShape(shape *schemaShape, statement string) error {
+	statement = strings.TrimSpace(strings.TrimSuffix(statement, ";"))
+	if matches := compatCreateTablePattern.FindStringSubmatch(statement); len(matches) == 3 {
+		tableName := strings.Trim(matches[1], `"`)
+		table := schemaTableShape{Columns: map[string]schemaColumnShape{}, Indexes: map[string]string{}}
+		for _, line := range splitSchemaDefinitionLines(matches[2]) {
+			line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(strings.TrimSuffix(line, ",")), ","))
+			if line == "" {
+				continue
+			}
+			upper := strings.ToUpper(line)
+			if strings.HasPrefix(upper, "PRIMARY KEY ") || strings.HasPrefix(upper, "UNIQUE ") || strings.HasPrefix(upper, "CHECK ") || strings.HasPrefix(upper, "FOREIGN KEY ") || strings.HasPrefix(upper, "CONSTRAINT ") {
+				table.Constraints = append(table.Constraints, normalizeConstraint(line))
+				continue
+			}
+			name, rest, err := parseSchemaLeadingIdent(line)
+			if err != nil {
+				return err
+			}
+			typeSpec, clauses := splitColumnTypeAndClauses(rest)
+			column, err := parseColumnShape(typeSpec, clauses)
+			if err != nil {
+				return fmt.Errorf("column %s: %w", name, err)
+			}
+			table.Columns[name] = column
+			if column.PrimaryKey {
+				table.Constraints = append(table.Constraints, normalizeConstraint(fmt.Sprintf("PRIMARY KEY (%s)", name)))
+			}
+			if column.Unique {
+				table.Constraints = append(table.Constraints, normalizeConstraint(fmt.Sprintf("UNIQUE (%s)", name)))
+			}
+			if column.Reference != "" {
+				table.Constraints = append(table.Constraints, normalizeConstraint(fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s", name, column.Reference)))
+			}
+			for _, check := range column.Checks {
+				table.Constraints = append(table.Constraints, normalizeConstraint("CHECK ("+check+")"))
+			}
+		}
+		sort.Strings(table.Constraints)
+		shape.Tables[tableName] = table
+		return nil
+	}
+	if matches := compatCreateIndexPattern.FindStringSubmatch(statement); len(matches) == 6 {
+		indexName := strings.Trim(matches[2], `"`)
+		tableName := strings.Trim(matches[3], `"`)
+		table, ok := shape.Tables[tableName]
+		if !ok {
+			return fmt.Errorf("index %s refers to unknown table %s", indexName, tableName)
+		}
+		table.Indexes[indexName] = normalizeIndexDefinition(matches[1] != "", tableName, matches[4], matches[5])
+		shape.Tables[tableName] = table
+		return nil
+	}
+	return fmt.Errorf("unsupported statement %q", statement)
+}
+
+func parseColumnShape(typeSpec, clauses string) (schemaColumnShape, error) {
+	column := schemaColumnShape{Type: normalizeSchemaType(typeSpec)}
+	for strings.TrimSpace(clauses) != "" {
+		clauses = strings.TrimSpace(clauses)
+		upper := strings.ToUpper(clauses)
+		switch {
+		case strings.HasPrefix(upper, "PRIMARY KEY"):
+			column.PrimaryKey, column.NotNull = true, true
+			clauses = strings.TrimSpace(clauses[len("PRIMARY KEY"):])
+		case strings.HasPrefix(upper, "NOT NULL"):
+			column.NotNull = true
+			clauses = strings.TrimSpace(clauses[len("NOT NULL"):])
+		case strings.HasPrefix(upper, "UNIQUE"):
+			column.Unique = true
+			clauses = strings.TrimSpace(clauses[len("UNIQUE"):])
+		case strings.HasPrefix(upper, "DEFAULT "):
+			value, remaining := splitColumnClauseValue(clauses[len("DEFAULT "):])
+			column.Default = normalizeDefault(value)
+			clauses = remaining
+		case strings.HasPrefix(upper, "REFERENCES "):
+			value, remaining := splitColumnClauseValue(clauses[len("REFERENCES "):])
+			column.Reference = normalizeReference(value)
+			clauses = remaining
+		case strings.HasPrefix(upper, "CHECK "):
+			condition, err := unwrapSchemaClause("CHECK", clauses)
+			if err != nil {
+				return schemaColumnShape{}, err
+			}
+			column.Checks = append(column.Checks, normalizeExpression(condition))
+			clauses = ""
+		default:
+			return schemaColumnShape{}, fmt.Errorf("unsupported column clause %q", clauses)
+		}
+	}
+	return column, nil
+}
+
+func normalizeSchemaType(value string) string {
+	v := strings.ToLower(compatSQLSpacePattern.ReplaceAllString(strings.TrimSpace(value), " "))
+	switch v {
+	case "timestamp with time zone":
+		return "timestamptz"
+	case "double precision":
+		return "double precision"
+	case "integer":
+		return "integer"
+	}
+	return v
+}
+
+func normalizeDefault(value string) string {
+	v := normalizeExpression(value)
+	v = compatSQLCastPattern.ReplaceAllString(v, "")
+	for strings.HasPrefix(v, "(") && strings.HasSuffix(v, ")") {
+		v = strings.TrimSpace(v[1 : len(v)-1])
+	}
+	switch v {
+	case "current_timestamp":
+		return "now()"
+	}
+	return v
+}
+
+func normalizeReference(value string) string {
+	return normalizeExpression(value)
+}
+
+func normalizeConstraint(value string) string {
+	v := normalizeExpression(value)
+	v = compatSQLCastPattern.ReplaceAllString(v, "")
+	v = strings.ReplaceAll(v, " = any (array[", " in (")
+	v = strings.ReplaceAll(v, "])", ")")
+	if strings.HasPrefix(v, "check (") && strings.HasSuffix(v, ")") {
+		return "check " + canonicalBooleanExpression(strings.TrimSpace(v[len("check "):]))
+	}
+	return v
+}
+
+func normalizeExpression(value string) string {
+	v := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), `"`, ""))
+	v = compatSQLSpacePattern.ReplaceAllString(v, " ")
+	v = strings.ReplaceAll(v, "( ", "(")
+	v = strings.ReplaceAll(v, " )", ")")
+	v = strings.ReplaceAll(v, ", ", ",")
+	v = strings.ReplaceAll(v, " ->> ", "->>")
+	return strings.TrimSpace(v)
+}
+
+var singleValueInPattern = regexp.MustCompile(`(?is)^(.+?)\s+in\s+\(([^,()]+)\)$`)
+
+func canonicalBooleanExpression(value string) string {
+	value = trimBalancedOuterParens(strings.TrimSpace(value))
+	if parts := splitTopLevelSQLKeyword(value, "or"); len(parts) > 1 {
+		canonical := make([]string, 0, len(parts))
+		for _, part := range parts {
+			canonical = append(canonical, canonicalBooleanExpression(part))
+		}
+		return "or(" + strings.Join(canonical, ",") + ")"
+	}
+	if parts := splitTopLevelSQLKeyword(value, "and"); len(parts) > 1 {
+		canonical := make([]string, 0, len(parts))
+		for _, part := range parts {
+			canonical = append(canonical, canonicalBooleanExpression(part))
+		}
+		return "and(" + strings.Join(canonical, ",") + ")"
+	}
+	value = trimBalancedOuterParens(value)
+	value = strings.ReplaceAll(value, "trim(both from ", "trim(")
+	if matches := singleValueInPattern.FindStringSubmatch(value); len(matches) == 3 {
+		return strings.TrimSpace(matches[1]) + " = " + strings.TrimSpace(matches[2])
+	}
+	return value
+}
+
+func trimBalancedOuterParens(value string) string {
+	for strings.HasPrefix(value, "(") && strings.HasSuffix(value, ")") {
+		end, err := findMatchingParen(value, 0)
+		if err != nil || end != len(value)-1 {
+			break
+		}
+		value = strings.TrimSpace(value[1 : len(value)-1])
+	}
+	return value
+}
+
+func splitTopLevelSQLKeyword(value, keyword string) []string {
+	depth := 0
+	quote := byte(0)
+	start := 0
+	var parts []string
+	lower := strings.ToLower(value)
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if quote != 0 {
+			if ch == quote {
+				if i+1 < len(value) && value[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			depth++
+		case ')':
+			depth--
+		default:
+			if depth == 0 && strings.HasPrefix(lower[i:], keyword) && sqlKeywordBoundary(lower, i-1) && sqlKeywordBoundary(lower, i+len(keyword)) {
+				parts = append(parts, strings.TrimSpace(value[start:i]))
+				i += len(keyword) - 1
+				start = i + 1
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	parts = append(parts, strings.TrimSpace(value[start:]))
+	return parts
+}
+
+func sqlKeywordBoundary(value string, index int) bool {
+	if index < 0 || index >= len(value) {
+		return true
+	}
+	ch := value[index]
+	return !(ch == '_' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9')
+}
+
+func normalizeIndexDefinition(unique bool, table, terms, where string) string {
+	prefix := "index"
+	if unique {
+		prefix = "unique index"
+	}
+	value := fmt.Sprintf("%s on %s (%s)", prefix, table, terms)
+	if strings.TrimSpace(where) != "" {
+		value += " " + strings.TrimSpace(where)
+	}
+	return normalizeConstraint(value)
+}
+
+func compareSchemaShapes(expected, actual schemaShape) []string {
+	var drift []string
+	for tableName, want := range expected.Tables {
+		got, ok := actual.Tables[tableName]
+		if !ok {
+			drift = append(drift, "missing table "+tableName)
+			continue
+		}
+		for columnName, wantColumn := range want.Columns {
+			gotColumn, ok := got.Columns[columnName]
+			if !ok {
+				drift = append(drift, fmt.Sprintf("missing column %s.%s", tableName, columnName))
+				continue
+			}
+			if wantColumn.Type != gotColumn.Type {
+				drift = append(drift, fmt.Sprintf("column %s.%s type is %s, want %s", tableName, columnName, gotColumn.Type, wantColumn.Type))
+			}
+			if wantColumn.NotNull != gotColumn.NotNull {
+				drift = append(drift, fmt.Sprintf("column %s.%s nullability differs", tableName, columnName))
+			}
+			if wantColumn.Default != gotColumn.Default {
+				drift = append(drift, fmt.Sprintf("column %s.%s default is %q, want %q", tableName, columnName, gotColumn.Default, wantColumn.Default))
+			}
+		}
+		for columnName := range got.Columns {
+			if _, ok := want.Columns[columnName]; !ok {
+				drift = append(drift, fmt.Sprintf("unexpected column %s.%s", tableName, columnName))
+			}
+		}
+		drift = append(drift, compareNamedDefinitions(tableName+" constraint", want.Constraints, got.Constraints)...)
+		for name, definition := range want.Indexes {
+			actualDefinition, ok := got.Indexes[name]
+			if !ok {
+				drift = append(drift, fmt.Sprintf("missing index %s", name))
+			} else if definition != actualDefinition {
+				drift = append(drift, fmt.Sprintf("index %s is %q, want %q", name, actualDefinition, definition))
+			}
+		}
+	}
+	sort.Strings(drift)
+	return drift
+}
+
+func compareNamedDefinitions(label string, want, got []string) []string {
+	w := append([]string(nil), want...)
+	g := append([]string(nil), got...)
+	sort.Strings(w)
+	sort.Strings(g)
+	if strings.Join(w, "\n") == strings.Join(g, "\n") {
+		return nil
+	}
+	wantSet := make(map[string]struct{}, len(w))
+	gotSet := make(map[string]struct{}, len(g))
+	for _, value := range w {
+		wantSet[value] = struct{}{}
+	}
+	for _, value := range g {
+		gotSet[value] = struct{}{}
+	}
+	var drift []string
+	for _, value := range w {
+		if _, ok := gotSet[value]; !ok {
+			drift = append(drift, fmt.Sprintf("missing %s %q", label, value))
+		}
+	}
+	for _, value := range g {
+		if _, ok := wantSet[value]; !ok {
+			drift = append(drift, fmt.Sprintf("unexpected %s %q", label, value))
+		}
+	}
+	return drift
+}
+
+func readRuntimeStoreOrigin(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) (*RuntimeStoreOrigin, error) {
+	var origin RuntimeStoreOrigin
+	var createdAt any
+	err := q.QueryRowContext(ctx, `SELECT swarm_version, platform_version, created_at FROM runtime_store_metadata WHERE id = 1`).Scan(&origin.SwarmVersion, &origin.PlatformVersion, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	switch value := createdAt.(type) {
+	case time.Time:
+		origin.CreatedAt = value
+	case string:
+		parsed, parseErr := parseRuntimeStoreTime(value)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse runtime store creation time %q: %w", value, parseErr)
+		}
+		origin.CreatedAt = parsed
+	case []byte:
+		parsed, parseErr := parseRuntimeStoreTime(string(value))
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse runtime store creation time %q: %w", string(value), parseErr)
+		}
+		origin.CreatedAt = parsed
+	default:
+		return nil, fmt.Errorf("runtime store creation time has unsupported type %T", createdAt)
+	}
+	origin.CreatedAt = origin.CreatedAt.UTC()
+	return &origin, nil
+}
+
+func parseRuntimeStoreTime(value string) (time.Time, error) {
+	var lastErr error
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05.999999999 -0700 MST"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, lastErr
+}

--- a/internal/store/schema_compatibility.go
+++ b/internal/store/schema_compatibility.go
@@ -380,6 +380,11 @@ func compareSchemaShapes(expected, actual schemaShape) []string {
 				drift = append(drift, fmt.Sprintf("index %s is %q, want %q", name, actualDefinition, definition))
 			}
 		}
+		for name := range got.Indexes {
+			if _, ok := want.Indexes[name]; !ok {
+				drift = append(drift, fmt.Sprintf("unexpected index %s", name))
+			}
+		}
 	}
 	sort.Strings(drift)
 	return drift

--- a/internal/store/schema_compatibility.go
+++ b/internal/store/schema_compatibility.go
@@ -34,6 +34,31 @@ type SchemaCompatibilityError struct {
 	Drift   []string
 }
 
+type schemaCompatibilityDiagnostic struct {
+	Backend SchemaDialect
+	Target  string
+	Current RuntimeStoreOrigin
+	Origin  *RuntimeStoreOrigin
+}
+
+func (d schemaCompatibilityDiagnostic) failure(drift []string) *SchemaCompatibilityError {
+	return &SchemaCompatibilityError{
+		Backend: d.Backend,
+		Target:  d.Target,
+		Current: d.Current,
+		Origin:  d.Origin,
+		Drift:   append([]string(nil), drift...),
+	}
+}
+
+func generatedStateDrift(tableName string, drift []string) []string {
+	prefixed := make([]string, len(drift))
+	for i, item := range drift {
+		prefixed[i] = fmt.Sprintf("generated state table %s: %s", tableName, item)
+	}
+	return prefixed
+}
+
 func (e *SchemaCompatibilityError) Error() string {
 	target := strings.TrimSpace(e.Target)
 	if target == "" {
@@ -451,6 +476,9 @@ func readRuntimeStoreOrigin(ctx context.Context, q interface {
 		return nil, fmt.Errorf("runtime store creation time has unsupported type %T", createdAt)
 	}
 	origin.CreatedAt = origin.CreatedAt.UTC()
+	if err := origin.validateStored(); err != nil {
+		return nil, err
+	}
 	return &origin, nil
 }
 

--- a/internal/store/schema_compatibility_bootstrap_test.go
+++ b/internal/store/schema_compatibility_bootstrap_test.go
@@ -133,6 +133,47 @@ func TestPostgresSchemaBootstrapAcceptsCanonicalTemplateAndRejectsDrift(t *testi
 	}
 }
 
+func TestSchemaBootstrapRejectsUnexpectedIndex(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	const createUnexpectedIndex = `CREATE UNIQUE INDEX drift_probe_idx ON timers(status) WHERE status = 'pending'`
+
+	t.Run("sqlite", func(t *testing.T) {
+		store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "unexpected-index.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		if err := store.BootstrapSchema(context.Background(), request); err != nil {
+			t.Fatalf("fresh bootstrap: %v", err)
+		}
+		if _, err := store.DB.Exec(createUnexpectedIndex); err != nil {
+			t.Fatal(err)
+		}
+		assertUnexpectedIndexRejected(t, store.BootstrapSchema(context.Background(), request))
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		_, db, cleanup := testutil.StartPostgres(t)
+		t.Cleanup(cleanup)
+		store := &PostgresStore{DB: db}
+		if _, err := db.Exec(createUnexpectedIndex); err != nil {
+			t.Fatal(err)
+		}
+		assertUnexpectedIndexRejected(t, store.BootstrapSchema(context.Background(), request))
+	})
+}
+
+func assertUnexpectedIndexRejected(t *testing.T, err error) {
+	t.Helper()
+	var incompatible *SchemaCompatibilityError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("unexpected-index bootstrap error = %v, want SchemaCompatibilityError", err)
+	}
+	if !strings.Contains(err.Error(), "unexpected index drift_probe_idx") {
+		t.Fatalf("unexpected-index bootstrap error = %v, want named index drift", err)
+	}
+}
+
 func TestPostgresSchemaBootstrapConcurrentFreshCreatorsConverge(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	dsn, db, cleanup := testutil.StartEmptyPostgres(t)

--- a/internal/store/schema_compatibility_bootstrap_test.go
+++ b/internal/store/schema_compatibility_bootstrap_test.go
@@ -174,6 +174,90 @@ func assertUnexpectedIndexRejected(t *testing.T, err error) {
 	}
 }
 
+func TestSQLiteSchemaBootstrapRejectsMalformedStoredOrigin(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	path := filepath.Join(t.TempDir(), "malformed-origin.db")
+	store, err := NewSQLiteRuntimeStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("fresh bootstrap: %v", err)
+	}
+	cases := []malformedStoredOriginCase{
+		{name: "blank swarm version", update: `UPDATE runtime_store_metadata SET swarm_version = ' ' WHERE id = 1`, wantDrift: "stored Swarm version is required"},
+		{name: "blank platform version", update: `UPDATE runtime_store_metadata SET platform_version = ' ' WHERE id = 1`, wantDrift: "stored platform version is required"},
+		{name: "zero creation time", update: `UPDATE runtime_store_metadata SET created_at = '0001-01-01T00:00:00Z' WHERE id = 1`, wantDrift: "stored creation time must be non-zero"},
+		{name: "invalid creation time", update: `UPDATE runtime_store_metadata SET created_at = 'not-a-time' WHERE id = 1`, wantDrift: "parse runtime store creation time"},
+	}
+	assertMalformedStoredOrigins(t, cases, func(statement string) error {
+		_, err := store.DB.Exec(statement)
+		return err
+	}, func() error {
+		_, err := store.DB.Exec(`UPDATE runtime_store_metadata SET swarm_version = ?, platform_version = ?, created_at = ? WHERE id = 1`, request.Origin.SwarmVersion, request.Origin.PlatformVersion, request.Origin.CreatedAt.UTC().Format(time.RFC3339Nano))
+		return err
+	}, func() error {
+		return store.BootstrapSchema(context.Background(), request)
+	}, SchemaDialectSQLite, path, request.Origin)
+}
+
+func TestPostgresSchemaBootstrapRejectsMalformedStoredOrigin(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	var target string
+	if err := db.QueryRow(`SELECT current_database()`).Scan(&target); err != nil {
+		t.Fatal(err)
+	}
+	cases := []malformedStoredOriginCase{
+		{name: "blank swarm version", update: `UPDATE runtime_store_metadata SET swarm_version = ' ' WHERE id = 1`, wantDrift: "stored Swarm version is required"},
+		{name: "blank platform version", update: `UPDATE runtime_store_metadata SET platform_version = ' ' WHERE id = 1`, wantDrift: "stored platform version is required"},
+		{name: "zero creation time", update: `UPDATE runtime_store_metadata SET created_at = TIMESTAMPTZ '0001-01-01 00:00:00+00' WHERE id = 1`, wantDrift: "stored creation time must be non-zero"},
+	}
+	assertMalformedStoredOrigins(t, cases, func(statement string) error {
+		_, err := db.Exec(statement)
+		return err
+	}, func() error {
+		_, err := db.Exec(`UPDATE runtime_store_metadata SET swarm_version = $1, platform_version = $2, created_at = $3 WHERE id = 1`, request.Origin.SwarmVersion, request.Origin.PlatformVersion, request.Origin.CreatedAt)
+		return err
+	}, func() error {
+		return store.BootstrapSchema(context.Background(), request)
+	}, SchemaDialectPostgres, target, request.Origin)
+}
+
+type malformedStoredOriginCase struct {
+	name      string
+	update    string
+	wantDrift string
+}
+
+func assertMalformedStoredOrigins(
+	t *testing.T,
+	cases []malformedStoredOriginCase,
+	update func(string) error,
+	restore func() error,
+	bootstrap func() error,
+	backend SchemaDialect,
+	target string,
+	current RuntimeStoreOrigin,
+) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := update(tc.update); err != nil {
+				t.Fatal(err)
+			}
+			bootstrapErr := bootstrap()
+			if err := restore(); err != nil {
+				t.Fatalf("restore canonical origin: %v", err)
+			}
+			assertSchemaCompatibilityDiagnostic(t, bootstrapErr, backend, target, current, nil, tc.wantDrift)
+		})
+	}
+}
+
 func TestPostgresSchemaBootstrapConcurrentFreshCreatorsConverge(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	dsn, db, cleanup := testutil.StartEmptyPostgres(t)
@@ -285,12 +369,14 @@ func TestSQLiteSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
 	if err := store.BootstrapSchema(context.Background(), request); err != nil {
 		t.Fatalf("create generated state: %v", err)
 	}
+	storedOrigin, err := readRuntimeStoreOrigin(context.Background(), store.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.DB.Exec(`ALTER TABLE generated_probe_state ADD COLUMN drift_probe TEXT`); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.BootstrapSchema(context.Background(), request); err == nil {
-		t.Fatal("incompatible generated state table was accepted")
-	}
+	assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), request), SchemaDialectSQLite, store.path, request.Origin, storedOrigin, "generated state table generated_probe_state:", "drift_probe")
 }
 
 func TestPostgresSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
@@ -299,14 +385,54 @@ func TestPostgresSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T)
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
+	var target string
+	if err := db.QueryRow(`SELECT current_database()`).Scan(&target); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.BootstrapSchema(context.Background(), request); err != nil {
 		t.Fatalf("create generated state: %v", err)
+	}
+	storedOrigin, err := readRuntimeStoreOrigin(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if _, err := db.Exec(`ALTER TABLE generated_probe_state ADD COLUMN drift_probe TEXT`); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.BootstrapSchema(context.Background(), request); err == nil {
-		t.Fatal("incompatible generated state table was accepted")
+	assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), request), SchemaDialectPostgres, target, request.Origin, storedOrigin, "generated state table generated_probe_state:", "drift_probe")
+}
+
+func assertSchemaCompatibilityDiagnostic(t *testing.T, err error, backend SchemaDialect, target string, current RuntimeStoreOrigin, wantOrigin *RuntimeStoreOrigin, wantDrift ...string) {
+	t.Helper()
+	var incompatible *SchemaCompatibilityError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("bootstrap error = %v (%T), want SchemaCompatibilityError", err, err)
+	}
+	if incompatible.Backend != backend || incompatible.Target != target {
+		t.Fatalf("diagnostic backend/target = %s/%q, want %s/%q", incompatible.Backend, incompatible.Target, backend, target)
+	}
+	if incompatible.Current != current {
+		t.Fatalf("diagnostic current origin = %#v, want %#v", incompatible.Current, current)
+	}
+	if wantOrigin != nil {
+		if incompatible.Origin == nil || *incompatible.Origin != *wantOrigin {
+			t.Fatalf("diagnostic stored origin = %#v, want %#v", incompatible.Origin, wantOrigin)
+		}
+	} else if incompatible.Origin != nil {
+		t.Fatalf("malformed stored origin was exposed as valid evidence: %#v", incompatible.Origin)
+	}
+	drift := strings.Join(incompatible.Drift, "; ")
+	for _, want := range wantDrift {
+		if !strings.Contains(drift, want) {
+			t.Fatalf("diagnostic drift = %v, want evidence %q", incompatible.Drift, want)
+		}
+	}
+	wantRemediation := "create and select a fresh PostgreSQL database (for example: createdb swarm_fresh, then set database.name to swarm_fresh)"
+	if backend == SchemaDialectSQLite {
+		wantRemediation = "stop Swarm and remove the incompatible local store with: rm -f -- " + shellQuote(target) + " " + shellQuote(target+"-wal") + " " + shellQuote(target+"-shm")
+	}
+	if !strings.Contains(err.Error(), "remediation: "+wantRemediation) {
+		t.Fatalf("diagnostic = %v, want remediation %q", err, wantRemediation)
 	}
 }
 

--- a/internal/store/schema_compatibility_bootstrap_test.go
+++ b/internal/store/schema_compatibility_bootstrap_test.go
@@ -1,0 +1,300 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/platform"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/testutil"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSQLiteSchemaBootstrapFreshSecondBootAndDriftRejection(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	path := filepath.Join(t.TempDir(), "dev.db")
+	first, err := NewSQLiteRuntimeStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	if err := first.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("fresh bootstrap: %v", err)
+	}
+	var createdAt string
+	if err := first.DB.QueryRow(`SELECT created_at FROM runtime_store_metadata WHERE id=1`).Scan(&createdAt); err != nil {
+		t.Fatal(err)
+	}
+	request.Origin.SwarmVersion = "later-build"
+	request.Origin.CreatedAt = request.Origin.CreatedAt.Add(time.Hour)
+	if err := first.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("compatible second boot: %v", err)
+	}
+	var after string
+	if err := first.DB.QueryRow(`SELECT created_at FROM runtime_store_metadata WHERE id=1`).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != createdAt {
+		t.Fatalf("origin stamp changed on second boot: %q -> %q", createdAt, after)
+	}
+	if _, err := first.DB.Exec(`ALTER TABLE timers ADD COLUMN drift_probe TEXT`); err != nil {
+		t.Fatal(err)
+	}
+	err = first.BootstrapSchema(context.Background(), request)
+	var incompatible *SchemaCompatibilityError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("drift bootstrap error = %v, want SchemaCompatibilityError", err)
+	}
+}
+
+func TestSQLiteSchemaBootstrapRejectsUnstampedWithoutWALMutation(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	store, err := NewSQLiteRuntimeStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if _, err := store.DB.Exec(`CREATE TABLE legacy_state (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BootstrapSchema(context.Background(), request); err == nil {
+		t.Fatal("unstamped non-empty store was accepted")
+	}
+	var mode string
+	if err := store.DB.QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode == "wal" {
+		t.Fatal("incompatible preflight changed journal mode to WAL")
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Fatalf("incompatible preflight created sidecar %s", sidecar)
+		}
+	}
+}
+
+func TestSQLiteSchemaBootstrapConcurrentCreatorsConverge(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	path := filepath.Join(t.TempDir(), "concurrent.db")
+	stores := make([]*SQLiteRuntimeStore, 2)
+	for i := range stores {
+		var err error
+		stores[i], err = NewSQLiteRuntimeStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		current := stores[i]
+		t.Cleanup(func() { _ = current.Close() })
+	}
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range stores {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = stores[i].BootstrapSchema(context.Background(), request)
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent bootstrap: %v", err)
+		}
+	}
+	var count int
+	if err := stores[0].DB.QueryRow(`SELECT COUNT(*) FROM runtime_store_metadata`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("origin rows = %d, err=%v", count, err)
+	}
+}
+
+func TestPostgresSchemaBootstrapAcceptsCanonicalTemplateAndRejectsDrift(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	if err := store.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("compatible template boot: %v", err)
+	}
+	if _, err := db.Exec(`ALTER TABLE timers ADD COLUMN drift_probe TEXT`); err != nil {
+		t.Fatal(err)
+	}
+	err := store.BootstrapSchema(context.Background(), request)
+	var incompatible *SchemaCompatibilityError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("drift bootstrap error = %v, want SchemaCompatibilityError", err)
+	}
+}
+
+func TestPostgresSchemaBootstrapConcurrentFreshCreatorsConverge(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	dsn, db, cleanup := testutil.StartEmptyPostgres(t)
+	t.Cleanup(cleanup)
+	second, err := NewPostgresStore(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.DB.Close() })
+	stores := []*PostgresStore{{DB: db}, second}
+	errs := make([]error, len(stores))
+	var wg sync.WaitGroup
+	for i := range stores {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = stores[i].BootstrapSchema(context.Background(), request)
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent postgres bootstrap: %v", err)
+		}
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM runtime_store_metadata`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("origin rows = %d, err=%v", count, err)
+	}
+}
+
+func TestPostgresSchemaBootstrapRejectsBeforeExtensionOrSchemaMutation(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	_, db, cleanup := testutil.StartEmptyPostgres(t)
+	t.Cleanup(cleanup)
+	if _, err := db.Exec(`CREATE TABLE legacy_state (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	store := &PostgresStore{DB: db}
+	if err := store.BootstrapSchema(context.Background(), request); err == nil {
+		t.Fatal("unstamped non-empty PostgreSQL store was accepted")
+	}
+	var extensionExists bool
+	if err := db.QueryRow(`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto')`).Scan(&extensionExists); err != nil {
+		t.Fatal(err)
+	}
+	if extensionExists {
+		t.Fatal("incompatible preflight created pgcrypto")
+	}
+	var columns int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.columns WHERE table_schema='public' AND table_name='legacy_state'`).Scan(&columns); err != nil {
+		t.Fatal(err)
+	}
+	if columns != 1 {
+		t.Fatalf("incompatible preflight mutated legacy_state columns: %d", columns)
+	}
+}
+
+func TestSchemaBootstrapRollsBackFailedFreshCreation(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			request := canonicalSchemaBootstrapTestRequest(t)
+			for i := range request.PlatformPlans {
+				if request.PlatformPlans[i].TableName != RuntimeStoreMetadataTable {
+					continue
+				}
+				statements := append([]string(nil), request.PlatformPlans[i].Statements...)
+				statements[0] = strings.TrimSuffix(strings.TrimSpace(statements[0]), ")") + ", CHECK (swarm_version = 'allowed'))"
+				request.PlatformPlans[i].Statements = statements
+				break
+			}
+			if backend == "sqlite" {
+				store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "rollback.db"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = store.Close() })
+				if err := store.BootstrapSchema(context.Background(), request); err == nil {
+					t.Fatal("invalid fresh bootstrap succeeded")
+				}
+				tables, err := sqliteUserTables(context.Background(), store.DB)
+				if err != nil || len(tables) != 0 {
+					t.Fatalf("failed SQLite bootstrap left objects %v, err=%v", tables, err)
+				}
+				return
+			}
+			_, db, cleanup := testutil.StartEmptyPostgres(t)
+			t.Cleanup(cleanup)
+			store := &PostgresStore{DB: db}
+			if err := store.BootstrapSchema(context.Background(), request); err == nil {
+				t.Fatal("invalid fresh bootstrap succeeded")
+			}
+			tables, err := postgresPublicTables(context.Background(), db)
+			if err != nil || len(tables) != 0 {
+				t.Fatalf("failed PostgreSQL bootstrap left objects %v, err=%v", tables, err)
+			}
+		})
+	}
+}
+
+func TestSQLiteSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	request.StatePlans = generatedProbeStatePlans()
+	store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("create generated state: %v", err)
+	}
+	if _, err := store.DB.Exec(`ALTER TABLE generated_probe_state ADD COLUMN drift_probe TEXT`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BootstrapSchema(context.Background(), request); err == nil {
+		t.Fatal("incompatible generated state table was accepted")
+	}
+}
+
+func TestPostgresSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
+	request := canonicalSchemaBootstrapTestRequest(t)
+	request.StatePlans = generatedProbeStatePlans()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	if err := store.BootstrapSchema(context.Background(), request); err != nil {
+		t.Fatalf("create generated state: %v", err)
+	}
+	if _, err := db.Exec(`ALTER TABLE generated_probe_state ADD COLUMN drift_probe TEXT`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BootstrapSchema(context.Background(), request); err == nil {
+		t.Fatal("incompatible generated state table was accepted")
+	}
+}
+
+func generatedProbeStatePlans() []SchemaTableDDL {
+	return []SchemaTableDDL{{
+		TableName:  "generated_probe_state",
+		SchemaKind: "state_schema",
+		Statements: []string{`CREATE TABLE IF NOT EXISTS generated_probe_state (
+    "entity_id" UUID NOT NULL,
+    "node_id" TEXT NOT NULL,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "value" TEXT,
+    PRIMARY KEY ("entity_id", "node_id")
+)`},
+	}}
+}
+
+func canonicalSchemaBootstrapTestRequest(t testing.TB) SchemaBootstrapRequest {
+	t.Helper()
+	var spec runtimecontracts.PlatformSpecDocument
+	if err := yaml.Unmarshal(platform.PlatformSpecYAML(), &spec); err != nil {
+		t.Fatal(err)
+	}
+	plans, err := GeneratePlatformTableDDLs(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return SchemaBootstrapRequest{
+		PlatformPlans: plans,
+		Origin:        RuntimeStoreOrigin{SwarmVersion: "schema-test", PlatformVersion: spec.Platform.Version, CreatedAt: time.Now().UTC()},
+	}
+}

--- a/internal/store/schema_compatibility_guard_test.go
+++ b/internal/store/schema_compatibility_guard_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLegacySchemaRepairRootsHaveNoProductionCallers(t *testing.T) {
+	forbidden := map[string]struct{}{
+		"ensurePostgresCanonicalFailureSchema": {},
+		"ensureSQLiteCanonicalFailureSchema":   {},
+		"ensureSchemaCompatibilityColumns":     {},
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		parsed, err := parser.ParseFile(files, filepath.Clean(name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			var called string
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				called = fn.Name
+			case *ast.SelectorExpr:
+				called = fn.Sel.Name
+			}
+			if _, blocked := forbidden[called]; blocked {
+				t.Errorf("production schema repair root %s remains callable at %s", called, files.Position(call.Pos()))
+			}
+			return true
+		})
+	}
+}

--- a/internal/store/sqlite_schema.go
+++ b/internal/store/sqlite_schema.go
@@ -26,6 +26,13 @@ type SQLiteSchemaStore struct {
 
 const sqliteDriverBusyTimeoutMillis = 50
 
+var sqliteSchemaBootstrapLocks sync.Map
+
+func sqliteSchemaBootstrapMutex(path string) *sync.Mutex {
+	value, _ := sqliteSchemaBootstrapLocks.LoadOrStore(filepath.Clean(path), &sync.Mutex{})
+	return value.(*sync.Mutex)
+}
+
 func NewSQLiteSchemaStore(path string) (*SQLiteSchemaStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -67,7 +74,6 @@ func sqliteFileDSN(path string) string {
 	q := u.Query()
 	q.Add("_pragma", "foreign_keys(ON)")
 	q.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteDriverBusyTimeoutMillis))
-	q.Add("_pragma", "journal_mode(WAL)")
 	u.RawQuery = q.Encode()
 	return u.String()
 }
@@ -109,78 +115,6 @@ func (s *SQLiteSchemaStore) configure(ctx context.Context) error {
 		return fmt.Errorf("configure sqlite busy timeout: %w", err)
 	}
 	return s.DB.PingContext(ctx)
-}
-
-func (s *SQLiteSchemaStore) EnsureSchemaTables(ctx context.Context, plans []SchemaTableDDL) error {
-	if s == nil || s.DB == nil {
-		return fmt.Errorf("sqlite schema store is required for schema ddl")
-	}
-	if len(plans) == 0 {
-		return nil
-	}
-	if schemaDDLIncludesPlatformTables(plans) {
-		if err := ensureSQLiteCanonicalFailureSchema(ctx, s.DB); err != nil {
-			return fmt.Errorf("migrate sqlite canonical runtime failures: %w", err)
-		}
-	}
-	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("begin sqlite schema ddl tx: %w", err)
-	}
-	committed := false
-	agentStatements := []string{}
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	for _, plan := range plans {
-		statements, err := SQLiteStatementsForPlan(plan)
-		if err != nil {
-			return err
-		}
-		if strings.TrimSpace(plan.TableName) == "agents" {
-			agentStatements = append(agentStatements, statements...)
-		}
-		for _, statement := range statements {
-			statement = strings.TrimSpace(statement)
-			if statement == "" {
-				continue
-			}
-			if _, err := tx.ExecContext(ctx, statement); err != nil {
-				return fmt.Errorf("ensure sqlite %s table %s: %w", strings.TrimSpace(plan.SchemaKind), strings.TrimSpace(plan.TableName), err)
-			}
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit sqlite schema ddl tx: %w", err)
-	}
-	committed = true
-	if schemaDDLIncludesPlatformTables(plans) {
-		if err := ensureSQLiteCanonicalFailureSchema(ctx, s.DB); err != nil {
-			return fmt.Errorf("validate sqlite canonical runtime failures: %w", err)
-		}
-	}
-	if len(agentStatements) > 0 {
-		if err := s.ensureSQLiteAgentLLMBackendProfiles(ctx, agentStatements); err != nil {
-			return err
-		}
-		if err := s.ensureSQLiteAgentModelAliases(ctx); err != nil {
-			return err
-		}
-		if err := s.ensureSQLiteAgentLifecycleColumns(ctx); err != nil {
-			return err
-		}
-	}
-	if err := s.ensureSQLiteMailboxDeferredUntil(ctx); err != nil {
-		return err
-	}
-	if err := s.ensureSQLiteReplyContextColumns(ctx); err != nil {
-		return err
-	}
-	_, err = s.BindSchemaCapabilities(ctx)
-	return err
 }
 
 func (s *SQLiteSchemaStore) ensureSQLiteReplyContextColumns(ctx context.Context) error {

--- a/internal/store/sqlite_schema_bootstrap.go
+++ b/internal/store/sqlite_schema_bootstrap.go
@@ -40,6 +40,7 @@ func (s *SQLiteSchemaStore) BootstrapSchema(ctx context.Context, request SchemaB
 	if err != nil {
 		return err
 	}
+	diagnostic := schemaCompatibilityDiagnostic{Backend: SchemaDialectSQLite, Target: s.path, Current: request.Origin, Origin: report.Origin}
 	switch report.State {
 	case schemaStateFresh:
 		if err := executeSQLitePlans(ctx, conn, request.PlatformPlans); err != nil {
@@ -50,11 +51,11 @@ func (s *SQLiteSchemaStore) BootstrapSchema(ctx context.Context, request SchemaB
 		}
 	case schemaStateCompatible:
 	case schemaStateIncompatible:
-		return &SchemaCompatibilityError{Backend: SchemaDialectSQLite, Target: s.path, Current: request.Origin, Origin: report.Origin, Drift: report.Drift}
+		return diagnostic.failure(report.Drift)
 	default:
 		return fmt.Errorf("unknown sqlite schema compatibility state %q", report.State)
 	}
-	if err := ensureSQLiteStatePlans(ctx, conn, request.StatePlans); err != nil {
+	if err := ensureSQLiteStatePlans(ctx, conn, request.StatePlans, diagnostic); err != nil {
 		return err
 	}
 	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
@@ -154,7 +155,7 @@ func executeSQLitePlans(ctx context.Context, conn *sql.Conn, plans []SchemaTable
 	return nil
 }
 
-func ensureSQLiteStatePlans(ctx context.Context, conn *sql.Conn, plans []SchemaTableDDL) error {
+func ensureSQLiteStatePlans(ctx context.Context, conn *sql.Conn, plans []SchemaTableDDL, diagnostic schemaCompatibilityDiagnostic) error {
 	for _, plan := range plans {
 		expected, err := expectedSchemaShape([]SchemaTableDDL{plan}, SchemaDialectSQLite)
 		if err != nil {
@@ -175,7 +176,7 @@ func ensureSQLiteStatePlans(ctx context.Context, conn *sql.Conn, plans []SchemaT
 			return err
 		}
 		if drift := compareSchemaShapes(expected, actual); len(drift) > 0 {
-			return fmt.Errorf("generated state table %s is incompatible: %s", plan.TableName, strings.Join(drift, "; "))
+			return diagnostic.failure(generatedStateDrift(plan.TableName, drift))
 		}
 	}
 	return nil

--- a/internal/store/sqlite_schema_bootstrap.go
+++ b/internal/store/sqlite_schema_bootstrap.go
@@ -1,0 +1,182 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (s *SQLiteSchemaStore) BootstrapSchema(ctx context.Context, request SchemaBootstrapRequest) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite store is required for schema bootstrap")
+	}
+	if err := request.validate(); err != nil {
+		return err
+	}
+	expected, err := expectedSchemaShape(request.PlatformPlans, SchemaDialectSQLite)
+	if err != nil {
+		return err
+	}
+	bootstrapMu := sqliteSchemaBootstrapMutex(s.path)
+	bootstrapMu.Lock()
+	defer bootstrapMu.Unlock()
+	conn, err := s.DB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("open serialized sqlite schema connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return fmt.Errorf("serialize sqlite schema bootstrap: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
+		}
+	}()
+	report, err := inspectSQLiteCompatibility(ctx, conn, expected)
+	if err != nil {
+		return err
+	}
+	switch report.State {
+	case schemaStateFresh:
+		if err := executeSQLitePlans(ctx, conn, request.PlatformPlans); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `INSERT INTO runtime_store_metadata (id, swarm_version, platform_version, created_at) VALUES (1, ?, ?, ?)`, request.Origin.SwarmVersion, request.Origin.PlatformVersion, request.Origin.CreatedAt.UTC().Format(time.RFC3339Nano)); err != nil {
+			return fmt.Errorf("stamp fresh sqlite store origin: %w", err)
+		}
+	case schemaStateCompatible:
+	case schemaStateIncompatible:
+		return &SchemaCompatibilityError{Backend: SchemaDialectSQLite, Target: s.path, Current: request.Origin, Origin: report.Origin, Drift: report.Drift}
+	default:
+		return fmt.Errorf("unknown sqlite schema compatibility state %q", report.State)
+	}
+	if err := ensureSQLiteStatePlans(ctx, conn, request.StatePlans); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
+		return fmt.Errorf("commit sqlite schema bootstrap: %w", err)
+	}
+	committed = true
+	if _, err := s.DB.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
+		return fmt.Errorf("enable sqlite WAL after schema acceptance: %w", err)
+	}
+	_, err = s.BindSchemaCapabilities(ctx)
+	return err
+}
+
+func inspectSQLiteCompatibility(ctx context.Context, q schemaQueryer, expected schemaShape) (schemaCompatibilityReport, error) {
+	tables, err := sqliteUserTables(ctx, q)
+	if err != nil {
+		return schemaCompatibilityReport{}, err
+	}
+	if len(tables) == 0 {
+		return schemaCompatibilityReport{State: schemaStateFresh}, nil
+	}
+	var origin *RuntimeStoreOrigin
+	var drift []string
+	if _, ok := tables[RuntimeStoreMetadataTable]; !ok {
+		drift = append(drift, "non-empty SQLite store has no runtime_store_metadata origin stamp")
+	} else {
+		origin, err = readRuntimeStoreOrigin(ctx, q)
+		if err != nil {
+			drift = append(drift, "runtime_store_metadata origin row is malformed: "+err.Error())
+		} else if origin == nil {
+			drift = append(drift, "runtime_store_metadata does not contain the required id=1 origin row")
+		}
+	}
+	actual, err := loadSQLiteSchemaShape(ctx, q, expected)
+	if err != nil {
+		return schemaCompatibilityReport{}, err
+	}
+	drift = append(drift, compareSchemaShapes(expected, actual)...)
+	state := schemaStateCompatible
+	if len(drift) > 0 {
+		state = schemaStateIncompatible
+	}
+	return schemaCompatibilityReport{State: state, Origin: origin, Drift: drift}, nil
+}
+
+func sqliteUserTables(ctx context.Context, q schemaQueryer) (map[string]struct{}, error) {
+	rows, err := q.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type IN ('table', 'view', 'index', 'trigger') AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect sqlite tables: %w", err)
+	}
+	defer rows.Close()
+	tables := map[string]struct{}{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		tables[strings.TrimSpace(name)] = struct{}{}
+	}
+	return tables, rows.Err()
+}
+
+func loadSQLiteSchemaShape(ctx context.Context, q schemaQueryer, expected schemaShape) (schemaShape, error) {
+	actual := schemaShape{Tables: map[string]schemaTableShape{}}
+	rows, err := q.QueryContext(ctx, `SELECT type, name, tbl_name, sql FROM sqlite_master WHERE type IN ('table', 'index') AND sql IS NOT NULL ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END, name`)
+	if err != nil {
+		return schemaShape{}, fmt.Errorf("inspect sqlite schema: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var objectType, name, tableName, statement string
+		if err := rows.Scan(&objectType, &name, &tableName, &statement); err != nil {
+			return schemaShape{}, err
+		}
+		if _, required := expected.Tables[tableName]; !required {
+			continue
+		}
+		if err := addStatementToShape(&actual, statement); err != nil {
+			return schemaShape{}, fmt.Errorf("inspect sqlite %s %s: %w", objectType, name, err)
+		}
+	}
+	return actual, rows.Err()
+}
+
+func executeSQLitePlans(ctx context.Context, conn *sql.Conn, plans []SchemaTableDDL) error {
+	for _, plan := range plans {
+		statements, err := SQLiteStatementsForPlan(plan)
+		if err != nil {
+			return err
+		}
+		for _, statement := range statements {
+			if _, err := conn.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("create sqlite %s table %s: %w", plan.SchemaKind, plan.TableName, err)
+			}
+		}
+	}
+	return nil
+}
+
+func ensureSQLiteStatePlans(ctx context.Context, conn *sql.Conn, plans []SchemaTableDDL) error {
+	for _, plan := range plans {
+		expected, err := expectedSchemaShape([]SchemaTableDDL{plan}, SchemaDialectSQLite)
+		if err != nil {
+			return err
+		}
+		tables, err := sqliteUserTables(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if _, exists := tables[plan.TableName]; !exists {
+			if err := executeSQLitePlans(ctx, conn, []SchemaTableDDL{plan}); err != nil {
+				return err
+			}
+			continue
+		}
+		actual, err := loadSQLiteSchemaShape(ctx, conn, expected)
+		if err != nil {
+			return err
+		}
+		if drift := compareSchemaShapes(expected, actual); len(drift) > 0 {
+			return fmt.Errorf("generated state table %s is incompatible: %s", plan.TableName, strings.Join(drift, "; "))
+		}
+	}
+	return nil
+}

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -589,7 +589,7 @@ func platformTableNamesForSQLiteSchemaTest() []string {
 		"dead_letters",
 		"runs",
 		"entity_mutations",
-		"schema_version",
+		"runtime_store_metadata",
 	}
 }
 

--- a/internal/store/storetest/sqlite.go
+++ b/internal/store/storetest/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/platform"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -44,8 +45,15 @@ func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context) *stor
 			t.Fatalf("close sqlite runtime store: %v", err)
 		}
 	})
-	if err := sqliteStore.EnsureSchemaTables(ctx, plans); err != nil {
-		t.Fatalf("EnsureSchemaTables: %v", err)
+	if err := sqliteStore.BootstrapSchema(ctx, store.SchemaBootstrapRequest{
+		PlatformPlans: plans,
+		Origin: store.RuntimeStoreOrigin{
+			SwarmVersion:    "storetest",
+			PlatformVersion: platformSpec.Platform.Version,
+			CreatedAt:       time.Now().UTC(),
+		},
+	}); err != nil {
+		t.Fatalf("BootstrapSchema: %v", err)
 	}
 	if _, err := os.Stat(dbPath); err != nil {
 		t.Fatalf("sqlite runtime store did not create file-backed db at %s: %v", dbPath, err)

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -707,14 +707,18 @@ func initializeDatabase(ctx context.Context, db *sql.DB, role string, spec runti
 			return fmt.Errorf("initialize postgres template statement %q: %w", stmt, err)
 		}
 	}
-	if err := platformschema.EnsurePostgresTables(ctx, db, plans, nil); err != nil {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin platform bootstrap: %w", err)
+	}
+	if err := platformschema.BootstrapFreshPostgres(ctx, tx, plans, "test-harness", spec.Platform.Version, time.Now().UTC()); err != nil {
+		_ = tx.Rollback()
 		return fmt.Errorf("bootstrap platform tables: %w", err)
 	}
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO schema_version (id, platform_version, applied_at)
-		VALUES (1, $1, now())
-		ON CONFLICT (id) DO UPDATE SET platform_version=EXCLUDED.platform_version, applied_at=EXCLUDED.applied_at`, spec.Platform.Version)
-	return err
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit platform bootstrap: %w", err)
+	}
+	return nil
 }
 
 func inspectSession(ctx context.Context, db *sql.DB) (string, string, error) {

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -59,7 +59,7 @@ func TestTemplateDigestUsesCanonicalGeneratedSchema(t *testing.T) {
 	changed := append([]platformschema.TableDDL(nil), plans...)
 	changed[0] = plans[0]
 	changed[0].Statements = append([]string(nil), plans[0].Statements...)
-	changed[0].Statements[0] += "\nALTER TABLE schema_version ADD COLUMN digest_probe text"
+	changed[0].Statements[0] += "\nALTER TABLE runtime_store_metadata ADD COLUMN digest_probe text"
 	third, err := templateDigest(changed, spec.Platform.Version, "role", "server", "version")
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +106,7 @@ func TestManagerLifecycleSupportedRepresentations(t *testing.T) {
 				t.Fatal(err)
 			}
 			var version string
-			if err := sandbox.DB.QueryRowContext(ctx, `SELECT platform_version FROM schema_version WHERE id=1`).Scan(&version); err != nil {
+			if err := sandbox.DB.QueryRowContext(ctx, `SELECT platform_version FROM runtime_store_metadata WHERE id=1`).Scan(&version); err != nil {
 				t.Fatalf("canonical schema missing: %v", err)
 			}
 			if err := sandbox.Release(ctx); err != nil {
@@ -119,9 +119,9 @@ func TestManagerLifecycleSupportedRepresentations(t *testing.T) {
 				t.Fatal(err)
 			}
 			var table *string
-			err = empty.DB.QueryRowContext(ctx, `SELECT to_regclass('public.schema_version')::text`).Scan(&table)
+			err = empty.DB.QueryRowContext(ctx, `SELECT to_regclass('public.runtime_store_metadata')::text`).Scan(&table)
 			if err != nil || table != nil {
-				t.Fatalf("empty sandbox schema_version = %v, err=%v", table, err)
+				t.Fatalf("empty sandbox runtime_store_metadata = %v, err=%v", table, err)
 			}
 			if err := empty.Release(ctx); err != nil {
 				t.Fatal(err)

--- a/internal/testutil/postgres_test.go
+++ b/internal/testutil/postgres_test.go
@@ -75,7 +75,7 @@ func assertStartPostgresSchema(t *testing.T, db *sql.DB, wantVersion string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	for _, table := range []string{"schema_version", "bundles", "runs", "events", "event_receipts", "timers"} {
+	for _, table := range []string{"runtime_store_metadata", "bundles", "runs", "events", "event_receipts", "timers"} {
 		var exists bool
 		if err := db.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, "public."+table).Scan(&exists); err != nil {
 			t.Fatalf("check table %s: %v", table, err)
@@ -86,10 +86,10 @@ func assertStartPostgresSchema(t *testing.T, db *sql.DB, wantVersion string) {
 	}
 
 	var gotVersion string
-	if err := db.QueryRowContext(ctx, `SELECT platform_version FROM schema_version WHERE id = 1`).Scan(&gotVersion); err != nil {
-		t.Fatalf("read schema_version: %v", err)
+	if err := db.QueryRowContext(ctx, `SELECT platform_version FROM runtime_store_metadata WHERE id = 1`).Scan(&gotVersion); err != nil {
+		t.Fatalf("read runtime_store_metadata: %v", err)
 	}
 	if gotVersion != wantVersion {
-		t.Fatalf("schema_version platform_version = %q, want %q", gotVersion, wantVersion)
+		t.Fatalf("runtime_store_metadata platform_version = %q, want %q", gotVersion, wantVersion)
 	}
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -11161,6 +11161,11 @@ platform_tables:
     status: pre_1_0_no_migration
     compatibility_authority: actual_selected_backend_catalog_shape
     origin_evidence: runtime_store_metadata
+    origin_validity: >
+      Creation-origin evidence is valid only when the required id=1 row has non-blank Swarm and platform versions after
+      trimming and created_at decodes to a non-zero timestamp. Missing, malformed, blank, invalid, or zero-valued evidence
+      makes the selected store incompatible and must use the same typed backend-specific diagnostic and fresh-store
+      remediation as catalog drift.
     rule: >
       Origin versions are immutable diagnostic evidence, never a compatibility verdict. Existing selected stores are
       inspected before any persistent schema or data mutation. A non-empty un-stamped store is not adopted. A stamped store
@@ -11173,7 +11178,8 @@ platform_tables:
       immutable runtime_store_metadata row. Failed or concurrent creation cannot leave a successful stamp over partial DDL.
     generated_node_state: >
       Contract-generated node-state tables are classified only after platform acceptance. Missing tables may be created;
-      existing incompatible tables fail before node-state mutation.
+      existing incompatible tables fail before node-state mutation through the same typed backend-specific compatibility
+      diagnostic, including selected-store target, running and stored origin evidence, exact drift, and fresh-store remediation.
   test_bootstrap:
     description: After legacy SQL deletion, normal runtime/test bootstrap creates only platform tables plus generated
       node-state tables. Product-specific typed entity table DDL is explicit future/legacy optimization-test input, not

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10319,7 +10319,7 @@ platform_tables:
       delete_all:
         - runs
       preserve:
-        - schema_version
+        - runtime_store_metadata
         - api_idempotency
         - runtime_ingress_state
         - agents
@@ -11074,19 +11074,20 @@ platform_tables:
       hot_path_cost: 'One extra read (old value) + one insert per field write. The read is a single JSONB field
         extraction from entity_state — sub-millisecond. The insert is append-only with no unique constraints
         on the hot path. Given LLM calls at 1-30 seconds per agent turn, the overhead is negligible.'
-    schema_version:
-      description: 'Platform schema versioning. Tracks which version of the platform DDL has been applied. The platform checks
-        this at boot: if the stored version < current platform version, it applies migrations. Products never read or write
-        this table.'
-      ddl: "CREATE TABLE schema_version (\n    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),\n    platform_version\
-        \  TEXT NOT NULL,\n    applied_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    migration_log     JSONB NOT NULL\
-        \ DEFAULT '[]'\n);"
+    runtime_store_metadata:
+      description: 'Immutable creation-origin evidence for a selected runtime store. The stored versions explain which Swarm
+        build and exact platform specification created the store; they never decide whether a later build may open it.
+        Products never read or write this table.'
+      ddl: "CREATE TABLE runtime_store_metadata (\n    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),\n    swarm_version\
+        \     TEXT NOT NULL,\n    platform_version  TEXT NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL\n);"
   notes:
     product_tables: Product-specific tables (entity fields, custom state) are generated from entities.yaml plus the shared
       type system.
       Those are contract-driven, not listed here.
-    migrations: Platform table schema is versioned with the platform version. The platform generates DDL at boot and applies
-      migrations if the schema version changed. Products never modify platform tables directly.
+    migrations: 'Pre-1.0 selected stores are not migrated or adopted at boot. Boot derives the complete required platform
+      shape from this specification, probes the actual selected-backend catalog before persistent mutation, and accepts only
+      a fresh empty namespace or an exactly compatible store carrying immutable runtime_store_metadata origin evidence.
+      Partial, un-stamped, conflicting, or drifted stores fail closed with backend-specific fresh-store remediation.'
     index_syntax: INDEX declarations are logical — the implementer may use CREATE INDEX statements or database-specific syntax.
       The spec declares intent, not SQL dialect.
   diagnostics_encoding:
@@ -11156,10 +11157,23 @@ platform_tables:
       spend: 'Aggregate from spend_ledger: SELECT SUM(cost_usd) FROM spend_ledger WHERE entity_id = X'
     digest_queries: Digest/reporting code should query entity_state for current metrics and spend_ledger for cost aggregates.
       No entity_metrics table.
-  migration_policy: 'schema_version is a platform table. It survives the legacy SQL deletion. MigrationSpec and ApplyManagedMigrations
-    remain as platform APIs — they apply DDL diffs between platform versions. ApplyMigrationFile is DELETED (no more file-based
-    migrations). The boot sequence: read schema_version → compare to current platform version → generate DDL diff → apply
-    → update schema_version.'
+  migration_policy:
+    status: pre_1_0_no_migration
+    compatibility_authority: actual_selected_backend_catalog_shape
+    origin_evidence: runtime_store_metadata
+    rule: >
+      Origin versions are immutable diagnostic evidence, never a compatibility verdict. Existing selected stores are
+      inspected before any persistent schema or data mutation. A non-empty un-stamped store is not adopted. A stamped store
+      is accepted only when every required table, column type, nullability, default, key, reference, check, and index derived
+      from the current platform plans is compatible. Existing compatible platform schema is not rerun through CREATE, ALTER,
+      UPDATE, DROP, backfill, rebuild, or repair paths. Incompatible stores fail closed; pre-1.0 continuity and managed
+      migrations remain deferred under issue #995.
+    fresh_bootstrap: >
+      Fresh platform creation is backend-serialized and atomically commits the complete platform schema plus exactly one
+      immutable runtime_store_metadata row. Failed or concurrent creation cannot leave a successful stamp over partial DDL.
+    generated_node_state: >
+      Contract-generated node-state tables are classified only after platform acceptance. Missing tables may be created;
+      existing incompatible tables fail before node-state mutation.
   test_bootstrap:
     description: After legacy SQL deletion, normal runtime/test bootstrap creates only platform tables plus generated
       node-state tables. Product-specific typed entity table DDL is explicit future/legacy optimization-test input, not


### PR DESCRIPTION
## Summary

- replace migration-oriented `schema_version` with immutable `runtime_store_metadata` creation-origin evidence
- make one request-shaped SQLite/PostgreSQL bootstrap owner derive compatibility from the complete generated platform schema and actual backend catalogs before persistent mutation
- serialize and atomically stamp fresh stores, verify generated node-state tables after platform acceptance, and emit backend-specific fresh-store remediation for incompatible stores
- remove the production `EnsureSchemaTables`/post-DDL repair path and move CLI boot, test templates/fixtures, cleanup preservation, and direct test producers to the new owner

## Governing Context

Binding implementation issue and independent gate: #2003, including the approved `selected_store_pre_1_0_schema_compatibility_authority` boundary. Parked parent policy/reopen trigger: #995.

Authoritative merge-bearing references updated in this PR:

- `platform-spec.yaml#platform_tables.tables.runtime_store_metadata`
- `platform-spec.yaml#platform_tables.notes.migrations`
- `platform-spec.yaml#platform_tables.migration_policy`
- `platform-spec.yaml#engine.runtime_store_schema_dialect_bootstrap`
- `platform-spec.yaml#engine.runtime_core_persistence_store_contracts`
- `platform-spec.yaml#cli_specification.foundations.output_contract.diagnostic_convention`
- `platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority`

## Semantic Migration

New canonical owner: `store.SchemaBootstrapper.BootstrapSchema(context.Context, store.SchemaBootstrapRequest)`, implemented by the selected PostgreSQL and SQLite stores over one generated-plan compatibility model.

Old producer/reader/writer paths now invalid:

- production `EnsureSchemaTables(ctx, plans)`
- `schema_version` as a migration/version verdict
- PostgreSQL pre/post-DDL canonical-failure and compatibility repair invocation
- SQLite pre/post-DDL failure normalization, table rebuild, backfill, and compatibility repair invocation
- PostgreSQL pre-verdict `pgcrypto` creation
- SQLite open-time `journal_mode(WAL)` mutation

Production paths checked for surviving old behavior: pre-catalog serve bootstrap, disk/local run, DB-loaded and multi-bundle serve, loaded-bundle node-state creation, builder reload, selected store construction, PostgreSQL templates, SQLite fixtures, direct bootstrap tests, schema capability binding, and destructive reset preservation. A guard fails if a legacy repair root regains a production caller.

Migration status: complete for #2003's selected-store pre-1.0 compatibility class. Managed migration/backup/downgrade continuity remains parked under #995.

## Proof

- `SWARM_TEST_POSTGRES_DSN=postgres://swarm_test:swarm-test@127.0.0.1:55432/postgres?sslmode=disable go test ./...`
- focused SQLite/PostgreSQL fresh, second-boot, unstamped, drift, rollback, concurrent-creator, no-WAL/no-pgcrypto, generated-state, cleanup, and template/fixture tests
- real served fresh default-SQLite and explicit host-PostgreSQL tests:
  - `TestRunServeRuntimeFreshEmptySQLiteBootsWithDevAbandon`
  - `TestRunServeRuntimeFreshEmptySQLiteBootsWithDirectAbandon`
  - `TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe`
  - `TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon`

Closes #2003
