### PR TITLE
[agent-a][issue #2005] Align verifier guards with canonical owners

### DIFF
--- a/.changes/platform/2005.yaml
+++ b/.changes/platform/2005.yaml
@@ -1,0 +1,6 @@
+issue: 2005
+impact: minor
+platform_train: 0.7.0
+summary: Preserve handler-origin provenance on canonical lifecycle topology edges.
+spec_sections:
+  - contract_formats.flow_schema.bounded_loops.topology

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -113,6 +113,7 @@ type StageGraphEdgeView struct {
 	To            string   `json:"to"`
 	Source        string   `json:"source"`
 	NodeID        string   `json:"node_id,omitempty"`
+	HandlerEvent  string   `json:"handler_event,omitempty"`
 	EventType     string   `json:"event_type,omitempty"`
 	TimerID       string   `json:"timer_id,omitempty"`
 	After         string   `json:"after,omitempty"`
@@ -550,6 +551,7 @@ func buildStageGraphEdgesForFlow(source semanticview.Source, flowID string) []St
 			To:            edge.To,
 			Source:        edge.Source,
 			NodeID:        edge.NodeID,
+			HandlerEvent:  edge.HandlerEvent,
 			EventType:     edge.EventType,
 			Timed:         edge.Timed,
 			TimerID:       edge.TimerID,

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -277,6 +277,9 @@ func TestBuildStageGraphShowsStageTimersAndTimedEdges(t *testing.T) {
 	if !timedEdge.Timed || timedEdge.After != "{{marginal_park_days}}d" || timedEdge.To != "expired" {
 		t.Fatalf("timed edge = %#v, want after-labeled transition to expired", timedEdge)
 	}
+	if timedEdge.HandlerEvent != "" {
+		t.Fatalf("timed edge handler origin = %q, want empty", timedEdge.HandlerEvent)
+	}
 }
 
 func TestBuildStageGraphShowsFanOutMultiplicity(t *testing.T) {
@@ -384,6 +387,9 @@ func TestBuildStageGraphShowsJoinCompleteAndTimeoutEdges(t *testing.T) {
 	}
 	if len(timeout.From) != 1 || timeout.From[0] != "awaiting" || timeout.To != "attention" || !timeout.Timed || timeout.After != "24h" || timeout.TimerID != "line_items" {
 		t.Fatalf("timeout edge = %#v", timeout)
+	}
+	if timeout.HandlerEvent != "item.completed" || timeout.EventType != "platform.join_timeout" {
+		t.Fatalf("timeout provenance = %#v", timeout)
 	}
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2642,16 +2643,11 @@ stages:
 }
 
 func TestRun_DoesNotWarnWhenOnCompleteBranchReachesDeclaredState(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      on_complete:
+        - condition: "true"
+          advances_to: review`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
-		Condition:  "true",
-		AdvancesTo: "review",
-	}}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -2661,16 +2657,12 @@ func TestRun_DoesNotWarnWhenOnCompleteBranchReachesDeclaredState(t *testing.T) {
 }
 
 func TestRun_DoesNotWarnWhenRuleBranchReachesDeclaredState(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      rules:
+        - id: review
+          condition: "true"
+          advances_to: review`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
-		Condition:  "true",
-		AdvancesTo: "review",
-	}}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -2680,18 +2672,14 @@ func TestRun_DoesNotWarnWhenRuleBranchReachesDeclaredState(t *testing.T) {
 }
 
 func TestRun_DoesNotWarnWhenAccumulateOnCompleteBranchReachesDeclaredState(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      accumulate:
+        expected_from: payload.entity_id
+        threshold: 1
+        on_complete:
+          - condition: "true"
+            advances_to: review`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.Accumulate = &runtimecontracts.AccumulateSpec{
-		OnComplete: []runtimecontracts.HandlerRuleEntry{{
-			Condition:  "true",
-			AdvancesTo: "review",
-		}},
-	}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -2701,20 +2689,15 @@ func TestRun_DoesNotWarnWhenAccumulateOnCompleteBranchReachesDeclaredState(t *te
 }
 
 func TestRun_DoesNotWarnWhenAccumulateOnTimeoutBranchReachesDeclaredState(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      accumulate:
+        expected_from: payload.entity_id
+        completion: timeout
+        timeout_ms: 1000
+        on_timeout:
+          condition: "true"
+          advances_to: review`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.Accumulate = &runtimecontracts.AccumulateSpec{
-		Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
-		TimeoutMS:  1000,
-		OnTimeout: &runtimecontracts.HandlerRuleEntry{
-			Condition:  "true",
-			AdvancesTo: "review",
-		},
-	}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -2747,20 +2730,15 @@ func TestRun_PreservesStateMachineCoherenceErrorWhenInvalidAccumulateTimeoutTarg
 }
 
 func TestRun_PreservesStateMachineCoherenceErrorWhenInvalidTargetExists(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      rules:
+        - id: review
+          condition: "true"
+          advances_to: review
+        - id: invalid
+          condition: "true"
+          advances_to: bogus_state`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.OnComplete = []runtimecontracts.HandlerRuleEntry{{
-		Condition:  "true",
-		AdvancesTo: "review",
-	}}
-	handler.Rules = []runtimecontracts.HandlerRuleEntry{{
-		Condition:  "true",
-		AdvancesTo: "bogus_state",
-	}}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -6832,24 +6810,18 @@ func TestRun_AllowsTimerCancelStateReachableFromEventStartContext(t *testing.T) 
 }
 
 func TestTimerReachabilityConsumesAccumulatorTransitionCarriers(t *testing.T) {
-	root := writeStateReachabilityFixture(t)
+	root := writeStateReachabilityFixtureWithClosedHandler(t, `      advances_to: done
+      accumulate:
+        expected_from: payload.entity_id
+        completion: timeout
+        timeout_ms: 1000
+        on_complete:
+          - condition: "true"
+            advances_to: review
+        on_timeout:
+          condition: "true"
+          advances_to: active`)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
-	node := bundle.Nodes["support-node"]
-	handler := node.EventHandlers["ticket.closed"]
-	handler.Accumulate = &runtimecontracts.AccumulateSpec{
-		Completion: runtimecontracts.ParseAccumulateCompletion("timeout"),
-		TimeoutMS:  1000,
-		OnComplete: []runtimecontracts.HandlerRuleEntry{{
-			Condition:  "true",
-			AdvancesTo: "review",
-		}},
-		OnTimeout: &runtimecontracts.HandlerRuleEntry{
-			Condition:  "true",
-			AdvancesTo: "active",
-		},
-	}
-	node.EventHandlers["ticket.closed"] = handler
-	bundle.Nodes["support-node"] = node
 
 	source := semanticview.Wrap(bundle)
 	declaredStates := map[string]struct{}{"waiting": {}, "active": {}, "review": {}, "done": {}}
@@ -6857,14 +6829,14 @@ func TestTimerReachabilityConsumesAccumulatorTransitionCarriers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseStartTrigger: %v", err)
 	}
-	activationStates := timerActivationStates(source, runtimecontracts.WorkflowTimerContract{FlowID: "support"}, trigger, "waiting", declaredStates)
+	activationStates := timerActivationStates(source, runtimecontracts.WorkflowTimerContract{FlowID: "support"}, trigger, declaredStates)
 	for _, want := range []string{"active", "review"} {
 		if _, ok := activationStates[want]; !ok {
 			t.Fatalf("timer activation states = %#v, want accumulator carrier target %s", activationStates, want)
 		}
 	}
 
-	edges := timerCancelStateGraphEdges(source, runtimecontracts.WorkflowTimerContract{FlowID: "support", Event: "timer.reminder"}, "waiting", declaredStates)
+	edges := timerCancelStateGraphEdges(source, runtimecontracts.WorkflowTimerContract{FlowID: "support", Event: "timer.reminder"})
 	if _, ok := edges["waiting"]["review"]; !ok {
 		t.Fatalf("timer cancel graph edges = %#v, want accumulator on_complete edge to review", edges)
 	}
@@ -7685,6 +7657,10 @@ consumer-node:
 }
 
 func writeStateReachabilityFixture(t *testing.T) string {
+	return writeStateReachabilityFixtureWithClosedHandler(t, "      advances_to: done")
+}
+
+func writeStateReachabilityFixtureWithClosedHandler(t *testing.T, closedHandler string) string {
 	t.Helper()
 	root := t.TempDir()
 
@@ -7719,7 +7695,7 @@ ticket.opened:
 ticket.closed:
   entity_id: string
 `)
-	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), `
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "nodes.yaml"), fmt.Sprintf(`
 support-node:
   id: support-node
   execution_type: system_node
@@ -7731,8 +7707,8 @@ support-node:
       create_entity: true
       advances_to: active
     ticket.closed:
