### PR TITLE
[agent-e][issue #2010] Unify serve lifecycle presentation

### DIFF
--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -35,7 +35,6 @@ func TestBootFloorConformanceNativeBashHostOptOutIsLoudUnsafe(t *testing.T) {
 		SelfCheck:            true,
 		RequireBundleMatch:   false,
 		ShutdownGrace:        runtimepkg.DefaultShutdownGrace,
-		Verbose:              true,
 		NoRequireBundleMatch: true,
 		TestLLMRuntime:       bootFloorNativeFallbackRuntime{},
 	})
@@ -55,6 +54,9 @@ func TestBootFloorConformanceNativeBashHostOptOutIsLoudUnsafe(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(output), "docker is not reachable") {
 		t.Fatalf("host opt-out serve output shows Docker dependency despite explicit host backend:\n%s", output)
+	}
+	if !strings.Contains(output, "swarm serve · ") || strings.Contains(output, "[1/22]") || strings.Contains(output, "\x1b[") {
+		t.Fatalf("default serve did not use concise non-TTY lifecycle presentation:\n%s", output)
 	}
 }
 

--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -44,9 +44,8 @@ func TestBootFloorConformanceNativeBashHostOptOutIsLoudUnsafe(t *testing.T) {
 	}
 	output := serve.outputString()
 	for _, want := range []string{
-		"workspace backend: host",
-		"native_tools.bash",
-		"UNSAFE: grants the agent execution on this machine",
+		"workspace                  host · agent \"native-bash-worker\" runs on this machine",
+		"WARNING: host workspace lets agents execute on this machine",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("serve output missing %q:\n%s", want, output)

--- a/cmd/swarm/builder_project_supervisor.go
+++ b/cmd/swarm/builder_project_supervisor.go
@@ -129,7 +129,7 @@ func newRuntimeProjectSupervisor(
 			return err
 		},
 		initStateStores: func(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
-			return initializeStateStores(ctx, stores, bundle, false)
+			return initializeStateStores(ctx, stores, bundle)
 		},
 		newWorkspaces: func(stores storeBundle, contractsRoot string, source semanticview.Source, mountSources workspaceMountSources) (workspace.Lifecycle, workspaceBackendSelection, error) {
 			decision, err := decideWorkspaceBackend(workspaceBackend, cfg, source)

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -608,7 +608,7 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 					stores := backend.open(t)
 					var active, maxActive atomic.Int32
 					bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
-					if _, err := initializeStateStores(context.Background(), stores, bundle, false); err != nil {
+					if _, err := initializeStateStores(context.Background(), stores, bundle); err != nil {
 						t.Fatalf("initializeStateStores: %v", err)
 					}
 					source := semanticview.Wrap(bundle)
@@ -805,7 +805,7 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 		t.Run(backend.name, func(t *testing.T) {
 			stores := backend.open(t)
 			bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
-			if _, err := initializeStateStores(context.Background(), stores, bundle, false); err != nil {
+			if _, err := initializeStateStores(context.Background(), stores, bundle); err != nil {
 				t.Fatalf("initializeStateStores: %v", err)
 			}
 			source := semanticview.Wrap(bundle)

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -338,6 +338,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Output = cmd.OutOrStdout()
+			opts.ErrorOutput = cmd.ErrOrStderr()
 			opts.SwarmDir, opts.SwarmDirSet = rootSwarmDirFlag(cmd)
 			code := runServe(ctx, assetCommandRepoRoot(repo), opts)
 			if code != 0 {
@@ -364,7 +365,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs have unavailable bundle source state")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs have unavailable bundle source state")
 	cmd.Flags().BoolVar(&opts.AbandonActiveRuns, "abandon-active-runs", opts.AbandonActiveRuns, "Cancel active runs and quiesce recoverable work before startup recovery")
-	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Emit the serve boot sequence to stdout as each phase completes")
+	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", opts.Verbose, "Render the canonical serve boot sequence after startup succeeds or fails")
 	return cmd
 }
 

--- a/cmd/swarm/cli.go
+++ b/cmd/swarm/cli.go
@@ -293,7 +293,6 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 			if opts.Dev {
 				opts.AbandonActiveRuns = true
 				opts.NoRequireBundleMatch = true
-				opts.Verbose = true
 			}
 			if opts.NoRequireBundleMatch {
 				opts.RequireBundleMatch = false
@@ -361,7 +360,7 @@ func newServeCommand(ctx context.Context, repo string, runServe func(context.Con
 	cmd.Flags().StringVar(&opts.MCPListenAddr, "mcp-listen-addr", opts.MCPListenAddr, "HTTP bind address for MCP and tools routes")
 	cmd.Flags().DurationVar(&opts.ShutdownGrace, "shutdown-grace", opts.ShutdownGrace, "Time to wait for in-flight work to drain after shutdown starts")
 	cmd.Flags().BoolVar(&opts.SelfCheck, "self-check", opts.SelfCheck, "Run runtime self-check during boot")
-	cmd.Flags().BoolVar(&opts.Dev, "dev", opts.Dev, "Enable local development mode: abandon active runs, skip bundle-match admission, emit verbose boot output, and clean up dev entity containers on shutdown")
+	cmd.Flags().BoolVar(&opts.Dev, "dev", opts.Dev, "Enable local development lifecycle: abandon active runs, skip bundle-match admission, use concise boot output, and clean up dev entity containers on shutdown")
 	cmd.Flags().BoolVar(&opts.RequireBundleMatch, "require-bundle-match", opts.RequireBundleMatch, "Refuse startup when active runs have unavailable bundle source state")
 	cmd.Flags().BoolVar(&opts.NoRequireBundleMatch, "no-require-bundle-match", opts.NoRequireBundleMatch, "Allow startup even when active runs have unavailable bundle source state")
 	cmd.Flags().BoolVar(&opts.AbandonActiveRuns, "abandon-active-runs", opts.AbandonActiveRuns, "Cancel active runs and quiesce recoverable work before startup recovery")

--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -538,17 +538,13 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Names:  []string{"action"},
 		Reason: "runtime-log action is exact LogEntry evidence, not a registered watchdog action",
 	},
-	"serve_lifecycle_presentation.go\x00boot": {
-		Names:  []string{"status"},
-		Reason: "canonical serve boot progress status is a lifecycle-presentation taxonomy, not a registered API code family",
-	},
 	"serve_lifecycle_presentation.go\x00writeBootEventLocked": {
 		Names:  []string{"status"},
 		Reason: "canonical serve boot progress status is a lifecycle-presentation taxonomy, not a registered API code family",
 	},
 	"serve_lifecycle_presentation.go\x00writeResolvedFactsLocked": {
 		Names:  []string{"status"},
-		Reason: "canonical startup recovery outcome is a lifecycle-presentation taxonomy, not a registered API code family",
+		Reason: "author-facing recovery status is an explicit serve lifecycle projection, not a registered API code family",
 	},
 	"main.go\x00printRunForkActivation": {
 		Names:  []string{"forkrunstatus", "sourcerunstatus"},

--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -538,13 +538,17 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Names:  []string{"action"},
 		Reason: "runtime-log action is exact LogEntry evidence, not a registered watchdog action",
 	},
-	"main.go\x00emit": {
+	"serve_lifecycle_presentation.go\x00boot": {
 		Names:  []string{"status"},
-		Reason: "serve boot progress status is process-progress output, not a registered API code family",
+		Reason: "canonical serve boot progress status is a lifecycle-presentation taxonomy, not a registered API code family",
 	},
-	"main.go\x00runtimeSink": {
+	"serve_lifecycle_presentation.go\x00writeBootEventLocked": {
 		Names:  []string{"status"},
-		Reason: "serve boot runtime event status feeds process-progress output, not a registered API code family",
+		Reason: "canonical serve boot progress status is a lifecycle-presentation taxonomy, not a registered API code family",
+	},
+	"serve_lifecycle_presentation.go\x00writeResolvedFactsLocked": {
+		Names:  []string{"status"},
+		Reason: "canonical startup recovery outcome is a lifecycle-presentation taxonomy, not a registered API code family",
 	},
 	"main.go\x00printRunForkActivation": {
 		Names:  []string{"forkrunstatus", "sourcerunstatus"},

--- a/cmd/swarm/doctor.go
+++ b/cmd/swarm/doctor.go
@@ -21,6 +21,7 @@ type doctorOptions struct {
 	mcpListenAddr       string
 	target              bool
 	asJSON              bool
+	schemaInventory     bool
 	apiOptions          rootCommandOptions
 }
 
@@ -38,6 +39,9 @@ func newDoctorCommand(ctx context.Context, repo string, rootOpts rootCommandOpti
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cliAPIConnectionFlagsChanged(cmd) && !opts.target {
 				return fmt.Errorf("--api-server and --api-token-file require --target")
+			}
+			if opts.target && opts.schemaInventory {
+				return fmt.Errorf("--schema-inventory cannot be combined with --target")
 			}
 			if cmd.Flags().Changed("data") {
 				opts.dataSource = strings.TrimSpace(opts.dataSource)
@@ -78,6 +82,7 @@ func newDoctorCommand(ctx context.Context, repo string, rootOpts rootCommandOpti
 	cmd.Flags().StringVar(&opts.mcpListenAddr, "mcp-listen-addr", opts.mcpListenAddr, "HTTP bind address to preflight for MCP and tools routes")
 	cmd.Flags().BoolVar(&opts.target, "target", false, "Explain local target, state directory, project, and context resolution without runtime preflight")
 	cmd.Flags().BoolVar(&opts.asJSON, "json", false, "Render the diagnostic report as JSON")
+	cmd.Flags().BoolVar(&opts.schemaInventory, "schema-inventory", false, "Show the generated state-store table and column inventory without starting runtime")
 	opts.apiOptions.rootFlags = rootOpts.rootFlags
 	bindCLIAPIConnectionFlags(cmd, &opts.apiOptions)
 	return cmd
@@ -115,6 +120,15 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		report := configReport
 		report.add(localPreflightBackendPrerequisite, "path_resolution_failed", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --contracts or --platform-spec")
 		return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+	}
+	if opts.schemaInventory {
+		inventory, err := buildDoctorSchemaInventory(repo, resolvedPaths)
+		if err != nil {
+			report := configReport
+			report.add(localPreflightBackendPrerequisite, "schema_inventory_unavailable", localPreflightSeverityBlocker, localPreflightStatusFailed, err.Error(), "fix --contracts or --platform-spec so the generated schema can be derived")
+			return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)
+		}
+		configReport.SchemaInventory = &inventory
 	}
 	providerPackLoad, err := loadConfiguredProviderTriggerPacks(repo, cfgResult)
 	if err != nil {
@@ -198,6 +212,7 @@ func runDoctorCommand(ctx context.Context, repo string, cmd *cobra.Command, opts
 		ProviderTriggerPacks:   providerPackLoad.Loaded,
 		ProviderTriggerCatalog: providerPackLoad.Catalog,
 	})
+	report.SchemaInventory = configReport.SchemaInventory
 	addUnifiedConfigDiagnosticsToReport(&report, cfgResult.Diagnostics)
 	addSwarmEnvFindingsToLocalPreflightReport(&report, envFindings)
 	return returnLocalPreflightResult(cmd, report.finalize(), opts.asJSON)

--- a/cmd/swarm/doctor_schema_inventory.go
+++ b/cmd/swarm/doctor_schema_inventory.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const doctorSchemaInventoryOwner = "platform-spec.yaml#cli_specification.command_catalog.doctor.schema_inventory"
+
+type doctorSchemaInventory struct {
+	Owner       string                    `json:"owner"`
+	TableCount  int                       `json:"table_count"`
+	ColumnCount int                       `json:"column_count"`
+	Tables      []serveSchemaTableSummary `json:"tables"`
+}
+
+func buildDoctorSchemaInventory(repo string, paths cliContractPlatformSpecPaths) (doctorSchemaInventory, error) {
+	_, bundle, err := newSwarmWorkflowModule(repo, paths.ContractsPath, paths.PlatformSpecPath)
+	if err != nil {
+		return doctorSchemaInventory{}, fmt.Errorf("load contract schema source: %w", err)
+	}
+	plans, err := stateStoreSchemaPlans(bundle)
+	if err != nil {
+		return doctorSchemaInventory{}, err
+	}
+	summary := newServeSchemaPlanSummary(plans.all())
+	return doctorSchemaInventory{
+		Owner:       doctorSchemaInventoryOwner,
+		TableCount:  summary.tableCount,
+		ColumnCount: summary.columnCount,
+		Tables:      append([]serveSchemaTableSummary(nil), summary.tables...),
+	}, nil
+}
+
+func writeDoctorSchemaInventoryText(out io.Writer, inventory *doctorSchemaInventory) {
+	if out == nil || inventory == nil {
+		return
+	}
+	fmt.Fprintf(out, "schema inventory: %d tables · %d columns\n", inventory.TableCount, inventory.ColumnCount)
+	for _, table := range inventory.Tables {
+		fmt.Fprintf(out, "  %s · %d columns\n", strings.TrimSpace(table.Name), table.ColumnCount)
+	}
+}

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -1051,7 +1051,7 @@ func TestRunServeRuntimeConsumesLocalClaudePreflightAfterBundleDecision(t *testi
 	if code != cliExitRuntime {
 		t.Fatalf("runServeRuntime code = %d, want %d\noutput:\n%s", code, cliExitRuntime, out.String())
 	}
-	if !strings.Contains(out.String(), "local_preflight") || !strings.Contains(out.String(), "missing_backend_credential") {
+	if !strings.Contains(out.String(), "claude_cli preflight: failed") || !strings.Contains(out.String(), "missing_backend_credential") {
 		t.Fatalf("serve output missing shared local preflight failure:\n%s", out.String())
 	}
 	for _, want := range []string{"db_connection", "bundle_load", "workspace backend: docker"} {

--- a/cmd/swarm/doctor_test.go
+++ b/cmd/swarm/doctor_test.go
@@ -89,6 +89,57 @@ func TestDoctorClaudeCLIPreflightReportsMissingPrerequisites(t *testing.T) {
 	}
 }
 
+func TestDoctorSchemaInventoryOwnsTypedHumanAndJSONReadback(t *testing.T) {
+	dockerBin := configureDoctorDockerStub(t)
+	setDoctorEmptyProviderSecrets(t)
+	configPath := writeDoctorClaudeConfig(t, dockerBin)
+
+	var humanOut, humanErr bytes.Buffer
+	humanArgs := append(doctorClaudeArgs(t, configPath, false), "--schema-inventory")
+	humanCode := executeRootCommandWithOptions(context.Background(), repoRoot(), humanArgs, &humanOut, &humanErr, defaultRootCommandOptions())
+	if humanCode != cliExitRuntime {
+		t.Fatalf("human doctor code = %d, want prerequisite failure %d\nstdout=%s\nstderr=%s", humanCode, cliExitRuntime, humanOut.String(), humanErr.String())
+	}
+	for _, want := range []string{"schema inventory:", " tables · ", "  events · ", " columns"} {
+		if !strings.Contains(humanOut.String(), want) {
+			t.Fatalf("human schema inventory missing %q:\n%s", want, humanOut.String())
+		}
+	}
+
+	var jsonOut, jsonErr bytes.Buffer
+	jsonArgs := append(doctorClaudeArgs(t, configPath, true), "--schema-inventory")
+	jsonCode := executeRootCommandWithOptions(context.Background(), repoRoot(), jsonArgs, &jsonOut, &jsonErr, defaultRootCommandOptions())
+	if jsonCode != cliExitRuntime {
+		t.Fatalf("json doctor code = %d, want prerequisite failure %d\nstdout=%s\nstderr=%s", jsonCode, cliExitRuntime, jsonOut.String(), jsonErr.String())
+	}
+	var report localPreflightReport
+	if err := json.Unmarshal(jsonOut.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor schema inventory JSON: %v\n%s", err, jsonOut.String())
+	}
+	if report.SchemaInventory == nil || report.SchemaInventory.Owner != doctorSchemaInventoryOwner {
+		t.Fatalf("schema inventory owner = %#v", report.SchemaInventory)
+	}
+	if report.SchemaInventory.TableCount == 0 || report.SchemaInventory.ColumnCount == 0 || len(report.SchemaInventory.Tables) != report.SchemaInventory.TableCount {
+		t.Fatalf("schema inventory counts = %#v", report.SchemaInventory)
+	}
+	for i := 1; i < len(report.SchemaInventory.Tables); i++ {
+		if report.SchemaInventory.Tables[i-1].Name >= report.SchemaInventory.Tables[i].Name {
+			t.Fatalf("schema inventory is not sorted: %#v", report.SchemaInventory.Tables)
+		}
+	}
+	if strings.Contains(humanOut.String(), "events(") || strings.Contains(jsonOut.String(), "events(") {
+		t.Fatalf("doctor retained retired table(count) compatibility rendering\nhuman=%s\njson=%s", humanOut.String(), jsonOut.String())
+	}
+}
+
+func TestDoctorSchemaInventoryRejectsTargetMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"doctor", "--target", "--schema-inventory"}, &stdout, &stderr, defaultRootCommandOptions())
+	if code != cliExitValidation || !strings.Contains(stderr.String(), "--schema-inventory cannot be combined with --target") {
+		t.Fatalf("doctor target/schema inventory code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestDoctorClaudeCLIPreflightReportsMissingDocker(t *testing.T) {
 	dockerBin := configureDoctorDockerStub(t)
 	setDoctorProviderSecret(t, "CLAUDE_CODE_OAUTH_TOKEN", "oauth-token")
@@ -1220,7 +1271,7 @@ func TestPlatformSpecLocalClaudeCLIPreflightAdmissionPromoted(t *testing.T) {
 		}
 	}
 	doctor := spec.CLISpecification.CommandCatalog.Doctor
-	if doctor.Command != "swarm doctor [--backend claude_cli] [--target] [--contracts <path>] [--json]" || doctor.ImplementationStatus != "implemented" || !strings.Contains(doctor.Owner, "local_claude_cli_preflight_admission") {
+	if doctor.Command != "swarm doctor [--backend claude_cli] [--target] [--schema-inventory] [--contracts <path>] [--json]" || doctor.ImplementationStatus != "implemented" || !strings.Contains(doctor.Owner, "local_claude_cli_preflight_admission") {
 		t.Fatalf("doctor command catalog = %#v", doctor)
 	}
 	if !strings.Contains(doctor.Owner, "local_target_resolution_authority") {

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -392,9 +392,14 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 	for _, provider := range []string{"partner_open", "partner_ack"} {
 		found := false
 		for _, line := range strings.Split(serveOutput, "\n") {
-			if strings.Contains(line, "standing ingress admitted:") && strings.Contains(line, ":matrix:"+provider+" ") && strings.Contains(line, "request_authentication=UNAUTHENTICATED") {
+			if strings.Contains(line, provider+" webhook") {
 				found = true
 				break
+			}
+		}
+		for _, forbidden := range []string{"request_authentication=", "catalog_generation=", "manifest_hash=", "policy_source=", "provenance=", "source_path=", "standing ingress admitted:"} {
+			if strings.Contains(serveOutput, forbidden) {
+				t.Fatalf("serve output leaked diagnostic field %q:\n%s", forbidden, serveOutput)
 			}
 		}
 		if !found {

--- a/cmd/swarm/local_preflight.go
+++ b/cmd/swarm/local_preflight.go
@@ -72,6 +72,7 @@ type localPreflightReport struct {
 	Backend            string                  `json:"backend"`
 	CapabilitySubjects []packs.Subject         `json:"capability_subjects,omitempty"`
 	Findings           []localPreflightFinding `json:"findings"`
+	SchemaInventory    *doctorSchemaInventory  `json:"schema_inventory,omitempty"`
 }
 
 type localPreflightRequest struct {
@@ -507,6 +508,7 @@ func writeLocalPreflightText(out io.Writer, report localPreflightReport) {
 	for _, finding := range report.Findings {
 		fmt.Fprintln(out, formatLocalPreflightFinding(report.Mode, finding))
 	}
+	writeDoctorSchemaInventoryText(out, report.SchemaInventory)
 }
 
 func formatLocalPreflightFinding(mode string, finding localPreflightFinding) string {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -67,7 +67,7 @@ const (
 	defaultMCPListenAddr    = "127.0.0.1:8082"
 	serveAPIRoutes          = "/healthz /readyz /v1/rpc /v1/ws /webhooks/"
 	serveMCPRoutes          = "/mcp /tools/"
-	serveReadinessRoutes    = "/healthz /readyz"
+	serveReadinessRoutes    = "/healthz"
 	serveExitDataIntegrity  = 78
 	runtimeStoreBackendHelp = "Runtime store backend: sqlite (local/dev default) or postgres (explicit opt-in production/external backend)"
 )
@@ -381,6 +381,7 @@ type serveOptions struct {
 	TestLLMRuntime                   runtimellm.Runtime
 	TestOutboxSweeperConfig          runtimebus.OutboxSweeperConfig
 	TestRuntimeReadyHook             func(*runtime.Runtime)
+	TestBeforeReadinessCommit        func() error
 }
 
 type serveRuntimeBundle struct {
@@ -1089,6 +1090,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 
 	runtimeContexts := make([]serveRuntimeBundleContext, 0, len(loadedBundles))
+	workspaceLabels := serveLifecycleWorkspaceLabels(loadedBundles)
 	for i, loaded := range loadedBundles {
 		contextToolGatewayBinding := toolgateway.Binding{}
 		if i == 0 {
@@ -1102,7 +1104,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			})
 			return 3
 		}
-		presenter.recordWorkspace(loaded.serveIdentityDetail(), workspaceBackend)
+		presenter.recordWorkspace(workspaceLabels[i], workspaceBackend)
 		var bootProgress func(runtime.BootProgressEvent)
 		if i == 0 {
 			bootProgress = presenter.runtimeSink()
@@ -1300,22 +1302,26 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	}
 	startServeRunStalledEscalation(ctx, stores, runtimeContexts, rt.Bus)
 	presenter.boot(20, "http_listener_bind", "ok", fmt.Sprintf("api_listener=%s api_routes=%s mcp_listener=%s mcp_routes=%s", apiListener.Addr(), serveAPIRoutes, mcpListener.Addr(), serveMCPRoutes))
-	ready.Store(true)
 	if err := waitForServeHealthEndpoints(ctx, apiListener.Addr()); err != nil {
 		presenter.fail(21, "health_endpoints_respond", err)
 		return 1
 	}
-	readyAfter := time.Since(bootStartedAt)
 	presenter.boot(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
 	standing, err := serveReadyStandingIngress(ctx, runtimeContextManager, providerCredentialStore, apiListener.Addr())
 	if err != nil {
-		ready.Store(false)
 		presenter.fail(22, "ready", err)
 		return 1
 	}
+	if opts.TestBeforeReadinessCommit != nil {
+		if err := opts.TestBeforeReadinessCommit(); err != nil {
+			presenter.fail(22, "ready", err)
+			return 1
+		}
+	}
+	readyAfter := time.Since(bootStartedAt)
 	presenter.boot(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", readyAfter.Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
 	flowCount, agentCount, toolCount := serveLifecycleSourceCounts(runtimeContexts)
-	presenter.readyPresentation(serveLifecycleReadyFacts{
+	if !presenter.commitReady(serveLifecycleReadyFacts{
 		ProjectName: serveLifecycleProjectName(localState, loadedBundles),
 		BundleCount: len(loadedBundles),
 		FlowCount:   flowCount,
@@ -1325,7 +1331,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		MCPListener: addrString(mcpListener.Addr()),
 		ReadyAfter:  readyAfter,
 		Standing:    standing,
-	})
+	}, func() { ready.Store(true) }) {
+		return 1
+	}
 
 	<-ctx.Done()
 	ready.Store(false)
@@ -1447,12 +1455,43 @@ func serveLifecycleProjectName(localState localRuntimeStateResolution, bundles [
 		}
 	}
 	if len(bundles) == 1 {
-		return bundles[0].serveIdentityDetail()
+		if label := serveRuntimeBundleAuthorLabel(bundles[0]); label != "" {
+			return label
+		}
 	}
 	if len(bundles) > 1 {
 		return fmt.Sprintf("%d persisted bundles", len(bundles))
 	}
 	return "runtime"
+}
+
+func serveRuntimeBundleAuthorLabel(bundle serveRuntimeBundle) string {
+	name := strings.TrimSpace(bundle.bootIdentity.WorkflowName)
+	version := strings.TrimSpace(bundle.bootIdentity.WorkflowVersion)
+	if name == "" {
+		return ""
+	}
+	if version == "" {
+		return name
+	}
+	return name + " " + version
+}
+
+func serveLifecycleWorkspaceLabels(bundles []serveRuntimeBundle) []string {
+	labels := make([]string, len(bundles))
+	counts := map[string]int{}
+	for i, bundle := range bundles {
+		labels[i] = serveRuntimeBundleAuthorLabel(bundle)
+		counts[labels[i]]++
+	}
+	for i, label := range labels {
+		if label == "" {
+			labels[i] = fmt.Sprintf("context %d", i+1)
+		} else if counts[label] > 1 {
+			labels[i] = fmt.Sprintf("%s context %d", label, i+1)
+		}
+	}
+	return labels
 }
 
 func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor, opts serveOptions, workspaces serveWorkspaceLifecycle) error {
@@ -3116,9 +3155,6 @@ func waitForServeHealthEndpoints(ctx context.Context, addr net.Addr) error {
 	var lastErr error
 	for {
 		lastErr = probeServeHealthEndpoint(ctx, client, baseURL+"/healthz")
-		if lastErr == nil {
-			lastErr = probeServeHealthEndpoint(ctx, client, baseURL+"/readyz")
-		}
 		if lastErr == nil {
 			return nil
 		}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -704,7 +703,7 @@ func buildServeRuntimeBundleContext(req serveRuntimeBundleContextRequest) (serve
 	stateStoreSummary := strings.TrimSpace(req.StateStoreSummary)
 	if stateStoreSummary == "" {
 		var err error
-		stateStoreSummary, err = initializeStateStores(req.Ctx, req.Stores, loaded.bundle, req.Options.Verbose)
+		stateStoreSummary, err = initializeStateStores(req.Ctx, req.Stores, loaded.bundle)
 		if err != nil {
 			return serveRuntimeBundleContext{}, err
 		}
@@ -812,21 +811,19 @@ func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Res
 func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	bootStartedAt := time.Now().UTC()
 	runtimeInstanceID := uuid.NewString()
-	reporter := newServeBootReporter(opts.Verbose, opts.Output)
-	reporter.emit(1, "process_start", "ok", "")
+	presenter := newServeLifecyclePresenter(opts)
+	presenter.boot(1, "process_start", "ok", "")
 	apiAuth, err := resolveServeAPIAuth(repo, opts)
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("configure v1 api auth: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	if err := validateServeAPIAuthBinding(opts.APIListenAddr, apiAuth); err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("configure v1 api auth: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	if apiAuth.UsesDefaultLoopbackToken() {
-		log.Print("using built-in dev API token on numeric loopback; use swarm serve --api-token-file or config serve.api_token_file before exposing")
+		presenter.note("using built-in dev API token on numeric loopback; configure serve.api_token_file before exposing the listener")
 	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.ContractsPath,
@@ -834,14 +831,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		ConfigPath:       opts.ConfigPath,
 	})
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("resolve CLI path config: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	projectContextRegistration, err := prepareServeProjectContextRegistration(ctx, repo, opts, resolvedPaths)
 	if err != nil {
-		reporter.emit(2, "serve_admission", "FAILED", err.Error())
-		log.Printf("prepare local project context registration: %v", err)
+		presenter.fail(2, "serve_admission", err)
 		return 3
 	}
 	defer projectContextRegistration.Release()
@@ -852,29 +847,25 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		BackendOverride: opts.Backend,
 	})
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("load config: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	cfg := cfgResult.Config
-	reporter.emit(2, "config_load", "ok", serveConfigLoadDetail(cfgResult.Detail(), resolvedPaths, opts))
+	presenter.boot(2, "config_load", "ok", serveConfigLoadDetail(cfgResult.Detail(), resolvedPaths, opts))
 	providerPackLoad, err := loadConfiguredProviderTriggerPacks(repo, cfgResult)
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("load provider trigger packs: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	if !opts.Dev && !opts.LocalRun {
 		if err := validateServeGatewayURLEnvForNonDev(); err != nil {
-			reporter.emit(2, "serve_admission", "FAILED", err.Error())
-			log.Printf("validate non-dev mcp gateway env: %v", err)
+			presenter.fail(2, "serve_admission", err)
 			return 3
 		}
 	}
 	swarmDir, err := resolveServeContextRegistrationSwarmDir(opts)
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("resolve Swarm dir: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	localState, err := resolveLocalRuntimeState(localRuntimeStateOptions{
@@ -889,37 +880,40 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		EnforceLegacySQLite:     true,
 	})
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("resolve local runtime state: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	mountSources := localState.MountSources
 	workspaceBackendPreference, err := resolveWorkspaceBackend(opts.WorkspaceBackend, opts.WorkspaceBackendSet, cfg)
 	if err != nil {
-		reporter.emit(2, "config_load", "FAILED", err.Error())
-		log.Printf("resolve workspace backend: %v", err)
+		presenter.fail(2, "config_load", err)
 		return 1
 	}
 	storeSelection := localState.StoreSelection
 	stores, err := buildStoresForServe(ctx, storeSelection, cfg)
 	if err != nil {
-		reporter.emit(3, "db_connection", "FAILED", err.Error())
-		log.Printf("init stores: %v", err)
+		presenter.fail(3, "db_connection", err)
 		return 1
 	}
-	reporter.emit(3, "db_connection", "ok", storeSelection.Backend.String())
+	presenter.recordStore(storeSelection)
 	storeFacade := stores.facade()
-	defer storeFacade.close()
+	storeClosed := false
+	defer func() {
+		if storeClosed {
+			return
+		}
+		if err := storeFacade.closeWithError(); err != nil {
+			presenter.runtimeFailure("store shutdown", err)
+		}
+	}()
 	if stores.SchemaBootstrapper != nil {
 		preCatalogPlatformSpecPath, err := servePreCatalogPlatformSpecPath(resolvedPaths, opts)
 		if err != nil {
-			reporter.emit(4, "bundle_load", "FAILED", err.Error())
-			log.Printf("resolve pre-catalog platform spec: %v", err)
+			presenter.fail(4, "bundle_load", err)
 			return 1
 		}
-		if _, err := initializeServePlatformStateStores(ctx, stores, preCatalogPlatformSpecPath, opts.Verbose); err != nil {
-			reporter.emit(4, "bundle_load", "FAILED", err.Error())
-			log.Printf("initialize platform state stores: %v", err)
+		if _, err := initializeServePlatformStateStores(ctx, stores, preCatalogPlatformSpecPath); err != nil {
+			presenter.fail(4, "bundle_load", err)
 			return 1
 		}
 	}
@@ -928,60 +922,62 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		detail := err.Error()
 		if _, ok := runtimecontracts.AsLoaderDiagnostic(err); ok {
 			detail = formatCLIAPIError(err)
-			log.Print(detail)
-		} else {
-			log.Printf("load Swarm contracts: %v", err)
 		}
-		reporter.emit(4, "bundle_load", "FAILED", detail)
+		presenter.fail(4, "bundle_load", errors.New(detail))
 		return 1
 	}
 	if len(loadedBundles) == 0 {
-		reporter.emit(4, "bundle_load", "FAILED", "no bundle contexts loaded")
+		presenter.fail(4, "bundle_load", errors.New("no bundle contexts loaded"))
 		return 1
 	}
-	defer func() {
+	bundleSourcesCleaned := false
+	cleanupLoadedBundleSources := func() error {
+		var cleanupErr error
 		for _, loaded := range loadedBundles {
 			if loaded.cleanup != nil {
-				if err := loaded.cleanup(); err != nil {
-					log.Printf("cleanup DB-loaded bundle runtime source failed: %v", err)
-				}
+				cleanupErr = errors.Join(cleanupErr, loaded.cleanup())
 			}
+		}
+		return cleanupErr
+	}
+	defer func() {
+		if bundleSourcesCleaned {
+			return
+		}
+		if err := cleanupLoadedBundleSources(); err != nil {
+			presenter.runtimeFailure("bundle source cleanup", err)
 		}
 	}()
 	loadedBundle := loadedBundles[0]
 	source := loadedBundle.source
 	resolvedPlatformSpecPath := loadedBundle.platformSpecPath
-	reporter.emit(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
+	presenter.boot(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
 	primaryWorkspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, source)
 	if err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		writeWorkspaceBackendDecisionFailure(opts.Output, "serve", err)
-		log.Printf("resolve workspace backend decision: %v", err)
+		presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
+			writeWorkspaceBackendDecisionFailure(out, "serve", err)
+		})
 		return 3
 	}
-	logWorkspaceBackendDecision(opts.Output, primaryWorkspaceBackend)
 	if shouldRunServeLocalClaudeCLIPreflight(opts) {
 		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources, providerPackLoad.Loaded, providerPackLoad.Catalog)
 		if preflight.HasBlockers() {
 			detail := preflight.BlockerSummary()
-			reporter.emit(5, "local_preflight", "FAILED", detail)
-			if opts.Output != nil {
-				writeLocalPreflightText(opts.Output, preflight)
-			}
-			log.Printf("local claude_cli preflight failed: %s", detail)
+			presenter.failWithDiagnostic(5, "local_preflight", errors.New(detail), func(out io.Writer) {
+				writeLocalPreflightText(out, preflight)
+			})
 			return 3
 		}
 	}
 	if err := validateServeMultiContextToolGatewayAdmission(cfg, loadedBundles); err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("validate multi-context tool gateway admission: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 3
 	}
 	stateStoreSummaries := make([]string, len(loadedBundles))
 	if stores.SchemaBootstrapper != nil {
-		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles, opts.Verbose)
+		summaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, loadedBundles)
 		if err != nil {
-			slog.Error("initialize state stores", "error", err)
+			presenter.fail(4, "state_store_schema", err)
 			return 1
 		}
 		stateStoreSummaries = summaries
@@ -989,7 +985,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	for i := range loadedBundles {
 		fact, err := prepareLoadedServeBundleSource(ctx, stores, loadedBundles[i], opts.Dev)
 		if err != nil {
-			slog.Error("prepare bundle source before startup recovery", "error", err)
+			presenter.fail(4, "bundle_source", err)
 			return 1
 		}
 		loadedBundles[i].bundleSourceFact = fact
@@ -997,20 +993,20 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	loadedBundle = loadedBundles[0]
 	if opts.AbandonActiveRuns {
 		if stores.RunQuiescenceStore == nil {
-			slog.Error("abandon active runs failed", "error", "selected store active-run quiescence owner is required")
+			presenter.fail(5, "run_quiescence", errors.New("selected store active-run quiescence owner is required"))
 			return 3
 		}
 		result, err := stores.RunQuiescenceStore.ApplyServeAbandonActiveRunQuiescence(ctx, time.Now().UTC())
 		if err != nil {
-			slog.Error("abandon active runs failed", "error", err)
+			presenter.fail(5, "run_quiescence", err)
 			return 3
 		}
-		log.Printf("serve abandon active runs complete: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
+		presenter.note(fmt.Sprintf("abandoned active work: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount))
 	}
 	if recoveryStore := storeFacade.startupRecoveryStore(); recoveryStore != nil {
 		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), cfg, loadedBundle.contractsRoot, source, mountSources, primaryWorkspaceBackend)
 		if err != nil {
-			slog.Error("configure recovery workspaces", "error", err)
+			presenter.fail(5, "recovery_workspace", err)
 			return 1
 		}
 		recoveryContainers := runtimestartuprecovery.ManagedContainerOwner(serveStartupRecoveryContainers{lifecycle: recoveryWorkspaces})
@@ -1024,56 +1020,57 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			RequestedAt:        time.Now().UTC(),
 		})
 		if err != nil {
-			slog.Error("unavailable bundle startup recovery failed", "error", err)
+			presenter.fail(5, "startup_recovery", err)
 			if runtimestartuprecovery.IsDataIntegrityError(err) {
 				return serveExitDataIntegrity
 			}
 			return 3
 		}
 		if len(recovery.OrphanTargets) > 0 || len(recovery.StoppedContainers) > 0 {
-			log.Printf("unavailable bundle startup recovery complete: orphaned_runs=%d deliveries=%d sessions=%d timers=%d containers=%d pipeline_receipts=%d",
+			presenter.note(fmt.Sprintf("recovered unavailable bundles: orphaned_runs=%d deliveries=%d sessions=%d timers=%d containers=%d pipeline_receipts=%d",
 				len(recovery.Cleanup.Runs),
 				len(recovery.Cleanup.Deliveries),
 				len(recovery.Cleanup.Sessions),
 				len(recovery.Cleanup.Timers),
 				len(recovery.StoppedContainers),
 				recovery.Cleanup.PipelineReceiptCount,
-			)
+			))
 		}
 	}
 	pinnedBundleHashes := servePinnedBundleHashes(loadedBundles)
+	if !opts.RequireBundleMatch {
+		presenter.note("bundle-match admission disabled after startup recovery consumed active-run bundle state")
+	}
 	if err := enforceServeBundleMatchAdmissionForHashes(ctx, storeFacade.runBundleAvailabilityStore(), serveRuntimeBundleIdentitiesDetail(loadedBundles), opts.RequireBundleMatch, pinnedBundleHashes); err != nil {
-		slog.Error("bundle match admission failed", "error", err)
+		presenter.fail(5, "bundle_match_admission", err)
 		return 3
 	}
 	credentialStore, err := buildCredentialStore()
 	if err != nil {
-		slog.Error("configure credentials", "error", err)
+		presenter.fail(5, "credentials", err)
 		return 1
 	}
 	managedCredentialStore, err := buildManagedCredentialStore()
 	if err != nil {
-		slog.Error("configure managed credentials", "error", err)
+		presenter.fail(5, "managed_credentials", err)
 		return 1
 	}
 	providerCredentialStore, err := buildProviderCredentialStore()
 	if err != nil {
-		slog.Error("configure provider credentials", "error", err)
+		presenter.fail(5, "provider_credentials", err)
 		return 1
 	}
 
 	apiListener, err := listenServeHTTPListener("api", opts.APIListenAddr)
 	if err != nil {
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("bind api listener: %v", err)
+		presenter.fail(20, "http_listener_bind", err)
 		return 3
 	}
 	defer apiListener.Close()
 	mcpListener, err := listenServeHTTPListener("mcp", opts.MCPListenAddr)
 	if err != nil {
 		_ = apiListener.Close()
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("bind mcp listener: %v", err)
+		presenter.fail(20, "http_listener_bind", err)
 		return 3
 	}
 	defer mcpListener.Close()
@@ -1081,8 +1078,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	if err != nil {
 		_ = mcpListener.Close()
 		_ = apiListener.Close()
-		reporter.emit(20, "http_listener_bind", "FAILED", err.Error())
-		log.Printf("configure mcp gateway binding: %v", err)
+		presenter.fail(20, "http_listener_bind", err)
 		return 3
 	}
 
@@ -1094,13 +1090,15 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		}
 		workspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, loaded.source)
 		if err != nil {
-			reporter.emit(5, "runtime_context", "FAILED", err.Error())
-			writeWorkspaceBackendDecisionFailure(opts.Output, "serve", err)
-			slog.Error("resolve workspace backend decision", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
+			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
+				writeWorkspaceBackendDecisionFailure(out, "serve", err)
+			})
 			return 3
 		}
-		if i > 0 {
-			logWorkspaceBackendDecision(opts.Output, workspaceBackend)
+		presenter.recordWorkspace(loaded.serveIdentityDetail(), workspaceBackend)
+		var bootProgress func(runtime.BootProgressEvent)
+		if i == 0 {
+			bootProgress = presenter.runtimeSink()
 		}
 		contextDef, err := buildServeRuntimeBundleContext(serveRuntimeBundleContextRequest{
 			Ctx:                    ctx,
@@ -1116,7 +1114,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			ProviderCredentials:    providerCredentialStore,
 			ProviderTriggerCatalog: providerPackLoad.Catalog,
 			BootStartedAt:          bootStartedAt,
-			BootProgress:           reporter.runtimeSink(),
+			BootProgress:           bootProgress,
 			EnableToolGateway:      i == 0,
 			ToolGatewayBinding:     contextToolGatewayBinding,
 			UseStartupOwnership:    len(loadedBundles) == 1 && i == 0,
@@ -1124,9 +1122,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			RequireBundleScopeName: len(loadedBundles) > 1,
 		})
 		if err != nil {
-			reporter.emit(5, "runtime_context", "FAILED", err.Error())
-			writeWorkspacePrerequisiteFailure(opts.Output, "serve", err)
-			slog.Error("build runtime context", "bundle_hash", strings.TrimSpace(loaded.bundleSourceFact.BundleHash), "error", err)
+			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
+				writeWorkspacePrerequisiteFailure(out, "serve", err)
+			})
 			return 1
 		}
 		runtimeContexts = append(runtimeContexts, contextDef)
@@ -1143,32 +1141,28 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	stateStoreSummary := serveRuntimeStateStoreSummary(runtimeContexts)
 	preflightContexts, err := plannedServeRuntimeContexts(runtimeContexts)
 	if err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("plan runtime contexts: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 1
 	}
 	installedTriggerSubjects, err := providerPackLoad.Catalog.InstalledCapabilitySubjects()
 	if err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("derive provider trigger capability subjects: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 1
 	}
 	admissionState := runtime.ProcessAdmissionState{GenerationID: providerPackLoad.Catalog.GenerationID(), InstalledSubjects: installedTriggerSubjects}
 	if err := runtime.ValidateRuntimeContextSetWithAdmission(admissionState, preflightContexts...); err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("validate runtime contexts: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 1
 	}
 	runtimeContextManager, err := runtime.NewRuntimeContextManagerWithAdmission(runtimeContextAvailabilityReader(stores), admissionState)
 	if err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("init runtime context manager: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 1
 	}
 
 	forkChatLLM, err := buildForkChatSandboxLLMRuntime(cfg, workspaces, toolGatewayBinding, providerCredentialStore)
 	if err != nil {
-		log.Printf("init forkchat sandbox runtime: %v", err)
+		presenter.fail(5, "forkchat_sandbox", err)
 		return 1
 	}
 
@@ -1183,17 +1177,21 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	if len(pinnedBundleHashes) > 0 {
 		supervisor.DisableSourceReplacement("swarm serve --bundle-hash pins persisted bundle contexts for the process; dynamic project reload is not supported in this mode")
 	}
+	var apiServer, mcpServer *http.Server
 	defer func() {
-		if err := closeAdditionalServeRuntimeContexts(context.Background(), runtimeContexts[1:], runtimeContextManager, opts); err != nil {
-			log.Printf("additional runtime context shutdown failed: %v", err)
-		}
-		if err := closeServeRuntime(context.Background(), supervisor, opts, workspaces); err != nil {
-			log.Printf("runtime shutdown failed: %v", err)
-		}
+		shutdownErr := shutdownHTTPServer("api", apiServer)
+		shutdownErr = errors.Join(shutdownErr, shutdownHTTPServer("mcp", mcpServer))
+		shutdownErr = errors.Join(shutdownErr, closeAdditionalServeRuntimeContexts(context.Background(), runtimeContexts[1:], runtimeContextManager, opts))
+		shutdownErr = errors.Join(shutdownErr, closeServeRuntime(context.Background(), supervisor, opts, workspaces))
+		shutdownErr = errors.Join(shutdownErr, cleanupLoadedBundleSources())
+		bundleSourcesCleaned = true
+		shutdownErr = errors.Join(shutdownErr, storeFacade.closeWithError())
+		storeClosed = true
+		presenter.shutdown(shutdownErr)
 	}()
 	mailboxDecisionRoutes, err := apiv1.MailboxDecisionRoutesFromSpec(resolvedPlatformSpecPath)
 	if err != nil {
-		log.Printf("load v1 api mailbox decision routes: %v", err)
+		presenter.fail(5, "mailbox_routes", err)
 		return 1
 	}
 	apiStoreCaps, err := storeFacade.apiCapabilities(selectedAPICapabilityRequest{
@@ -1212,8 +1210,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		RuntimeContextManager:   runtimeContextManager,
 	})
 	if err != nil {
-		reporter.emit(5, "runtime_context", "FAILED", err.Error())
-		log.Printf("init runtime context manager: %v", err)
+		presenter.fail(5, "runtime_context", err)
 		return 1
 	}
 	apiReadOptions := apiv1.OperatorReadOptions{
@@ -1266,46 +1263,58 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		Subscriptions:    apiv1.OperatorSubscriptions(apiReadOptions),
 	})
 	if err != nil {
-		log.Printf("init v1 api: %v", err)
+		presenter.fail(20, "api_initialization", err)
 		return 1
 	}
 	var inboundHandler http.Handler
 	if rt.InboundGateway != nil {
 		inboundHandler = runtimeProcessInboundHandler{contexts: runtimeContextManager}
 	}
-	apiServer := newAPIServer(&ready, apiV1Handler, inboundHandler)
-	mcpServer := newMCPServer(rt.ToolGateway)
+	apiServer = newAPIServer(&ready, apiV1Handler, inboundHandler)
+	mcpServer = newMCPServer(rt.ToolGateway)
 	if err := projectContextRegistration.WriteFinal(runtimeInstanceID, apiListener.Addr(), apiAuth, resolvedPaths, storeSelection, mountSources); err != nil {
-		reporter.emit(20, "context_registry", "FAILED", err.Error())
-		log.Printf("register local project context: %v", err)
+		presenter.fail(20, "context_registry", err)
 		return 3
 	}
 	defer projectContextRegistration.Unregister()
-	go serveHTTPServer("api", apiServer, apiListener)
-	go serveHTTPServer("mcp", mcpServer, mcpListener)
-	defer shutdownHTTPServer("mcp", mcpServer)
-	defer shutdownHTTPServer("api", apiServer)
-	logBootWarnings(bootReport, opts.Output)
+	go serveHTTPServer("api", apiServer, apiListener, presenter.runtimeFailure)
+	go serveHTTPServer("mcp", mcpServer, mcpListener, presenter.runtimeFailure)
+	presenter.recordBootWarnings(bootReport)
 	if err := startServeRuntimeContexts(ctx, runtimeContexts, runtimeContextManager); err != nil {
-		reporter.emit(22, "ready", "FAILED", err.Error())
-		log.Printf("start runtime: %v", err)
+		presenter.fail(22, "ready", err)
 		return 1
 	}
 	if opts.TestRuntimeReadyHook != nil {
 		opts.TestRuntimeReadyHook(rt)
 	}
 	startServeRunStalledEscalation(ctx, stores, runtimeContexts, rt.Bus)
-	reporter.emit(20, "http_listener_bind", "ok", fmt.Sprintf("api_listener=%s api_routes=%s mcp_listener=%s mcp_routes=%s", apiListener.Addr(), serveAPIRoutes, mcpListener.Addr(), serveMCPRoutes))
+	presenter.boot(20, "http_listener_bind", "ok", fmt.Sprintf("api_listener=%s api_routes=%s mcp_listener=%s mcp_routes=%s", apiListener.Addr(), serveAPIRoutes, mcpListener.Addr(), serveMCPRoutes))
 	ready.Store(true)
 	if err := waitForServeHealthEndpoints(ctx, apiListener.Addr()); err != nil {
-		reporter.emit(21, "health_endpoints_respond", "FAILED", err.Error())
-		log.Printf("health endpoint verification failed: %v", err)
+		presenter.fail(21, "health_endpoints_respond", err)
 		return 1
 	}
-	reporter.emit(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
-	reporter.emit(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", time.Since(bootStartedAt).Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
-	logReadySummary(source, contractsRoot, apiListener.Addr(), mcpListener.Addr())
-	logReadyStandingIngress(runtimeContextManager, apiListener.Addr(), opts.Output)
+	readyAfter := time.Since(bootStartedAt)
+	presenter.boot(21, "health_endpoints_respond", "ok", serveReadinessRoutes)
+	standing, err := serveReadyStandingIngress(ctx, runtimeContextManager, providerCredentialStore, apiListener.Addr())
+	if err != nil {
+		ready.Store(false)
+		presenter.fail(22, "ready", err)
+		return 1
+	}
+	presenter.boot(22, "ready", "ok", fmt.Sprintf("total=%s state_stores=%s", readyAfter.Round(time.Millisecond), strings.TrimSpace(stateStoreSummary)))
+	flowCount, agentCount, toolCount := serveLifecycleSourceCounts(runtimeContexts)
+	presenter.readyPresentation(serveLifecycleReadyFacts{
+		ProjectName: serveLifecycleProjectName(localState, loadedBundles),
+		BundleCount: len(loadedBundles),
+		FlowCount:   flowCount,
+		AgentCount:  agentCount,
+		ToolCount:   toolCount,
+		APIListener: addrString(apiListener.Addr()),
+		MCPListener: addrString(mcpListener.Addr()),
+		ReadyAfter:  readyAfter,
+		Standing:    standing,
+	})
 
 	<-ctx.Done()
 	ready.Store(false)
@@ -1346,20 +1355,93 @@ func plannedServeRuntimeContexts(contexts []serveRuntimeBundleContext) ([]runtim
 	return planned, nil
 }
 
-func logReadyStandingIngress(manager *runtime.RuntimeContextManager, apiAddr net.Addr, out io.Writer) {
+func serveReadyStandingIngress(ctx context.Context, manager *runtime.RuntimeContextManager, credentials runtimecredentials.Store, apiAddr net.Addr) ([]serveLifecycleIngressFact, error) {
 	if manager == nil || apiAddr == nil {
-		return
+		return nil, nil
 	}
+	targets := map[string]runtime.StandingTarget{}
+	for _, contextDef := range manager.LoadedContexts() {
+		for _, target := range contextDef.StandingTargets {
+			key := serveStandingIngressKey(target.BundleHash, target.Alias, target.Provider)
+			if _, exists := targets[key]; exists {
+				return nil, fmt.Errorf("standing ingress readiness has duplicate loaded target %s/%s", target.Alias, target.Provider)
+			}
+			targets[key] = target
+		}
+	}
+
+	facts := []serveLifecycleIngressFact{}
 	for _, subject := range manager.CapabilitySubjects() {
 		if subject.Kind != packs.SubjectProviderTrigger || subject.Applicability != "effective" {
 			continue
 		}
-		message := fmt.Sprintf("standing ingress admitted: api_base_url=http://%s %s", apiAddr.String(), packs.RenderSubject(subject, false))
-		log.Print(message)
-		if out != nil {
-			fmt.Fprintln(out, message)
+		admission := subject.TriggerAdmission
+		if admission == nil {
+			return nil, fmt.Errorf("effective provider trigger %s has no compiled admission readback", subject.ID)
+		}
+		key := serveStandingIngressKey(admission.BundleHash, admission.Alias, subject.Provider)
+		target, ok := targets[key]
+		if !ok {
+			return nil, fmt.Errorf("effective provider trigger %s has no loaded standing target", subject.ID)
+		}
+		bound := false
+		signingSecret := strings.TrimSpace(target.SigningSecret)
+		if signingSecret != "" {
+			if credentials == nil {
+				return nil, fmt.Errorf("standing ingress credential readback is unavailable for %s/%s", target.Alias, target.Provider)
+			}
+			value, found, err := credentials.Get(ctx, signingSecret)
+			if err != nil {
+				return nil, fmt.Errorf("read standing ingress credential %s: %w", signingSecret, err)
+			}
+			bound = found && strings.TrimSpace(value) != ""
+		}
+		facts = append(facts, serveLifecycleIngressFact{
+			Provider:      strings.TrimSpace(target.Provider),
+			URL:           fmt.Sprintf("http://%s/webhooks/%s/%s", apiAddr.String(), target.Alias, target.Provider),
+			SigningSecret: signingSecret,
+			SigningBound:  bound,
+			BundleHash:    strings.TrimSpace(target.BundleHash),
+			Subject:       subject,
+		})
+		delete(targets, key)
+	}
+	if len(targets) != 0 {
+		return nil, fmt.Errorf("standing ingress readiness is missing %d effective capability subjects", len(targets))
+	}
+	return facts, nil
+}
+
+func serveStandingIngressKey(bundleHash, alias, provider string) string {
+	return strings.TrimSpace(bundleHash) + "\x00" + strings.TrimSpace(alias) + "\x00" + strings.TrimSpace(provider)
+}
+
+func serveLifecycleSourceCounts(contexts []serveRuntimeBundleContext) (flows, agents, tools int) {
+	for _, contextDef := range contexts {
+		source := contextDef.loaded.source
+		if source == nil {
+			continue
+		}
+		flows += len(source.FlowSchemaEntries())
+		agents += len(source.AgentEntries())
+		tools += len(runtimetools.RuntimeAvailableToolNamesForSource(source))
+	}
+	return flows, agents, tools
+}
+
+func serveLifecycleProjectName(localState localRuntimeStateResolution, bundles []serveRuntimeBundle) string {
+	if root := strings.TrimSpace(localState.Project.CanonicalProjectRoot); root != "" {
+		if name := strings.TrimSpace(filepath.Base(root)); name != "" && name != "." {
+			return name
 		}
 	}
+	if len(bundles) == 1 {
+		return bundles[0].serveIdentityDetail()
+	}
+	if len(bundles) > 1 {
+		return fmt.Sprintf("%d persisted bundles", len(bundles))
+	}
+	return "runtime"
 }
 
 func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor, opts serveOptions, workspaces serveWorkspaceLifecycle) error {
@@ -1376,20 +1458,6 @@ func closeServeRuntime(ctx context.Context, supervisor *runtimeProjectSupervisor
 		_, cleanupErr = workspaces.CleanupDevEntityContainers(ctx)
 	}
 	return errors.Join(shutdownErr, cleanupErr)
-}
-
-func logWorkspaceBackendDecision(out io.Writer, decision workspaceBackendSelection) {
-	detail := workspaceBackendDecisionDetail(decision)
-	log.Print(detail)
-	if out != nil {
-		fmt.Fprintln(out, detail)
-	}
-	if warning := workspaceBackendUnsafeWarning(decision); warning != "" {
-		log.Print(warning)
-		if out != nil {
-			fmt.Fprintln(out, warning)
-		}
-	}
 }
 
 func startServeRuntimeContexts(ctx context.Context, contexts []serveRuntimeBundleContext, manager *runtime.RuntimeContextManager) error {
@@ -2552,9 +2620,6 @@ func enforceServeBundleMatchAdmission(ctx context.Context, availability selected
 func enforceServeBundleMatchAdmissionForHashes(ctx context.Context, availability selectedRunBundleAvailabilityStore, bootIdentity string, requireMatch bool, pinnedBundleHashes []string) error {
 	bootIdentity = strings.TrimSpace(bootIdentity)
 	pinnedBundleHashes = uniqueTrimmedServeBundleHashes(pinnedBundleHashes)
-	if !requireMatch {
-		log.Printf("legacy bundle match admission disabled by --no-require-bundle-match; startup recovery has already consumed active run bundle source state")
-	}
 	enforceActiveAvailability := requireMatch || len(pinnedBundleHashes) > 0
 	if enforceActiveAvailability && bootIdentity == "" {
 		return fmt.Errorf("boot bundle identity is required")
@@ -2655,30 +2720,50 @@ func uniqueTrimmedServeBundleHashes(values []string) []string {
 	return out
 }
 
-func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle, verbose bool) (string, error) {
+func initializeStateStores(ctx context.Context, stores storeBundle, bundle *runtimecontracts.WorkflowContractBundle) (string, error) {
 	if stores.SchemaBootstrapper == nil || bundle == nil {
 		return "store wiring ready", nil
 	}
-	platformPlans, err := store.GeneratePlatformTableDDLs(bundle.Platform)
+	plans, err := stateStoreSchemaPlans(bundle)
 	if err != nil {
-		return "", fmt.Errorf("platform-owned tables: %w", err)
+		return "", err
 	}
-	statePlans, err := store.GenerateNodeStateTableDDLs(bundle.NodeEntries())
-	if err != nil {
-		return "", fmt.Errorf("state_schema tables: %w", err)
-	}
-	request, err := schemaBootstrapRequest(bundle.Platform, platformPlans, statePlans)
+	request, err := schemaBootstrapRequest(bundle.Platform, plans.platform, plans.state)
 	if err != nil {
 		return "", err
 	}
 	if err := ensureServeSchemaTables(ctx, stores, request); err != nil {
 		return "", err
 	}
-	plans := append(append([]store.SchemaTableDDL{}, platformPlans...), statePlans...)
-	return summarizeServeSchemaPlans(plans, verbose), nil
+	return summarizeServeSchemaPlans(plans.all()), nil
 }
 
-func initializeServePlatformStateStores(ctx context.Context, stores storeBundle, platformSpecPath string, verbose bool) (string, error) {
+type stateStoreSchemaPlanSet struct {
+	platform []store.SchemaTableDDL
+	state    []store.SchemaTableDDL
+}
+
+func (p stateStoreSchemaPlanSet) all() []store.SchemaTableDDL {
+	plans := append([]store.SchemaTableDDL{}, p.platform...)
+	return append(plans, p.state...)
+}
+
+func stateStoreSchemaPlans(bundle *runtimecontracts.WorkflowContractBundle) (stateStoreSchemaPlanSet, error) {
+	if bundle == nil {
+		return stateStoreSchemaPlanSet{}, fmt.Errorf("workflow contract bundle is required")
+	}
+	platformPlans, err := store.GeneratePlatformTableDDLs(bundle.Platform)
+	if err != nil {
+		return stateStoreSchemaPlanSet{}, fmt.Errorf("platform-owned tables: %w", err)
+	}
+	statePlans, err := store.GenerateNodeStateTableDDLs(bundle.NodeEntries())
+	if err != nil {
+		return stateStoreSchemaPlanSet{}, fmt.Errorf("state_schema tables: %w", err)
+	}
+	return stateStoreSchemaPlanSet{platform: platformPlans, state: statePlans}, nil
+}
+
+func initializeServePlatformStateStores(ctx context.Context, stores storeBundle, platformSpecPath string) (string, error) {
 	if stores.SchemaBootstrapper == nil {
 		return "store wiring ready", nil
 	}
@@ -2697,13 +2782,13 @@ func initializeServePlatformStateStores(ctx context.Context, stores storeBundle,
 	if err := ensureServeSchemaTables(ctx, stores, request); err != nil {
 		return "", err
 	}
-	return summarizeServeSchemaPlans(plans, verbose), nil
+	return summarizeServeSchemaPlans(plans), nil
 }
 
-func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBundle, loaded []serveRuntimeBundle, verbose bool) ([]string, error) {
+func initializeLoadedServeRuntimeStateStores(ctx context.Context, stores storeBundle, loaded []serveRuntimeBundle) ([]string, error) {
 	summaries := make([]string, len(loaded))
 	for i, bundle := range loaded {
-		summary, err := initializeStateStores(ctx, stores, bundle.bundle, verbose)
+		summary, err := initializeStateStores(ctx, stores, bundle.bundle)
 		if err != nil {
 			return nil, fmt.Errorf("bundle %s state stores: %w", bundle.serveIdentityDetail(), err)
 		}
@@ -2774,39 +2859,39 @@ func loadServePlatformSpecDocument(platformSpecPath string) (runtimecontracts.Pl
 type serveSchemaPlanSummary struct {
 	tableCount  int
 	columnCount int
-	detail      string
+	tables      []serveSchemaTableSummary
 }
 
-func summarizeServeSchemaPlans(plans []store.SchemaTableDDL, verbose bool) string {
+type serveSchemaTableSummary struct {
+	Name        string `json:"name"`
+	ColumnCount int    `json:"column_count"`
+}
+
+func summarizeServeSchemaPlans(plans []store.SchemaTableDDL) string {
 	summary := newServeSchemaPlanSummary(plans)
-	slog.Info("swarm boot state stores", "tables", summary.tableCount, "columns", summary.columnCount)
-	return summary.text(verbose)
+	return summary.text()
 }
 
 func newServeSchemaPlanSummary(plans []store.SchemaTableDDL) serveSchemaPlanSummary {
-	tableNames := make([]string, 0, len(plans))
+	tables := make([]serveSchemaTableSummary, 0, len(plans))
 	totalColumns := 0
 	for _, plan := range plans {
-		tableNames = append(tableNames, fmt.Sprintf("%s(%d)", strings.TrimSpace(plan.TableName), plan.ColumnCount))
+		tables = append(tables, serveSchemaTableSummary{Name: strings.TrimSpace(plan.TableName), ColumnCount: plan.ColumnCount})
 		totalColumns += plan.ColumnCount
 	}
-	sort.Strings(tableNames)
+	sort.Slice(tables, func(i, j int) bool { return tables[i].Name < tables[j].Name })
 	return serveSchemaPlanSummary{
 		tableCount:  len(plans),
 		columnCount: totalColumns,
-		detail:      strings.Join(tableNames, ", "),
+		tables:      tables,
 	}
 }
 
-func (summary serveSchemaPlanSummary) text(verbose bool) string {
+func (summary serveSchemaPlanSummary) text() string {
 	if summary.tableCount == 0 {
 		return "verified 0 generated tables"
 	}
-	base := fmt.Sprintf("verified %d generated tables", summary.tableCount)
-	if verbose && strings.TrimSpace(summary.detail) != "" {
-		return fmt.Sprintf("%s (%s)", base, summary.detail)
-	}
-	return base
+	return fmt.Sprintf("verified %d generated tables", summary.tableCount)
 }
 
 func serveStateStoreSummaryAt(summaries []string, index int) string {
@@ -2869,42 +2954,6 @@ func (m *swarmWorkflowModule) ActionRegistry() runtimepipeline.ActionRegistry {
 	return m.actionRegistry
 }
 
-type serveBootReporter struct {
-	enabled bool
-	out     io.Writer
-}
-
-func newServeBootReporter(enabled bool, out io.Writer) serveBootReporter {
-	if out == nil {
-		out = io.Discard
-	}
-	return serveBootReporter{enabled: enabled, out: out}
-}
-
-func (r serveBootReporter) runtimeSink() func(runtime.BootProgressEvent) {
-	if !r.enabled {
-		return nil
-	}
-	return func(evt runtime.BootProgressEvent) {
-		r.emit(evt.Step, evt.Name, evt.Status, evt.Detail)
-	}
-}
-
-func (r serveBootReporter) emit(step int, name, status, detail string) {
-	if !r.enabled || r.out == nil {
-		return
-	}
-	status = strings.TrimSpace(status)
-	if status == "" {
-		status = "ok"
-	}
-	detail = strings.TrimSpace(detail)
-	if detail != "" {
-		detail = "  (" + detail + ")"
-	}
-	fmt.Fprintf(r.out, "[%d/%d] %-34s %s%s\n", step, runtime.BootProgressTotalSteps, strings.TrimSpace(name), status, detail)
-}
-
 func serveBootRegistryDetail(source semanticview.Source) string {
 	availableToolNames := runtimetools.RuntimeAvailableToolNamesForSource(source)
 	return fmt.Sprintf("nodes=%d agents=%d events=%d tools=%d", len(source.NodeEntries()), len(source.AgentEntries()), len(source.ResolvedEventCatalog()), len(availableToolNames))
@@ -2916,25 +2965,6 @@ func serveBootBundleLoadDetail(fingerprint string, source semanticview.Source) s
 		return serveBootRegistryDetail(source)
 	}
 	return fmt.Sprintf("%s, %s", fingerprint, serveBootRegistryDetail(source))
-}
-
-func logBootWarnings(report runtimebootverify.Report, out io.Writer) {
-	warningCounts := make(map[string]int, len(report.Findings))
-	for _, finding := range report.Warnings() {
-		warningCounts[strings.TrimSpace(finding.CheckID)]++
-	}
-	if len(warningCounts) > 0 {
-		slog.Info("swarm boot validation warning summary",
-			"event_wiring_warnings", warningCounts["event_chain_integrity"]+warningCounts["event_consumer_exists"]+warningCounts["event_producer_exists"],
-			"tool_warnings", warningCounts["prompt_exists"]+warningCounts["tool_resolution"],
-		)
-	}
-	for _, finding := range report.Warnings() {
-		slog.Warn("swarm boot validation warning", "check_id", finding.CheckID, "location", finding.Location, "detail", finding.Message)
-		if out != nil {
-			fmt.Fprintln(out, runtimebootverify.FormatSurfaceFinding(finding, false))
-		}
-	}
 }
 
 type systemWorkspaceContainerLister interface {
@@ -3054,12 +3084,14 @@ func listenServeHTTPListener(name, addr string) (net.Listener, error) {
 	return listener, nil
 }
 
-func serveHTTPServer(name string, server *http.Server, listener net.Listener) {
+func serveHTTPServer(name string, server *http.Server, listener net.Listener, onFailure func(string, error)) {
 	if server == nil || listener == nil {
 		return
 	}
 	if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Printf("%s server stopped: %v", name, err)
+		if onFailure != nil {
+			onFailure(name+" server", err)
+		}
 	}
 }
 
@@ -3121,28 +3153,16 @@ func probeServeHealthEndpoint(ctx context.Context, client *http.Client, endpoint
 	return nil
 }
 
-func shutdownHTTPServer(name string, server *http.Server) {
+func shutdownHTTPServer(name string, server *http.Server) error {
 	if server == nil {
-		return
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Printf("%s server shutdown failed: %v", name, err)
+		return fmt.Errorf("%s server shutdown: %w", name, err)
 	}
-}
-
-func logReadySummary(source semanticview.Source, contractsRoot string, apiAddr, mcpAddr net.Addr) {
-	log.Printf(
-		"swarm runtime ready contracts=%s flows=%d nodes=%d agents=%d events=%d api_listener=%s mcp_listener=%s",
-		contractsRoot,
-		len(source.FlowSchemaEntries()),
-		len(source.NodeEntries()),
-		len(source.AgentEntries()),
-		len(source.ResolvedEventCatalog()),
-		addrString(apiAddr),
-		addrString(mcpAddr),
-	)
+	return nil
 }
 
 func addrString(addr net.Addr) string {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1034,14 +1034,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			return 3
 		}
 		if len(recovery.OrphanTargets) > 0 || len(recovery.StoppedContainers) > 0 {
-			presenter.recordRecoveredWork(
-				len(recovery.Cleanup.Runs),
-				len(recovery.Cleanup.Deliveries),
-				len(recovery.Cleanup.Sessions),
-				len(recovery.Cleanup.Timers),
-				len(recovery.StoppedContainers),
-				recovery.Cleanup.PipelineReceiptCount,
-			)
+			presenter.recordClosedUnavailableWork()
 		}
 	}
 	pinnedBundleHashes := servePinnedBundleHashes(loadedBundles)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -954,8 +954,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 	presenter.boot(4, "bundle_load", "ok", serveBootBundleLoadDetail(serveRuntimeBundleIdentitiesDetail(loadedBundles), source))
 	primaryWorkspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, source)
 	if err != nil {
-		presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
+		presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) bool {
 			writeWorkspaceBackendDecisionFailure(out, "serve", err)
+			return true
 		})
 		return 3
 	}
@@ -963,8 +964,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		preflight := runServeLocalClaudeCLIPreflight(ctx, repo, opts, cfg, resolvedPaths, workspaceBackendPreference, mountSources, providerPackLoad.Loaded, providerPackLoad.Catalog)
 		if preflight.HasBlockers() {
 			detail := preflight.BlockerSummary()
-			presenter.failWithDiagnostic(5, "local_preflight", errors.New(detail), func(out io.Writer) {
+			presenter.failWithDiagnostic(5, "local_preflight", errors.New(detail), func(out io.Writer) bool {
 				writeLocalPreflightText(out, preflight)
+				return true
 			})
 			return 3
 		}
@@ -1090,8 +1092,9 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		}
 		workspaceBackend, err := decideWorkspaceBackend(workspaceBackendPreference, cfg, loaded.source)
 		if err != nil {
-			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
+			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) bool {
 				writeWorkspaceBackendDecisionFailure(out, "serve", err)
+				return true
 			})
 			return 3
 		}
@@ -1122,8 +1125,8 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			RequireBundleScopeName: len(loadedBundles) > 1,
 		})
 		if err != nil {
-			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) {
-				writeWorkspacePrerequisiteFailure(out, "serve", err)
+			presenter.failWithDiagnostic(5, "runtime_context", err, func(out io.Writer) bool {
+				return writeWorkspacePrerequisiteFailure(out, "serve", err)
 			})
 			return 1
 		}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -373,6 +373,7 @@ type serveOptions struct {
 	AbandonActiveRuns                bool
 	Verbose                          bool
 	Output                           io.Writer
+	ErrorOutput                      io.Writer
 	LocalRun                         bool
 	TestEntityStateHook              func(entityID, state string)
 	TestWorkflowNodeHandlerStartHook runtimepipeline.WorkflowNodeHandlerStartHook
@@ -809,9 +810,12 @@ func buildForkChatSandboxLLMRuntime(cfg *config.Config, workspaces workspace.Res
 }
 
 func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
+	ctx, cancelServe := context.WithCancel(ctx)
+	defer cancelServe()
 	bootStartedAt := time.Now().UTC()
 	runtimeInstanceID := uuid.NewString()
 	presenter := newServeLifecyclePresenter(opts)
+	defer presenter.finish()
 	presenter.boot(1, "process_start", "ok", "")
 	apiAuth, err := resolveServeAPIAuth(repo, opts)
 	if err != nil {
@@ -823,7 +827,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 1
 	}
 	if apiAuth.UsesDefaultLoopbackToken() {
-		presenter.note("using built-in dev API token on numeric loopback; configure serve.api_token_file before exposing the listener")
+		presenter.recordDefaultAPITokenWarning()
 	}
 	resolvedPaths, err := resolveCLIContractPlatformSpecPaths(repo, cliContractPlatformSpecPathOptions{
 		ContractsPath:    opts.ContractsPath,
@@ -903,7 +907,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			return
 		}
 		if err := storeFacade.closeWithError(); err != nil {
-			presenter.runtimeFailure("store shutdown", err)
+			presenter.cleanupFailure("store shutdown", err)
 		}
 	}()
 	if stores.SchemaBootstrapper != nil {
@@ -945,7 +949,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			return
 		}
 		if err := cleanupLoadedBundleSources(); err != nil {
-			presenter.runtimeFailure("bundle source cleanup", err)
+			presenter.cleanupFailure("bundle source cleanup", err)
 		}
 	}()
 	loadedBundle := loadedBundles[0]
@@ -1003,7 +1007,7 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			presenter.fail(5, "run_quiescence", err)
 			return 3
 		}
-		presenter.note(fmt.Sprintf("abandoned active work: runs=%d deliveries=%d pipeline_receipts=%d", len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount))
+		presenter.recordAbandonedWork(len(result.Runs), len(result.Deliveries), result.PipelineReceiptCount)
 	}
 	if recoveryStore := storeFacade.startupRecoveryStore(); recoveryStore != nil {
 		recoveryWorkspaces, err := configuredWorkspaceLifecycleForServe(storeFacade.workspaceDB(), cfg, loadedBundle.contractsRoot, source, mountSources, primaryWorkspaceBackend)
@@ -1029,19 +1033,19 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 			return 3
 		}
 		if len(recovery.OrphanTargets) > 0 || len(recovery.StoppedContainers) > 0 {
-			presenter.note(fmt.Sprintf("recovered unavailable bundles: orphaned_runs=%d deliveries=%d sessions=%d timers=%d containers=%d pipeline_receipts=%d",
+			presenter.recordRecoveredWork(
 				len(recovery.Cleanup.Runs),
 				len(recovery.Cleanup.Deliveries),
 				len(recovery.Cleanup.Sessions),
 				len(recovery.Cleanup.Timers),
 				len(recovery.StoppedContainers),
 				recovery.Cleanup.PipelineReceiptCount,
-			))
+			)
 		}
 	}
 	pinnedBundleHashes := servePinnedBundleHashes(loadedBundles)
 	if !opts.RequireBundleMatch {
-		presenter.note("bundle-match admission disabled after startup recovery consumed active-run bundle state")
+		presenter.recordBundleMatchDisabledWarning()
 	}
 	if err := enforceServeBundleMatchAdmissionForHashes(ctx, storeFacade.runBundleAvailabilityStore(), serveRuntimeBundleIdentitiesDetail(loadedBundles), opts.RequireBundleMatch, pinnedBundleHashes); err != nil {
 		presenter.fail(5, "bundle_match_admission", err)
@@ -1280,8 +1284,12 @@ func runServeRuntime(ctx context.Context, repo string, opts serveOptions) int {
 		return 3
 	}
 	defer projectContextRegistration.Unregister()
-	go serveHTTPServer("api", apiServer, apiListener, presenter.runtimeFailure)
-	go serveHTTPServer("mcp", mcpServer, mcpListener, presenter.runtimeFailure)
+	runtimeFailure := func(subject string, err error) {
+		presenter.runtimeFailure(subject, err)
+		cancelServe()
+	}
+	go serveHTTPServer("api", apiServer, apiListener, runtimeFailure)
+	go serveHTTPServer("mcp", mcpServer, mcpListener, runtimeFailure)
 	presenter.recordBootWarnings(bootReport)
 	if err := startServeRuntimeContexts(ctx, runtimeContexts, runtimeContextManager); err != nil {
 		presenter.fail(22, "ready", err)

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3734,6 +3734,13 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 	if loaded.serveIdentityDetail() != projection.BundleHash {
 		t.Fatalf("serve identity = %q, want bundle hash %q", loaded.serveIdentityDetail(), projection.BundleHash)
 	}
+	authorLabel := serveRuntimeBundleAuthorLabel(loaded)
+	if authorLabel == "" || strings.Contains(authorLabel, projection.BundleHash) || strings.Contains(authorLabel, loaded.bootIdentity.Fingerprint) {
+		t.Fatalf("author label = %q, want workflow name/version without bundle identity", authorLabel)
+	}
+	if projectName := serveLifecycleProjectName(localRuntimeStateResolution{}, []serveRuntimeBundle{loaded}); projectName != authorLabel {
+		t.Fatalf("no-root project name = %q, want author label %q", projectName, authorLabel)
+	}
 	if loaded.bundleSourceFact.BundleHash != projection.BundleHash || loaded.bundleSourceFact.BundleSource != storerunlifecycle.BundleSourcePersisted {
 		t.Fatalf("bundle source fact = %#v, want persisted %s", loaded.bundleSourceFact, projection.BundleHash)
 	}
@@ -10140,12 +10147,20 @@ func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testin
 		SelfCheck:          true,
 		RequireBundleMatch: true,
 		AbandonActiveRuns:  true,
-		Verbose:            true,
+		Verbose:            false,
 	})
 
 	serve.waitForReadyLine()
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	if !strings.Contains(serve.outputString(), "active work cleared for a clean start") {
+		t.Fatalf("concise abandon output omitted author outcome:\n%s", serve.outputString())
+	}
+	for _, forbidden := range []string{"deliveries", "sessions", "timers", "containers", "pipeline receipts"} {
+		if strings.Contains(serve.outputString(), forbidden) {
+			t.Fatalf("concise abandon output exposed bookkeeping %q:\n%s", forbidden, serve.outputString())
+		}
 	}
 	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
 	if err != nil {
@@ -10373,7 +10388,7 @@ func TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness(t *te
 		MCPListenAddr:           "127.0.0.1:0",
 		SelfCheck:               true,
 		RequireBundleMatch:      false,
-		Verbose:                 true,
+		Verbose:                 false,
 		TestLLMRuntime:          runtimellm.NoopRuntime{},
 		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
 	})
@@ -10381,9 +10396,14 @@ func TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness(t *te
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
-	for _, want := range []string{firstHash, secondHash, "[22/22] ready"} {
+	for _, want := range []string{"swarm serve · 2 persisted bundles", "2 bundles", "ready in "} {
 		if !strings.Contains(serve.outputString(), want) {
 			t.Fatalf("serve output missing %q:\n%s", want, serve.outputString())
+		}
+	}
+	for _, forbidden := range []string{firstHash, secondHash, "bundle-v1:sha256:", "sha256:", "fingerprint"} {
+		if strings.Contains(serve.outputString(), forbidden) {
+			t.Fatalf("concise multi-context output exposed identity %q:\n%s", forbidden, serve.outputString())
 		}
 	}
 }
@@ -10558,12 +10578,20 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
 		RequireBundleMatch: true,
-		Verbose:            true,
+		Verbose:            false,
 	})
 
 	serve.waitForReadyLine()
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
+	}
+	if !strings.Contains(serve.outputString(), "unfinished work restored") {
+		t.Fatalf("concise recovery output omitted author outcome:\n%s", serve.outputString())
+	}
+	for _, forbidden := range []string{"deliveries", "sessions", "timers", "containers", "pipeline receipts"} {
+		if strings.Contains(serve.outputString(), forbidden) {
+			t.Fatalf("concise recovery output exposed bookkeeping %q:\n%s", forbidden, serve.outputString())
+		}
 	}
 	assertServeRuntimeRunStillActive(t, context.Background(), &store.PostgresStore{DB: db}, persistedRunID)
 	for _, target := range orphanTargets {
@@ -14795,11 +14823,15 @@ func postgresMainTestTableExists(t *testing.T, db *sql.DB, tableName string) boo
 	return exists
 }
 
-func TestWaitForServeHealthEndpointsProvesHealthAndReadyRoutes(t *testing.T) {
+func TestWaitForServeHealthEndpointsProvesOnlyPreCommitLiveness(t *testing.T) {
+	var readyCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/healthz", "/readyz":
+		case "/healthz":
 			w.WriteHeader(http.StatusOK)
+		case "/readyz":
+			readyCalls.Add(1)
+			http.Error(w, "not committed", http.StatusServiceUnavailable)
 		default:
 			http.NotFound(w, r)
 		}
@@ -14808,6 +14840,9 @@ func TestWaitForServeHealthEndpointsProvesHealthAndReadyRoutes(t *testing.T) {
 
 	if err := waitForServeHealthEndpoints(context.Background(), server.Listener.Addr()); err != nil {
 		t.Fatalf("waitForServeHealthEndpoints: %v", err)
+	}
+	if readyCalls.Load() != 0 {
+		t.Fatalf("pre-commit liveness probe called /readyz %d times", readyCalls.Load())
 	}
 }
 
@@ -15068,6 +15103,63 @@ func TestStartLocalRunServeClaudeCLIStaleGatewayEnvUsesTypedBinding(t *testing.T
 	}
 	binding := receiveToolGatewayBinding(t, bindingCh, "")
 	assertToolGatewayBindingUsesMCPPort(t, binding, mcpPort, stalePort)
+}
+
+func TestStartLocalRunServeLateReadinessGateFailureDoesNotCommit(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	stubServeRuntimeWorkspaceLifecycle(t)
+	apiPortText := freeDoctorTCPPort(t)
+	apiPort, err := strconv.Atoi(apiPortText)
+	if err != nil {
+		t.Fatalf("parse api port %q: %v", apiPortText, err)
+	}
+
+	apiOpts := defaultRootCommandOptions()
+	apiOpts.apiRPCEndpointOverride = "http://127.0.0.1:" + apiPortText + "/v1/rpc"
+	apiOpts.runReadyTimeout = serveRuntimeReadyTimeout
+	apiOpts.runReadyPoll = 10 * time.Millisecond
+	mcpListenAddr := "127.0.0.1:" + freeDoctorTCPPort(t)
+	var readyStatus atomic.Int32
+	apiOpts.runServe = func(ctx context.Context, repo string, serveOpts serveOptions) int {
+		serveOpts.MCPListenAddr = mcpListenAddr
+		serveOpts.TestBeforeReadinessCommit = func() error {
+			response, probeErr := http.Get("http://127.0.0.1:" + apiPortText + "/readyz")
+			if probeErr != nil {
+				return fmt.Errorf("probe pre-commit readiness: %w", probeErr)
+			}
+			readyStatus.Store(int32(response.StatusCode))
+			_ = response.Body.Close()
+			return errors.New("late readiness proof failed")
+		}
+		return runServeRuntime(ctx, repo, serveOpts)
+	}
+
+	var startupFailure bytes.Buffer
+	stop, err := startLocalRunServe(context.Background(), repoRoot(), runCommandOptions{
+		apiOptions:       apiOpts,
+		configPath:       writeStoreBackendRuntimeConfigWithWorkspaceFields(t, "sqlite", filepath.Join(t.TempDir(), "late-gate.sqlite"), nil),
+		contractsPath:    filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		dataSource:       t.TempDir(),
+		platformSpecPath: defaultPlatformSpecPath,
+		apiPort:          apiPort,
+	}, &startupFailure)
+	if stop != nil {
+		stop()
+		t.Fatal("local run accepted readiness before the late gate committed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "exited before readiness") {
+		t.Fatalf("startLocalRunServe error = %v, want pre-readiness exit", err)
+	}
+	if readyStatus.Load() != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz during final pre-commit gate = %d, want %d", readyStatus.Load(), http.StatusServiceUnavailable)
+	}
+	text := startupFailure.String()
+	if !strings.Contains(text, "serve failed · ready · late readiness proof failed") {
+		t.Fatalf("local run did not replay the truthful late-gate failure:\n%s", text)
+	}
+	if strings.Contains(text, "ready in ") || strings.Contains(text, "shutdown · complete") {
+		t.Fatalf("local run late-gate failure exposed readiness:\n%s", text)
+	}
 }
 
 func TestCreateServeToolGatewayBindingIgnoresStaleLocalURLEnv(t *testing.T) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10585,7 +10585,7 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
-	if !strings.Contains(serve.outputString(), "unfinished work restored") {
+	if !strings.Contains(serve.outputString(), "unfinished work could not be resumed and was closed") {
 		t.Fatalf("concise recovery output omitted author outcome:\n%s", serve.outputString())
 	}
 	for _, forbidden := range []string{"deliveries", "sessions", "timers", "containers", "pipeline receipts"} {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
 	"github.com/division-sh/swarm/internal/events"
@@ -3393,12 +3394,161 @@ func TestServeLifecyclePresenterProjectsBootFactsByMode(t *testing.T) {
 	}
 
 	var verbose bytes.Buffer
-	newServeLifecyclePresenter(serveOptions{Verbose: true, Output: &verbose}).boot(1, "process_start", "ok", "contracts=contracts")
+	verbosePresenter := newServeLifecyclePresenter(serveOptions{Verbose: true, Output: &verbose})
+	verbosePresenter.boot(1, "process_start", "ok", "contracts=contracts")
+	if verbose.Len() != 0 {
+		t.Fatalf("verbose presenter emitted uncommitted startup facts = %q", verbose.String())
+	}
+	verbosePresenter.fail(2, "config_load", errors.New("invalid config"))
+	verbosePresenter.finish()
 	out := verbose.String()
-	for _, want := range []string{"[1/22]", "process_start", "ok", "contracts=contracts"} {
+	for _, want := range []string{"[1/22]", "process_start", "ok", "contracts=contracts", "[2/22]", "config_load", "FAILED"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("verbose output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestCLI_ServeLifecycleRoutesDiagnosticsToStderr(t *testing.T) {
+	tests := []struct {
+		name           string
+		run            func(*serveLifecyclePresenter)
+		code           int
+		wantStderr     string
+		wantStdout     string
+		startupFailure bool
+	}{
+		{
+			name: "generic startup failure", code: 1, wantStderr: "ERROR: serve failed · config load · missing config", startupFailure: true,
+			run: func(p *serveLifecyclePresenter) { p.fail(2, "config_load", errors.New("missing config")) },
+		},
+		{
+			name: "specialized startup failure", code: 3, wantStderr: "[BLOCKER] workspace_prerequisite", startupFailure: true,
+			run: func(p *serveLifecyclePresenter) {
+				p.failWithDiagnostic(5, "runtime_context", errors.New("workspace unavailable"), func(out io.Writer) bool {
+					fmt.Fprintln(out, "[BLOCKER] workspace_prerequisite: workspace unavailable")
+					return true
+				})
+			},
+		},
+		{
+			name: "listener failure", code: 3, wantStderr: "ERROR: serve failed · http listener bind · address already in use", startupFailure: true,
+			run: func(p *serveLifecyclePresenter) {
+				p.fail(20, "http_listener_bind", errors.New("address already in use"))
+			},
+		},
+		{
+			name: "boot warning", code: 0, wantStderr: "WARNING: using the built-in development API token", wantStdout: "ready in",
+			run: func(p *serveLifecyclePresenter) {
+				p.recordDefaultAPITokenWarning()
+				p.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+				p.shutdown(nil)
+			},
+		},
+		{
+			name: "runtime failure", code: 1, wantStderr: "ERROR: runtime failed · api server · accept failed", wantStdout: "ready in",
+			run: func(p *serveLifecyclePresenter) {
+				p.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+				p.runtimeFailure("api server", errors.New("accept failed"))
+				p.shutdown(nil)
+			},
+		},
+		{
+			name: "failed shutdown", code: 1, wantStderr: "ERROR: shutdown · failed · drain timed out", wantStdout: "ready in",
+			run: func(p *serveLifecyclePresenter) {
+				p.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+				p.shutdown(errors.New("drain timed out"))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := defaultRootCommandOptions()
+			opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+				presenter := newServeLifecyclePresenter(serveOpts)
+				test.run(presenter)
+				presenter.finish()
+				return test.code
+			}
+			var stdout, stderr bytes.Buffer
+			code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve"}, &stdout, &stderr, opts)
+			if code != test.code {
+				t.Fatalf("code = %d, want %d\nstdout=%s\nstderr=%s", code, test.code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), test.wantStderr) {
+				t.Fatalf("stderr missing %q:\n%s", test.wantStderr, stderr.String())
+			}
+			if test.wantStdout != "" && !strings.Contains(stdout.String(), test.wantStdout) {
+				t.Fatalf("stdout missing %q:\n%s", test.wantStdout, stdout.String())
+			}
+			if test.startupFailure && stdout.Len() != 0 {
+				t.Fatalf("startup failure contaminated stdout: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCLI_ServeMissingPlatformSpecWritesOnlyStderr(t *testing.T) {
+	isolateCLIAPIConfigEnv(t)
+	var stdout, stderr bytes.Buffer
+	missing := filepath.Join(t.TempDir(), "missing-platform-spec.yaml")
+	configPath := writeStoreBackendRuntimeConfigWithWorkspaceFields(t, "sqlite", filepath.Join(t.TempDir(), "missing-spec.sqlite"), nil)
+	code := executeRootCommand(context.Background(), repoRoot(), []string{
+		"serve",
+		"--config", configPath,
+		"--contracts", filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		"--platform-spec", missing,
+		"--store", "sqlite",
+	}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("serve code = 0, want startup failure\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("missing platform spec contaminated stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "ERROR: serve failed") || !strings.Contains(stderr.String(), "missing-platform-spec.yaml") {
+		t.Fatalf("missing platform spec stderr is incomplete:\n%s", stderr.String())
+	}
+}
+
+func TestRunServeRuntimeJoinsEarlyStartupAndStoreCleanupFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	mock.ExpectClose().WillReturnError(errors.New("close journal"))
+
+	oldBuildStores := buildStoresForServe
+	buildStoresForServe = func(context.Context, storebackend.Selection, *config.Config) (storeBundle, error) {
+		return storeBundle{SQLDB: db}, nil
+	}
+	t.Cleanup(func() { buildStoresForServe = oldBuildStores })
+
+	var stdout, stderr bytes.Buffer
+	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
+		ConfigPath:         writeStoreBackendRuntimeConfigWithWorkspaceFields(t, "sqlite", filepath.Join(t.TempDir(), "unused.sqlite"), nil),
+		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
+		PlatformSpecPath:   defaultPlatformSpecPath,
+		StoreMode:          "sqlite",
+		StoreModeSet:       true,
+		APIListenAddr:      "127.0.0.1:0",
+		MCPListenAddr:      "127.0.0.1:0",
+		RequireBundleMatch: false,
+		Output:             &stdout,
+		ErrorOutput:        &stderr,
+	})
+	if code == 0 {
+		t.Fatalf("runServeRuntime code = 0, want startup failure\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("close expectation: %v", err)
+	}
+	text := stderr.String()
+	if strings.Count(text, "ERROR:") != 1 || !strings.Contains(text, "close journal") {
+		t.Fatalf("startup and store cleanup did not produce one joined terminal failure:\n%s", text)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("early startup failure contaminated stdout: %q", stdout.String())
 	}
 }
 
@@ -9673,7 +9823,7 @@ func TestRunServeRuntimeNoAgentDefaultBootsWithoutDocker(t *testing.T) {
 	if code := serve.stop(); code != 0 {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
-	if !strings.Contains(serve.outputString(), "workspace backend: none") {
+	if !strings.Contains(serve.outputString(), "workspace                  not required") {
 		t.Fatalf("serve output missing no-workspace decision:\n%s", serve.outputString())
 	}
 	if strings.Contains(serve.outputString(), "workspace image") || strings.Contains(serve.outputString(), "Docker is not reachable") {
@@ -9708,7 +9858,7 @@ func TestRunServeRuntimeAPIAgentDefaultHostBootsWithoutDocker(t *testing.T) {
 		t.Fatalf("runServeRuntime code = %d\noutput:\n%s", code, serve.outputString())
 	}
 	output := serve.outputString()
-	if !strings.Contains(output, "workspace backend: host") {
+	if !strings.Contains(output, "workspace                  host · agent work runs on this machine") {
 		t.Fatalf("serve output missing host workspace decision for API-backed agent:\n%s", output)
 	}
 	if strings.Contains(strings.ToLower(output), "docker is not reachable") {
@@ -9742,7 +9892,7 @@ func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) 
 		t.Fatalf("runServeRuntime code = 0, want Docker prerequisite failure\noutput:\n%s", out.String())
 	}
 	output := out.String()
-	for _, want := range []string{"[5/22] runtime_context", "workspace backend: docker", "native_tools.bash", "Docker is not reachable", missingDocker + " info"} {
+	for _, want := range []string{"[5/22] startup_ownership_lease", "workspace                  docker · agent \"native-bash-worker\" runs in a container", "Docker is not reachable", missingDocker + " info"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("serve output missing %q:\n%s", want, output)
 		}
@@ -9882,7 +10032,7 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForUnusableArtifac
 		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
 	}
 	for _, want := range []string{
-		"[5/22] runtime_context",
+		"[5/22] startup_ownership_lease",
 		"artifact repo root startup validation failed",
 		rootFile,
 		"SWARM_ARTIFACT_ROOT=<writable runtime-private absolute path>",
@@ -9927,7 +10077,7 @@ func TestRunServeRuntimeArtifactRepoCommitFailsBeforeReadinessForBlockedRepoStor
 		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
 	}
 	for _, want := range []string{
-		"[5/22] runtime_context",
+		"[5/22] startup_ownership_lease",
 		"artifact repo root startup validation failed",
 		artifactRoot,
 		reposFile,
@@ -10182,7 +10332,7 @@ func TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness(t *testing.T) {
 		t.Fatalf("runServeRuntime code = 0, want startup failure\noutput:\n%s", out.String())
 	}
 	for _, want := range []string{
-		"[5/22] runtime_context",
+		"[5/22] startup_ownership_lease",
 		`duplicate runtime context agent_id "shared-worker"`,
 		firstHash,
 		secondHash,
@@ -10276,7 +10426,7 @@ func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrFo
 	}
 	for _, want := range []string{
 		"[4/22] bundle_load",
-		"[5/22] runtime_context",
+		"[5/22] startup_ownership_lease",
 		"multi-context swarm serve --bundle-hash",
 		"llm.backend=claude_cli",
 		"ToolGatewayBinding",
@@ -15028,7 +15178,7 @@ func assertRunServeRuntimeRetiredGatewayURLAdmissionFailure(t *testing.T, envNam
 	}
 	for _, want := range []string{
 		"config_load",
-		"serve_admission",
+		"serve admission",
 		envName,
 		"retired",
 		"unset " + envName,

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1099,11 +1098,29 @@ func TestCLI_ServeDevFlagComposesClosedServeOwners(t *testing.T) {
 	if !captured.NoRequireBundleMatch || captured.RequireBundleMatch {
 		t.Fatalf("serve bundle match = require:%t no-require:%t, want dev no-require composition", captured.RequireBundleMatch, captured.NoRequireBundleMatch)
 	}
-	if !captured.Verbose {
-		t.Fatal("serve verbose = false, want dev composition")
+	if captured.Verbose {
+		t.Fatal("serve verbose = true, want dev and presentation verbosity to remain independent")
 	}
 	if captured.ShutdownGrace != wantGrace {
 		t.Fatalf("serve shutdown grace = %s, want explicit %s", captured.ShutdownGrace, wantGrace)
+	}
+}
+
+func TestCLI_ServeDevAndExplicitVerboseComposeIndependently(t *testing.T) {
+	var captured serveOptions
+	opts := defaultRootCommandOptions()
+	opts.runServe = func(_ context.Context, _ string, serveOpts serveOptions) int {
+		captured = serveOpts
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"serve", "--dev", "--verbose"}, &stdout, &stderr, opts)
+	if code != 0 {
+		t.Fatalf("serve code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !captured.Dev || !captured.Verbose {
+		t.Fatalf("serve dev/verbose = %t/%t, want both explicit modes", captured.Dev, captured.Verbose)
 	}
 }
 
@@ -1151,8 +1168,8 @@ func TestCLI_ServeDevAcceptsExplicitRequireBundleMatchFalse(t *testing.T) {
 
 func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 	spec := loadServeDevModeSpec(t)
-	if strings.TrimSpace(spec.ImplementedBy) != "#830" {
-		t.Fatalf("dev mode implemented_by = %q, want #830", spec.ImplementedBy)
+	if !strings.Contains(spec.ImplementedBy, "#830") || !strings.Contains(spec.ImplementedBy, "#2010") {
+		t.Fatalf("dev mode implemented_by = %q, want #830/#2010 migration", spec.ImplementedBy)
 	}
 	if strings.TrimSpace(spec.Flag) != "--dev" {
 		t.Fatalf("dev mode flag = %q, want --dev", spec.Flag)
@@ -1160,7 +1177,7 @@ func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 	for _, want := range []string{
 		"`--abandon-active-runs`",
 		"`--no-require-bundle-match`",
-		"`--verbose`",
+		"without setting `--verbose`",
 		"dev entity-container cleanup",
 	} {
 		if !stringSliceContains(spec.Composition, want) {
@@ -1178,6 +1195,11 @@ func TestPlatformSpecServeDevModeCompositionPromoted(t *testing.T) {
 		}
 	}
 	for _, want := range []string{"--dev --require-bundle-match=false", "redundant but valid"} {
+		if !stringSliceContains(spec.ConflictRules, want) {
+			t.Fatalf("dev mode conflict rules missing %q: %#v", want, spec.ConflictRules)
+		}
+	}
+	for _, want := range []string{"--dev --verbose", "not redundant"} {
 		if !stringSliceContains(spec.ConflictRules, want) {
 			t.Fatalf("dev mode conflict rules missing %q: %#v", want, spec.ConflictRules)
 		}
@@ -3362,15 +3384,16 @@ func TestCloseServeRuntimeDevCleanupRunsAfterShutdownAndJoinsErrors(t *testing.T
 	}
 }
 
-func TestServeBootReporterEmitsNumberedProgressOnlyWhenVerbose(t *testing.T) {
+func TestServeLifecyclePresenterProjectsBootFactsByMode(t *testing.T) {
 	var quiet bytes.Buffer
-	newServeBootReporter(false, &quiet).emit(1, "process_start", "ok", "")
+	concise := newServeLifecyclePresenter(serveOptions{Output: &quiet})
+	concise.boot(1, "process_start", "ok", "")
 	if quiet.Len() != 0 {
-		t.Fatalf("quiet reporter output = %q, want empty", quiet.String())
+		t.Fatalf("concise presenter emitted before readiness = %q", quiet.String())
 	}
 
 	var verbose bytes.Buffer
-	newServeBootReporter(true, &verbose).emit(1, "process_start", "ok", "contracts=contracts")
+	newServeLifecyclePresenter(serveOptions{Verbose: true, Output: &verbose}).boot(1, "process_start", "ok", "contracts=contracts")
 	out := verbose.String()
 	for _, want := range []string{"[1/22]", "process_start", "ok", "contracts=contracts"} {
 		if !strings.Contains(out, want) {
@@ -14389,116 +14412,76 @@ func TestServeBootRegistryDetail_UsesRuntimeToolInventoryCount(t *testing.T) {
 	}
 }
 
-func TestSummarizeServeSchemaPlansDefaultOmitsTableBreakdown(t *testing.T) {
+func TestSummarizeServeSchemaPlansOmitsTableBreakdown(t *testing.T) {
 	plans := []store.SchemaTableDDL{
 		{TableName: "events", ColumnCount: 17},
 		{TableName: "runs", ColumnCount: 14},
 	}
 
-	summary, logOutput := captureServeSchemaPlanSummary(t, plans, false)
+	summary := summarizeServeSchemaPlans(plans)
 
 	if summary != "verified 2 generated tables" {
 		t.Fatalf("summary = %q, want concise generated-table count", summary)
 	}
 	for _, forbidden := range []string{"events(17)", "runs(14)", "detail="} {
-		if strings.Contains(summary, forbidden) || strings.Contains(logOutput, forbidden) {
-			t.Fatalf("default schema summary leaked %q\nsummary=%s\nlog=%s", forbidden, summary, logOutput)
-		}
-	}
-	for _, want := range []string{"swarm boot state stores", "tables=2", "columns=31"} {
-		if !strings.Contains(logOutput, want) {
-			t.Fatalf("default schema log missing %q:\n%s", want, logOutput)
+		if strings.Contains(summary, forbidden) {
+			t.Fatalf("serve schema summary leaked %q: %s", forbidden, summary)
 		}
 	}
 }
 
-func TestSummarizeServeSchemaPlansVerboseRetainsTableBreakdown(t *testing.T) {
+func TestDoctorSchemaInventoryRetainsTypedSortedTableBreakdown(t *testing.T) {
 	plans := []store.SchemaTableDDL{
 		{TableName: "runs", ColumnCount: 14},
 		{TableName: "events", ColumnCount: 17},
 	}
 
-	summary, logOutput := captureServeSchemaPlanSummary(t, plans, true)
-
-	if summary != "verified 2 generated tables (events(17), runs(14))" {
-		t.Fatalf("summary = %q, want sorted verbose table breakdown", summary)
+	summary := newServeSchemaPlanSummary(plans)
+	if summary.tableCount != 2 || summary.columnCount != 31 {
+		t.Fatalf("summary counts = %d/%d, want 2/31", summary.tableCount, summary.columnCount)
 	}
-	for _, forbidden := range []string{"events(17)", "runs(14)", "detail="} {
-		if strings.Contains(logOutput, forbidden) {
-			t.Fatalf("process log leaked verbose schema detail %q:\n%s", forbidden, logOutput)
-		}
+	if len(summary.tables) != 2 || summary.tables[0].Name != "events" || summary.tables[0].ColumnCount != 17 || summary.tables[1].Name != "runs" || summary.tables[1].ColumnCount != 14 {
+		t.Fatalf("typed inventory = %#v, want sorted events/runs rows", summary.tables)
 	}
 }
 
 func TestSummarizeServeSchemaPlansZeroPlans(t *testing.T) {
-	summary, logOutput := captureServeSchemaPlanSummary(t, nil, true)
+	summary := summarizeServeSchemaPlans(nil)
 
 	if summary != "verified 0 generated tables" {
 		t.Fatalf("summary = %q, want zero generated-table summary", summary)
 	}
-	for _, want := range []string{"tables=0", "columns=0"} {
-		if !strings.Contains(logOutput, want) {
-			t.Fatalf("zero-plan schema log missing %q:\n%s", want, logOutput)
-		}
-	}
-	if strings.Contains(logOutput, "detail=") {
-		t.Fatalf("zero-plan schema log emitted empty detail:\n%s", logOutput)
-	}
 }
 
-func TestInitializeServeSchemaStateStoresConsumeVerboseOwner(t *testing.T) {
+func TestInitializeServeSchemaStateStoresNeverExposeTableInventory(t *testing.T) {
 	ctx := context.Background()
 	bundle := loadStoreBackendSelectionWorkflowBundle(t)
 	stores := storeBundle{SchemaBootstrapper: recordingSchemaBootstrapper{}}
 
-	defaultSummary, err := initializeStateStores(ctx, stores, bundle, false)
+	defaultSummary, err := initializeStateStores(ctx, stores, bundle)
 	if err != nil {
-		t.Fatalf("initializeStateStores(default): %v", err)
+		t.Fatalf("initializeStateStores: %v", err)
 	}
 	if strings.Contains(defaultSummary, "(") {
-		t.Fatalf("default loaded-bundle state store summary leaked table detail:\n%s", defaultSummary)
+		t.Fatalf("loaded-bundle state store summary leaked table detail:\n%s", defaultSummary)
 	}
 
-	verboseSummary, err := initializeStateStores(ctx, stores, bundle, true)
+	loadedDefaultSummaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, []serveRuntimeBundle{{bundle: bundle}, {bundle: bundle}})
 	if err != nil {
-		t.Fatalf("initializeStateStores(verbose): %v", err)
-	}
-	if !strings.Contains(verboseSummary, "(") || !strings.Contains(verboseSummary, ")") {
-		t.Fatalf("verbose loaded-bundle state store summary missing table detail:\n%s", verboseSummary)
-	}
-
-	loadedDefaultSummaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, []serveRuntimeBundle{{bundle: bundle}, {bundle: bundle}}, false)
-	if err != nil {
-		t.Fatalf("initializeLoadedServeRuntimeStateStores(default): %v", err)
+		t.Fatalf("initializeLoadedServeRuntimeStateStores: %v", err)
 	}
 	for _, summary := range loadedDefaultSummaries {
 		if strings.Contains(summary, "(") {
-			t.Fatalf("default loaded runtime state store summary leaked table detail:\n%v", loadedDefaultSummaries)
+			t.Fatalf("loaded runtime state store summary leaked table detail:\n%v", loadedDefaultSummaries)
 		}
 	}
 
-	loadedVerboseSummaries, err := initializeLoadedServeRuntimeStateStores(ctx, stores, []serveRuntimeBundle{{bundle: bundle}}, true)
+	defaultPlatformSummary, err := initializeServePlatformStateStores(ctx, stores, filepath.Join(repoRoot(), defaultPlatformSpecPath))
 	if err != nil {
-		t.Fatalf("initializeLoadedServeRuntimeStateStores(verbose): %v", err)
-	}
-	if len(loadedVerboseSummaries) != 1 || !strings.Contains(loadedVerboseSummaries[0], "(") || !strings.Contains(loadedVerboseSummaries[0], ")") {
-		t.Fatalf("verbose loaded runtime state store summary missing table detail:\n%v", loadedVerboseSummaries)
-	}
-
-	defaultPlatformSummary, err := initializeServePlatformStateStores(ctx, stores, filepath.Join(repoRoot(), defaultPlatformSpecPath), false)
-	if err != nil {
-		t.Fatalf("initializeServePlatformStateStores(default): %v", err)
+		t.Fatalf("initializeServePlatformStateStores: %v", err)
 	}
 	if strings.Contains(defaultPlatformSummary, "(") {
-		t.Fatalf("default pre-catalog platform state store summary leaked table detail:\n%s", defaultPlatformSummary)
-	}
-
-	verbosePlatformSummary, err := initializeServePlatformStateStores(ctx, stores, filepath.Join(repoRoot(), defaultPlatformSpecPath), true)
-	if err != nil {
-		t.Fatalf("initializeServePlatformStateStores(verbose): %v", err)
-	}
-	if !strings.Contains(verbosePlatformSummary, "(") || !strings.Contains(verbosePlatformSummary, ")") {
-		t.Fatalf("verbose pre-catalog platform state store summary missing table detail:\n%s", verbosePlatformSummary)
+		t.Fatalf("pre-catalog platform state store summary leaked table detail:\n%s", defaultPlatformSummary)
 	}
 }
 
@@ -14507,7 +14490,7 @@ func TestInitializeStateStoresDoesNotPlanGeneratedEntityTables(t *testing.T) {
 	bundle := workflowBundleWithGeneratedEntitySchemaForStateStoreTest(t)
 	recorder := &capturingSchemaBootstrapper{}
 
-	summary, err := initializeStateStores(ctx, storeBundle{SchemaBootstrapper: recorder}, bundle, true)
+	summary, err := initializeStateStores(ctx, storeBundle{SchemaBootstrapper: recorder}, bundle)
 	if err != nil {
 		t.Fatalf("initializeStateStores: %v", err)
 	}
@@ -14532,7 +14515,7 @@ func TestInitializeStateStoresSQLiteDoesNotCreateGeneratedEntityTables(t *testin
 		}
 	})
 
-	if _, err := initializeStateStores(ctx, storeBundle{SchemaBootstrapper: sqliteStore}, bundle, false); err != nil {
+	if _, err := initializeStateStores(ctx, storeBundle{SchemaBootstrapper: sqliteStore}, bundle); err != nil {
 		t.Fatalf("initializeStateStores(sqlite): %v", err)
 	}
 	if !sqliteMainTestTableExists(t, sqliteStore.DB, "entity_state") {
@@ -14558,7 +14541,7 @@ func TestInitializeStateStoresPostgresDoesNotCreateGeneratedEntityTables(t *test
 		}
 	})
 
-	if _, err := initializeStateStores(ctx, selectedPostgresStoreBundle(pg, &config.Config{}), bundle, false); err != nil {
+	if _, err := initializeStateStores(ctx, selectedPostgresStoreBundle(pg, &config.Config{}), bundle); err != nil {
 		t.Fatalf("initializeStateStores(postgres): %v", err)
 	}
 	if !postgresMainTestTableExists(t, db, "entity_state") {
@@ -14573,27 +14556,12 @@ func TestServeRuntimeStateStoreSummaryDedupesSchemaSummaries(t *testing.T) {
 	got := serveRuntimeStateStoreSummary([]serveRuntimeBundleContext{
 		{stateStoreSummary: "verified 2 generated tables"},
 		{stateStoreSummary: "verified 2 generated tables"},
-		{stateStoreSummary: "verified 2 generated tables (events(17), runs(14))"},
 		{stateStoreSummary: " "},
 	})
 
-	if strings.Count(got, "verified 2 generated tables") != 2 {
-		t.Fatalf("summary = %q, want one concise and one verbose summary after de-dupe", got)
+	if strings.Count(got, "verified 2 generated tables") != 1 {
+		t.Fatalf("summary = %q, want one concise summary after de-dupe", got)
 	}
-	if strings.Count(got, "events(17)") != 1 {
-		t.Fatalf("summary = %q, want one verbose table detail after de-dupe", got)
-	}
-}
-
-func captureServeSchemaPlanSummary(t *testing.T, plans []store.SchemaTableDDL, verbose bool) (string, string) {
-	t.Helper()
-	var logOutput bytes.Buffer
-	previous := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	t.Cleanup(func() {
-		slog.SetDefault(previous)
-	})
-	return summarizeServeSchemaPlans(plans, verbose), logOutput.String()
 }
 
 type recordingSchemaBootstrapper struct{}
@@ -14699,33 +14667,12 @@ func TestRunServeRuntimeVerboseEmitsPlatformSpecBootSequence(t *testing.T) {
 		t.Fatalf("serve boot progress spec step count = %d, want %d", got, want)
 	}
 
-	oldBuildStores := buildStoresForServe
-	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	dsn, _, cleanup := testutil.StartPostgres(t)
-	t.Cleanup(cleanup)
-	runtimePG, err := store.NewPostgresStore(dsn)
-	if err != nil {
-		t.Fatalf("NewPostgresStore: %v", err)
-	}
-	buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
-		if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
-			return storeBundle{}, err
-		}
-		return selectedPostgresStoreBundle(runtimePG, cfg), nil
-	}
-	configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
-		return serveRuntimeWorkspaceStub{}, nil
-	}
-	t.Cleanup(func() {
-		buildStoresForServe = oldBuildStores
-		configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
-	})
-
+	sqlitePath := filepath.Join(t.TempDir(), "verbose-sequence.sqlite")
 	serve := startServeRuntimeTestProcess(t, serveOptions{
-		ConfigPath:         writeServeRuntimeTestConfig(t),
+		ConfigPath:         writeStoreBackendRuntimeConfigWithWorkspaceFields(t, "sqlite", sqlitePath, nil),
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 		PlatformSpecPath:   defaultPlatformSpecPath,
-		StoreMode:          "postgres",
+		StoreMode:          "sqlite",
 		APIListenAddr:      "127.0.0.1:0",
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
@@ -14772,27 +14719,6 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
 			t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
-			oldBuildStores := buildStoresForServe
-			oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-			dsn, _, cleanup := testutil.StartPostgres(t)
-			t.Cleanup(cleanup)
-			runtimePG, err := store.NewPostgresStore(dsn)
-			if err != nil {
-				t.Fatalf("NewPostgresStore: %v", err)
-			}
-			buildStoresForServe = func(ctx context.Context, _ storebackend.Selection, cfg *config.Config) (storeBundle, error) {
-				if _, err := runtimePG.BindSchemaCapabilities(ctx); err != nil {
-					return storeBundle{}, err
-				}
-				return selectedPostgresStoreBundle(runtimePG, cfg), nil
-			}
-			configuredWorkspaceLifecycleForServe = func(*sql.DB, *config.Config, string, semanticview.Source, workspaceMountSources, workspaceBackendSelection) (serveWorkspaceLifecycle, error) {
-				return serveRuntimeWorkspaceStub{}, nil
-			}
-			t.Cleanup(func() {
-				buildStoresForServe = oldBuildStores
-				configuredWorkspaceLifecycleForServe = oldWorkspaceLifecycle
-			})
 
 			occupied, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
@@ -14806,27 +14732,32 @@ func TestRunServeRuntimeListenerBindFailuresExitBeforeReadiness(t *testing.T) {
 			} else {
 				mcpAddr = occupied.Addr().String()
 			}
+			verbose := !tt.occupyAPI
 
 			var out lockedBuffer
 			code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
-				ConfigPath:         writeServeRuntimeTestConfig(t),
+				ConfigPath:         writeStoreBackendRuntimeConfigWithWorkspaceFields(t, "sqlite", filepath.Join(t.TempDir(), "listener-bind.sqlite"), nil),
 				ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
 				PlatformSpecPath:   defaultPlatformSpecPath,
-				StoreMode:          "postgres",
+				StoreMode:          "sqlite",
 				APIListenAddr:      apiAddr,
 				MCPListenAddr:      mcpAddr,
 				SelfCheck:          true,
 				RequireBundleMatch: true,
-				Verbose:            true,
+				Verbose:            verbose,
 				Output:             &out,
 			})
 			if code != 3 {
 				t.Fatalf("runServeRuntime code = %d, want 3\noutput:\n%s", code, out.String())
 			}
-			if !strings.Contains(out.String(), "http_listener_bind") || !strings.Contains(out.String(), "FAILED") {
-				t.Fatalf("serve output missing bind failure proof:\n%s", out.String())
+			if verbose {
+				if !strings.Contains(out.String(), "http_listener_bind") || !strings.Contains(out.String(), "FAILED") {
+					t.Fatalf("verbose serve output missing bind failure proof:\n%s", out.String())
+				}
+			} else if !strings.Contains(out.String(), "serve failed · http listener bind") {
+				t.Fatalf("concise serve output missing bind failure proof:\n%s", out.String())
 			}
-			if strings.Contains(out.String(), "ready                      ok") {
+			if strings.Contains(out.String(), "ready                      ok") || strings.Contains(out.String(), "\n  ready in ") {
 				t.Fatalf("serve reported readiness after listener bind failure:\n%s", out.String())
 			}
 		})
@@ -15737,7 +15668,7 @@ func waitForServeReadyLine(t *testing.T, out *lockedBuffer, done <-chan int) {
 		case <-deadline:
 			t.Fatalf("timed out waiting for serve ready line\noutput:\n%s", out.String())
 		case <-ticker.C:
-			if strings.Contains(out.String(), "[22/22]") {
+			if serveOutputIsReady(out.String()) {
 				return
 			}
 		}
@@ -15800,7 +15731,7 @@ func (p *serveRuntimeTestProcess) waitForReadyLine() {
 			}
 			p.t.Fatalf("timed out waiting for serve ready line and stopping runServeRuntime\noutput:\n%s", p.outputString())
 		case <-ticker.C:
-			if strings.Contains(p.outputString(), "[22/22]") {
+			if serveOutputIsReady(p.outputString()) {
 				return
 			}
 		}
@@ -15861,15 +15792,23 @@ func (p *serveRuntimeTestProcess) recordStopped(code int) {
 func serveRuntimeAPIListenerFromOutput(t *testing.T, output string) string {
 	t.Helper()
 	for _, line := range strings.Split(output, "\n") {
-		for _, field := range strings.Fields(line) {
+		fields := strings.Fields(line)
+		for i, field := range fields {
 			field = strings.Trim(field, "(),")
 			if addr, ok := strings.CutPrefix(field, "api_listener="); ok && strings.TrimSpace(addr) != "" {
 				return addr
+			}
+			if strings.TrimSpace(line) != "" && fields[0] == "listeners" && field == "api" && i+1 < len(fields) {
+				return strings.Trim(fields[i+1], "(),")
 			}
 		}
 	}
 	t.Fatalf("serve output missing api_listener:\n%s", output)
 	return ""
+}
+
+func serveOutputIsReady(output string) bool {
+	return strings.Contains(output, "[22/22]") || strings.Contains(output, "\n  ready in ")
 }
 
 type serveBootProgressRow struct {

--- a/cmd/swarm/run_command.go
+++ b/cmd/swarm/run_command.go
@@ -429,6 +429,7 @@ func startLocalRunServe(ctx context.Context, repo string, opts runCommandOptions
 	serveOpts.LocalRun = true
 	var startupOutput runStartupOutput
 	serveOpts.Output = &startupOutput
+	serveOpts.ErrorOutput = &startupOutput
 	if opts.apiPort > 0 {
 		serveOpts.APIListenAddr = net.JoinHostPort("127.0.0.1", strconv.Itoa(opts.apiPort))
 	}

--- a/cmd/swarm/serve_lifecycle_presentation.go
+++ b/cmd/swarm/serve_lifecycle_presentation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -135,7 +136,7 @@ func (p *serveLifecyclePresenter) fail(step int, name string, err error) {
 	p.failWithDiagnostic(step, name, err, nil)
 }
 
-func (p *serveLifecyclePresenter) failWithDiagnostic(step int, name string, err error, render func(io.Writer)) {
+func (p *serveLifecyclePresenter) failWithDiagnostic(step int, name string, err error, render func(io.Writer) bool) {
 	if p == nil || err == nil {
 		return
 	}
@@ -158,9 +159,12 @@ func (p *serveLifecyclePresenter) failWithDiagnostic(step int, name string, err 
 		p.writeBootEventLocked(event)
 	}
 	if render != nil {
-		p.writeFailureContextLocked()
-		render(p.out)
-		return
+		var rendered bytes.Buffer
+		if render(&rendered) {
+			p.writeFailureContextLocked()
+			_, _ = io.Copy(p.out, &rendered)
+			return
+		}
 	}
 	if !p.verbose {
 		p.writeFailureLocked(event.Name, event.Detail)

--- a/cmd/swarm/serve_lifecycle_presentation.go
+++ b/cmd/swarm/serve_lifecycle_presentation.go
@@ -1,0 +1,462 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/division-sh/swarm/internal/packs"
+	"github.com/division-sh/swarm/internal/runtime"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+)
+
+type serveLifecycleWorkspaceFact struct {
+	Bundle   string
+	Decision workspaceBackendSelection
+}
+
+type serveLifecycleIngressFact struct {
+	Provider      string
+	URL           string
+	SigningSecret string
+	SigningBound  bool
+	BundleHash    string
+	Subject       packs.Subject
+}
+
+type serveLifecycleReadyFacts struct {
+	ProjectName string
+	BundleCount int
+	FlowCount   int
+	AgentCount  int
+	ToolCount   int
+	APIListener string
+	MCPListener string
+	ReadyAfter  time.Duration
+	Standing    []serveLifecycleIngressFact
+}
+
+// serveLifecyclePresenter is the sole human presentation owner for serve
+// boot, readiness, standing ingress, and shutdown facts.
+type serveLifecyclePresenter struct {
+	mu sync.Mutex
+
+	out     io.Writer
+	dev     bool
+	verbose bool
+
+	bootEvents map[int]runtime.BootProgressEvent
+	store      *storebackend.Selection
+	workspaces []serveLifecycleWorkspaceFact
+	warnings   []runtimebootverify.Finding
+	notes      []string
+
+	ready         bool
+	failed        bool
+	runtimeFailed bool
+}
+
+func newServeLifecyclePresenter(opts serveOptions) *serveLifecyclePresenter {
+	out := opts.Output
+	if out == nil {
+		out = io.Discard
+	}
+	return &serveLifecyclePresenter{
+		out:        out,
+		dev:        opts.Dev,
+		verbose:    opts.Verbose,
+		bootEvents: map[int]runtime.BootProgressEvent{},
+	}
+}
+
+func (p *serveLifecyclePresenter) runtimeSink() func(runtime.BootProgressEvent) {
+	if p == nil {
+		return nil
+	}
+	return p.observeBoot
+}
+
+func (p *serveLifecyclePresenter) boot(step int, name, status, detail string) {
+	if p == nil {
+		return
+	}
+	p.observeBoot(runtime.BootProgressEvent{
+		Step:   step,
+		Total:  runtime.BootProgressTotalSteps,
+		Name:   strings.TrimSpace(name),
+		Status: strings.TrimSpace(status),
+		Detail: strings.TrimSpace(detail),
+		At:     time.Now().UTC(),
+	})
+}
+
+func (p *serveLifecyclePresenter) observeBoot(event runtime.BootProgressEvent) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	event.Name = strings.TrimSpace(event.Name)
+	event.Status = strings.TrimSpace(event.Status)
+	event.Detail = strings.TrimSpace(event.Detail)
+	if event.Total == 0 {
+		event.Total = runtime.BootProgressTotalSteps
+	}
+	if event.Status == "" {
+		event.Status = "ok"
+	}
+	p.bootEvents[event.Step] = event
+	if strings.EqualFold(event.Status, "failed") {
+		if p.failed {
+			return
+		}
+		p.failed = true
+		if p.verbose {
+			p.writeBootEventLocked(event)
+		} else {
+			p.writeFailureLocked(event.Name, event.Detail)
+		}
+		return
+	}
+	if p.verbose {
+		p.writeBootEventLocked(event)
+	}
+}
+
+func (p *serveLifecyclePresenter) fail(step int, name string, err error) {
+	if err == nil {
+		return
+	}
+	p.failWithDiagnostic(step, name, err, nil)
+}
+
+func (p *serveLifecyclePresenter) failWithDiagnostic(step int, name string, err error, render func(io.Writer)) {
+	if p == nil || err == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.failed {
+		return
+	}
+	p.failed = true
+	event := runtime.BootProgressEvent{
+		Step:   step,
+		Total:  runtime.BootProgressTotalSteps,
+		Name:   strings.TrimSpace(name),
+		Status: "FAILED",
+		Detail: strings.TrimSpace(err.Error()),
+		At:     time.Now().UTC(),
+	}
+	p.bootEvents[step] = event
+	if p.verbose {
+		p.writeBootEventLocked(event)
+	}
+	if render != nil {
+		p.writeFailureContextLocked()
+		render(p.out)
+		return
+	}
+	if !p.verbose {
+		p.writeFailureLocked(event.Name, event.Detail)
+	}
+	p.writeFailureContextLocked()
+}
+
+func (p *serveLifecyclePresenter) writeFailureContextLocked() {
+	if !p.verbose && p.store != nil {
+		if p.store.Backend == storebackend.BackendSQLite {
+			fmt.Fprintf(p.out, "  store                      sqlite · %s\n", strings.TrimSpace(p.store.SQLitePath))
+		} else {
+			fmt.Fprintf(p.out, "  store                      %s · path not applicable\n", p.store.Backend.String())
+		}
+	}
+	for _, detail := range p.workspaceDetailsLocked() {
+		if detail == "not required" {
+			continue
+		}
+		fmt.Fprintf(p.out, "  workspace                  %s\n", detail)
+	}
+}
+
+func (p *serveLifecyclePresenter) recordStore(selection storebackend.Selection) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	copy := selection
+	p.store = &copy
+	p.mu.Unlock()
+
+	detail := "backend=" + selection.Backend.String()
+	if selection.Backend == storebackend.BackendSQLite {
+		detail += " path=" + strings.TrimSpace(selection.SQLitePath)
+	} else {
+		detail += " path=not_applicable"
+	}
+	p.boot(3, "db_connection", "ok", detail)
+}
+
+func (p *serveLifecyclePresenter) recordWorkspace(bundle string, decision workspaceBackendSelection) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.workspaces = append(p.workspaces, serveLifecycleWorkspaceFact{
+		Bundle:   strings.TrimSpace(bundle),
+		Decision: decision,
+	})
+}
+
+func (p *serveLifecyclePresenter) note(message string) {
+	if p == nil || strings.TrimSpace(message) == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.notes = append(p.notes, strings.TrimSpace(message))
+}
+
+func (p *serveLifecyclePresenter) recordBootWarnings(report runtimebootverify.Report) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.warnings = append(p.warnings, report.Warnings()...)
+}
+
+func (p *serveLifecyclePresenter) readyPresentation(facts serveLifecycleReadyFacts) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.failed || p.ready {
+		return
+	}
+	p.ready = true
+	if !p.verbose {
+		p.writeConciseReadyLocked(facts)
+	} else {
+		p.writeResolvedFactsLocked(facts)
+	}
+	p.writeWarningsLocked()
+}
+
+func (p *serveLifecyclePresenter) runtimeFailure(subject string, err error) {
+	if p == nil || err == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.runtimeFailed = true
+	fmt.Fprintf(p.out, "runtime failed · %s · %s\n", displayServeLifecycleName(subject), strings.TrimSpace(err.Error()))
+}
+
+func (p *serveLifecyclePresenter) shutdown(err error) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.ready {
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(p.out, "shutdown · failed · %s\n", strings.TrimSpace(err.Error()))
+		return
+	}
+	if p.runtimeFailed {
+		return
+	}
+	fmt.Fprintln(p.out, "shutdown · complete")
+}
+
+func (p *serveLifecyclePresenter) writeBootEventLocked(event runtime.BootProgressEvent) {
+	detail := strings.TrimSpace(event.Detail)
+	if detail != "" {
+		detail = "  (" + detail + ")"
+	}
+	fmt.Fprintf(p.out, "[%d/%d] %-34s %s%s\n", event.Step, runtime.BootProgressTotalSteps, event.Name, event.Status, detail)
+}
+
+func (p *serveLifecyclePresenter) writeFailureLocked(name, detail string) {
+	fmt.Fprintf(p.out, "serve failed · %s", displayServeLifecycleName(name))
+	if strings.TrimSpace(detail) != "" {
+		fmt.Fprintf(p.out, " · %s", strings.TrimSpace(detail))
+	}
+	fmt.Fprintln(p.out)
+}
+
+func (p *serveLifecyclePresenter) writeConciseReadyLocked(facts serveLifecycleReadyFacts) {
+	command := "swarm serve"
+	if p.dev {
+		command += " --dev"
+	}
+	project := strings.TrimSpace(facts.ProjectName)
+	if project == "" {
+		project = "runtime"
+	}
+	fmt.Fprintf(p.out, "%s · %s\n\n", command, project)
+	bundleLabel := "bundle"
+	if facts.BundleCount > 1 {
+		bundleLabel = fmt.Sprintf("%d bundles", facts.BundleCount)
+	}
+	fmt.Fprintf(p.out, "  config · %-16s ready · %d %s · %d %s · %d %s\n",
+		bundleLabel,
+		facts.FlowCount, serveCountLabel(facts.FlowCount, "flow"),
+		facts.AgentCount, serveCountLabel(facts.AgentCount, "agent"),
+		facts.ToolCount, serveCountLabel(facts.ToolCount, "tool"),
+	)
+	p.writeResolvedFactsLocked(facts)
+	fmt.Fprintf(p.out, "\n  ready in %s\n", facts.ReadyAfter.Round(time.Millisecond))
+	if len(facts.Standing) > 0 {
+		fmt.Fprintln(p.out)
+	}
+	p.writeStandingIngressLocked(facts.Standing)
+	fmt.Fprintln(p.out)
+}
+
+func (p *serveLifecyclePresenter) writeResolvedFactsLocked(facts serveLifecycleReadyFacts) {
+	if p.store != nil {
+		if p.store.Backend == storebackend.BackendSQLite {
+			fmt.Fprintf(p.out, "  store                      sqlite · %s\n", strings.TrimSpace(p.store.SQLitePath))
+		} else {
+			fmt.Fprintf(p.out, "  store                      %s · path not applicable\n", p.store.Backend.String())
+		}
+	}
+	for _, detail := range p.workspaceDetailsLocked() {
+		fmt.Fprintf(p.out, "  workspace                  %s\n", detail)
+	}
+	status, detail := p.recoveryDetailLocked()
+	fmt.Fprintf(p.out, "  recovery                   %s", status)
+	if detail != "" {
+		fmt.Fprintf(p.out, " · %s", detail)
+	}
+	fmt.Fprintln(p.out)
+	fmt.Fprintf(p.out, "  listeners                  api %s · mcp %s\n", strings.TrimSpace(facts.APIListener), strings.TrimSpace(facts.MCPListener))
+	for _, note := range serveUniqueSortedStrings(p.notes) {
+		fmt.Fprintf(p.out, "  note                       %s\n", note)
+	}
+	if p.verbose {
+		p.writeStandingIngressLocked(facts.Standing)
+	}
+}
+
+func (p *serveLifecyclePresenter) workspaceDetailsLocked() []string {
+	seen := map[string]struct{}{}
+	details := make([]string, 0, len(p.workspaces))
+	for _, fact := range p.workspaces {
+		detail := workspaceBackendDecisionDetail(fact.Decision)
+		if fact.Bundle != "" && len(p.workspaces) > 1 {
+			detail = fact.Bundle + " · " + detail
+		}
+		if _, ok := seen[detail]; ok {
+			continue
+		}
+		seen[detail] = struct{}{}
+		details = append(details, detail)
+	}
+	sort.Strings(details)
+	if len(details) == 0 {
+		return []string{"not required"}
+	}
+	return details
+}
+
+func (p *serveLifecyclePresenter) recoveryDetailLocked() (string, string) {
+	event, ok := p.bootEvents[7]
+	if !ok {
+		return "complete", ""
+	}
+	status := strings.TrimSpace(event.Status)
+	if status == "" {
+		status = "complete"
+	}
+	return status, strings.TrimSpace(event.Detail)
+}
+
+func (p *serveLifecyclePresenter) writeStandingIngressLocked(facts []serveLifecycleIngressFact) {
+	if len(facts) == 0 {
+		fmt.Fprintln(p.out, "  standing ingress           none configured")
+		return
+	}
+	sorted := append([]serveLifecycleIngressFact(nil), facts...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Provider != sorted[j].Provider {
+			return sorted[i].Provider < sorted[j].Provider
+		}
+		if sorted[i].URL != sorted[j].URL {
+			return sorted[i].URL < sorted[j].URL
+		}
+		return sorted[i].BundleHash < sorted[j].BundleHash
+	})
+	for _, fact := range sorted {
+		fmt.Fprintf(p.out, "  %-27s %s\n", strings.TrimSpace(fact.Provider)+" webhook", strings.TrimSpace(fact.URL))
+		if strings.TrimSpace(fact.Subject.ID) != "" {
+			fmt.Fprintf(p.out, "  standing ingress admitted: %s\n", packs.RenderSubject(fact.Subject, false))
+		}
+		if strings.TrimSpace(fact.SigningSecret) == "" {
+			continue
+		}
+		state := "unbound"
+		if fact.SigningBound {
+			state = "bound"
+		}
+		fmt.Fprintf(p.out, "  %-27s %s %s\n", "signing", strings.TrimSpace(fact.SigningSecret), state)
+	}
+}
+
+func (p *serveLifecyclePresenter) writeWarningsLocked() {
+	for _, finding := range p.warnings {
+		fmt.Fprintln(p.out, runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
+			CheckID:     strings.TrimSpace(finding.CheckID),
+			Severity:    strings.TrimSpace(finding.Severity),
+			Location:    strings.TrimSpace(finding.Location),
+			Message:     strings.TrimSpace(finding.Message),
+			Remediation: strings.TrimSpace(finding.Remediation),
+			Evidence:    append([]string(nil), finding.Evidence...),
+		}, false))
+	}
+}
+
+func displayServeLifecycleName(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "_", " ")
+	if value == "" {
+		return "startup"
+	}
+	return value
+}
+
+func serveCountLabel(count int, singular string) string {
+	if count == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+func serveUniqueSortedStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/swarm/serve_lifecycle_presentation.go
+++ b/cmd/swarm/serve_lifecycle_presentation.go
@@ -47,7 +47,7 @@ type serveLifecycleNoticeKind string
 const (
 	serveLifecycleNoticeNoActiveWork      serveLifecycleNoticeKind = "no_active_work"
 	serveLifecycleNoticeActiveWorkCleared serveLifecycleNoticeKind = "active_work_cleared"
-	serveLifecycleNoticeWorkRestored      serveLifecycleNoticeKind = "work_restored"
+	serveLifecycleNoticeUnavailableClosed serveLifecycleNoticeKind = "unavailable_work_closed"
 )
 
 type serveLifecycleNotice struct {
@@ -266,15 +266,13 @@ func (p *serveLifecyclePresenter) recordAbandonedWork(runs, deliveries, pipeline
 	p.notices = append(p.notices, serveLifecycleNotice{Kind: kind})
 }
 
-func (p *serveLifecyclePresenter) recordRecoveredWork(runs, deliveries, sessions, timers, containers, pipelineReceipts int) {
+func (p *serveLifecyclePresenter) recordClosedUnavailableWork() {
 	if p == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if runs > 0 || deliveries > 0 || sessions > 0 || timers > 0 || containers > 0 || pipelineReceipts > 0 {
-		p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeWorkRestored})
-	}
+	p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeUnavailableClosed})
 }
 
 func (p *serveLifecyclePresenter) recordBootWarnings(report runtimebootverify.Report) {
@@ -549,7 +547,7 @@ func (p *serveLifecyclePresenter) recoveryDetailLocked() (string, string) {
 	case "recovery_disabled_no_persisted_work", "recovery_enabled_no_persisted_work", "no_active_run":
 		return "clean start", ""
 	case "recovery_enabled_with_persisted_work":
-		return "restored persisted work", ""
+		return "persisted work recovery enabled", ""
 	case "recovery_disabled_with_manager_snapshot_work":
 		return "started without manager replay", ""
 	}
@@ -656,8 +654,8 @@ func serveLifecycleNoticeDetail(notice serveLifecycleNotice) string {
 		return "no active work to clear"
 	case serveLifecycleNoticeActiveWorkCleared:
 		return "active work cleared for a clean start"
-	case serveLifecycleNoticeWorkRestored:
-		return "unfinished work restored"
+	case serveLifecycleNoticeUnavailableClosed:
+		return "unfinished work could not be resumed and was closed"
 	default:
 		return "completed"
 	}

--- a/cmd/swarm/serve_lifecycle_presentation.go
+++ b/cmd/swarm/serve_lifecycle_presentation.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -41,24 +42,51 @@ type serveLifecycleReadyFacts struct {
 	Standing    []serveLifecycleIngressFact
 }
 
+type serveLifecycleNoticeKind string
+
+const (
+	serveLifecycleNoticeAbandonedWork serveLifecycleNoticeKind = "abandoned_work"
+	serveLifecycleNoticeRecoveredWork serveLifecycleNoticeKind = "recovered_work"
+)
+
+type serveLifecycleNotice struct {
+	Kind             serveLifecycleNoticeKind
+	Runs             int
+	Deliveries       int
+	Sessions         int
+	Timers           int
+	Containers       int
+	PipelineReceipts int
+}
+
 // serveLifecyclePresenter is the sole human presentation owner for serve
 // boot, readiness, standing ingress, and shutdown facts.
 type serveLifecyclePresenter struct {
 	mu sync.Mutex
 
 	out     io.Writer
+	errOut  io.Writer
 	dev     bool
 	verbose bool
 
-	bootEvents map[int]runtime.BootProgressEvent
-	store      *storebackend.Selection
-	workspaces []serveLifecycleWorkspaceFact
-	warnings   []runtimebootverify.Finding
-	notes      []string
+	bootEvents       map[int]runtime.BootProgressEvent
+	store            *storebackend.Selection
+	workspaces       []serveLifecycleWorkspaceFact
+	warnings         []runtimebootverify.Finding
+	operatorWarnings []string
+	notices          []serveLifecycleNotice
 
-	ready         bool
-	failed        bool
-	runtimeFailed bool
+	ready              bool
+	failed             bool
+	failure            *runtime.BootProgressEvent
+	failureDiagnostic  string
+	cleanupErr         error
+	runtimeFailureErr  error
+	runtimeFailureName string
+	shutdownErr        error
+	warningsWritten    bool
+	bootWritten        bool
+	terminalWritten    bool
 }
 
 func newServeLifecyclePresenter(opts serveOptions) *serveLifecyclePresenter {
@@ -66,8 +94,13 @@ func newServeLifecyclePresenter(opts serveOptions) *serveLifecyclePresenter {
 	if out == nil {
 		out = io.Discard
 	}
+	errOut := opts.ErrorOutput
+	if errOut == nil {
+		errOut = out
+	}
 	return &serveLifecyclePresenter{
 		out:        out,
+		errOut:     errOut,
 		dev:        opts.Dev,
 		verbose:    opts.Verbose,
 		bootEvents: map[int]runtime.BootProgressEvent{},
@@ -117,15 +150,8 @@ func (p *serveLifecyclePresenter) observeBoot(event runtime.BootProgressEvent) {
 			return
 		}
 		p.failed = true
-		if p.verbose {
-			p.writeBootEventLocked(event)
-		} else {
-			p.writeFailureLocked(event.Name, event.Detail)
-		}
-		return
-	}
-	if p.verbose {
-		p.writeBootEventLocked(event)
+		copy := event
+		p.failure = &copy
 	}
 }
 
@@ -155,36 +181,29 @@ func (p *serveLifecyclePresenter) failWithDiagnostic(step int, name string, err 
 		At:     time.Now().UTC(),
 	}
 	p.bootEvents[step] = event
-	if p.verbose {
-		p.writeBootEventLocked(event)
-	}
+	copy := event
+	p.failure = &copy
 	if render != nil {
 		var rendered bytes.Buffer
 		if render(&rendered) {
-			p.writeFailureContextLocked()
-			_, _ = io.Copy(p.out, &rendered)
-			return
+			p.failureDiagnostic = rendered.String()
 		}
 	}
-	if !p.verbose {
-		p.writeFailureLocked(event.Name, event.Detail)
-	}
-	p.writeFailureContextLocked()
 }
 
-func (p *serveLifecyclePresenter) writeFailureContextLocked() {
+func (p *serveLifecyclePresenter) writeFailureContextLocked(out io.Writer) {
 	if !p.verbose && p.store != nil {
 		if p.store.Backend == storebackend.BackendSQLite {
-			fmt.Fprintf(p.out, "  store                      sqlite · %s\n", strings.TrimSpace(p.store.SQLitePath))
+			fmt.Fprintf(out, "  store                      sqlite · %s\n", strings.TrimSpace(p.store.SQLitePath))
 		} else {
-			fmt.Fprintf(p.out, "  store                      %s · path not applicable\n", p.store.Backend.String())
+			fmt.Fprintf(out, "  store                      %s · path not applicable\n", p.store.Backend.String())
 		}
 	}
 	for _, detail := range p.workspaceDetailsLocked() {
 		if detail == "not required" {
 			continue
 		}
-		fmt.Fprintf(p.out, "  workspace                  %s\n", detail)
+		fmt.Fprintf(out, "  workspace                  %s\n", detail)
 	}
 }
 
@@ -216,15 +235,45 @@ func (p *serveLifecyclePresenter) recordWorkspace(bundle string, decision worksp
 		Bundle:   strings.TrimSpace(bundle),
 		Decision: decision,
 	})
+	if decision.UnsafeHost {
+		p.operatorWarnings = append(p.operatorWarnings, "host workspace lets agents execute on this machine")
+	}
 }
 
-func (p *serveLifecyclePresenter) note(message string) {
-	if p == nil || strings.TrimSpace(message) == "" {
+func (p *serveLifecyclePresenter) recordDefaultAPITokenWarning() {
+	if p == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.notes = append(p.notes, strings.TrimSpace(message))
+	p.operatorWarnings = append(p.operatorWarnings, "using the built-in development API token on loopback; configure serve.api_token_file before exposing the listener")
+}
+
+func (p *serveLifecyclePresenter) recordBundleMatchDisabledWarning() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.operatorWarnings = append(p.operatorWarnings, "bundle matching is disabled for this startup")
+}
+
+func (p *serveLifecyclePresenter) recordAbandonedWork(runs, deliveries, pipelineReceipts int) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeAbandonedWork, Runs: runs, Deliveries: deliveries, PipelineReceipts: pipelineReceipts})
+}
+
+func (p *serveLifecyclePresenter) recordRecoveredWork(runs, deliveries, sessions, timers, containers, pipelineReceipts int) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeRecoveredWork, Runs: runs, Deliveries: deliveries, Sessions: sessions, Timers: timers, Containers: containers, PipelineReceipts: pipelineReceipts})
 }
 
 func (p *serveLifecyclePresenter) recordBootWarnings(report runtimebootverify.Report) {
@@ -249,6 +298,7 @@ func (p *serveLifecyclePresenter) readyPresentation(facts serveLifecycleReadyFac
 	if !p.verbose {
 		p.writeConciseReadyLocked(facts)
 	} else {
+		p.writeBootEventsLocked(p.out, runtime.BootProgressTotalSteps)
 		p.writeResolvedFactsLocked(facts)
 	}
 	p.writeWarningsLocked()
@@ -260,8 +310,19 @@ func (p *serveLifecyclePresenter) runtimeFailure(subject string, err error) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.runtimeFailed = true
-	fmt.Fprintf(p.out, "runtime failed · %s · %s\n", displayServeLifecycleName(subject), strings.TrimSpace(err.Error()))
+	if p.runtimeFailureErr == nil {
+		p.runtimeFailureName = displayServeLifecycleName(subject)
+	}
+	p.runtimeFailureErr = errors.Join(p.runtimeFailureErr, err)
+}
+
+func (p *serveLifecyclePresenter) cleanupFailure(subject string, err error) {
+	if p == nil || err == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cleanupErr = errors.Join(p.cleanupErr, fmt.Errorf("%s: %w", displayServeLifecycleName(subject), err))
 }
 
 func (p *serveLifecyclePresenter) shutdown(err error) {
@@ -270,33 +331,113 @@ func (p *serveLifecyclePresenter) shutdown(err error) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !p.ready {
-		return
-	}
 	if err != nil {
-		fmt.Fprintf(p.out, "shutdown · failed · %s\n", strings.TrimSpace(err.Error()))
-		return
+		if p.ready {
+			p.shutdownErr = errors.Join(p.shutdownErr, err)
+		} else {
+			p.cleanupErr = errors.Join(p.cleanupErr, err)
+		}
 	}
-	if p.runtimeFailed {
-		return
-	}
-	fmt.Fprintln(p.out, "shutdown · complete")
 }
 
-func (p *serveLifecyclePresenter) writeBootEventLocked(event runtime.BootProgressEvent) {
+func (p *serveLifecyclePresenter) finish() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.terminalWritten {
+		return
+	}
+	p.terminalWritten = true
+	p.writeWarningsLocked()
+
+	if p.failed {
+		if p.verbose {
+			failureStep := runtime.BootProgressTotalSteps
+			if p.failure != nil && p.failure.Step > 0 {
+				failureStep = p.failure.Step
+			}
+			p.writeBootEventsLocked(p.errOut, failureStep)
+		}
+		if p.failureDiagnostic != "" {
+			p.writeFailureContextLocked(p.errOut)
+			_, _ = io.WriteString(p.errOut, p.failureDiagnostic)
+			p.writeCleanupContextLocked()
+			return
+		}
+		name := "startup"
+		var primary error
+		if p.failure != nil {
+			name = p.failure.Name
+			if strings.TrimSpace(p.failure.Detail) != "" {
+				primary = errors.New(strings.TrimSpace(p.failure.Detail))
+			}
+		}
+		p.writeFailureLocked(p.errOut, name, errors.Join(primary, p.runtimeFailureErr, p.cleanupErr))
+		p.writeFailureContextLocked(p.errOut)
+		return
+	}
+	if p.runtimeFailureErr != nil {
+		detail := serveLifecycleErrorDetail(errors.Join(p.runtimeFailureErr, p.shutdownErr, p.cleanupErr))
+		fmt.Fprintf(p.errOut, "ERROR: runtime failed · %s", p.runtimeFailureName)
+		if detail != "" {
+			fmt.Fprintf(p.errOut, " · %s", detail)
+		}
+		fmt.Fprintln(p.errOut)
+		return
+	}
+	if p.ready {
+		if err := errors.Join(p.shutdownErr, p.cleanupErr); err != nil {
+			fmt.Fprintf(p.errOut, "ERROR: shutdown · failed · %s\n", serveLifecycleErrorDetail(err))
+			return
+		}
+		fmt.Fprintln(p.out, "shutdown · complete")
+		return
+	}
+	if p.cleanupErr != nil {
+		fmt.Fprintf(p.errOut, "ERROR: serve failed · cleanup · %s\n", serveLifecycleErrorDetail(p.cleanupErr))
+	}
+}
+
+func (p *serveLifecyclePresenter) writeBootEventsLocked(out io.Writer, throughStep int) {
+	if p.bootWritten {
+		return
+	}
+	p.bootWritten = true
+	for step := 1; step <= throughStep && step <= runtime.BootProgressTotalSteps; step++ {
+		event, ok := p.bootEvents[step]
+		if !ok {
+			continue
+		}
+		event.Step = step
+		if canonical := runtime.CanonicalBootProgressName(step); canonical != "" {
+			event.Name = canonical
+		}
+		p.writeBootEventLocked(out, event)
+	}
+}
+
+func (p *serveLifecyclePresenter) writeBootEventLocked(out io.Writer, event runtime.BootProgressEvent) {
 	detail := strings.TrimSpace(event.Detail)
 	if detail != "" {
 		detail = "  (" + detail + ")"
 	}
-	fmt.Fprintf(p.out, "[%d/%d] %-34s %s%s\n", event.Step, runtime.BootProgressTotalSteps, event.Name, event.Status, detail)
+	fmt.Fprintf(out, "[%d/%d] %-34s %s%s\n", event.Step, runtime.BootProgressTotalSteps, event.Name, event.Status, detail)
 }
 
-func (p *serveLifecyclePresenter) writeFailureLocked(name, detail string) {
-	fmt.Fprintf(p.out, "serve failed · %s", displayServeLifecycleName(name))
-	if strings.TrimSpace(detail) != "" {
-		fmt.Fprintf(p.out, " · %s", strings.TrimSpace(detail))
+func (p *serveLifecyclePresenter) writeFailureLocked(out io.Writer, name string, err error) {
+	fmt.Fprintf(out, "ERROR: serve failed · %s", displayServeLifecycleName(name))
+	if detail := serveLifecycleErrorDetail(err); detail != "" {
+		fmt.Fprintf(out, " · %s", detail)
 	}
-	fmt.Fprintln(p.out)
+	fmt.Fprintln(out)
+}
+
+func (p *serveLifecyclePresenter) writeCleanupContextLocked() {
+	if detail := serveLifecycleErrorDetail(errors.Join(p.runtimeFailureErr, p.cleanupErr)); detail != "" {
+		fmt.Fprintf(p.errOut, "  cleanup                    %s\n", detail)
+	}
 }
 
 func (p *serveLifecyclePresenter) writeConciseReadyLocked(facts serveLifecycleReadyFacts) {
@@ -346,8 +487,8 @@ func (p *serveLifecyclePresenter) writeResolvedFactsLocked(facts serveLifecycleR
 	}
 	fmt.Fprintln(p.out)
 	fmt.Fprintf(p.out, "  listeners                  api %s · mcp %s\n", strings.TrimSpace(facts.APIListener), strings.TrimSpace(facts.MCPListener))
-	for _, note := range serveUniqueSortedStrings(p.notes) {
-		fmt.Fprintf(p.out, "  note                       %s\n", note)
+	for _, notice := range p.notices {
+		fmt.Fprintf(p.out, "  recovery action            %s\n", serveLifecycleNoticeDetail(notice))
 	}
 	if p.verbose {
 		p.writeStandingIngressLocked(facts.Standing)
@@ -358,7 +499,7 @@ func (p *serveLifecyclePresenter) workspaceDetailsLocked() []string {
 	seen := map[string]struct{}{}
 	details := make([]string, 0, len(p.workspaces))
 	for _, fact := range p.workspaces {
-		detail := workspaceBackendDecisionDetail(fact.Decision)
+		detail := serveLifecycleWorkspaceDetail(fact.Decision)
 		if fact.Bundle != "" && len(p.workspaces) > 1 {
 			detail = fact.Bundle + " · " + detail
 		}
@@ -378,13 +519,26 @@ func (p *serveLifecyclePresenter) workspaceDetailsLocked() []string {
 func (p *serveLifecyclePresenter) recoveryDetailLocked() (string, string) {
 	event, ok := p.bootEvents[7]
 	if !ok {
+		return "clean start", ""
+	}
+	switch strings.TrimSpace(event.Detail) {
+	case "recovery_disabled_no_persisted_work", "recovery_enabled_no_persisted_work", "no_active_run":
+		return "clean start", ""
+	case "recovery_enabled_with_persisted_work":
+		return "restored persisted work", ""
+	case "recovery_disabled_with_manager_snapshot_work":
+		return "started without manager replay", ""
+	}
+	switch strings.ToLower(strings.TrimSpace(event.Status)) {
+	case "clean_start":
+		return "clean start", ""
+	case "degraded":
+		return "completed with warnings", ""
+	case "skipped":
+		return "not required", ""
+	default:
 		return "complete", ""
 	}
-	status := strings.TrimSpace(event.Status)
-	if status == "" {
-		status = "complete"
-	}
-	return status, strings.TrimSpace(event.Detail)
 }
 
 func (p *serveLifecyclePresenter) writeStandingIngressLocked(facts []serveLifecycleIngressFact) {
@@ -404,9 +558,6 @@ func (p *serveLifecyclePresenter) writeStandingIngressLocked(facts []serveLifecy
 	})
 	for _, fact := range sorted {
 		fmt.Fprintf(p.out, "  %-27s %s\n", strings.TrimSpace(fact.Provider)+" webhook", strings.TrimSpace(fact.URL))
-		if strings.TrimSpace(fact.Subject.ID) != "" {
-			fmt.Fprintf(p.out, "  standing ingress admitted: %s\n", packs.RenderSubject(fact.Subject, false))
-		}
 		if strings.TrimSpace(fact.SigningSecret) == "" {
 			continue
 		}
@@ -419,8 +570,15 @@ func (p *serveLifecyclePresenter) writeStandingIngressLocked(facts []serveLifecy
 }
 
 func (p *serveLifecyclePresenter) writeWarningsLocked() {
+	if p.warningsWritten {
+		return
+	}
+	p.warningsWritten = true
+	for _, warning := range serveUniqueSortedStrings(p.operatorWarnings) {
+		fmt.Fprintf(p.errOut, "WARNING: %s\n", warning)
+	}
 	for _, finding := range p.warnings {
-		fmt.Fprintln(p.out, runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
+		fmt.Fprintln(p.errOut, runtimebootverify.FormatTypedDiagnosticFinding(runtimebootverify.TypedDiagnosticFinding{
 			CheckID:     strings.TrimSpace(finding.CheckID),
 			Severity:    strings.TrimSpace(finding.Severity),
 			Location:    strings.TrimSpace(finding.Location),
@@ -429,6 +587,68 @@ func (p *serveLifecyclePresenter) writeWarningsLocked() {
 			Evidence:    append([]string(nil), finding.Evidence...),
 		}, false))
 	}
+}
+
+func serveLifecycleWorkspaceDetail(decision workspaceBackendSelection) string {
+	if decision.NoWorkspace || strings.TrimSpace(decision.Backend) == workspaceBackendNone {
+		return "not required"
+	}
+	backend := strings.TrimSpace(decision.Backend)
+	if backend == "" {
+		backend = "unknown"
+	}
+	agents := make([]string, 0, len(decision.Reasons))
+	for _, reason := range decision.Reasons {
+		if agent := strings.TrimSpace(reason.AgentID); agent != "" {
+			agents = append(agents, agent)
+		}
+	}
+	agents = serveUniqueSortedStrings(agents)
+	subject := "agent work"
+	verb := "runs"
+	if len(agents) == 1 {
+		subject = fmt.Sprintf("agent %q", agents[0])
+	} else if len(agents) > 1 {
+		subject = fmt.Sprintf("%d agents", len(agents))
+		verb = "run"
+	}
+	switch backend {
+	case "docker":
+		container := "a container"
+		if len(agents) > 1 {
+			container = "containers"
+		}
+		return fmt.Sprintf("docker · %s %s in %s", subject, verb, container)
+	case "host":
+		return fmt.Sprintf("host · %s %s on this machine", subject, verb)
+	default:
+		return backend
+	}
+}
+
+func serveLifecycleNoticeDetail(notice serveLifecycleNotice) string {
+	switch notice.Kind {
+	case serveLifecycleNoticeAbandonedWork:
+		return fmt.Sprintf("abandoned %d runs, %d deliveries, %d pipeline receipts", notice.Runs, notice.Deliveries, notice.PipelineReceipts)
+	case serveLifecycleNoticeRecoveredWork:
+		return fmt.Sprintf("recovered %d runs, %d deliveries, %d sessions, %d timers, %d containers, %d pipeline receipts", notice.Runs, notice.Deliveries, notice.Sessions, notice.Timers, notice.Containers, notice.PipelineReceipts)
+	default:
+		return "completed"
+	}
+}
+
+func serveLifecycleErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(err.Error()), "\n")
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line = strings.TrimSpace(line); line != "" {
+			parts = append(parts, line)
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 func displayServeLifecycleName(value string) string {

--- a/cmd/swarm/serve_lifecycle_presentation.go
+++ b/cmd/swarm/serve_lifecycle_presentation.go
@@ -17,7 +17,7 @@ import (
 )
 
 type serveLifecycleWorkspaceFact struct {
-	Bundle   string
+	Context  string
 	Decision workspaceBackendSelection
 }
 
@@ -45,18 +45,13 @@ type serveLifecycleReadyFacts struct {
 type serveLifecycleNoticeKind string
 
 const (
-	serveLifecycleNoticeAbandonedWork serveLifecycleNoticeKind = "abandoned_work"
-	serveLifecycleNoticeRecoveredWork serveLifecycleNoticeKind = "recovered_work"
+	serveLifecycleNoticeNoActiveWork      serveLifecycleNoticeKind = "no_active_work"
+	serveLifecycleNoticeActiveWorkCleared serveLifecycleNoticeKind = "active_work_cleared"
+	serveLifecycleNoticeWorkRestored      serveLifecycleNoticeKind = "work_restored"
 )
 
 type serveLifecycleNotice struct {
-	Kind             serveLifecycleNoticeKind
-	Runs             int
-	Deliveries       int
-	Sessions         int
-	Timers           int
-	Containers       int
-	PipelineReceipts int
+	Kind serveLifecycleNoticeKind
 }
 
 // serveLifecyclePresenter is the sole human presentation owner for serve
@@ -225,14 +220,14 @@ func (p *serveLifecyclePresenter) recordStore(selection storebackend.Selection) 
 	p.boot(3, "db_connection", "ok", detail)
 }
 
-func (p *serveLifecyclePresenter) recordWorkspace(bundle string, decision workspaceBackendSelection) {
+func (p *serveLifecyclePresenter) recordWorkspace(contextLabel string, decision workspaceBackendSelection) {
 	if p == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.workspaces = append(p.workspaces, serveLifecycleWorkspaceFact{
-		Bundle:   strings.TrimSpace(bundle),
+		Context:  strings.TrimSpace(contextLabel),
 		Decision: decision,
 	})
 	if decision.UnsafeHost {
@@ -264,7 +259,11 @@ func (p *serveLifecyclePresenter) recordAbandonedWork(runs, deliveries, pipeline
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeAbandonedWork, Runs: runs, Deliveries: deliveries, PipelineReceipts: pipelineReceipts})
+	kind := serveLifecycleNoticeNoActiveWork
+	if runs > 0 || deliveries > 0 || pipelineReceipts > 0 {
+		kind = serveLifecycleNoticeActiveWorkCleared
+	}
+	p.notices = append(p.notices, serveLifecycleNotice{Kind: kind})
 }
 
 func (p *serveLifecyclePresenter) recordRecoveredWork(runs, deliveries, sessions, timers, containers, pipelineReceipts int) {
@@ -273,7 +272,9 @@ func (p *serveLifecyclePresenter) recordRecoveredWork(runs, deliveries, sessions
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeRecoveredWork, Runs: runs, Deliveries: deliveries, Sessions: sessions, Timers: timers, Containers: containers, PipelineReceipts: pipelineReceipts})
+	if runs > 0 || deliveries > 0 || sessions > 0 || timers > 0 || containers > 0 || pipelineReceipts > 0 {
+		p.notices = append(p.notices, serveLifecycleNotice{Kind: serveLifecycleNoticeWorkRestored})
+	}
 }
 
 func (p *serveLifecyclePresenter) recordBootWarnings(report runtimebootverify.Report) {
@@ -286,13 +287,17 @@ func (p *serveLifecyclePresenter) recordBootWarnings(report runtimebootverify.Re
 }
 
 func (p *serveLifecyclePresenter) readyPresentation(facts serveLifecycleReadyFacts) {
+	p.commitReady(facts, nil)
+}
+
+func (p *serveLifecyclePresenter) commitReady(facts serveLifecycleReadyFacts, publish func()) bool {
 	if p == nil {
-		return
+		return false
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.failed || p.ready {
-		return
+		return false
 	}
 	p.ready = true
 	if !p.verbose {
@@ -302,6 +307,10 @@ func (p *serveLifecyclePresenter) readyPresentation(facts serveLifecycleReadyFac
 		p.writeResolvedFactsLocked(facts)
 	}
 	p.writeWarningsLocked()
+	if publish != nil {
+		publish()
+	}
+	return true
 }
 
 func (p *serveLifecyclePresenter) runtimeFailure(subject string, err error) {
@@ -314,6 +323,19 @@ func (p *serveLifecyclePresenter) runtimeFailure(subject string, err error) {
 		p.runtimeFailureName = displayServeLifecycleName(subject)
 	}
 	p.runtimeFailureErr = errors.Join(p.runtimeFailureErr, err)
+	if !p.ready && !p.failed {
+		p.failed = true
+		event := runtime.BootProgressEvent{
+			Step:   runtime.BootProgressTotalSteps,
+			Total:  runtime.BootProgressTotalSteps,
+			Name:   strings.TrimSpace(subject),
+			Status: "FAILED",
+			At:     time.Now().UTC(),
+		}
+		p.bootEvents[event.Step] = event
+		copy := event
+		p.failure = &copy
+	}
 }
 
 func (p *serveLifecyclePresenter) cleanupFailure(subject string, err error) {
@@ -496,23 +518,25 @@ func (p *serveLifecyclePresenter) writeResolvedFactsLocked(facts serveLifecycleR
 }
 
 func (p *serveLifecyclePresenter) workspaceDetailsLocked() []string {
-	seen := map[string]struct{}{}
-	details := make([]string, 0, len(p.workspaces))
+	contextsByDetail := map[string][]string{}
 	for _, fact := range p.workspaces {
 		detail := serveLifecycleWorkspaceDetail(fact.Decision)
-		if fact.Bundle != "" && len(p.workspaces) > 1 {
-			detail = fact.Bundle + " · " + detail
+		contextsByDetail[detail] = append(contextsByDetail[detail], fact.Context)
+	}
+	if len(contextsByDetail) == 0 {
+		return []string{"not required"}
+	}
+	details := make([]string, 0, len(contextsByDetail))
+	for detail, contexts := range contextsByDetail {
+		if len(contextsByDetail) > 1 {
+			labels := serveUniqueSortedStrings(contexts)
+			if len(labels) > 0 {
+				detail = strings.Join(labels, ", ") + " · " + detail
+			}
 		}
-		if _, ok := seen[detail]; ok {
-			continue
-		}
-		seen[detail] = struct{}{}
 		details = append(details, detail)
 	}
 	sort.Strings(details)
-	if len(details) == 0 {
-		return []string{"not required"}
-	}
 	return details
 }
 
@@ -628,10 +652,12 @@ func serveLifecycleWorkspaceDetail(decision workspaceBackendSelection) string {
 
 func serveLifecycleNoticeDetail(notice serveLifecycleNotice) string {
 	switch notice.Kind {
-	case serveLifecycleNoticeAbandonedWork:
-		return fmt.Sprintf("abandoned %d runs, %d deliveries, %d pipeline receipts", notice.Runs, notice.Deliveries, notice.PipelineReceipts)
-	case serveLifecycleNoticeRecoveredWork:
-		return fmt.Sprintf("recovered %d runs, %d deliveries, %d sessions, %d timers, %d containers, %d pipeline receipts", notice.Runs, notice.Deliveries, notice.Sessions, notice.Timers, notice.Containers, notice.PipelineReceipts)
+	case serveLifecycleNoticeNoActiveWork:
+		return "no active work to clear"
+	case serveLifecycleNoticeActiveWorkCleared:
+		return "active work cleared for a clean start"
+	case serveLifecycleNoticeWorkRestored:
+		return "unfinished work restored"
 	default:
 		return "completed"
 	}

--- a/cmd/swarm/serve_lifecycle_presentation_test.go
+++ b/cmd/swarm/serve_lifecycle_presentation_test.go
@@ -235,11 +235,11 @@ func TestServeLifecyclePresenterProjectsRecoveryOutcomesWithoutBookkeeping(t *te
 	var out bytes.Buffer
 	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
 	presenter.recordAbandonedWork(1, 2, 3)
-	presenter.recordRecoveredWork(1, 2, 3, 4, 5, 6)
+	presenter.recordClosedUnavailableWork()
 	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
 
 	text := out.String()
-	for _, want := range []string{"active work cleared for a clean start", "unfinished work restored"} {
+	for _, want := range []string{"active work cleared for a clean start", "unfinished work could not be resumed and was closed"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("recovery projection missing %q:\n%s", want, text)
 		}
@@ -248,6 +248,21 @@ func TestServeLifecyclePresenterProjectsRecoveryOutcomesWithoutBookkeeping(t *te
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("recovery projection exposed bookkeeping %q:\n%s", forbidden, text)
 		}
+	}
+}
+
+func TestServeLifecyclePresenterDoesNotTreatRecoveryAdmissionAsRestoration(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.boot(7, "recovery_decision", "allowed", "recovery_enabled_with_persisted_work")
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+
+	text := out.String()
+	if !strings.Contains(text, "recovery                   persisted work recovery enabled") {
+		t.Fatalf("recovery admission projection missing:\n%s", text)
+	}
+	if strings.Contains(text, "restored") {
+		t.Fatalf("recovery admission was presented as a terminal restoration:\n%s", text)
 	}
 }
 
@@ -489,7 +504,7 @@ func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T)
 			t.Fatalf("boot output boundary missing %q: %s", want, boot.OutputBoundary)
 		}
 	}
-	for _, want := range []string{"typed store", "Diagnostic detail renderers", "docker · agent", "clean start", "bound/unbound", "workflow name/version", "active work cleared", "never context labels"} {
+	for _, want := range []string{"typed store", "Diagnostic detail renderers", "docker · agent", "clean start", "bound/unbound", "workflow name/version", "active work cleared", "could not be resumed and was closed", "persisted work recovery enabled", "later runtime facts", "MUST NOT", "never context labels"} {
 		if !strings.Contains(boot.ProjectionBoundary, want) {
 			t.Fatalf("boot projection boundary missing %q: %s", want, boot.ProjectionBoundary)
 		}

--- a/cmd/swarm/serve_lifecycle_presentation_test.go
+++ b/cmd/swarm/serve_lifecycle_presentation_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/runtime"
+	runtimebootverify "github.com/division-sh/swarm/internal/runtime/bootverify"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"gopkg.in/yaml.v3"
@@ -30,7 +31,7 @@ func TestServeLifecyclePresenterConciseReadinessUsesTypedFacts(t *testing.T) {
 		SQLitePath:       "/tmp/project/.swarm/stores/dev.db",
 		SQLitePathSource: storebackend.SourceProjectDefault,
 	})
-	presenter.recordWorkspace("bundle-a", workspaceBackendSelection{Backend: workspace.BackendDocker})
+	presenter.recordWorkspace("bundle-a", workspaceBackendSelection{Backend: workspace.BackendDocker, Reasons: []workspaceCapabilityReason{{Kind: workspaceReasonClaudeCLI, AgentID: "phrase-completer"}}})
 	presenter.readyPresentation(serveLifecycleReadyFacts{
 		ProjectName: "tg-chat",
 		BundleCount: 1,
@@ -46,14 +47,15 @@ func TestServeLifecyclePresenterConciseReadinessUsesTypedFacts(t *testing.T) {
 		},
 	})
 	presenter.shutdown(nil)
+	presenter.finish()
 
 	text := out.String()
 	for _, want := range []string{
 		"swarm serve --dev · tg-chat",
 		"ready · 2 flows · 1 agent · 15 tools",
 		"store                      sqlite · /tmp/project/.swarm/stores/dev.db",
-		"workspace                  workspace backend: docker",
-		"recovery                   clean_start · no_active_run",
+		"workspace                  docker · agent \"phrase-completer\" runs in a container",
+		"recovery                   clean start",
 		"listeners                  api 127.0.0.1:8081 · mcp 127.0.0.1:8082",
 		"ready in 871ms",
 		"github webhook",
@@ -128,6 +130,7 @@ func TestServeLifecyclePresenterFailureNeverPrintsReadiness(t *testing.T) {
 	presenter.fail(20, "http_listener_bind", errors.New("address already in use"))
 	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "must-not-render"})
 	presenter.shutdown(nil)
+	presenter.finish()
 
 	text := out.String()
 	if !strings.Contains(text, "serve failed · http listener bind · address already in use") {
@@ -146,6 +149,7 @@ func TestServeLifecyclePresenterUnhandledDiagnosticFallsBackToGenericFailure(t *
 	presenter.failWithDiagnostic(5, "runtime_context", errors.New("construct runtime graph"), func(io.Writer) bool {
 		return false
 	})
+	presenter.finish()
 
 	text := out.String()
 	if !strings.Contains(text, "serve failed · runtime context · construct runtime graph") {
@@ -161,6 +165,7 @@ func TestServeLifecyclePresenterRendersZeroIngressAndShutdownFailure(t *testing.
 	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
 	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "empty", ReadyAfter: time.Millisecond})
 	presenter.shutdown(errors.New("runtime drain timed out; dev container cleanup failed"))
+	presenter.finish()
 
 	text := out.String()
 	for _, want := range []string{"standing ingress           none configured", "shutdown · failed · runtime drain timed out; dev container cleanup failed"} {
@@ -176,6 +181,7 @@ func TestServeLifecyclePresenterDoesNotContradictRuntimeFailureWithCleanShutdown
 	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
 	presenter.runtimeFailure("api server", errors.New("accept failed"))
 	presenter.shutdown(nil)
+	presenter.finish()
 
 	text := out.String()
 	if !strings.Contains(text, "runtime failed · api server · accept failed") {
@@ -183,6 +189,87 @@ func TestServeLifecyclePresenterDoesNotContradictRuntimeFailureWithCleanShutdown
 	}
 	if strings.Contains(text, "shutdown · complete") {
 		t.Fatalf("runtime failure was contradicted by clean shutdown:\n%s", text)
+	}
+}
+
+func TestServeLifecyclePresenterFailureUsesDiagnosticChannel(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &stdout, ErrorOutput: &stderr})
+	presenter.fail(20, "http_listener_bind", errors.New("address already in use"))
+	presenter.finish()
+
+	if stdout.Len() != 0 {
+		t.Fatalf("failure contaminated stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "ERROR: serve failed · http listener bind · address already in use") {
+		t.Fatalf("stderr missing canonical failure:\n%s", stderr.String())
+	}
+}
+
+func TestServeLifecyclePresenterJoinsEarlyFailureAndCleanupOnce(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &stdout, ErrorOutput: &stderr})
+	presenter.fail(4, "bundle_load", errors.New("bundle validation failed"))
+	presenter.cleanupFailure("bundle source cleanup", errors.New("remove bundle tempdir"))
+	presenter.cleanupFailure("store shutdown", errors.New("close journal"))
+	presenter.finish()
+
+	text := stderr.String()
+	if strings.Count(text, "ERROR:") != 1 || strings.Count(text, "serve failed") != 1 {
+		t.Fatalf("failure rendered more than one terminal disposition:\n%s", text)
+	}
+	for _, want := range []string{"bundle validation failed", "bundle source cleanup: remove bundle tempdir", "store shutdown: close journal"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("joined failure missing %q:\n%s", want, text)
+		}
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("joined failure contaminated stdout: %q", stdout.String())
+	}
+}
+
+func TestServeLifecyclePresenterVerboseFailureCoalescesCanonicalSequence(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Verbose: true, Output: &stdout, ErrorOutput: &stderr})
+	presenter.boot(1, "process_start", "ok", "")
+	presenter.boot(18, "boot_self_check_optional", "ok", "subscribed")
+	presenter.boot(19, "platform_boot_event_published", "ok", "event-id")
+	presenter.boot(18, "boot_self_check_optional", "FAILED", "self-check timed out")
+	presenter.finish()
+
+	if stdout.Len() != 0 {
+		t.Fatalf("failed verbose startup contaminated stdout: %q", stdout.String())
+	}
+	rows := parseServeBootProgressRows(t, stderr.String())
+	if len(rows) != 2 || rows[0].Step != 1 || rows[1].Step != 18 || rows[1].Name != "boot_self_check_optional" {
+		t.Fatalf("coalesced rows = %#v, want canonical steps 1 and 18\n%s", rows, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "platform_boot_event_published") || strings.Count(stderr.String(), "boot_self_check_optional") != 1 {
+		t.Fatalf("verbose failure retained a later or duplicate step:\n%s", stderr.String())
+	}
+}
+
+func TestServeLifecyclePresenterPreservesWarningsOnLateStartupFailure(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &stdout, ErrorOutput: &stderr})
+	report := runtimebootverify.Report{}
+	report.Add(runtimebootverify.Finding{
+		CheckID:     "unsigned_webhook",
+		Severity:    runtimebootverify.SeveritySemanticDriftWarn,
+		Location:    "telegram",
+		Message:     "telegram accepts unsigned webhooks",
+		Remediation: "configure webhook signing",
+	})
+	presenter.recordBootWarnings(report)
+	presenter.fail(22, "ready", errors.New("start runtime contexts"))
+	presenter.finish()
+
+	text := stderr.String()
+	if strings.Count(text, "[WARN]") != 1 || !strings.Contains(text, "telegram accepts unsigned webhooks") || !strings.Contains(text, "serve failed · ready") {
+		t.Fatalf("late failure did not retain exactly one warning and terminal failure:\n%s", text)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("late failure contaminated stdout: %q", stdout.String())
 	}
 }
 
@@ -279,6 +366,16 @@ func TestServeLifecycleOwnerRejectsParallelTerminalWriters(t *testing.T) {
 			}
 		}
 	}
+
+	presenterSource, err := os.ReadFile(filepath.Join(repoRoot(), "cmd", "swarm", "serve_lifecycle_presentation.go"))
+	if err != nil {
+		t.Fatalf("read serve lifecycle presenter: %v", err)
+	}
+	for _, forbidden := range []string{"workspaceBackendDecisionDetail(", "packs.RenderSubject("} {
+		if strings.Contains(string(presenterSource), forbidden) {
+			t.Errorf("serve lifecycle presenter delegates author-facing semantics through %s", forbidden)
+		}
+	}
 }
 
 func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T) {
@@ -287,10 +384,15 @@ func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T)
 			CommandCatalog struct {
 				Serve struct {
 					Boot struct {
-						CanonicalOwner string `yaml:"canonical_presentation_owner"`
-						Rule           string `yaml:"rule"`
-						OutputBoundary string `yaml:"output_boundary"`
-						SchemaDetail   string `yaml:"schema_inventory_detail"`
+						CanonicalOwner     string `yaml:"canonical_presentation_owner"`
+						Rule               string `yaml:"rule"`
+						OutputBoundary     string `yaml:"output_boundary"`
+						ProjectionBoundary string `yaml:"projection_boundary"`
+						SchemaDetail       string `yaml:"schema_inventory_detail"`
+						BootProgress       struct {
+							CanonicalNameOwner string `yaml:"canonical_name_owner"`
+							RenderingRule      string `yaml:"rendering_rule"`
+						} `yaml:"boot_progress_sequence"`
 					} `yaml:"boot_observability"`
 				} `yaml:"serve"`
 				Doctor struct {
@@ -322,10 +424,23 @@ func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T)
 			t.Fatalf("boot rule missing %q: %s", want, boot.Rule)
 		}
 	}
-	for _, want := range []string{"one writer", "Direct log", "Local foreground `swarm run start`", "buffered failure replay"} {
+	for _, want := range []string{"one writer", "Direct log", "Local foreground `swarm run start`", "buffered failure replay", "stdout", "stderr", "one joined terminal disposition"} {
 		if !strings.Contains(boot.OutputBoundary, want) {
 			t.Fatalf("boot output boundary missing %q: %s", want, boot.OutputBoundary)
 		}
+	}
+	for _, want := range []string{"typed store", "Diagnostic detail renderers", "docker · agent", "clean start", "bound/unbound"} {
+		if !strings.Contains(boot.ProjectionBoundary, want) {
+			t.Fatalf("boot projection boundary missing %q: %s", want, boot.ProjectionBoundary)
+		}
+	}
+	for _, want := range []string{"coalesces repeated updates", "numeric order", "stderr", "canonical step name"} {
+		if !strings.Contains(boot.BootProgress.RenderingRule, want) {
+			t.Fatalf("boot rendering rule missing %q: %s", want, boot.BootProgress.RenderingRule)
+		}
+	}
+	if !strings.Contains(boot.BootProgress.CanonicalNameOwner, "runtime.CanonicalBootProgressName") {
+		t.Fatalf("boot canonical name owner is incomplete: %s", boot.BootProgress.CanonicalNameOwner)
 	}
 	for _, want := range []string{"Default, dev, explicit verbose", "MUST NOT render per-table", "doctor.schema_inventory"} {
 		if !strings.Contains(boot.SchemaDetail, want) {

--- a/cmd/swarm/serve_lifecycle_presentation_test.go
+++ b/cmd/swarm/serve_lifecycle_presentation_test.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,6 +137,22 @@ func TestServeLifecyclePresenterFailureNeverPrintsReadiness(t *testing.T) {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("failure output contains %q:\n%s", forbidden, text)
 		}
+	}
+}
+
+func TestServeLifecyclePresenterUnhandledDiagnosticFallsBackToGenericFailure(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Dev: true, Output: &out})
+	presenter.failWithDiagnostic(5, "runtime_context", errors.New("construct runtime graph"), func(io.Writer) bool {
+		return false
+	})
+
+	text := out.String()
+	if !strings.Contains(text, "serve failed · runtime context · construct runtime graph") {
+		t.Fatalf("unhandled diagnostic dropped generic failure:\n%s", text)
+	}
+	if strings.Contains(text, "ready in") {
+		t.Fatalf("unhandled diagnostic rendered readiness:\n%s", text)
 	}
 }
 

--- a/cmd/swarm/serve_lifecycle_presentation_test.go
+++ b/cmd/swarm/serve_lifecycle_presentation_test.go
@@ -192,6 +192,65 @@ func TestServeLifecyclePresenterDoesNotContradictRuntimeFailureWithCleanShutdown
 	}
 }
 
+func TestServeLifecyclePresenterPreReadyRuntimeFailureSuppressesCommit(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &stdout, ErrorOutput: &stderr})
+	presenter.runtimeFailure("api server", errors.New("accept failed before readiness"))
+	published := false
+	if presenter.commitReady(serveLifecycleReadyFacts{ProjectName: "must-not-render"}, func() { published = true }) {
+		t.Fatal("readiness committed after a pre-ready runtime failure")
+	}
+	presenter.finish()
+
+	if published {
+		t.Fatal("public readiness was published after a pre-ready runtime failure")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("pre-ready runtime failure rendered readiness: %q", stdout.String())
+	}
+	if text := stderr.String(); !strings.Contains(text, "serve failed · api server · accept failed before readiness") || strings.Contains(text, "must-not-render") {
+		t.Fatalf("pre-ready runtime failure output is not one startup disposition:\n%s", text)
+	}
+}
+
+func TestServeLifecyclePresenterUsesAuthorSafeMultiContextWorkspaceProjection(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.recordWorkspace("review 1.0.0", workspaceBackendSelection{Backend: workspace.BackendDocker})
+	presenter.recordWorkspace("notifications 2.0.0", workspaceBackendSelection{Backend: workspace.BackendDocker})
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "2 persisted bundles", BundleCount: 2})
+
+	text := out.String()
+	if strings.Count(text, "workspace                  docker · agent work runs in a container") != 1 {
+		t.Fatalf("identical workspace decisions were not aggregated:\n%s", text)
+	}
+	for _, forbidden := range []string{"bundle-v1:sha256:", "sha256:", "fingerprint"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("multi-context projection exposed %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestServeLifecyclePresenterProjectsRecoveryOutcomesWithoutBookkeeping(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.recordAbandonedWork(1, 2, 3)
+	presenter.recordRecoveredWork(1, 2, 3, 4, 5, 6)
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+
+	text := out.String()
+	for _, want := range []string{"active work cleared for a clean start", "unfinished work restored"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("recovery projection missing %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{"deliveries", "sessions", "timers", "containers", "pipeline receipts"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("recovery projection exposed bookkeeping %q:\n%s", forbidden, text)
+		}
+	}
+}
+
 func TestServeLifecyclePresenterFailureUsesDiagnosticChannel(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	presenter := newServeLifecyclePresenter(serveOptions{Output: &stdout, ErrorOutput: &stderr})
@@ -388,6 +447,7 @@ func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T)
 						Rule               string `yaml:"rule"`
 						OutputBoundary     string `yaml:"output_boundary"`
 						ProjectionBoundary string `yaml:"projection_boundary"`
+						ReadinessBoundary  string `yaml:"readiness_commit_boundary"`
 						SchemaDetail       string `yaml:"schema_inventory_detail"`
 						BootProgress       struct {
 							CanonicalNameOwner string `yaml:"canonical_name_owner"`
@@ -429,9 +489,14 @@ func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T)
 			t.Fatalf("boot output boundary missing %q: %s", want, boot.OutputBoundary)
 		}
 	}
-	for _, want := range []string{"typed store", "Diagnostic detail renderers", "docker · agent", "clean start", "bound/unbound"} {
+	for _, want := range []string{"typed store", "Diagnostic detail renderers", "docker · agent", "clean start", "bound/unbound", "workflow name/version", "active work cleared", "never context labels"} {
 		if !strings.Contains(boot.ProjectionBoundary, want) {
 			t.Fatalf("boot projection boundary missing %q: %s", want, boot.ProjectionBoundary)
+		}
+	}
+	for _, want := range []string{"one commit point", "standing-ingress", "`/readyz`", "`health.check`", "local foreground startup", "server/runtime failure before"} {
+		if !strings.Contains(boot.ReadinessBoundary, want) {
+			t.Fatalf("boot readiness boundary missing %q: %s", want, boot.ReadinessBoundary)
 		}
 	}
 	for _, want := range []string{"coalesces repeated updates", "numeric order", "stderr", "canonical step name"} {

--- a/cmd/swarm/serve_lifecycle_presentation_test.go
+++ b/cmd/swarm/serve_lifecycle_presentation_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime"
+	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
+	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
+	"gopkg.in/yaml.v3"
+)
+
+func TestServeLifecyclePresenterConciseReadinessUsesTypedFacts(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Dev: true, Output: &out})
+	presenter.boot(1, "process_start", "ok", "")
+	presenter.boot(7, "recovery_decision", "clean_start", "no_active_run")
+	presenter.recordStore(storebackend.Selection{
+		Backend:          storebackend.BackendSQLite,
+		BackendSource:    storebackend.SourceRolloutDefault,
+		SQLitePath:       "/tmp/project/.swarm/stores/dev.db",
+		SQLitePathSource: storebackend.SourceProjectDefault,
+	})
+	presenter.recordWorkspace("bundle-a", workspaceBackendSelection{Backend: workspace.BackendDocker})
+	presenter.readyPresentation(serveLifecycleReadyFacts{
+		ProjectName: "tg-chat",
+		BundleCount: 1,
+		FlowCount:   2,
+		AgentCount:  1,
+		ToolCount:   15,
+		APIListener: "127.0.0.1:8081",
+		MCPListener: "127.0.0.1:8082",
+		ReadyAfter:  871 * time.Millisecond,
+		Standing: []serveLifecycleIngressFact{
+			{Provider: "telegram", URL: "http://127.0.0.1:8081/webhooks/ingress/telegram", SigningSecret: "webhook_signing.telegram", SigningBound: true, BundleHash: "bundle-b"},
+			{Provider: "github", URL: "http://127.0.0.1:8081/webhooks/ingress/github", SigningSecret: "webhook_signing.github", SigningBound: false, BundleHash: "bundle-a"},
+		},
+	})
+	presenter.shutdown(nil)
+
+	text := out.String()
+	for _, want := range []string{
+		"swarm serve --dev · tg-chat",
+		"ready · 2 flows · 1 agent · 15 tools",
+		"store                      sqlite · /tmp/project/.swarm/stores/dev.db",
+		"workspace                  workspace backend: docker",
+		"recovery                   clean_start · no_active_run",
+		"listeners                  api 127.0.0.1:8081 · mcp 127.0.0.1:8082",
+		"ready in 871ms",
+		"github webhook",
+		"webhook_signing.github unbound",
+		"telegram webhook",
+		"webhook_signing.telegram bound",
+		"shutdown · complete",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("concise lifecycle output missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "[1/22]") || strings.Contains(text, "\x1b[") {
+		t.Fatalf("concise non-TTY output contains verbose or terminal decoration:\n%q", text)
+	}
+	if strings.Contains(text, "bundle-a") || strings.Contains(text, "bundle-b") {
+		t.Fatalf("single-bundle concise output exposed internal bundle labels:\n%s", text)
+	}
+}
+
+func TestServeLifecyclePresenterVerbosePreservesExactlyCanonicalBootSequence(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Verbose: true, Output: &out})
+	names := []string{
+		"process_start",
+		"config_load",
+		"db_connection",
+		"bundle_load",
+		"startup_ownership_lease",
+		"recovery_snapshot_inspection",
+		"recovery_decision",
+		"pipeline_maintenance",
+		"system_nodes_start",
+		"schedule_restoration",
+		"manager_recovery_if_enabled",
+		"outbox_sweeper",
+		"static_agents_bootstrap",
+		"flow_required_agents",
+		"workspace_validation_and_system_containers",
+		"mcp_tool_validation",
+		"manager_event_loop_start",
+		"boot_self_check_optional",
+		"platform_boot_event_published",
+		"http_listener_bind",
+		"health_endpoints_respond",
+		"ready",
+	}
+	for i, name := range names {
+		presenter.boot(i+1, name, "ok", "")
+	}
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project", APIListener: "127.0.0.1:8081", MCPListener: "127.0.0.1:8082"})
+
+	rows := parseServeBootProgressRows(t, out.String())
+	if len(rows) != runtime.BootProgressTotalSteps {
+		t.Fatalf("verbose rows = %d, want %d\n%s", len(rows), runtime.BootProgressTotalSteps, out.String())
+	}
+	for i, row := range rows {
+		if row.Step != i+1 || row.Total != runtime.BootProgressTotalSteps || row.Name != names[i] {
+			t.Fatalf("row %d = %#v, want step/name %d/%s", i, row, i+1, names[i])
+		}
+	}
+	for _, forbidden := range []string{"events(", "runs(", "table(count)"} {
+		if strings.Contains(out.String(), forbidden) {
+			t.Fatalf("verbose serve retained schema inventory %q:\n%s", forbidden, out.String())
+		}
+	}
+}
+
+func TestServeLifecyclePresenterFailureNeverPrintsReadiness(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.fail(20, "http_listener_bind", errors.New("address already in use"))
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "must-not-render"})
+	presenter.shutdown(nil)
+
+	text := out.String()
+	if !strings.Contains(text, "serve failed · http listener bind · address already in use") {
+		t.Fatalf("failure output = %q", text)
+	}
+	for _, forbidden := range []string{"\n  ready in ", "must-not-render", "shutdown · complete"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("failure output contains %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestServeLifecyclePresenterRendersZeroIngressAndShutdownFailure(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "empty", ReadyAfter: time.Millisecond})
+	presenter.shutdown(errors.New("runtime drain timed out; dev container cleanup failed"))
+
+	text := out.String()
+	for _, want := range []string{"standing ingress           none configured", "shutdown · failed · runtime drain timed out; dev container cleanup failed"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestServeLifecyclePresenterDoesNotContradictRuntimeFailureWithCleanShutdown(t *testing.T) {
+	var out bytes.Buffer
+	presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+	presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+	presenter.runtimeFailure("api server", errors.New("accept failed"))
+	presenter.shutdown(nil)
+
+	text := out.String()
+	if !strings.Contains(text, "runtime failed · api server · accept failed") {
+		t.Fatalf("runtime failure missing:\n%s", text)
+	}
+	if strings.Contains(text, "shutdown · complete") {
+		t.Fatalf("runtime failure was contradicted by clean shutdown:\n%s", text)
+	}
+}
+
+func TestServeLifecyclePresenterUsesResolvedStoreSelectionVerbatim(t *testing.T) {
+	tests := []struct {
+		name      string
+		selection storebackend.Selection
+		want      string
+		forbidden string
+	}{
+		{
+			name:      "project local",
+			selection: storebackend.Selection{Backend: storebackend.BackendSQLite, SQLitePath: "/project/.swarm/stores/dev.db", SQLitePathSource: storebackend.SourceProjectDefault},
+			want:      "sqlite · /project/.swarm/stores/dev.db",
+		},
+		{
+			name:      "borrowed project key",
+			selection: storebackend.Selection{Backend: storebackend.BackendSQLite, SQLitePath: "/home/user/.swarm/stores/projects/tg-chat-4eaae51056bb/dev.db", SQLitePathSource: storebackend.SourceSwarmDirDefault},
+			want:      "sqlite · /home/user/.swarm/stores/projects/tg-chat-4eaae51056bb/dev.db",
+		},
+		{
+			name:      "configured sqlite",
+			selection: storebackend.Selection{Backend: storebackend.BackendSQLite, SQLitePath: "/var/lib/swarm/custom.db", SQLitePathSource: storebackend.SourceRuntimeConfig},
+			want:      "sqlite · /var/lib/swarm/custom.db",
+		},
+		{
+			name:      "postgres",
+			selection: storebackend.Selection{Backend: storebackend.BackendPostgres, BackendSource: storebackend.SourceRuntimeConfig},
+			want:      "postgres · path not applicable",
+			forbidden: ".db",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out bytes.Buffer
+			presenter := newServeLifecyclePresenter(serveOptions{Output: &out})
+			presenter.recordStore(test.selection)
+			presenter.readyPresentation(serveLifecycleReadyFacts{ProjectName: "project"})
+			if !strings.Contains(out.String(), test.want) {
+				t.Fatalf("store output missing %q:\n%s", test.want, out.String())
+			}
+			if test.forbidden != "" && strings.Contains(out.String(), test.forbidden) {
+				t.Fatalf("store output contains reconstructed path marker %q:\n%s", test.forbidden, out.String())
+			}
+		})
+	}
+}
+
+func TestServeLifecycleOwnerRejectsParallelTerminalWriters(t *testing.T) {
+	path := filepath.Join(repoRoot(), "cmd", "swarm", "main.go")
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+	guarded := map[string]bool{
+		"runServeRuntime":                           true,
+		"serveReadyStandingIngress":                 true,
+		"serveLifecycleSourceCounts":                true,
+		"serveLifecycleProjectName":                 true,
+		"enforceServeBundleMatchAdmission":          true,
+		"enforceServeBundleMatchAdmissionForHashes": true,
+		"serveHTTPServer":                           true,
+		"shutdownHTTPServer":                        true,
+	}
+	for _, declaration := range parsed.Decls {
+		fn, ok := declaration.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !guarded[fn.Name.Name] {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			owner, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if owner.Name == "log" || owner.Name == "slog" || (owner.Name == "fmt" && strings.HasPrefix(selector.Sel.Name, "Fprint")) {
+				t.Errorf("%s bypasses serveLifecyclePresenter through %s.%s", fn.Name.Name, owner.Name, selector.Sel.Name)
+			}
+			return true
+		})
+	}
+
+	for _, retired := range []string{"serveBootReporter", "logWorkspaceBackendDecision", "logReadySummary", "logReadyStandingIngress", "logBootWarnings"} {
+		for _, declaration := range parsed.Decls {
+			if fn, ok := declaration.(*ast.FuncDecl); ok && fn.Name.Name == retired {
+				t.Errorf("retired parallel presentation owner %s remains live", retired)
+			}
+		}
+	}
+}
+
+func TestPlatformSpecOwnsServeLifecycleAndDoctorSchemaPresentation(t *testing.T) {
+	var spec struct {
+		CLISpecification struct {
+			CommandCatalog struct {
+				Serve struct {
+					Boot struct {
+						CanonicalOwner string `yaml:"canonical_presentation_owner"`
+						Rule           string `yaml:"rule"`
+						OutputBoundary string `yaml:"output_boundary"`
+						SchemaDetail   string `yaml:"schema_inventory_detail"`
+					} `yaml:"boot_observability"`
+				} `yaml:"serve"`
+				Doctor struct {
+					Command         string `yaml:"command"`
+					SchemaInventory struct {
+						CanonicalOwner string `yaml:"canonical_owner"`
+						SourceOwner    string `yaml:"source_owner"`
+						Behavior       string `yaml:"behavior"`
+					} `yaml:"schema_inventory"`
+				} `yaml:"doctor"`
+			} `yaml:"command_catalog"`
+		} `yaml:"cli_specification"`
+	}
+	raw, err := os.ReadFile(filepath.Join(repoRoot(), defaultPlatformSpecPath))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	boot := spec.CLISpecification.CommandCatalog.Serve.Boot
+	for _, want := range []string{"serveLifecyclePresenter"} {
+		if !strings.Contains(boot.CanonicalOwner, want) {
+			t.Fatalf("boot canonical owner missing %q: %s", want, boot.CanonicalOwner)
+		}
+	}
+	for _, want := range []string{"Default `swarm serve`", "`swarm serve --dev`", "does not imply verbose", "22-step"} {
+		if !strings.Contains(boot.Rule, want) {
+			t.Fatalf("boot rule missing %q: %s", want, boot.Rule)
+		}
+	}
+	for _, want := range []string{"one writer", "Direct log", "Local foreground `swarm run start`", "buffered failure replay"} {
+		if !strings.Contains(boot.OutputBoundary, want) {
+			t.Fatalf("boot output boundary missing %q: %s", want, boot.OutputBoundary)
+		}
+	}
+	for _, want := range []string{"Default, dev, explicit verbose", "MUST NOT render per-table", "doctor.schema_inventory"} {
+		if !strings.Contains(boot.SchemaDetail, want) {
+			t.Fatalf("schema disposition missing %q: %s", want, boot.SchemaDetail)
+		}
+	}
+	doctor := spec.CLISpecification.CommandCatalog.Doctor
+	if !strings.Contains(doctor.Command, "--schema-inventory") || !strings.Contains(doctor.SchemaInventory.CanonicalOwner, "doctor.schema_inventory") || !strings.Contains(doctor.SchemaInventory.SourceOwner, "stateStoreSchemaPlans") {
+		t.Fatalf("doctor schema inventory ownership is incomplete: %#v", doctor)
+	}
+	for _, want := range []string{"without starting runtime", "without", "database state", "JSON adds a typed schema_inventory object"} {
+		if !strings.Contains(doctor.SchemaInventory.Behavior, want) {
+			t.Fatalf("doctor schema inventory behavior missing %q: %s", want, doctor.SchemaInventory.Behavior)
+		}
+	}
+}

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -55,7 +55,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	opts := serveOptions{
 		ConfigPath: configPath, ContractsPath: contractsRoot, PlatformSpecPath: defaultPlatformSpecPath,
 		StoreMode: "sqlite", APIListenAddr: "127.0.0.1:0", MCPListenAddr: "127.0.0.1:0",
-		SelfCheck: true, RequireBundleMatch: false, Dev: true, Verbose: true,
+		SelfCheck: true, RequireBundleMatch: false, Dev: true,
 		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
 	}
 
@@ -70,6 +70,27 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	requireStandingTelegramCalls(t, calls, 2, sqlitePath)
 	if code := first.stop(); code != 0 {
 		t.Fatalf("first serve exit = %d", code)
+	}
+	firstOutput := first.outputString()
+	for _, want := range []string{
+		"swarm serve --dev · ",
+		"store                      sqlite · " + sqlitePath,
+		"workspace                  workspace backend:",
+		"listeners                  api 127.0.0.1:",
+		"ready in ",
+		"telegram webhook",
+		"webhook_signing.telegram bound",
+		"shutdown · complete",
+	} {
+		if !strings.Contains(firstOutput, want) {
+			t.Fatalf("concise supported serve output missing %q:\n%s", want, firstOutput)
+		}
+	}
+	if strings.Contains(firstOutput, "[1/22]") || strings.Contains(firstOutput, "telegram-secret") || strings.Contains(firstOutput, "\x1b[") {
+		t.Fatalf("concise supported serve output leaked verbose, secret, or terminal decoration:\n%s", firstOutput)
+	}
+	if strings.Count(firstOutput, "workspace backend:") != 1 || strings.Count(firstOutput, "ready in ") != 1 {
+		t.Fatalf("concise supported serve output retained parallel lifecycle writers:\n%s", firstOutput)
 	}
 
 	second := startServeRuntimeTestProcess(t, opts)

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -75,7 +75,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	for _, want := range []string{
 		"swarm serve --dev · ",
 		"store                      sqlite · " + sqlitePath,
-		"workspace                  workspace backend:",
+		"workspace                  not required",
 		"listeners                  api 127.0.0.1:",
 		"ready in ",
 		"telegram webhook",
@@ -89,8 +89,13 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if strings.Contains(firstOutput, "[1/22]") || strings.Contains(firstOutput, "telegram-secret") || strings.Contains(firstOutput, "\x1b[") {
 		t.Fatalf("concise supported serve output leaked verbose, secret, or terminal decoration:\n%s", firstOutput)
 	}
-	if strings.Count(firstOutput, "workspace backend:") != 1 || strings.Count(firstOutput, "ready in ") != 1 {
+	if strings.Count(firstOutput, "workspace                  not required") != 1 || strings.Count(firstOutput, "ready in ") != 1 {
 		t.Fatalf("concise supported serve output retained parallel lifecycle writers:\n%s", firstOutput)
+	}
+	for _, forbidden := range []string{"request_authentication=", "catalog_generation=", "manifest_hash=", "policy_source=", "provenance=", "source_path=", "standing ingress admitted:"} {
+		if strings.Contains(firstOutput, forbidden) {
+			t.Fatalf("concise supported serve output leaked diagnostic field %q:\n%s", forbidden, firstOutput)
+		}
 	}
 
 	second := startServeRuntimeTestProcess(t, opts)

--- a/cmd/swarm/store_backend_selection_test.go
+++ b/cmd/swarm/store_backend_selection_test.go
@@ -661,7 +661,7 @@ func TestBuildStoresSQLiteRuntimeNoLongerFailsClosedOnMailboxMaterializationOwne
 		t.Fatalf("sqlite runtimeStores ConstructionBlocker = %q, want construction blocker removed after mailbox_write owner", runtimeStores.ConstructionBlocker)
 	}
 	bundle := loadStoreBackendSelectionWorkflowBundle(t)
-	if _, err := initializeStateStores(ctx, stores, bundle, false); err != nil {
+	if _, err := initializeStateStores(ctx, stores, bundle); err != nil {
 		t.Fatalf("initializeStateStores(sqlite): %v", err)
 	}
 	rt, err := runtime.NewRuntime(ctx, runtime.RuntimeDeps{

--- a/cmd/swarm/store_facade.go
+++ b/cmd/swarm/store_facade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 
 	apiv1 "github.com/division-sh/swarm/internal/apiv1"
 	"github.com/division-sh/swarm/internal/config"
@@ -122,7 +123,16 @@ func (f selectedRuntimeStoreFacade) runtimeStores() runtime.Stores {
 }
 
 func (f selectedRuntimeStoreFacade) close() {
-	closeDB(f.stores.SQLDB)
+	if err := f.closeWithError(); err != nil {
+		log.Printf("close db: %v", err)
+	}
+}
+
+func (f selectedRuntimeStoreFacade) closeWithError() error {
+	if f.stores.SQLDB == nil {
+		return nil
+	}
+	return f.stores.SQLDB.Close()
 }
 
 func (f selectedRuntimeStoreFacade) workspaceDB() *sql.DB {

--- a/cmd/swarm/store_facade_guard_test.go
+++ b/cmd/swarm/store_facade_guard_test.go
@@ -59,7 +59,8 @@ func selectedStoreFacadeProducerBackendReferences(path, body string) []string {
 		},
 		filepath.Join("cmd", "swarm", "store_facade.go"): {
 			"SQLDB:               s.RuntimeSQLDB",
-			"closeDB(f.stores.SQLDB)",
+			"f.stores.SQLDB == nil",
+			"f.stores.SQLDB.Close()",
 			"return f.stores.SQLDB",
 		},
 		filepath.Join("cmd", "swarm", "store_roles.go"): {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -119,6 +119,39 @@ type validatedRuntimeDeps struct {
 }
 
 const BootProgressTotalSteps = 22
+
+var canonicalBootProgressNames = [...]string{
+	"process_start",
+	"config_load",
+	"db_connection",
+	"bundle_load",
+	"startup_ownership_lease",
+	"recovery_snapshot_inspection",
+	"recovery_decision",
+	"pipeline_maintenance",
+	"system_nodes_start",
+	"schedule_restoration",
+	"manager_recovery_if_enabled",
+	"outbox_sweeper",
+	"static_agents_bootstrap",
+	"flow_required_agents",
+	"workspace_validation_and_system_containers",
+	"mcp_tool_validation",
+	"manager_event_loop_start",
+	"boot_self_check_optional",
+	"platform_boot_event_published",
+	"http_listener_bind",
+	"health_endpoints_respond",
+	"ready",
+}
+
+func CanonicalBootProgressName(step int) string {
+	if step < 1 || step > len(canonicalBootProgressNames) {
+		return ""
+	}
+	return canonicalBootProgressNames[step-1]
+}
+
 const DefaultShutdownGrace = runtimemanager.DefaultShutdownGrace
 
 type ShutdownOptions struct {
@@ -180,6 +213,9 @@ type Runtime struct {
 func (rt *Runtime) emitBootProgress(step int, name, status, detail string) {
 	if rt == nil || rt.Options.BootProgress == nil {
 		return
+	}
+	if canonical := CanonicalBootProgressName(step); canonical != "" {
+		name = canonical
 	}
 	rt.Options.BootProgress(BootProgressEvent{
 		Step:   step,
@@ -1006,7 +1042,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 
 	if rt.Pipeline != nil {
 		if _, err := rt.Pipeline.RepairContractEntityTypes(ctx); err != nil {
-			rt.emitBootProgress(8, "entity_type_contract_repair", "FAILED", err.Error())
+			rt.emitBootProgress(8, "pipeline_maintenance", "FAILED", err.Error())
 			return fmt.Errorf("repair contract entity types: %w", err)
 		}
 		rt.backgroundActive.Add(1)

--- a/internal/runtime/runtime_boot_selfcheck_test.go
+++ b/internal/runtime/runtime_boot_selfcheck_test.go
@@ -3,12 +3,15 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 )
 
 type bootSelfCheckDescriptorStore struct {
@@ -16,6 +19,45 @@ type bootSelfCheckDescriptorStore struct {
 	descriptors []runtimebus.ActiveAgentDescriptor
 	deliveries  []string
 	events      []events.Event
+}
+
+func TestRuntimeStart_PipelineMaintenanceFailureUsesCanonicalBootStepIdentity(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	mock.ExpectQuery("SELECT").WillReturnError(context.DeadlineExceeded)
+
+	module := loadRuntimeOwnershipWorkflowModule(t)
+	store := &bootSelfCheckDescriptorStore{}
+	progress := []BootProgressEvent{}
+	rt, err := NewRuntime(context.Background(), RuntimeDeps{Config: testOperationalRuntimeConfig(), Stores: Stores{
+		EventStore: store,
+	}, Options: RuntimeOptions{
+		WorkflowModule: module,
+		LLMRuntime:     noopLLMRuntime{},
+		BootProgress: func(evt BootProgressEvent) {
+			progress = append(progress, evt)
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	rt.Pipeline = runtimepipeline.NewPipelineCoordinatorWithOptions(rt.Bus, db, runtimepipeline.PipelineCoordinatorOptions{Module: module})
+	if err := rt.Start(context.Background()); err == nil {
+		t.Fatal("Start error = nil, want pipeline maintenance failure")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
+	}
+	if len(progress) == 0 {
+		t.Fatal("boot progress is empty")
+	}
+	got := progress[len(progress)-1]
+	if got.Step != 8 || got.Name != "pipeline_maintenance" || !strings.EqualFold(got.Status, "failed") {
+		t.Fatalf("pipeline failure progress = %#v, want canonical step 8 pipeline_maintenance failed", got)
+	}
 }
 
 func (s *bootSelfCheckDescriptorStore) AppendEvent(_ context.Context, evt events.Event) error {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -19435,7 +19435,16 @@ cli_specification:
           generations, policy/authentication field names, hashes, provenance, and implementation bookkeeping MUST NOT decide
           or leak into the concise author-facing vocabulary. Workspace text uses `docker · agent "<id>" runs in a container`,
           the no-work recovery outcome uses `clean start`, and standing ingress renders provider webhook URL plus bound/unbound
-          signing-reference state without credential values.
+          signing-reference state without credential values. Multi-context labels use author-facing workflow name/version and
+          aggregate identical workspace decisions; bundle hashes and fingerprints are never context labels. Recovery actions
+          render stable author outcomes such as `active work cleared for a clean start` or `unfinished work restored`, never
+          delivery/session/timer/container/receipt accounting.
+        readiness_commit_boundary: >
+          Initial serve readiness has one commit point after runtime contexts start, the non-readiness HTTP liveness probe
+          succeeds, standing-ingress facts validate, and every remaining startup gate succeeds. `/readyz`, `health.check`,
+          gated API/webhook routes, local foreground startup, and the human ready presentation consume that committed state.
+          They MUST NOT observe readiness while a proof-bearing startup gate can still fail. A server/runtime failure before
+          commit is a startup failure and suppresses both public and human readiness; post-commit failure is a runtime failure.
         concise_projection:
           required_facts:
           - bundle/source counts from loaded semantic sources

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -19437,7 +19437,11 @@ cli_specification:
           the no-work recovery outcome uses `clean start`, and standing ingress renders provider webhook URL plus bound/unbound
           signing-reference state without credential values. Multi-context labels use author-facing workflow name/version and
           aggregate identical workspace decisions; bundle hashes and fingerprints are never context labels. Recovery actions
-          render stable author outcomes such as `active work cleared for a clean start` or `unfinished work restored`, never
+          distinguish replay restoration from unavailable-bundle preservation cleanup: the latter renders `unfinished work
+          could not be resumed and was closed`, matching its cancelled/stopped/terminated/dead-lettered mutations. It MUST NOT
+          be described as restored. The initial `recovery_enabled_with_persisted_work` admission fact renders `persisted work
+          recovery enabled`; it MUST NOT claim restoration because schedule and manager replay outcomes are owned by later
+          runtime facts. Active-run abandon renders `active work cleared for a clean start`. None of these outcomes renders
           delivery/session/timer/container/receipt accounting.
         readiness_commit_boundary: >
           Initial serve readiness has one commit point after runtime contexts start, the non-readiness HTTP liveness probe

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -19425,7 +19425,17 @@ cli_specification:
           Human serve boot, readiness, standing-ingress, failure, and shutdown output has one writer:
           serveLifecyclePresenter. Direct log, slog, reporter, and output writers are non-authoritative and MUST NOT emit
           parallel normal terminal presentation. Local foreground `swarm run start` consumes this owner while preserving
-          quiet successful startup and buffered failure replay. Machine/persisted diagnostics remain separate fact owners.
+          quiet successful startup and buffered failure replay. The owner receives distinct successful stdout and diagnostic
+          stderr writers: readiness and clean shutdown render to stdout; warnings, startup/runtime/shutdown failures, and
+          specialized diagnostics render only to stderr. It retains startup failure until all acquired cleanup completes and
+          emits one joined terminal disposition. Machine/persisted diagnostics remain separate fact owners.
+        projection_boundary: >
+          Concise lifecycle wording is projected directly from typed store, workspace, recovery, listener, ingress, and
+          signing facts. Diagnostic detail renderers, raw boot reason codes, capability-subject inventory renderers, catalog
+          generations, policy/authentication field names, hashes, provenance, and implementation bookkeeping MUST NOT decide
+          or leak into the concise author-facing vocabulary. Workspace text uses `docker · agent "<id>" runs in a container`,
+          the no-work recovery outcome uses `clean start`, and standing ingress renders provider webhook URL plus bound/unbound
+          signing-reference state without credential values.
         concise_projection:
           required_facts:
           - bundle/source counts from loaded semantic sources
@@ -19445,6 +19455,12 @@ cli_specification:
           without starting runtime or reading/writing runtime database state.
         boot_progress_sequence:
           total_steps: 22
+          canonical_name_owner: internal/runtime.CanonicalBootProgressName, asserted against this ordered spec sequence
+          rendering_rule: >
+            Explicit verbose presentation buffers boot facts until startup succeeds or fails, coalesces repeated updates by
+            canonical step identity, and renders observed rows once in numeric order. A failed step suppresses later observed
+            rows. Failed verbose startup renders the sequence to stderr; a successful sequence renders to stdout. Runtime
+            producers MUST use the canonical step name for failures as well as successful updates.
           steps:
           - step: 1
             name: process_start

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -18841,7 +18841,7 @@ cli_specification:
           - remote server build date
           - server-local bundle path
     doctor:
-      command: swarm doctor [--backend claude_cli] [--target] [--contracts <path>] [--json]
+      command: swarm doctor [--backend claude_cli] [--target] [--schema-inventory] [--contracts <path>] [--json]
       group: getting_started
       tier: should_have
       implementation_status: implemented
@@ -18858,6 +18858,23 @@ cli_specification:
         preflight or local state writes. Human typed findings render through the shared typed diagnostic list renderer
         as `[BLOCKER]`, `[WARN]`, or `[INFO]` lines with remediation when present. JSON output is supported for scripts
         and remains the existing doctor/preflight report shape.
+      schema_inventory:
+        flag: --schema-inventory
+        canonical_owner: platform-spec.yaml#cli_specification.command_catalog.doctor.schema_inventory
+        implementation_owner: cmd/swarm/doctor_schema_inventory.go doctorSchemaInventory
+        source_owner: cmd/swarm/main.go stateStoreSchemaPlans
+        behavior: >
+          Explicitly derives the generated platform and node state-store table plans from the selected contract bundle and
+          platform spec without starting runtime or reading/writing runtime database state. Human output renders sorted table
+          names and column counts. JSON adds a typed schema_inventory object with owner, aggregate counts, and table rows.
+          The flag is incompatible with `--target`, whose dry-run target-resolution contract remains separate.
+        consumers:
+        - swarm doctor --schema-inventory
+        - swarm doctor --schema-inventory --json
+        forbidden:
+        - serving or booting runtime
+        - inspecting a live database to guess generated ownership
+        - per-table inventory in default, dev, verbose, or local-run serve output
       split_scope:
       - workspace image build
       - local API connection discovery files
@@ -19393,19 +19410,39 @@ cli_specification:
         - 'API/MCP enable-disable implementation may be a later child if not absorbed with listener implementation.'
         - '`--log-level` is governed by cli_specification.foundations.cli_logging_policy, not listener topology.'
       boot_observability:
-        implemented_by: '#802'
+        implemented_by: '#802/#2010 boot-presentation first slice'
+        canonical_presentation_owner: cmd/swarm/serve_lifecycle_presentation.go serveLifecyclePresenter
         flags:
         - --verbose
         - '-v'
         rule: >
-          By default `swarm serve` remains quiet except for readiness and errors. With `--verbose` or `-v`, serve prints
-          the numbered boot-progress sequence to stdout as the canonical serve/runtime boot phases complete. The CLI
-          owns stdout rendering; runtime owns the boot-progress facts and the persisted `platform.boot` payload.
+          Default `swarm serve` and `swarm serve --dev` render one concise boot/readiness presentation from the canonical
+          runtime boot-progress facts plus typed local-state, workspace, listener, standing-ingress, and shutdown facts.
+          With explicit `--verbose` or `-v`, the same presentation owner renders the numbered 22-step boot-progress sequence
+          in canonical order. `--dev` does not imply verbose; `--dev --verbose` is meaningful. Runtime owns boot facts and
+          persisted `platform.boot`; the CLI presentation never reconstructs runtime decisions from process-log prose.
+        output_boundary: >
+          Human serve boot, readiness, standing-ingress, failure, and shutdown output has one writer:
+          serveLifecyclePresenter. Direct log, slog, reporter, and output writers are non-authoritative and MUST NOT emit
+          parallel normal terminal presentation. Local foreground `swarm run start` consumes this owner while preserving
+          quiet successful startup and buffered failure replay. Machine/persisted diagnostics remain separate fact owners.
+        concise_projection:
+          required_facts:
+          - bundle/source counts from loaded semantic sources
+          - exact resolved store backend and SQLite path, or explicit path-not-applicable for Postgres
+          - resolved workspace backend decision
+          - canonical recovery outcome
+          - bound API and MCP listener addresses
+          - readiness duration
+          - zero, one, or multiple standing-ingress targets with bound/unbound signing state and no secret values
+          - normal or failed shutdown disposition
+          tty_policy: Plain words and values are authoritative; non-TTY output contains no ANSI control sequences or emoji.
         schema_inventory_detail: >
-          Default serve and local foreground run process logs may report concise generated state-store schema counts
-          such as `tables=N` and `columns=M`, but MUST NOT dump per-table `table(column_count)` inventory details.
-          Per-table generated schema inventory is diagnostic boot detail owned by the explicit serve verbose channel
-          (`swarm serve --verbose/-v`, and `--dev` through its verbose composition).
+          Default, dev, explicit verbose, local foreground run, and process-log serve output may report only the concise
+          generated-table count carried by the canonical boot fact. They MUST NOT render per-table table/column inventory.
+          Complete generated schema inventory is owned exclusively by
+          `cli_specification.command_catalog.doctor.schema_inventory`, which consumes the same generated schema-plan owner
+          without starting runtime or reading/writing runtime database state.
         boot_progress_sequence:
           total_steps: 22
           steps:
@@ -19550,20 +19587,21 @@ cli_specification:
           `--dev`, dev entity-container shutdown cleanup, `platform.shutdown` event persistence, and persisted delivery/receipt
           interruption reasons remain outside this owner and under #750 unless a later child promotes them.
       dev_mode_lifecycle_composition:
-        implemented_by: '#830'
+        implemented_by: '#830/#2010 boot-presentation first slice'
         flag: --dev
         owner: >
           `cmd/swarm serve` owns command-line composition; existing serve startup owners perform active-run abandon,
-          bundle-match admission, and verbose boot output; `internal/runtime/workspace` plus
+          bundle-match admission, and concise lifecycle presentation; `internal/runtime/workspace` plus
           `internal/runtime/containeridentity` own dev entity-container cleanup and preservation.
         composition:
         - sets `--abandon-active-runs`
         - sets `--no-require-bundle-match`
-        - sets `--verbose`
+        - consumes concise serve boot/readiness presentation without setting `--verbose`
         - enables dev entity-container cleanup after runtime shutdown/drain
         conflict_rules:
         - '`--dev --require-bundle-match` or `--dev --require-bundle-match=true` fails before runtime boot because dev mode disables bundle-match admission.'
-        - '`--dev --require-bundle-match=false`, `--dev --no-require-bundle-match`, `--dev --abandon-active-runs`, and `--dev --verbose` are redundant but valid.'
+        - '`--dev --require-bundle-match=false`, `--dev --no-require-bundle-match`, and `--dev --abandon-active-runs` are redundant but valid.'
+        - '`--dev --verbose` is valid and selects explicit 22-step presentation; it is not redundant.'
         shutdown_ordering: >
           On serve shutdown, runtime shutdown admission and the runtime/manager shutdown-grace drain run first. Dev cleanup runs
           only after that shutdown attempt reaches its completion point. Cleanup still runs after a shutdown timeout/error and


### PR DESCRIPTION
## Summary

- route default, dev, verbose, failure, readiness, standing-ingress, runtime-failure, and shutdown human output through one typed `serveLifecyclePresenter`
- make `--dev` independent of `--verbose` while preserving the canonical explicit 22-step verbose sequence
- render the exact resolved store backend/path and move per-table schema inventory out of serve into typed `swarm doctor --schema-inventory` human and JSON readback
- join HTTP, runtime, dev-container, bundle-source, and store-close outcomes before the single shutdown disposition

Part of #2010

This PR closes the approved first-slice class `serve_boot_readiness_shutdown_presentation_drift`. It does not implement or claim closure of the durable AuthorActivity feed; #2010 remains open for that parent class.

## Governing Contract

Exact authoritative references:

- `platform-spec.yaml#cli_specification.command_catalog.serve.boot_observability`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_data_source_authority`
- `platform-spec.yaml#cli_specification.command_catalog.serve.workspace_backend_selection`
- `platform-spec.yaml#cli_specification.command_catalog.serve.dev_mode_lifecycle_composition`
- `platform-spec.yaml#cli_specification.command_catalog.doctor.schema_inventory`
- `platform-spec.yaml#cli_specification.foundations.local_runtime_state_authority`
- `platform-spec.yaml#cli_specification.foundations.output_contract`

Binding gate context:

- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/2010#issuecomment-4952594791
- independent gate approval and conditions: https://github.com/division-sh/swarm/issues/2010#issuecomment-4952611213

## Semantic Migration

- **New canonical human presentation owner:** `cmd/swarm/serve_lifecycle_presentation.go serveLifecyclePresenter`.
- **Old paths now invalid:** `serveBootReporter`, direct workspace/readiness/standing-ingress helpers, serve-local `log`/`slog` lifecycle writers, direct shutdown writers, and verbose-only per-table serve schema rendering.
- **Production paths checked:** default serve, dev serve, explicit verbose, local foreground run buffering/replay, SQLite, Postgres selection, persisted/DB-loaded multi-context, API/MCP bind and health, zero/multiple standing ingress, bound/unbound signing, startup failures, cancellation, and joined shutdown/cleanup.
- **Migration completeness:** complete for the approved boot/readiness/standing-ingress/shutdown class. Diagnostic process evidence remains a different concept. Durable activity projection, cursor/reconnect, and live-feed consumers remain in open #2010 and its named dependencies.

## Verification

Passed:

- focused lifecycle, ownership, spec, doctor inventory, dev-composition, listener, SQLite standing-ingress, local-run, and verbose-sequence proofs
- `go run ./cmd/swarm-test-postgres -- go test ./cmd/swarm -count=1`
- `go run ./cmd/swarm-test-postgres -- go test -p 1 ./... -skip '^TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer$'`

The unmodified `TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer` is independently intermittent: an isolated `-count=10` run produced 6 passes and 4 `unclassified_runtime_error` failures. It is tracked with the exact reproducer and no-skip acceptance criteria in #2017. Unqualified `go test ./...` therefore remains nondeterministic for a pre-existing, unrelated run-fork proof; every other repository test passed in the serial tracked-exception run.