-      advances_to: done
-`)
+%s
+`, closedHandler))
 
 	return root
 }

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	"github.com/division-sh/swarm/internal/runtime/routingtopology"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -93,9 +94,15 @@ func (c *checkerContext) eventWarnings() []Finding {
 	}
 	emitted := topologyWarningEndpoints(census.Producers(), true)
 	subscribed := topologyWarningEndpoints(append(census.Consumers(), census.InputPins()...), false)
+	generatedActivityEvents := generatedActivityResultEventNamesLocal(c.source)
 	for _, key := range sortedSetKeysLocal(emitted) {
 		entry := emitted[key]
 		ref := entry.Event
+		if _, generated := generatedActivityEvents[eventidentity.Normalize(ref.Canonical)]; generated {
+			// The generated schema and durable attempt journal own these results;
+			// authors neither declare their schemas nor need to subscribe to them.
+			continue
+		}
 		if !ref.HasSchema {
 			if strings.HasPrefix(ref.DisplayName(), "timer.") || strings.HasPrefix(ref.DisplayName(), "platform.") {
 				continue
@@ -173,6 +180,28 @@ func (c *checkerContext) eventWarnings() []Finding {
 		})
 	}
 	return c.eventWarningFindings
+}
+
+func generatedActivityResultEventNamesLocal(source semanticview.Source) map[string]struct{} {
+	out := map[string]struct{}{}
+	if source == nil {
+		return out
+	}
+	for _, nodeID := range sortedNodeIDs(source) {
+		flowID := ""
+		if contractSource, ok := source.NodeContractSource(nodeID); ok {
+			flowID = strings.TrimSpace(contractSource.FlowID)
+		}
+		for _, site := range runtimecontracts.ActivitySitesForNode(flowID, nodeID, source.NodeEventHandlers(nodeID)) {
+			results := runtimecontracts.ActivityResultEventsForSite(site)
+			for _, eventType := range []string{results.SuccessEvent, results.FailureEvent} {
+				if normalized := eventidentity.Normalize(eventType); normalized != "" {
+					out[normalized] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
 }
 
 func legacyQualifiedConsumersForEvent(topology routingtopology.Topology, canonical string) []routingtopology.LegacyQualifiedSubscription {

--- a/internal/runtime/bootverify/workflow_generated_activity_topology_test.go
+++ b/internal/runtime/bootverify/workflow_generated_activity_topology_test.go
@@ -1,0 +1,132 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRunAcceptsGeneratedActivityResultsWithoutAuthoredSchemas(t *testing.T) {
+	report := runGeneratedActivityFixture(t, false)
+	for _, checkID := range []string{"event_chain_integrity", "event_consumer_exists", "transition_reference_validation"} {
+		if reportContains(report.Findings, checkID, "send") {
+			t.Fatalf("unexpected %s generated-result finding: %#v", checkID, report.Findings)
+		}
+	}
+}
+
+func TestRunAcceptsSubscriptionsToGeneratedActivityResultSchemas(t *testing.T) {
+	report := runGeneratedActivityFixture(t, true)
+	for _, checkID := range []string{"event_chain_integrity", "event_consumer_exists", "event_producer_exists", "transition_reference_validation", "condition_payload_alignment"} {
+		if reportContains(report.Findings, checkID, "send") {
+			t.Fatalf("unexpected %s generated-result finding: %#v", checkID, report.Findings)
+		}
+	}
+}
+
+func TestGeneratedActivityResultNamesCoverHandlerAndRuleSites(t *testing.T) {
+	handlers := map[string]runtimecontracts.SystemNodeEventHandler{
+		"request": {
+			Activity: runtimecontracts.ActivitySpec{ID: "direct", Tool: "send"},
+			Rules: []runtimecontracts.HandlerRuleEntry{{
+				ID:       "fallback",
+				Activity: runtimecontracts.ActivitySpec{Tool: "send"},
+			}},
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes:     map[string]runtimecontracts.SystemNodeContract{"activity-node": {EventHandlers: handlers}},
+		Semantics: runtimecontracts.WorkflowSemanticView{NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{"activity-node": handlers}},
+	}
+	names := generatedActivityResultEventNamesLocal(semanticview.Wrap(bundle))
+	sites := runtimecontracts.ActivitySitesForNode("", "activity-node", handlers)
+	if len(sites) != 2 {
+		t.Fatalf("activity sites = %#v", sites)
+	}
+	for _, site := range sites {
+		results := runtimecontracts.ActivityResultEventsForSite(site)
+		for _, eventType := range []string{results.SuccessEvent, results.FailureEvent} {
+			if _, ok := names[eventidentity.Normalize(eventType)]; !ok {
+				t.Fatalf("generated names = %#v, missing %s", names, eventType)
+			}
+		}
+	}
+}
+
+func runGeneratedActivityFixture(t *testing.T, subscribeResults bool) Report {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: generated-activity-topology
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows: []
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: generated-activity-topology\nstages: []\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+request:
+  message: text
+  swarm:
+    source: external
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), `
+send:
+  description: send one message
+  handler_type: http
+  effect_class: read_only
+  input_schema:
+    type: object
+    properties:
+      message: {type: string}
+    required: [message]
+  output_schema:
+    type: object
+    properties:
+      delivered: {type: boolean}
+  response_success: {kind: http_status_2xx}
+  http:
+    method: POST
+    url: https://example.invalid/send
+    body:
+      message: "{{input.message}}"
+`)
+	resultHandlers := ""
+	resultSubscriptions := ""
+	if subscribeResults {
+		resultSubscriptions = ", send.succeeded, send.failed"
+		resultHandlers = `
+    send.succeeded:
+      rules:
+        - id: observe_success
+          condition: payload.result != null
+    send.failed:
+      rules:
+        - id: observe_failure
+          condition: payload.failure != null
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+activity-node:
+  id: activity-node
+  execution_type: system_node
+  subscribes_to: [request`+resultSubscriptions+`]
+  event_handlers:
+    request:
+      activity:
+        id: send
+        tool: send
+        input:
+          message:
+            ref: payload.message
+`+resultHandlers)
+	repoRoot := repoRootForBootverifyTest(t)
+	bundle := loadFixtureBundleAt(t, repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	return Run(context.Background(), semanticview.Wrap(bundle), Options{})
+}

--- a/internal/runtime/bootverify/workflow_generated_activity_topology_test.go
+++ b/internal/runtime/bootverify/workflow_generated_activity_topology_test.go
@@ -28,6 +28,38 @@ func TestRunAcceptsSubscriptionsToGeneratedActivityResultSchemas(t *testing.T) {
 	}
 }
 
+func TestRunAcceptsNestedFlowGeneratedActivityResultOwnership(t *testing.T) {
+	source := loadNestedGeneratedActivityFixture(t)
+	report := Run(context.Background(), source, Options{})
+	for _, checkID := range []string{"event_chain_integrity", "event_consumer_exists", "event_producer_exists", "transition_reference_validation", "condition_payload_alignment"} {
+		if reportContains(report.Findings, checkID, "child.send") {
+			t.Fatalf("unexpected %s nested generated-result finding: %#v", checkID, report.Findings)
+		}
+	}
+
+	generated := generatedActivityResultEventNamesLocal(source)
+	census := semanticview.BuildAuthoredEventEndpointCensus(source)
+	for _, eventType := range []string{"child.send.succeeded", "child.send.failed"} {
+		if _, ok := generated[eventType]; !ok {
+			t.Fatalf("nested generated identities = %#v, missing %s", generated, eventType)
+		}
+		proof := semanticview.ResolveFlowEventProof(source, "child", eventType)
+		if !proof.HasSchema {
+			t.Fatalf("nested generated event %s has no engine-owned payload schema: %#v", eventType, proof)
+		}
+		routed := false
+		for _, endpoint := range census.MatchingConsumers("child", proof.EventKey()) {
+			if endpoint.Kind == semanticview.EventEndpointNodeHandler && endpoint.NodeID == "observer-node" && endpoint.HandlerEvent == eventType {
+				routed = true
+				break
+			}
+		}
+		if !routed {
+			t.Fatalf("nested generated event %s has no canonical observer route", eventType)
+		}
+	}
+}
+
 func TestGeneratedActivityResultNamesCoverHandlerAndRuleSites(t *testing.T) {
 	handlers := map[string]runtimecontracts.SystemNodeEventHandler{
 		"request": {
@@ -129,4 +161,83 @@ activity-node:
 	repoRoot := repoRootForBootverifyTest(t)
 	bundle := loadFixtureBundleAt(t, repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	return Run(context.Background(), semanticview.Wrap(bundle), Options{})
+}
+
+func loadNestedGeneratedActivityFixture(t *testing.T) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: nested-generated-activity-topology
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: nested-generated-activity-topology\nstages: []\n")
+	for _, file := range []string{"entities.yaml", "policy.yaml", "tools.yaml", "agents.yaml", "events.yaml", "nodes.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, file), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), "name: child\nmode: static\nstages: []\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "entities.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+request:
+  message: text
+  swarm:
+    source: external
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "tools.yaml"), `
+send:
+  description: send one message
+  handler_type: http
+  effect_class: read_only
+  input_schema:
+    type: object
+    properties:
+      message: {type: string}
+    required: [message]
+  output_schema:
+    type: object
+    properties:
+      delivered: {type: boolean}
+  response_success: {kind: http_status_2xx}
+  http:
+    method: POST
+    url: https://example.invalid/send
+    body:
+      message: "{{input.message}}"
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
+activity-node:
+  id: activity-node
+  execution_type: system_node
+  subscribes_to: [request]
+  event_handlers:
+    request:
+      activity:
+        id: send
+        tool: send
+        input:
+          message:
+            ref: payload.message
+observer-node:
+  id: observer-node
+  execution_type: system_node
+  subscribes_to: [child.send.succeeded, child.send.failed]
+  event_handlers:
+    child.send.succeeded:
+      rules:
+        - id: observe_success
+          condition: payload.result.delivered == true
+    child.send.failed:
+      rules:
+        - id: observe_failure
+          condition: payload.failure != null
+`)
+	repoRoot := repoRootForBootverifyTest(t)
+	bundle := loadFixtureBundleAt(t, repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	return semanticview.Wrap(bundle)
 }

--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -244,8 +244,7 @@ func joinDelayValid(source semanticview.Source, flowID, raw string) bool {
 }
 
 func joinStageCanReenter(source semanticview.Source, flowID, stage string) bool {
-	states := declaredStatesForFlow(source, flowID)
-	edges := authoredStateGraphEdges(source, flowID, source.FlowInitialStage(flowID), states)
+	edges := workflowStageGraphEdges(source, flowID, nil)
 	stage = strings.TrimSpace(stage)
 	seen := map[string]struct{}{}
 	queue := make([]string, 0, len(edges[stage]))

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -117,6 +117,7 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 				tc.mutate(&h, bundle)
 				bundle.Nodes["join-node"].EventHandlers["item.completed"] = h
 			}
+			rebuildJoinValidationTopology(bundle)
 			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 			if tc.wantError == "" {
 				if reportContains(report.HardInvalidities(), joinValidationCheckID, "") {
@@ -183,7 +184,7 @@ func joinValidationBundle() *runtimecontracts.WorkflowContractBundle {
 		TimeoutFound: true,
 		Timeout:      runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention", Emit: runtimecontracts.EmitSpec{Event: "join.timed_out", Fields: map[string]runtimecontracts.ExpressionValue{"missing": runtimecontracts.CELExpression("join.missing")}}}},
 	}
-	return &runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootSchema:   &runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true, Entries: []runtimecontracts.FlowStageDeclaration{{ID: "awaiting", Initial: true}, {ID: "ready"}, {ID: "attention", Terminal: true}}}},
 		RootEntities: runtimecontracts.EntityContractsDocument{"Order": {Fields: map[string]runtimecontracts.EntityFieldDecl{"expected": {Type: "[text]", Initial: []any{}}}}},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
@@ -196,5 +197,38 @@ func joinValidationBundle() *runtimecontracts.WorkflowContractBundle {
 			InitialStage: "awaiting", Stages: []runtimecontracts.WorkflowStageContract{{ID: "awaiting"}, {ID: "ready"}, {ID: "attention"}}, TerminalStages: []string{"attention"},
 			Transitions: []runtimecontracts.WorkflowTransitionContract{{ID: "complete", From: []string{"awaiting"}, To: "ready"}, {ID: "timeout", From: []string{"awaiting"}, To: "attention"}},
 		},
+	}
+	rebuildJoinValidationTopology(bundle)
+	return bundle
+}
+
+func rebuildJoinValidationTopology(bundle *runtimecontracts.WorkflowContractBundle) {
+	transitions := []runtimecontracts.HandlerTransitionSemantic{}
+	for nodeID, node := range bundle.Nodes {
+		for eventType, handler := range node.EventHandlers {
+			transitions = append(transitions, runtimecontracts.HandlerTransitionSemantic{
+				NodeID:       nodeID,
+				EventType:    eventType,
+				CreateEntity: handler.CreateEntity,
+				AdvancesTo:   handler.AdvancesTo,
+				OnComplete:   handler.OnComplete,
+				Rules:        handler.Rules,
+				Accumulate:   handler.Accumulate,
+				Join:         handler.Join,
+				Loop:         handler.Loop,
+			})
+		}
+	}
+	bundle.Semantics.HandlerTransitions = transitions
+	bundle.Semantics.StageTopologies = map[string]runtimecontracts.WorkflowStageTopology{
+		"": runtimecontracts.BuildWorkflowStageTopology(
+			"",
+			"awaiting",
+			[]string{"awaiting", "ready", "attention"},
+			[]string{"attention"},
+			transitions,
+			nil,
+			nil,
+		),
 	}
 }

--- a/internal/runtime/bootverify/workflow_payload_named_field_test.go
+++ b/internal/runtime/bootverify/workflow_payload_named_field_test.go
@@ -1,0 +1,60 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRunAcceptsNormalizerReadingNestedPathBelowPayloadNamedField(t *testing.T) {
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: payload-normalizer
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows: []
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: payload-normalizer
+initial_state: active
+states: [active, done]
+terminal_states: [done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "entities.yaml"), `
+chat:
+  chat_id: text
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+inbound.telegram:
+  entity_id: text
+  payload: json
+  swarm:
+    source: external
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+normalizer:
+  id: normalizer
+  execution_type: system_node
+  subscribes_to: [inbound.telegram]
+  event_handlers:
+    inbound.telegram:
+      data_accumulation:
+        writes:
+          - target_field: chat_id
+            value:
+              ref: payload.payload.message.chat.id
+      advances_to: done
+`)
+	for _, file := range []string{"policy.yaml", "tools.yaml", "agents.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, file), "{}\n")
+	}
+	repoRoot := repoRootForBootverifyTest(t)
+	bundle := loadFixtureBundleAt(t, repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "payload_field_coverage", "payload.payload.message.chat.id") || reportContains(report.Errors(), "payload_field_coverage", "payload.message.chat.id") {
+		t.Fatalf("normalizer path rejected: %#v", report.Errors())
+	}
+}

--- a/internal/runtime/bootverify/workflow_stage_topology_consumption_test.go
+++ b/internal/runtime/bootverify/workflow_stage_topology_consumption_test.go
@@ -1,0 +1,209 @@
+package bootverify
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestRunAcceptsTimerOnlyReachableTerminalStage(t *testing.T) {
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: timer-reachability
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	for _, file := range []string{"schema.yaml", "policy.yaml", "tools.yaml", "agents.yaml", "events.yaml", "nodes.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, file), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+name: support
+stages:
+  active:
+    initial: true
+    timers:
+      - after: 720h
+        advances_to: closed
+  closed:
+    terminal: true
+`)
+	for _, file := range []string{"entities.yaml", "policy.yaml", "tools.yaml", "agents.yaml", "events.yaml", "nodes.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", file), "{}\n")
+	}
+	repoRoot := repoRootForBootverifyTest(t)
+	bundle := loadFixtureBundleAt(t, repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if reportContains(report.Errors(), "semantic_drift_unreachable_state", "closed") {
+		t.Fatalf("timer-only terminal was classified unreachable: %#v", report.Errors())
+	}
+}
+
+func TestTimerActivationUsesExactHandlerOriginForTwoJoinsOnOneNode(t *testing.T) {
+	joinA := runtimecontracts.JoinSpec{
+		ID: "join-a", Stage: "awaiting-a",
+		OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "complete-a"},
+		Timeout:    runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "timeout-a"}},
+	}
+	joinB := runtimecontracts.JoinSpec{
+		ID: "join-b", Stage: "awaiting-b",
+		OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "complete-b"},
+		Timeout:    runtimecontracts.JoinTimeoutSpec{After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "timeout-b"}},
+	}
+	handlers := map[string]runtimecontracts.SystemNodeEventHandler{
+		"join.a.requested": {Join: &joinA},
+		"join.b.requested": {Join: &joinB},
+	}
+	transitions := []runtimecontracts.HandlerTransitionSemantic{
+		{NodeID: "join-node", EventType: "join.a.requested", Join: &joinA},
+		{NodeID: "join-node", EventType: "join.b.requested", Join: &joinB},
+	}
+	stages := []string{"waiting", "awaiting-a", "complete-a", "timeout-a", "awaiting-b", "complete-b", "timeout-b"}
+	topology := runtimecontracts.BuildWorkflowStageTopology("", "waiting", stages, []string{"complete-a", "timeout-a", "complete-b", "timeout-b"}, transitions, nil, nil)
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true}},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"join.a.requested": {},
+			"join.b.requested": {},
+		},
+		Nodes: map[string]runtimecontracts.SystemNodeContract{"join-node": {EventHandlers: handlers}},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			InitialStage: "waiting",
+			Stages:       stageContracts(stages),
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{"join-node": handlers},
+			StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{
+				"": topology,
+			},
+		},
+	}
+	trigger, err := timeridentity.ParseStartTrigger("event:join.a.requested")
+	if err != nil {
+		t.Fatal(err)
+	}
+	declared := stringSet(stages)
+	got := timerActivationStates(semanticview.Wrap(bundle), runtimecontracts.WorkflowTimerContract{}, trigger, declared)
+	for _, target := range []string{"complete-a", "timeout-a"} {
+		if _, ok := got[target]; !ok {
+			t.Fatalf("activation states = %#v, missing %s", got, target)
+		}
+	}
+	for _, crossed := range []string{"complete-b", "timeout-b"} {
+		if _, ok := got[crossed]; ok {
+			t.Fatalf("activation states = %#v, cross-associated %s", got, crossed)
+		}
+	}
+}
+
+func TestTimerActivationConsumesEveryCanonicalHandlerCarrier(t *testing.T) {
+	accumulate := &runtimecontracts.AccumulateSpec{
+		OnComplete: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "accumulated"}},
+		OnTimeout:  &runtimecontracts.HandlerRuleEntry{AdvancesTo: "timed-out"},
+	}
+	tests := []struct {
+		name       string
+		handler    runtimecontracts.SystemNodeEventHandler
+		transition runtimecontracts.HandlerTransitionSemantic
+		loops      []runtimecontracts.WorkflowLoopPlan
+		want       []string
+	}{
+		{name: "source scopes without target", want: []string{"waiting", "working"}},
+		{name: "direct", handler: runtimecontracts.SystemNodeEventHandler{AdvancesTo: "direct"}, transition: runtimecontracts.HandlerTransitionSemantic{AdvancesTo: "direct"}, want: []string{"direct"}},
+		{name: "rules", handler: runtimecontracts.SystemNodeEventHandler{Rules: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "ruled"}}}, transition: runtimecontracts.HandlerTransitionSemantic{Rules: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "ruled"}}}, want: []string{"ruled"}},
+		{name: "on complete", handler: runtimecontracts.SystemNodeEventHandler{OnComplete: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "completed"}}}, transition: runtimecontracts.HandlerTransitionSemantic{OnComplete: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "completed"}}}, want: []string{"completed"}},
+		{name: "accumulator", handler: runtimecontracts.SystemNodeEventHandler{Accumulate: accumulate}, transition: runtimecontracts.HandlerTransitionSemantic{Accumulate: accumulate}, want: []string{"accumulated", "timed-out"}},
+		{
+			name: "loop target and escape",
+			handler: runtimecontracts.SystemNodeEventHandler{
+				AdvancesTo: "working",
+				Loop:       &runtimecontracts.LoopOperationSpec{Repeat: "revision", From: "working"},
+			},
+			transition: runtimecontracts.HandlerTransitionSemantic{
+				AdvancesTo: "working",
+				Loop:       &runtimecontracts.LoopOperationSpec{Repeat: "revision", From: "working"},
+			},
+			loops: []runtimecontracts.WorkflowLoopPlan{{
+				ID: "revision", Escape: runtimecontracts.LoopEscapeSpec{AdvancesTo: "escaped"},
+				Operations: []runtimecontracts.WorkflowLoopOperationPlan{{NodeID: "node", HandlerEvent: "work", Kind: runtimecontracts.LoopOperationRepeat, From: "working"}},
+			}},
+			want: []string{"escaped", "working"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stages := []string{"waiting", "working", "done"}
+			for _, target := range tc.want {
+				if _, exists := stringSet(stages)[target]; !exists {
+					stages = append(stages, target)
+				}
+			}
+			transition := tc.transition
+			transition.NodeID = "node"
+			transition.EventType = "work"
+			topology := runtimecontracts.BuildWorkflowStageTopology("", "waiting", stages, []string{"done"}, []runtimecontracts.HandlerTransitionSemantic{transition}, nil, tc.loops)
+			handlers := map[string]runtimecontracts.SystemNodeEventHandler{"work": tc.handler}
+			bundle := &runtimecontracts.WorkflowContractBundle{
+				Events: map[string]runtimecontracts.EventCatalogEntry{"work": {}},
+				Nodes:  map[string]runtimecontracts.SystemNodeContract{"node": {EventHandlers: handlers}},
+				Semantics: runtimecontracts.WorkflowSemanticView{
+					NodeHandlers:    map[string]map[string]runtimecontracts.SystemNodeEventHandler{"node": handlers},
+					StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{"": topology},
+				},
+			}
+			trigger, err := timeridentity.ParseStartTrigger("event:work")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := timerActivationStates(semanticview.Wrap(bundle), runtimecontracts.WorkflowTimerContract{}, trigger, stringSet(stages))
+			if len(got) != len(tc.want) {
+				t.Fatalf("activation states = %#v, want %v", got, tc.want)
+			}
+			for _, want := range tc.want {
+				if _, ok := got[want]; !ok {
+					t.Fatalf("activation states = %#v, missing %s", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLifecycleReachabilityConsumesLoopEscapeAndTimerCancelPreservesNonHandlerEdges(t *testing.T) {
+	topology := runtimecontracts.WorkflowStageTopology{
+		FlowID: "", InitialStage: "waiting", Stages: []string{"waiting", "review", "done"}, TerminalStages: []string{"done"},
+		Edges: []runtimecontracts.WorkflowStageTopologyEdge{
+			{From: "waiting", To: "review", Source: "handler.advances_to", NodeID: "node", HandlerEvent: "work.started", EventType: "work.started"},
+			{From: "review", To: "done", Source: "loop.escape", NodeID: "node", HandlerEvent: "review.revision_requested", EventType: "review.revision_requested"},
+		},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events:    map[string]runtimecontracts.EventCatalogEntry{"work.started": {}},
+		Nodes:     map[string]runtimecontracts.SystemNodeContract{"node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.started": {AdvancesTo: "review"}}}},
+		Semantics: runtimecontracts.WorkflowSemanticView{StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{"": topology}},
+	}
+	source := semanticview.Wrap(bundle)
+	reachable := authoredReachableStates(source, "", "waiting")
+	if _, ok := reachable["done"]; !ok {
+		t.Fatalf("reachable = %#v, want loop escape target", reachable)
+	}
+	edges := timerCancelStateGraphEdges(source, runtimecontracts.WorkflowTimerContract{Event: "work.started"})
+	if _, ok := edges["waiting"]["review"]; ok {
+		t.Fatalf("cancel graph retained firing handler edge: %#v", edges)
+	}
+	if _, ok := edges["review"]["done"]; !ok {
+		t.Fatalf("cancel graph dropped loop escape edge: %#v", edges)
+	}
+}
+
+func stageContracts(ids []string) []runtimecontracts.WorkflowStageContract {
+	out := make([]runtimecontracts.WorkflowStageContract, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, runtimecontracts.WorkflowStageContract{ID: id})
+	}
+	return out
+}

--- a/internal/runtime/bootverify/workflow_stage_topology_consumption_test.go
+++ b/internal/runtime/bootverify/workflow_stage_topology_consumption_test.go
@@ -101,6 +101,55 @@ func TestTimerActivationUsesExactHandlerOriginForTwoJoinsOnOneNode(t *testing.T)
 	}
 }
 
+func TestTimerActivationUnionsMultipleMatchingHandlerTopologies(t *testing.T) {
+	stages := []string{"waiting", "exact-target", "pattern-target"}
+	handlers := map[string]runtimecontracts.SystemNodeContract{
+		"exact-node": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"work.requested": {AdvancesTo: "exact-target"},
+			},
+		},
+		"pattern-node": {
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+				"*.requested": {AdvancesTo: "pattern-target"},
+			},
+		},
+	}
+	topology := runtimecontracts.BuildWorkflowStageTopology(
+		"", "waiting", stages, []string{"exact-target", "pattern-target"},
+		[]runtimecontracts.HandlerTransitionSemantic{
+			{NodeID: "exact-node", EventType: "work.requested", AdvancesTo: "exact-target"},
+			{NodeID: "pattern-node", EventType: "*.requested", AdvancesTo: "pattern-target"},
+		},
+		nil,
+		nil,
+	)
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{"work.requested": {}},
+		Nodes:  handlers,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"exact-node":   handlers["exact-node"].EventHandlers,
+				"pattern-node": handlers["pattern-node"].EventHandlers,
+			},
+			StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{"": topology},
+		},
+	}
+	trigger, err := timeridentity.ParseStartTrigger("event:work.requested")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := timerActivationStates(semanticview.Wrap(bundle), runtimecontracts.WorkflowTimerContract{}, trigger, stringSet(stages))
+	for _, target := range []string{"exact-target", "pattern-target"} {
+		if _, ok := got[target]; !ok {
+			t.Fatalf("activation states = %#v, missing %s from matching handler union", got, target)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("activation states = %#v, want exact union of two handler topologies", got)
+	}
+}
+
 func TestTimerActivationConsumesEveryCanonicalHandlerCarrier(t *testing.T) {
 	accumulate := &runtimecontracts.AccumulateSpec{
 		OnComplete: []runtimecontracts.HandlerRuleEntry{{AdvancesTo: "accumulated"}},
@@ -173,30 +222,61 @@ func TestTimerActivationConsumesEveryCanonicalHandlerCarrier(t *testing.T) {
 	}
 }
 
-func TestLifecycleReachabilityConsumesLoopEscapeAndTimerCancelPreservesNonHandlerEdges(t *testing.T) {
-	topology := runtimecontracts.WorkflowStageTopology{
-		FlowID: "", InitialStage: "waiting", Stages: []string{"waiting", "review", "done"}, TerminalStages: []string{"done"},
-		Edges: []runtimecontracts.WorkflowStageTopologyEdge{
-			{From: "waiting", To: "review", Source: "handler.advances_to", NodeID: "node", HandlerEvent: "work.started", EventType: "work.started"},
-			{From: "review", To: "done", Source: "loop.escape", NodeID: "node", HandlerEvent: "review.revision_requested", EventType: "review.revision_requested"},
+func TestLifecycleReachabilityConsumesLoopEscapeAndTimerCancelPreservesEveryOtherCarrier(t *testing.T) {
+	join := &runtimecontracts.JoinSpec{
+		ID: "approval", Stage: "joining",
+		OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "joined"},
+		Timeout: runtimecontracts.JoinTimeoutSpec{
+			After:   "1h",
+			Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "join-timed-out"},
 		},
 	}
+	stages := []string{"waiting", "review", "joining", "joined", "join-timed-out", "expired", "escaped"}
+	topology := runtimecontracts.BuildWorkflowStageTopology(
+		"", "waiting", stages, []string{"joined", "join-timed-out", "expired", "escaped"},
+		[]runtimecontracts.HandlerTransitionSemantic{
+			{NodeID: "work-node", EventType: "work.started", AdvancesTo: "review"},
+			{NodeID: "join-node", EventType: "approval.requested", AdvancesTo: "joining", Join: join},
+		},
+		[]runtimecontracts.WorkflowTimerContract{{ID: "review.expire", Stage: "review", StageOwned: true, Event: runtimecontracts.WorkflowStageTimerInternalEvent, AdvancesTo: "expired"}},
+		[]runtimecontracts.WorkflowLoopPlan{{
+			ID: "revision", Escape: runtimecontracts.LoopEscapeSpec{AdvancesTo: "escaped"},
+			Operations: []runtimecontracts.WorkflowLoopOperationPlan{{NodeID: "review-node", HandlerEvent: "review.revision_requested", Kind: runtimecontracts.LoopOperationRepeat, From: "review"}},
+		}},
+	)
+	handlers := map[string]runtimecontracts.SystemNodeContract{
+		"work-node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.started": {AdvancesTo: "review"}}},
+		"join-node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"approval.requested": {AdvancesTo: "joining", Join: join}}},
+	}
 	bundle := &runtimecontracts.WorkflowContractBundle{
-		Events:    map[string]runtimecontracts.EventCatalogEntry{"work.started": {}},
-		Nodes:     map[string]runtimecontracts.SystemNodeContract{"node": {EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.started": {AdvancesTo: "review"}}}},
-		Semantics: runtimecontracts.WorkflowSemanticView{StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{"": topology}},
+		Events: map[string]runtimecontracts.EventCatalogEntry{"work.started": {}, "approval.requested": {}},
+		Nodes:  handlers,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"work-node": handlers["work-node"].EventHandlers,
+				"join-node": handlers["join-node"].EventHandlers,
+			},
+			StageTopologies: map[string]runtimecontracts.WorkflowStageTopology{"": topology},
+		},
 	}
 	source := semanticview.Wrap(bundle)
 	reachable := authoredReachableStates(source, "", "waiting")
-	if _, ok := reachable["done"]; !ok {
+	if _, ok := reachable["escaped"]; !ok {
 		t.Fatalf("reachable = %#v, want loop escape target", reachable)
 	}
 	edges := timerCancelStateGraphEdges(source, runtimecontracts.WorkflowTimerContract{Event: "work.started"})
 	if _, ok := edges["waiting"]["review"]; ok {
 		t.Fatalf("cancel graph retained firing handler edge: %#v", edges)
 	}
-	if _, ok := edges["review"]["done"]; !ok {
-		t.Fatalf("cancel graph dropped loop escape edge: %#v", edges)
+	for _, edge := range [][2]string{
+		{"review", "escaped"},
+		{"review", "expired"},
+		{"joining", "joined"},
+		{"joining", "join-timed-out"},
+	} {
+		if _, ok := edges[edge[0]][edge[1]]; !ok {
+			t.Fatalf("cancel graph dropped %s -> %s carrier: %#v", edge[0], edge[1], edges)
+		}
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
+++ b/internal/runtime/bootverify/workflow_state_machine_reachability_checks.go
@@ -36,7 +36,7 @@ func (c *checkerContext) stateReachability() []Finding {
 			continue
 		}
 
-		reachable := authoredReachableStates(c.source, flowID, initial, declaredStates)
+		reachable := authoredReachableStates(c.source, flowID, initial)
 		unreachable := make(map[string]struct{}, len(declaredStates))
 		for state := range declaredStates {
 			if _, ok := reachable[state]; ok {
@@ -60,7 +60,7 @@ func (c *checkerContext) stateReachability() []Finding {
 		}
 		for _, state := range sortedSetKeys(unreachable) {
 			message := fmt.Sprintf(
-				"flow %s declares %s %s but no transition path from %s %s reaches %s in the authored handler graph.\n\nReachable states: %s\nUnreachable states: %s",
+				"flow %s declares %s %s but no transition path from %s %s reaches %s in the authored transition graph.\n\nReachable states: %s\nUnreachable states: %s",
 				validationFlowLabel(flowID),
 				declaredNoun,
 				state,
@@ -98,12 +98,12 @@ func (c *checkerContext) stateReachability() []Finding {
 	return c.stateReachabilityFindings
 }
 
-func authoredReachableStates(source semanticview.Source, flowID, initial string, declaredStates map[string]struct{}) map[string]struct{} {
+func authoredReachableStates(source semanticview.Source, flowID, initial string) map[string]struct{} {
 	flowID = strings.TrimSpace(flowID)
 	initial = strings.TrimSpace(initial)
 
 	reachable := map[string]struct{}{initial: {}}
-	edges := authoredStateGraphEdges(source, flowID, initial, declaredStates)
+	edges := workflowStageGraphEdges(source, flowID, nil)
 	queue := []string{initial}
 	for len(queue) > 0 {
 		state := strings.TrimSpace(queue[0])
@@ -119,72 +119,28 @@ func authoredReachableStates(source semanticview.Source, flowID, initial string,
 	return reachable
 }
 
-func authoredStateGraphEdges(source semanticview.Source, flowID, initial string, declaredStates map[string]struct{}) map[string]map[string]struct{} {
-	return authoredStateGraphEdgesFiltered(source, flowID, initial, declaredStates, nil)
-}
-
-func authoredStateGraphEdgesFiltered(
+func workflowStageGraphEdges(
 	source semanticview.Source,
-	flowID, initial string,
-	declaredStates map[string]struct{},
-	includeHandler func(nodeID, eventType string, handler runtimecontracts.SystemNodeEventHandler) bool,
+	flowID string,
+	include func(runtimecontracts.WorkflowStageTopologyEdge) bool,
 ) map[string]map[string]struct{} {
-	edges := make(map[string]map[string]struct{}, len(declaredStates))
-	nonTerminalStates := authoredNonTerminalStates(source, flowID, declaredStates)
-	for nodeID, node := range source.NodeEntries() {
-		nodeID = strings.TrimSpace(nodeID)
-		if nodeID == "" || strings.TrimSpace(nodeFlowID(source, nodeID)) != flowID {
+	edges := map[string]map[string]struct{}{}
+	topology, ok := semanticview.WorkflowStageTopology(source, strings.TrimSpace(flowID))
+	if !ok {
+		return edges
+	}
+	for _, edge := range topology.Edges {
+		if include != nil && !include(edge) {
 			continue
 		}
-		for eventType, handler := range node.EventHandlers {
-			eventType = strings.TrimSpace(eventType)
-			if includeHandler != nil && !includeHandler(nodeID, eventType, handler) {
-				continue
-			}
-			sources := authoredHandlerSourceStates(initial, nonTerminalStates, handler)
-			for _, target := range authoredReachabilityTargets(handler) {
-				target = strings.TrimSpace(target)
-				if target == "" {
-					continue
-				}
-				if _, ok := declaredStates[target]; !ok {
-					continue
-				}
-				for _, sourceState := range sources {
-					sourceState = strings.TrimSpace(sourceState)
-					if sourceState == "" {
-						continue
-					}
-					if edges[sourceState] == nil {
-						edges[sourceState] = map[string]struct{}{}
-					}
-					edges[sourceState][target] = struct{}{}
-				}
-			}
+		from, to := strings.TrimSpace(edge.From), strings.TrimSpace(edge.To)
+		if from == "" || to == "" {
+			continue
 		}
+		if edges[from] == nil {
+			edges[from] = map[string]struct{}{}
+		}
+		edges[from][to] = struct{}{}
 	}
 	return edges
-}
-
-func authoredReachabilityTargets(handler runtimecontracts.SystemNodeEventHandler) []string {
-	return runtimecontracts.HandlerAdvanceTargets(handler)
-}
-
-func authoredNonTerminalStates(source semanticview.Source, flowID string, declaredStates map[string]struct{}) []string {
-	terminalStates := stringSet(source.FlowTerminalStages(flowID))
-	out := make([]string, 0, len(declaredStates))
-	for _, state := range sortedSetKeys(declaredStates) {
-		if _, ok := terminalStates[state]; ok {
-			continue
-		}
-		out = append(out, state)
-	}
-	return out
-}
-
-func authoredHandlerSourceStates(initial string, nonTerminalStates []string, handler runtimecontracts.SystemNodeEventHandler) []string {
-	if handler.CreateEntity {
-		return []string{strings.TrimSpace(initial)}
-	}
-	return append([]string{}, nonTerminalStates...)
 }

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -251,7 +251,7 @@ func (c *checkerContext) validateTimerCancelStateReachability(timer runtimecontr
 	if strings.TrimSpace(initial) == "" {
 		return
 	}
-	activationStates := timerActivationStates(c.source, timer, startTrigger, initial, declaredStates)
+	activationStates := timerActivationStates(c.source, timer, startTrigger, declaredStates)
 	if len(activationStates) == 0 {
 		c.timerFindings = append(c.timerFindings, Finding{
 			CheckID:  "timer_validation",
@@ -261,7 +261,7 @@ func (c *checkerContext) validateTimerCancelStateReachability(timer runtimecontr
 		})
 		return
 	}
-	edges := timerCancelStateGraphEdges(c.source, timer, initial, declaredStates)
+	edges := timerCancelStateGraphEdges(c.source, timer)
 	unreachableActivationStates := timerActivationStatesWithoutPostActivationReachability(edges, activationStates, cancelState)
 	if len(unreachableActivationStates) == 0 {
 		return
@@ -282,7 +282,7 @@ func (c *checkerContext) validateTimerCancelStateReachability(timer runtimecontr
 	})
 }
 
-func timerActivationStates(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, startTrigger timeridentity.Trigger, initial string, declaredStates map[string]struct{}) map[string]struct{} {
+func timerActivationStates(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, startTrigger timeridentity.Trigger, declaredStates map[string]struct{}) map[string]struct{} {
 	out := map[string]struct{}{}
 	if source == nil || !startTrigger.Valid() {
 		return out
@@ -296,23 +296,20 @@ func timerActivationStates(source semanticview.Source, timer runtimecontracts.Wo
 	case timeridentity.TriggerKindEvent:
 		flowID := strings.TrimSpace(timer.FlowID)
 		ref := semanticview.ResolveFlowEventProof(source, flowID, startTrigger.Name)
-		nonTerminalStates := authoredNonTerminalStates(source, flowID, declaredStates)
-		for nodeID, node := range source.NodeEntries() {
-			nodeID = strings.TrimSpace(nodeID)
-			if nodeID == "" || strings.TrimSpace(nodeFlowID(source, nodeID)) != flowID {
+		topology, ok := semanticview.WorkflowStageTopology(source, flowID)
+		if !ok {
+			return out
+		}
+		for _, handler := range topology.Handlers {
+			if !timerHandlerMatchesEvent(source, flowID, handler.EventType, ref) {
 				continue
 			}
-			for eventType, handler := range node.EventHandlers {
-				if !timerHandlerMatchesEvent(source, flowID, eventType, ref) {
-					continue
-				}
-				targets := authoredReachabilityTargets(handler)
-				if len(targets) == 0 {
-					addTimerActivationStates(out, declaredStates, authoredHandlerSourceStates(initial, nonTerminalStates, handler))
-					continue
-				}
-				addTimerActivationStates(out, declaredStates, targets)
+			targets := topology.HandlerTargets(handler.NodeID, handler.EventType)
+			if len(targets) == 0 {
+				addTimerActivationStates(out, declaredStates, handler.Stages)
+				continue
 			}
+			addTimerActivationStates(out, declaredStates, targets)
 		}
 	}
 	return out
@@ -331,11 +328,12 @@ func addTimerActivationStates(out map[string]struct{}, declaredStates map[string
 	}
 }
 
-func timerCancelStateGraphEdges(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract, initial string, declaredStates map[string]struct{}) map[string]map[string]struct{} {
+func timerCancelStateGraphEdges(source semanticview.Source, timer runtimecontracts.WorkflowTimerContract) map[string]map[string]struct{} {
 	flowID := strings.TrimSpace(timer.FlowID)
 	fireRef := semanticview.ResolveFlowEventProof(source, flowID, timer.Event)
-	return authoredStateGraphEdgesFiltered(source, flowID, initial, declaredStates, func(_ string, eventType string, _ runtimecontracts.SystemNodeEventHandler) bool {
-		return !timerHandlerMatchesEvent(source, flowID, eventType, fireRef)
+	return workflowStageGraphEdges(source, flowID, func(edge runtimecontracts.WorkflowStageTopologyEdge) bool {
+		handlerEvent := strings.TrimSpace(edge.HandlerEvent)
+		return handlerEvent == "" || !timerHandlerMatchesEvent(source, flowID, handlerEvent, fireRef)
 	})
 }
 

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -362,6 +362,7 @@ type WorkflowStageTopologyEdge struct {
 	To            string
 	Source        string
 	NodeID        string
+	HandlerEvent  string
 	EventType     string
 	LoopID        string
 	LoopOperation LoopOperationKind

--- a/internal/runtime/contracts/workflow_contract_yaml.go
+++ b/internal/runtime/contracts/workflow_contract_yaml.go
@@ -8,15 +8,7 @@ import (
 )
 
 func hasYAMLMappingKey(node *yaml.Node, key string) bool {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return false
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if strings.TrimSpace(node.Content[i].Value) == key {
-			return true
-		}
-	}
-	return false
+	return yamlMappingValue(node, key) != nil
 }
 
 func hasAnyYAMLMappingKey(node *yaml.Node, keys ...string) bool {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -900,7 +900,7 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 	if e == nil {
 		return nil
 	}
-	if hasYAMLMappingKey(node, "payload") {
+	if payloadNode := yamlMappingValue(node, "payload"); eventPayloadNodeIsRetiredNestedBlock(payloadNode) {
 		return fmt.Errorf("RETIRED: nested events.yaml payload blocks are no longer supported; move payload fields to the event top level")
 	}
 	if err := rejectRetiredEventMetadataFields(node); err != nil {
@@ -929,7 +929,6 @@ func (e *EventCatalogEntry) UnmarshalYAML(node *yaml.Node) error {
 		RuntimeHandling    string                 `yaml:"runtime_handling"`
 		OwningNode         string                 `yaml:"owning_node"`
 		DeliveryChannel    yaml.Node              `yaml:"delivery_channel"`
-		Payload            yaml.Node              `yaml:"payload"`
 		Required           []string               `yaml:"required"`
 	}
 	if err := node.Decode(&aux); err != nil {

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -1184,38 +1184,7 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 		return wave1ParsedFieldNode{}, fmt.Errorf("unsupported %s yaml node kind %d", opts.Context, node.Kind)
 	}
 
-	allowed := map[string]struct{}{
-		"type":        {},
-		"description": {},
-		"pattern":     {},
-		"length":      {},
-		"range":       {},
-		"equal_to":    {},
-	}
-	if opts.AllowInitial {
-		allowed["initial"] = struct{}{}
-	}
-	if opts.AllowImmutable {
-		allowed["immutable"] = struct{}{}
-	}
-	if opts.AllowIndexed {
-		allowed["indexed"] = struct{}{}
-	}
-	if opts.AllowUnusedReason {
-		allowed["_unused_reason"] = struct{}{}
-	}
-	if opts.AllowUnusedReaderReason {
-		allowed["_unused_reader_reason"] = struct{}{}
-	}
-	if opts.AllowMaterializeFrom {
-		allowed["materialize_from"] = struct{}{}
-	}
-	if opts.AllowProject {
-		allowed["project"] = struct{}{}
-	}
-	if opts.AllowCitation {
-		allowed["citation"] = struct{}{}
-	}
+	allowed := wave1FieldNodeAllowedKeys(opts)
 
 	var field wave1ParsedFieldNode
 	var listOf string
@@ -1357,6 +1326,69 @@ func decodeWave1FieldNode(node *yaml.Node, opts wave1FieldNodeOptions) (wave1Par
 		return wave1ParsedFieldNode{}, fmt.Errorf("%s _unused_reader_reason must be at least 10 characters", opts.Context)
 	}
 	return field, nil
+}
+
+func wave1FieldNodeAllowedKeys(opts wave1FieldNodeOptions) map[string]struct{} {
+	allowed := map[string]struct{}{
+		"type":        {},
+		"description": {},
+		"pattern":     {},
+		"length":      {},
+		"range":       {},
+		"equal_to":    {},
+	}
+	if opts.AllowInitial {
+		allowed["initial"] = struct{}{}
+	}
+	if opts.AllowImmutable {
+		allowed["immutable"] = struct{}{}
+	}
+	if opts.AllowIndexed {
+		allowed["indexed"] = struct{}{}
+	}
+	if opts.AllowUnusedReason {
+		allowed["_unused_reason"] = struct{}{}
+	}
+	if opts.AllowUnusedReaderReason {
+		allowed["_unused_reader_reason"] = struct{}{}
+	}
+	if opts.AllowMaterializeFrom {
+		allowed["materialize_from"] = struct{}{}
+	}
+	if opts.AllowProject {
+		allowed["project"] = struct{}{}
+	}
+	if opts.AllowCitation {
+		allowed["citation"] = struct{}{}
+	}
+	return allowed
+}
+
+func wave1FieldNodeSupportsKey(opts wave1FieldNodeOptions, key string) bool {
+	if strings.TrimSpace(key) == "of" {
+		return true
+	}
+	_, ok := wave1FieldNodeAllowedKeys(opts)[strings.TrimSpace(key)]
+	return ok
+}
+
+func eventPayloadNodeIsRetiredNestedBlock(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	if hasAnyYAMLMappingKey(node, "properties", "fields", "shape", "required") {
+		return true
+	}
+	hasType := hasYAMLMappingKey(node, "type")
+	opts := wave1FieldNodeOptions{Context: "event payload field", AllowCitation: true}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if key == "" || wave1FieldNodeSupportsKey(opts, key) {
+			continue
+		}
+		return !hasType
+	}
+	return false
 }
 
 func decodeSchemaRefinementPattern(node *yaml.Node) (string, error) {
@@ -1576,7 +1608,7 @@ func buildFlatEventPayloadSpec(node *yaml.Node) (EventPayloadSpec, error) {
 			continue
 		}
 		switch key {
-		case "description", "swarm", "emitter", "emitter_type", "producer", "_producer", "alternate_emitters", "consumer", "_consumer", "consumer_type", "_consumer_type", "_source", "_status", "_note", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "payload", "required":
+		case "description", "swarm", "emitter", "emitter_type", "producer", "_producer", "alternate_emitters", "consumer", "_consumer", "consumer_type", "_consumer_type", "_source", "_status", "_note", "intercepted", "passthrough", "runtime_handling", "owning_node", "delivery_channel", "required":
 			continue
 		}
 		var field EventFieldSpec

--- a/internal/runtime/contracts/workflow_event_payload_field_test.go
+++ b/internal/runtime/contracts/workflow_event_payload_field_test.go
@@ -1,0 +1,72 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestEventCatalogPayloadFieldSupportsEveryWave1Shape(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantType    string
+		wantPattern string
+		wantCite    string
+	}{
+		{name: "scalar", yaml: "payload: json\n", wantType: "json"},
+		{name: "singleton list", yaml: "payload: [json]\n", wantType: "[json]"},
+		{name: "mapping", yaml: "payload: {type: json, description: raw provider envelope}\n", wantType: "json"},
+		{
+			name: "mapping refinements and citation",
+			yaml: `payload:
+  type: text
+  description: provider payload
+  pattern: "^[a-z]+$"
+  citation:
+    criteria: provider_contract
+    allowed_classes: [raw]
+`,
+			wantType: "text", wantPattern: "^[a-z]+$", wantCite: "provider_contract",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var entry EventCatalogEntry
+			if err := yaml.Unmarshal([]byte(tc.yaml), &entry); err != nil {
+				t.Fatalf("yaml.Unmarshal: %v", err)
+			}
+			field, ok := entry.Payload.Properties["payload"]
+			if !ok {
+				t.Fatal("canonical payload property was discarded")
+			}
+			if field.Type != tc.wantType || field.Refinements.Pattern != tc.wantPattern || field.Citation.Criteria != tc.wantCite {
+				t.Fatalf("payload field = %#v", field)
+			}
+		})
+	}
+}
+
+func TestEventCatalogPayloadFieldDistinguishesRetiredBlocksFromMalformedFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{name: "properties block", yaml: "payload:\n  properties:\n    message: json\n", wantErr: "RETIRED: nested events.yaml payload blocks"},
+		{name: "child field block", yaml: "payload:\n  message: json\n", wantErr: "RETIRED: nested events.yaml payload blocks"},
+		{name: "missing type", yaml: "payload:\n  description: raw provider envelope\n", wantErr: "event payload field type is required"},
+		{name: "unknown metadata with type", yaml: "payload:\n  type: json\n  mystery: true\n", wantErr: "event payload field field \"mystery\" is not supported"},
+		{name: "invalid refinement", yaml: "payload:\n  type: text\n  pattern: \"[\"\n", wantErr: "must compile as a regular expression"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var entry EventCatalogEntry
+			err := yaml.Unmarshal([]byte(tc.yaml), &entry)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/runtime/contracts/workflow_event_payload_field_test.go
+++ b/internal/runtime/contracts/workflow_event_payload_field_test.go
@@ -18,6 +18,7 @@ func TestEventCatalogPayloadFieldSupportsEveryWave1Shape(t *testing.T) {
 		{name: "scalar", yaml: "payload: json\n", wantType: "json"},
 		{name: "singleton list", yaml: "payload: [json]\n", wantType: "[json]"},
 		{name: "mapping", yaml: "payload: {type: json, description: raw provider envelope}\n", wantType: "json"},
+		{name: "mapping list", yaml: "payload: {type: list, of: json}\n", wantType: "[json]"},
 		{
 			name: "mapping refinements and citation",
 			yaml: `payload:

--- a/internal/runtime/contracts/workflow_stage_topology.go
+++ b/internal/runtime/contracts/workflow_stage_topology.go
@@ -73,6 +73,7 @@ func BuildWorkflowStageTopology(
 					To:            strings.TrimSpace(carrier.AdvancesTo),
 					Source:        edgeSource,
 					NodeID:        strings.TrimSpace(transition.NodeID),
+					HandlerEvent:  strings.TrimSpace(transition.EventType),
 					EventType:     eventType,
 					LoopID:        loopID,
 					LoopOperation: loopKind,
@@ -96,6 +97,7 @@ func BuildWorkflowStageTopology(
 				To:            strings.TrimSpace(plan.Escape.AdvancesTo),
 				Source:        "loop.escape",
 				NodeID:        strings.TrimSpace(operation.NodeID),
+				HandlerEvent:  strings.TrimSpace(operation.HandlerEvent),
 				EventType:     strings.TrimSpace(operation.HandlerEvent),
 				LoopID:        strings.TrimSpace(plan.ID),
 				LoopOperation: LoopOperationRepeat,
@@ -154,6 +156,20 @@ func (t WorkflowStageTopology) HandlerStages(nodeID, eventType string) []string 
 		}
 	}
 	return nil
+}
+
+func (t WorkflowStageTopology) HandlerTargets(nodeID, handlerEvent string) []string {
+	nodeID, handlerEvent = strings.TrimSpace(nodeID), strings.TrimSpace(handlerEvent)
+	targets := map[string]struct{}{}
+	for _, edge := range t.Edges {
+		if strings.TrimSpace(edge.NodeID) != nodeID || strings.TrimSpace(edge.HandlerEvent) != handlerEvent {
+			continue
+		}
+		if target := strings.TrimSpace(edge.To); target != "" {
+			targets[target] = struct{}{}
+		}
+	}
+	return sortedStringSet(targets)
 }
 
 func BindWorkflowLoopRegions(plans []WorkflowLoopPlan, topologies map[string]WorkflowStageTopology) []WorkflowLoopPlan {
@@ -228,7 +244,7 @@ func joinTimerDelay(transition HandlerTransitionSemantic, carrier HandlerAdvance
 }
 
 func topologyEdgeSortKey(edge WorkflowStageTopologyEdge) string {
-	return strings.Join([]string{edge.From, edge.To, edge.Source, edge.NodeID, edge.EventType, edge.LoopID, string(edge.LoopOperation), edge.TimerID, edge.After}, "\x00")
+	return strings.Join([]string{edge.From, edge.To, edge.Source, edge.NodeID, edge.HandlerEvent, edge.EventType, edge.LoopID, string(edge.LoopOperation), edge.TimerID, edge.After}, "\x00")
 }
 
 func normalizedStringSet(values []string) map[string]struct{} {

--- a/internal/runtime/contracts/workflow_stage_topology_provenance_test.go
+++ b/internal/runtime/contracts/workflow_stage_topology_provenance_test.go
@@ -1,0 +1,87 @@
+package contracts
+
+import "testing"
+
+func TestWorkflowStageTopologyPreservesHandlerOriginAndEffectiveEvent(t *testing.T) {
+	joinA := JoinSpec{
+		ID: "join-a", Stage: "awaiting-a",
+		OnComplete: HandlerRuleEntry{AdvancesTo: "complete-a"},
+		Timeout:    JoinTimeoutSpec{After: "1h", Outcome: HandlerRuleEntry{AdvancesTo: "timeout-a"}},
+	}
+	joinB := JoinSpec{
+		ID: "join-b", Stage: "awaiting-b",
+		OnComplete: HandlerRuleEntry{AdvancesTo: "complete-b"},
+		Timeout:    JoinTimeoutSpec{After: "2h", Outcome: HandlerRuleEntry{AdvancesTo: "timeout-b"}},
+	}
+	topology := BuildWorkflowStageTopology(
+		"", "waiting",
+		[]string{"waiting", "awaiting-a", "complete-a", "timeout-a", "awaiting-b", "complete-b", "timeout-b"},
+		[]string{"complete-a", "timeout-a", "complete-b", "timeout-b"},
+		[]HandlerTransitionSemantic{
+			{NodeID: "join-node", EventType: "join.a.requested", Join: &joinA},
+			{NodeID: "join-node", EventType: "join.b.requested", Join: &joinB},
+		},
+		nil,
+		nil,
+	)
+
+	assertTargets := func(handler string, want ...string) {
+		t.Helper()
+		got := topology.HandlerTargets("join-node", handler)
+		if len(got) != len(want) {
+			t.Fatalf("HandlerTargets(%q) = %v, want %v", handler, got, want)
+		}
+		for idx := range want {
+			if got[idx] != want[idx] {
+				t.Fatalf("HandlerTargets(%q) = %v, want %v", handler, got, want)
+			}
+		}
+	}
+	assertTargets("join.a.requested", "complete-a", "timeout-a")
+	assertTargets("join.b.requested", "complete-b", "timeout-b")
+
+	for _, edge := range topology.Edges {
+		if edge.Source != string(HandlerAdvanceCarrierJoinTimeout) {
+			continue
+		}
+		if edge.EventType != "platform.join_timeout" {
+			t.Fatalf("join timeout effective event = %q", edge.EventType)
+		}
+		if edge.HandlerEvent != "join.a.requested" && edge.HandlerEvent != "join.b.requested" {
+			t.Fatalf("join timeout handler origin = %q", edge.HandlerEvent)
+		}
+	}
+}
+
+func TestWorkflowStageTopologyStampsLoopAndTimerOrigins(t *testing.T) {
+	topology := BuildWorkflowStageTopology(
+		"", "drafting", []string{"drafting", "review", "exhausted", "expired"}, []string{"exhausted", "expired"},
+		nil,
+		[]WorkflowTimerContract{{ID: "review.expire", Stage: "review", StageOwned: true, Event: WorkflowStageTimerInternalEvent, AdvancesTo: "expired"}},
+		[]WorkflowLoopPlan{{
+			ID: "revision", Escape: LoopEscapeSpec{AdvancesTo: "exhausted"},
+			Operations: []WorkflowLoopOperationPlan{{NodeID: "review-node", HandlerEvent: "review.revision_requested", Kind: LoopOperationRepeat, From: "review"}},
+		}},
+	)
+	for _, edge := range topology.Edges {
+		switch edge.Source {
+		case "loop.escape":
+			if edge.HandlerEvent != "review.revision_requested" {
+				t.Fatalf("loop escape origin = %q", edge.HandlerEvent)
+			}
+		case "timer":
+			if edge.HandlerEvent != "" {
+				t.Fatalf("stage timer handler origin = %q, want empty", edge.HandlerEvent)
+			}
+		}
+	}
+}
+
+func TestTopologyEdgeIdentityIncludesHandlerOrigin(t *testing.T) {
+	stages := map[string]struct{}{"waiting": {}, "done": {}}
+	edges := appendTopologyEdge(nil, stages, WorkflowStageTopologyEdge{From: "waiting", To: "done", Source: "handler.join.timeout", NodeID: "node", HandlerEvent: "a", EventType: "platform.join_timeout"})
+	edges = appendTopologyEdge(edges, stages, WorkflowStageTopologyEdge{From: "waiting", To: "done", Source: "handler.join.timeout", NodeID: "node", HandlerEvent: "b", EventType: "platform.join_timeout"})
+	if len(edges) != 2 {
+		t.Fatalf("edges = %#v, want distinct handler origins", edges)
+	}
+}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -383,6 +383,14 @@ contract_formats:
         declared text revision field. Verify requires one start, at least one
         repeat and close, and disjoint flat regions. Nested, overlapping,
         computed, unbounded, or arbitrary loops are rejected and belong to #1671.
+        Every handler-derived typed edge preserves the originating handler event
+        separately from its effective execution event. They are equal for
+        ordinary handler carriers; a join-timeout edge retains its originating
+        handler while its effective event is platform.join_timeout. Loop escape
+        edges retain the operation handler, and stage-timer edges have no handler
+        origin. Edge identity and every verifier/projection consumer use this
+        typed provenance rather than reconstructing ownership from node, source,
+        or timer strings.
       identity_and_admission: >
         Activation and revision IDs are deterministic run/entity/flow/loop facts.
         Exact delivery identity remains idempotent. A prior or post-close revision


### PR DESCRIPTION
## Summary

This batch closes three independently audited verifier/loader failure classes without merging their semantic ownership:

- lifecycle reachability, join re-entry, timer cancellation, and timer activation now consume one provenance-complete `WorkflowStageTopology`;
- generated durable-activity results are recognized from the canonical activity-site/result identity owners rather than treated as authored orphan events;
- an event field literally named `payload` now traverses every supported Wave 1 field shape, while true nested legacy payload blocks remain retired.

Closes #2005
Closes #2006
Part of #2009

`#2009` remains open for walls 2/3, owned by #1962.

## Governing authority

- `platform-spec.yaml#contract_formats.flow_schema.stages_authoring.temporal_rows`: stage-timer `advances_to` lowers to the transition-edge model.
- `platform-spec.yaml#contract_formats.flow_schema.bounded_loops.topology`: one canonical lifecycle graph owns handler/join/timer/loop edges. This PR adds the approved origin-handler versus effective-event provenance clarification and `.changes/platform/2005.yaml` for platform train `0.7.0`.
- `platform-spec.yaml#contract_formats.event_schema`: non-reserved top-level event keys are flat producer-owned payload fields.
- `platform-spec.yaml#system_node_contract.event_handlers.activity.generated_result_events`: activity results are contract-derived, schema-visible, and not authored in `events.yaml`.
- Binding issue/gate context: #2005, #2006, and wall 1 of #2009.

## Semantic migrations

### Lifecycle topology

- **New canonical owner:** `WorkflowStageTopologyEdge.HandlerEvent` preserves originating handler provenance independently from effective `EventType`; `BuildWorkflowStageTopology`, edge identity, authoring projection, and bootverify consume it.
- **Invalid old readers removed:** `authoredStateGraphEdges`, `authoredStateGraphEdgesFiltered`, `authoredReachabilityTargets`, and `authoredHandlerSourceStates`.
- **Production consumers checked:** ordinary reachability, join re-entry, timer cancel-state graph, timer event activation, loop SCC validation, and authoring graph projection.
- **Migration complete for the chosen class:** yes. #1961 remains the separate exact source-stage authoring/runtime-admission parent.

### Generated activity results

- **Canonical owners:** `ActivitySitesForNode` and `ActivityResultEventsForSite`, normalized through `eventidentity.Normalize`.
- **Invalid old interpretation:** event-topology schema/consumer checks treating exact generated results as ordinary authored events.
- **Production paths checked:** generated catalog/schema registry, effective node produces, endpoint census/routing, subscriptions, handler payload validation, and authored/generated collision validation.
- **Migration complete for the chosen class:** yes; generated producer endpoints and collisions remain intact.

### `payload`-named event fields

- **Canonical owner:** shared Wave 1 `EventFieldSpec` vocabulary and decoder.
- **Invalid old readers removed:** key-presence retirement, flat reserved-key exclusion, and the unused aux `Payload yaml.Node` metadata capture.
- **Production paths checked:** scalar/list/mapping field decoding, malformed diagnostics, retired structural blocks, canonical payload lowering, resolved schema consumption, and nested normalizer coverage.
- **Migration complete for wall 1:** yes. Provider-pack catalog injection remains #1962.

## Verification

- `SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`
- focused contracts/semanticview/authoringview/bootverify suites
- new high-risk parser/topology/activity/normalizer tests repeated with `-count=10`
- `git diff --check`
