### PR TITLE
[agent-b][issue #2015] Type test database isolation

### DIFF
--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -592,7 +592,7 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 		{
 			name: "postgres",
 			open: func(t *testing.T) storeBundle {
-				dsn, _, cleanup := testutil.StartPostgres(t)
+				dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				store, err := store.NewPostgresStore(dsn)
 				if err != nil {
@@ -798,7 +798,7 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 			return stores
 		}},
 		{name: "postgres", open: func(t *testing.T) storeBundle {
-			dsn, _, cleanup := testutil.StartPostgres(t)
+			dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 			pg, err := store.NewPostgresStore(dsn)
 			if err != nil {

--- a/cmd/swarm/claude_attempt_identity_test.go
+++ b/cmd/swarm/claude_attempt_identity_test.go
@@ -122,7 +122,7 @@ func (s claudeAttemptProofProviderHeadFaultStore) SettleExternalAttemptAndPromot
 func TestClaudeAttemptStartRejectionRetriesThroughSelectedStore(t *testing.T) {
 	for _, backendName := range []string{"sqlite", "postgres"} {
 		t.Run(backendName, func(t *testing.T) {
-			backend := newClaudeAttemptProofBackend(t, backendName)
+			backend := newClaudeAttemptProofBackend(t, backendName, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 			t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "proof-oauth-token")
 			t.Setenv("SWARM_CLAUDE_USE_MCP", "0")
 			captureDir := t.TempDir()
@@ -192,7 +192,7 @@ func makeClaudeAttemptProofDeliveryRetryEligible(t *testing.T, backend claudeAtt
 func TestClaudePostlaunchFailureTerminalizesAndRestartSkips(t *testing.T) {
 	for _, backendName := range []string{"sqlite", "postgres"} {
 		t.Run(backendName, func(t *testing.T) {
-			backend := newClaudeAttemptProofBackend(t, backendName)
+			backend := newClaudeAttemptProofBackend(t, backendName, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 			t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "proof-oauth-token")
 			t.Setenv("SWARM_CLAUDE_USE_MCP", "0")
 			captureDir := t.TempDir()
@@ -243,7 +243,7 @@ func TestClaudePostlaunchFailureTerminalizesAndRestartSkips(t *testing.T) {
 func TestClaudeProviderHeadCommitFailureSettlesUncertain(t *testing.T) {
 	for _, backendName := range []string{"sqlite", "postgres"} {
 		t.Run(backendName, func(t *testing.T) {
-			backend := newClaudeAttemptProofBackend(t, backendName)
+			backend := newClaudeAttemptProofBackend(t, backendName, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 			baseStore := backend.store
 			backend.store = claudeAttemptProofProviderHeadFaultStore{
 				claudeAttemptProofStore: baseStore,
@@ -315,7 +315,7 @@ func TestClaudeAttemptIdentitySelectedStoreModeAndProcessParity(t *testing.T) {
 			}
 			for _, backendName := range []string{"sqlite", "postgres"} {
 				t.Run(surface.name+"/"+backendName, func(t *testing.T) {
-					backend := newClaudeAttemptProofBackend(t, backendName)
+					backend := newClaudeAttemptProofBackend(t, backendName, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 					t.Setenv("SWARM_CLAUDE_USE_MCP", "0")
 					captureDir := t.TempDir()
 					t.Setenv("SWARM_CLAUDE_ATTEMPT_PROOF_CAPTURE", captureDir)
@@ -370,7 +370,7 @@ func (claudeAttemptProofChainDepthAgent) OnEvent(context.Context, events.Event) 
 func TestAgentManagerDirectDeadLetterPersistsCanonicalEnvelopeSelectedStores(t *testing.T) {
 	for _, backendName := range []string{"sqlite", "postgres"} {
 		t.Run(backendName, func(t *testing.T) {
-			backend := newClaudeAttemptProofBackend(t, backendName)
+			backend := newClaudeAttemptProofBackend(t, backendName, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 			eventBus, err := runtimebus.NewEventBus(backend.store)
 			if err != nil {
 				t.Fatalf("new chain-depth proof event bus: %v", err)
@@ -394,7 +394,7 @@ func TestAgentManagerDirectDeadLetterPersistsCanonicalEnvelopeSelectedStores(t *
 	}
 }
 
-func newClaudeAttemptProofBackend(t *testing.T, name string) claudeAttemptProofBackend {
+func newClaudeAttemptProofBackend(t *testing.T, name string, requirement testutil.DatabaseRequirement, sqliteRequirement testutil.DatabaseRequirement) claudeAttemptProofBackend {
 	t.Helper()
 	switch name {
 	case "sqlite":
@@ -406,7 +406,7 @@ func newClaudeAttemptProofBackend(t *testing.T, name string) claudeAttemptProofB
 		if err != nil {
 			t.Fatalf("generate SQLite schema: %v", err)
 		}
-		sqliteStore, err := store.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "runtime.db"))
+		sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, sqliteRequirement, filepath.Join(t.TempDir(), "runtime.db")))
 		if err != nil {
 			t.Fatalf("new SQLite runtime store: %v", err)
 		}
@@ -414,7 +414,7 @@ func newClaudeAttemptProofBackend(t *testing.T, name string) claudeAttemptProofB
 		bootstrapSQLiteSchemaForTest(t, context.Background(), sqliteStore, plans)
 		return claudeAttemptProofBackend{name: name, store: sqliteStore, db: sqliteStore.DB, sessions: sqliteStore}
 	case "postgres":
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, requirement)
 		pg := &store.PostgresStore{DB: db}
 		return claudeAttemptProofBackend{name: name, store: pg, db: db, sessions: runtimesessions.NewPostgresRegistry(db, time.Minute)}
 	default:

--- a/cmd/swarm/entities_test.go
+++ b/cmd/swarm/entities_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -103,7 +104,7 @@ func TestEntitiesListEmptyResultOmitsUnsetParams(t *testing.T) {
 func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	ctx := context.Background()
 	setCLIAPITestToken(t, "test-token")
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	runID := "11111111-1111-1111-1111-111111111111"
 	entityA := "22222222-2222-2222-2222-222222222222"
 	entityB := "33333333-3333-3333-3333-333333333333"

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -31,7 +31,7 @@ import (
 func TestInboundAdmissionSupportedSurfacePolicyMatrixSQLiteAndPostgres(t *testing.T) {
 	for _, backend := range []string{"sqlite", "postgres"} {
 		t.Run(backend, func(t *testing.T) {
-			runInboundAdmissionSupportedSurfacePolicyMatrix(t, backend)
+			runInboundAdmissionSupportedSurfacePolicyMatrix(t, backend, testutil.PostgresRowState(), testutil.SQLiteFreshFile())
 		})
 	}
 }
@@ -226,7 +226,7 @@ func TestInboundAdmissionSupportedSurfaceStartupFailuresSQLiteAndPostgres(t *tes
 			var postgresStore *store.PostgresStore
 			var postgresDSN string
 			if backend == "postgres" {
-				dsn, _, cleanup := testutil.StartPostgres(t)
+				dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				postgresDSN = dsn
 				t.Cleanup(cleanup)
 				oldBuildStores := buildStoresForServe
@@ -314,7 +314,7 @@ func TestInboundAdmissionSupportedSurfaceStartupFailuresSQLiteAndPostgres(t *tes
 	}
 }
 
-func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend string) {
+func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend string, requirement testutil.DatabaseRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	isolateCLIAPIConfigEnv(t)
 	platformDirs, externalDirs := writeInboundAdmissionPackInventory(t)
@@ -343,7 +343,7 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 		sqlitePath := filepath.Join(dataRoot, "admission.sqlite")
 		configPath = writeInboundAdmissionRuntimeConfig(t, backend, sqlitePath, platformDirs, externalDirs)
 	} else {
-		dsn, _, cleanup := testutil.StartPostgres(t)
+		dsn, _, cleanup := testutil.AcquirePostgres(t, requirement)
 		postgresDSN = dsn
 		t.Cleanup(cleanup)
 		postgresStore, err = store.NewPostgresStore(dsn)
@@ -446,7 +446,7 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 
 	if backend == "sqlite" {
 		sqlitePath := inboundAdmissionSQLitePathFromConfig(t, configPath)
-		sqliteStore, err = store.NewSQLiteRuntimeStore(sqlitePath)
+		sqliteStore, err = store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, sqliteRequirement, sqlitePath))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -10615,7 +10615,7 @@ func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory f
 	t.Helper()
 	return installServeRuntimePostgresTestStoresForDatabase(t, func(workspaceMountSources) serveWorkspaceLifecycle {
 		return workspaceFactory()
-	}, false, testutil.PostgresFreshPhysical())
+	}, false, testutil.PostgresEmptyPhysical())
 }
 
 func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string, requirement testutil.DatabaseRequirement) (string, string) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3765,7 +3765,8 @@ func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing
 func TestRunServeRuntimeDBLoadedUsesEmbeddedSpecBeforeCatalogRead(t *testing.T) {
 	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
@@ -3806,7 +3807,8 @@ func TestRunServeRuntimeDBLoadedUsesEmbeddedSpecBeforeCatalogRead(t *testing.T) 
 func TestRunServeRuntimeDBLoadedExecutesExplicitHostRefusal(t *testing.T) {
 	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	bundleHash := seedServeRuntimeBundleCatalog(t, ctx, pg, doctorAgentContractsPath)
 	var out lockedBuffer
@@ -3847,7 +3849,8 @@ func TestRunServeRuntimeDBLoadedExecutesDockerManagerRecovery(t *testing.T) {
 			return "", nil
 		})
 		return manager
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	bundleHash := seedServeRuntimeBundleCatalogRoot(t, ctx, pg, contractsRoot)
 	var out lockedBuffer
@@ -3878,7 +3881,8 @@ func TestRunServeRuntimeDBLoadedExecutesDockerManagerRecovery(t *testing.T) {
 func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersistedIdentity(t *testing.T) {
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	bundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	projection, err := runtimecontracts.BuildBundleCatalogProjection(bundle)
@@ -3991,7 +3995,7 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 }
 
 func TestRunServeRuntimeJoinFailureReachesAPIAndCLI(t *testing.T) {
-	endpoint, db, bundleHash := startServedJoinProofRuntime(t)
+	endpoint, db, bundleHash := startServedJoinProofRuntime(t, testutil.PostgresRowState())
 	initial := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
 		"event_name":      "order.started",
 		"bundle_hash":     bundleHash,
@@ -4051,7 +4055,7 @@ func TestRunServeRuntimeJoinFailureReachesAPIAndCLI(t *testing.T) {
 }
 
 func TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer(t *testing.T) {
-	endpoint, db, bundleHash := startServedJoinProofRuntime(t)
+	endpoint, db, bundleHash := startServedJoinProofRuntime(t, testutil.PostgresRowState())
 	initial := requireServedEventPublishRPCResult(t, endpoint, map[string]any{
 		"event_name": "order.started", "bundle_hash": bundleHash,
 		"payload":         map[string]any{"expected": []any{"a", "b"}, "dispatch_id": "dispatch-1"},
@@ -4124,7 +4128,8 @@ func TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer(t *testing.T) 
 func TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetIdentity(t *testing.T) {
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	sourceBundle := loadWorkflowValidationFixtureBundle(t, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	sourceProjection, err := runtimecontracts.BuildBundleCatalogProjection(sourceBundle)
@@ -4357,7 +4362,8 @@ func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathDefaultSQLite(t *test
 func TestRunServeRuntimeEventPublishRunIDFollowUpServedPathPostgres(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	contractsPath := writeServedEventPublishFollowUpFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4421,7 +4427,8 @@ func TestRunServeRuntimeEventPublishTargetRouteServedPathDefaultSQLite(t *testin
 func TestRunServeRuntimeEventPublishTargetRouteServedPathPostgres(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	contractsPath := writeServedEventPublishTargetRouteFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4489,7 +4496,8 @@ func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathDefaultSQLite
 func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	contractsPath := writeServedEventPublishActiveLoadFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4517,16 +4525,18 @@ func TestRunServeRuntimeEventPublishExistingRunActiveLoadServedPathPostgres(t *t
 }
 
 func TestRunServeRuntimeEventPublishDynamicAutoEmitServedPathDefaultSQLite(t *testing.T) {
-	runServedDynamicAutoEmitBackendProof(t, servedparity.BackendDefaultSQLite)
+	runServedDynamicAutoEmitBackendProof(t, servedparity.BackendDefaultSQLite, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
 }
 
 func TestRunServeRuntimeEventPublishDynamicAutoEmitServedPathPostgres(t *testing.T) {
-	runServedDynamicAutoEmitBackendProof(t, servedparity.BackendExplicitPostgres)
+	runServedDynamicAutoEmitBackendProof(t, servedparity.BackendExplicitPostgres, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
 }
 
 func TestServedParityHarnessEventPublishDynamicAutoEmitLifecycle(t *testing.T) {
 	scenario := servedparity.MustScenario(servedparity.ScenarioEventPublishDynamicAutoEmitLifecycle)
-	servedparity.Run(t, scenario, runServedDynamicAutoEmitBackendProof)
+	servedparity.Run(t, scenario, func(t *testing.T, backend servedparity.Backend) {
+		runServedDynamicAutoEmitBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessLiveAgentEventReplayLifecycle(t *testing.T) {
@@ -4534,7 +4544,9 @@ func TestServedParityHarnessLiveAgentEventReplayLifecycle(t *testing.T) {
 		servedparity.MustScenario(servedparity.ScenarioEventReplayLiveAgentLifecycle),
 		servedparity.MustScenario(servedparity.ScenarioAgentReplayLiveAgentLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedLiveAgentEventReplayBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedLiveAgentEventReplayBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessRunControlLifecycle(t *testing.T) {
@@ -4543,24 +4555,32 @@ func TestServedParityHarnessRunControlLifecycle(t *testing.T) {
 		servedparity.MustScenario(servedparity.ScenarioRunContinueControlLifecycle),
 		servedparity.MustScenario(servedparity.ScenarioRunStopControlLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedRunControlBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedRunControlBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessLiveAgentReplayBacklogLifecycle(t *testing.T) {
 	scenarios := []servedparity.Scenario{
 		servedparity.MustScenario(servedparity.ScenarioAgentReplayBacklogLiveAgentLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedLiveAgentReplayBacklogBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedLiveAgentReplayBacklogBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessAgentRestartLifecycle(t *testing.T) {
 	scenario := servedparity.MustScenario(servedparity.ScenarioAgentRestartLifecycle)
-	servedparity.Run(t, scenario, runServedAgentRestartBackendProof)
+	servedparity.Run(t, scenario, func(t *testing.T, backend servedparity.Backend) {
+		runServedAgentRestartBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessAgentDirectiveOutcomeLifecycle(t *testing.T) {
 	scenario := servedparity.MustScenario(servedparity.ScenarioAgentDirectiveOutcomeLifecycle)
-	servedparity.Run(t, scenario, runServedAgentDirectiveBackendProof)
+	servedparity.Run(t, scenario, func(t *testing.T, backend servedparity.Backend) {
+		runServedAgentDirectiveBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessRuntimeIngressControlLifecycle(t *testing.T) {
@@ -4568,7 +4588,9 @@ func TestServedParityHarnessRuntimeIngressControlLifecycle(t *testing.T) {
 		servedparity.MustScenario(servedparity.ScenarioRuntimePauseIngressLifecycle),
 		servedparity.MustScenario(servedparity.ScenarioRuntimeResumeIngressLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedRuntimeIngressControlBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedRuntimeIngressControlBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessMailboxDecisionLifecycle(t *testing.T) {
@@ -4577,12 +4599,16 @@ func TestServedParityHarnessMailboxDecisionLifecycle(t *testing.T) {
 		servedparity.MustScenario(servedparity.ScenarioMailboxRejectDecisionLifecycle),
 		servedparity.MustScenario(servedparity.ScenarioMailboxDeferDecisionLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedMailboxDecisionBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedMailboxDecisionBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessTestSetupEntitiesLifecycle(t *testing.T) {
 	scenario := servedparity.MustScenario(servedparity.ScenarioTestSetupEntitiesLifecycle)
-	servedparity.Run(t, scenario, runServedTestSetupEntitiesBackendProof)
+	servedparity.Run(t, scenario, func(t *testing.T, backend servedparity.Backend) {
+		runServedTestSetupEntitiesBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestServedParityHarnessConversationForkLifecycle(t *testing.T) {
@@ -4591,11 +4617,13 @@ func TestServedParityHarnessConversationForkLifecycle(t *testing.T) {
 		servedparity.MustScenario(servedparity.ScenarioConversationForkChatLifecycle),
 		servedparity.MustScenario(servedparity.ScenarioConversationForkDeleteLifecycle),
 	}
-	servedparity.RunScenarioGroup(t, scenarios, runServedConversationForkBackendProof)
+	servedparity.RunScenarioGroup(t, scenarios, func(t *testing.T, backend servedparity.Backend) {
+		runServedConversationForkBackendProof(t, backend, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
+	})
 }
 
 func TestRunServeRuntimeSQLiteOptionalMutatorsFailClosed(t *testing.T) {
-	rt := startServedControlProofRuntime(t, servedparity.BackendDefaultSQLite)
+	rt := startServedControlProofRuntime(t, servedparity.BackendDefaultSQLite, testutil.PostgresEmptyPhysical(), testutil.SQLiteDefaultTemp())
 	cases := []struct {
 		method string
 		params map[string]any
@@ -4655,21 +4683,21 @@ type servedConversationForkProofRuntime struct {
 	LLMRequests *atomic.Int32
 }
 
-func startServedLiveAgentProofRuntime(t *testing.T, backend servedparity.Backend) servedControlProofRuntime {
-	return startServedLiveAgentProofRuntimeWithLLM(t, backend, servedLiveAgentProofLLMRuntime{})
+func startServedLiveAgentProofRuntime(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedControlProofRuntime {
+	return startServedLiveAgentProofRuntimeWithLLM(t, backend, servedLiveAgentProofLLMRuntime{}, postgresRequirement, sqliteRequirement)
 }
 
-func startServedLiveAgentProofRuntimeWithLLM(t *testing.T, backend servedparity.Backend, llm servedLiveAgentProofLLMRuntime) servedControlProofRuntime {
-	return startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t, backend, llm, nil)
+func startServedLiveAgentProofRuntimeWithLLM(t *testing.T, backend servedparity.Backend, llm servedLiveAgentProofLLMRuntime, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedControlProofRuntime {
+	return startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t, backend, llm, nil, postgresRequirement, sqliteRequirement)
 }
 
-func startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t *testing.T, backend servedparity.Backend, llm servedLiveAgentProofLLMRuntime, faults *servedDirectivePersistenceFaults) servedControlProofRuntime {
+func startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t *testing.T, backend servedparity.Backend, llm servedLiveAgentProofLLMRuntime, faults *servedDirectivePersistenceFaults, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedControlProofRuntime {
 	t.Helper()
 	switch backend {
 	case servedparity.BackendDefaultSQLite:
 		unsetStoreSelectorEnv(t)
 		stubServeRuntimeWorkspaceLifecycle(t)
-		sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+		sqlitePath := testutil.SQLitePath(t, sqliteRequirement)
 		contractsPath := writeServedLiveAgentFixture(t)
 		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 		probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4707,7 +4735,8 @@ func startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t *testing.T, bac
 	case servedparity.BackendExplicitPostgres:
 		_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 			return serveRuntimeWorkspaceStub{}
-		})
+		}, postgresRequirement)
+
 		if faults != nil {
 			oldBuildStores := buildStoresForServe
 			t.Cleanup(func() { buildStoresForServe = oldBuildStores })
@@ -4760,13 +4789,13 @@ func wrapServedDirectiveFaultStore(t *testing.T, stores storeBundle, faults *ser
 	return stores
 }
 
-func startServedControlProofRuntime(t *testing.T, backend servedparity.Backend) servedControlProofRuntime {
+func startServedControlProofRuntime(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedControlProofRuntime {
 	t.Helper()
 	switch backend {
 	case servedparity.BackendDefaultSQLite:
 		unsetStoreSelectorEnv(t)
 		stubServeRuntimeWorkspaceLifecycle(t)
-		sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+		sqlitePath := testutil.SQLitePath(t, sqliteRequirement)
 		contractsPath := writeServedEventPublishFollowUpFixture(t)
 		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 		probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4802,7 +4831,8 @@ func startServedControlProofRuntime(t *testing.T, backend servedparity.Backend) 
 	case servedparity.BackendExplicitPostgres:
 		_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 			return serveRuntimeWorkspaceStub{}
-		})
+		}, postgresRequirement)
+
 		contractsPath := writeServedEventPublishFollowUpFixture(t)
 		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 		probe := lifecycletest.New(t, lifecycletest.WithTimeout(servedEventPublishLifecycleProbeWaitTimeout))
@@ -4827,64 +4857,64 @@ func startServedControlProofRuntime(t *testing.T, backend servedparity.Backend) 
 	}
 }
 
-func runServedRunControlBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedRunControlBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedControlProofRuntime(t, backend)
+	rt := startServedControlProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedRunControlLifecycleProof(t, rt)
 }
 
-func runServedLiveAgentEventReplayBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedLiveAgentEventReplayBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedLiveAgentProofRuntime(t, backend)
+	rt := startServedLiveAgentProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedLiveAgentEventReplayLifecycleProof(t, rt)
 }
 
-func runServedLiveAgentReplayBacklogBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedLiveAgentReplayBacklogBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedLiveAgentProofRuntime(t, backend)
+	rt := startServedLiveAgentProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedLiveAgentReplayBacklogLifecycleProof(t, rt)
 }
 
-func runServedAgentRestartBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedAgentRestartBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedLiveAgentProofRuntime(t, backend)
+	rt := startServedLiveAgentProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedAgentRestartLifecycleProof(t, rt)
 }
 
-func runServedAgentDirectiveBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedAgentDirectiveBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	var effects atomic.Int32
 	faults := &servedDirectivePersistenceFaults{}
-	rt := startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t, backend, servedLiveAgentProofLLMRuntime{calls: &effects, directiveFailures: true}, faults)
+	rt := startServedLiveAgentProofRuntimeWithLLMAndDirectiveFaults(t, backend, servedLiveAgentProofLLMRuntime{calls: &effects, directiveFailures: true}, faults, postgresRequirement, sqliteRequirement)
 	runServedAgentDirectiveOutcomeLifecycleProof(t, rt, &effects, faults)
 }
 
-func runServedRuntimeIngressControlBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedRuntimeIngressControlBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	t.Cleanup(runtimebus.ResumeRuntimeIngress)
-	rt := startServedControlProofRuntime(t, backend)
+	rt := startServedControlProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedRuntimeIngressControlLifecycleProof(t, rt)
 }
 
-func runServedMailboxDecisionBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedMailboxDecisionBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedControlProofRuntime(t, backend)
+	rt := startServedControlProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedMailboxDecisionLifecycleProof(t, rt)
 }
 
-func runServedTestSetupEntitiesBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedTestSetupEntitiesBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedTestSetupEntitiesProofRuntime(t, backend)
+	rt := startServedTestSetupEntitiesProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedTestSetupEntitiesLifecycleProof(t, rt)
 }
 
-func runServedConversationForkBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedConversationForkBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
-	rt := startServedConversationForkProofRuntime(t, backend)
+	rt := startServedConversationForkProofRuntime(t, backend, postgresRequirement, sqliteRequirement)
 	runServedConversationForkLifecycleProof(t, rt)
 }
 
-func startServedConversationForkProofRuntime(t *testing.T, backend servedparity.Backend) servedConversationForkProofRuntime {
+func startServedConversationForkProofRuntime(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedConversationForkProofRuntime {
 	t.Helper()
 	requests := &atomic.Int32{}
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4955,12 +4985,12 @@ func startServedConversationForkProofRuntime(t *testing.T, backend servedparity.
 	case servedparity.BackendDefaultSQLite:
 		unsetStoreSelectorEnv(t)
 		stubServeRuntimeWorkspaceLifecycle(t)
-		sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+		sqlitePath := testutil.SQLitePath(t, sqliteRequirement)
 		configPath := writeServedConversationForkConfig(t, storebackend.BackendSQLite.String(), sqlitePath, provider.URL)
 		rt = start(configPath, serveOptions{})
 		rt.Backend = "sqlite"
 	case servedparity.BackendExplicitPostgres:
-		_, _, _ = installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle { return serveRuntimeWorkspaceStub{} })
+		_, _, _ = installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle { return serveRuntimeWorkspaceStub{} }, postgresRequirement)
 		configPath := writeServedConversationForkConfig(t, storebackend.BackendPostgres.String(), "", provider.URL)
 		rt = start(configPath, serveOptions{StoreMode: "postgres", StoreModeSet: true})
 		rt.Backend = "postgres"
@@ -5295,13 +5325,13 @@ func setServedConversationForkExpiry(t *testing.T, db *sql.DB, backend, forkID s
 	}
 }
 
-func startServedTestSetupEntitiesProofRuntime(t *testing.T, backend servedparity.Backend) servedControlProofRuntime {
+func startServedTestSetupEntitiesProofRuntime(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) servedControlProofRuntime {
 	t.Helper()
 	switch backend {
 	case servedparity.BackendDefaultSQLite:
 		unsetStoreSelectorEnv(t)
 		stubServeRuntimeWorkspaceLifecycle(t)
-		sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+		sqlitePath := testutil.SQLitePath(t, sqliteRequirement)
 		contractsPath := writeServedTestSetupFixture(t)
 		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 		oldBuildStores := buildStoresForServe
@@ -5335,7 +5365,8 @@ func startServedTestSetupEntitiesProofRuntime(t *testing.T, backend servedparity
 	case servedparity.BackendExplicitPostgres:
 		_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 			return serveRuntimeWorkspaceStub{}
-		})
+		}, postgresRequirement)
+
 		contractsPath := writeServedTestSetupFixture(t)
 		bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 		endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
@@ -6254,23 +6285,23 @@ func requireServedMailboxEventCount(t *testing.T, db *sql.DB, backend, eventName
 	}
 }
 
-func runServedDynamicAutoEmitBackendProof(t *testing.T, backend servedparity.Backend) {
+func runServedDynamicAutoEmitBackendProof(t *testing.T, backend servedparity.Backend, postgresRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	switch backend {
 	case servedparity.BackendDefaultSQLite:
-		runServedDynamicAutoEmitSQLiteProof(t)
+		runServedDynamicAutoEmitSQLiteProof(t, sqliteRequirement)
 	case servedparity.BackendExplicitPostgres:
-		runServedDynamicAutoEmitPostgresProof(t)
+		runServedDynamicAutoEmitPostgresProof(t, postgresRequirement)
 	default:
 		t.Fatalf("unknown served dynamic auto_emit backend %q", backend)
 	}
 }
 
-func runServedDynamicAutoEmitSQLiteProof(t *testing.T) {
+func runServedDynamicAutoEmitSQLiteProof(t *testing.T, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	unsetStoreSelectorEnv(t)
 	stubServeRuntimeWorkspaceLifecycle(t)
-	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	sqlitePath := testutil.SQLitePath(t, sqliteRequirement)
 	contractsPath := writeServedDynamicAutoEmitFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	blocked := make(chan servedEventPublishPreHandlerProof, 1)
@@ -6327,11 +6358,12 @@ func runServedDynamicAutoEmitSQLiteProof(t *testing.T) {
 	runServedDynamicAutoEmitProof(t, endpoint, servedDB, "sqlite", bundleHash, blocked, release, &releaseOnce)
 }
 
-func runServedDynamicAutoEmitPostgresProof(t *testing.T) {
+func runServedDynamicAutoEmitPostgresProof(t *testing.T, postgresRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, postgresRequirement)
+
 	contractsPath := writeServedDynamicAutoEmitFixture(t)
 	bundleHash := servedEventPublishFixtureBundleHash(t, contractsPath)
 	blocked := make(chan servedEventPublishPreHandlerProof, 1)
@@ -7682,11 +7714,12 @@ scorer:
 	return root
 }
 
-func startServedJoinProofRuntime(t *testing.T) (string, *sql.DB, string) {
+func startServedJoinProofRuntime(t *testing.T, requirement testutil.DatabaseRequirement) (string, *sql.DB, string) {
 	t.Helper()
 	_, db, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, requirement)
+
 	root := writeServedJoinProofFixture(t)
 	bundleHash := seedServeRuntimeBundleCatalogRoot(t, context.Background(), pg, root)
 	endpoint, _ := startServedEventPublishFollowUpRuntime(t, serveOptions{
@@ -9750,7 +9783,7 @@ func TestRunServeRuntimePassesDataFlagToWorkspaceLifecycle(t *testing.T) {
 	_, _, _ = installServeRuntimePostgresTestStoresWithWorkspaceFactory(t, func(mountSources workspaceMountSources) serveWorkspaceLifecycle {
 		capturedMountSources = mountSources
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
 
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:         writeServeRuntimeTestConfig(t),
@@ -9912,7 +9945,8 @@ func TestRunServeRuntimeNativeBashDefaultDockerFailsWithoutDocker(t *testing.T) 
 func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsServe(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:         writeServeRuntimeTestConfig(t),
 		ContractsPath:      filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
@@ -9940,7 +9974,8 @@ func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDiskContractsSer
 func TestRunServeRuntimeFreshEmptyPostgresBootstrapsSchemaBeforeDevAbandon(t *testing.T) {
 	_, db, _ := installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:           writeServeRuntimeTestConfig(t),
 		ContractsPath:        filepath.Join("tests", "tier8-boot-verification", "test-boot-success"),
@@ -10217,7 +10252,8 @@ func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testin
 func TestRunServeRuntimeBundleHashMissingFailsBeforeReadiness(t *testing.T) {
 	_, _, _ = installServeRuntimeEmptyPostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresEmptyPhysical())
+
 	missingHash := "bundle-v1:sha256:2222222222222222222222222222222222222222222222222222222222222222"
 	var out lockedBuffer
 	code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
@@ -10318,7 +10354,8 @@ func TestRunServeRuntimeDuplicateAgentSlugFailsBeforeReadiness(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
 	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	firstRoot := writeServeRuntimeAgentSlugFixtureWithKey(t, "duplicate-agent-slug-a", "alpha", "shared-worker")
 	secondRoot := writeServeRuntimeAgentSlugFixtureWithKey(t, "duplicate-agent-slug-b", "beta", "shared-worker")
@@ -10368,7 +10405,8 @@ func TestRunServeRuntimeDistinctAgentSlugsBootPinnedContextsReachReadiness(t *te
 	isolateCLIAPIConfigEnv(t)
 	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	firstRoot := writeServeRuntimeAgentSlugFixture(t, "distinct-agent-slug-a", "alpha-worker")
 	secondRoot := writeServeRuntimeAgentSlugFixture(t, "distinct-agent-slug-b", "beta-worker")
@@ -10418,7 +10456,8 @@ func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrFo
 	_, _, pg := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		workspaceConfigured.Store(true)
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	firstHash := seedServeRuntimeBundleCatalog(t, ctx, pg, filepath.Join("tests", "tier8-boot-verification", "test-boot-success"))
 	secondHash := seedServeRuntimeBundleCatalog(t, ctx, pg, filepath.Join("tests", "tier1-primitives", "test-emits-single"))
@@ -10471,7 +10510,8 @@ func TestRunServeRuntimeMultiContextClaudeCLIFailsClosedBeforePrimaryGatewayOrFo
 func TestRunServeRuntimeUnavailableBundleStartupRecoveryFailsPersistedMissingBeforeCleanup(t *testing.T) {
 	_, db, _ := installServeRuntimePostgresTestStores(t, func() serveWorkspaceLifecycle {
 		return serveRuntimeWorkspaceStub{}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	persistedMissingRunID := uuid.NewString()
 	legacyRunID := uuid.NewString()
@@ -10519,7 +10559,8 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 			},
 			stoppedContainers: &stoppedContainers,
 		}
-	})
+	}, testutil.PostgresRowState())
+
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO agents (agent_id, role, model, conversation_mode, runtime_descriptor)
@@ -10604,18 +10645,19 @@ func TestRunServeRuntimeUnavailableBundleStartupRecoveryOrphansExpectedUnavailab
 
 const serveRuntimeLegacyRunIDForTest = "11111111-2222-3333-4444-555555555555"
 
-func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+func installServeRuntimePostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle, requirement testutil.DatabaseRequirement) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
 	return installServeRuntimePostgresTestStoresWithWorkspaceFactory(t, func(workspaceMountSources) serveWorkspaceLifecycle {
 		return workspaceFactory()
-	})
+	}, requirement)
+
 }
 
-func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory func() serveWorkspaceLifecycle, requirement testutil.DatabaseRequirement) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
 	return installServeRuntimePostgresTestStoresForDatabase(t, func(workspaceMountSources) serveWorkspaceLifecycle {
 		return workspaceFactory()
-	}, false, testutil.PostgresEmptyPhysical())
+	}, false, requirement)
 }
 
 func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string, requirement testutil.DatabaseRequirement) (string, string) {
@@ -10682,9 +10724,9 @@ func stubServeRuntimeWorkspaceLifecycle(t *testing.T) {
 	})
 }
 
-func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
+func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle, requirement testutil.DatabaseRequirement) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
-	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true, testutil.PostgresRowState())
+	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true, requirement)
 }
 
 func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle, useTemplate bool, requirement testutil.DatabaseRequirement) (string, *sql.DB, *store.PostgresStore) {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -3553,7 +3553,7 @@ func TestRunServeRuntimeJoinsEarlyStartupAndStoreCleanupFailure(t *testing.T) {
 }
 
 func TestServeBundleMatchAdmissionRejectsActiveAvailabilityConflicts(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	bootFingerprint := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
@@ -3601,7 +3601,7 @@ func TestServeBundleMatchAdmissionRejectsActiveAvailabilityConflicts(t *testing.
 }
 
 func TestServeBundleMatchAdmissionAllowsPersistedPresentAndDisabled(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	bootFingerprint := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
@@ -3638,7 +3638,7 @@ func TestServeBundleMatchAdmissionAllowsPersistedPresentAndDisabled(t *testing.T
 }
 
 func TestServeBundleMatchAdmissionRejectsDifferentPersistedActiveRunInDBLoadedMode(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	pinnedHash := "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111"
@@ -3687,7 +3687,7 @@ func TestServeBundleMatchAdmissionRejectsDifferentPersistedActiveRunInDBLoadedMo
 }
 
 func TestLoadServeRuntimeBundleFromCatalogLoadsPersistedRuntimeSource(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
@@ -10136,7 +10136,7 @@ func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testin
 	stubServeRuntimeWorkspaceLifecycle(t)
 	unsetStoreSelectorEnv(t)
 	sqlitePath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	runID, eventID := seedServeRuntimeSQLiteAbandonWork(t, sqlitePath)
+	runID, eventID := seedServeRuntimeSQLiteAbandonWork(t, sqlitePath, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	serve := startServeRuntimeTestProcess(t, serveOptions{
 		ConfigPath:         writeStoreBackendRuntimeConfig(t, storebackend.BackendSQLite.String(), sqlitePath),
@@ -10162,7 +10162,7 @@ func TestRunServeRuntimeSQLiteAbandonActiveRunsQuiescesBeforeReadiness(t *testin
 			t.Fatalf("concise abandon output exposed bookkeeping %q:\n%s", forbidden, serve.outputString())
 		}
 	}
-	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), sqlitePath))
 	if err != nil {
 		t.Fatalf("reopen sqlite store: %v", err)
 	}
@@ -10615,10 +10615,10 @@ func installServeRuntimeEmptyPostgresTestStores(t *testing.T, workspaceFactory f
 	t.Helper()
 	return installServeRuntimePostgresTestStoresForDatabase(t, func(workspaceMountSources) serveWorkspaceLifecycle {
 		return workspaceFactory()
-	}, false)
+	}, false, testutil.PostgresFreshPhysical())
 }
 
-func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string, string) {
+func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string, requirement testutil.DatabaseRequirement) (string, string) {
 	t.Helper()
 	spec, err := loadServePlatformSpecDocument(filepath.Join(repoRoot(), defaultPlatformSpecPath))
 	if err != nil {
@@ -10628,7 +10628,7 @@ func seedServeRuntimeSQLiteAbandonWork(t *testing.T, sqlitePath string) (string,
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, requirement, sqlitePath))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}
@@ -10684,10 +10684,10 @@ func stubServeRuntimeWorkspaceLifecycle(t *testing.T) {
 
 func installServeRuntimePostgresTestStoresWithWorkspaceFactory(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
-	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true)
+	return installServeRuntimePostgresTestStoresForDatabase(t, workspaceFactory, true, testutil.PostgresRowState())
 }
 
-func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle, useTemplate bool) (string, *sql.DB, *store.PostgresStore) {
+func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFactory func(workspaceMountSources) serveWorkspaceLifecycle, useTemplate bool, requirement testutil.DatabaseRequirement) (string, *sql.DB, *store.PostgresStore) {
 	t.Helper()
 	oldBuildStores := buildStoresForServe
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
@@ -10695,9 +10695,9 @@ func installServeRuntimePostgresTestStoresForDatabase(t *testing.T, workspaceFac
 	var db *sql.DB
 	var cleanup func()
 	if useTemplate {
-		dsn, db, cleanup = testutil.StartPostgres(t)
+		dsn, db, cleanup = testutil.AcquirePostgres(t, requirement)
 	} else {
-		dsn, db, cleanup = testutil.StartEmptyPostgres(t)
+		dsn, db, cleanup = testutil.AcquirePostgres(t, requirement)
 	}
 	t.Cleanup(cleanup)
 	runtimePG, err := store.NewPostgresStore(dsn)
@@ -10866,7 +10866,7 @@ func assertServeRuntimeUnavailableBundleRunOrphaned(t *testing.T, ctx context.Co
 }
 
 func TestPrepareServeBundleSourcePersistsCatalogForContractsServe(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier12-runtime-tools/test-flow-data-access")
@@ -10892,7 +10892,7 @@ func TestPrepareServeBundleSourcePersistsCatalogForContractsServe(t *testing.T) 
 }
 
 func TestPrepareServeBundleSourceDevStampsEphemeralWithoutCatalogRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier12-runtime-tools/test-flow-data-access")
@@ -11190,7 +11190,7 @@ func TestProjectRunOperationalStatus_PreservesHealthyRunningWhenActiveDeliveries
 }
 
 func TestRunForkRuntimeOwnerHarness_DryRunUsesCanonicalPlannerJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -11246,7 +11246,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunUsesCanonicalPlannerJSON(t *testing.T)
 }
 
 func TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -11299,7 +11299,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady(t 
 }
 
 func TestRunForkRuntimeOwnerHarness_DryRunContractsAddsContractFrontierAdmissionJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -11483,7 +11483,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateWithContractsReachesSelectedActivati
 }
 
 func TestRunForkRuntimeOwnerHarness_SelectedContractsBorrowedRequireExplicitData(t *testing.T) {
-	dsn, _, _ := testutil.StartPostgres(t)
+	dsn, _, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	repo := repoRoot()
 	borrowedRoot := t.TempDir()
@@ -11513,7 +11513,7 @@ flows: []
 }
 
 func TestRunForkRuntimeOwnerHarness_SelectedContractsExecutesExplicitHostRefusal(t *testing.T) {
-	dsn, _, _ := testutil.StartPostgres(t)
+	dsn, _, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	configPath := os.Getenv("SWARM_CONFIG")
 	rawConfig, err := os.ReadFile(configPath)
@@ -11536,7 +11536,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecutesExplicitHostRefusal
 }
 
 func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteThroughCanonicalOwnerJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	repo := repoRoot()
 	contractsRoot := filepath.Join(repo, "tests/tier1-primitives/test-emits-multiple")
@@ -11628,7 +11628,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteThroughCanonicalOwne
 }
 
 func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteReportsSourceAdvancedBranchJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	repo := repoRoot()
 	contractsRoot := filepath.Join(repo, "tests/tier1-primitives/test-emits-multiple")
@@ -11679,7 +11679,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteReportsSourceAdvance
 }
 
 func TestRunForkRuntimeOwnerHarness_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -11785,7 +11785,7 @@ func TestRunForkRuntimeOwnerHarness_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t
 }
 
 func TestRunForkRuntimeOwnerHarness_ActivateUsesCanonicalStoreOwnerJSON(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	pg := &store.PostgresStore{DB: db}
 	runID := uuid.NewString()
@@ -11835,7 +11835,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateUsesCanonicalStoreOwnerJSON(t *testi
 }
 
 func TestRunForkRuntimeOwnerHarness_ActivateNonSelectedDoesNotRequireSelectedBindingSchema(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	setPostgresEnvFromDSN(t, dsn)
 	pg := &store.PostgresStore{DB: db}
 	runID := uuid.NewString()
@@ -11872,7 +11872,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateNonSelectedDoesNotRequireSelectedBin
 }
 
 func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingConsumesRuntimeAdmission(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -11933,7 +11933,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingConsumesRuntimeAdmiss
 }
 
 func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSelectedRecipientPlan(t *testing.T) {
-	dsn, db, _ := testutil.StartPostgres(t)
+	dsn, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -12581,7 +12581,7 @@ func TestLoadRuntimeConfig_RejectsUnsupportedRuntimeControlsFromFile(t *testing.
 }
 
 func TestRunState_UsesDurableCompletedRunState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	eb, err := runtimebus.NewEventBus(pg)
 	if err != nil {
@@ -12617,7 +12617,7 @@ func TestRunState_UsesDurableCompletedRunState(t *testing.T) {
 }
 
 func TestRunState_KeepsSupportedRunRunningUntilManagerWorkSettles(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	eb, err := runtimebus.NewEventBus(pg)
 	if err != nil {
@@ -12730,7 +12730,7 @@ func TestRunState_KeepsSupportedRunRunningUntilManagerWorkSettles(t *testing.T) 
 }
 
 func TestRunState_PreservesRunningTruthWhileManagerWorkIsActive(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	eb, err := runtimebus.NewEventBus(pg)
 	if err != nil {
@@ -14683,7 +14683,7 @@ func TestInitializeStateStoresDoesNotPlanGeneratedEntityTables(t *testing.T) {
 func TestInitializeStateStoresSQLiteDoesNotCreateGeneratedEntityTables(t *testing.T) {
 	ctx := context.Background()
 	bundle := workflowBundleWithGeneratedEntitySchemaForStateStoreTest(t)
-	sqliteStore, err := store.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "dev.db")))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}
@@ -14707,7 +14707,7 @@ func TestInitializeStateStoresSQLiteDoesNotCreateGeneratedEntityTables(t *testin
 func TestInitializeStateStoresPostgresDoesNotCreateGeneratedEntityTables(t *testing.T) {
 	ctx := context.Background()
 	bundle := workflowBundleWithGeneratedEntitySchemaForStateStoreTest(t)
-	dsn, db, cleanup := testutil.StartEmptyPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresEmptyPhysical())
 	t.Cleanup(cleanup)
 	pg, err := store.NewPostgresStore(dsn)
 	if err != nil {
@@ -15418,7 +15418,7 @@ func TestValidateServeGatewayURLEnvForNonDevRejectsAnyRetiredURLEnv(t *testing.T
 func TestRunServeRuntimeAbandonActiveRunsQuiescesBeforeBundleMatchAdmission(t *testing.T) {
 	oldBuildStores := buildStoresForServe
 	oldWorkspaceLifecycle := configuredWorkspaceLifecycleForServe
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	runtimePG, err := store.NewPostgresStore(dsn)
 	if err != nil {

--- a/cmd/swarm/provider_trigger_packs_test.go
+++ b/cmd/swarm/provider_trigger_packs_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/division-sh/swarm/internal/testutil"
 	"io/fs"
 	"net"
 	"net/http"
@@ -44,7 +45,7 @@ func TestProviderTriggerReleaseLayoutLoadsCompleteFilesystemInventory(t *testing
 		t.Fatalf("mkdir release data: %v", err)
 	}
 	sqlitePath := filepath.Join(releaseRoot, "runtime.db")
-	seedReleaseProviderTriggerStore(t, platformSpecBody, sqlitePath)
+	seedReleaseProviderTriggerStore(t, platformSpecBody, sqlitePath, testutil.SQLiteDefaultTemp())
 	configPath := filepath.Join(releaseRoot, "platform-config.yaml")
 	writeReleaseProviderTriggerConfig(t, configPath, sqlitePath)
 
@@ -294,7 +295,7 @@ func writeReleaseProviderTriggerConfig(t *testing.T, path, sqlitePath string) {
 	writeRuntimeConfigText(t, path, strings.Join(lines, "\n")+"\n")
 }
 
-func seedReleaseProviderTriggerStore(t *testing.T, platformSpecBody []byte, sqlitePath string) {
+func seedReleaseProviderTriggerStore(t *testing.T, platformSpecBody []byte, sqlitePath string, requirement testutil.DatabaseRequirement) {
 	t.Helper()
 	var platformSpec runtimecontracts.PlatformSpecDocument
 	decodeAuthoritativeYAMLBytesForTest(t, platformSpecBody, &platformSpec)
@@ -302,7 +303,7 @@ func seedReleaseProviderTriggerStore(t *testing.T, platformSpecBody []byte, sqli
 	if err != nil {
 		t.Fatalf("generate release platform tables: %v", err)
 	}
-	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, requirement, sqlitePath))
 	if err != nil {
 		t.Fatalf("create release SQLite store: %v", err)
 	}

--- a/cmd/swarm/provider_trigger_shopify_smoke_test.go
+++ b/cmd/swarm/provider_trigger_shopify_smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/division-sh/swarm/internal/testutil"
 	"io"
 	"net/http"
 	"os"
@@ -57,7 +58,7 @@ func TestShopifyLocalProviderToolSmoke(t *testing.T) {
 		providerEventName = "inbound.shopify"
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedProviderTriggerSmokeRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, clientSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)

--- a/cmd/swarm/provider_trigger_typeform_smoke_test.go
+++ b/cmd/swarm/provider_trigger_typeform_smoke_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"io"
 	"net"
 	"net/http"
@@ -43,7 +44,7 @@ func TestTypeformManualLiveHTTPSWebhookSmoke(t *testing.T) {
 	timeout := typeformLiveSmokeTimeout(t)
 
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedProviderTriggerSmokeRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -126,6 +126,11 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "digest source is an explicit SQL read-model exception pending selected read-owner migration",
 		},
+		"internal/testpostgres/row_pool.go": {
+			Classification: rawSQLTestSupportBoundary,
+			Issue:          2015,
+			Reason:         "typed test database owner uses raw PostgreSQL catalog and reset operations to fence lease authority and validate reusable row-state slots",
+		},
 		"internal/runtime/bus/eventbus.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -166,7 +166,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	}
 	requireChangedStandingColdStartMatrix(t, opts, contractsRoot, nil)
 
-	sqliteStore, err := store.NewSQLiteRuntimeStore(sqlitePath)
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), sqlitePath))
 	if err != nil {
 		t.Fatalf("open SQLite runtime store: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestStandingIngressUnsupportedAliasFailsBeforeServeReadiness(t *testing.T) 
 
 func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndReplies(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	runtimePG, err := store.NewPostgresStore(dsn)
 	if err != nil {
@@ -533,7 +533,7 @@ func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, sql
 			if strings.HasPrefix(sqlitePath, "postgres:") {
 				diagnostics = standingPostgresDiagnostics(strings.TrimPrefix(sqlitePath, "postgres:"))
 			} else if strings.TrimSpace(sqlitePath) != "" {
-				diagnostics = standingSQLiteDiagnostics(sqlitePath)
+				diagnostics = standingSQLiteDiagnostics(sqlitePath, testutil.SQLiteDefaultTemp())
 			}
 			t.Fatalf("timed out waiting for Telegram reply %d/%d; diagnostics: %s", i+1, len(chatIDs), diagnostics)
 		}
@@ -592,8 +592,12 @@ func standingPostgresDiagnostics(dsn string) string {
 	return strings.Join(parts, ",")
 }
 
-func standingSQLiteDiagnostics(path string) string {
-	store, err := store.NewSQLiteRuntimeStore(path)
+func standingSQLiteDiagnostics(path string, requirement testutil.DatabaseRequirement) string {
+	declaredPath, err := testutil.DeclareSQLitePath(requirement, path)
+	if err != nil {
+		return err.Error()
+	}
+	store, err := store.NewSQLiteRuntimeStore(declaredPath)
 	if err != nil {
 		return err.Error()
 	}

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -122,7 +122,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if firstEntity == "" || firstEntity != secondEntity {
 		t.Fatalf("delivery entities = %q and %q, want one standing entity", firstEntity, secondEntity)
 	}
-	requireStandingTelegramCalls(t, calls, sqlitePath, 42, 42)
+	requireStandingTelegramCalls(t, calls, sqlitePath, testutil.SQLiteDefaultTemp(), 42, 42)
 	if code := first.stop(); code != 0 {
 		t.Fatalf("first serve exit = %d", code)
 	}
@@ -160,7 +160,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if restartedEntity != firstEntity {
 		t.Fatalf("restart entity = %q, want %q", restartedEntity, firstEntity)
 	}
-	requireStandingTelegramCalls(t, calls, sqlitePath, 84)
+	requireStandingTelegramCalls(t, calls, sqlitePath, testutil.SQLiteDefaultTemp(), 84)
 	if code := second.stop(); code != 0 {
 		t.Fatalf("second serve exit = %d", code)
 	}
@@ -326,7 +326,7 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 	if got := sendStandingTelegramUpdate(t, baseURL, 202, 42); got != entity {
 		t.Fatalf("second entity = %q, want %q", got, entity)
 	}
-	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, 42, 42)
+	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, testutil.SQLiteDefaultTemp(), 42, 42)
 	if code := first.stop(); code != 0 {
 		t.Fatalf("first serve exit = %d", code)
 	}
@@ -339,7 +339,7 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 	if got := sendStandingTelegramUpdate(t, "http://"+serveRuntimeAPIListenerFromOutput(t, second.outputString()), 203, 84); got != entity {
 		t.Fatalf("restart entity = %q, want %q", got, entity)
 	}
-	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, 84)
+	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, testutil.SQLiteDefaultTemp(), 84)
 	if code := second.stop(); code != 0 {
 		t.Fatalf("second serve exit = %d", code)
 	}
@@ -520,7 +520,7 @@ func sendStandingTelegramUpdate(t testing.TB, baseURL string, updateID, chatID i
 	return strings.TrimSpace(fmt.Sprint(payload["entity_id"]))
 }
 
-func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, sqlitePath string, chatIDs ...int) {
+func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, sqlitePath string, sqliteRequirement testutil.DatabaseRequirement, chatIDs ...int) {
 	t.Helper()
 	for i, chatID := range chatIDs {
 		select {
@@ -533,7 +533,7 @@ func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, sql
 			if strings.HasPrefix(sqlitePath, "postgres:") {
 				diagnostics = standingPostgresDiagnostics(strings.TrimPrefix(sqlitePath, "postgres:"))
 			} else if strings.TrimSpace(sqlitePath) != "" {
-				diagnostics = standingSQLiteDiagnostics(sqlitePath, testutil.SQLiteDefaultTemp())
+				diagnostics = standingSQLiteDiagnostics(sqlitePath, sqliteRequirement)
 			}
 			t.Fatalf("timed out waiting for Telegram reply %d/%d; diagnostics: %s", i+1, len(chatIDs), diagnostics)
 		}

--- a/cmd/swarm/store_roles_test.go
+++ b/cmd/swarm/store_roles_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"github.com/division-sh/swarm/internal/testutil"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -70,7 +71,7 @@ func TestValidateSelectedStoreBundleRolesAcceptsSQLiteBuildStores(t *testing.T) 
 }
 
 func TestValidateSelectedStoreBundleRolesAcceptsPostgresSelectedBundle(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteDefaultTemp(), ":memory:"))
 	if err != nil {
 		t.Fatalf("open inert sql handle for selected postgres role projection: %v", err)
 	}

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	db := sqliteStore.DB
 	controller := &fakeAgentControlController{
 		directiveResponse: "accepted",
@@ -109,7 +109,7 @@ func TestOperatorAgentControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.
 }
 
 func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{
@@ -156,7 +156,7 @@ func TestOperatorAgentControlHandlersTypedResourceErrors(t *testing.T) {
 }
 
 func TestOperatorAgentDirectiveFailureUsesCanonicalNestedEnvelope(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	failure := runtimeagentcontrol.DirectiveExecutionLeaseExpiredFailure()
 	operation := runtimeagentcontrol.DirectiveOperation{
 		OperationID:      "00000000-0000-0000-0000-000000000801",
@@ -209,7 +209,7 @@ func TestOperatorAgentDirectiveFailureUsesCanonicalNestedEnvelope(t *testing.T) 
 }
 
 func TestOperatorAgentSendDirectiveRunTargetErrors(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	db := sqliteStore.DB
 	missingRunID := "00000000-0000-0000-0000-000000000404"
 	terminalRunID := "00000000-0000-0000-0000-000000000405"
@@ -267,7 +267,7 @@ func TestOperatorAgentSendDirectiveRunTargetErrors(t *testing.T) {
 }
 
 func TestOperatorAgentSendDirectivePersistsDirectiveEventOnceOnReplay(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBus(pg)
@@ -317,7 +317,7 @@ func TestOperatorAgentSendDirectivePersistsDirectiveEventOnceOnReplay(t *testing
 }
 
 func TestOperatorAgentSendDirectiveUsesLegacyRunBundleSourceUntilSourceStampingOwnerLands(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bootFingerprint := "sha256:4444444444444444444444444444444444444444444444444444444444444444"
@@ -368,7 +368,7 @@ func TestOperatorAgentSendDirectiveUsesLegacyRunBundleSourceUntilSourceStampingO
 }
 
 func TestOperatorAgentControlHandlersRestrictAgentNotRunningToSendDirective(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
 		Handlers: OperatorReadHandlers(OperatorReadOptions{

--- a/internal/apiv1/operator_bundle_delete_test.go
+++ b/internal/apiv1/operator_bundle_delete_test.go
@@ -363,7 +363,7 @@ func TestOperatorBundleDeleteBlocksPostDeleteNewWorkFromPersistedRuntimeSource(t
 		{name: "force", deleteParams: `"bundle_hash":"` + runStartTestBundleHash + `","force":true,"idempotency_key":"force-delete-current-runtime"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 			pg := &store.PostgresStore{DB: db}
 			ctx := context.Background()

--- a/internal/apiv1/operator_entity_test.go
+++ b/internal/apiv1/operator_entity_test.go
@@ -123,7 +123,7 @@ func TestOperatorEntityHandlersExposeEntityNativeReads(t *testing.T) {
 
 func TestOperatorEntityHandlersServeContractEntityTypesFromPostgres(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -199,7 +199,7 @@ func TestOperatorEntityHandlersServeContractEntityTypesFromPostgres(t *testing.T
 
 func TestOperatorEntityHandlersServeContractEntityTypesFromSQLite(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	runID := "11111111-1111-1111-1111-111111111111"
 	entityA := "22222222-2222-2222-2222-222222222222"
 	entityB := "33333333-3333-3333-3333-333333333333"

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempotency(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -111,7 +111,7 @@ func TestOperatorEventPublishHandlersPersistEventReportDeliveriesAndReplayIdempo
 }
 
 func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	started := make(chan struct{}, 1)
@@ -181,7 +181,7 @@ func TestOperatorEventPublishReturnsDurableAckBeforePostCommitDispatchCompletes(
 
 func TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runStartTestEventBusOptions(source))
 	if err != nil {
@@ -247,7 +247,7 @@ func TestOperatorEventPublishSQLiteIdempotentFirstEventPublishesWithoutLock(t *t
 
 func TestOperatorEventPublishSQLitePayloadFailureLeavesNoIdempotencyCompletionOrRows(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runtimebus.EventBusOptions{
 		ContractBundle:   source,
@@ -283,7 +283,7 @@ func TestOperatorEventPublishSQLitePayloadFailureLeavesNoIdempotencyCompletionOr
 }
 
 func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(flowScopedEventPublishTestBundle())
 	canonicalEventName := "repo-scaffold/repo_scaffold.repo_commit_succeeded"
@@ -331,7 +331,7 @@ func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
 }
 
 func TestOperatorEventPublishRootEventNameWinsOverFlowLeafAliases(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(rootAndAmbiguousFlowScopedEventPublishTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -360,7 +360,7 @@ func TestOperatorEventPublishRootEventNameWinsOverFlowLeafAliases(t *testing.T) 
 
 func TestOperatorEventPublishFlowScopedEventNameFailuresFailClosed(t *testing.T) {
 	t.Run("unknown flow scoped event", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(flowScopedEventPublishTestBundle())
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -385,7 +385,7 @@ func TestOperatorEventPublishFlowScopedEventNameFailuresFailClosed(t *testing.T)
 	})
 
 	t.Run("ambiguous unscoped leaf", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(ambiguousFlowScopedEventPublishTestBundle())
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -411,7 +411,7 @@ func TestOperatorEventPublishFlowScopedEventNameFailuresFailClosed(t *testing.T)
 }
 
 func TestOperatorEventPublishHandlersRequireCanonicalBundleHashForCreateNewWork(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -431,7 +431,7 @@ func TestOperatorEventPublishHandlersRequireCanonicalBundleHashForCreateNewWork(
 }
 
 func TestOperatorEventPublishHandlersUseActiveEphemeralBundleScopeForCreateNewWork(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -461,7 +461,7 @@ func TestOperatorEventPublishHandlersUseActiveEphemeralBundleScopeForCreateNewWo
 }
 
 func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -535,7 +535,7 @@ func TestOperatorEventPublishPersistsIdempotencyBeforeReadbackFailure(t *testing
 }
 
 func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	failing := &failStandalonePipelineReceiptOnceStore{
 		PostgresStore: pg,
@@ -596,7 +596,7 @@ func TestOperatorEventPublishPostCommitReceiptFailureReplaysWithoutDuplicate(t *
 }
 
 func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	failing := &failNormalRunCompletionStore{
 		PostgresStore: pg,
@@ -655,7 +655,7 @@ func TestOperatorEventPublishPostCommitCompletionFailureReplaysWithoutDuplicate(
 }
 
 func TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	failing := &failCommittedReplayScopeStore{
 		PostgresStore: pg,
@@ -693,7 +693,7 @@ func TestOperatorEventPublishPreCommitFailureFailsClosedWithDeclaredError(t *tes
 }
 
 func TestOperatorEventPublishFailsClosedWithoutDurableAckPublisher(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	publisher := &legacyOnlyEventPublisher{}
@@ -722,7 +722,7 @@ func TestOperatorEventPublishFailsClosedWithoutDurableAckPublisher(t *testing.T)
 }
 
 func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -800,7 +800,7 @@ func TestOperatorEventPublishExplicitRunTargetRequiresExistingNonterminalRun(t *
 }
 
 func TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersistence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishFollowUpTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -883,7 +883,7 @@ func TestOperatorEventPublishExplicitRunFollowUpRequiresRecipientBeforePersisten
 
 func TestOperatorEventPublishExistingRunTargetRouteValidatesAndPersistsCanonicalTarget(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishTargetRouteTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -942,7 +942,7 @@ func TestOperatorEventPublishExistingRunTargetRouteValidatesAndPersistsCanonical
 
 func TestOperatorEventPublishRootEventTemplateInputNameCollisionPayloadEntityIDDoesNotSelectTarget(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishRootTemplateCollisionTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -998,7 +998,7 @@ func TestOperatorEventPublishRootEventTemplateInputNameCollisionPayloadEntityIDD
 
 func TestOperatorEventPublishExistingRunTargetRouteRejectsInvalidTargetBeforePersistence(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishTargetRouteTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1102,7 +1102,7 @@ func TestOperatorEventPublishExistingRunTargetRouteRejectsInvalidTargetBeforePer
 
 func TestOperatorEventPublishExplicitRunRequiresRecipientPlanCheckerBeforePersistence(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishFollowUpTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1150,7 +1150,7 @@ func TestOperatorEventPublishExplicitRunRequiresRecipientPlanCheckerBeforePersis
 
 func TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	source := semanticview.Wrap(eventPublishFollowUpTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runStartTestEventBusOptions(source))
 	if err != nil {
@@ -1198,7 +1198,7 @@ func TestOperatorEventPublishSQLiteExplicitRunFollowUpUsesSelectedRun(t *testing
 }
 
 func TestOperatorEventPublishRejectsCallerEntityIDForCreateEntityBeforePersistence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(eventPublishCreateEntityTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1236,7 +1236,7 @@ func TestOperatorEventPublishRejectsCallerEntityIDForCreateEntityBeforePersisten
 
 func TestOperatorEventPublishSQLiteRejectsCallerEntityIDForCreateEntityBeforePersistence(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	source := semanticview.Wrap(eventPublishCreateEntityTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(sqliteStore, runStartTestEventBusOptions(source))
 	if err != nil {
@@ -1272,7 +1272,7 @@ func TestOperatorEventPublishSQLiteRejectsCallerEntityIDForCreateEntityBeforePer
 }
 
 func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1320,7 +1320,7 @@ func TestOperatorEventPublishSourceEventIDValidatesSameRunLineage(t *testing.T) 
 }
 
 func TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1433,7 +1433,7 @@ func TestOperatorEventPublishSourceEventIDRejectsInvalidLineageBeforePersistence
 
 func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	t.Run("non-routable bundle hash", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1453,7 +1453,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("invalid canonical bundle hash", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1473,7 +1473,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("canonical and legacy bundle params conflict", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1493,7 +1493,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("undeclared event", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1513,7 +1513,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("payload validation", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
@@ -1542,7 +1542,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("invalid run id", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -1560,7 +1560,7 @@ func TestOperatorEventPublishHandlersFailClosedBeforePersistence(t *testing.T) {
 }
 
 func TestOperatorEventPublishQueuesWhileRuntimePaused(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestOperatorEventReplayPublishesDistinctReplayEventAuditAndIdempotency(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	bus := eventReplayTestBus(t, pg)
 	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -142,7 +142,7 @@ func TestReplayEventFromOriginalUsesCanonicalEventEntityOnly(t *testing.T) {
 
 func TestOperatorEventReplayStoresIdempotencyBeforeAuditPublishReadiness(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	inner := eventReplayTestBus(t, pg)
 	publisher := &failOnceAuditEventPublisher{inner: inner, err: errors.New("audit publish temporarily unavailable")}
@@ -184,7 +184,7 @@ func TestOperatorEventReplayStoresIdempotencyBeforeAuditPublishReadiness(t *test
 
 func TestOperatorEventReplayStoresIdempotencyBeforeDirectPublishFanoutError(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	bus := eventReplayTestBus(t, pg)
 	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -235,7 +235,7 @@ func TestOperatorEventReplayStoresIdempotencyBeforeDirectPublishFanoutError(t *t
 func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 	t.Run("subset targets only requested original subscriber", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -258,7 +258,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 	})
 
 	t.Run("missing event", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		handler := eventReplayTestHandler(t, pg, eventReplayTestBus(t, pg))
 		resp := rpcCall(t, handler, eventReplayBody(uuid.NewString(), nil, "idem-missing"))
@@ -275,7 +275,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 
 	t.Run("zero original agent delivery history", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		original := seedReplayableOperatorEvent(t, ctx, pg, "scan.requested", nil, eventReplayStatusDelivered)
 		handler := eventReplayTestHandler(t, pg, eventReplayTestBus(t, pg))
@@ -290,7 +290,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 
 	t.Run("pending node-only delivery is not replay eligible and does not mutate", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		eventID := uuid.NewString()
 		runID := uuid.NewString()
@@ -346,7 +346,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 
 	t.Run("requested subscriber was not original", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -368,7 +368,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 
 	t.Run("original subscriber no longer deliverable", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -389,7 +389,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 	for _, status := range []string{eventReplayStatusPending, eventReplayStatusInProgress} {
 		t.Run("nonterminal original delivery is not eligible "+status, func(t *testing.T) {
 			ctx := context.Background()
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &store.PostgresStore{DB: db}
 			bus := eventReplayTestBus(t, pg)
 			seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -429,7 +429,7 @@ func TestOperatorEventReplaySubsetAndFailClosedCases(t *testing.T) {
 
 func TestOperatorAgentReplayProjectsSingletonEventReplayOwner(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	bus := eventReplayTestBus(t, pg)
 	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -494,7 +494,7 @@ func TestOperatorAgentReplayProjectsSingletonEventReplayOwner(t *testing.T) {
 func TestOperatorAgentReplayFailClosedCases(t *testing.T) {
 	t.Run("requested agent was not original subscriber", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -517,7 +517,7 @@ func TestOperatorAgentReplayFailClosedCases(t *testing.T) {
 
 	t.Run("original agent no longer deliverable", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -538,7 +538,7 @@ func TestOperatorAgentReplayFailClosedCases(t *testing.T) {
 
 	t.Run("nonterminal original delivery is not eligible", func(t *testing.T) {
 		ctx := context.Background()
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		bus := eventReplayTestBus(t, pg)
 		seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "agent-a")
@@ -567,7 +567,7 @@ func TestOperatorEventReplayQueuesWhenDispatchGated(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &store.PostgresStore{DB: db}
 			bus, err := runtimebus.NewEventBusWithOptions(pg, tc.opts)
 			if err != nil {

--- a/internal/apiv1/operator_mailbox_materialization_test.go
+++ b/internal/apiv1/operator_mailbox_materialization_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 
 func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteMailboxMaterializationAPIStore(t, ctx)
+	sqliteStore := newSQLiteMailboxMaterializationAPIStore(t, ctx, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -82,7 +83,7 @@ func TestOperatorMailboxHandlersSQLiteReadsMaterializedMailboxWrite(t *testing.T
 	}
 }
 
-func newSQLiteMailboxMaterializationAPIStore(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
+func newSQLiteMailboxMaterializationAPIStore(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) *storepkg.SQLiteRuntimeStore {
 	t.Helper()
-	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, requirement)
 }

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
 		PayloadValidator: mailboxItemDecidedPayloadValidator(t, mailboxItemDecidedStrictPayloadSchema(true)),
@@ -397,7 +397,7 @@ func TestOperatorMailboxGetDegradesEntityContextReadFailure(t *testing.T) {
 }
 
 func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
@@ -478,7 +478,7 @@ func TestOperatorMailboxApproveRejectsUndeclaredMailboxPayloadSchemaAndRollsBack
 }
 
 func TestOperatorMailboxApprovePublishFailureLeavesItemRetryable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceEventID := uuid.NewString()
@@ -603,7 +603,7 @@ func TestOperatorMailboxRejectAndDeferPublishFailureLeavesItemRetryable(t *testi
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &store.PostgresStore{DB: db}
 			ctx := context.Background()
 			now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
@@ -672,7 +672,7 @@ func TestOperatorMailboxRejectAndDeferPublishFailureLeavesItemRetryable(t *testi
 }
 
 func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
@@ -820,7 +820,7 @@ func TestOperatorMailboxApproveQueuesTransactionalPublishWhileRuntimePaused(t *t
 }
 
 func TestOperatorMailboxApproveRunsPublishDispatchAfterDecisionCommit(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 

--- a/internal/apiv1/operator_mailbox_write_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_write_supported_surface_test.go
@@ -37,7 +37,7 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 			name: "sqlite_default_no_selector",
 			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
-				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 				probe := runtimelifecycleprobe.New()
 				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore, probe)
 				return handler, sqliteStore.DB, bus, probe
@@ -47,7 +47,7 @@ func TestOperatorMailboxWriteSupportedSurfacePublishesAndReadsAcrossBackends(t *
 			name: "postgres_explicit_opt_in",
 			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
 				probe := runtimelifecycleprobe.New()
@@ -110,7 +110,7 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			name: "sqlite_default_no_selector",
 			setup: func(t *testing.T, ctx context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
-				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+				sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 				probe := runtimelifecycleprobe.New()
 				handler, bus := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, sqliteStore, probe)
 				return handler, sqliteStore.DB, bus, probe
@@ -120,7 +120,7 @@ func TestOperatorRuleMailboxWriteSupportedSurfaceIsBranchScopedAcrossBackends(t 
 			name: "postgres_explicit_opt_in",
 			setup: func(t *testing.T, _ context.Context, source semanticview.Source, fact runtimecorrelation.BundleSourceFact) (*Handler, *sql.DB, *runtimebus.EventBus, *runtimelifecycleprobe.Probe) {
 				t.Helper()
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				pg := &store.PostgresStore{DB: db}
 				probe := runtimelifecycleprobe.New()
@@ -165,7 +165,7 @@ func TestOperatorMailboxWriteSupportedSurfaceMissingMaterializerIsLoud(t *testin
 	bundle := mailboxWriteSupportedSurfaceBundle(t)
 	source := semanticview.Wrap(bundle)
 	fact := bundleSourceFactForTestBundle(t, bundle)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	probe := runtimelifecycleprobe.New()
 	handler, _ := newMailboxWriteSupportedSurfaceHandler(t, ctx, sqliteStore, sqliteStore.DB, source, fact, nil, probe)
 

--- a/internal/apiv1/operator_run_completion_system_node_test.go
+++ b/internal/apiv1/operator_run_completion_system_node_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestOperatorRunCompletionSystemNodeFlowConvergesSupportedSurfaces(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}

--- a/internal/apiv1/operator_run_control_test.go
+++ b/internal/apiv1/operator_run_control_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBus(pg)
@@ -108,7 +108,7 @@ func TestOperatorRunControlHandlersUseCanonicalOwnerAndIdempotency(t *testing.T)
 }
 
 func TestOperatorRunControlHandlersTypedResourceErrors(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBus(pg)

--- a/internal/apiv1/operator_run_start_test.go
+++ b/internal/apiv1/operator_run_start_test.go
@@ -42,7 +42,7 @@ func runStartTestEventBusOptions(source semanticview.Source) runtimebus.EventBus
 }
 
 func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -112,7 +112,7 @@ func TestOperatorRunStartHandlersPersistRootEventAndReplayIdempotency(t *testing
 }
 
 func TestOperatorRunStartHandlersUseActiveEphemeralBundleScopeForCreateNewWork(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -134,7 +134,7 @@ func TestOperatorRunStartHandlersUseActiveEphemeralBundleScopeForCreateNewWork(t
 }
 
 func TestOperatorRunStartHandlersRequireBundleScopeForCreateNewWorkWithoutActiveRuntimeFact(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	handler := runStartTestHandler(t, pg, missingRunStartBundleScopePublisher{}, source)
@@ -161,7 +161,7 @@ func TestOperatorRunStartHandlersRequireBundleScopeForCreateNewWorkWithoutActive
 }
 
 func TestOperatorRunStartHandlersAcceptCanonicalBundleHashForCreateNewWork(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -179,7 +179,7 @@ func TestOperatorRunStartHandlersAcceptCanonicalBundleHashForCreateNewWork(t *te
 }
 
 func TestOperatorRunStartRejectsFlowScopedEventName(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(flowScopedEventPublishTestBundle())
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -206,7 +206,7 @@ func TestOperatorRunStartRejectsFlowScopedEventName(t *testing.T) {
 
 func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	t.Run("non-routable bundle hash", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -227,7 +227,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("existing run bundle mismatch", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -259,7 +259,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("invalid canonical bundle hash", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -280,7 +280,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("invalid canonical bundle hash", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -301,7 +301,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("canonical and legacy bundle params conflict", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -322,7 +322,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("undeclared event", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -354,7 +354,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("declared but unroutable root input", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		const eventName = "scan.unroutable_requested"
 		bundle := runStartTestBundle(eventName)
@@ -393,7 +393,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("payload validation", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
@@ -423,7 +423,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("invalid caller run id", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -454,7 +454,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("payload entity id is not envelope authority", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))
@@ -491,7 +491,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("publish failure", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		handler := runStartTestHandler(t, pg, failingRunStartPublisher{err: errors.New("simulated run.start publish failure")}, source)
@@ -513,7 +513,7 @@ func TestOperatorRunStartHandlersFailClosedBeforePersistence(t *testing.T) {
 	})
 
 	t.Run("post-validation invalid event type is a publish contradiction", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		pg := &store.PostgresStore{DB: db}
 		source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 		handler := runStartTestHandler(t, pg, failingRunStartPublisher{err: runtimebus.ErrInvalidEventType}, source)
@@ -574,7 +574,7 @@ func TestInvalidEventTypeMappersSeparateRootInputFromCatalogFailures(t *testing.
 }
 
 func TestOperatorRunStartHandlersLeaveSplitControlMethodsUnavailable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(runStartTestBundle("scan.requested"))
 	bus, err := runtimebus.NewEventBusWithOptions(pg, runStartTestEventBusOptions(source))

--- a/internal/apiv1/operator_runtime_context_test.go
+++ b/internal/apiv1/operator_runtime_context_test.go
@@ -29,7 +29,7 @@ const runtimeContextTestBundleHashB = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbb
 const runtimeContextTestBundleHashC = "bundle-v1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 
 func TestOperatorRuntimeContextManagerRoutesCreateNewWorkToSelectedBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	handler := fixture.handler(t)
 	chPrimary := fixture.busA.Subscribe("scan-orchestrator", events.EventType("triage.requested"))
 	defer fixture.busA.Unsubscribe("scan-orchestrator")
@@ -65,7 +65,7 @@ func TestOperatorRuntimeContextManagerRoutesCreateNewWorkToSelectedBundle(t *tes
 }
 
 func TestOperatorRuntimeContextManagerRoutesExistingRunByStoredBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	handler := fixture.handler(t)
 	chSelected := fixture.busB.Subscribe("scan-orchestrator", events.EventType("triage.requested"))
 	defer fixture.busB.Unsubscribe("scan-orchestrator")
@@ -149,7 +149,7 @@ func TestOperatorRuntimeContextManagerRejectsExistingRunUnavailableSourceStates(
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fixture := newOperatorRuntimeContextFixture(t)
+			fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 			if tt.seedBundleRow {
 				seedOperatorBundleDeleteBundle(t, context.Background(), fixture.db, tt.bundleHash)
 			}
@@ -202,7 +202,7 @@ func TestOperatorRuntimeContextManagerRejectsExistingRunRequestedHashMismatch(t 
 	}
 	for _, tt := range tests {
 		t.Run(tt.method, func(t *testing.T) {
-			fixture := newOperatorRuntimeContextFixture(t)
+			fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 			handler := fixture.handler(t)
 			runID := uuid.NewString()
 			seedRuntimeContextRunBundle(t, fixture.db, runID, runtimeContextTestBundleHashB, storerunlifecycle.BundleSourcePersisted, "")
@@ -217,7 +217,7 @@ func TestOperatorRuntimeContextManagerRejectsExistingRunRequestedHashMismatch(t 
 }
 
 func TestOperatorRuntimeContextManagerRoutesEventReplayByOriginalRunBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	handler := fixture.handler(t)
 	ctx := context.Background()
 	seedActiveAPIV1RuntimeBusAgent(t, ctx, fixture.pg, "agent-a")
@@ -241,7 +241,7 @@ func TestOperatorRuntimeContextManagerRoutesEventReplayByOriginalRunBundle(t *te
 }
 
 func TestOperatorRuntimeContextManagerRoutesRunControlByStoredBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	baseStore := &recordingRuntimeContextRunControlStore{}
 	selectedStore := &recordingRuntimeContextRunControlStore{}
 	baseControl := runtimeruncontrol.NewController(baseStore, nil, runtimeruncontrol.Options{})
@@ -278,7 +278,7 @@ func TestOperatorRuntimeContextManagerRoutesRunControlByStoredBundle(t *testing.
 }
 
 func TestOperatorRuntimeContextManagerRoutesAgentDirectiveByStoredBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	baseAgent := &directiveIntegrationAgent{id: "agent-1"}
 	selectedAgent := &directiveIntegrationAgent{id: "agent-1"}
 	baseManager := runtimeContextTestAgentManager(t, fixture.pg, fixture.busA, baseAgent)
@@ -313,7 +313,7 @@ func TestOperatorRuntimeContextManagerRoutesAgentDirectiveByStoredBundle(t *test
 }
 
 func TestOperatorRuntimeContextManagerFailsClosedForUnloadedBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	handler := fixture.handler(t)
 	resp := rpcCall(t, handler, eventPublishBodyWithBundleHash("", runtimeContextTestBundleHashC, "triage.requested", `{"topic":"missing"}`, "", "idem-unloaded-context"))
 	if resp.Error == nil {
@@ -358,7 +358,7 @@ func TestOperatorRuntimeContextManagerFailsClosedForUnloadedBundle(t *testing.T)
 }
 
 func TestOperatorRuntimeContextManagerFailsClosedForDeactivatedBundle(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	result := fixture.manager.DeactivateBundleHash(runtimeContextTestBundleHashB, swruntime.RuntimeContextCauseUnloaded)
 	if !result.Found || !result.Changed {
 		t.Fatalf("DeactivateBundleHash result = %#v, want changed", result)
@@ -456,7 +456,7 @@ func TestRunForkExecutorForBundleContextRebindsSelectedContractSelection(t *test
 }
 
 func TestOperatorRuntimeContextManagerFailsClosedForAmbiguousRuntimeConsumers(t *testing.T) {
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	ingress := &recordingRuntimeIngress{}
 	runtimeHandler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -570,9 +570,9 @@ type operatorRuntimeContextFixture struct {
 	manager *swruntime.RuntimeContextManager
 }
 
-func newOperatorRuntimeContextFixture(t *testing.T) operatorRuntimeContextFixture {
+func newOperatorRuntimeContextFixture(t *testing.T, requirement testutil.DatabaseRequirement) operatorRuntimeContextFixture {
 	t.Helper()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, requirement)
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	seedOperatorBundleDeleteBundle(t, ctx, db, runStartTestBundleHash)

--- a/internal/apiv1/operator_runtime_control_test.go
+++ b/internal/apiv1/operator_runtime_control_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestOperatorRuntimeControlHandlersUseIngressOwnerAndIdempotency(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &store.PostgresStore{DB: db}
 	bus, err := runtimebus.NewEventBus(pg)

--- a/internal/apiv1/operator_runtime_nuke_test.go
+++ b/internal/apiv1/operator_runtime_nuke_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,7 +107,7 @@ func TestOperatorRuntimeNukeApplyReportsPartialFailureAndIdempotency(t *testing.
 
 func TestOperatorRuntimeNukeIncludeBundlesDeactivatesLoadedRuntimeContexts(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	owners := newRecordingRuntimeNukeOwners()
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -133,7 +134,7 @@ func TestOperatorRuntimeNukeIncludeBundlesDeactivatesLoadedRuntimeContexts(t *te
 func TestOperatorRuntimeNukeIncludeBundlesPartialFailureDeactivatesLoadedRuntimeContextsAndReplay(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
 	idempotency := newRecordingAPIIdempotencyStore()
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	owners := newRecordingRuntimeNukeOwners()
 	owners.containerFailure = "docker stop denied"
 	handler := testHandler(t, Options{
@@ -165,7 +166,7 @@ func TestOperatorRuntimeNukeIncludeBundlesPartialFailureDeactivatesLoadedRuntime
 	}
 	assertRuntimeContextsUnloaded(t, fixture.manager)
 
-	replayFixture := newOperatorRuntimeContextFixture(t)
+	replayFixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	replayOwners := newRecordingRuntimeNukeOwners()
 	replayHandler := testHandler(t, Options{
 		AuthTokens: []string{testToken},
@@ -203,7 +204,7 @@ func assertRuntimeContextsUnloaded(t *testing.T, manager *swruntime.RuntimeConte
 
 func TestOperatorRuntimeNukeExcludeBundlesLeavesRuntimeContextsLoaded(t *testing.T) {
 	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
-	fixture := newOperatorRuntimeContextFixture(t)
+	fixture := newOperatorRuntimeContextFixture(t, testutil.PostgresRowState())
 	owners := newRecordingRuntimeNukeOwners()
 	handler := testHandler(t, Options{
 		AuthTokens: []string{testToken},

--- a/internal/apiv1/operator_test_setup_test.go
+++ b/internal/apiv1/operator_test_setup_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestOperatorTestSetupHandlersPersistEntitiesAndReplayIdempotency(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	source := semanticview.Wrap(testSetupValidationBundle(t))
 	handler := testSetupHandler(t, pg, source)
@@ -177,7 +177,7 @@ func TestOperatorTestSetupRejectsContractInvalidEntities(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &store.PostgresStore{DB: db}
 			handler := testSetupHandler(t, pg, semanticview.Wrap(testSetupValidationBundle(t)))
 			entity := validTestSetupEntity(uuid.NewString(), "waiting", "seeded", true)

--- a/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
+++ b/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 func TestSQLiteAgentUsageOwnerBacksSupportedAPISurface(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteAgentUsageAgent(t, ctx, sqliteStore, "agent-1")
 	seedSQLiteAgentUsageAgent(t, ctx, sqliteStore, "agent-2")
 
@@ -71,7 +72,7 @@ func TestSQLiteAgentUsageOwnerBacksSupportedAPISurface(t *testing.T) {
 
 func TestSQLiteAgentDeliveryLifecycleOwnerBacksSupportedAPISurface(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteAgentUsageAgent(t, ctx, sqliteStore, "agent-1")
 
 	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
@@ -125,9 +126,9 @@ func TestSQLiteAgentDeliveryLifecycleOwnerBacksSupportedAPISurface(t *testing.T)
 	}
 }
 
-func newSQLiteAgentUsageStoreFixture(t *testing.T, ctx context.Context) *storepkg.SQLiteRuntimeStore {
+func newSQLiteAgentUsageStoreFixture(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) *storepkg.SQLiteRuntimeStore {
 	t.Helper()
-	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	return storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, requirement)
 }
 
 func seedSQLiteAgentUsageAgent(t *testing.T, ctx context.Context, sqliteStore *storepkg.SQLiteRuntimeStore, agentID string) {

--- a/internal/apiv1/sqlite_observability_supported_surface_test.go
+++ b/internal/apiv1/sqlite_observability_supported_surface_test.go
@@ -21,13 +21,13 @@ import (
 
 func TestSQLiteObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	ctx := context.Background()
-	fixture := newSQLiteObservabilitySurfaceFixture(t, ctx)
+	fixture := newSQLiteObservabilitySurfaceFixture(t, ctx, testutil.SQLiteDefaultTemp())
 	assertObservabilityOwnerBacksSupportedAPISurfaces(t, fixture)
 }
 
 func TestPostgresObservabilityOwnerBacksSupportedAPISurfaces(t *testing.T) {
 	ctx := context.Background()
-	fixture := newPostgresObservabilitySurfaceFixture(t, ctx)
+	fixture := newPostgresObservabilitySurfaceFixture(t, ctx, testutil.PostgresRowState())
 	assertObservabilityOwnerBacksSupportedAPISurfaces(t, fixture)
 }
 
@@ -161,7 +161,7 @@ func traceRowsContainEvent(t *testing.T, rows []any, eventName string) bool {
 
 func TestSQLiteRunTraceAPISurfacePaginatesAndUsesMaterializationWindow(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	base := time.Unix(1700003100, 0).UTC()
 	runID := "00000000-0000-0000-0000-000000001429"
 	eventOnlyID := "00000000-0000-0000-0000-000000001401"
@@ -255,15 +255,15 @@ type observabilitySurfaceFixture struct {
 	now          time.Time
 }
 
-func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context) observabilitySurfaceFixture {
+func newSQLiteObservabilitySurfaceFixture(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) observabilitySurfaceFixture {
 	t.Helper()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, requirement)
 	return newObservabilitySurfaceFixture(t, ctx, sqliteStore)
 }
 
-func newPostgresObservabilitySurfaceFixture(t *testing.T, ctx context.Context) observabilitySurfaceFixture {
+func newPostgresObservabilitySurfaceFixture(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) observabilitySurfaceFixture {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	pg := &storepkg.PostgresStore{DB: db}
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {

--- a/internal/apiv1/sqlite_operator_read_supported_surface_test.go
+++ b/internal/apiv1/sqlite_operator_read_supported_surface_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"fmt"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 func TestSQLiteAgentConversationOwnerBacksSupportedAPISurface(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx, testutil.SQLiteDefaultTemp())
 	agentID := "agent-operator-read"
 	sessionID := uuid.NewString()
 	turnID := uuid.NewString()
@@ -91,7 +92,7 @@ func TestSQLiteAgentConversationOwnerBacksSupportedAPISurface(t *testing.T) {
 
 func TestSQLiteConversationListSupportsLegacyTurnsWithoutTurnBlocks(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx, testutil.SQLiteFreshFile())
 	if _, err := sqliteStore.DB.ExecContext(ctx, `ALTER TABLE agent_turns DROP COLUMN turn_blocks`); err != nil {
 		t.Fatalf("drop optional turn_blocks column: %v", err)
 	}
@@ -148,7 +149,7 @@ func TestSQLiteConversationListSupportsLegacyTurnsWithoutTurnBlocks(t *testing.T
 
 func TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx)
+	sqliteStore := newSQLiteAgentUsageStoreFixture(t, ctx, testutil.SQLiteDefaultTemp())
 	bundleHash := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json, data_blob, metadata, ingested_at)

--- a/internal/dashboard/server/observability_sql_test.go
+++ b/internal/dashboard/server/observability_sql_test.go
@@ -66,7 +66,7 @@ func canonicalRuntimeLogTestPayload(t *testing.T, component, action, code, messa
 }
 
 func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -145,7 +145,7 @@ func TestSQLObservabilityReader_ListEvents_UsesCanonicalDeliveryLifecycle(t *tes
 }
 
 func TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -209,7 +209,7 @@ func TestSQLObservabilityReader_ListEvents_FiltersTypedSubscriberIdentity(t *tes
 }
 
 func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -265,7 +265,7 @@ func TestSQLObservabilityReader_GetEvent_UsesCanonicalDeliveryRows(t *testing.T)
 }
 
 func TestSQLObservabilityReader_EventIdentityDoesNotPromotePayloadEntity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -378,7 +378,7 @@ func TestHandler_EventDetailIncludesDeliveryLifecycle(t *testing.T) {
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -434,7 +434,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_ProjectsDeliveryLifecycleFields(
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalPayload(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -460,7 +460,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedOnMalformedCanonicalP
 }
 
 func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -504,7 +504,7 @@ func TestSQLObservabilityReader_ListIncidents_UsesCanonicalRuntimeLogPayloads(t 
 }
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalComponent(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -526,7 +526,7 @@ func TestSQLObservabilityReader_ListIncidents_FailsClosedOnMissingCanonicalCompo
 }
 
 func TestSQLObservabilityReader_ListIncidents_IgnoresErrorLogsWithoutCanonicalFailure(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -558,7 +558,7 @@ func TestSQLObservabilityReader_ListIncidents_IgnoresErrorLogsWithoutCanonicalFa
 }
 
 func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: canonicalObservabilityCaps()})
 	ctx := context.Background()
 
@@ -593,7 +593,7 @@ func TestSQLObservabilityReader_ListIncidents_SortsByRawLastSeenBeforeLimit(t *t
 }
 
 func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListEvents(context.Background(), EventFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -602,7 +602,7 @@ func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCapabilityOwner(t *
 }
 
 func TestSQLObservabilityReader_GetEvent_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, _, err := reader.GetEvent(context.Background(), "evt-1"); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -611,7 +611,7 @@ func TestSQLObservabilityReader_GetEvent_FailsClosedWithoutCapabilityOwner(t *te
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListRuntimeLogs(context.Background(), RuntimeLogFilter{}, 10); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -620,7 +620,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCapabilityOwne
 }
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedWithoutCapabilityOwner(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	reader := NewSQLObservabilityReader(db, nil)
 
 	if _, err := reader.ListIncidents(context.Background(), IncidentFilter{SinceHours: 24}); err == nil || !strings.Contains(err.Error(), "observability reader requires explicit schema capability owner") {
@@ -629,7 +629,7 @@ func TestSQLObservabilityReader_ListIncidents_FailsClosedWithoutCapabilityOwner(
 }
 
 func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCanonicalEventSurface(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Deliveries = store.SchemaFlavorLegacy
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -640,7 +640,7 @@ func TestSQLObservabilityReader_ListEvents_FailsClosedWithoutCanonicalEventSurfa
 }
 
 func TestSQLObservabilityReader_GetEvent_FailsClosedWhenCapabilityOwnerReportsUnavailableEventSurface(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Deliveries = store.SchemaFlavorUnavailable
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -651,7 +651,7 @@ func TestSQLObservabilityReader_GetEvent_FailsClosedWhenCapabilityOwnerReportsUn
 }
 
 func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRuntimeLogSurface(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Log = store.SchemaFlavorLegacy
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})
@@ -662,7 +662,7 @@ func TestSQLObservabilityReader_ListRuntimeLogs_FailsClosedWithoutCanonicalRunti
 }
 
 func TestSQLObservabilityReader_ListIncidents_FailsClosedWhenCapabilityOwnerReportsUnavailableRuntimeLogSurface(t *testing.T) {
-	db := storetest.StartSQLiteRuntimeStore(t).DB
+	db := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp()).DB
 	caps := canonicalObservabilityCaps()
 	caps.Events.Log = store.SchemaFlavorUnavailable
 	reader := NewSQLObservabilityReader(db, stubObservabilityCaps{caps: caps})

--- a/internal/dashboard/server/server_test.go
+++ b/internal/dashboard/server/server_test.go
@@ -2354,7 +2354,7 @@ func TestSQLAgentReader_ListGenericAgents_FailsClosedWithoutLifecycleFactOwner(t
 }
 
 func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelector(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := store.NewPostgresStore(dsn)
@@ -2463,7 +2463,7 @@ func TestSQLAgentReader_ListGenericAgents_AlignsBacklogWithCanonicalPendingSelec
 }
 
 func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := store.NewPostgresStore(dsn)
@@ -2543,7 +2543,7 @@ func TestSQLAgentReader_ListGenericAgents_UsesFullPendingDeliveryFactHorizon(t *
 }
 
 func TestSQLAgentReader_ListGenericAgents_ScopesLiveTurnToSelectedActiveSession(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := store.NewPostgresStore(dsn)

--- a/internal/digest/source_test.go
+++ b/internal/digest/source_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewSource_RequiresTerminalStates(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	_, err := NewSource(db, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}))
@@ -23,7 +23,7 @@ func TestNewSource_RequiresTerminalStates(t *testing.T) {
 }
 
 func TestNewSourceUsesRootTerminalStagesNotChildAggregate(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	source, err := NewSource(db, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
@@ -53,7 +53,7 @@ func TestNewSourceUsesRootTerminalStagesNotChildAggregate(t *testing.T) {
 }
 
 func TestSource_FiltersTerminalStatesFromDigestReads(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	source, err := NewSource(db, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{

--- a/internal/runtime/artifact_action_result_delivery_test.go
+++ b/internal/runtime/artifact_action_result_delivery_test.go
@@ -49,7 +49,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughDurableCallbackDelivery(t *tes
 			resultEventType := "repo-scaffold/inst-1/" + tc.resultEventName
 			bundle := loadRuntimeTempBundle(t, artifactActionResultDeliveryFixtureFiles())
 			source := semanticview.Wrap(bundle)
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 			ctx := seedRuntimeTestRun(t, db)
 			pg := &store.PostgresStore{DB: db}
@@ -208,7 +208,7 @@ func TestArtifactRepoCommitResultEventsFlowThroughStaticServiceCallbackDelivery(
 			resultEventType := "repo-scaffold/" + tc.resultEventName
 			bundle := loadRuntimeTempBundle(t, artifactActionResultStaticDeliveryFixtureFiles())
 			source := semanticview.Wrap(bundle)
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 			ctx := seedRuntimeTestRun(t, db)
 			pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -460,7 +460,7 @@ func countPipelineReceiptsForEvent(t *testing.T, ctx context.Context, db *sql.DB
 }
 
 func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := eventBusTestRunContext(t, db)
@@ -525,7 +525,7 @@ func TestEventBusPublishTransactionalPostCommitReceiptFailureIsRecoverable(t *te
 }
 
 func TestEventBusPublishTransactionalPostCommitCompletionFailureIsRecoverable(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := eventBusTestRunContext(t, db)
@@ -1270,7 +1270,7 @@ func TestEventBusWaitForQuiescenceWaitsForPublishCompletion(t *testing.T) {
 }
 
 func TestEventBusPublishAcknowledgedReturnsBeforePostCommitDispatchCompletes(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -1394,7 +1394,7 @@ func TestEventBusPublishNonTransactional_PersistsBeforeInterceptorsRun(t *testin
 }
 
 func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -1439,7 +1439,7 @@ func TestEventBusPublishTransactional_RunsInterceptorsAfterCommit(t *testing.T) 
 }
 
 func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecordsReceipt(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -1487,7 +1487,7 @@ func TestEventBusPublishTransactional_ReturnsPostCommitInterceptorErrorAndRecord
 }
 
 func TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -1542,7 +1542,7 @@ func TestEventBusPublishInMutationRunsInterceptorsAfterMutationCommit(t *testing
 }
 
 func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{})
 	if err != nil {
@@ -1587,7 +1587,7 @@ func TestEventBusPublishTransactional_RecordsTargetFailureDeadLetter(t *testing.
 }
 
 func TestEventBusPublishInMutationSQLiteRecordsTargetFailureDeadLetter(t *testing.T) {
-	sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+	sqliteStore := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 	eb, err := runtimebus.NewEventBusWithOptions(sqliteStore, runtimebus.EventBusOptions{})
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
@@ -1675,7 +1675,7 @@ func TestEventBusPublishInMutationSQLiteRecordsTargetFailureDeadLetter(t *testin
 }
 
 func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	runID := uuid.NewString()
 	fingerprint := "sha256:3333333333333333333333333333333333333333333333333333333333333333"
@@ -1705,7 +1705,7 @@ func TestEventBusPublish_ClassifiesRunBundleSourceThroughRunLifecycleOwner(t *te
 }
 
 func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	runID := uuid.NewString()
 	sourceFact := runtimecorrelation.BundleSourceFact{
@@ -1747,7 +1747,7 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 }
 
 func TestEventBusPublishDeferred_RunsInterceptorsAfterDeferredEventCommit(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	eventID := "22222222-2222-2222-2222-222222222222"
 	eb, err := runtimebus.NewEventBusWithOptions(pg, runtimebus.EventBusOptions{
@@ -1999,7 +1999,7 @@ func TestEventBusPublish_RuntimeLogBypassesContradictionRouting(t *testing.T) {
 }
 
 func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersistedDeliveries(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
@@ -2065,7 +2065,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 }
 
 func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalReceipt(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
@@ -2155,7 +2155,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 }
 
 func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	ctx := eventBusTestRunContext(t, db)
@@ -2404,7 +2404,7 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	module := newFixtureWorkflowModule(t, bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -2549,7 +2549,7 @@ func contains(items []string, want string) bool {
 }
 
 func TestEventBusPublish_MixedEmptyAndTargetedNodeRoutesExecuteAndSettle(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := eventBusTestRunContext(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -2816,7 +2816,7 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	module := newFixtureWorkflowModule(t, bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -2949,7 +2949,7 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	module := newFixtureWorkflowModule(t, bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1825,14 +1825,16 @@ func TestEventBusPublish_ZeroRecipientsDoesNotEmitContradiction(t *testing.T) {
 
 func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) {
 	testCases := []struct {
-		name  string
-		setup func(*testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner)
-		count func(*testing.T, context.Context, *sql.DB, string, string) (int, int)
+		name        string
+		requirement testutil.DatabaseRequirement
+		setup       func(*testing.T, testutil.DatabaseRequirement) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner)
+		count       func(*testing.T, context.Context, *sql.DB, string, string) (int, int)
 	}{
 		{
-			name: "postgres",
-			setup: func(t *testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
-				_, db, cleanup := testutil.StartPostgres(t)
+			name:        "postgres",
+			requirement: testutil.PostgresRowState(),
+			setup: func(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
+				_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 				t.Cleanup(cleanup)
 				ctx := eventBusTestRunContext(t, db)
 				pg := &store.PostgresStore{DB: db}
@@ -1841,9 +1843,10 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 			count: countPostgresInboundBatchRows,
 		},
 		{
-			name: "sqlite",
-			setup: func(t *testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
-				sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+			name:        "sqlite",
+			requirement: testutil.SQLiteDefaultTemp(),
+			setup: func(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
+				sqliteStore := storetest.StartSQLiteRuntimeStore(t, requirement)
 				ctx := runtimecorrelation.WithRunID(context.Background(), eventBusTestRunID)
 				if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, eventBusTestRunID); err != nil {
 					t.Fatalf("seed SQLite event bus test run: %v", err)
@@ -1856,7 +1859,7 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, db, eventStore, runner := tc.setup(t)
+			ctx, db, eventStore, runner := tc.setup(t, tc.requirement)
 			proofStore := &failingInboundBatchStore{EventStore: eventStore, runner: runner, failAppend: 2}
 			rawID := uuid.NewString()
 			normalizedID := uuid.NewString()

--- a/internal/runtime/bus/run_control_dispatch_test.go
+++ b/internal/runtime/bus/run_control_dispatch_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
@@ -104,7 +104,7 @@ func TestEventBusRunControlPauseQueuesOnlyTargetRunAndContinueReleases(t *testin
 }
 
 func TestEventBusRunControlContinueReleasesPendingDeliveryWithPipelineReceipt(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
@@ -167,7 +167,7 @@ func TestEventBusRunControlContinueReleasesPendingDeliveryWithPipelineReceipt(t 
 }
 
 func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()
@@ -241,7 +241,7 @@ func TestEventBusRunControlPauseQueuesBeforeInterceptorsAndContinueReplaysThem(t
 }
 
 func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()

--- a/internal/runtime/cataloge2e/assertions_test.go
+++ b/internal/runtime/cataloge2e/assertions_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCatalogCausalEntityIDs_FollowsSourceEventIDChain(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	rootID := "11111111-1111-1111-1111-111111111111"
 	childID := "22222222-2222-2222-2222-222222222222"
 	grandchildID := "33333333-3333-3333-3333-333333333333"
@@ -167,7 +167,7 @@ func TestCatalogRecognizesHandlerOutcome_RejectsTyposAndUnsupportedValues(t *tes
 }
 
 func TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof(t *testing.T) {
-	h := newCatalogAssertionHarness(t)
+	h := newCatalogAssertionHarness(t, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 
@@ -185,7 +185,7 @@ func TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof(t *te
 }
 
 func TestAssertCatalogRuntimeOutcome_IgnoresEntityNonSuccessPreviewProof(t *testing.T) {
-	h := newCatalogAssertionHarness(t)
+	h := newCatalogAssertionHarness(t, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 
@@ -207,7 +207,7 @@ func TestAssertCatalogRuntimeOutcome_IgnoresEntityNonSuccessPreviewProof(t *test
 }
 
 func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testing.T) {
-	h := newCatalogAssertionHarness(t)
+	h := newCatalogAssertionHarness(t, testutil.PostgresRowState())
 	entityID := "11111111-1111-1111-1111-111111111111"
 	bundle := loadFixtureBundle(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier11-flow-composition", "test-subject-id-cross-flow-inherit"))
 	h.bundle = bundle
@@ -231,9 +231,9 @@ func TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission(t *testin
 	assertEmittedEvents(t, h.db, h.startedAt, h.publishedIDs, entityID, []string{"score.requested"}, "", semanticview.Wrap(bundle))
 }
 
-func newCatalogAssertionHarness(t *testing.T) *runtimeHarness {
+func newCatalogAssertionHarness(t *testing.T, requirement testutil.DatabaseRequirement) *runtimeHarness {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	ctx := catalogRuntimeContext()
 	if _, err := db.ExecContext(ctx, `

--- a/internal/runtime/cataloge2e/required_smoke_test.go
+++ b/internal/runtime/cataloge2e/required_smoke_test.go
@@ -27,17 +27,17 @@ func TestCatalogRequiredSmoke(t *testing.T) {
 	t.Run("assertions_ignore_top_level_non_success_preview", TestAssertCatalogRuntimeOutcome_IgnoresTopLevelNonSuccessPreviewProof)
 	t.Run("assertions_cross_flow_emitted_events", TestAssertEmittedEvents_AcceptsCrossFlowInheritDispatcherEmission)
 	t.Run("tier1_emits_single_runtime", func(t *testing.T) {
-		runCatalogRequiredSmokeFixture(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier1-primitives", "test-emits-single"), false)
+		runCatalogRequiredSmokeFixture(t, filepath.Join(repoRootFromCatalogE2E(t), "tests", "tier1-primitives", "test-emits-single"), false, testutil.PostgresRowState())
 	})
 }
 
-func runCatalogRequiredSmokeFixture(t *testing.T, fixtureRoot string, startRuntime bool) {
+func runCatalogRequiredSmokeFixture(t *testing.T, fixtureRoot string, startRuntime bool, requirement testutil.DatabaseRequirement) {
 	t.Helper()
 
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-	h := newRuntimeHarness(t, fixtureRoot, startRuntime, testutil.PostgresRowState())
+	h := newRuntimeHarness(t, fixtureRoot, startRuntime, requirement)
 	h.seedEntityFields(expected)
 	for _, step := range expected.triggerSequence() {
 		h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/required_smoke_test.go
+++ b/internal/runtime/cataloge2e/required_smoke_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"path/filepath"
 	"testing"
 )
@@ -36,7 +37,7 @@ func runCatalogRequiredSmokeFixture(t *testing.T, fixtureRoot string, startRunti
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-	h := newRuntimeHarness(t, fixtureRoot, startRuntime)
+	h := newRuntimeHarness(t, fixtureRoot, startRuntime, testutil.PostgresRowState())
 	h.seedEntityFields(expected)
 	for _, step := range expected.triggerSequence() {
 		h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -152,7 +152,7 @@ type agentFixtureEmit struct {
 	Payload map[string]any `yaml:"payload"`
 }
 
-func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHarness {
+func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool, requirement testutil.DatabaseRequirement) *runtimeHarness {
 	t.Helper()
 	runtimeCatalogHarnessStartupPolicy().apply(t)
 	bundle := loadFixtureBundle(t, fixtureRoot)
@@ -165,7 +165,7 @@ func newRuntimeHarness(t *testing.T, fixtureRoot string, start bool) *runtimeHar
 		t.Fatalf("newFixtureWorkflowModule: %v", err)
 	}
 
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	waitForCatalogHarnessDB(t, db)
 

--- a/internal/runtime/cataloge2e/tier10_policy_patterns_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier10_policy_patterns_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,7 +27,7 @@ func TestTier10PolicyPatternCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier11_flow_composition_e2e_test.go
@@ -3,6 +3,7 @@ package cataloge2e
 import (
 	"context"
 	"database/sql"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -77,7 +78,7 @@ func TestTier11FlowCompositionCatalogFixtures_RealRuntime(t *testing.T) {
 			}
 
 			_, startRuntime := tier11StartedRuntimeFixtures[fixtureName]
-			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
+			h := newRuntimeHarness(t, fixtureRoot, startRuntime, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)
@@ -128,7 +129,7 @@ func TestTier11DynamicFlowInstanceFlowMatchTarget_RealRuntime(t *testing.T) {
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-	h := newRuntimeHarness(t, fixtureRoot, true)
+	h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
 	h.seedEntityFields(expected)
 	for _, step := range expected.triggerSequence() {
 		h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier11_probe_test.go
+++ b/internal/runtime/cataloge2e/tier11_probe_test.go
@@ -2,6 +2,7 @@ package cataloge2e
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +46,7 @@ func TestTier11Probe(t *testing.T) {
 				t.Logf("boot errors=%#v", report.Errors())
 				return
 			}
-			h := newRuntimeHarness(t, fixtureRoot, true)
+			h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -36,7 +37,7 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-	h := newRuntimeHarness(t, fixtureRoot, true)
+	h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
 	// Source execution is paused at T; register recipient evidence through runtime APIs before publishing.
 	h.rt.Bus.RegisterRuntimeActiveAgentDescriptor(runtimebus.ActiveAgentDescriptor{AgentID: "test-agent"})
 	_ = h.rt.Bus.Subscribe("test-agent", events.EventType("task.ready"))
@@ -395,7 +396,7 @@ func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot stri
 	t.Helper()
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
-	h := newRuntimeHarness(t, fixtureRoot, true)
+	h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
 	pauseCatalogRun(t, h)
 	h.seedEntityFields(expected)
 	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -128,7 +128,7 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 	assertSourceRowsFrozen(t, sourceRowsBefore, selectedContractSourceRowSnapshot(t, h.db, sourceRunID, sourceEventID), "source rows after selected execution")
 	assertSourceRunLifecycle(t, h.db, sourceRunID, "forked", true)
 	negativeFixtureRoot := filepath.Join(repoRoot, "tests", "tier12-runtime-fork", "test-non-agent-replay-fail-closed")
-	assertUnsupportedHistoricalReplayFailsClosed(t, negativeFixtureRoot)
+	assertUnsupportedHistoricalReplayFailsClosed(t, negativeFixtureRoot, testutil.PostgresRowState())
 }
 
 func TestTier12RuntimeForkFixtures_AreExplicitlyClassified(t *testing.T) {
@@ -392,11 +392,11 @@ func assertSourceRunLifecycle(t testing.TB, db *sql.DB, runID, wantStatus string
 	}
 }
 
-func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot string) {
+func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot string, requirement testutil.DatabaseRequirement) {
 	t.Helper()
 	var expected catalogExpectedDocument
 	loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
-	h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
+	h := newRuntimeHarness(t, fixtureRoot, true, requirement)
 	pauseCatalogRun(t, h)
 	h.seedEntityFields(expected)
 	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier12_runtime_tools_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_tools_e2e_test.go
@@ -2,6 +2,7 @@ package cataloge2e
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +21,7 @@ func TestTier12RuntimeTools_FlowDataAccessFixture(t *testing.T) {
 	repoRoot := repoRootFromCatalogE2E(t)
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier12-runtime-tools", "test-flow-data-access")
 
-	h := newRuntimeHarness(t, fixtureRoot, true)
+	h := newRuntimeHarness(t, fixtureRoot, true, testutil.PostgresRowState())
 	cfg, ok := h.rt.Manager.GetAgentConfig("reference-agent")
 	if !ok {
 		t.Fatal("reference-agent config was not registered")

--- a/internal/runtime/cataloge2e/tier1_primitives_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier1_primitives_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -53,7 +54,7 @@ func TestTier1PrimitiveCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier2_accumulation_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -32,7 +33,7 @@ func TestTier2AccumulationCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier3_list_processing_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier3_list_processing_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,7 +36,7 @@ func TestTier3ListProcessingCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier4_cross_entity_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,7 +28,7 @@ func TestTier4CrossEntityCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier5_lifecycle_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -44,7 +45,7 @@ func TestTier5LifecycleCatalogFixtures_RealRuntime(t *testing.T) {
 				fixtureName == "test-create-flow-instance-duplicate" ||
 				fixtureName == "test-timer-fire" ||
 				fixtureName == "test-timer-recurring"
-			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
+			h := newRuntimeHarness(t, fixtureRoot, startRuntime, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			if expected.Trigger.Boot || strings.TrimSpace(expected.Expected.BootResult) != "" {
 				assertCatalogRuntimeOutcome(t, h, expected)

--- a/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier6_event_loop_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -32,7 +33,7 @@ func TestTier6EventLoopCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			if len(expected.Trigger.Concurrent) > 0 {
 				h.publishConcurrentAndWait(expected.Trigger.Concurrent, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier7_composition_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier7_composition_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -43,7 +44,7 @@ func TestTier7CompositionCatalogFixtures_RealRuntime(t *testing.T) {
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
 			_, startRuntime := tier7StartedRuntimeFixtures[fixtureName]
-			h := newRuntimeHarness(t, fixtureRoot, startRuntime)
+			h := newRuntimeHarness(t, fixtureRoot, startRuntime, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/cataloge2e/tier9_composition_patterns_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier9_composition_patterns_e2e_test.go
@@ -1,6 +1,7 @@
 package cataloge2e
 
 import (
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,7 +35,7 @@ func TestTier9CompositionPatternCatalogFixtures_RealRuntime(t *testing.T) {
 			var expected catalogExpectedDocument
 			loadYAML(t, filepath.Join(fixtureRoot, "expected.yaml"), &expected)
 
-			h := newRuntimeHarness(t, fixtureRoot, false)
+			h := newRuntimeHarness(t, fixtureRoot, false, testutil.PostgresRowState())
 			h.seedEntityFields(expected)
 			for _, step := range expected.triggerSequence() {
 				h.publishAndWait(step, catalogRuntimePublishTimeout)

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -162,7 +162,7 @@ func TestDeliveryLifecycleConformance(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			fx := newDeliveryLifecycleFixture(t, ctx)
+			fx := newDeliveryLifecycleFixture(t, ctx, testutil.PostgresRowState())
 			eventID := tc.seed(t, ctx, fx)
 			got := fx.snapshot(t, ctx, eventID)
 			assertDeliveryLifecycleExpectation(t, got, tc.expect, eventID)
@@ -198,9 +198,9 @@ type deliveryLifecycleFixture struct {
 	subscription events.EventType
 }
 
-func newDeliveryLifecycleFixture(t *testing.T, ctx context.Context) *deliveryLifecycleFixture {
+func newDeliveryLifecycleFixture(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) *deliveryLifecycleFixture {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
+++ b/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
@@ -46,7 +46,7 @@ func TestNotifyAllChildrenRuntimeConformance_MixedValidAndStaleRoutesPersistAndR
 		{
 			name: "postgres",
 			setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				return &store.PostgresStore{DB: db}, db
 			},
@@ -54,7 +54,7 @@ func TestNotifyAllChildrenRuntimeConformance_MixedValidAndStaleRoutesPersistAndR
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
-				backend := storetest.StartSQLiteRuntimeStore(t)
+				backend := storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 				return backend, backend.DB
 			},
 		},

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -81,7 +81,7 @@ func acquireLiveConversationSession(t *testing.T, ctx context.Context, db *sql.D
 
 func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalConversationSurface(t, ctx, pg)
@@ -157,7 +157,7 @@ func TestCanonicalTurnSummarySurface_RoundTripsThroughConversationReader(t *test
 
 func TestCanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalConversationSurface(t, ctx, pg)
@@ -227,7 +227,7 @@ func TestCanonicalSessionWatchdogSurface_RoundTripsThroughConversationReader(t *
 
 func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -382,7 +382,7 @@ func TestReusedLiveSessionKeepsDeliveryFrontierBoundToCanonicalSession(t *testin
 
 func TestCLISessionFailureDoesNotRotateFromStderrProse(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -521,7 +521,7 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalConversationSurface(t, ctx, pg)
@@ -573,7 +573,7 @@ func TestConversationPersistenceDoesNotPromoteAuditRowsIntoLiveSessions(t *testi
 
 func TestTaskConversationReader_HidesLegacyTaskRowsWithoutCanonicalAudit(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalConversationSurface(t, ctx, pg)
@@ -662,7 +662,7 @@ func TestTaskConversationReader_HidesLegacyTaskRowsWithoutCanonicalAudit(t *test
 
 func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalRuntimeLogSurface(t, ctx, pg)
@@ -745,7 +745,7 @@ func TestCanonicalRuntimeLogSurface_RoundTripsThroughObservabilityReader(t *test
 }
 
 func TestAccumulatorCompletionOutcomeSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
@@ -1157,7 +1157,7 @@ func loadConformanceWorkflowFixtureModule(t *testing.T, fixtureRoot string) conf
 
 func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 	requireCanonicalRuntimeLogSurface(t, ctx, pg)
@@ -1243,7 +1243,7 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 
 func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWithoutPlatformReset(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -1327,7 +1327,7 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 
 func TestStartupTimerRecoveryAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -1482,7 +1482,7 @@ func (h conformanceRuntimeLoggerHook) Log(ctx context.Context, level runtimediag
 
 func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -1605,7 +1605,7 @@ func TestResetOrphanedSessionAftermathSurface_RoundTripsThroughObservabilityRead
 
 func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -1738,7 +1738,7 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 
 func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &store.PostgresStore{DB: db}
 
@@ -1876,7 +1876,7 @@ func TestStartupPipelineReplayAftermathSurface_RoundTripsThroughObservabilityRea
 
 func TestCanonicalRuntimeLogTurnBlockSurface_RoundTripsThroughConversationReader(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	requireCanonicalConversationSurface(t, ctx, pg)
@@ -1954,7 +1954,7 @@ func TestCanonicalRuntimeLogTurnBlockSurface_RoundTripsThroughConversationReader
 }
 
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrites(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	if _, err := db.ExecContext(ctx, `
@@ -2012,7 +2012,7 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForWorkflowWrite
 }
 
 func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t *testing.T) {
-	ctx, exec, db, runID := newEntityToolConformanceHarness(t)
+	ctx, exec, db, runID := newEntityToolConformanceHarness(t, testutil.PostgresRowState())
 
 	requireMutationSurface(t, db)
 
@@ -2048,7 +2048,7 @@ func TestCanonicalMutationSurface_ReconstructsTrackedEntityStateForToolWrites(t 
 }
 
 func TestCanonicalMutationSurface_FailsOnMalformedCanonicalMutationField(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 
@@ -2310,9 +2310,9 @@ func mustCanonicalJSON(t *testing.T, value any) string {
 	return string(raw)
 }
 
-func newEntityToolConformanceHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB, string) {
+func newEntityToolConformanceHarness(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB, string) {
 	t.Helper()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, requirement)
 	runID := uuid.NewString()
 	if _, err := db.ExecContext(context.Background(), `
 		INSERT INTO runs (run_id, status)

--- a/internal/runtime/conformance/reply_resolution_conformance_test.go
+++ b/internal/runtime/conformance/reply_resolution_conformance_test.go
@@ -257,7 +257,7 @@ func TestReplyResolutionConformance_DurableRestartRoutesOverlappingRequestsOnBot
 		{
 			name: "postgres",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				return &store.PostgresStore{DB: db}
 			},
@@ -265,7 +265,7 @@ func TestReplyResolutionConformance_DurableRestartRoutesOverlappingRequestsOnBot
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				return storetest.StartSQLiteRuntimeStore(t)
+				return storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 			},
 		},
 	} {
@@ -360,7 +360,7 @@ func TestReplyResolutionConformance_DurableExplicitCorrelationFailsClosedOnBothB
 		{
 			name: "postgres",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				return &store.PostgresStore{DB: db}
 			},
@@ -368,7 +368,7 @@ func TestReplyResolutionConformance_DurableExplicitCorrelationFailsClosedOnBothB
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				return storetest.StartSQLiteRuntimeStore(t)
+				return storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 			},
 		},
 	} {
@@ -454,7 +454,7 @@ func TestReplyResolutionConformance_DurableMailboxAndHumanTaskResumeToTerminalRe
 		{
 			name: "postgres",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 				t.Cleanup(cleanup)
 				return &store.PostgresStore{DB: db}
 			},
@@ -462,7 +462,7 @@ func TestReplyResolutionConformance_DurableMailboxAndHumanTaskResumeToTerminalRe
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) durableReplyConformanceStore {
-				return storetest.StartSQLiteRuntimeStore(t)
+				return storetest.StartSQLiteRuntimeStore(t, testutil.SQLiteDefaultTemp())
 			},
 		},
 	} {

--- a/internal/runtime/conformance/session_scope_conformance_test.go
+++ b/internal/runtime/conformance/session_scope_conformance_test.go
@@ -45,7 +45,7 @@ type sessionScopeConformanceCase struct {
 
 func TestSessionScopeConformance(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 
 	cases := []sessionScopeConformanceCase{

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -409,7 +409,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 }
 
 func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
@@ -444,7 +444,7 @@ func TestRuntimeLogger_Log_StampsBundleSourceFactOnRunRow(t *testing.T) {
 }
 
 func TestRuntimeLogger_LogRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
@@ -778,7 +778,7 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnSyncCountsFailure(t *tes
 
 func TestRuntimeLogger_Log_PersistsCanonicalRunOwnershipFromContext(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
@@ -814,7 +814,7 @@ func TestRuntimeLogger_Log_PersistsCanonicalRunOwnershipFromContext(t *testing.T
 
 func TestRuntimeLogger_Log_DoesNotInferRunOwnershipFromDetailPayload(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	payloadRunID := uuid.NewString()
@@ -847,7 +847,7 @@ func TestRuntimeLogger_Log_DoesNotInferRunOwnershipFromDetailPayload(t *testing.
 
 func TestRuntimeLogger_Log_DerivesLineageFromPersistedSubjectEvent(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
@@ -896,7 +896,7 @@ func TestRuntimeLogger_Log_DerivesLineageFromPersistedSubjectEvent(t *testing.T)
 
 func TestRuntimeLogger_Log_DoesNotDeriveLineageFromUnpersistedSubjectEvent(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()
@@ -928,7 +928,7 @@ func TestRuntimeLogger_Log_DoesNotDeriveLineageFromUnpersistedSubjectEvent(t *te
 
 func TestRuntimeLogger_Log_PersistsTypedRuntimeLineage(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
 	runID := uuid.NewString()

--- a/internal/runtime/engine/compute_module_replay_test.go
+++ b/internal/runtime/engine/compute_module_replay_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +30,7 @@ import (
 
 func TestExecuteWithPersistedComputeModuleReplayEvidenceLoadsAndFailsClosedOnStoredDivergence(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newComputeModuleReplaySQLiteStore(t)
+	sqliteStore := newComputeModuleReplaySQLiteStore(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
@@ -98,7 +99,7 @@ func persistComputeModuleReplayEvidenceForExecution(t *testing.T, ctx context.Co
 	}
 }
 
-func newComputeModuleReplaySQLiteStore(t *testing.T) *store.SQLiteRuntimeStore {
+func newComputeModuleReplaySQLiteStore(t *testing.T, requirement testutil.DatabaseRequirement) *store.SQLiteRuntimeStore {
 	t.Helper()
 	var spec runtimecontracts.PlatformSpecDocument
 	source, err := yamlsource.Load(platform.PlatformSpecYAML())
@@ -113,7 +114,7 @@ func newComputeModuleReplaySQLiteStore(t *testing.T) *store.SQLiteRuntimeStore {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
 	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	sqliteStore, err := store.NewSQLiteRuntimeStore(dbPath)
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, requirement, dbPath))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}

--- a/internal/runtime/final_flow_instance_authoring_runtime_test.go
+++ b/internal/runtime/final_flow_instance_authoring_runtime_test.go
@@ -29,7 +29,7 @@ func TestFinalFlowInstanceAuthoringRuntime_PublishActivatesAndExecutesSelectedTe
 		t.Fatalf("final flow-instance authoring hard invalidities = %#v, want none", got)
 	}
 
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/github_app_issue_comment_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_comment_supported_surface_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -73,7 +73,7 @@ func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *te
 			flowInstance = "github-app-issue-comment-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/github_app_issue_workflow_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_workflow_supported_surface_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -67,7 +67,7 @@ func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *t
 			flowInstance = "github-app-issue-workflow-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	const (
@@ -133,7 +133,7 @@ func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch
 }
 
 func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	const (
@@ -236,7 +236,7 @@ func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(
 }
 
 func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	const (
@@ -353,7 +353,7 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 		providerEventName = "inbound.stripe"
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)
@@ -401,7 +401,7 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 }
 
 func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	const (
@@ -480,7 +480,7 @@ func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testin
 		providerEventName = "inbound.twilio"
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)
@@ -532,7 +532,7 @@ func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testin
 }
 
 func TestInboundGateway_ShopifyPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	const (
@@ -607,7 +607,7 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 		providerEventName = "inbound.shopify"
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)
@@ -655,7 +655,7 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 }
 
 func TestInboundGateway_TelegramPostgresPersistsConfiguredManifestDelivery(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	const (
@@ -731,7 +731,7 @@ func TestInboundGateway_TelegramSQLitePersistsConfiguredManifestDelivery(t *test
 		providerEventName = "inbound.telegram"
 	)
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := runtimebus.NewEventBus(sqliteStore)
@@ -824,7 +824,7 @@ func TestInboundGateway_TypeformAndIntercomPostgresPersistsConfiguredManifestDel
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 
 			ctx := runtimecorrelation.WithRunID(context.Background(), tc.runID)
@@ -920,7 +920,7 @@ func TestInboundGateway_TypeformAndIntercomSQLitePersistsConfiguredManifestDeliv
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := runtimecorrelation.WithRunID(context.Background(), tc.runID)
-			sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+			sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 			seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
 
 			bus, err := runtimebus.NewEventBus(sqliteStore)

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -1325,7 +1325,7 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 }
 
 func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	const runID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
@@ -1417,7 +1417,7 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 }
 
 func TestDeactivateFlowInstanceModel_PostCommitSideEffectsFollowTerminalCommit(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	const runID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -64,7 +64,7 @@ func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJou
 			flowInstance = "microsoft-graph-connector-client-credentials-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -86,7 +86,7 @@ func TestReconstructEntityStateProjection_AppliesNestedFieldMutationsOverTopLeve
 }
 
 func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	runID := uuid.NewString()
 	sourceFact := runtimecorrelation.BundleSourceFact{
 		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",
@@ -122,7 +122,7 @@ func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
 }
 
 func TestInsertRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	runID := uuid.NewString()
 	sourceFact := runtimecorrelation.BundleSourceFact{
 		BundleHash:        "bundle-v1:sha256:1111111111111111111111111111111111111111111111111111111111111111",

--- a/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -64,7 +64,7 @@ func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *
 			flowInstance = "notion-connector-managed-credential-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "notion-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/pipeline/activity_boring_proof_test.go
+++ b/internal/runtime/pipeline/activity_boring_proof_test.go
@@ -43,7 +43,7 @@ func TestActivityBoringProofHandAuthoredFlowDispatchesOutsideTransactionAndReuse
 			}))
 			defer server.Close()
 
-			fixture = newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical())
+			fixture = newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 			seedActivityBoringSourceFlow(t, fixture, tc.kind, sourceEvent)
 			fixture.pc.SetTestWorkflowNodeHandlerStartHook(func(ctx context.Context, nodeID string, evt events.Event) error {
 				if nodeID != "scanner" || evt.ID() != sourceEvent.ID() {
@@ -115,7 +115,7 @@ func TestActivityBoringProofHandAuthoredFlowCrashAfterRequestBeforeResultComplet
 	}))
 	defer server.Close()
 
-	fixture := newActivityBoringFullFlowFixture(t, activityBoringStorePostgres, server.URL, false, testutil.PostgresFreshPhysical())
+	fixture := newActivityBoringFullFlowFixture(t, activityBoringStorePostgres, server.URL, false, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 	seedActivityBoringSourceFlow(t, fixture, activityBoringStorePostgres, sourceEvent)
 	ctx := runtimecorrelation.WithRunID(context.Background(), sourceEvent.RunID())
 	handled, err := fixture.pc.handleEventResult(ctx, sourceEvent)
@@ -169,7 +169,7 @@ func TestActivityBoringProofHandAuthoredReadOnlyForkReexecuteUsesForkLocalIdenti
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical())
+			fixture := newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 			sourceEvent := newActivityBoringSourceEvent(entityID, uuid.NewString(), "https://example.com/source")
 			forkEvent := newActivityBoringSourceEvent(entityID, uuid.NewString(), "https://example.com/source")
 			sourceExpected := activityBoringExpectedIntentForSourceEvent(sourceEvent, "https://example.com/source")
@@ -209,7 +209,7 @@ func TestActivityBoringProofDuplicateRequestReusesRecordedReadResult(t *testing.
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 			intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 			ctx := runtimecorrelation.WithRunID(context.Background(), intent.SourceRunID)
 			request, err := activityRequestEmitIntent(intent)
@@ -252,7 +252,7 @@ func TestActivityBoringProofCrashAfterIntentBeforeResultCompletesOncePostgres(t 
 	}))
 	defer server.Close()
 
-	fixture := newActivityBoringFixture(t, activityBoringStorePostgres, server.URL, testutil.PostgresFreshPhysical())
+	fixture := newActivityBoringFixture(t, activityBoringStorePostgres, server.URL, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 	intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 	ctx := runtimecorrelation.WithRunID(context.Background(), intent.SourceRunID)
 	writer := pipelineActivityIntentWriter{coordinator: fixture.pc}
@@ -305,7 +305,7 @@ func TestActivityBoringProofReadOnlyForkReexecuteUsesForkLocalRequestIdentity(t 
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 			sourceRunID := uuid.NewString()
 			forkRunID := uuid.NewString()
 			sourceIntent := newActivityBoringIntent("https://example.com/source", sourceRunID)
@@ -354,7 +354,7 @@ func TestActivityBoringProofRetryIsBoundedAndTraced(t *testing.T) {
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 			intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 			intent.RetryMaxAttempts = 3
 			intent.RetryBackoff = "none"
@@ -437,11 +437,11 @@ type activityBoringFixture struct {
 	pc  *PipelineCoordinator
 }
 
-func newActivityBoringFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, requirement testutil.DatabaseRequirement) activityBoringFixture {
+func newActivityBoringFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, requirement, sqliteRequirement testutil.DatabaseRequirement) activityBoringFixture {
 	t.Helper()
 	switch kind {
 	case activityBoringStoreSQLite:
-		db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
+		db := newSQLiteWorkflowInstanceStoreTestDB(t, sqliteRequirement)
 		bus := &persistingActivityBoringBus{appendEvent: func(ctx context.Context, evt events.Event) error {
 			return appendActivityBoringEvent(ctx, db, kind, evt)
 		}}
@@ -476,11 +476,11 @@ func newActivityBoringCoordinator(t *testing.T, db *sql.DB, kind activityBoringS
 	return activityBoringFixture{db: db, bus: bus, pc: pc}
 }
 
-func newActivityBoringFullFlowFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, handleActivityRequests bool, requirement testutil.DatabaseRequirement) activityBoringFixture {
+func newActivityBoringFullFlowFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, handleActivityRequests bool, requirement, sqliteRequirement testutil.DatabaseRequirement) activityBoringFixture {
 	t.Helper()
 	switch kind {
 	case activityBoringStoreSQLite:
-		db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
+		db := newSQLiteWorkflowInstanceStoreTestDB(t, sqliteRequirement)
 		return newActivityBoringFullFlowCoordinator(t, db, kind, serverURL, handleActivityRequests)
 	case activityBoringStorePostgres:
 		_, db, cleanup := testutil.AcquirePostgres(t, requirement)

--- a/internal/runtime/pipeline/activity_boring_proof_test.go
+++ b/internal/runtime/pipeline/activity_boring_proof_test.go
@@ -43,7 +43,7 @@ func TestActivityBoringProofHandAuthoredFlowDispatchesOutsideTransactionAndReuse
 			}))
 			defer server.Close()
 
-			fixture = newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true)
+			fixture = newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical())
 			seedActivityBoringSourceFlow(t, fixture, tc.kind, sourceEvent)
 			fixture.pc.SetTestWorkflowNodeHandlerStartHook(func(ctx context.Context, nodeID string, evt events.Event) error {
 				if nodeID != "scanner" || evt.ID() != sourceEvent.ID() {
@@ -115,7 +115,7 @@ func TestActivityBoringProofHandAuthoredFlowCrashAfterRequestBeforeResultComplet
 	}))
 	defer server.Close()
 
-	fixture := newActivityBoringFullFlowFixture(t, activityBoringStorePostgres, server.URL, false)
+	fixture := newActivityBoringFullFlowFixture(t, activityBoringStorePostgres, server.URL, false, testutil.PostgresFreshPhysical())
 	seedActivityBoringSourceFlow(t, fixture, activityBoringStorePostgres, sourceEvent)
 	ctx := runtimecorrelation.WithRunID(context.Background(), sourceEvent.RunID())
 	handled, err := fixture.pc.handleEventResult(ctx, sourceEvent)
@@ -169,7 +169,7 @@ func TestActivityBoringProofHandAuthoredReadOnlyForkReexecuteUsesForkLocalIdenti
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true)
+			fixture := newActivityBoringFullFlowFixture(t, tc.kind, server.URL, true, testutil.PostgresFreshPhysical())
 			sourceEvent := newActivityBoringSourceEvent(entityID, uuid.NewString(), "https://example.com/source")
 			forkEvent := newActivityBoringSourceEvent(entityID, uuid.NewString(), "https://example.com/source")
 			sourceExpected := activityBoringExpectedIntentForSourceEvent(sourceEvent, "https://example.com/source")
@@ -209,7 +209,7 @@ func TestActivityBoringProofDuplicateRequestReusesRecordedReadResult(t *testing.
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL)
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
 			intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 			ctx := runtimecorrelation.WithRunID(context.Background(), intent.SourceRunID)
 			request, err := activityRequestEmitIntent(intent)
@@ -252,7 +252,7 @@ func TestActivityBoringProofCrashAfterIntentBeforeResultCompletesOncePostgres(t 
 	}))
 	defer server.Close()
 
-	fixture := newActivityBoringFixture(t, activityBoringStorePostgres, server.URL)
+	fixture := newActivityBoringFixture(t, activityBoringStorePostgres, server.URL, testutil.PostgresFreshPhysical())
 	intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 	ctx := runtimecorrelation.WithRunID(context.Background(), intent.SourceRunID)
 	writer := pipelineActivityIntentWriter{coordinator: fixture.pc}
@@ -305,7 +305,7 @@ func TestActivityBoringProofReadOnlyForkReexecuteUsesForkLocalRequestIdentity(t 
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL)
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
 			sourceRunID := uuid.NewString()
 			forkRunID := uuid.NewString()
 			sourceIntent := newActivityBoringIntent("https://example.com/source", sourceRunID)
@@ -354,7 +354,7 @@ func TestActivityBoringProofRetryIsBoundedAndTraced(t *testing.T) {
 			}))
 			defer server.Close()
 
-			fixture := newActivityBoringFixture(t, tc.kind, server.URL)
+			fixture := newActivityBoringFixture(t, tc.kind, server.URL, testutil.PostgresFreshPhysical())
 			intent := newActivityBoringIntent("https://example.com/source", testPipelineRunID)
 			intent.RetryMaxAttempts = 3
 			intent.RetryBackoff = "none"
@@ -437,11 +437,11 @@ type activityBoringFixture struct {
 	pc  *PipelineCoordinator
 }
 
-func newActivityBoringFixture(t *testing.T, kind activityBoringStoreKind, serverURL string) activityBoringFixture {
+func newActivityBoringFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, requirement testutil.DatabaseRequirement) activityBoringFixture {
 	t.Helper()
 	switch kind {
 	case activityBoringStoreSQLite:
-		db := newSQLiteWorkflowInstanceStoreTestDB(t)
+		db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 		bus := &persistingActivityBoringBus{appendEvent: func(ctx context.Context, evt events.Event) error {
 			return appendActivityBoringEvent(ctx, db, kind, evt)
 		}}
@@ -451,7 +451,7 @@ func newActivityBoringFixture(t *testing.T, kind activityBoringStoreKind, server
 		})
 		return activityBoringFixture{db: db, bus: bus, pc: pc}
 	case activityBoringStorePostgres:
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 		t.Cleanup(cleanup)
 		return newActivityBoringCoordinator(t, db, kind, serverURL)
 	default:
@@ -476,14 +476,14 @@ func newActivityBoringCoordinator(t *testing.T, db *sql.DB, kind activityBoringS
 	return activityBoringFixture{db: db, bus: bus, pc: pc}
 }
 
-func newActivityBoringFullFlowFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, handleActivityRequests bool) activityBoringFixture {
+func newActivityBoringFullFlowFixture(t *testing.T, kind activityBoringStoreKind, serverURL string, handleActivityRequests bool, requirement testutil.DatabaseRequirement) activityBoringFixture {
 	t.Helper()
 	switch kind {
 	case activityBoringStoreSQLite:
-		db := newSQLiteWorkflowInstanceStoreTestDB(t)
+		db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 		return newActivityBoringFullFlowCoordinator(t, db, kind, serverURL, handleActivityRequests)
 	case activityBoringStorePostgres:
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 		t.Cleanup(cleanup)
 		return newActivityBoringFullFlowCoordinator(t, db, kind, serverURL, handleActivityRequests)
 	default:

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -485,7 +485,7 @@ func TestPipelineActivityRequestExecutesNonIdempotentHTTPToolOnceWithStaticCrede
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -589,7 +589,7 @@ func TestGeneratedSyntheticConnectorUsesCanonicalActivityJournalOnReplay(t *test
 	runID := uuid.NewString()
 	sourceEventID := uuid.NewString()
 	entityID := uuid.NewString()
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	bus := &recordingPipelineBus{}
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
@@ -632,14 +632,14 @@ func TestPipelineActivityRequestTelegramConnectorRoundTripThroughInboundDelivery
 		{
 			name: "sqlite",
 			setup: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				db, store := newSQLiteActivityJournalStore(t, ctx)
+				db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 				return db, store, true
 			},
 		},
 		{
 			name: "postgres",
 			setup: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				_, db, _ := testutil.StartPostgres(t)
+				_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				return db, NewWorkflowInstanceStore(db), false
 			},
 		},
@@ -792,7 +792,7 @@ func TestPipelineActivityRequestNonIdempotentFailureDoesNotRetry(t *testing.T) {
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -839,7 +839,7 @@ func TestPipelineActivityRequestNonIdempotentTransportErrorMarksUncertain(t *tes
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -911,7 +911,7 @@ func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatchWithoutTer
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -948,7 +948,7 @@ func TestPipelineActivityRequestStartedJournalBlocksProviderRedispatchWithoutTer
 func TestLoopActivityClaimCommitAcknowledgmentLossReconcilesWithoutDispatch(t *testing.T) {
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, runID); err != nil {
 		t.Fatal(err)
 	}
@@ -1054,7 +1054,7 @@ func TestPipelineActivityRequestConcurrentDuplicatePreservesOriginalTerminalResu
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -1136,7 +1136,7 @@ func TestPipelineActivityRequestMissingCredentialFailsAfterClaimBeforeDispatch(t
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	emptyCredentials := testActivityCredentialStore(t, "", "")
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
@@ -1187,7 +1187,7 @@ func TestPipelineActivityRequestTelegramConnectorMissingTokenFailsAfterClaimBefo
 		},
 	})
 	bus := &recordingPipelineBus{}
-	db, store := newSQLiteActivityJournalStore(t, ctx)
+	db, store := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 	seedActivityRun(t, db, true, runID)
 	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
 		Module:        staticSemanticWorkflowModule{source: source},
@@ -1407,10 +1407,10 @@ func (f activityRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, err
 	return f(req)
 }
 
-func newSQLiteActivityJournalStore(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore) {
+func newSQLiteActivityJournalStore(t *testing.T, ctx context.Context, requirement testutil.DatabaseRequirement) (*sql.DB, *WorkflowInstanceStore) {
 	t.Helper()
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
-	db, err := sql.Open("sqlite", "file:"+name+"?mode=memory&cache=shared")
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, requirement, "file:"+name+"?mode=memory&cache=shared"))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/runtime/pipeline/activity_journal_test.go
+++ b/internal/runtime/pipeline/activity_journal_test.go
@@ -136,7 +136,7 @@ func TestActivityAttemptJournalPreservesReplyContextAcrossRestart(t *testing.T) 
 }
 
 func TestLoopActivityClaimOrdersAgainstRepeatAndCloseOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 

--- a/internal/runtime/pipeline/activity_journal_test.go
+++ b/internal/runtime/pipeline/activity_journal_test.go
@@ -23,14 +23,14 @@ func TestActivityAttemptJournalSQLiteAndPostgres(t *testing.T) {
 		{
 			name: "sqlite",
 			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				db, journal := newSQLiteActivityJournalStore(t, ctx)
+				db, journal := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 				return db, journal, true
 			},
 		},
 		{
 			name: "postgres",
 			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				t.Cleanup(cleanup)
 				return db, NewWorkflowInstanceStore(db), false
 			},
@@ -96,14 +96,14 @@ func TestActivityAttemptJournalPreservesReplyContextAcrossRestart(t *testing.T) 
 		{
 			name: "sqlite",
 			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				db, journal := newSQLiteActivityJournalStore(t, ctx)
+				db, journal := newSQLiteActivityJournalStore(t, ctx, testutil.SQLiteFreshFile())
 				return db, journal, true
 			},
 		},
 		{
 			name: "postgres",
 			store: func(t *testing.T, ctx context.Context) (*sql.DB, *WorkflowInstanceStore, bool) {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				t.Cleanup(cleanup)
 				return db, NewWorkflowInstanceStore(db), false
 			},
@@ -136,7 +136,7 @@ func TestActivityAttemptJournalPreservesReplyContextAcrossRestart(t *testing.T) 
 }
 
 func TestLoopActivityClaimOrdersAgainstRepeatAndCloseOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -172,7 +172,7 @@ func seedHistoricalReplayRecoverySourceRun(t *testing.T, db *sql.DB, sourceRunID
 
 func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -279,7 +279,7 @@ func TestRecoveryManager_ReplaysPersistedCorrelationEnvelope(t *testing.T) {
 
 func TestRecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -429,7 +429,7 @@ func TestRecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows(t *testing
 
 func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -519,7 +519,7 @@ func TestRecoveryManager_QuarantinesMissingPersistedRunIDAndContinues(t *testing
 
 func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	if _, err := db.ExecContext(ctx, `ALTER TABLE events DROP COLUMN run_id`); err != nil {
@@ -569,7 +569,7 @@ func TestRecoveryManager_QuarantinesMissingRunIDSchemaCapability(t *testing.T) {
 
 func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg1 := &store.PostgresStore{DB: db}
@@ -651,7 +651,7 @@ func TestRecoveryManager_ClaimsReplayOwnershipUnderOverlap(t *testing.T) {
 
 func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -711,7 +711,7 @@ func TestRecoveryManager_ExplicitlySkipsReplayWithoutPersistedRecipients(t *test
 
 func TestRecoveryManager_DoesNotEmitAftermathLogForRuntimeLogReplayCandidate(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -756,7 +756,7 @@ func TestRecoveryManager_DoesNotEmitAftermathLogForRuntimeLogReplayCandidate(t *
 
 func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscriptions(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -850,7 +850,7 @@ func TestRecoveryManager_UsesPersistedDeliveryRecipientsInsteadOfCurrentSubscrip
 
 func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}
@@ -901,7 +901,7 @@ func TestRecoveryManager_ReplaysSubscribedInternalOnlyUsingCommittedReplayScope(
 
 func TestRecoveryManager_DirectEmptyManifestDoesNotBroadenToCurrentInternalSubscribers(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/pipeline/create_entity_exact_once_test.go
+++ b/internal/runtime/pipeline/create_entity_exact_once_test.go
@@ -24,7 +24,7 @@ func TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations(t *testing.T
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context, *recordingPipelineBus, *recordingScheduleStore, *recordingMailboxWriteMaterializer) {
-				db := newSQLiteWorkflowInstanceStoreTestDB(t)
+				db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 				ctx := sqliteExactOnceRunContext(t, db)
 				return newExactOnceCoordinator(t, db, newSQLiteWorkflowInstanceStoreForTest(t, db)), ctx, nil, nil, nil
 			},
@@ -32,7 +32,7 @@ func TestCreateEntityHandlerEffectsAreExactOnceAcrossStoreMutations(t *testing.T
 		{
 			name: "postgres",
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context, *recordingPipelineBus, *recordingScheduleStore, *recordingMailboxWriteMaterializer) {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				t.Cleanup(cleanup)
 				pc := newExactOnceCoordinator(t, db, NewWorkflowInstanceStore(db))
 				return pc, testPipelineCoordinatorRunContext(t, pc), nil, nil, nil
@@ -120,7 +120,7 @@ func TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler(t *te
 		{
 			name: "sqlite",
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context) {
-				db := newSQLiteWorkflowInstanceStoreTestDB(t)
+				db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 				pc := newExactOnceCoordinator(t, db, newSQLiteWorkflowInstanceStoreForTest(t, db))
 				return pc, sqliteExactOnceRunContext(t, db)
 			},
@@ -128,7 +128,7 @@ func TestDispatchWorkflowNodeEventSkipsAlreadyProcessedCreateEntityHandler(t *te
 		{
 			name: "postgres",
 			setup: func(t *testing.T) (*PipelineCoordinator, context.Context) {
-				_, db, cleanup := testutil.StartPostgres(t)
+				_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				t.Cleanup(cleanup)
 				pc := newExactOnceCoordinator(t, db, NewWorkflowInstanceStore(db))
 				return pc, testPipelineCoordinatorRunContext(t, pc)

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -72,7 +72,7 @@ func (s *typedSystemNodeReceiptStore) MarkSystemNodeProcessedAndSettleDelivery(c
 }
 
 func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := testPipelineRunContext(t, db)
 	runner := newSystemNodeRunner("node-a", deadLetterTestBus{}, db, func() []events.EventType { return []events.EventType{"source.evt"} }, func(context.Context, events.Event) error {
 		return runtimefailures.New(runtimefailures.ClassConnectorFailure, "test_connector_failure", "pipeline-test", "handle", nil)
@@ -141,7 +141,7 @@ func TestSystemNodeRunner_RecordsDeadLetterRow(t *testing.T) {
 }
 
 func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	entityID := uuid.NewString()
 	evt := eventtest.RootIngress(
@@ -211,7 +211,7 @@ func TestCoordinator_RecordsChainDepthDeadLetterRow(t *testing.T) {
 }
 
 func TestSystemNodeRunner_SkipsQuiescedDestructiveResetDelivery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := testPipelineRunContext(t, db)
 	eventID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
@@ -299,7 +299,7 @@ func TestSystemNodeRunner_NonRetryableRuntimeErrorDeadLettersImmediately(t *test
 }
 
 func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	entityID := uuid.NewString()
 	evt := eventtest.RootIngress(
@@ -342,7 +342,7 @@ func TestSystemNodeRunner_FailsClosedWithoutCanonicalEventReceiptsCapability(t *
 }
 
 func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	entityID := uuid.NewString()
 	evt := eventtest.RootIngress(
@@ -392,7 +392,7 @@ func TestSystemNodeRunner_UsesCanonicalEventReceiptsCapabilityForIdempotency(t *
 }
 
 func TestSystemNodeRunner_SkipsWithoutPersistedNodeDeliveryAuthority(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	entityID := uuid.NewString()
 	evt := eventtest.RootIngress(
@@ -468,7 +468,7 @@ func TestSystemNodeRunner_UsesTypedReceiptOwnerWithoutRawDB(t *testing.T) {
 }
 
 func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -119,7 +119,7 @@ func TestApplyEngineStateMutationScopesChildFlowGates(t *testing.T) {
 }
 
 func TestPipelineEngineEvaluatorQueryEntitiesUsesExecutingFlowID(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	source := loadWorkflowTempSource(t, map[string]string{
@@ -354,7 +354,7 @@ func mutationParentRoutePinOutputSource() semanticview.Source {
 }
 
 func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bundle := &runtimecontracts.WorkflowContractBundle{
@@ -400,7 +400,7 @@ func TestMaybeDeactivateTerminalFlowInstance_IgnoresRootWorkflowEntity(t *testin
 }
 
 func TestMaybeDeactivateTerminalFlowInstance_PassesTerminalStateToTemplateDeactivation(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bundle := &runtimecontracts.WorkflowContractBundle{
@@ -559,7 +559,7 @@ func TestApplyEngineStateMutationDoesNotCaptureSubjectIDFromMetadata(t *testing.
 }
 
 func TestUpdateEntityState_ReturnsWorkflowStoreMutationError(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	if err := db.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
@@ -582,7 +582,7 @@ func TestUpdateEntityState_ReturnsWorkflowStoreMutationError(t *testing.T) {
 }
 
 func TestPipelineEngineStateRepoSaveStateRejectsForeignFlowWrite(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 	entityID := "11111111-1111-1111-1111-111111111111"
 	if err := store.Upsert(testWorkflowStoreRunContext(t, store), WorkflowInstance{
@@ -647,7 +647,7 @@ review_entity:
 	if !ok {
 		t.Fatal("expected temp workflow bundle")
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	repo := pipelineEngineStateRepo{
 		coordinator: &PipelineCoordinator{
@@ -666,7 +666,7 @@ review_entity:
 }
 
 func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -715,7 +715,7 @@ func TestPipelineEngineStateRepoRoundTripsTypedCarrier(t *testing.T) {
 }
 
 func TestPipelineEngineStateRepoLoadStateRejectsMalformedPersistedCarrier(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	t.Run("state_buckets", func(t *testing.T) {
@@ -741,7 +741,7 @@ func TestPipelineEngineStateRepoLoadStateRejectsMalformedPersistedCarrier(t *tes
 }
 
 func TestRecordWorkflowEvidence_ReturnsWorkflowStoreMutationError(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	if err := db.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
@@ -756,7 +756,7 @@ func TestRecordWorkflowEvidence_ReturnsWorkflowStoreMutationError(t *testing.T) 
 }
 
 func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	if err := db.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
@@ -810,7 +810,7 @@ func TestPipelineEngineActionRunner_RecordEvidenceReturnsMutationError(t *testin
 }
 
 func TestPipelineEngineActionRunner_RecordEvidenceUsesMatchedHandlerEvidenceTargetForConcreteEvents(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -1153,7 +1153,7 @@ func (m *recordingMailboxWriteMaterializer) rows() []MailboxWriteMaterialization
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitMaterializesLocalGitRef(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	artifactRoot := t.TempDir()
@@ -1419,7 +1419,7 @@ func TestSourceUsesArtifactRepoCommitDetectsSupportedActionSurfaces(t *testing.T
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsAgentVisibleArtifactRoot(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -1491,7 +1491,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoo
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			defer cleanup()
 			store := NewWorkflowInstanceStore(db)
 			bus := &recordingPipelineBus{}
@@ -1534,7 +1534,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsUnusableArtifactRoo
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitQueuesSuccessResultEvent(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -1635,7 +1635,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitQueuesSuccessResultEvent(t
 }
 
 func TestExecuteNodeContractHandlerArtifactRepoCommitQueuesSuccessResultThroughOutbox(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	workflowStore := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -1712,7 +1712,7 @@ func TestExecuteNodeContractHandlerArtifactRepoCommitQueuesSuccessResultThroughO
 }
 
 func TestExecuteNodeContractHandlerArtifactRepoCommitQueuesFailureResultThroughOutbox(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	workflowStore := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -1793,7 +1793,7 @@ func TestExecuteNodeContractHandlerArtifactRepoCommitQueuesFailureResultThroughO
 }
 
 func TestExecuteNodeContractHandlerArtifactRepoCommitFailureResultOutboxFailureRollsBackState(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	workflowStore := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{outboxErr: errors.New("outbox unavailable")}
@@ -1864,7 +1864,7 @@ func TestExecuteNodeContractHandlerArtifactRepoCommitFailureResultOutboxFailureR
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedWithoutResultEventCollector(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{publishErr: errors.New("direct publish must not be used")}
@@ -1922,7 +1922,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedWithoutResultEv
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnInvalidSuccessResultEvent(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -1977,7 +1977,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnInvalidSucces
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAllowlist(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -2039,7 +2039,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnPathOutsideAl
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMismatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -2079,7 +2079,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitFailsClosedOnYAMLSchemaMis
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentConflict(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
@@ -2126,7 +2126,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRejectsRequestIDContentCon
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistory(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}
@@ -2200,7 +2200,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRecordsNoDiffRequestHistor
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitRepairsDBStateFromGitHistory(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}
@@ -2255,7 +2255,7 @@ func TestPipelineEngineActionRunner_ArtifactRepoCommitRepairsDBStateFromGitHisto
 }
 
 func TestPipelineEngineActionRunner_ArtifactRepoCommitEnforcesProjectedRepoSize(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := NewWorkflowInstanceStore(db)
 	pc := &PipelineCoordinator{db: db, workflowStore: store, artifactRoot: t.TempDir()}

--- a/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
+++ b/internal/runtime/pipeline/final_flow_instance_authoring_delivery_test.go
@@ -19,7 +19,7 @@ import (
 func TestFinalFlowInstanceAuthoringFixturePipelineDispatchPersistsSingletonContainedStateReadback(t *testing.T) {
 	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, workflowStore := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
 	ctx := testPipelineCoordinatorRunContext(t, pc)
@@ -106,7 +106,7 @@ func TestFinalFlowInstanceAuthoringFixturePipelineDispatchPersistsSingletonConta
 func TestFinalFlowInstanceAuthoringFixturePipelineDispatchLocalizesTemplateInputConnectEvent(t *testing.T) {
 	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, workflowStore := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
 	ctx := testPipelineCoordinatorRunContext(t, pc)
@@ -175,7 +175,7 @@ func TestFinalFlowInstanceAuthoringFixturePipelineDispatchLocalizesTemplateInput
 func TestFinalFlowInstanceAuthoringFixturePipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
 	bundle := finalflowinstanceauthoring.LoadBundle(t, finalflowinstanceauthoring.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, _ := newFinalFlowInstanceAuthoringPipelineCoordinator(t, db, bundle, source)
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -524,7 +524,7 @@ node-a:
 }
 
 func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIsMissing(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, bus := newEmitPersistenceTestCoordinator(db)
@@ -592,7 +592,7 @@ func TestExecuteNodeContractHandlerRejectsEmitWhenPersistencePrerequisiteFieldIs
 }
 
 func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSucceeds(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, bus := newEmitPersistenceTestCoordinator(db)
@@ -669,7 +669,7 @@ func TestExecuteNodeContractHandlerPublishesAfterPersistencePrerequisiteFieldSuc
 }
 
 func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
@@ -761,7 +761,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommittedOutcome(t *
 }
 
 func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
@@ -832,7 +832,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionEvaluationFailure(t 
 }
 
 func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, bus := newAccumulatorOutcomeTestCoordinator(db)
@@ -906,7 +906,7 @@ func TestExecuteNodeContractHandlerLogsAccumulatorCompletionCommitFailure(t *tes
 }
 
 func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
@@ -988,7 +988,7 @@ func TestExecuteNodeContractHandlerPersistsArithmeticDataAccumulationExpression(
 }
 
 func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
@@ -1062,7 +1062,7 @@ func TestExecuteNodeContractHandlerFailsClosedOnDataAccumulationCELRuntimeError(
 }
 
 func TestExecuteNodeContractHandlerPersistsNullPresenceCheckDataAccumulationExpression(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(&recordingPipelineBus{}, db, PipelineCoordinatorOptions{
@@ -1622,7 +1622,7 @@ func TestResolveHandlerEntityIDForFlowCreateEntityDoesNotSeedSubjectID(t *testin
 }
 
 func TestExecuteNodeContractHandlerCreateEntityPersistsSchemaInitialValuesBeforeGuardReads(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -1753,7 +1753,7 @@ node-a:
 }
 
 func TestExecuteNodeContractHandlerQueryEntitiesGuardUsesWorkflowContext(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -1879,7 +1879,7 @@ func seedQueryEntitiesGuardInstance(t *testing.T, store *WorkflowInstanceStore, 
 }
 
 func TestExecuteNodeContractHandlerCreateEntityPersistsNonValidationChildFlowIdentity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -2006,7 +2006,7 @@ func assertCreatedChildFlowIdentityCoherent(t *testing.T, db *sql.DB, flowID, en
 }
 
 func TestExecuteNodeContractHandlerCreateEntityAllowsLaterClearOfSchemaInitialValue(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -2428,7 +2428,7 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	store := NewWorkflowInstanceStore(db)
 	bus := &recordingPipelineBus{}

--- a/internal/runtime/pipeline/mutation_logging_test.go
+++ b/internal/runtime/pipeline/mutation_logging_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestUpdateEntityState_LogsMutationRowForStateTransition(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 
 	entityID := uuid.NewString()
 	pc := &PipelineCoordinator{
@@ -82,7 +82,7 @@ func TestUpdateEntityState_LogsMutationRowForStateTransition(t *testing.T) {
 }
 
 func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLog(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 	entityID := uuid.NewString()
 
@@ -148,7 +148,7 @@ func TestWorkflowInstanceStore_UpsertTracksFieldsGatesAndAccumulatorInMutationLo
 }
 
 func TestWorkflowInstanceStore_ReplaysContainedStateMapListProjection(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 	entityID := uuid.NewString()
 
@@ -219,7 +219,7 @@ func TestWorkflowInstanceStore_ReplaysContainedStateMapListProjection(t *testing
 }
 
 func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	pc := testMutationLoggingCoordinator(db)
 	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
@@ -238,7 +238,7 @@ func TestApplyWorkflowGateMutation_LogsMutationRow(t *testing.T) {
 }
 
 func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	pc := testMutationLoggingCoordinator(db)
 	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
@@ -257,7 +257,7 @@ func TestRecordWorkflowEvidence_LogsMutationRow(t *testing.T) {
 }
 
 func TestMutationLogTrackedStateFailsOnMalformedCanonicalMutationField(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	pc := testMutationLoggingCoordinator(db)
 	seedMutationLoggingInstance(t, pc.workflowStore, entityID)
@@ -284,7 +284,7 @@ func TestMutationLogTrackedStateFailsOnMalformedCanonicalMutationField(t *testin
 
 func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *testing.T) {
 	t.Run("state transition", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 		entityID := uuid.NewString()
 		pc := testMutationLoggingCoordinator(db)
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
@@ -298,7 +298,7 @@ func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *te
 	})
 
 	t.Run("gate mutation", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 		entityID := uuid.NewString()
 		pc := testMutationLoggingCoordinator(db)
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)
@@ -312,7 +312,7 @@ func TestMutationLoggedPipelineWritesFailClosedWithoutEntityMutationsTable(t *te
 	})
 
 	t.Run("evidence write", func(t *testing.T) {
-		_, db, _ := testutil.StartPostgres(t)
+		_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 		entityID := uuid.NewString()
 		pc := testMutationLoggingCoordinator(db)
 		seedMutationLoggingInstance(t, pc.workflowStore, entityID)

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -31,7 +31,7 @@ func (b *systemNodeCompletionBus) ConvergeNormalRunCompletionForEvent(_ context.
 }
 
 func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCompletion(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -121,7 +121,7 @@ func TestSystemNodeRunner_MarkProcessedSettlesNodeDeliveryAndTriggersNormalRunCo
 }
 
 func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -183,7 +183,7 @@ func TestSystemNodeRunner_TargetSetSameNodeSettlesEachTargetDelivery(t *testing.
 }
 
 func TestSystemNodeRunner_TargetSetSameNodeFailureKeepsSiblingPending(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -234,7 +234,7 @@ func TestSystemNodeRunner_TargetSetSameNodeFailureKeepsSiblingPending(t *testing
 }
 
 func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -279,7 +279,7 @@ func TestSystemNodeRunner_TargetSetSameNodeDeadLetterKeepsSiblingExecutable(t *t
 }
 
 func TestSQLiteSystemNodeTargetSetSameNodeTransitionsAreTargetScoped(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -346,7 +346,7 @@ func TestSQLiteSystemNodeTargetSetSameNodeTransitionsAreTargetScoped(t *testing.
 }
 
 func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -446,7 +446,7 @@ func TestSystemNodeRunnerLifecycleProbeEmitsHandlerBoundaries(t *testing.T) {
 }
 
 func TestSystemNodeRunner_RetryableFailureWritesFailedBeforeRetry(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -518,7 +518,7 @@ func TestSystemNodeRunner_RetryableFailureWritesFailedBeforeRetry(t *testing.T) 
 }
 
 func TestSystemNodeRunner_RetryableFailureExhaustsConfiguredRetryLimit(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -577,7 +577,7 @@ func TestSystemNodeRunner_RetryableFailureExhaustsConfiguredRetryLimit(t *testin
 }
 
 func TestSystemNodeRunner_PipelineNamedNodeDoesNotMaskPlatformReceipt(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -640,7 +640,7 @@ func TestSystemNodeRunner_PipelineNamedNodeDoesNotMaskPlatformReceipt(t *testing
 }
 
 func TestSystemNodeProcessedSettlementFailsWithoutNodeDeliveryAuthority(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
@@ -690,7 +690,7 @@ func TestSystemNodeProcessedSettlementFailsWithTerminalNodeDeliveryAuthority(t *
 		{name: "retry_exhausted_failed", status: "failed", retryCount: DefaultSystemNodeRetryLimit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			ctx := context.Background()
 			runID := uuid.NewString()
 			eventID := uuid.NewString()

--- a/internal/runtime/pipeline/on_timeout_pipeline_test.go
+++ b/internal/runtime/pipeline/on_timeout_pipeline_test.go
@@ -27,7 +27,7 @@ func TestExecuteAuthoritativeNodeHandler_OnTimeoutAdvancesPartial(t *testing.T) 
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{

--- a/internal/runtime/pipeline/select_entity_test.go
+++ b/internal/runtime/pipeline/select_entity_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestExecuteNodeContractHandlerSelectEntityUpdatesTargetOwnedEntity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -67,7 +67,7 @@ func TestExecuteNodeContractHandlerSelectEntityUpdatesTargetOwnedEntity(t *testi
 }
 
 func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -113,7 +113,7 @@ func TestExecuteNodeContractHandlerSelectEntityReplayUsesSameTargetEntity(t *tes
 }
 
 func TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -192,7 +192,7 @@ func TestExecuteNodeContractHandlerSelectEntityMatchesTypedStatusField(t *testin
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -225,7 +225,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityCreatesTargetOwnedEntity(
 }
 
 func TestRepairContractEntityTypesUsesBundleAvailabilityAndDoesNotPromoteLegacyFingerprint(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -307,7 +307,7 @@ func TestRepairContractEntityTypesUsesBundleAvailabilityAndDoesNotPromoteLegacyF
 }
 
 func TestRepairContractEntityTypesBlocksPersistedMissingBundleRow(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -357,7 +357,7 @@ func TestRepairContractEntityTypesBlocksPersistedMissingBundleRow(t *testing.T) 
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -385,7 +385,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityReplayUsesSameDeclaredKey
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnAmbiguousMatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -402,7 +402,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnAmbiguousMat
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnDeterministicIDConflict(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -438,7 +438,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFailsClosedOnDeterministi
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityConcurrentDuplicateCreatesOneEntity(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -474,7 +474,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityConcurrentDuplicateCreate
 }
 
 func TestBackgroundWorkflowNodeSelectOrCreateEntityDuplicateSameEventIsReceiptIdempotent(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectOrCreateEntityTestCoordinator(t, db)
@@ -509,7 +509,7 @@ func TestBackgroundWorkflowNodeSelectOrCreateEntityDuplicateSameEventIsReceiptId
 }
 
 func TestExecuteNodeContractHandlerSelectOrCreateEntityFeedsEntityIDToArtifactRepoCommit(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, _ := newSelectEntityTestCoordinator(t, db)
@@ -548,7 +548,7 @@ func TestExecuteNodeContractHandlerSelectOrCreateEntityFeedsEntityIDToArtifactRe
 }
 
 func TestBackgroundWorkflowNodeSelectEntityDuplicateSameEventIsReceiptIdempotent(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -596,7 +596,7 @@ func TestBackgroundWorkflowNodeSelectEntityDuplicateSameEventIsReceiptIdempotent
 }
 
 func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatches(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -661,7 +661,7 @@ func TestExecuteNodeContractHandlerSelectEntityIgnoresTerminalAndTerminatedMatch
 }
 
 func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -677,7 +677,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnNoMatch(t *testing.T
 }
 
 func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnMissingPayloadRef(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)
@@ -693,7 +693,7 @@ func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnMissingPayloadRef(t 
 }
 
 func TestExecuteNodeContractHandlerSelectEntityFailsClosedOnAmbiguousMatch(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc, source := newSelectEntityTestCoordinator(t, db)

--- a/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
+++ b/internal/runtime/pipeline/singleton_coordinator_pilot_delivery_test.go
@@ -19,7 +19,7 @@ import (
 func TestSingletonCoordinatorPilotPipelineDispatchPersistsContainedStateReadback(t *testing.T) {
 	bundle := singletoncoordinatorpilot.LoadBundle(t, singletoncoordinatorpilot.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, workflowStore := newSingletonCoordinatorPilotPipelineCoordinator(t, db, bundle, source)
 	ctx := testPipelineCoordinatorRunContext(t, pc)
@@ -106,7 +106,7 @@ func TestSingletonCoordinatorPilotPipelineDispatchPersistsContainedStateReadback
 func TestSingletonCoordinatorPilotPipelineRejectsContainedItemDeliveryTarget(t *testing.T) {
 	bundle := singletoncoordinatorpilot.LoadBundle(t, singletoncoordinatorpilot.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, _ := newSingletonCoordinatorPilotPipelineCoordinator(t, db, bundle, source)
 

--- a/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
+++ b/internal/runtime/pipeline/sqlite_dynamic_activation_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"github.com/division-sh/swarm/internal/testutil"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestSQLiteFanOutCreateFlowInstanceDeliveriesPersistWithoutDeadLetter(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	workflowStore := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := sqliteExactOnceRunContext(t, db)
 	pc, bus := newSQLiteDynamicActivationCoordinator(t, db, workflowStore)

--- a/internal/runtime/pipeline/standing_ownership_test.go
+++ b/internal/runtime/pipeline/standing_ownership_test.go
@@ -17,10 +17,10 @@ func TestValidatePersistedStandingOwnershipIsPredecessorOwnedAcrossBackends(t *t
 			var db *sql.DB
 			var store *WorkflowInstanceStore
 			if backend == "sqlite" {
-				db = newSQLiteWorkflowInstanceStoreTestDB(t)
+				db = newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 				store = newSQLiteWorkflowInstanceStoreForTest(t, db)
 			} else {
-				_, db, _ = testutil.StartPostgres(t)
+				_, db, _ = testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 				store = NewWorkflowInstanceStore(db)
 			}
 			existing := runtimecorrelation.BundleSourceFact{

--- a/internal/runtime/pipeline/template_flow_pilot_delivery_test.go
+++ b/internal/runtime/pipeline/template_flow_pilot_delivery_test.go
@@ -19,7 +19,7 @@ import (
 func TestTemplateFlowPilotPipelineDispatchUpdatesSelectedTemplateInstance(t *testing.T) {
 	bundle := templateflowpilot.LoadBundle(t, templateflowpilot.Options{})
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pc, workflowStore := newTemplateFlowPilotPipelineCoordinator(t, db, bundle, source)
 	ctx := testPipelineCoordinatorRunContext(t, pc)

--- a/internal/runtime/pipeline/workflow_instance_activation_test.go
+++ b/internal/runtime/pipeline/workflow_instance_activation_test.go
@@ -79,7 +79,7 @@ func TestCreateFlowInstanceResolvesInstanceIDFromPayloadPath(t *testing.T) {
 
 func TestCreateFlowInstanceArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
 	runID := uuid.NewString()
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	schedules := &recordingSchedulePersistence{}
 	source := semanticview.Wrap(stageTimerTemplateLifecycleBundle())
@@ -714,7 +714,7 @@ opco.ceo_ready:
 		t.Fatalf("handler event key = %q, want opco.product_initialization_requested", got)
 	}
 
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	bus := &recordingPipelineBus{}
 	pc := &PipelineCoordinator{
 		bus:                     bus,
@@ -797,7 +797,7 @@ states: [initializing, ready]
 		t.Fatalf("resolved evidence target = %q, want build_evidence", got)
 	}
 
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	workflowStore := NewWorkflowInstanceStore(db)
 	pc := &PipelineCoordinator{

--- a/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_mutate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWorkflowInstanceStoreMutateE_RollsBackCallbackFailure(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	store := NewWorkflowInstanceStore(db)
 	entityID := uuid.NewString()
@@ -35,7 +35,7 @@ func TestWorkflowInstanceStoreMutateE_RollsBackCallbackFailure(t *testing.T) {
 }
 
 func TestWorkflowInstanceStoreMutate_SerializesOverlappingMutations(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -101,7 +101,7 @@ func TestWorkflowInstanceStoreMutate_SerializesOverlappingMutations(t *testing.T
 }
 
 func TestUpdateEntityState_PreservesMutationCommittedWhileTransitionWaits(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -160,7 +160,7 @@ func TestUpdateEntityState_PreservesMutationCommittedWhileTransitionWaits(t *tes
 }
 
 func TestWorkflowInstanceStoreMutate_PersistsSingleWriterUpdates(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -196,7 +196,7 @@ func TestWorkflowInstanceStoreMutate_PersistsSingleWriterUpdates(t *testing.T) {
 }
 
 func TestWorkflowInstanceStoreMutate_IgnoresSchedulerOwnedTimerRows(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)

--- a/internal/runtime/pipeline/workflow_instance_store_projection_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_projection_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -154,7 +154,7 @@ func TestWorkflowInstanceStoreProjection_RoundTripPreservesCanonicalState(t *tes
 }
 
 func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	workflowStore := NewWorkflowInstanceStore(db)
@@ -226,7 +226,7 @@ func TestWorkflowInstanceStoreProjection_DoesNotExposeControlStatusAsEntityField
 }
 
 func TestWorkflowInstanceStoreCreateRejectsDuplicateWithoutMutatingProjection(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -325,7 +325,7 @@ func TestWorkflowInstanceStoreCreateRejectsDuplicateWithoutMutatingProjection(t 
 }
 
 func TestWorkflowInstanceStoreProjection_StaticRowsDoNotGainMaterializedFlowPathOnRoundTrip(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := NewWorkflowInstanceStore(db)
@@ -425,7 +425,7 @@ func TestWorkflowInstanceStoreProjection_RejectsMalformedPersistedShapes(t *test
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 
 			store := NewWorkflowInstanceStore(db)

--- a/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_run_scope_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWorkflowInstanceStore_RequiresRunContext(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 
 	err := store.Upsert(context.Background(), WorkflowInstance{
@@ -28,7 +28,7 @@ func TestWorkflowInstanceStore_RequiresRunContext(t *testing.T) {
 }
 
 func TestWorkflowInstanceStore_RunScopedCurrentStateRowsDoNotBleed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 	runA := uuid.NewString()
 	runB := uuid.NewString()
@@ -71,7 +71,7 @@ func TestWorkflowInstanceStore_RunScopedCurrentStateRowsDoNotBleed(t *testing.T)
 }
 
 func TestWorkflowInstanceStore_RunScopedTimerRowsDoNotBleed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	store := NewWorkflowInstanceStore(db)
 	runA := uuid.NewString()
 	runB := uuid.NewString()

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/division-sh/swarm/internal/testutil"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRows(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
@@ -50,7 +51,7 @@ func TestSQLiteWorkflowInstanceStore_PreservesCreateEntityInitialValueMutationRo
 }
 
 func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	storageRef := "review/inst-1"
@@ -98,7 +99,7 @@ func TestSQLiteWorkflowInstanceStore_PreservesParentRouteControlMetadata(t *test
 }
 
 func TestSQLiteWorkflowInstanceStore_MarkTerminatedUsesRuntimeMutationRunner(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	runner := &recordingRuntimeMutationRunner{db: db}
 	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
 	storageRef := "root/terminated"
@@ -132,7 +133,7 @@ func TestSQLiteWorkflowInstanceStore_MarkTerminatedUsesRuntimeMutationRunner(t *
 }
 
 func TestSQLiteWorkflowInstanceStore_RunPipelineMutationRequiresRuntimeMutationRunner(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := NewSQLiteWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	called := false
@@ -150,7 +151,7 @@ func TestSQLiteWorkflowInstanceStore_RunPipelineMutationRequiresRuntimeMutationR
 }
 
 func TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	runner := &recordingRuntimeMutationRunner{db: db}
 	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
@@ -184,7 +185,7 @@ func TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunne
 }
 
 func TestSQLiteWorkflowInstanceStore_MutateERollsBackCallbackFailure(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	runner := &recordingRuntimeMutationRunner{db: db}
 	store := NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, runner)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
@@ -209,7 +210,7 @@ func TestSQLiteWorkflowInstanceStore_MutateERollsBackCallbackFailure(t *testing.
 }
 
 func TestSQLiteWorkflowInstanceStore_RunPipelineMutationDoesNotRetryActiveTransaction(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := NewSQLiteWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	tx, err := db.BeginTx(ctx, nil)
@@ -240,7 +241,7 @@ func TestSQLiteWorkflowInstanceStore_RunPipelineMutationDoesNotRetryActiveTransa
 }
 
 func TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := NewWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	busyErr := errors.New("SQLITE_BUSY: database is locked")
@@ -296,10 +297,10 @@ func newSQLiteWorkflowInstanceStoreForTest(t *testing.T, db *sql.DB) *WorkflowIn
 	return NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, &recordingRuntimeMutationRunner{db: db})
 }
 
-func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T) *sql.DB {
+func newSQLiteWorkflowInstanceStoreTestDB(t *testing.T, requirement testutil.DatabaseRequirement) *sql.DB {
 	t.Helper()
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
-	db, err := sql.Open("sqlite", "file:"+name+"?mode=memory&cache=shared")
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, requirement, "file:"+name+"?mode=memory&cache=shared"))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -137,7 +137,7 @@ func TestArmWorkflowJoinPostgresParity(t *testing.T) {
 }
 
 func TestWorkflowJoinCustomCompletionControlsExpectedZeroOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			bundle := workflowJoinLifecycleBundle()
@@ -227,7 +227,7 @@ func TestWorkflowJoinArmRejectsCatalogInvalidNamedResultExpression(t *testing.T)
 }
 
 func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			bundle := workflowJoinLifecycleBundle()
@@ -299,10 +299,10 @@ type workflowJoinStoreCase struct {
 	open func(*testing.T) (*WorkflowInstanceStore, context.Context)
 }
 
-func workflowJoinStoreCases(requirement testutil.DatabaseRequirement) []workflowJoinStoreCase {
+func workflowJoinStoreCases(requirement, sqliteRequirement testutil.DatabaseRequirement) []workflowJoinStoreCase {
 	return []workflowJoinStoreCase{
 		{name: "sqlite", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, sqliteRequirement)
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -35,7 +35,7 @@ func TestArmWorkflowJoinPersistsActivationAndScheduleAtomically(t *testing.T) {
 		{name: "zero members complete immediately", members: []any{}, wantStatus: joinruntime.StatusClosed, wantReason: joinruntime.CloseReasonComplete, wantEvent: joinCompleteEvent, wantKind: timeridentity.TimerHandleJoinComplete},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 			schedules := &recordingSchedulePersistence{}
 			bundle := workflowJoinLifecycleBundle()
@@ -99,7 +99,7 @@ func TestArmWorkflowJoinPostgresParity(t *testing.T) {
 		{name: "expected zero", members: []any{}, wantStatus: joinruntime.StatusClosed, wantEvent: joinCompleteEvent},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -137,7 +137,7 @@ func TestArmWorkflowJoinPostgresParity(t *testing.T) {
 }
 
 func TestWorkflowJoinCustomCompletionControlsExpectedZeroOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			bundle := workflowJoinLifecycleBundle()
@@ -189,7 +189,7 @@ func TestWorkflowJoinCustomCompletionControlsExpectedZeroOnBothStores(t *testing
 }
 
 func TestWorkflowJoinArmRejectsCatalogInvalidNamedResultExpression(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	bundle := workflowJoinLifecycleBundle()
 	node := bundle.Nodes["join-node"]
@@ -227,7 +227,7 @@ func TestWorkflowJoinArmRejectsCatalogInvalidNamedResultExpression(t *testing.T)
 }
 
 func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			bundle := workflowJoinLifecycleBundle()
@@ -299,14 +299,14 @@ type workflowJoinStoreCase struct {
 	open func(*testing.T) (*WorkflowInstanceStore, context.Context)
 }
 
-func workflowJoinStoreCases() []workflowJoinStoreCase {
+func workflowJoinStoreCases(requirement testutil.DatabaseRequirement) []workflowJoinStoreCase {
 	return []workflowJoinStoreCase{
 		{name: "sqlite", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", open: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -323,11 +323,11 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
 	}{
 		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -421,11 +421,11 @@ func TestWorkflowJoinArmArrivalRaceIsEarlyOrAdmittedOnBothStores(t *testing.T) {
 		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
 	}{
 		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -505,11 +505,11 @@ func TestWorkflowJoinPersistedArrivalClassificationOnBothStores(t *testing.T) {
 		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
 	}{
 		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -596,11 +596,11 @@ func TestWorkflowJoinExpectedZeroCompletesAfterRestartOnBothStores(t *testing.T)
 		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
 	}{
 		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -684,11 +684,11 @@ func TestWorkflowJoinExpectedZeroStageExitCancelsPendingCompletionOnBothStores(t
 		store func(*testing.T) (*WorkflowInstanceStore, context.Context)
 	}{
 		{name: "sqlite", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			db := newSQLiteWorkflowInstanceStoreTestDB(t)
+			db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 			return newSQLiteWorkflowInstanceStoreForTest(t, db), runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 		}},
 		{name: "postgres", store: func(t *testing.T) (*WorkflowInstanceStore, context.Context) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			runID := uuid.NewString()
 			if _, err := db.ExecContext(context.Background(), `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
@@ -759,7 +759,7 @@ func TestWorkflowJoinExpectedZeroStageExitCancelsPendingCompletionOnBothStores(t
 }
 
 func TestWorkflowJoinFailurePersistsCanonicalReceiptAndRuntimeLog(t *testing.T) {
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	ctx := sqliteExactOnceRunContext(t, db)
 	bundle := workflowJoinLifecycleBundle()

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pc, bus := newDeliveryAuthorityCoordinator(t, db)
 	runCtx := testPipelineCoordinatorRunContext(t, pc)
@@ -43,7 +43,7 @@ func TestPipelineCoordinatorInterceptSkipsNodeWithoutPersistedDeliveryAuthority(
 }
 
 func TestPipelineCoordinatorInterceptDeliveryRouteConsumesTargetWithoutGenericAuthorityLog(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pc, bus := newDeliveryAuthorityCoordinator(t, db)
 	runCtx := testPipelineCoordinatorRunContext(t, pc)
@@ -76,7 +76,7 @@ func TestPipelineCoordinatorInterceptDeliveryRouteConsumesTargetWithoutGenericAu
 }
 
 func TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pc, bus := newDeliveryAuthorityCoordinator(t, db)
 	runCtx := testPipelineCoordinatorRunContext(t, pc)
@@ -115,7 +115,7 @@ func TestPipelineCoordinatorInterceptTerminalNodeDeliveryDoesNotAuthorizeExecuti
 		{name: "retry_exhausted_failed", status: "failed", retryCount: DefaultSystemNodeRetryLimit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			ctx := context.Background()
 			pc, bus := newDeliveryAuthorityCoordinator(t, db)
 			runCtx := testPipelineCoordinatorRunContext(t, pc)
@@ -146,7 +146,7 @@ func TestPipelineCoordinatorInterceptTerminalNodeDeliveryDoesNotAuthorizeExecuti
 }
 
 func TestPipelineCoordinatorInterceptSkipsWhenCanonicalDeliveryAuthorityUnavailable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pc, bus := newDeliveryAuthorityCoordinatorWithReceipts(t, db, false)
 	runCtx := testPipelineCoordinatorRunContext(t, pc)
@@ -170,7 +170,7 @@ func TestPipelineCoordinatorInterceptSkipsWhenCanonicalDeliveryAuthorityUnavaila
 }
 
 func TestPipelineCoordinatorInterceptSettlesAuthorizedNodeDelivery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pc, _ := newDeliveryAuthorityCoordinator(t, db)
 	runCtx := testPipelineCoordinatorRunContext(t, pc)

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -288,7 +288,7 @@ func TestWorkflowTimerFireAtSupportsPolicyRenderedDayDelay(t *testing.T) {
 
 func TestHandleWorkflowStageTimerFireMarksFiredAndAdvancesWithSQLiteStore(t *testing.T) {
 	runID := uuid.NewString()
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	if _, err := db.Exec(`INSERT INTO runs (run_id, status) VALUES (?, 'running')`, runID); err != nil {
 		t.Fatalf("seed sqlite run: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestHandleWorkflowStageTimerFireMarksFiredAndAdvancesWithSQLiteStore(t *tes
 
 func TestHandleWorkflowStageTimerFireDeactivatesTerminalTemplateFlow(t *testing.T) {
 	runID := uuid.NewString()
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	source := semanticview.Wrap(stageTimerTemplateLifecycleBundle())
 	var deactivated FlowInstanceDeactivationRequest
@@ -474,7 +474,7 @@ func TestHandleWorkflowStageTimerFireDeactivatesTerminalTemplateFlow(t *testing.
 
 func TestPipelineEngineStateRepoSaveStateArmsInitialStageTimersWithSQLiteStore(t *testing.T) {
 	runID := uuid.NewString()
-	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	db := newSQLiteWorkflowInstanceStoreTestDB(t, testutil.SQLiteFreshFile())
 	store := newSQLiteWorkflowInstanceStoreForTest(t, db)
 	schedules := &recordingSchedulePersistence{}
 	source := semanticview.Wrap(stageTimerLifecycleBundle())
@@ -534,7 +534,7 @@ func TestLoopConnectedRecurringTimerFailsClosedAtRuntimeOnBothStores(t *testing.
 			StartOn: "state:review", Delay: "1h", Recurring: true,
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			_, entityID := seedLoopActivityInstance(t, store, ctx, "review")
@@ -580,7 +580,7 @@ func TestLoopTimerCannotBypassCloseAtRuntimeOnBothStores(t *testing.T) {
 			StartOn: "state:review", Delay: "1h", AdvancesTo: "expired",
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			_, entityID := seedLoopActivityInstance(t, store, ctx, "review")
@@ -609,7 +609,7 @@ func TestLoopTimerGenerationRejectsPriorAttemptAndAdvancesCurrentAttemptOnBothSt
 			StartOn: "state:review", Delay: "1h", AdvancesTo: "drafting",
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases() {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			prior, entityID := seedLoopActivityInstance(t, store, ctx, "review")
@@ -691,7 +691,7 @@ func TestExecuteNodeHandlerPlan_EventTimerStartOnRegistersSchedule(t *testing.T)
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -764,7 +764,7 @@ func TestPipelineIntercept_EventTimerStartOnRegistersSchedule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -823,18 +823,18 @@ func TestRegisterWorkflowTimerSchedule_PostCommitClaimDropsPipelineTransaction(t
 	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) error {
 		pc.registerWorkflowTimerSchedule(ctx, sc)
 		return nil
-	})
+	}, testutil.PostgresRowState())
 }
 
 func TestPersistWorkflowTimerSchedule_PostCommitClaimDropsPipelineTransaction(t *testing.T) {
 	assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t, func(pc *PipelineCoordinator, ctx context.Context, sc Schedule) error {
 		return pc.persistWorkflowTimerSchedule(ctx, sc)
-	})
+	}, testutil.PostgresRowState())
 }
 
-func assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t *testing.T, schedule func(*PipelineCoordinator, context.Context, Schedule) error) {
+func assertWorkflowTimerSchedulePostCommitClaimDropsPipelineTransaction(t *testing.T, schedule func(*PipelineCoordinator, context.Context, Schedule) error, requirement testutil.DatabaseRequirement) {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	store := &recordingSchedulePersistence{}
 	scheduler := NewScheduler()
@@ -1006,7 +1006,7 @@ func TestExecuteNodeHandlerPlan_DoesNotRunOtherNodeHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
@@ -1082,7 +1082,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutRegistersSchedule(t *testing.T)
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -1167,7 +1167,7 @@ func TestReconcileAccumulationTimeoutScheduleUsesMatchedHandlerEventKey(t *testi
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -1238,7 +1238,7 @@ func TestReconcileAccumulationTimeoutScheduleUsesFanInPinDerivedWindow(t *testin
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -1336,7 +1336,7 @@ func TestReconcileAccumulationTimeoutScheduleRejectsAmbiguousFanInInput(t *testi
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -1387,7 +1387,7 @@ func TestExecuteNodeHandlerPlan_AccumulateTimeoutCancelsScheduleOnTimeout(t *tes
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	store := &recordingSchedulePersistence{}
@@ -1478,7 +1478,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pc := NewPipelineCoordinatorWithOptions(noopPipelineBus{}, db, PipelineCoordinatorOptions{
@@ -1583,7 +1583,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -1642,7 +1642,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -1734,7 +1734,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}
@@ -1828,7 +1828,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	if err != nil {
 		t.Fatalf("newPipelineFixtureWorkflowModule: %v", err)
 	}
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	bus := &recordingPipelineBus{}

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -534,7 +534,7 @@ func TestLoopConnectedRecurringTimerFailsClosedAtRuntimeOnBothStores(t *testing.
 			StartOn: "state:review", Delay: "1h", Recurring: true,
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			_, entityID := seedLoopActivityInstance(t, store, ctx, "review")
@@ -580,7 +580,7 @@ func TestLoopTimerCannotBypassCloseAtRuntimeOnBothStores(t *testing.T) {
 			StartOn: "state:review", Delay: "1h", AdvancesTo: "expired",
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			_, entityID := seedLoopActivityInstance(t, store, ctx, "review")
@@ -609,7 +609,7 @@ func TestLoopTimerGenerationRejectsPriorAttemptAndAdvancesCurrentAttemptOnBothSt
 			StartOn: "state:review", Delay: "1h", AdvancesTo: "drafting",
 		}},
 	}}
-	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical()) {
+	for _, tc := range workflowJoinStoreCases(testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile()) {
 		t.Run(tc.name, func(t *testing.T) {
 			store, ctx := tc.open(t)
 			prior, entityID := seedLoopActivityInstance(t, store, ctx, "review")

--- a/internal/runtime/runforkexecution/activity_fork_execution_test.go
+++ b/internal/runtime/runforkexecution/activity_fork_execution_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestExecuteSelectedContractRunForkExecutesOrReusesLoopActivityThroughRuntimeContainer(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -238,7 +238,7 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 }
 
 func TestExecuteSelectedContractRunForkLoadsDBBackedSourceAndStampsPersistedIdentity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -318,7 +318,7 @@ func TestExecuteSelectedContractRunForkLoadsDBBackedSourceAndStampsPersistedIden
 }
 
 func TestExecuteSelectedContractRunForkFailsClosedBeforeMaterializationForAgentRecipientWithoutHandlerMaterializer(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -366,7 +366,7 @@ func TestExecuteSelectedContractRunForkFailsClosedBeforeMaterializationForAgentR
 }
 
 func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRuntime(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -669,7 +669,7 @@ func (selectedContractCleanupRuntime) ContinueSession(context.Context, *runtimel
 }
 
 func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -759,7 +759,7 @@ func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(
 }
 
 func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSelectedRecipients(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -886,7 +886,7 @@ func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSe
 }
 
 func TestActivateSelectedContractRunForkFailsBeforePublishForPostTReplayScopeMarker(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -951,7 +951,7 @@ func TestActivateSelectedContractRunForkFailsBeforePublishForPostTReplayScopeMar
 }
 
 func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1059,7 +1059,7 @@ func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(
 }
 
 func TestExecuteSelectedContractRunForkAdmitsSameSourceActiveDeliveryForkPointEmission(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1206,7 +1206,7 @@ func TestExecuteSelectedContractRunForkAdmitsSameSourceActiveDeliveryForkPointEm
 }
 
 func TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBranchDivergence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1331,7 +1331,7 @@ func TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBra
 }
 
 func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1406,7 +1406,7 @@ func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t 
 }
 
 func TestExecuteSelectedContractRunForkTreatsSameEventReplayScopeMarkerWriteSkewAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1472,7 +1472,7 @@ func TestExecuteSelectedContractRunForkTreatsSameEventReplayScopeMarkerWriteSkew
 }
 
 func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterialization(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1520,7 +1520,7 @@ func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterializ
 }
 
 func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)
@@ -1580,7 +1580,7 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(
 }
 
 func TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
 	repoRoot := runForkExecutionRepoRoot(t)

--- a/internal/runtime/runtime_operational_config_test.go
+++ b/internal/runtime/runtime_operational_config_test.go
@@ -134,7 +134,7 @@ func testOperationalRuntimeConfig() *config.Config {
 
 func TestNewRuntimeRejectsInvalidArtifactRootEnv(t *testing.T) {
 	t.Setenv("SWARM_ARTIFACT_ROOT", "/data/swarm/artifacts")
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 

--- a/internal/runtime/runtime_recovery_diagnostics_test.go
+++ b/internal/runtime/runtime_recovery_diagnostics_test.go
@@ -398,7 +398,7 @@ func assertContainsClass(t *testing.T, classes []string, want string) {
 
 func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	scheduleStore := &recordingRuntimeScheduleStore{
@@ -452,7 +452,7 @@ func TestRuntimeStart_RecoveryDisabledEmitsDeniedDecisionForActiveSchedules(t *t
 
 func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
@@ -533,7 +533,7 @@ func TestRuntimeStart_RecoveryDisabledAllowsAndLogsManagerSnapshotWork(t *testin
 
 func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	scheduleStore := &recordingRuntimeScheduleStore{
@@ -601,7 +601,7 @@ func TestRuntimeStart_RecoveryEnabledEmitsAllowedDecisionSummary(t *testing.T) {
 
 func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	scheduleStore := &recordingRuntimeScheduleStore{
@@ -733,7 +733,7 @@ func TestRuntimeStart_RecoveryEnabledEmitsTimerRecoveryAftermathAndSummary(t *te
 
 func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	managerStore := &startupManagerReplayRuntimeStore{
@@ -849,7 +849,7 @@ func TestRuntimeStart_RecoveryEnabledEmitsManagerReplayAftermathAndSummary(t *te
 
 func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	eventStore := &startupRecoveryEventStore{
@@ -905,7 +905,7 @@ func TestRuntimeStart_RecoveryFailureEmitsDegradedDecisionSummary(t *testing.T) 
 
 func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartup(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 
@@ -955,7 +955,7 @@ func TestRuntimeStart_RecoveryInspectionFailureDoesNotBlockRecoveryEnabledStartu
 
 func TestRuntimeStart_InspectionFailurePreservesDecisionErrorAcrossTimerSkipAndDrop(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	module := loadRuntimeOwnershipWorkflowModule(t)
 	scheduleStore := &recordingRuntimeScheduleStore{

--- a/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -67,7 +67,7 @@ func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *t
 			flowInstance = "slack-connector-managed-credential-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/telegram_connector_supported_surface_test.go
+++ b/internal/runtime/telegram_connector_supported_surface_test.go
@@ -34,7 +34,7 @@ import (
 // The process-served standing-ingress tests own the supported E2E claim.
 func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *testing.T) {
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 		t.Cleanup(cleanup)
 
 		const (
@@ -69,7 +69,7 @@ func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *te
 			flowInstance = "telegram-connector-supported-surface-sqlite"
 		)
 		ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 		workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, sqliteStore.DB, flowInstance, true)

--- a/internal/runtime/template_flow_pilot_runtime_test.go
+++ b/internal/runtime/template_flow_pilot_runtime_test.go
@@ -29,7 +29,7 @@ func TestTemplateFlowPilotRuntime_ParentConnectCreatesTemplateInstanceAndPersist
 		t.Fatalf("template-flow pilot hard invalidities = %#v, want none", got)
 	}
 
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -916,13 +916,15 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 		{name: "immediately before commit", mutation: providerRollbackBeforeCommit, retry: true},
 	}
 	backends := []struct {
-		name  string
-		setup func(*testing.T, providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore)
+		name        string
+		requirement testutil.DatabaseRequirement
+		setup       func(*testing.T, testutil.DatabaseRequirement, providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore)
 	}{
 		{
-			name: "postgres",
-			setup: func(t *testing.T, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
-				_, db, cleanup := testutil.StartPostgres(t)
+			name:        "postgres",
+			requirement: testutil.PostgresRowState(),
+			setup: func(t *testing.T, requirement testutil.DatabaseRequirement, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
+				_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 				t.Cleanup(cleanup)
 				ctx := seedRuntimeTestRun(t, db)
 				return ctx, db, &providerRollbackPostgresStore{
@@ -932,9 +934,10 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 			},
 		},
 		{
-			name: "sqlite",
-			setup: func(t *testing.T, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
-				sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+			name:        "sqlite",
+			requirement: testutil.SQLiteDefaultTemp(),
+			setup: func(t *testing.T, requirement testutil.DatabaseRequirement, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
+				sqliteStore := storetest.StartSQLiteRuntimeStore(t, requirement)
 				ctx := runtimecorrelation.WithRunID(context.Background(), templateInstanceDeliveryRunID)
 				if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, templateInstanceDeliveryRunID); err != nil {
 					t.Fatalf("seed SQLite rollback run: %v", err)
@@ -950,7 +953,7 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 	for _, backend := range backends {
 		for _, checkpoint := range checkpoints {
 			t.Run(backend.name+"/"+checkpoint.name, func(t *testing.T) {
-				ctx, db, eventStore := backend.setup(t, checkpoint.mutation)
+				ctx, db, eventStore := backend.setup(t, backend.requirement, checkpoint.mutation)
 				source := providerRollbackSemanticSource(t, !checkpoint.withoutCarrier)
 				plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, []runtimeprovideroutput.Authorization{providerRollbackAuthorization()})
 				if len(issues) != 0 || len(plans) != 1 {

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -37,7 +37,7 @@ const templateInstanceDeliveryRunID = "99999999-9999-4999-8999-999999999901"
 func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScopeSeparately(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceDeliveryFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -108,7 +108,7 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsReceiptAndReplayScope
 func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandlerExecution(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceDeliveryFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -162,7 +162,7 @@ func TestTemplateInstanceNoTargetSystemNodeDeliveryPersistsAuthorityBeforeHandle
 func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireStyleFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -253,7 +253,7 @@ func TestTemplateInstanceAutoEmitDispatchesLocalHandlerAndEmpireStyleSideEffect(
 func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliveryRows(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceActivationConfigSubscriberFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -327,7 +327,7 @@ func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliv
 func TestTemplateInstanceConnectLifecyclePublishRollbackDoesNotLeakInstanceOrRoute(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceConnectLifecycleRollbackFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -407,7 +407,7 @@ func TestTemplateInstanceConnectLifecyclePublishRollbackDoesNotLeakInstanceOrRou
 func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInternalCarrierAndEmpireStyleSideEffect(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireOutboxFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
@@ -525,7 +525,7 @@ func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInt
 func TestTemplateInstanceRootOutboxEventDispatchesRoutedSystemNodeAndEmpireStyleSideEffect(t *testing.T) {
 	bundle := loadRuntimeTempBundle(t, templateInstanceEmpireOutboxFixtureFiles())
 	source := semanticview.Wrap(bundle)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := seedRuntimeTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -340,7 +340,7 @@ func TestRoleScopedEntityTools_OptedInActorReceivesGeneratedSurfaceOnly(t *testi
 		"search_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresRowState())
 
 	defs := exec.ToolDefinitionsForActor(actor)
 	names := roleScopedToolDefinitionMap(defs)
@@ -490,7 +490,7 @@ func TestRoleScopedEntityTools_CurrentEntityEligibilityFiltersTurnSurface(t *tes
 		"query_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresRowState())
 	currentID := uuid.NewString()
 	foreignID := uuid.NewString()
 	seedEntityStateRow(t, db, currentID, "", "validation/inst-1", "validation_case", "queued", map[string]any{
@@ -559,7 +559,7 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 	if errs := runtimetools.ValidateGeneratedToolSchemaClosureForSource(source); len(errs) > 0 {
 		t.Fatalf("ValidateGeneratedToolSchemaClosureForSource errors = %#v", errs)
 	}
-	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresFreshPhysical())
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
 	saveSchema := names["save_validation_case_business_brief"].Schema.(map[string]any)
 	if err := runtimetools.ValidatePayloadAgainstSchema(saveSchema, map[string]any{
@@ -606,7 +606,7 @@ func TestRoleScopedEntityTools_GeneratedSchemasAreClosedAndRuntimeRejectsExtras(
 func TestRoleScopedEntityTools_NonOptedActorReceivesGeneratedSurfaceByDefault(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"get_entity", "query_entities"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, false)
-	_, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	_, exec, _ := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresRowState())
 
 	names := roleScopedToolDefinitionMap(exec.ToolDefinitionsForActor(actor))
 	for _, name := range []string{"get_entity", "query_entities"} {
@@ -627,7 +627,7 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 		"query_entities",
 	}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresRowState())
 	currentID := uuid.NewString()
 	siblingID := uuid.NewString()
 	foreignID := uuid.NewString()
@@ -703,7 +703,7 @@ func TestRoleScopedEntityTools_CurrentEntityBindingAndBypassRejection(t *testing
 func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator"}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false)
+	ctx, exec, db := newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, false, testutil.PostgresRowState())
 	entityID := uuid.NewString()
 	brief := strings.Repeat("business brief ", 1800)
 	specProblem := strings.Repeat("problem statement ", 900)
@@ -1290,7 +1290,7 @@ types: {}
 accounts:
   status: text
 `)
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -1387,7 +1387,7 @@ types: {}
 accounts:
   status: text
 `)
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &store.PostgresStore{DB: db}
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -2224,7 +2224,7 @@ foreign:
 		Role:  "analyzer",
 		Tools: []string{"save_entity_field", "get_entity"},
 	}
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ensureEntityToolTestRun(t, db)
 	bus := &entityToolRuntimeLogBus{}
 	pg := &store.PostgresStore{DB: db}
@@ -2739,12 +2739,12 @@ accounts:
 
 func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
-	return newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, true)
+	return newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, true, testutil.PostgresRowState())
 }
 
-func newEntityToolTestHarnessWithBundleAndLegacyAccess(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, allowInternalLegacy bool) (context.Context, *runtimetools.Executor, *sql.DB) {
+func newEntityToolTestHarnessWithBundleAndLegacyAccess(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, allowInternalLegacy bool, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, requirement)
 	ensureEntityToolTestRun(t, db)
 	pg := &store.PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(unmanagedToolTestContext(), entityToolTestRunID)

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -104,7 +104,7 @@ func assertEntityToolDiagnosticLineage(t *testing.T, bus *entityToolRuntimeLogBu
 }
 
 func TestEntityTools_HappyPath(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"name":          "Acme",
@@ -254,7 +254,7 @@ func TestEntityTools_HappyPath(t *testing.T) {
 }
 
 func TestEntityTools_SaveEntityField_JSONBRoundTripsPlainTextWithoutBase64(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -294,7 +294,7 @@ func TestEntityTools_SaveEntityField_JSONBRoundTripsPlainTextWithoutBase64(t *te
 }
 
 func TestEntityTools_CreateEntityAcceptsAnnotatedJSONBFields(t *testing.T) {
-	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	ctx, exec := newAnnotatedEntityToolExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/inst-1",
 		"fields": map[string]any{
@@ -770,7 +770,7 @@ func TestRoleScopedEntityTools_ReadsLargeValidationCaseWithoutLoss(t *testing.T)
 }
 
 func TestEntityTools_SaveEntityFieldAcceptsAnnotatedJSONBFields(t *testing.T) {
-	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	ctx, exec := newAnnotatedEntityToolExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{"flow_instance": "validation/inst-1"})
 	if _, err := exec.Execute(ctx, "save_entity_field", map[string]any{
 		"entity_id": entityID,
@@ -799,7 +799,7 @@ func TestEntityTools_SaveEntityFieldAcceptsAnnotatedJSONBFields(t *testing.T) {
 }
 
 func TestEntityTools_SearchEntitiesAcceptsAnnotatedJSONBFilter(t *testing.T) {
-	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	ctx, exec := newAnnotatedEntityToolExecutor(t, testutil.PostgresRowState())
 	brief := map[string]any{"summary": "validated"}
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/inst-1",
@@ -831,7 +831,7 @@ func TestEntityTools_SearchEntitiesAcceptsAnnotatedJSONBFilter(t *testing.T) {
 }
 
 func TestEntityTools_SaveEntityFieldAllowsDeclaredNestedWritePath(t *testing.T) {
-	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	ctx, exec := newAnnotatedEntityToolExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/inst-1",
 		"fields": map[string]any{
@@ -880,7 +880,7 @@ func TestEntityTools_SaveEntityFieldAllowsDeclaredNestedWritePath(t *testing.T) 
 }
 
 func TestEntityTools_SaveEntityFieldAllowsNestedListWritePath(t *testing.T) {
-	ctx, exec := newAnnotatedEntityToolExecutor(t)
+	ctx, exec := newAnnotatedEntityToolExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/inst-1",
 		"fields": map[string]any{
@@ -925,7 +925,8 @@ func TestEntityTools_SaveEntityFieldRejectsInvalidDottedPathsBeforePersistence(t
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
-	})
+	}, testutil.PostgresRowState())
+
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -999,7 +1000,7 @@ accounts:
     immutable: true
   status: text
 `)
-	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1032,7 +1033,8 @@ func TestEntityTools_ReadsIgnoreLegacyUndeclaredStoredFields(t *testing.T) {
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "query_entities"},
-	})
+	}, testutil.PostgresRowState())
+
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1083,7 +1085,7 @@ func TestEntityTools_ReadsIgnoreLegacyUndeclaredStoredFields(t *testing.T) {
 }
 
 func TestEntityTools_SaveEntityField_LogsMutationRow(t *testing.T) {
-	ctx, exec, db := newEntityToolTestHarness(t)
+	ctx, exec, db := newEntityToolTestHarness(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1141,7 +1143,8 @@ func TestEntityTools_SaveEntityField_LogsNestedMutationRow(t *testing.T) {
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
-	})
+	}, testutil.PostgresRowState())
+
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1195,7 +1198,7 @@ func TestEntityTools_SaveEntityField_LogsNestedMutationRow(t *testing.T) {
 }
 
 func TestEntityTools_CreateEntity_LogsInitialMutationRows(t *testing.T) {
-	ctx, exec, db := newEntityToolTestHarness(t)
+	ctx, exec, db := newEntityToolTestHarness(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1244,7 +1247,7 @@ func TestEntityTools_CreateEntity_LogsInitialMutationRows(t *testing.T) {
 }
 
 func TestEntityTools_GetEntityReturnsStoredCurrentState(t *testing.T) {
-	ctx, exec, db := newEntityToolTestHarness(t)
+	ctx, exec, db := newEntityToolTestHarness(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1503,7 +1506,7 @@ accounts:
 }
 
 func TestEntityTools_SearchAndQueryUseStoredCurrentState(t *testing.T) {
-	ctx, exec, db := newEntityToolTestHarness(t)
+	ctx, exec, db := newEntityToolTestHarness(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1559,7 +1562,7 @@ func TestEntityTools_SearchAndQueryUseStoredCurrentState(t *testing.T) {
 }
 
 func TestEntityTools_QueryEntitiesFilterAllowsDeclaredNestedLeaf(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	_ = mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -1593,7 +1596,7 @@ func TestEntityTools_QueryEntitiesFilterAllowsDeclaredNestedLeaf(t *testing.T) {
 }
 
 func TestEntityTools_QueryEntitiesFilterRejectsUndeclaredFieldBeforeEvalWithNearestMatch(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 
 	_, err := exec.Execute(ctx, "query_entities", map[string]any{
 		"filter": `metadata.regoin == "us"`,
@@ -1609,7 +1612,7 @@ func TestEntityTools_QueryEntitiesFilterRejectsUndeclaredFieldBeforeEvalWithNear
 }
 
 func TestEntityTools_QueryEntitiesFilterRejectsEntityScopedSelectors(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 
 	_, err := exec.Execute(ctx, "query_entities", map[string]any{
 		"filter": `entity.metadata.region == "us"`,
@@ -1625,7 +1628,7 @@ func TestEntityTools_QueryEntitiesFilterRejectsEntityScopedSelectors(t *testing.
 }
 
 func TestEntityTools_QueryMetricsFilterRejectsUndeclaredFieldBeforeEval(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 
 	_, err := exec.Execute(ctx, "query_metrics", map[string]any{
 		"metric": "count",
@@ -1662,7 +1665,8 @@ signal:
 		ID:    "researcher",
 		Role:  "researcher",
 		Tools: []string{"query_entities", "query_metrics", "search_entities"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
+
 	subjectID := uuid.NewString()
 	seedEntityStateRow(t, db, uuid.NewString(), subjectID, "discovery/run-1", "campaign", "active", map[string]any{"status": "open"}, time.Now().UTC().Truncate(time.Second))
 	seedEntityStateRow(t, db, uuid.NewString(), subjectID, "signal-search/run-1", "signal", "active", map[string]any{
@@ -1779,7 +1783,7 @@ child_subject:
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides(%s): %v", root, err)
 	}
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle, testutil.PostgresRowState())
 	rootID := uuid.NewString()
 	childID := uuid.NewString()
 	seedEntityStateRow(t, db, rootID, rootID, "", "root_subject", "active", map[string]any{
@@ -1856,7 +1860,7 @@ validation_case:
     initial: {}
   score: integer
 `)
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle, testutil.PostgresRowState())
 
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/case-1",
@@ -1985,7 +1989,7 @@ signal:
 		ID:    "researcher",
 		Role:  "researcher",
 		Tools: []string{"query_entities", "query_metrics", "search_entities"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
 
 	_, err := exec.Execute(ctx, "query_entities", map[string]any{
 		"entity_type": "discovery.campaign",
@@ -2049,7 +2053,7 @@ signal:
 }
 
 func TestEntityTools_InvalidField(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "review/inst-1",
 		"fields": map[string]any{
@@ -2068,7 +2072,7 @@ func TestEntityTools_InvalidField(t *testing.T) {
 }
 
 func TestEntityTools_GetEntityNotFound(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	_, err := exec.Execute(ctx, "get_entity", map[string]any{
 		"entity_id": uuid.NewString(),
 	})
@@ -2079,7 +2083,7 @@ func TestEntityTools_GetEntityNotFound(t *testing.T) {
 }
 
 func TestEntityTools_CreateEntityRejectsCallerSuppliedEntityID(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	_, err := exec.Execute(ctx, "create_entity", map[string]any{
 		"entity_id":     uuid.NewString(),
 		"flow_instance": "review/inst-1",
@@ -2096,7 +2100,7 @@ func TestEntityTools_CreateEntityRejectsCallerSuppliedEntityID(t *testing.T) {
 }
 
 func TestEntityTools_CreateEntityRejectsCallerSuppliedEntityType(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	_, err := exec.Execute(ctx, "create_entity", map[string]any{
 		"entity_type":   "accounts",
 		"flow_instance": "review/inst-1",
@@ -2111,7 +2115,7 @@ func TestEntityTools_CreateEntityRejectsCallerSuppliedEntityType(t *testing.T) {
 }
 
 func TestEntityTools_CreateEntityRejectsCallerSuppliedSubjectID(t *testing.T) {
-	ctx, exec := newEntityToolTestExecutor(t)
+	ctx, exec := newEntityToolTestExecutor(t, testutil.PostgresRowState())
 	_, err := exec.Execute(ctx, "create_entity", map[string]any{
 		"subject_id":    uuid.NewString(),
 		"flow_instance": "review/inst-1",
@@ -2130,7 +2134,8 @@ func TestEntityTools_ConstrainedAllowedToolsDoNotPermitLegacyEntityTools(t *test
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"emit_something"},
-	})
+	}, testutil.PostgresRowState())
+
 	entityID := uuid.NewString()
 	if _, err := exec.Execute(ctx, "create_entity", map[string]any{
 		"entity_id":     entityID,
@@ -2154,7 +2159,8 @@ func TestEntityTools_CreateEntityRejectsFlowWithoutEntityContract(t *testing.T) 
 		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
 	}, &runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{InitialStage: "queued"},
-	})
+	}, testutil.PostgresRowState())
+
 	_, err := exec.Execute(ctx, "create_entity", map[string]any{
 		"flow_instance": "review/inst-1",
 	})
@@ -2186,7 +2192,8 @@ foreign:
 		ID:    "analyzer",
 		Role:  "analyzer",
 		Tools: []string{"save_entity_field", "get_entity"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
+
 	entityID := uuid.NewString()
 	seedEntityStateRow(t, db, entityID, entityID, "other-flow/inst-1", "foreign", "queued", map[string]any{"status": "open"}, time.Now().UTC().Truncate(time.Second))
 
@@ -2271,7 +2278,8 @@ analysis:
 		ID:    "analyzer",
 		Role:  "analyzer",
 		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
+
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "analyzer-flow/inst-1",
 		"fields": map[string]any{
@@ -2302,7 +2310,8 @@ analysis:
 		ID:    "analyzer",
 		Role:  "analyzer",
 		Tools: []string{"create_entity", "save_entity_field", "get_entity"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
+
 	entityID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "analyzer-flow/inst-1",
 		"fields": map[string]any{
@@ -2341,7 +2350,8 @@ foreign:
 		ID:    "analyzer",
 		Role:  "analyzer",
 		Tools: []string{"get_entity"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
+
 	entityID := uuid.NewString()
 	seedEntityStateRow(t, db, entityID, entityID, "other-flow/inst-1", "foreign", "open", map[string]any{"status": "foreign"}, time.Now().UTC().Truncate(time.Second))
 
@@ -2377,7 +2387,7 @@ operating_case:
 `,
 		},
 	})
-	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, db := newEntityToolTestHarnessWithBundle(t, actor, bundle, testutil.PostgresRowState())
 	firstID := mustCreateEntityID(t, ctx, exec, map[string]any{
 		"flow_instance": "validation/case-1",
 		"fields": map[string]any{
@@ -2586,7 +2596,7 @@ foreign:
 		ID:    "analyzer",
 		Role:  "analyzer",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field"},
-	}, bundle)
+	}, bundle, testutil.PostgresRowState())
 
 	scoringID := uuid.NewString()
 	subjectID := uuid.NewString()
@@ -2620,17 +2630,18 @@ foreign:
 	}
 }
 
-func newEntityToolTestExecutor(t *testing.T) (context.Context, *runtimetools.Executor) {
+func newEntityToolTestExecutor(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor) {
 	t.Helper()
 	ctx, exec, _ := newEntityToolTestHarnessWithActor(t, models.AgentConfig{
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
-	})
+	}, requirement)
+
 	return ctx, exec
 }
 
-func newEntityToolTestExecutorWithActor(t *testing.T, actor models.AgentConfig) (context.Context, *runtimetools.Executor) {
+func newEntityToolTestExecutorWithActor(t *testing.T, actor models.AgentConfig, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor) {
 	t.Helper()
 	bundle := loadWave1EntityToolBundle(t, actor, "review", "accounts", `
 types:
@@ -2657,17 +2668,17 @@ accounts:
   mvp_spec: Spec
   validation_kit: ValidationKit
 `)
-	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle, requirement)
 	return ctx, exec
 }
 
-func newEntityToolTestExecutorWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor) {
+func newEntityToolTestExecutorWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor) {
 	t.Helper()
-	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	ctx, exec, _ := newEntityToolTestHarnessWithBundle(t, actor, bundle, requirement)
 	return ctx, exec
 }
 
-func newAnnotatedEntityToolExecutor(t *testing.T) (context.Context, *runtimetools.Executor) {
+func newAnnotatedEntityToolExecutor(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor) {
 	t.Helper()
 	return newEntityToolTestExecutorWithBundle(t, models.AgentConfig{
 		ID:    "tester",
@@ -2692,19 +2703,21 @@ validation:
   business_brief: Brief
   mvp_spec: Spec
   validation_kit: ValidationKit
-`))
+`), requirement)
+
 }
 
-func newEntityToolTestHarness(t *testing.T) (context.Context, *runtimetools.Executor, *sql.DB) {
+func newEntityToolTestHarness(t *testing.T, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
 	return newEntityToolTestHarnessWithActor(t, models.AgentConfig{
 		ID:    "tester",
 		Role:  "operator",
 		Tools: []string{"create_entity", "get_entity", "save_entity_field", "search_entities", "query_entities", "query_metrics"},
-	})
+	}, requirement)
+
 }
 
-func newEntityToolTestHarnessWithActor(t *testing.T, actor models.AgentConfig) (context.Context, *runtimetools.Executor, *sql.DB) {
+func newEntityToolTestHarnessWithActor(t *testing.T, actor models.AgentConfig, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
 	if strings.TrimSpace(actor.Type) == "" {
 		actor.Type = "internal"
@@ -2734,12 +2747,12 @@ accounts:
   mvp_spec: Spec
   validation_kit: ValidationKit
 `)
-	return newEntityToolTestHarnessWithBundle(t, actor, bundle)
+	return newEntityToolTestHarnessWithBundle(t, actor, bundle, requirement)
 }
 
-func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle) (context.Context, *runtimetools.Executor, *sql.DB) {
+func newEntityToolTestHarnessWithBundle(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB) {
 	t.Helper()
-	return newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, true, testutil.PostgresRowState())
+	return newEntityToolTestHarnessWithBundleAndLegacyAccess(t, actor, bundle, true, requirement)
 }
 
 func newEntityToolTestHarnessWithBundleAndLegacyAccess(t *testing.T, actor models.AgentConfig, bundle *runtimecontracts.WorkflowContractBundle, allowInternalLegacy bool, requirement testutil.DatabaseRequirement) (context.Context, *runtimetools.Executor, *sql.DB) {

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -68,7 +68,7 @@ accounts:
   score: numeric
   priority: integer
 `)
-	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ensureSQLiteEntityToolTestRun(t, sqliteStore)
 	ctx := runtimetools.WithActor(runtimecorrelation.WithRunID(unmanagedToolTestContext(), entityToolTestRunID), actor)
 	exec := runtimetools.NewExecutorWithOptions(nil, nil, runtimetools.ExecutorOptions{
@@ -139,7 +139,7 @@ accounts:
 }
 
 func TestSQLiteEntityPersistence_MarshalsStructuredFilterValues(t *testing.T) {
-	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ensureSQLiteEntityToolTestRun(t, sqliteStore)
 	ctx := runtimecorrelation.WithRunID(unmanagedToolTestContext(), entityToolTestRunID)
 	entityID := uuid.NewString()
@@ -181,7 +181,7 @@ func TestSQLiteEntityPersistence_MarshalsStructuredFilterValues(t *testing.T) {
 func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
 	actor := models.AgentConfig{ID: "validation-orchestrator", Role: "validation_orchestrator", Tools: []string{"save_entity_field"}}
 	bundle := loadRoleScopedEntityToolBundle(t, actor, true)
-	sqliteStore := newSQLiteRuntimeToolStoreForTest(t)
+	sqliteStore := newSQLiteRuntimeToolStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ensureSQLiteEntityToolTestRun(t, sqliteStore)
 	ctx := runtimecorrelation.WithRunID(unmanagedToolTestContext(), entityToolTestRunID)
 	entityID := uuid.NewString()
@@ -243,8 +243,8 @@ func TestHumanTaskTools_BackendNeutralPersistence(t *testing.T) {
 		name  string
 		store humanTaskToolStore
 	}{
-		{name: "postgres", store: newPostgresHumanTaskToolStoreForTest(t)},
-		{name: "sqlite", store: newSQLiteRuntimeToolStoreForTest(t)},
+		{name: "postgres", store: newPostgresHumanTaskToolStoreForTest(t, testutil.PostgresRowState())},
+		{name: "sqlite", store: newSQLiteRuntimeToolStoreForTest(t, testutil.SQLiteDefaultTemp())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &config.Config{Extensions: map[string]any{
@@ -478,14 +478,14 @@ func createHumanTaskWithExecutor(t *testing.T, exec *runtimetools.Executor, acto
 	return taskID
 }
 
-func newPostgresHumanTaskToolStoreForTest(t *testing.T) *store.PostgresStore {
+func newPostgresHumanTaskToolStoreForTest(t *testing.T, requirement testutil.DatabaseRequirement) *store.PostgresStore {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	return &store.PostgresStore{DB: db}
 }
 
-func newSQLiteRuntimeToolStoreForTest(t *testing.T) *store.SQLiteRuntimeStore {
+func newSQLiteRuntimeToolStoreForTest(t *testing.T, requirement testutil.DatabaseRequirement) *store.SQLiteRuntimeStore {
 	t.Helper()
 	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(runtimepipeline.WorkflowRepoRoot()))
 	if err != nil {
@@ -499,7 +499,7 @@ func newSQLiteRuntimeToolStoreForTest(t *testing.T) *store.SQLiteRuntimeStore {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	sqliteStore, err := store.NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "dev.db"))
+	sqliteStore, err := store.NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, requirement, filepath.Join(t.TempDir(), "dev.db")))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -315,7 +315,7 @@ func TestResolveWorkspace_PerFlowInstanceSharesByFlowPath(t *testing.T) {
 }
 
 func TestRuntimeWorkspaceContainersWithoutRunContextReturnsStaticContainers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	manager := NewDockerManager(db)
 	containers, err := manager.RuntimeWorkspaceContainers(context.Background())
 	if err != nil {

--- a/internal/store/agent_directive_operations_test.go
+++ b/internal/store/agent_directive_operations_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSQLiteDirectiveOperationOwnsReservationExecutionAndCompletion(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	req := directiveOperationReservationForTest(t, "00000000-0000-0000-0000-000000001001", "00000000-0000-0000-0000-000000001002", "idem-1", "hash-1", now)
 
@@ -87,7 +87,7 @@ func TestSQLiteDirectiveOperationOwnsReservationExecutionAndCompletion(t *testin
 
 func TestSQLiteDirectiveOperationRecoveryNeverReadmitsUncertainExecution(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
 
 	executingReq := directiveOperationReservationForTest(t, "00000000-0000-0000-0000-000000001101", "00000000-0000-0000-0000-000000001102", "idem-recovery", "hash-recovery", now)
@@ -147,8 +147,8 @@ func TestSQLiteDirectiveOperationRecoveryNeverReadmitsUncertainExecution(t *test
 func TestSQLiteDirectiveOperationConcurrentSameKeyHasOneReservation(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "directive.db")
-	first := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
-	second, err := NewSQLiteRuntimeStore(path)
+	first := newBootstrappedSQLiteRuntimeStoreForPath(t, path, testutil.SQLiteSharedFile())
+	second, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), path))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore second handle: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestSQLiteDirectiveOperationFinalizationFailuresRollbackToExecuted(t *testi
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+			store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 			now := time.Date(2026, 7, 10, 14, 30, 0, 0, time.UTC)
 			reserved := reserveAndRecordExecutedDirectiveForTest(t, ctx, store, now)
 			if _, err := store.DB.Exec(tc.triggerSQL); err != nil {
@@ -248,7 +248,7 @@ func TestSQLiteDirectiveOperationFinalizationFailuresRollbackToExecuted(t *testi
 
 func TestSQLiteDirectiveOperationResultPersistenceFailureBecomesIndeterminate(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 7, 10, 14, 45, 0, 0, time.UTC)
 	req := directiveOperationReservationForTest(t, "00000000-0000-0000-0000-000000001251", "00000000-0000-0000-0000-000000001252", "result-failure", "result-hash", now)
 	reserved, err := store.ReserveDirectiveOperation(ctx, req)
@@ -285,7 +285,7 @@ func TestSQLiteDirectiveOperationResultPersistenceFailureBecomesIndeterminate(t 
 
 func TestSQLiteDirectiveOperationReservationFailureRollsBackEveryFact(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 7, 10, 14, 50, 0, 0, time.UTC)
 	if _, err := store.DB.Exec(`CREATE TRIGGER fail_directive_event BEFORE INSERT ON events WHEN NEW.event_name = 'platform.agent_directive' BEGIN SELECT RAISE(ABORT, 'injected event failure'); END`); err != nil {
 		t.Fatalf("create event trigger: %v", err)
@@ -310,7 +310,7 @@ func TestSQLiteDirectiveOperationReservationFailureRollsBackEveryFact(t *testing
 }
 
 func TestPostgresDirectiveOperationOwnsReservationExecutionAndCompletion(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	store := &PostgresStore{DB: db}
@@ -345,7 +345,7 @@ func TestPostgresDirectiveOperationOwnsReservationExecutionAndCompletion(t *test
 }
 
 func TestPostgresDirectiveOperationConcurrentSameKeyHasOneReservationAndAdmission(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	stores := []*PostgresStore{{DB: db}, {DB: db}}
@@ -399,7 +399,7 @@ func TestPostgresDirectiveOperationConcurrentSameKeyHasOneReservationAndAdmissio
 }
 
 func TestPostgresDirectiveOperationRecoveryNeverReadmitsUncertainExecution(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	store := &PostgresStore{DB: db}
@@ -458,7 +458,7 @@ func TestPostgresDirectiveOperationFinalizationFailuresRollbackToExecuted(t *tes
 		{name: "api projection failure", triggerName: "fail_pg_directive_projection", table: "api_idempotency"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, cleanup := testutil.StartPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			ctx := context.Background()
 			store := &PostgresStore{DB: db}
@@ -492,7 +492,7 @@ func TestPostgresDirectiveOperationFinalizationFailuresRollbackToExecuted(t *tes
 }
 
 func TestPostgresDirectiveOperationResultPersistenceFailureBecomesIndeterminate(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	store := &PostgresStore{DB: db}
@@ -523,7 +523,7 @@ func TestPostgresDirectiveOperationResultPersistenceFailureBecomesIndeterminate(
 }
 
 func TestPostgresDirectiveOperationReservationFailureRollsBackEveryFact(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	store := &PostgresStore{DB: db}

--- a/internal/store/agent_directive_run_target_test.go
+++ b/internal/store/agent_directive_run_target_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPostgresStoreResolveAgentDirectiveRunTarget(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}

--- a/internal/store/agent_lifecycle_effects_test.go
+++ b/internal/store/agent_lifecycle_effects_test.go
@@ -22,22 +22,22 @@ type lifecycleEffectStore interface {
 }
 
 func TestLifecycleAndExternalEffectAuthoritySQLite(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	proveLifecycleAndExternalEffectAuthority(t, store, store.DB, true)
 }
 
 func TestLifecycleAndExternalEffectAuthorityPostgres(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	proveLifecycleAndExternalEffectAuthority(t, &PostgresStore{DB: db}, db, false)
 }
 
 func TestProviderHeadSettlementFencesLifecycleAndLeaseSQLite(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	proveProviderHeadSettlementFencesLifecycleAndLease(t, store, store.DB, true)
 }
 
 func TestProviderHeadSettlementFencesLifecycleAndLeasePostgres(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	proveProviderHeadSettlementFencesLifecycleAndLease(t, &PostgresStore{DB: db}, db, false)
 }
 

--- a/internal/store/agent_lifecycle_read_surface_test.go
+++ b/internal/store/agent_lifecycle_read_surface_test.go
@@ -28,7 +28,7 @@ func TestAgentLifecycleBlockingLayerCoversEveryCurrentProducerState(t *testing.T
 }
 
 func TestPostgresStore_ListAgentDeliveryLifecycleFacts_CoversEveryCurrentStateLayerPair(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := NewPostgresStore(dsn)
@@ -97,7 +97,7 @@ func TestPostgresStore_ListAgentDeliveryLifecycleFacts_CoversEveryCurrentStateLa
 }
 
 func TestPostgresStore_ListAgentDeliveryLifecycleFacts_UsesCanonicalLiveLifecycle(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := NewPostgresStore(dsn)
@@ -150,7 +150,7 @@ func TestPostgresStore_ListAgentDeliveryLifecycleFacts_UsesCanonicalLiveLifecycl
 }
 
 func TestPostgresStore_ListAgentDeliveryLifecycleFacts_UsesCanonicalTerminalLifecycleWhenNoLiveWorkRemains(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	pg, err := NewPostgresStore(dsn)

--- a/internal/store/budget_spend_test.go
+++ b/internal/store/budget_spend_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"regexp"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ import (
 
 func TestSQLiteRuntimeStoreBudgetSpendPersistence(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	activeEntity := uuid.NewString()
 	terminalEntity := uuid.NewString()

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBundleCatalogReadSurfaceListGetAgentsAndCursor(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -122,7 +122,7 @@ agents:
 }
 
 func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -151,7 +151,7 @@ func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.
 }
 
 func TestBundleCatalogWriteSurfaceUpsertsAndRejectsHashCollision(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	bundleHash := "bundle-v1:sha256:5555555555555555555555555555555555555555555555555555555555555555"
@@ -197,7 +197,7 @@ func TestBundleCatalogWriteSurfaceUpsertsAndRejectsHashCollision(t *testing.T) {
 }
 
 func TestBundleCatalogUpsertRegistersDuplicatesConflictsAndDoesNotRestoreDeletedRuns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 

--- a/internal/store/bundle_delete_test.go
+++ b/internal/store/bundle_delete_test.go
@@ -21,7 +21,7 @@ const bundleDeleteTestHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const bundleDeleteOtherHash = "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 func TestPostgresStore_BundleDeleteForceCleanupAndFinalMutation(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestPostgresStore_BundleDeleteForceCleanupAndFinalMutation(t *testing.T) {
 }
 
 func TestPostgresStore_BundleDeleteFinalMutationFailsBeforeDeletingWithActiveRuns(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -146,7 +146,7 @@ func TestPostgresStore_BundleDeleteFinalMutationFailsBeforeDeletingWithActiveRun
 }
 
 func TestPostgresStore_BundleDeleteFinalMutationMarksOnlyNonActivePersistedRunsDeleted(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestPostgresStore_BundleDeleteFinalMutationMarksOnlyNonActivePersistedRunsD
 }
 
 func TestPostgresStore_BundleDeleteFinalMutationSerializesConcurrentRunCreation(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -256,7 +256,7 @@ func TestPostgresStore_BundleDeleteFinalMutationSerializesConcurrentRunCreation(
 }
 
 func TestPostgresStore_BundleDeleteFinalMutationBlocksPostDeletePersistedSourceRunCreation(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/conversation_fork_lifecycle_test.go
+++ b/internal/store/conversation_fork_lifecycle_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPostgresStore_ConversationForkLifecycleOwnsCreateListViewDelete(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := activeConversationForkTestClock()
@@ -140,7 +140,7 @@ func activeConversationForkTestClock() time.Time {
 }
 
 func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := activeConversationForkTestClock()
@@ -185,7 +185,7 @@ func TestPostgresStore_ConversationForkLifecycleFailsClosedForSelectors(t *testi
 }
 
 func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := activeConversationForkTestClock()
@@ -407,7 +407,7 @@ func TestPostgresStore_ConversationForkChatOwnsSnapshotTranscriptAndIsolation(t 
 }
 
 func TestPostgresStore_ConversationForkChatAllocatesConcurrentTurns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := activeConversationForkTestClock()

--- a/internal/store/dead_letters_test.go
+++ b/internal/store/dead_letters_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRecordDeadLetter_PersistsAndDedupes(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -71,7 +71,7 @@ func TestRecordDeadLetter_PersistsAndDedupes(t *testing.T) {
 }
 
 func TestRecordDeadLetter_AllowsNonUUIDEntityIDViaSourceEventPayload(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -112,7 +112,7 @@ func TestRecordDeadLetter_AllowsNonUUIDEntityIDViaSourceEventPayload(t *testing.
 }
 
 func TestRecordDeadLetter_PersistsTargetResolutionFailureContext(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 

--- a/internal/store/delivery_receipt_invariants_test.go
+++ b/internal/store/delivery_receipt_invariants_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"strings"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func TestCanonicalDeliveryOwnerInvariant_PendingSurfacesAgree_V2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pg, cleanup := newTestPostgresStore(t)
+			pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 			defer cleanup()
 
 			ctx := context.Background()
@@ -97,7 +98,7 @@ func TestCanonicalDeliveryOwnerInvariant_PendingSurfacesAgree_V2(t *testing.T) {
 }
 
 func TestCanonicalDeliveryOwnerInvariant_ReceiptRowsRemainOutcomeOnly_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesRunScopedRowsAndPreservesBoundaries(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesRunScopedRowsAndPrese
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunCountsWithoutMutation(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -148,7 +148,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunCountsWithoutMutation(
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_RejectsExecutingDirectiveAuthority(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RetainsTerminalDirectiveAuth
 		runtimeagentcontrol.DirectiveOperationFailed,
 	} {
 		t.Run(string(terminalState), func(t *testing.T) {
-			dsn, _, cleanup := testutil.StartPostgres(t)
+			dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			t.Cleanup(cleanup)
 			pg, err := NewPostgresStore(dsn)
 			if err != nil {
@@ -257,7 +257,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RetainsTerminalDirectiveAuth
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesDeletesBundleCatalog(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -299,7 +299,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesDeletesBundleC
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_ExcludeBundlesPreservesBundleCatalog(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -341,7 +341,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_ExcludeBundlesPreservesBundl
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunIncludeBundlesCountsWithoutMutation(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -377,7 +377,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DryRunIncludeBundlesCountsWi
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesRejectsOutOfPlanPersistedRun(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -421,7 +421,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_IncludeBundlesRejectsOutOfPl
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_DoesNotDeleteRunsCreatedAfterPlan(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -478,7 +478,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DoesNotDeleteRunsCreatedAfte
 }
 
 func TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanup(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -530,7 +530,7 @@ func TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanu
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesIntoCleanupSet(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -731,7 +731,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesForkLineageRowsByLinkedEventsAndDeliveries(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -858,7 +858,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_DeletesForkLineageRowsByLink
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_RollsBackOnUnknownForeignKeyReference(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -908,7 +908,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RollsBackOnUnknownForeignKey
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_RequiresAppliedQuiescence(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -932,7 +932,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RequiresAppliedQuiescence(t 
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_RejectsStaleQuiescenceEnvelope(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -970,7 +970,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_RejectsStaleQuiescenceEnvelo
 }
 
 func TestPostgresStore_ApplyDestructiveResetCleanup_RequiresPlannedCleanupRunSet(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/destructive_reset_directive_integration_test.go
+++ b/internal/store/destructive_reset_directive_integration_test.go
@@ -45,7 +45,7 @@ func (a *destructiveResetBlockingDirectiveAgent) BoardStep(context.Context, runt
 }
 
 func TestDestructiveResetFailsClosedWhileDirectiveBoardStepIsRunning(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 	pg := &store.PostgresStore{DB: db}

--- a/internal/store/destructive_reset_lock_test.go
+++ b/internal/store/destructive_reset_lock_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPostgresStore_TryAcquireSerializesDestructiveResetLock(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/destructive_reset_quiescence_test.go
+++ b/internal/store/destructive_reset_quiescence_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDeliveries(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -175,7 +175,7 @@ func TestPostgresStore_ApplyDestructiveResetQuiescence_TerminalizesRunsAndDelive
 }
 
 func TestPostgresStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableWork(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -278,7 +278,7 @@ func TestPostgresStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableW
 }
 
 func TestSQLiteRuntimeStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecoverableWork(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	now := time.Date(2026, 5, 18, 2, 10, 0, 0, time.UTC)
 	runID := uuid.NewString()
@@ -383,7 +383,7 @@ func TestSQLiteRuntimeStore_ApplyServeAbandonActiveRunQuiescence_QuiescesRecover
 }
 
 func TestPostgresStore_ApplyDestructiveResetQuiescence_DryRunDoesNotMutate(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/diagnostic_direct_replay_test.go
+++ b/internal/store/diagnostic_direct_replay_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSQLiteRuntimeStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	now := time.Now().Add(-time.Minute).UTC()
@@ -97,7 +97,7 @@ func TestSQLiteRuntimeStoreListEventsMissingPipelineReceiptExcludesDiagnosticDir
 
 func TestPostgresStoreListEventsMissingPipelineReceiptExcludesDiagnosticDirectEvents(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
 	entityID := uuid.NewString()

--- a/internal/store/directive_acknowledgment_test.go
+++ b/internal/store/directive_acknowledgment_test.go
@@ -180,14 +180,14 @@ type directiveAmbiguityBackend struct {
 	db    *sql.DB
 }
 
-func forEachDirectiveAmbiguityBackend(t *testing.T, run func(*testing.T, directiveAmbiguityBackend)) {
+func forEachDirectiveAmbiguityBackend(t *testing.T, run func(*testing.T, directiveAmbiguityBackend), requirement testutil.DatabaseRequirement, sqliteRequirement testutil.DatabaseRequirement) {
 	t.Helper()
 	t.Run("sqlite", func(t *testing.T) {
-		store := newBootstrappedSQLiteRuntimeStoreForPath(t, filepath.Join(t.TempDir(), "directive-ambiguity.db"))
+		store := newBootstrappedSQLiteRuntimeStoreForPath(t, filepath.Join(t.TempDir(), "directive-ambiguity.db"), sqliteRequirement)
 		run(t, directiveAmbiguityBackend{name: "sqlite", store: store, db: store.DB})
 	})
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 		t.Cleanup(cleanup)
 		store := &PostgresStore{DB: db}
 		run(t, directiveAmbiguityBackend{name: "postgres", store: store, db: db})
@@ -236,7 +236,7 @@ func TestDirectiveFailureFinalizationAcknowledgmentMatrix(t *testing.T) {
 				}
 			})
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveResultRecordingAcknowledgmentMatrix(t *testing.T) {
@@ -287,7 +287,7 @@ func TestDirectiveResultRecordingAcknowledgmentMatrix(t *testing.T) {
 				})
 			}
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveSuccessFinalizationAcknowledgmentMatrix(t *testing.T) {
@@ -328,7 +328,7 @@ func TestDirectiveSuccessFinalizationAcknowledgmentMatrix(t *testing.T) {
 				})
 			}
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveReconciliationAcknowledgmentMatrix(t *testing.T) {
@@ -373,7 +373,7 @@ func TestDirectiveReconciliationAcknowledgmentMatrix(t *testing.T) {
 				})
 			}
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveFailureFinalizationRollsBackReceiptAndOperationTogether(t *testing.T) {
@@ -400,7 +400,7 @@ func TestDirectiveFailureFinalizationRollsBackReceiptAndOperationTogether(t *tes
 		if got := h.agent.calls.Load(); got != 1 {
 			t.Fatalf("BoardStep calls after convergence = %d, want 1", got)
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveMalformedTypedBoardStepFailureCanonicalizesBeforePersistence(t *testing.T) {
@@ -419,7 +419,7 @@ func TestDirectiveMalformedTypedBoardStepFailureCanonicalizesBeforePersistence(t
 		if got := h.agent.calls.Load(); got != 1 {
 			t.Fatalf("BoardStep calls = %d, want 1", got)
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 func TestDirectiveOperationDatabaseEnforcesStateEvidenceEquivalence(t *testing.T) {
@@ -466,7 +466,7 @@ func TestDirectiveOperationDatabaseEnforcesStateEvidenceEquivalence(t *testing.T
 				assertDirectiveOperationEvidence(t, persisted, runtimeagentcontrol.DirectiveOperationPrepared, false, false)
 			})
 		}
-	})
+	}, testutil.PostgresFreshPhysical(), testutil.SQLiteFreshFile())
 }
 
 type directiveAmbiguityHarness struct {

--- a/internal/store/entity_state_run_scope_test.go
+++ b/internal/store/entity_state_run_scope_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEntityStateSchema_AllowsSameEntityIDInDifferentRuns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	runA := uuid.NewString()
 	runB := uuid.NewString()

--- a/internal/store/event_admission_persistence_test.go
+++ b/internal/store/event_admission_persistence_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPostgresEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -43,7 +43,7 @@ func TestPostgresEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 }
 
 func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFacts(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -85,7 +85,7 @@ func TestPostgresEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritative
 }
 
 func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 
 	err := sqliteStore.AppendEvent(ctx, eventtest.MalformedChildWithoutLineage(
@@ -110,7 +110,7 @@ func TestSQLiteEventAdmissionRejectsMalformedChildDirectAppend(t *testing.T) {
 }
 
 func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFacts(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 
 	err := sqliteStore.AppendEvent(ctx, eventtest.MalformedProjectionWithoutAuthoritativeFacts(
@@ -151,7 +151,7 @@ func TestSQLiteEventAdmissionRejectsProjectionDirectAppendWithoutAuthoritativeFa
 }
 
 func TestPostgresDiagnosticDirectWritersUseAdmissionFactsAndRemainNonRouted(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -208,7 +208,7 @@ func TestPostgresDiagnosticDirectWritersUseAdmissionFactsAndRemainNonRouted(t *t
 }
 
 func TestSQLiteRuntimeLogDiagnosticDirectUsesAdmissionFacts(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 
 	logger := runtimepkg.NewRuntimeLogger(sqliteStore)

--- a/internal/store/event_delivery_routes_test.go
+++ b/internal/store/event_delivery_routes_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgresStore_EventDeliveryRoutesPersistNodeTargetRows(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 
 	ctx := context.Background()

--- a/internal/store/failure_schema_migration_test.go
+++ b/internal/store/failure_schema_migration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPostgresCanonicalFailureMigrationNormalizesEveryDurableCarrier(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	createPostgresLegacyFailureTables(t, ctx, db)
 	ids := seedPostgresLegacyFailures(t, ctx, db)
@@ -43,7 +43,7 @@ func TestPostgresCanonicalFailureMigrationNormalizesEveryDurableCarrier(t *testi
 }
 
 func TestPostgresCanonicalFailureMigrationRejectsUnknownRowsAtomically(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	createPostgresLegacyFailureTables(t, ctx, db)
 	if _, err := db.ExecContext(ctx, `
@@ -63,7 +63,7 @@ func TestPostgresCanonicalFailureMigrationRejectsUnknownRowsAtomically(t *testin
 }
 
 func TestSQLiteCanonicalFailureMigrationNormalizesEveryDurableCarrier(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "failure-migration.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "failure-migration.db")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestSQLiteCanonicalFailureMigrationNormalizesEveryDurableCarrier(t *testing
 }
 
 func TestSQLiteCanonicalFailureMigrationPreservesReplyContextAddedByNewerMaster(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "failure-migration-reply-context.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "failure-migration-reply-context.db")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestSQLiteCanonicalFailureMigrationPreservesReplyContextAddedByNewerMaster(
 }
 
 func TestSQLiteCanonicalFailureMigrationRejectsUnknownRowsAtomically(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "failure-migration-unknown.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "failure-migration-unknown.db")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestSQLiteCanonicalFailureMigrationRejectsUnknownRowsAtomically(t *testing.
 }
 
 func TestPostgresRunTerminalEvidenceMigrationSplitsFailureFromCancellationReason(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `
 		DROP TABLE IF EXISTS run_control_state CASCADE;
@@ -182,7 +182,7 @@ func TestPostgresRunTerminalEvidenceMigrationSplitsFailureFromCancellationReason
 }
 
 func TestPostgresRunTerminalEvidenceMigrationRejectsAmbiguousFailedProseAtomically(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `DROP TABLE IF EXISTS runs CASCADE; CREATE TABLE runs (run_id UUID PRIMARY KEY, status TEXT NOT NULL, error_summary TEXT, ended_at TIMESTAMPTZ)`)
 	runID := uuid.NewString()
@@ -197,7 +197,7 @@ func TestPostgresRunTerminalEvidenceMigrationRejectsAmbiguousFailedProseAtomical
 }
 
 func TestSQLiteRunTerminalEvidenceMigrationSplitsFailureFromCancellationReason(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "run-terminal-migration.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "run-terminal-migration.db")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestSQLiteRunTerminalEvidenceMigrationSplitsFailureFromCancellationReason(t
 }
 
 func TestSQLiteRunTerminalEvidenceMigrationRejectsAmbiguousFailedProseAtomically(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "run-terminal-migration-reject.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "run-terminal-migration-reject.db")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestSQLiteRunTerminalEvidenceMigrationRejectsAmbiguousFailedProseAtomically
 }
 
 func TestPostgresCanonicalFailureMigrationReplacesEmptyAgentTurnError(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `DROP TABLE IF EXISTS agent_turns CASCADE`)
 	mustExecTest(t, ctx, db, `CREATE TABLE agent_turns (turn_id UUID PRIMARY KEY, error TEXT)`)
@@ -269,7 +269,7 @@ func TestPostgresCanonicalFailureMigrationReplacesEmptyAgentTurnError(t *testing
 }
 
 func TestPostgresCanonicalFailureMigrationRejectsAmbiguousAgentTurnErrorAtomically(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `DROP TABLE IF EXISTS agent_turns CASCADE`)
 	mustExecTest(t, ctx, db, `CREATE TABLE agent_turns (turn_id UUID PRIMARY KEY, error TEXT)`)
@@ -285,7 +285,7 @@ func TestPostgresCanonicalFailureMigrationRejectsAmbiguousAgentTurnErrorAtomical
 }
 
 func TestSQLiteCanonicalFailureMigrationReplacesEmptyAgentTurnError(t *testing.T) {
-	db := openSQLiteFailureMigrationTestDB(t, "agent-turn-empty.db")
+	db := openSQLiteFailureMigrationTestDB(t, "agent-turn-empty.db", testutil.SQLiteFreshFile())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `
 		CREATE TABLE agent_turns (turn_id TEXT PRIMARY KEY, error TEXT);
@@ -302,7 +302,7 @@ func TestSQLiteCanonicalFailureMigrationReplacesEmptyAgentTurnError(t *testing.T
 }
 
 func TestSQLiteCanonicalFailureMigrationRejectsAmbiguousAgentTurnErrorAtomically(t *testing.T) {
-	db := openSQLiteFailureMigrationTestDB(t, "agent-turn-ambiguous.db")
+	db := openSQLiteFailureMigrationTestDB(t, "agent-turn-ambiguous.db", testutil.SQLiteFreshFile())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `
 		CREATE TABLE agent_turns (turn_id TEXT PRIMARY KEY, error TEXT);
@@ -320,7 +320,7 @@ func TestSQLiteCanonicalFailureMigrationRejectsAmbiguousAgentTurnErrorAtomically
 }
 
 func TestPostgresCanonicalFailureMigrationNormalizesFailureBearingEvents(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `DROP TABLE IF EXISTS events CASCADE`)
 	mustExecTest(t, ctx, db, `CREATE TABLE events (event_id UUID PRIMARY KEY, event_name TEXT NOT NULL, payload JSONB NOT NULL)`)
@@ -335,7 +335,7 @@ func TestPostgresCanonicalFailureMigrationNormalizesFailureBearingEvents(t *test
 }
 
 func TestSQLiteCanonicalFailureMigrationNormalizesFailureBearingEvents(t *testing.T) {
-	db := openSQLiteFailureMigrationTestDB(t, "failure-events.db")
+	db := openSQLiteFailureMigrationTestDB(t, "failure-events.db", testutil.SQLiteFreshFile())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `CREATE TABLE events (event_id TEXT PRIMARY KEY, event_name TEXT NOT NULL, payload TEXT NOT NULL)`)
 	fixtures := seedSQLiteLegacyFailureEvents(t, ctx, db)
@@ -349,7 +349,7 @@ func TestSQLiteCanonicalFailureMigrationNormalizesFailureBearingEvents(t *testin
 }
 
 func TestPostgresCanonicalFailureMigrationRejectsUnknownFailureEventAtomically(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `DROP TABLE IF EXISTS events CASCADE`)
 	mustExecTest(t, ctx, db, `CREATE TABLE events (event_id UUID PRIMARY KEY, event_name TEXT NOT NULL, payload JSONB NOT NULL)`)
@@ -367,7 +367,7 @@ func TestPostgresCanonicalFailureMigrationRejectsUnknownFailureEventAtomically(t
 }
 
 func TestSQLiteCanonicalFailureMigrationRejectsUnknownFailureEventAtomically(t *testing.T) {
-	db := openSQLiteFailureMigrationTestDB(t, "failure-events-unknown.db")
+	db := openSQLiteFailureMigrationTestDB(t, "failure-events-unknown.db", testutil.SQLiteFreshFile())
 	ctx := context.Background()
 	mustExecTest(t, ctx, db, `CREATE TABLE events (event_id TEXT PRIMARY KEY, event_name TEXT NOT NULL, payload TEXT NOT NULL)`)
 	id := uuid.NewString()
@@ -471,9 +471,9 @@ func assertMigratedFailureEvents(t testing.TB, fixtures []legacyFailureEventFixt
 	}
 }
 
-func openSQLiteFailureMigrationTestDB(t testing.TB, name string) *sql.DB {
+func openSQLiteFailureMigrationTestDB(t testing.TB, name string, requirement testutil.DatabaseRequirement) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), name))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, requirement, filepath.Join(t.TempDir(), name)))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -605,7 +605,7 @@ func seedSQLiteLegacyFailures(t testing.TB, ctx context.Context, db *sql.DB) leg
 }
 
 func TestPostgresDirectiveOperationFailureMigrationMapsOnlyClosedRecoveryCodes(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	createPostgresLegacyDirectiveOperationTable(t, ctx, db)
 	leaseID, notAdmittedID := uuid.NewString(), uuid.NewString()
@@ -630,7 +630,7 @@ func TestPostgresDirectiveOperationFailureMigrationMapsOnlyClosedRecoveryCodes(t
 }
 
 func TestSQLiteDirectiveOperationFailureMigrationMapsOnlyClosedRecoveryCodes(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "directive-failure-migration.db"))
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "directive-failure-migration.db")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +663,7 @@ func TestPostgresDirectiveOperationFailureMigrationRejectsAmbiguousRowsAtomicall
 	tests := directiveOperationBlockedMigrationRows()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			ctx := context.Background()
 			createPostgresLegacyDirectiveOperationTable(t, ctx, db)
 			id := uuid.NewString()
@@ -682,7 +682,7 @@ func TestPostgresDirectiveOperationFailureMigrationRejectsAmbiguousRowsAtomicall
 func TestSQLiteDirectiveOperationFailureMigrationRejectsAmbiguousRowsAtomically(t *testing.T) {
 	for _, test := range directiveOperationBlockedMigrationRows() {
 		t.Run(test.name, func(t *testing.T) {
-			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "directive-failure-blocked.db"))
+			db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "directive-failure-blocked.db")))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/store/flow_instance_descriptors_sqlite_test.go
+++ b/internal/store/flow_instance_descriptors_sqlite_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -13,7 +14,7 @@ import (
 func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
 	const runID = "11111111-1111-4111-8111-111111111111"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
@@ -69,7 +70,7 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsFiltersToActiveTempl
 
 func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWithoutRunScope(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
@@ -104,7 +105,7 @@ func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWi
 
 func TestSQLiteRuntimeStoreListActiveFlowInstanceDescriptorsReadsPipelineTransaction(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
+	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx, testutil.SQLiteDefaultTemp())
 
 	tx, err := sqliteStore.DB.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/store/flow_instance_routes_test.go
+++ b/internal/store/flow_instance_routes_test.go
@@ -64,7 +64,7 @@ func ensureFlowInstanceRouteTables(t *testing.T, ctx context.Context, db *sql.DB
 
 func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -113,7 +113,7 @@ func TestPostgresStoreFlowInstanceRoutes(t *testing.T) {
 
 func TestPostgresStoreUpsertFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -171,7 +171,7 @@ func TestPostgresStoreUpsertFlowInstanceRouteUsesPipelineTransaction(t *testing.
 
 func TestPostgresStoreDeleteFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -229,7 +229,7 @@ func TestPostgresStoreDeleteFlowInstanceRouteUsesPipelineTransaction(t *testing.
 
 func TestPostgresStoreRollbackFlowInstanceRouteUsesPipelineTransaction(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -287,7 +287,7 @@ func TestPostgresStoreRollbackFlowInstanceRouteUsesPipelineTransaction(t *testin
 
 func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -336,7 +336,7 @@ func TestPostgresStoreFlowInstanceRoutes_NestedTemplateScope(t *testing.T) {
 
 func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -389,7 +389,7 @@ func TestPostgresStoreFlowInstanceRoutes_CanonicalizesInstancePathOnlyIdentity(t
 
 func TestPostgresStoreFlowInstanceRouteDeletionRequiresCanonicalTermination(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -442,7 +442,7 @@ func TestPostgresStoreFlowInstanceRouteDeletionRequiresCanonicalTermination(t *t
 
 func TestPostgresStoreListFlowInstanceRoutesFiltersTerminatedInstances(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -487,7 +487,7 @@ func TestPostgresStoreListFlowInstanceRoutesFiltersTerminatedInstances(t *testin
 func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(t *testing.T) {
 	const runID = "11111111-1111-4111-8111-111111111111"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -545,7 +545,7 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsFiltersToActiveTemplates(
 
 func TestPostgresStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWithoutRunScope(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 
@@ -582,7 +582,7 @@ func TestPostgresStoreListActiveFlowInstanceDescriptorsOmitsAddressFieldsWithout
 
 func TestPostgresStoreListActiveFlowInstanceDescriptorsReadsPipelineTransaction(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ensureFlowInstanceRouteTables(t, ctx, db)
 

--- a/internal/store/inbound_sqlite_test.go
+++ b/internal/store/inbound_sqlite_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
 
 func TestSQLiteRuntimeStore_RecordInboundEvent_DedupesWithCanonicalMarker(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	entityID := uuid.NewString()

--- a/internal/store/mailbox_materialization_test.go
+++ b/internal/store/mailbox_materialization_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	store := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -82,7 +82,7 @@ func TestPostgresStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *t
 }
 
 func TestSQLiteRuntimeStore_MaterializeMailboxWriteUsesTransactionAndV1ReadOwner(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	eventID := uuid.NewString()

--- a/internal/store/mailbox_v1_test.go
+++ b/internal/store/mailbox_v1_test.go
@@ -46,7 +46,7 @@ func TestMailboxDecisionCarriesLoopRevisionWithoutExposingInternalGeneration(t *
 }
 
 func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
@@ -311,7 +311,7 @@ func TestPostgresStore_V1MailboxReadDecisionAndIdempotencyOwners(t *testing.T) {
 }
 
 func TestPostgresStore_APIIdempotencyReplaysAndConflicts(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)

--- a/internal/store/manager_error_branches_test.go
+++ b/internal/store/manager_error_branches_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPostgresStore_Manager_ErrorBranches(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	const runID = "44444444-4444-4444-4444-444444444444"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)

--- a/internal/store/manager_retry_policy_test.go
+++ b/internal/store/manager_retry_policy_test.go
@@ -23,7 +23,7 @@ import (
 const retryPolicyEntityStateRunID = "22222222-2222-2222-2222-222222222222"
 
 func TestUpsertEventReceipt_DeadLettersAfterOneRetry_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -61,7 +61,7 @@ func TestUpsertEventReceipt_DeadLettersAfterOneRetry_V2(t *testing.T) {
 }
 
 func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -128,7 +128,7 @@ func TestUpsertEventReceipt_PreservesRetryableVsTerminalDeliveryStatus_V2(t *tes
 }
 
 func TestUpsertEventReceipt_ImmediateTerminalPreservesOriginalFailure_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 	ctx := context.Background()
 	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
@@ -151,7 +151,7 @@ func TestUpsertEventReceipt_ImmediateTerminalPreservesOriginalFailure_V2(t *test
 }
 
 func TestUpsertEventReceipt_DirectDeadLetterIsNotRetryExhaustion_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 	ctx := context.Background()
 	entityID, agentID := seedEntityAndAgent(t, ctx, pg)
@@ -174,7 +174,7 @@ func TestUpsertEventReceipt_DirectDeadLetterIsNotRetryExhaustion_V2(t *testing.T
 }
 
 func TestUpsertEventReceipt_AlignsRetryOwnershipOnCanonicalDelivery_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -245,7 +245,7 @@ func TestUpsertEventReceipt_AlignsRetryOwnershipOnCanonicalDelivery_V2(t *testin
 }
 
 func TestUpsertEventReceipt_FailsClosedOnLegacyReceiptOnlyRetryHistory_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -294,7 +294,7 @@ func TestUpsertEventReceipt_FailsClosedOnLegacyReceiptOnlyRetryHistory_V2(t *tes
 }
 
 func TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -369,7 +369,7 @@ func TestUpsertEventReceipt_ConcurrentErrorRetriesAdvanceAtomically_V2(t *testin
 }
 
 func TestUpsertEventReceipt_ConcurrentTerminalReceiptsConvergeStandaloneRuntimeRun_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresFreshPhysical())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -483,7 +483,7 @@ func TestUpsertEventReceipt_ConcurrentTerminalReceiptsConvergeStandaloneRuntimeR
 }
 
 func TestUpsertEventReceipt_RollsBackReceiptWhenDeliverySyncFails_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresFreshPhysical())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -566,7 +566,7 @@ func TestUpsertEventReceipt_RollsBackReceiptWhenDeliverySyncFails_V2(t *testing.
 }
 
 func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -621,7 +621,7 @@ func TestListPendingEventsForAgent_RetryBackoff_V2(t *testing.T) {
 }
 
 func TestListPendingSubscribedEvents_RetryBackoff_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -677,7 +677,7 @@ func TestPendingAgentEvents_IgnoreLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pg, cleanup := newTestPostgresStore(t)
+			pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 			defer cleanup()
 
 			ctx := context.Background()
@@ -720,7 +720,7 @@ func TestPendingAgentEvents_IgnoreLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
 }
 
 func TestListPendingAgentDeliveryFacts_IgnoresLegacyReceiptOnlyRetryOwner_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -753,7 +753,7 @@ func TestListPendingAgentDeliveryFacts_IgnoresLegacyReceiptOnlyRetryOwner_V2(t *
 }
 
 func TestListPendingAgentDeliveryFacts_AlignsWithCanonicalPendingStates_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -804,7 +804,7 @@ func TestListPendingAgentDeliveryFacts_AlignsWithCanonicalPendingStates_V2(t *te
 }
 
 func TestListPendingAgentDeliveryDetails_PagesCanonicalQueueTruth_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -925,7 +925,7 @@ func assertPendingDeliveryDetail(t *testing.T, got store.PendingAgentDeliveryDet
 }
 
 func TestListPendingAgentDeliveryFacts_UsesFullPendingHorizon_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -964,7 +964,7 @@ func TestListPendingAgentDeliveryFacts_UsesFullPendingHorizon_V2(t *testing.T) {
 }
 
 func TestListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -987,7 +987,7 @@ func TestListPendingEventsForAgent_InProgressWithoutReceipt_RemainsPending(t *te
 }
 
 func TestMarkEventDeliveryInProgress_AllowsRetryableFailedDeliveryClaim_V2(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -1020,7 +1020,7 @@ func TestMarkEventDeliveryInProgress_AllowsRetryableFailedDeliveryClaim_V2(t *te
 }
 
 func TestListPendingSubscribedEvents_UsesCanonicalMatcherParity(t *testing.T) {
-	pg, cleanup := newTestPostgresStore(t)
+	pg, cleanup := newTestPostgresStore(t, testutil.PostgresRowState())
 	defer cleanup()
 
 	ctx := context.Background()
@@ -1116,9 +1116,9 @@ func rewindCanonicalDeliveryAttempt(t *testing.T, ctx context.Context, pg *store
 	}
 }
 
-func newTestPostgresStore(t *testing.T) (*store.PostgresStore, func()) {
+func newTestPostgresStore(t *testing.T, requirement testutil.DatabaseRequirement) (*store.PostgresStore, func()) {
 	t.Helper()
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, requirement)
 	appDSN := dsn
 	pg, err := store.NewPostgresStore(appDSN)
 	if err != nil {

--- a/internal/store/manager_runtime_descriptor_regression_test.go
+++ b/internal/store/manager_runtime_descriptor_regression_test.go
@@ -42,7 +42,7 @@ func TestManagerStore_LoadAgents_FailsClosedOnMalformedRuntimeDescriptor(t *test
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 

--- a/internal/store/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/operator_agent_conversation_read_surface_test.go
@@ -551,7 +551,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDiagnosisUsesSelectedOwners(t *testing
 }
 
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOwner(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -684,7 +684,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOw
 }
 
 func TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -786,7 +786,7 @@ func TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated(t *testin
 
 func TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-1", "active")
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-2", "active")
 
@@ -833,7 +833,7 @@ func TestSQLiteRuntimeStoreLoadAgentUsageSplitsExactAndEstimated(t *testing.T) {
 
 func TestSQLiteRuntimeStoreLoadAgentUsageEmptyAndAgentExistence(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-empty", "active")
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-terminated", "terminated")
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-ephemeral", "ephemeral")
@@ -858,7 +858,7 @@ func TestSQLiteRuntimeStoreLoadAgentUsageEmptyAndAgentExistence(t *testing.T) {
 
 func TestSQLiteRuntimeStoreLoadAgentUsageFailsClosedOnMalformedRows(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	seedOperatorAgentUsageAgent(t, ctx, sqliteStore, "agent-1", "active")
 	if _, err := sqliteStore.DB.ExecContext(ctx, `
 		INSERT INTO spend_ledger (
@@ -894,7 +894,7 @@ func seedOperatorAgentUsageAgent(t *testing.T, ctx context.Context, store *SQLit
 }
 
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsDoesNotRequireConversationOwners(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -945,7 +945,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsDoesNotRequireConve
 }
 
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -1145,7 +1145,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres(t *testing.T
 }
 
 func TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	if err := sqliteStore.UpsertAgent(ctx, runtimemanager.PersistedAgent{
 		Config: runtimeactors.AgentConfig{
@@ -1393,7 +1393,7 @@ func assertAgentDeliveryLifecycleRows(t *testing.T, got []OperatorAgentDeliveryL
 }
 
 func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsFailsClosedOnDeadLetterMismatch(t *testing.T) {
-	dsn, db, cleanup := testutil.StartPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/operator_entity_read_surface_test.go
+++ b/internal/store/operator_entity_read_surface_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runA := uuid.NewString()
@@ -165,7 +165,7 @@ func TestOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 
 func TestSQLiteOperatorEntityReadOwnerListGetAggregateAndCursor(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	db := sqliteStore.DB
 
 	runA := uuid.NewString()

--- a/internal/store/operator_observability_read_surface_test.go
+++ b/internal/store/operator_observability_read_surface_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -135,7 +135,7 @@ func TestOperatorObservabilityEventOwnerFiltersDetailsAndCursor(t *testing.T) {
 
 func TestOperatorObservabilityEventOwnerDoesNotPromotePayloadEntityIdentity(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -203,7 +203,7 @@ func TestOperatorObservabilityEventOwnerDoesNotPromotePayloadEntityIdentity(t *t
 
 func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -336,7 +336,7 @@ func TestOperatorRuntimeObservabilityOwnerLogsIncidentsAndCursor(t *testing.T) {
 
 func TestPostgresRuntimeLogSourceFilterMatchesProjectionFallback(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -478,7 +478,7 @@ func assertRuntimeLogIDsAndSources(t *testing.T, logs []OperatorRuntimeLogEntry,
 
 func TestOperatorRuntimeLogsFilterBySessionAndTimeWindow(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -533,7 +533,7 @@ func TestOperatorRuntimeLogsFilterBySessionAndTimeWindow(t *testing.T) {
 
 func TestOperatorRuntimeObservabilityFiltersByBundleHash(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	bundleA := "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -614,7 +614,7 @@ func TestOperatorRuntimeObservabilityFiltersByBundleHash(t *testing.T) {
 
 func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -697,7 +697,7 @@ func TestRunDebugTracePageCursorAndRunNotFound(t *testing.T) {
 
 func TestRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()
@@ -734,7 +734,7 @@ func TestRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
 
 func TestRunDebugTracePageTypedFilters(t *testing.T) {
 	ctx := context.Background()
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	runID := uuid.NewString()

--- a/internal/store/postgres_helpers_test.go
+++ b/internal/store/postgres_helpers_test.go
@@ -73,7 +73,7 @@ func TestDSNFromConfigPinsDefaultNonSecretKeywordsAgainstPGEnv(t *testing.T) {
 }
 
 func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	connection, err := testpostgres.ParseConnection(dsn)
 	if err != nil {

--- a/internal/store/postgres_smoke_test.go
+++ b/internal/store/postgres_smoke_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	const runID = "66666666-6666-6666-6666-666666666666"
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -75,7 +75,7 @@ func acquireLiveTestSession(t *testing.T, ctx context.Context, db *sql.DB, agent
 }
 
 func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -153,7 +153,7 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationBackfillsLegacyRo
 }
 
 func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeliveries(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -238,7 +238,7 @@ func TestPostgresStore_MarkRunTerminal_UsesCanonicalCountersAndRejectsActiveDeli
 }
 
 func TestPostgresRunLifecycleEntityCountUsesEntityState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -288,7 +288,7 @@ func TestPostgresRunLifecycleEntityCountUsesEntityState(t *testing.T) {
 }
 
 func TestPostgresRunLifecycleFailsClosedWhenEntityStateCountSourceUnavailable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -341,7 +341,7 @@ func TestPostgresRunLifecycleFailsClosedWhenEntityStateCountSourceUnavailable(t 
 }
 
 func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -400,7 +400,7 @@ func TestPostgresStore_AppendEvent_ReopensPrematureCompletedRunAndSyncsCounters(
 }
 
 func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -470,7 +470,7 @@ func TestPostgresStore_AppendEvent_DuplicateDoesNotReopenCompletedRun(t *testing
 }
 
 func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -536,7 +536,7 @@ func TestPostgresStore_AppendEvent_AllowsRunsWithoutTriggerColumns(t *testing.T)
 }
 
 func TestPostgresStore_MarkRunTerminal_RejectsRunsWithoutCanonicalTerminalEvidenceColumns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -578,7 +578,7 @@ func TestPostgresStore_MarkRunTerminal_RejectsRunsWithoutCanonicalTerminalEviden
 }
 
 func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeDependentDDL(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -658,7 +658,7 @@ func TestPostgresStore_EnsureSchemaTables_PhasesAgentSessionCompatibilityBeforeD
 }
 
 func TestPostgresStore_EnsureSchemaTables_ReportsOutdatedSchemaForLegacyTimers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -714,7 +714,7 @@ func TestPostgresStore_EnsureSchemaTables_ReportsOutdatedSchemaForLegacyTimers(t
 }
 
 func TestPostgresStore_EnsureSchemaTables_AllowsCurrentTimerSchema(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -724,7 +724,7 @@ func TestPostgresStore_EnsureSchemaTables_AllowsCurrentTimerSchema(t *testing.T)
 }
 
 func TestPostgresStore_EnsureSchemaTables_AddsMailboxDeferredUntilAndNormalizesLegacyDeferredRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -857,7 +857,7 @@ func legacyTimerDiagnosticPlan() SchemaTableDDL {
 }
 
 func TestPostgresStore_EnsureSchemaTables_PhasesAgentRuntimeDescriptorCompatibilityBeforeDependentDDL(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -929,7 +929,7 @@ func TestPostgresStore_EnsureSchemaTables_PhasesAgentRuntimeDescriptorCompatibil
 }
 
 func TestPostgresStore_EnsureSchemaCompatibilityColumnsMigratesAgentLLMBackendProfiles(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1014,7 +1014,7 @@ func TestPostgresStore_EnsureSchemaCompatibilityColumnsMigratesAgentLLMBackendPr
 }
 
 func TestPostgresStore_EnsureAgentModelAliasColumnMigratesLegacyModelTier(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1075,7 +1075,7 @@ func TestPostgresStore_EnsureAgentModelAliasColumnMigratesLegacyModelTier(t *tes
 }
 
 func TestPostgresStore_EnsureAgentModelAliasColumnRejectsUnmappableLegacyModelTier(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1106,7 +1106,7 @@ func TestPostgresStore_EnsureAgentModelAliasColumnRejectsUnmappableLegacyModelTi
 }
 
 func TestPostgresStore_EnsureSchemaTables_PhasesConversationAuditRunIDCompatibilityBeforeDependentDDL(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1183,7 +1183,7 @@ func TestPostgresStore_EnsureSchemaTables_PhasesConversationAuditRunIDCompatibil
 }
 
 func TestPostgresStore_EnsureSchemaTables_DropsDeprecatedEntitySubjectCompatibility(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1245,7 +1245,7 @@ func TestPostgresStore_EnsureSchemaTables_DropsDeprecatedEntitySubjectCompatibil
 }
 
 func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurnsSupportsResetAll(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1338,7 +1338,7 @@ func TestPostgresStore_AgentSessionTerminationMetadataMigrationWithoutAgentTurns
 }
 
 func TestPostgresStore_AgentSessionsPartialUniquenessAllowsTerminatedHistoryButRejectsSecondLiveOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -1377,7 +1377,7 @@ func TestPostgresStore_AgentSessionsPartialUniquenessAllowsTerminatedHistoryButR
 }
 
 func TestPostgresRegistry_AcquireFailsClosedOnSuspendedResumableOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -1400,7 +1400,7 @@ func TestPostgresRegistry_AcquireFailsClosedOnSuspendedResumableOwner(t *testing
 }
 
 func TestPostgresRegistry_ResetAllMarksActiveSessionsOrphaned(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -1447,7 +1447,7 @@ func TestPostgresRegistry_ResetAllMarksActiveSessionsOrphaned(t *testing.T) {
 }
 
 func TestPostgresStore_AgentSessionSuccessorInvariantsRejectCrossScopeAndLegacyWrites(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -1614,7 +1614,7 @@ func installFailAgentTurnInsertTrigger(t *testing.T, ctx context.Context, db *sq
 }
 
 func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1707,7 +1707,7 @@ func TestPostgresStore_AppendEvent_EntityIDBoundaryContract(t *testing.T) {
 }
 
 func TestPostgresStore_PersistEventWithDeliveries_RejectsInvalidEntityID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1746,7 +1746,7 @@ func TestPostgresStore_PersistEventWithDeliveries_RejectsInvalidEntityID(t *test
 }
 
 func TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersistence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	pg.SetEventPayloadValidator(func(eventType string, payload []byte) error {
 		if strings.TrimSpace(eventType) != "task.completed" {
@@ -1787,7 +1787,7 @@ func TestPostgresStore_AppendEvent_RejectsPayloadValidatorFailureBeforePersisten
 }
 
 func TestPostgresStore_RecordInboundEvent_RejectsPayloadValidatorFailureBeforePersistence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	pg.SetEventPayloadValidator(func(eventType string, payload []byte) error {
 		if strings.TrimSpace(eventType) != "platform.inbound_recorded" {
@@ -1819,7 +1819,7 @@ func TestPostgresStore_RecordInboundEvent_RejectsPayloadValidatorFailureBeforePe
 }
 
 func TestPostgresStore_RecordInboundEvent_PlatformCatalogSchemaMatchesProducerPayload(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	pg.SetEventPayloadValidator(currentPlatformPayloadValidatorForStoreTest(t))
 	ctx := context.Background()
@@ -1875,7 +1875,7 @@ func currentPlatformPayloadValidatorForStoreTest(t testing.TB) EventPayloadValid
 }
 
 func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminalDelivery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1932,7 +1932,7 @@ func TestPostgresStore_GetEventReceipt_FallsBackToPersistedReceiptForNonTerminal
 }
 
 func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1993,7 +1993,7 @@ func TestPostgresStore_AppendEvent_InheritsParentRunID(t *testing.T) {
 }
 
 func TestPostgresStore_EventReceiptsTypedIdentitySeparatesReceiptWriters(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2098,7 +2098,7 @@ func TestPostgresStore_EventReceiptsTypedIdentitySeparatesReceiptWriters(t *test
 }
 
 func TestPostgresStore_EnsureSchemaTables_MigratesEventReceiptsTypedSubscriberIdentity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
@@ -2187,7 +2187,7 @@ func TestPostgresStore_EnsureSchemaTables_MigratesEventReceiptsTypedSubscriberId
 }
 
 func TestPostgresStore_EnsureSchemaTables_FailsClosedOnNodePipelineMigrationConflict(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
@@ -2220,7 +2220,7 @@ func TestPostgresStore_EnsureSchemaTables_FailsClosedOnNodePipelineMigrationConf
 }
 
 func TestPostgresStore_EnsureSchemaTables_FailsClosedOnAmbiguousNodePipelineRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	downgradeEventReceiptsToUntypedSubscriberIdentity(t, ctx, db)
@@ -2296,7 +2296,7 @@ func eventReceiptsTypedIdentityPlans(t *testing.T) []SchemaTableDDL {
 }
 
 func TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2376,7 +2376,7 @@ func TestPostgresStore_MarkRunTerminal_PersistsCanonicalLifecycle(t *testing.T) 
 }
 
 func TestPostgresStore_ListPendingEventsForAgent_PreservesRunID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	pg.schemaCaps = StoreSchemaCapabilities{
 		Events: EventSchemaCapabilities{
@@ -2474,7 +2474,7 @@ func TestPostgresStore_ListPendingEventsForAgent_PreservesRunID(t *testing.T) {
 }
 
 func TestPostgresStore_ListPendingEventsForAgent_UsesTypedEnvelopeMetadata(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2525,7 +2525,7 @@ func TestPostgresStore_ListPendingEventsForAgent_UsesTypedEnvelopeMetadata(t *te
 }
 
 func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2583,7 +2583,7 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery(t *testing.T) {
 }
 
 func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCapability(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx, `ALTER TABLE events DROP COLUMN run_id`); err != nil {
@@ -2623,7 +2623,7 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCap
 }
 
 func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2662,7 +2662,7 @@ func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
 }
 
 func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2705,7 +2705,7 @@ func TestPostgresStore_PersistEventWithDeliveries_SuccessAndRollbackOnFailure(t 
 }
 
 func TestPostgresStore_Inbound_ValidationAndNotFound(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2721,7 +2721,7 @@ func TestPostgresStore_Inbound_ValidationAndNotFound(t *testing.T) {
 }
 
 func TestPostgresStore_Inbound_PurgeDeletes(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2749,7 +2749,7 @@ func TestPostgresStore_Inbound_PurgeDeletes(t *testing.T) {
 }
 
 func TestPostgresStore_Inbound_RecordAndPurge(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2769,7 +2769,7 @@ func TestPostgresStore_Inbound_RecordAndPurge(t *testing.T) {
 }
 
 func TestPostgresStore_Mailbox_CRUD_Expire_Notify(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	s := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2944,7 +2944,7 @@ func TestNormalizeJSONPayload_RedactsSensitiveText(t *testing.T) {
 }
 
 func TestSchedules_UpsertLoadCancelAndMarkFired(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -2999,7 +2999,7 @@ func TestSchedules_UpsertLoadCancelAndMarkFired(t *testing.T) {
 }
 
 func TestSchedules_ExactIdentityUsesTaskID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	entityID := uuid.NewString()
@@ -3072,7 +3072,7 @@ func TestSchedules_ExactIdentityUsesTaskID(t *testing.T) {
 }
 
 func TestSchedules_ExactIdentityUsesFlowInstance(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	entityID := uuid.NewString()
@@ -3166,7 +3166,7 @@ func TestSchedules_ExactIdentityUsesFlowInstance(t *testing.T) {
 }
 
 func TestSchedules_ExactIdentityUsesRunID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runA := uuid.NewString()
@@ -3252,7 +3252,7 @@ func TestSchedules_ExactIdentityUsesRunID(t *testing.T) {
 }
 
 func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	entityID := uuid.NewString()
@@ -3284,7 +3284,7 @@ func TestSchedules_LoadActiveSchedulesPreservesFlowInstance(t *testing.T) {
 }
 
 func TestSchedules_LoadActiveSchedulesIgnoresWorkflowSidecarRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -3320,7 +3320,7 @@ func TestSchedules_LoadActiveSchedulesIgnoresWorkflowSidecarRows(t *testing.T) {
 }
 
 func TestSchedules_LoadActiveSchedulesDoesNotReconstructTaskIDFromTimerName(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	entityID := uuid.NewString()
@@ -3356,7 +3356,7 @@ func TestSchedules_LoadActiveSchedulesDoesNotReconstructTaskIDFromTimerName(t *t
 }
 
 func TestSchedules_MarkScheduleFiredExact_PreservesRecurringReplayAndFiresOnceSchedules(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	entityID := uuid.NewString()
@@ -3444,7 +3444,7 @@ func TestSchedules_MarkScheduleFiredExact_PreservesRecurringReplayAndFiresOnceSc
 }
 
 func TestSchedules_ClaimSchedule_IsExclusiveAcrossStores(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pg1 := &PostgresStore{DB: db}
 	pg2 := &PostgresStore{DB: db}
@@ -3493,7 +3493,7 @@ func TestSchedules_ClaimSchedule_IsExclusiveAcrossStores(t *testing.T) {
 }
 
 func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pg1 := &PostgresStore{DB: db}
 	pg2 := &PostgresStore{DB: db}
@@ -3575,7 +3575,7 @@ func TestSchedules_ClaimedOwnerIsOnlyRestoredTimerThatFires(t *testing.T) {
 }
 
 func TestSchedules_CancelExactTerminalAllowsSubsequentReclaim(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pgOwner := &PostgresStore{DB: db}
 	pgSuccessor := &PostgresStore{DB: db}
@@ -3626,7 +3626,7 @@ func TestSchedules_CancelExactTerminalAllowsSubsequentReclaim(t *testing.T) {
 }
 
 func TestSchedules_CompleteScheduleFireExactReleasesClaimForRecreatedOnceTimer(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	pgOwner := &PostgresStore{DB: db}
 	pgSuccessor := &PostgresStore{DB: db}
@@ -3677,7 +3677,7 @@ func TestSchedules_CompleteScheduleFireExactReleasesClaimForRecreatedOnceTimer(t
 }
 
 func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3733,7 +3733,7 @@ func TestEventReceipts_RetryToDeadLetter_AndPendingQueries(t *testing.T) {
 }
 
 func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3788,7 +3788,7 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 }
 
 func TestPendingEventQueries_PreserveParentCorrelation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3844,7 +3844,7 @@ func TestPendingEventQueries_PreserveParentCorrelation(t *testing.T) {
 }
 
 func TestManagerStore_EventReceiptBranches(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3879,7 +3879,7 @@ func TestManagerStore_EventReceiptBranches(t *testing.T) {
 }
 
 func TestManagerStore_GetEventReceipt_FailsClosedOnMalformedSideEffects(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3910,7 +3910,7 @@ func TestManagerStore_GetEventReceipt_FailsClosedOnMalformedSideEffects(t *testi
 }
 
 func TestManagerStore_MarkEventDeliveryInProgress_RequiresIDs(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -3923,7 +3923,7 @@ func TestManagerStore_MarkEventDeliveryInProgress_RequiresIDs(t *testing.T) {
 }
 
 func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
@@ -3972,7 +3972,7 @@ func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
 }
 
 func TestManagerStore_LoadRoutingRules_DoesNotJoinRunScopedEntityState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -4017,7 +4017,7 @@ func TestManagerStore_LoadRoutingRules_DoesNotJoinRunScopedEntityState(t *testin
 }
 
 func TestManagerStore_EnsureEntitySchema(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
@@ -4030,7 +4030,7 @@ func TestManagerStore_EnsureEntitySchema(t *testing.T) {
 }
 
 func TestManagerStore_RoutingRules_DeactivateAndBootstrapVersion(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 
@@ -4073,7 +4073,7 @@ func TestManagerStore_RoutingRules_DeactivateAndBootstrapVersion(t *testing.T) {
 }
 
 func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4142,7 +4142,7 @@ func TestManagerStore_Conversations_AndAgentTurns(t *testing.T) {
 }
 
 func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	baseCtx := context.Background()
 	resetAgentSessionsSpecTable(t, baseCtx, pg)
@@ -4191,7 +4191,7 @@ func TestManagerStore_ConversationPersistence_SessionPerEntityUsesActorContext(t
 }
 
 func TestManagerStore_AppendAgentTurn_PersistsObservedToolCalls(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4246,7 +4246,7 @@ func TestManagerStore_AppendAgentTurn_PersistsObservedToolCalls(t *testing.T) {
 }
 
 func TestManagerStore_LiveConversationPersistenceRequiresCanonicalLiveSession(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4279,7 +4279,7 @@ func TestManagerStore_LiveConversationPersistenceRequiresCanonicalLiveSession(t 
 }
 
 func TestManagerStore_LoadActiveConversationIncludesRetryLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4378,7 +4378,7 @@ func TestManagerStore_LoadActiveConversationIncludesRetryLineage(t *testing.T) {
 }
 
 func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalRuntimeState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4401,7 +4401,7 @@ func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalRuntimeStat
 }
 
 func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalWatchdogRuntimeState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4424,7 +4424,7 @@ func TestManagerStore_LoadActiveConversationFailsOnMalformedCanonicalWatchdogRun
 }
 
 func TestManagerStore_UpdateLiveSessionWatchdog_RoundTripsThroughLoadActiveConversation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4466,7 +4466,7 @@ func TestManagerStore_UpdateLiveSessionWatchdog_RoundTripsThroughLoadActiveConve
 }
 
 func TestManagerStore_UpdateLiveSessionWatchdogRejectsMalformedWrite(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4501,7 +4501,7 @@ func TestManagerStore_UpdateLiveSessionWatchdogRejectsMalformedWrite(t *testing.
 }
 
 func TestManagerStore_UpdateLiveSessionWatchdog_PreservesCanonicalSummary(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4552,7 +4552,7 @@ func TestManagerStore_UpdateLiveSessionWatchdog_PreservesCanonicalSummary(t *tes
 }
 
 func TestManagerStore_Conversations_AndAgentTurns_PersistRunIDWhenColumnsExist(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -4631,7 +4631,7 @@ func TestManagerStore_Conversations_AndAgentTurns_PersistRunIDWhenColumnsExist(t
 }
 
 func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -4680,7 +4680,7 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 }
 
 func TestManagerStore_AppendAgentTurn_CanonicalizesTurnBlocksThroughSingleStoreAdapter(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -4727,7 +4727,7 @@ func TestManagerStore_AppendAgentTurn_CanonicalizesTurnBlocksThroughSingleStoreA
 }
 
 func TestManagerStore_AppendAgentTurn_LeavesLiveSessionRuntimeStateForLiveOwnershipAndPersistsTurnRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4785,7 +4785,7 @@ func TestManagerStore_AppendAgentTurn_LeavesLiveSessionRuntimeStateForLiveOwners
 }
 
 func TestManagerStore_AppendAgentTurn_PreservesLiveSessionRetryLineageRuntimeState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4833,7 +4833,7 @@ func TestManagerStore_AppendAgentTurn_PreservesLiveSessionRetryLineageRuntimeSta
 }
 
 func TestManagerStore_AppendAgentTurn_RollsBackTaskAuditAndTurnRowWhenTurnInsertFails(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4871,7 +4871,7 @@ func TestManagerStore_AppendAgentTurn_RollsBackTaskAuditAndTurnRowWhenTurnInsert
 }
 
 func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4942,7 +4942,7 @@ func TestManagerStore_StatelessConversationPersistsAuditRowWithoutReload(t *test
 }
 
 func TestManagerStore_StatelessConversationFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -4976,7 +4976,7 @@ func TestManagerStore_StatelessConversationFailsClosedWithoutAuditCapabilityAndD
 }
 
 func TestManagerStore_TaskAppendTurnFailsClosedWithoutAuditCapabilityAndDoesNotCreateTable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5009,7 +5009,7 @@ func TestManagerStore_TaskAppendTurnFailsClosedWithoutAuditCapabilityAndDoesNotC
 }
 
 func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5063,7 +5063,7 @@ func TestManagerStore_SessionConversationDoesNotPersistAuditRow(t *testing.T) {
 }
 
 func TestManagerStore_TaskConversationUpsertIsIdempotentBySessionID(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5108,7 +5108,7 @@ func TestManagerStore_TaskConversationUpsertIsIdempotentBySessionID(t *testing.T
 }
 
 func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5184,7 +5184,7 @@ func TestManagerStore_AppendAgentTurn_TaskCreatesAuditRowIfMissing(t *testing.T)
 }
 
 func TestManagerStore_AppendAgentTurn_TaskEntityScopeSurvivesConversationUpsert(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5269,7 +5269,7 @@ func TestManagerStore_AppendAgentTurn_TaskEntityScopeSurvivesConversationUpsert(
 }
 
 func TestManagerStore_AppendAgentTurn_TaskFlowScopeSurvivesConversationUpsert(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5354,7 +5354,7 @@ func TestManagerStore_AppendAgentTurn_TaskFlowScopeSurvivesConversationUpsert(t 
 }
 
 func TestManagerStore_AppendAgentTurn_TaskDoesNotAdoptLegacySessionRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5418,7 +5418,7 @@ func TestManagerStore_AppendAgentTurn_TaskDoesNotAdoptLegacySessionRow(t *testin
 }
 
 func TestPostgresStore_EnsureConversationAuditTable_DoesNotMigrateLegacyTaskSessionRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -5490,7 +5490,7 @@ func TestPostgresStore_EnsureConversationAuditTable_DoesNotMigrateLegacyTaskSess
 }
 
 func TestPostgresStore_EnsureSchemaTables_NeutralizesLegacyTaskSessionRowsBeforeLiveSessionAcquire(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -5647,7 +5647,7 @@ func TestPostgresStore_EnsureSchemaTables_NeutralizesLegacyTaskSessionRowsBefore
 }
 
 func TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlock(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5687,7 +5687,7 @@ func TestManagerStore_AppendAgentTurn_FailsOnMalformedCanonicalRuntimeLogTurnBlo
 }
 
 func TestManagerStore_AppendAgentTurn_FailsOnNonStringCanonicalRuntimeLogTurnBlockField(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5727,7 +5727,7 @@ func TestManagerStore_AppendAgentTurn_FailsOnNonStringCanonicalRuntimeLogTurnBlo
 }
 
 func TestManagerStore_AppendAgentTurn_TaskReactivatesExistingInactiveAuditRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5791,7 +5791,7 @@ func TestManagerStore_AppendAgentTurn_TaskReactivatesExistingInactiveAuditRow(t 
 }
 
 func TestManagerStore_TaskConversationDoesNotPersistLiveSessionRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -5844,7 +5844,7 @@ func TestManagerStore_TaskConversationDoesNotPersistLiveSessionRow(t *testing.T)
 }
 
 func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -5887,7 +5887,7 @@ func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
 }
 
 func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6004,7 +6004,7 @@ func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *test
 }
 
 func TestManagerStore_UpsertAgent_PersistsPlatformInternalGlobalSessionAuthority(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6113,7 +6113,7 @@ func TestProjectPersistedAgentConfig_UsesCanonicalLLMBackendProfiles(t *testing.
 }
 
 func TestManagerStore_UpsertAgent_RejectsInvalidConversationModeAtAdmission(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6143,7 +6143,7 @@ func TestManagerStore_UpsertAgent_RejectsInvalidConversationModeAtAdmission(t *t
 }
 
 func TestManagerStore_UpsertAgent_FailsClosedWithoutHotPathSchemaRepair(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6203,7 +6203,7 @@ func TestManagerStore_UpsertAgent_FailsClosedWithoutHotPathSchemaRepair(t *testi
 }
 
 func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeKeys(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6231,7 +6231,7 @@ func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeK
 }
 
 func TestPostgresStore_EnsureSchemaCompatibilityColumnsAddsMultiBundleRunColumnsAsLegacy(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -6293,7 +6293,7 @@ func TestPostgresStore_EnsureSchemaCompatibilityColumnsAddsMultiBundleRunColumns
 }
 
 func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelMissing(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6321,7 +6321,7 @@ func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelMissing(t *testing
 }
 
 func TestManagerStore_LoadAgents_FailsClosedWithoutHotPathSchemaRepair(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6378,7 +6378,7 @@ func TestManagerStore_LoadAgents_FailsClosedWithoutHotPathSchemaRepair(t *testin
 }
 
 func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithRunID(context.Background(), specEntityStateRunID)
 	resetAgentSessionsSpecTable(t, ctx, pg)
@@ -6567,7 +6567,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 }
 
 func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6620,7 +6620,7 @@ func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *
 }
 
 func TestPostgresStore_LoadAgents_BackfillsRuntimeDescriptorTypeFromModelOnColumnUpgrade(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -6713,7 +6713,7 @@ func TestPostgresStore_LoadAgents_BackfillsRuntimeDescriptorTypeFromModelOnColum
 }
 
 func TestPostgresStore_MarkAgentTerminated_CleansRuntimeState(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	resetAgentSessionsSpecTable(t, ctx, pg)

--- a/internal/store/preservation_cleanup_test.go
+++ b/internal/store/preservation_cleanup_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPostgresStore_ApplyUnavailableBundleStartupPreservationCleanup_OrphansRunScopedState(t *testing.T) {
-	dsn, _, cleanup := testutil.StartPostgres(t)
+	dsn, _, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
 	if err != nil {

--- a/internal/store/reply_context_store_test.go
+++ b/internal/store/reply_context_store_test.go
@@ -36,8 +36,12 @@ func TestReplyContinuationRows_BackendParityMailboxAndHumanTaskRestoreContext(t 
 		name  string
 		setup func(*testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error)
 	}{
-		{name: "postgres", setup: setupPostgresReplyContextStoreTest},
-		{name: "sqlite", setup: setupSQLiteReplyContextStoreTest},
+		{name: "postgres", setup: func(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+			return setupPostgresReplyContextStoreTest(t, testutil.PostgresRowState())
+		}},
+		{name: "sqlite", setup: func(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+			return setupSQLiteReplyContextStoreTest(t, testutil.SQLiteDefaultTemp())
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			base, seed := tc.setup(t)
@@ -243,8 +247,12 @@ func TestReplyContextStore_BackendParityAtomicClaimAndDeliveryReadback(t *testin
 		name  string
 		setup func(*testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error)
 	}{
-		{name: "postgres", setup: setupPostgresReplyContextStoreTest},
-		{name: "sqlite", setup: setupSQLiteReplyContextStoreTest},
+		{name: "postgres", setup: func(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+			return setupPostgresReplyContextStoreTest(t, testutil.PostgresRowState())
+		}},
+		{name: "sqlite", setup: func(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+			return setupSQLiteReplyContextStoreTest(t, testutil.SQLiteDefaultTemp())
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store, seed := tc.setup(t)
@@ -351,9 +359,9 @@ func TestReplyContextStore_BackendParityAtomicClaimAndDeliveryReadback(t *testin
 	}
 }
 
-func setupPostgresReplyContextStoreTest(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+func setupPostgresReplyContextStoreTest(t *testing.T, requirement testutil.DatabaseRequirement) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
 	t.Helper()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, requirement)
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
 	return store, func(ctx context.Context, runID string, eventIDs ...string) error {
@@ -376,9 +384,9 @@ func setupPostgresReplyContextStoreTest(t *testing.T) (replyContextStoreTestSurf
 	}
 }
 
-func setupSQLiteReplyContextStoreTest(t *testing.T) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
+func setupSQLiteReplyContextStoreTest(t *testing.T, requirement testutil.DatabaseRequirement) (replyContextStoreTestSurface, func(context.Context, string, ...string) error) {
 	t.Helper()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, requirement)
 	return store, func(ctx context.Context, runID string, eventIDs ...string) error {
 		if _, err := store.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, time.Now().UTC()); err != nil {
 			return err

--- a/internal/store/run_api_read_surface_test.go
+++ b/internal/store/run_api_read_surface_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -130,7 +130,7 @@ func TestRunAPIReadSurface_LoadAndListRunHeaders(t *testing.T) {
 }
 
 func TestRunAPIReadSurface_LoadRunHeaderNotFound(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	_, err := pg.LoadRunHeader(context.Background(), uuid.NewString())
 	if !errors.Is(err, ErrRunNotFound) {

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsServeAdmissionFingerprint(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := runtimecorrelation.WithBundleFingerprint(context.Background(), testBootBundleFingerprint)
 	runID := uuid.NewString()
@@ -47,7 +47,7 @@ func TestPostgresStore_RunBundleSourceClassifiesCurrentWritersAsLegacyAndKeepsSe
 }
 
 func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
 	if _, err := db.ExecContext(context.Background(), `
@@ -87,7 +87,7 @@ func TestPostgresStore_RunBundleSourceConsumesCanonicalSourceFact(t *testing.T) 
 }
 
 func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	runID := uuid.NewString()
 
@@ -101,7 +101,7 @@ func TestPostgresStore_RunBundleSourceAllowsUnknownLegacyRows(t *testing.T) {
 }
 
 func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleHashOnReopen(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -133,7 +133,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleH
 }
 
 func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
@@ -156,7 +156,7 @@ func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) 
 }
 
 func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	err := storerunlifecycle.EnsureActive(context.Background(), db, uuid.NewString(), "", "", storerunlifecycle.EnsureActiveOptions{
 		HasBundleHashCol:   true,
 		HasBundleSourceCol: true,
@@ -168,7 +168,7 @@ func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) 
 }
 
 func TestRunLifecycleOwnerRejectsPersistedSourceWithoutBundleRow(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := uuid.NewString()
 
@@ -185,7 +185,7 @@ func TestRunLifecycleOwnerRejectsPersistedSourceWithoutBundleRow(t *testing.T) {
 }
 
 func TestPostgresStore_ActiveRunBundleAvailabilityConflicts(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	legacyRunID := uuid.NewString()

--- a/internal/store/run_completion_test.go
+++ b/internal/store/run_completion_test.go
@@ -100,7 +100,7 @@ func assertRunCompletionStatus(t *testing.T, db *sql.DB, runID, want string, wan
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_MarksCompletedWhenTerminalAndIdle(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "review/inst-1", "review")
@@ -140,7 +140,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_MarksCompletedWhenTerminalAnd
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWithMissingPipelineReceipt(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
@@ -151,7 +151,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWithMissingPipelin
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileDeliveryActive(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
@@ -183,7 +183,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileDeliveryActiv
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedUntilNodeDeliverySettled(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
@@ -222,7 +222,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedUntilNodeDeliveryS
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileTimerActiveThenCompletesAfterTimerSettled(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
@@ -256,7 +256,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileTimerActiveTh
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileSessionLeaseActive(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "done", "", "")
@@ -310,7 +310,7 @@ func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhileSessionLeaseA
 }
 
 func TestPostgresStore_ConvergeNormalRunCompletion_FailsClosedWhenEntityNotTerminal(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	fixture := seedNormalRunCompletionFixture(t, db, "working", "", "")

--- a/internal/store/run_control_test.go
+++ b/internal/store/run_control_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -112,7 +112,7 @@ func TestPostgresStore_RunControlTransitionsAndStopAbandonsPendingWork(t *testin
 }
 
 func TestPostgresStore_RunControlContinueRequiresOperatorPauseOwner(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()

--- a/internal/store/run_debug_read_surface_test.go
+++ b/internal/store/run_debug_read_surface_test.go
@@ -42,7 +42,7 @@ func assertRunTestQuiescence(t *testing.T, got RunTestQuiescence, want RunTestQu
 }
 
 func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -105,7 +105,7 @@ func TestRunDebugReadSurface_ListRunDebugRuns_UsesCanonicalRunScope(t *testing.T
 }
 
 func TestRunDebugReadSurface_ResolveLatestRunDebugRunID_UsesLatestPersistedRun(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -143,7 +143,7 @@ func TestRunDebugReadSurface_ResolveLatestRunDebugRunID_UsesLatestPersistedRun(t
 }
 
 func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMutations(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -296,7 +296,7 @@ func TestRunDebugReadSurface_LoadRunDebugReport_UsesCanonicalRunIDForLogsAndMuta
 }
 
 func TestRunDebugReadSurface_LoadRunDebugReport_ProjectsTestQuiescenceCounts(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -397,7 +397,7 @@ func TestRunDebugReadSurface_LoadRunDebugReport_ProjectsTestQuiescenceCounts(t *
 }
 
 func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -500,7 +500,7 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_JoinsEventDeliverySessionAndTurn(
 }
 
 func TestRunDebugReadSurface_LoadRunDebugTrace_SinceUsesRowMaterializationWatermark(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -584,7 +584,7 @@ func TestRunDebugReadSurface_LoadRunDebugTrace_SinceUsesRowMaterializationWaterm
 }
 
 func TestRunDebugReadSurface_LoadRunDebugTrace_UsesTaskAuditSessionWhenLiveSessionDoesNotExist(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 

--- a/internal/store/run_fork_activity_generation_test.go
+++ b/internal/store/run_fork_activity_generation_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestSelectedContractForkRemintsActivityRequestAndReusesRecordedWriteEvidence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
 	sourceRunID, entityID := uuid.NewString(), uuid.NewString()
@@ -132,7 +132,7 @@ func TestSelectedContractForkRemintsActivityRequestAndReusesRecordedWriteEvidenc
 }
 
 func TestSelectedContractForkRemintsReadOnlyActivityForReexecution(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
 	sourceRunID, entityID, sourceEventID := uuid.NewString(), uuid.NewString(), uuid.NewString()
@@ -209,7 +209,7 @@ func TestSelectedContractForkRemintsReadOnlyActivityForReexecution(t *testing.T)
 }
 
 func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	pg := &PostgresStore{DB: db}
 	sourceRunID, entityID, sourceEventID := uuid.NewString(), uuid.NewString(), uuid.NewString()

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -228,7 +228,7 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 }
 
 func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlowAbsent(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -316,7 +316,7 @@ func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlow
 }
 
 func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -385,7 +385,7 @@ func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *tes
 }
 
 func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeHasNoSourceMetadataAuthority(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -431,7 +431,7 @@ func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeHasNoSourceMetadataAuthori
 }
 
 func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeConflictsWithSourceMetadata(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -491,7 +491,7 @@ func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeConflictsWithSourceMetadat
 }
 
 func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -559,7 +559,7 @@ func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *tes
 }
 
 func TestRunForkSelectedContractBinding_MaterializesDurableBundleHashBinding(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -611,7 +611,7 @@ func TestRunForkSelectedContractBinding_MaterializesDurableBundleHashBinding(t *
 }
 
 func TestRunForkSelectedContractBinding_FailsClosedOnMissingDuplicateAndInvalidSelection(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -667,7 +667,7 @@ func TestRunForkSelectedContractBinding_FailsClosedOnMissingDuplicateAndInvalidS
 }
 
 func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -768,7 +768,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 }
 
 func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -838,7 +838,7 @@ func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.
 }
 
 func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1159,7 +1159,7 @@ func TestRunForkActivation_RejectsOwnerWorkOutsideCurrentSafePendingEvidence(t *
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 
@@ -1257,7 +1257,7 @@ func TestRunForkDeliveryEventReplayValidationRejectsUnsafeCurrentEvidence(t *tes
 }
 
 func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1315,7 +1315,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 }
 
 func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1355,7 +1355,7 @@ func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *
 }
 
 func TestRunForkActivation_FailsClosedForForkReplayStateWithTaxonomy(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1441,7 +1441,7 @@ func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testin
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 
@@ -1481,7 +1481,7 @@ func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testin
 }
 
 func TestRunForkActivation_ToleratesOptionalLegacyReplaySchemas(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -61,7 +61,7 @@ func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
 }
 
 func TestRunForkPlanner_FailsClosedForOpenReplyContextAtForkPoint(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
@@ -107,7 +107,7 @@ func TestRunForkPlanner_FailsClosedForOpenReplyContextAtForkPoint(t *testing.T) 
 }
 
 func TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -173,7 +173,7 @@ func TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations(t *testi
 }
 
 func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -290,7 +290,7 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 }
 
 func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -342,7 +342,7 @@ func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *te
 }
 
 func TestRunForkPlanner_NodePendingDeliveryRemainsBlocked(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -433,7 +433,7 @@ func TestRunForkPlanner_NonAgentDeliveryStatesRemainNamedBlockers(t *testing.T) 
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 
@@ -497,7 +497,7 @@ func TestRunForkPlanner_NonAgentDeliveryStatesRemainNamedBlockers(t *testing.T) 
 }
 
 func TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -546,7 +546,7 @@ func TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker(t *testin
 }
 
 func TestRunForkPlanner_SystemDeliveryRowsAreNotCanonicalEventDeliveries(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 
 	runID := uuid.NewString()
@@ -581,7 +581,7 @@ func TestRunForkPlanner_SystemDeliveryRowsAreNotCanonicalEventDeliveries(t *test
 }
 
 func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -674,7 +674,7 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 }
 
 func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -741,7 +741,7 @@ func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
 }
 
 func TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -824,7 +824,7 @@ func TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery(t *testing.T) {
 }
 
 func TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -887,7 +887,7 @@ func TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork(t *test
 }
 
 func TestRunForkPlanner_SuppressesPostForkTerminalMetadata(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -944,7 +944,7 @@ func TestRunForkPlanner_SuppressesPostForkTerminalMetadata(t *testing.T) {
 }
 
 func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1031,7 +1031,7 @@ func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testi
 }
 
 func TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1099,7 +1099,7 @@ func TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers(t *testing.T
 }
 
 func TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1146,7 +1146,7 @@ func TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker(t *testing.T
 }
 
 func TestRunForkPlanner_TerminatedSessionBeforeForkIsLineageOnly(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1199,7 +1199,7 @@ func TestRunForkPlanner_TerminatedSessionBeforeForkIsLineageOnly(t *testing.T) {
 }
 
 func TestRunForkPlanner_TerminatedAuditStillBlocksWithoutAtForkTerminationProof(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 
@@ -1246,7 +1246,7 @@ func TestRunForkPlanner_TerminatedAuditStillBlocksWithoutAtForkTerminationProof(
 }
 
 func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `DROP TABLE entity_mutations`); err != nil {
@@ -1265,7 +1265,7 @@ func TestRunForkPlanner_FailsClosedWhenMutationLogUnavailable(t *testing.T) {
 }
 
 func TestRunForkPlanner_FailsClosedWhenDeadLettersUnavailable(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `DROP TABLE dead_letters`); err != nil {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFrontier(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -71,7 +71,7 @@ func TestSelectedContractExecutionMaterializationAllowsSelectedPendingNodeFronti
 }
 
 func TestSelectedContractExecutionMaterializationStampsPersistedBundleIdentity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -110,7 +110,7 @@ func TestSelectedContractExecutionMaterializationStampsPersistedBundleIdentity(t
 }
 
 func TestSelectedContractExecutionMaterializationConsumesPlanSnapshotMetadata(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -176,7 +176,7 @@ func TestSelectedContractExecutionMaterializationConsumesPlanSnapshotMetadata(t 
 }
 
 func TestSelectedContractExecutionMaterializationTreatsSourceConversationHistoryAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -249,7 +249,7 @@ func TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersA
 		{name: "subscribed", reasonCode: replayScopeReasonSubscribed},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 			sourceRunID := uuid.NewString()
@@ -295,7 +295,7 @@ func TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersA
 }
 
 func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCouplingFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -336,7 +336,7 @@ func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCoupl
 }
 
 func TestSelectedContractExecutionMaterializationAdmitsSameSourceDeliveryForkPointEmission(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -419,7 +419,7 @@ func TestSelectedContractExecutionMaterializationAdmitsSameSourceDeliveryForkPoi
 }
 
 func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliveryFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -492,7 +492,7 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 }
 
 func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliveryWithoutConversationHistoryFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -560,7 +560,7 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 }
 
 func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsActiveSessionCoupling(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -621,7 +621,7 @@ func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsA
 }
 
 func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWithoutConversationHistoryFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -695,7 +695,7 @@ func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWith
 }
 
 func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -734,7 +734,7 @@ func TestSelectedContractExecutionMaterializationPreflightsLineageCapability(t *
 }
 
 func TestSelectedContractExecutionMaterializationPreflightsBranchDivergenceOwnerCapability(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -773,7 +773,7 @@ func TestSelectedContractExecutionMaterializationPreflightsBranchDivergenceOwner
 }
 
 func TestSelectedContractExecutionMaterializationPreflightsRouteRecoveryCapability(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -812,7 +812,7 @@ func TestSelectedContractExecutionMaterializationPreflightsRouteRecoveryCapabili
 }
 
 func TestSelectedContractExecutionMaterializationReconstructsActiveTimer(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -964,7 +964,7 @@ func TestSelectedContractExecutionMaterializationFailsClosedForUnsupportedTimerH
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 			sourceRunID := uuid.NewString()
@@ -1009,7 +1009,7 @@ func TestSelectedContractTimerReconstructionFailsClosedForInvalidPayload(t *test
 }
 
 func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappearsAfterPlanning(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1051,7 +1051,7 @@ func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappea
 }
 
 func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1137,7 +1137,7 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 }
 
 func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHistory(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1201,7 +1201,7 @@ func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHist
 }
 
 func TestPostTSourceConversationHistoryMaterializationKeepsActiveCouplingFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1235,7 +1235,7 @@ func TestPostTSourceConversationHistoryMaterializationKeepsActiveCouplingFailClo
 }
 
 func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1386,7 +1386,7 @@ func TestPostTSourceConversationHistoryActivatesAsBranchDivergence(t *testing.T)
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, db, _ := testutil.StartPostgres(t)
+			_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 			pg := &PostgresStore{DB: db}
 			ctx := context.Background()
 			sourceRunID := uuid.NewString()
@@ -1445,7 +1445,7 @@ func TestPostTSourceConversationHistoryActivatesAsBranchDivergence(t *testing.T)
 }
 
 func TestSelectedContractExecutionActivationRecordsSameSourceDeliveryCouplingAsBranchDivergence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1520,7 +1520,7 @@ func TestSelectedContractExecutionActivationRecordsSameSourceDeliveryCouplingAsB
 }
 
 func TestPostTSourceConversationHistoryActivationKeepsActiveCouplingFailClosed(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1561,7 +1561,7 @@ func TestPostTSourceConversationHistoryActivationKeepsActiveCouplingFailClosed(t
 }
 
 func TestSelectedContractActivationTreatsSameEventReplayScopeMarkerWriteSkewAsLineage(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1603,7 +1603,7 @@ func TestSelectedContractActivationTreatsSameEventReplayScopeMarkerWriteSkewAsLi
 }
 
 func TestSelectedContractActivationAllowsFreshForkConversationRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1706,7 +1706,7 @@ func TestSelectedContractActivationAllowsFreshForkConversationRows(t *testing.T)
 }
 
 func TestSelectedContractActivationAllowsCausalForkLocalRuntimePlatformControlEvent(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1763,7 +1763,7 @@ func TestSelectedContractActivationAllowsCausalForkLocalRuntimePlatformControlEv
 }
 
 func TestSelectedContractActivationAllowsCausalForkLocalRuntimeLogDiagnostic(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1813,7 +1813,7 @@ func TestSelectedContractActivationAllowsCausalForkLocalRuntimeLogDiagnostic(t *
 }
 
 func TestSelectedContractActivationRejectsUncausedForkLocalRuntimePlatformControlEvent(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1862,7 +1862,7 @@ func TestSelectedContractActivationRejectsUncausedForkLocalRuntimePlatformContro
 }
 
 func TestSelectedContractActivationRejectsUncausedForkLocalRuntimeLogDiagnostic(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1912,7 +1912,7 @@ func TestSelectedContractActivationRejectsUncausedForkLocalRuntimeLogDiagnostic(
 }
 
 func TestSelectedContractActivationRejectsUncausedForkLocalToolExecutorRuntimeLogDiagnostic(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -1962,7 +1962,7 @@ func TestSelectedContractActivationRejectsUncausedForkLocalToolExecutorRuntimeLo
 }
 
 func TestSelectedContractActivationRejectsUnownedPlatformEventWithSelectedParent(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -2011,7 +2011,7 @@ func TestSelectedContractActivationRejectsUnownedPlatformEventWithSelectedParent
 }
 
 func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -2068,7 +2068,7 @@ func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t 
 }
 
 func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()

--- a/internal/store/run_fork_selected_contract_route_recovery_test.go
+++ b/internal/store/run_fork_selected_contract_route_recovery_test.go
@@ -52,7 +52,7 @@ func TestNormalizeRunForkSelectedContractRouteRecoveryRejectsCurrentRouteOwner(t
 }
 
 func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -107,7 +107,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsForkLocalEvidence(t
 }
 
 func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsBundleHashSelection(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -169,7 +169,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryRoundTripsBundleHashSelection
 }
 
 func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJSONB(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -227,7 +227,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughJS
 }
 
 func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughBundleHashJSONB(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()
@@ -294,7 +294,7 @@ func TestRecordRunForkSelectedContractRouteRecoveryFeedsManagerRecoveryThroughBu
 }
 
 func TestRecordRunForkSelectedContractRouteRecoveryRejectsJSONBTamperDuringManagerRecovery(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	sourceRunID := uuid.NewString()

--- a/internal/store/runbundle/availability_test.go
+++ b/internal/store/runbundle/availability_test.go
@@ -15,7 +15,7 @@ const (
 )
 
 func TestLoadAvailabilityClassifiesBundleSourceStates(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 
 	persistedPresent := seedRunBundleAvailability(t, db, "running", testBundleHash, storerunlifecycle.BundleSourcePersisted, "")
@@ -67,7 +67,7 @@ func TestLoadAvailabilityClassifiesBundleSourceStates(t *testing.T) {
 }
 
 func TestLoadAvailabilityClassifiesPersistedMissingHashAsDataIntegrity(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	runID := seedRunBundleAvailability(t, db, "running", "", storerunlifecycle.BundleSourcePersisted, "")
 
@@ -81,7 +81,7 @@ func TestLoadAvailabilityClassifiesPersistedMissingHashAsDataIntegrity(t *testin
 }
 
 func TestLoadAvailabilityReadsSourceBeforeBundleRows(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	ctx := context.Background()
 	runID := seedRunBundleAvailability(t, db, "running", "", storerunlifecycle.BundleSourceLegacy, testBundleHash)
 	if _, err := db.ExecContext(ctx, `DROP TABLE bundles`); err != nil {
@@ -98,7 +98,7 @@ func TestLoadAvailabilityReadsSourceBeforeBundleRows(t *testing.T) {
 }
 
 func TestListActiveConflictsUsesAvailabilityOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	ctx := context.Background()
 	persistedPresent := seedRunBundleAvailability(t, db, "running", testBundleHash, storerunlifecycle.BundleSourcePersisted, "")
 	legacy := seedRunBundleAvailability(t, db, "paused", "", storerunlifecycle.BundleSourceLegacy, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/internal/store/runtime_ingress_state_test.go
+++ b/internal/store/runtime_ingress_state_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRuntimeIngressStatePersistsTypedTransitions(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	subjectEventID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
@@ -82,7 +82,7 @@ func TestSQLiteRuntimeLogPersistenceWritesLoggerRowsForObservability(t *testing.
 
 func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	if _, err := store.DB.ExecContext(ctx, `
@@ -127,7 +127,7 @@ func TestSQLiteRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *
 
 func TestPostgresRuntimeLogCarriesComputeModuleReplayEvidenceForReplayConsumer(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &PostgresStore{DB: db}
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
@@ -198,7 +198,7 @@ func computeModuleReplayEvidenceTestEnvelope() computemodule.ReplayEnvelope {
 
 func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
@@ -302,7 +302,7 @@ func TestSQLiteRuntimeLogSourceProjectionAndFilterParity(t *testing.T) {
 
 func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &PostgresStore{DB: db}
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -370,7 +370,7 @@ func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T)
 
 func TestPostgresRuntimeLogPersistenceReusesAmbientEventTransaction(t *testing.T) {
 	ctx := context.Background()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	defer cleanup()
 	pg := &PostgresStore{DB: db}
 	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {

--- a/internal/store/runtime_mutation_test.go
+++ b/internal/store/runtime_mutation_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSQLiteRuntimeStore_RunRuntimeMutationRetriesBusyAndFlushesPostCommitOnce(t *testing.T) {
-	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond)
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond, testutil.SQLiteFreshFile())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -92,7 +92,7 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationRetriesBusyAndFlushesPostCommitOnc
 }
 
 func TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline(t *testing.T) {
-	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond)
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, time.Millisecond, testutil.SQLiteFreshFile())
 	baseCtx := context.Background()
 
 	lockTx, err := lockStore.DB.BeginTx(baseCtx, nil)
@@ -127,7 +127,7 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline(t *tes
 }
 
 func TestSQLiteRuntimeStore_RunRuntimeMutationContextDeadlineCapsDriverBusyTimeout(t *testing.T) {
-	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, 50*time.Millisecond)
+	store, lockStore := newSQLiteRuntimeMutationBusyStores(t, 50*time.Millisecond, testutil.SQLiteFreshFile())
 	baseCtx := context.Background()
 
 	lockTx, err := lockStore.DB.BeginTx(baseCtx, nil)
@@ -162,7 +162,7 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationContextDeadlineCapsDriverBusyTimeo
 }
 
 func TestSQLiteRuntimeStore_RunRuntimeMutationDoesNotRetryActiveTransaction(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx := context.Background()
 	tx, err := store.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -188,7 +188,7 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationDoesNotRetryActiveTransaction(t *t
 }
 
 func TestSQLiteRuntimeStore_RunRuntimeMutationPostCommitCanReenterRuntimeMutation(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -238,7 +238,7 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationPostCommitCanReenterRuntimeMutatio
 }
 
 func TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks(t *testing.T) {
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -280,11 +280,11 @@ func TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks(t *testing.T
 	}
 }
 
-func newSQLiteRuntimeMutationBusyStores(t *testing.T, busyTimeout time.Duration) (*SQLiteRuntimeStore, *SQLiteRuntimeStore) {
+func newSQLiteRuntimeMutationBusyStores(t *testing.T, busyTimeout time.Duration, requirement testutil.DatabaseRequirement) (*SQLiteRuntimeStore, *SQLiteRuntimeStore) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "runtime.db")
-	store := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
-	lockStore := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
+	store := newBootstrappedSQLiteRuntimeStoreForPath(t, path, requirement)
+	lockStore := newBootstrappedSQLiteRuntimeStoreForPath(t, path, requirement)
 	for _, db := range []*sql.DB{store.DB, lockStore.DB} {
 		if _, err := db.ExecContext(context.Background(), fmt.Sprintf("PRAGMA busy_timeout = %d", int(busyTimeout/time.Millisecond))); err != nil {
 			t.Fatalf("set sqlite busy_timeout: %v", err)

--- a/internal/store/runtime_startup_ownership_test.go
+++ b/internal/store/runtime_startup_ownership_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPostgresStore_AcquireRuntimeStartupOwnership_DeniesCompetingOwner(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresRowState())
 	pg := &PostgresStore{DB: db}
 
 	lease1, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-1")
@@ -28,7 +28,7 @@ func TestPostgresStore_AcquireRuntimeStartupOwnership_DeniesCompetingOwner(t *te
 }
 
 func TestPostgresStore_AcquireRuntimeStartupOwnership_ReleaseAllowsSuccessor(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
+	_, db, _ := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	pg := &PostgresStore{DB: db}
 
 	lease1, err := pg.AcquireRuntimeStartupOwnership(context.Background(), "runtime-1")

--- a/internal/store/scenario_setup_test.go
+++ b/internal/store/scenario_setup_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"github.com/division-sh/swarm/internal/testutil"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +12,7 @@ import (
 
 func TestSQLiteScenarioSetupEntitiesIdempotentExistingRows(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	entityID := uuid.NewString()
 	req := ScenarioSetupRequest{

--- a/internal/store/schema_compatibility_bootstrap_test.go
+++ b/internal/store/schema_compatibility_bootstrap_test.go
@@ -19,7 +19,7 @@ import (
 func TestSQLiteSchemaBootstrapFreshSecondBootAndDriftRejection(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	path := filepath.Join(t.TempDir(), "dev.db")
-	first, err := NewSQLiteRuntimeStore(path)
+	first, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), path))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestSQLiteSchemaBootstrapFreshSecondBootAndDriftRejection(t *testing.T) {
 func TestSQLiteSchemaBootstrapRejectsUnstampedWithoutWALMutation(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	path := filepath.Join(t.TempDir(), "legacy.db")
-	store, err := NewSQLiteRuntimeStore(path)
+	store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), path))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestSQLiteSchemaBootstrapConcurrentCreatorsConverge(t *testing.T) {
 	stores := make([]*SQLiteRuntimeStore, 2)
 	for i := range stores {
 		var err error
-		stores[i], err = NewSQLiteRuntimeStore(path)
+		stores[i], err = NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), path))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -117,7 +117,7 @@ func TestSQLiteSchemaBootstrapConcurrentCreatorsConverge(t *testing.T) {
 
 func TestPostgresSchemaBootstrapAcceptsCanonicalTemplateAndRejectsDrift(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
 	if err := store.BootstrapSchema(context.Background(), request); err != nil {
@@ -138,7 +138,7 @@ func TestSchemaBootstrapRejectsUnexpectedIndex(t *testing.T) {
 	const createUnexpectedIndex = `CREATE UNIQUE INDEX drift_probe_idx ON timers(status) WHERE status = 'pending'`
 
 	t.Run("sqlite", func(t *testing.T) {
-		store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "unexpected-index.db"))
+		store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "unexpected-index.db")))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +153,7 @@ func TestSchemaBootstrapRejectsUnexpectedIndex(t *testing.T) {
 	})
 
 	t.Run("postgres", func(t *testing.T) {
-		_, db, cleanup := testutil.StartPostgres(t)
+		_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 		t.Cleanup(cleanup)
 		store := &PostgresStore{DB: db}
 		if _, err := db.Exec(createUnexpectedIndex); err != nil {
@@ -177,7 +177,7 @@ func assertUnexpectedIndexRejected(t *testing.T, err error) {
 func TestSQLiteSchemaBootstrapRejectsMalformedStoredOrigin(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	path := filepath.Join(t.TempDir(), "malformed-origin.db")
-	store, err := NewSQLiteRuntimeStore(path)
+	store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), path))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestSQLiteSchemaBootstrapRejectsMalformedStoredOrigin(t *testing.T) {
 
 func TestPostgresSchemaBootstrapRejectsMalformedStoredOrigin(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
 	var target string
@@ -260,7 +260,7 @@ func assertMalformedStoredOrigins(
 
 func TestPostgresSchemaBootstrapConcurrentFreshCreatorsConverge(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
-	dsn, db, cleanup := testutil.StartEmptyPostgres(t)
+	dsn, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresEmptyPhysical())
 	t.Cleanup(cleanup)
 	second, err := NewPostgresStore(dsn)
 	if err != nil {
@@ -291,7 +291,7 @@ func TestPostgresSchemaBootstrapConcurrentFreshCreatorsConverge(t *testing.T) {
 
 func TestPostgresSchemaBootstrapRejectsBeforeExtensionOrSchemaMutation(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
-	_, db, cleanup := testutil.StartEmptyPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresEmptyPhysical())
 	t.Cleanup(cleanup)
 	if _, err := db.Exec(`CREATE TABLE legacy_state (id TEXT PRIMARY KEY)`); err != nil {
 		t.Fatal(err)
@@ -330,7 +330,7 @@ func TestSchemaBootstrapRollsBackFailedFreshCreation(t *testing.T) {
 				break
 			}
 			if backend == "sqlite" {
-				store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "rollback.db"))
+				store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "rollback.db")))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -344,7 +344,7 @@ func TestSchemaBootstrapRollsBackFailedFreshCreation(t *testing.T) {
 				}
 				return
 			}
-			_, db, cleanup := testutil.StartEmptyPostgres(t)
+			_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresEmptyPhysical())
 			t.Cleanup(cleanup)
 			store := &PostgresStore{DB: db}
 			if err := store.BootstrapSchema(context.Background(), request); err == nil {
@@ -361,7 +361,7 @@ func TestSchemaBootstrapRollsBackFailedFreshCreation(t *testing.T) {
 func TestSQLiteSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	request.StatePlans = generatedProbeStatePlans()
-	store, err := NewSQLiteRuntimeStore(filepath.Join(t.TempDir(), "state.db"))
+	store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, testutil.SQLiteFreshFile(), filepath.Join(t.TempDir(), "state.db")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +382,7 @@ func TestSQLiteSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
 func TestPostgresSchemaBootstrapCreatesThenValidatesGeneratedState(t *testing.T) {
 	request := canonicalSchemaBootstrapTestRequest(t)
 	request.StatePlans = generatedProbeStatePlans()
-	_, db, cleanup := testutil.StartPostgres(t)
+	_, db, cleanup := testutil.AcquirePostgres(t, testutil.PostgresFreshPhysical())
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
 	var target string

--- a/internal/store/sqlite_conversation_fork_lifecycle_test.go
+++ b/internal/store/sqlite_conversation_fork_lifecycle_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"sort"
 	"sync"
 	"testing"
@@ -13,7 +14,7 @@ import (
 
 func TestSQLiteRuntimeStoreConversationForkLifecycleParity(t *testing.T) {
 	ctx := context.Background()
-	s := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	s := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := activeConversationForkTestClock()
 	source := seedSQLiteConversationForkSource(t, s, now)
 

--- a/internal/store/sqlite_run_api_read_surface_test.go
+++ b/internal/store/sqlite_run_api_read_surface_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Unix(1700000000, 0).UTC()
 	newer := uuid.NewString()
 	older := uuid.NewString()
@@ -201,7 +202,7 @@ func TestSQLiteRunAPIReadSurface_LoadListAndDiagnoseEvidence(t *testing.T) {
 
 func TestSQLiteRunAPIReadSurface_LoadRunDebugReportProjectsTestQuiescenceCounts(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
 	sqliteStore.nowFn = func() time.Time { return now }
 
@@ -313,7 +314,7 @@ func TestSQLiteRunAPIReadSurface_LoadRunDebugReportProjectsTestQuiescenceCounts(
 }
 
 func TestSQLiteRunAPIReadSurface_LoadRunHeaderNotFound(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	_, err := sqliteStore.LoadRunHeader(context.Background(), uuid.NewString())
 	if !errors.Is(err, ErrRunNotFound) {
 		t.Fatalf("LoadRunHeader error = %v, want ErrRunNotFound", err)

--- a/internal/store/sqlite_run_completion_test.go
+++ b/internal/store/sqlite_run_completion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -77,7 +78,7 @@ func assertSQLiteRunCompletionStatus(t *testing.T, db *sql.DB, runID, want strin
 
 func TestSQLiteRuntimeStoreConvergeNormalRunCompletionMarksCompletedAndIgnoresRuntimeLogs(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	fixture := seedSQLiteNormalRunCompletionFixture(t, store, "done")
 	if err := store.UpsertPipelineReceipt(ctx, fixture.EventID, "processed", nil); err != nil {
 		t.Fatalf("UpsertPipelineReceipt: %v", err)
@@ -115,7 +116,7 @@ func TestSQLiteRuntimeStoreConvergeNormalRunCompletionMarksCompletedAndIgnoresRu
 
 func TestSQLiteRuntimeStoreMarkRunTerminalPreservesFailureAndRejectsConflict(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	if _, err := store.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`, runID, time.Now().UTC()); err != nil {
 		t.Fatalf("seed sqlite run: %v", err)
@@ -142,7 +143,7 @@ func TestSQLiteRuntimeStoreMarkRunTerminalPreservesFailureAndRejectsConflict(t *
 
 func TestSQLiteRunLifecycleEntityCountUsesEntityState(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Now().UTC()
 	runID := uuid.NewString()
 	eventEntityA := uuid.NewString()
@@ -190,7 +191,7 @@ func TestSQLiteRunLifecycleEntityCountUsesEntityState(t *testing.T) {
 
 func TestSQLiteRuntimeStoreConvergeNormalRunCompletionFailsClosedWhileDeliveryActive(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	fixture := seedSQLiteNormalRunCompletionFixture(t, store, "done")
 	if _, err := store.DB.ExecContext(ctx, `
 		INSERT INTO event_deliveries (

--- a/internal/store/sqlite_run_trace_parity_test.go
+++ b/internal/store/sqlite_run_trace_parity_test.go
@@ -3,13 +3,14 @@ package store
 import (
 	"context"
 	"errors"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 )
 
 func TestSQLiteRunDebugTracePagePaginationWindowAndFilterParity(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	fixture := seedSQLiteRunTraceParityRows(t, ctx, sqliteStore)
 	mainFilter := RunDebugTraceFilter{
 		EventNames: []string{"trace.event_only", "trace.late_delivered", "trace.failed", "trace.second_delivered"},
@@ -91,7 +92,7 @@ func TestSQLiteRunDebugTracePagePaginationWindowAndFilterParity(t *testing.T) {
 
 func TestSQLiteRunDebugTracePageDeterministicDeliveryAndTurnTiePaging(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	fixture := seedSQLiteRunTraceParityRows(t, ctx, sqliteStore)
 
 	var got []string
@@ -130,7 +131,7 @@ func TestSQLiteRunDebugTracePageDeterministicDeliveryAndTurnTiePaging(t *testing
 
 func TestSQLiteRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 
 	runID := "00000000-0000-0000-0000-000000001816"
 	businessEvent := "00000000-0000-0000-0000-000000001817"
@@ -166,7 +167,7 @@ func TestSQLiteRunDebugTracePageExcludeRuntimeLogs(t *testing.T) {
 
 func TestSQLiteRunDebugTracePageIncludesTaskAuditSessionsInWatermark(t *testing.T) {
 	ctx := context.Background()
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	base := time.Unix(1700003200, 0).UTC()
 	runID := "00000000-0000-0000-0000-000000001430"
 	eventID := "00000000-0000-0000-0000-000000001431"

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/division-sh/swarm/internal/testutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ import (
 
 func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
@@ -245,7 +246,7 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 
 func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
 	agentDeliveryID := uuid.NewString()
@@ -359,7 +360,7 @@ func TestSQLiteRuntimeStore_RunControlStopAbandonsPendingWork(t *testing.T) {
 
 func TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 
 	tx, err := store.DB.BeginTx(ctx, nil)
 	if err != nil {
@@ -412,7 +413,7 @@ func TestSQLiteRuntimeStoreUpsertAgentConsumesActivePipelineTransaction(t *testi
 
 func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 	bus := &sqliteFlowActivationBus{}
 	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
@@ -451,7 +452,7 @@ func TestSQLiteDynamicFlowActivationRequiredAgentsUsePipelineTransaction(t *test
 
 func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	workflowStore := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(sqliteStore.DB, sqliteStore)
 	bus := &sqliteFlowActivationBus{}
 	manager := runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
@@ -681,7 +682,7 @@ func assertSQLiteRouteMaterializationVars(t *testing.T, bus *sqliteFlowActivatio
 
 func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	bus, err := runtimebus.NewEventBus(store)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -754,7 +755,7 @@ func TestSQLiteRuntimeStoreAPIIdempotencyAllowsNestedEventBusPublish(t *testing.
 
 func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOrRows(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	store.SetEventPayloadValidator(func(eventType string, _ []byte) error {
 		if eventType == "item.failed" {
 			return errors.New("schema violation")
@@ -807,8 +808,8 @@ func TestSQLiteRuntimeStoreAPIIdempotencyFailedNestedPublishLeavesNoCompletionOr
 func TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
-	storeA := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath)
-	storeB := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath)
+	storeA := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath, testutil.SQLiteSharedFile())
+	storeB := newBootstrappedSQLiteRuntimeStoreForPath(t, dbPath, testutil.SQLiteSharedFile())
 	req := APIIdempotencyRequest{
 		Method:         "event.publish",
 		ActorTokenID:   "token-1",
@@ -892,7 +893,7 @@ func TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles(t *test
 
 func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	tx, err := store.BeginEventTx(ctx)
 	if err != nil {
 		t.Fatalf("BeginEventTx: %v", err)
@@ -931,7 +932,7 @@ func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
 
 func TestSQLiteRuntimeStoreRuntimeIngressReadDuringPublishDoesNotReenterWrite(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	if _, err := store.DB.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status)
@@ -987,7 +988,7 @@ func assertSQLiteRuntimeCount(t *testing.T, store *SQLiteRuntimeStore, query str
 
 func TestSQLiteRuntimeStorePipelineWorkflowInstanceOwner(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	owner := runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(store.DB, store)
@@ -1040,7 +1041,7 @@ func TestSQLiteRuntimeStorePipelineWorkflowInstanceOwner(t *testing.T) {
 
 func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
@@ -1104,7 +1105,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerSettlesDelivery(t *testing.T) {
 
 func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
@@ -1160,7 +1161,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerDeadLettersDelivery(t *testing.
 
 func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithoutDeliveryAuthority(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
@@ -1211,7 +1212,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+			store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 			runID := uuid.NewString()
 			ctx = runtimecorrelation.WithRunID(ctx, runID)
 			eventID := uuid.NewString()
@@ -1266,7 +1267,7 @@ func TestSQLiteRuntimeStoreSystemNodeReceiptOwnerFailsWithTerminalDeliveryAuthor
 
 func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	now := time.Now().UTC()
@@ -1395,7 +1396,7 @@ func TestSQLiteRuntimeStoreDeliveryReplayAndReceiptSemantics(t *testing.T) {
 
 func TestSQLiteRuntimeStoreImmediateTerminalReceiptPreservesOriginalFailure(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	now := time.Now().UTC()
@@ -1430,7 +1431,7 @@ func TestSQLiteRuntimeStoreImmediateTerminalReceiptPreservesOriginalFailure(t *t
 
 func TestSQLiteRuntimeStoreDirectDeadLetterIsNotRetryExhaustion(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
@@ -1454,7 +1455,7 @@ func TestSQLiteRuntimeStoreDirectDeadLetterIsNotRetryExhaustion(t *testing.T) {
 
 func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Now().UTC()
 	store.SetNowFnForTest(func() time.Time { return now })
 
@@ -1595,7 +1596,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 
 func TestSQLiteRuntimeStore_TaskAuditAppendThenUpsertUsesGlobalScope(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	sessionID := uuid.NewString()
 
@@ -1668,7 +1669,7 @@ func TestSQLiteRuntimeStore_TaskAuditAppendThenUpsertUsesGlobalScope(t *testing.
 
 func TestSQLiteRuntimeStore_TaskAuditEntityScopeSurvivesConversationUpsert(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	sessionID := uuid.NewString()
 	entityID := uuid.NewString()
@@ -1739,7 +1740,7 @@ func TestSQLiteRuntimeStore_TaskAuditEntityScopeSurvivesConversationUpsert(t *te
 
 func TestSQLiteRuntimeStore_TaskAuditFlowScopeSurvivesConversationUpsert(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	sessionID := uuid.NewString()
 	flowInstance := "review/inst-1"
@@ -1810,7 +1811,7 @@ func TestSQLiteRuntimeStore_TaskAuditFlowScopeSurvivesConversationUpsert(t *test
 
 func TestSQLiteRuntimeStoreMarkAgentTerminatedCleansRuntimeState(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 	store.SetNowFnForTest(func() time.Time { return now })
 
@@ -1929,7 +1930,7 @@ func operatorDeliveriesContain(deliveries []OperatorEventDelivery, subscriberTyp
 
 func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 	ctx := context.Background()
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	eventID := uuid.NewString()
@@ -2138,7 +2139,7 @@ func TestSQLiteRuntimeStoreV1MailboxAPISelectedOwner(t *testing.T) {
 }
 
 func TestSQLiteRuntimeStoreClaimScheduleRequiresActiveRow(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	seedSQLiteScheduleRun(t, store, ctx, runID)
@@ -2188,7 +2189,7 @@ func TestSQLiteRuntimeStoreClaimScheduleRequiresActiveRow(t *testing.T) {
 }
 
 func TestSQLiteRuntimeStoreScheduleUsesPipelineTransactionForCommitVisibility(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	seedSQLiteScheduleRun(t, store, ctx, runID)
@@ -2245,7 +2246,7 @@ func TestSQLiteRuntimeStoreScheduleUsesPipelineTransactionForCommitVisibility(t 
 }
 
 func TestSQLiteRuntimeStoreScheduleUsesPipelineTransactionForRollbackVisibility(t *testing.T) {
-	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t, testutil.SQLiteDefaultTemp())
 	runID := uuid.NewString()
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	seedSQLiteScheduleRun(t, store, ctx, runID)
@@ -2328,19 +2329,19 @@ func assertSQLiteActiveScheduleCount(t *testing.T, store *SQLiteRuntimeStore, ct
 	}
 }
 
-func newBootstrappedSQLiteRuntimeStoreForTest(t *testing.T) *SQLiteRuntimeStore {
+func newBootstrappedSQLiteRuntimeStoreForTest(t *testing.T, requirement testutil.DatabaseRequirement) *SQLiteRuntimeStore {
 	t.Helper()
-	return newBootstrappedSQLiteRuntimeStoreForPath(t, filepath.Join(t.TempDir(), ".swarm", "dev.db"))
+	return newBootstrappedSQLiteRuntimeStoreForPath(t, filepath.Join(t.TempDir(), ".swarm", "dev.db"), requirement)
 }
 
-func newBootstrappedSQLiteRuntimeStoreForPath(t *testing.T, dbPath string) *SQLiteRuntimeStore {
+func newBootstrappedSQLiteRuntimeStoreForPath(t *testing.T, dbPath string, requirement testutil.DatabaseRequirement) *SQLiteRuntimeStore {
 	t.Helper()
 	spec := loadPlatformSpecForSQLiteSchemaTest(t)
 	plans, err := GeneratePlatformTableDDLs(spec)
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	store, err := NewSQLiteRuntimeStore(dbPath)
+	store, err := NewSQLiteRuntimeStore(testutil.SQLiteDeclaredPath(t, requirement, dbPath))
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)
 	}

--- a/internal/store/storetest/sqlite.go
+++ b/internal/store/storetest/sqlite.go
@@ -3,24 +3,24 @@ package storetest
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/platform"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
 // StartSQLiteRuntimeStore creates a file-backed SQLite runtime store with the
 // canonical platform schema for backend-neutral tests.
-func StartSQLiteRuntimeStore(t testing.TB) *store.SQLiteRuntimeStore {
+func StartSQLiteRuntimeStore(t testing.TB, requirement testutil.DatabaseRequirement) *store.SQLiteRuntimeStore {
 	t.Helper()
-	return StartSQLiteRuntimeStoreWithContext(t, context.Background())
+	return StartSQLiteRuntimeStoreWithContext(t, context.Background(), requirement)
 }
 
-func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context) *store.SQLiteRuntimeStore {
+func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context, requirement testutil.DatabaseRequirement) *store.SQLiteRuntimeStore {
 	t.Helper()
 
 	var platformSpec runtimecontracts.PlatformSpecDocument
@@ -35,7 +35,7 @@ func StartSQLiteRuntimeStoreWithContext(t testing.TB, ctx context.Context) *stor
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	dbPath := filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	dbPath := testutil.SQLitePath(t, requirement)
 	sqliteStore, err := store.NewSQLiteRuntimeStore(dbPath)
 	if err != nil {
 		t.Fatalf("NewSQLiteRuntimeStore: %v", err)

--- a/internal/store/tool_persistence_loop_test.go
+++ b/internal/store/tool_persistence_loop_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"github.com/division-sh/swarm/internal/testutil"
 	"testing"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func TestToolEntityReadbackProjectsLoopsWithoutReservedState(t *testing.T) {
-	db, err := sql.Open("sqlite", "file:"+t.Name()+"?mode=memory&cache=shared")
+	db, err := sql.Open("sqlite", testutil.SQLiteDeclaredDSN(t, testutil.SQLiteDefaultTemp(), "file:"+t.Name()+"?mode=memory&cache=shared"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testpostgres/connection.go
+++ b/internal/testpostgres/connection.go
@@ -136,6 +136,20 @@ func (d Connection) WithDatabase(database string) (Connection, error) {
 	return newConnection(cfg)
 }
 
+func (d Connection) WithIdentity(database, user, password string) (Connection, error) {
+	if strings.TrimSpace(database) == "" {
+		return Connection{}, fmt.Errorf("postgres test database name is required")
+	}
+	if strings.TrimSpace(user) == "" || password == "" {
+		return Connection{}, fmt.Errorf("postgres test lease user and password are required")
+	}
+	cfg := d.config.Clone()
+	cfg.Database = database
+	cfg.User = user
+	cfg.Password = password
+	return newConnection(cfg)
+}
+
 func (d Connection) Open() (*sql.DB, error) {
 	connector, err := pq.NewConnectorConfig(d.config.Clone())
 	if err != nil {

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -27,6 +27,9 @@ const (
 	controlNamePrefix      = "mas_control_v1_"
 	templateNamePrefix     = "mas_template_v1_"
 	sandboxNamePrefix      = "mas_test_v1_"
+	poolNamePrefix         = "mas_pool_v1_"
+	leaseRolePrefix        = "mas_lease_v1_"
+	dmlRolePrefix          = "mas_dml_v1_"
 	intentTableName        = "swarm_test_resource_intents_v1"
 )
 
@@ -40,8 +43,11 @@ type Manager struct {
 	templateName string
 	spec         runtimecontracts.PlatformSpecDocument
 	ddlPlans     []platformschema.TableDDL
+	dmlRole      string
+	rowPool      rowStatePool
 
 	afterCandidateSnapshot func()
+	beforeLeaseRoleCommit  func(role string) error
 }
 
 type Sandbox struct {
@@ -62,6 +68,8 @@ type resourceMetadata struct {
 	Identity string `json:"identity"`
 	LeaseKey int64  `json:"lease_key,omitempty"`
 	Template string `json:"template,omitempty"`
+	Role     string `json:"role,omitempty"`
+	Lease    string `json:"lease,omitempty"`
 }
 
 type resourceIntent struct {
@@ -112,7 +120,14 @@ func NewManager(ctx context.Context, admin Connection) (*Manager, error) {
 		admin: admin, role: role, ownershipKey: keyDigest[:], templateID: digest,
 		spec: spec, ddlPlans: plans,
 	}
-	controlID := hex.EncodeToString(keyDigest[:])[:24]
+	m.dmlRole = m.signedResourceName(dmlRolePrefix, "dml-role", controlIDForKey(keyDigest[:]))
+	if err := m.preflightCapabilities(ctx, db); err != nil {
+		return nil, err
+	}
+	if err := m.ensureDMLRole(ctx, db); err != nil {
+		return nil, err
+	}
+	controlID := controlIDForKey(keyDigest[:])
 	m.controlName = m.signedResourceName(controlNamePrefix, "control", controlID)
 	m.control, err = admin.WithDatabase(m.controlName)
 	if err != nil {
@@ -183,11 +198,17 @@ func (m *Manager) Acquire(ctx context.Context, withTemplate bool) (*Sandbox, err
 
 	if withTemplate {
 		err = m.withDDLAdmission(ctx, adminDB, "clone sandbox "+name, func(conn *sql.Conn) error {
-			return createDatabaseFromTemplate(ctx, conn, name, m.templateName)
+			if err := createDatabaseFromTemplate(ctx, conn, name, m.templateName); err != nil {
+				return err
+			}
+			return hardenManagedDatabase(ctx, conn, name)
 		})
 	} else {
 		err = m.withDDLAdmission(ctx, adminDB, "create empty sandbox "+name, func(conn *sql.Conn) error {
-			return createDatabase(ctx, conn, name)
+			if err := createDatabase(ctx, conn, name); err != nil {
+				return err
+			}
+			return hardenManagedDatabase(ctx, conn, name)
 		})
 	}
 	if err != nil {
@@ -265,11 +286,17 @@ func (m *Manager) ensureControlDatabase(ctx context.Context, adminDB *sql.DB) er
 			if err != nil || exists {
 				return err
 			}
-			return createDatabase(ctx, conn, m.controlName)
+			if err := createDatabase(ctx, conn, m.controlName); err != nil {
+				return err
+			}
+			return hardenManagedDatabase(ctx, conn, m.controlName)
 		})
 	}
 	if err != nil {
 		return fmt.Errorf("initialize postgres test control database: %w", err)
+	}
+	if err := hardenManagedDatabase(ctx, adminDB, m.controlName); err != nil {
+		return err
 	}
 	controlDB, err := m.control.Open()
 	if err != nil {
@@ -430,6 +457,9 @@ func (m *Manager) intentMatchesName(intent resourceIntent) bool {
 	case "template":
 		identity, ok := m.verifyResourceName(intent.Name, templateNamePrefix, "template")
 		return ok && identity == intent.Identity && intent.LeaseKey == 0 && intent.Template == ""
+	case "pool":
+		identity, ok := m.verifyResourceName(intent.Name, poolNamePrefix, "pool")
+		return ok && identity == intent.Identity && intent.LeaseKey == advisoryKey("pool:"+identity) && intent.Template == m.templateName
 	default:
 		return false
 	}
@@ -444,7 +474,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	rows, err := db.QueryContext(ctx, `
 		SELECT d.datname, COALESCE(shobj_description(d.oid, 'pg_database'), ''), r.rolname
 		FROM pg_database d JOIN pg_roles r ON r.oid=d.datdba
-		WHERE d.datname LIKE 'mas_test_v1_%' OR d.datname LIKE 'mas_template_v1_%'
+		WHERE d.datname LIKE 'mas_test_v1_%' OR d.datname LIKE 'mas_template_v1_%' OR d.datname LIKE 'mas_pool_v1_%'
 		ORDER BY d.datname`)
 	if err != nil {
 		return fmt.Errorf("list postgres test resources: %w", err)
@@ -506,13 +536,15 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 			return err
 		}
 	}
-	return nil
+	return m.reconcileLeaseRoles(ctx, db)
 }
 
 func (m *Manager) reconcileDatabaseCandidate(ctx context.Context, db *sql.DB, candidate databaseCandidate) error {
 	kind, prefix := "sandbox", sandboxNamePrefix
 	if strings.HasPrefix(candidate.name, templateNamePrefix) {
 		kind, prefix = "template", templateNamePrefix
+	} else if strings.HasPrefix(candidate.name, poolNamePrefix) {
+		kind, prefix = "pool", poolNamePrefix
 	}
 	identity, signed := m.verifyResourceName(candidate.name, prefix, kind)
 	if !signed {
@@ -521,6 +553,8 @@ func (m *Manager) reconcileDatabaseCandidate(ctx context.Context, db *sql.DB, ca
 	lockKey := advisoryKey("template:" + candidate.name)
 	if kind == "sandbox" {
 		lockKey = advisoryKey("sandbox:" + identity)
+	} else if kind == "pool" {
+		lockKey = advisoryKey("pool:" + identity)
 	}
 	lockConn, acquired, err := tryAdvisoryLock(ctx, db, lockKey)
 	if err != nil || !acquired {
@@ -557,6 +591,8 @@ func (m *Manager) reconcileDatabaseCandidateLocked(ctx context.Context, db *sql.
 	kind, prefix := "sandbox", sandboxNamePrefix
 	if strings.HasPrefix(candidate.name, templateNamePrefix) {
 		kind, prefix = "template", templateNamePrefix
+	} else if strings.HasPrefix(candidate.name, poolNamePrefix) {
+		kind, prefix = "pool", poolNamePrefix
 	}
 	identity, signed := m.verifyResourceName(candidate.name, prefix, kind)
 	if !signed {
@@ -589,6 +625,11 @@ func (m *Manager) reconcileDatabaseCandidateLocked(ctx context.Context, db *sql.
 			return nil
 		}
 	}
+	if metadataErr == nil && metadata.Role != "" {
+		if err := m.retireLeaseRole(ctx, db, candidate.name, metadata.Role, metadata.Lease, metadata.LeaseKey); err != nil {
+			return fmt.Errorf("reconcile stale postgres lease role %q: %w", metadata.Role, err)
+		}
+	}
 	if err := m.dropSandbox(ctx, db, candidate.name); err != nil {
 		return fmt.Errorf("reconcile stale postgres test %s %q: %w", kind, candidate.name, err)
 	}
@@ -608,6 +649,15 @@ func (m *Manager) validResourceMetadata(metadata resourceMetadata) bool {
 		return ok
 	case "template":
 		return metadata.LeaseKey == 0 && metadata.Template == ""
+	case "pool":
+		if metadata.LeaseKey != advisoryKey("pool:"+metadata.Identity) || metadata.Template != m.templateName {
+			return false
+		}
+		if (metadata.Role == "") != (metadata.Lease == "") {
+			return false
+		}
+		_, ok := m.verifyResourceName(m.signedResourceName(poolNamePrefix, "pool", metadata.Identity), poolNamePrefix, "pool")
+		return ok
 	default:
 		return false
 	}
@@ -665,7 +715,10 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 		return err
 	}
 	if err := m.withExclusiveDDLAdmission(ctx, adminDB, "create template "+m.templateName, func(conn *sql.Conn) error {
-		return createDatabase(ctx, conn, m.templateName)
+		if err := createDatabase(ctx, conn, m.templateName); err != nil {
+			return err
+		}
+		return hardenManagedDatabase(ctx, conn, m.templateName)
 	}); err != nil {
 		cleanupErr := m.retireIntentIfDatabaseAbsent(context.Background(), adminDB, m.templateName)
 		return errors.Join(fmt.Errorf("create postgres template %q: %w", m.templateName, err), cleanupErr)
@@ -680,7 +733,7 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 		_ = m.dropSandbox(context.Background(), adminDB, m.templateName)
 		return err
 	}
-	if err := initializeDatabase(ctx, templateDB, m.role, m.spec, m.ddlPlans); err != nil {
+	if err := initializeDatabase(ctx, templateDB, m.role, m.dmlRole, m.spec, m.ddlPlans); err != nil {
 		_ = templateDB.Close()
 		_ = m.dropSandbox(context.Background(), adminDB, m.templateName)
 		return err
@@ -697,7 +750,7 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 	return m.deleteIntent(ctx, m.templateName)
 }
 
-func initializeDatabase(ctx context.Context, db *sql.DB, role string, spec runtimecontracts.PlatformSpecDocument, plans []platformschema.TableDDL) error {
+func initializeDatabase(ctx context.Context, db *sql.DB, role, dmlRole string, spec runtimecontracts.PlatformSpecDocument, plans []platformschema.TableDDL) error {
 	for _, stmt := range []string{
 		`CREATE SCHEMA IF NOT EXISTS public`,
 		`GRANT ALL ON SCHEMA public TO ` + quoteIdent(role),
@@ -718,7 +771,21 @@ func initializeDatabase(ctx context.Context, db *sql.DB, role string, spec runti
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit platform bootstrap: %w", err)
 	}
+	for _, stmt := range []string{
+		`REVOKE CREATE ON SCHEMA public FROM PUBLIC`,
+		`GRANT USAGE ON SCHEMA public TO ` + quoteIdent(dmlRole),
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ` + quoteIdent(dmlRole),
+		`GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO ` + quoteIdent(dmlRole),
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("initialize postgres template lease privilege %q: %w", stmt, err)
+		}
+	}
 	return nil
+}
+
+func controlIDForKey(key []byte) string {
+	return hex.EncodeToString(key)[:24]
 }
 
 func inspectSession(ctx context.Context, db *sql.DB) (string, string, error) {
@@ -901,6 +968,14 @@ func createDatabaseFromTemplate(ctx context.Context, db databaseExecer, name, te
 	return err
 }
 
+func hardenManagedDatabase(ctx context.Context, db databaseExecer, name string) error {
+	_, err := db.ExecContext(ctx, `REVOKE CONNECT, TEMPORARY ON DATABASE `+quoteIdent(name)+` FROM PUBLIC`)
+	if err != nil {
+		return fmt.Errorf("revoke public authority on managed postgres database %q: %w", name, err)
+	}
+	return nil
+}
+
 func dropDatabase(ctx context.Context, db databaseExecer, name string) error {
 	if _, err := db.ExecContext(ctx, `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname=$1 AND pid<>pg_backend_pid()`, name); err != nil {
 		return err
@@ -972,7 +1047,7 @@ func templateDigest(plans []platformschema.TableDDL, platformVersion, role, serv
 	}
 	hash := sha256.New()
 	for _, value := range [][]byte{
-		[]byte(resourceMetadataPrefix), canonical, []byte(platformVersion),
+		[]byte(resourceMetadataPrefix), []byte("lease-dml-v1"), canonical, []byte(platformVersion),
 		[]byte(role), []byte(serverID), []byte(serverVersion),
 	} {
 		_, _ = hash.Write(value)

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -47,6 +47,7 @@ type Manager struct {
 	rowPool      rowStatePool
 
 	afterCandidateSnapshot func()
+	beforeDMLRoleCommit    func(role string) error
 	beforeLeaseRoleCommit  func(role string) error
 }
 

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -657,7 +657,7 @@ func TestManagerRetiresFailedCreateIntentOnlyAfterExactAbsence(t *testing.T) {
 	}
 }
 
-func integrationManager(t *testing.T) *Manager {
+func integrationManager(t testing.TB) *Manager {
 	t.Helper()
 	raw := strings.TrimSpace(os.Getenv(SourceEnv))
 	if raw == "" {
@@ -674,6 +674,31 @@ func integrationManager(t *testing.T) *Manager {
 		t.Fatal(err)
 	}
 	return manager
+}
+
+func BenchmarkRowStateLeaseLifecycle(b *testing.B) {
+	manager := integrationManager(b)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	var acquireTime, releaseTime time.Duration
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		started := time.Now()
+		lease, err := manager.AcquireRowState(ctx)
+		acquireTime += time.Since(started)
+		if err != nil {
+			b.Fatal(err)
+		}
+		started = time.Now()
+		if err := lease.Release(ctx); err != nil {
+			b.Fatal(err)
+		}
+		releaseTime += time.Since(started)
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(acquireTime.Nanoseconds())/float64(b.N), "acquire-ns/op")
+		b.ReportMetric(float64(releaseTime.Nanoseconds())/float64(b.N), "release-ns/op")
+	}
 }
 
 func TestRowStateLeaseProcessDeathReconciliationFencesRoleAndRetiresSlot(t *testing.T) {
@@ -853,6 +878,34 @@ func TestRowStateLeaseRoleTransactionRollbackLeavesNoRole(t *testing.T) {
 	}
 	if exists {
 		t.Fatalf("lease role %q survived transaction rollback", attemptedRole)
+	}
+}
+
+func TestPermanentDMLRoleTransactionRollbackLeavesNoUnstampedRole(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	db, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	manager.dmlRole = dmlRolePrefix + "rollback_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	manager.beforeDMLRoleCommit = func(role string) error {
+		if role != manager.dmlRole {
+			t.Fatalf("DML role commit hook role = %q, want %q", role, manager.dmlRole)
+		}
+		return errors.New("injected permanent role pre-commit failure")
+	}
+	if err := manager.ensureDMLRole(ctx, db); err == nil || !strings.Contains(err.Error(), "injected permanent role pre-commit failure") {
+		t.Fatalf("ensureDMLRole error=%v, want injected rollback", err)
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)`, manager.dmlRole).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatalf("unstamped permanent DML role %q survived transaction rollback", manager.dmlRole)
 	}
 }
 

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -3,10 +3,12 @@ package testpostgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -354,6 +356,9 @@ func TestManagerRetainsStampedTemplateFromOlderSchemaDigest(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer dropDatabase(context.Background(), db, name)
+	if err := hardenManagedDatabase(ctx, db, name); err != nil {
+		t.Fatal(err)
+	}
 	if err := setDatabaseMetadata(ctx, db, name, resourceMetadata{Version: 1, Kind: "template", Identity: identity}); err != nil {
 		t.Fatal(err)
 	}
@@ -669,6 +674,331 @@ func integrationManager(t *testing.T) *Manager {
 		t.Fatal(err)
 	}
 	return manager
+}
+
+func TestRowStateLeaseProcessDeathReconciliationFencesRoleAndRetiresSlot(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	lease, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, role, connection := lease.Name, lease.role, lease.Connection
+	_ = lease.DB.Close()
+	releaseAdvisoryLock(lease.slot.leaseConn, lease.slot.leaseKey)
+	lease.slot.leaseConn = nil
+
+	if _, err := NewManager(ctx, manager.admin); err != nil {
+		t.Fatalf("startup reconciliation: %v", err)
+	}
+	assertDatabaseAbsent(t, manager.admin, name)
+	db, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var exists bool
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)`, role).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatalf("stale lease role %q survived startup reconciliation", role)
+	}
+	stale, err := connection.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stale.Close()
+	if err := stale.PingContext(ctx); err == nil {
+		t.Fatal("stale process-death lease credential remained usable")
+	}
+}
+
+func TestRowStateLeaseOrphanRoleReconciliationWithoutSlot(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	lease, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	role := lease.role
+	_ = lease.DB.Close()
+	releaseAdvisoryLock(lease.slot.leaseConn, lease.slot.leaseKey)
+	lease.slot.leaseConn = nil
+	adminDB, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dropDatabase(ctx, adminDB, lease.Name); err != nil {
+		_ = adminDB.Close()
+		t.Fatal(err)
+	}
+	_ = adminDB.Close()
+	if _, err := NewManager(ctx, manager.admin); err != nil {
+		t.Fatalf("orphan-role reconciliation: %v", err)
+	}
+	db, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)`, role).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatalf("orphan lease role %q survived reconciliation", role)
+	}
+}
+
+func TestRowStateLeaseSchemaContaminationRetiresSlot(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	lease, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminConnection, err := manager.admin.WithDatabase(lease.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adminDB, err := adminConnection.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `CREATE TABLE contamination_probe (id bigint)`); err != nil {
+		t.Fatal(err)
+	}
+	_ = adminDB.Close()
+	if err := lease.Release(ctx); err == nil || !strings.Contains(err.Error(), "shape changed") {
+		t.Fatalf("contaminated lease release error=%v, want shape retirement", err)
+	}
+	assertDatabaseAbsent(t, manager.admin, lease.Name)
+}
+
+func TestRowStateLeaseConnectAndPrivilegeBoundary(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	leaseA, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer leaseA.Release(context.Background())
+	leaseB, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer leaseB.Release(context.Background())
+	sandbox, err := manager.Acquire(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sandbox.Release(context.Background())
+	if err := leaseA.DB.PingContext(ctx); err != nil {
+		t.Fatalf("assigned slot connection: %v", err)
+	}
+	for _, database := range []string{leaseB.Name, manager.controlName, manager.templateName, sandbox.Name, "postgres"} {
+		projected, err := leaseA.Connection.WithDatabase(database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		db, err := projected.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = db.PingContext(ctx)
+		_ = db.Close()
+		if err == nil {
+			t.Fatalf("lease role connected outside assigned slot to %q", database)
+		}
+	}
+	if _, err := leaseA.DB.ExecContext(ctx, `UPDATE runtime_store_metadata SET swarm_version='lease-dml' WHERE id=1`); err != nil {
+		t.Fatalf("required DML failed: %v", err)
+	}
+	if _, err := leaseA.DB.ExecContext(ctx, `SET ROLE `+quoteIdent(manager.role)); err == nil {
+		t.Fatal("lease role escalated to manager role")
+	}
+	if _, err := leaseA.DB.ExecContext(ctx, `CREATE TABLE forbidden_boundary_probe (id bigint)`); err == nil {
+		t.Fatal("lease role acquired schema creation authority")
+	}
+}
+
+func TestRowStateLeaseRoleTransactionRollbackLeavesNoRole(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	db, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var attemptedRole string
+	manager.beforeLeaseRoleCommit = func(role string) error {
+		attemptedRole = role
+		return errors.New("injected pre-commit failure")
+	}
+	if _, err := manager.AcquireRowState(ctx); err == nil || !strings.Contains(err.Error(), "injected pre-commit failure") {
+		t.Fatalf("AcquireRowState error=%v, want injected rollback", err)
+	}
+	if attemptedRole == "" {
+		t.Fatal("lease role commit hook did not observe the attempted role")
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)`, attemptedRole).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatalf("lease role %q survived transaction rollback", attemptedRole)
+	}
+}
+
+func TestManagerSupportsNonSuperuserCreatedbCreaterole(t *testing.T) {
+	if os.Getenv("SWARM_TEST_MINIMAL_MANAGER_CHILD") != "1" {
+		executable, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, thisFile, _, _ := runtime.Caller(0)
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+		cmd := exec.Command("go", "run", "./cmd/swarm-test-postgres", "--", executable, "-test.run=^TestManagerSupportsNonSuperuserCreatedbCreaterole$", "-test.v")
+		cmd.Dir = repoRoot
+		cmd.Env = append(os.Environ(), "SWARM_TEST_MINIMAL_MANAGER_CHILD=1")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("isolated minimally privileged manager proof: %v\n%s", err, output)
+		}
+		return
+	}
+	adminConnection, err := ConnectionFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	adminDB, err := adminConnection.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminDB.Close()
+	var superuser bool
+	if err := adminDB.QueryRowContext(ctx, `SELECT rolsuper FROM pg_roles WHERE rolname=current_user`).Scan(&superuser); err != nil {
+		t.Fatal(err)
+	}
+	if !superuser {
+		t.Skip("minimal manager bootstrap requires the runner-owned superuser")
+	}
+	identity := strings.ReplaceAll(uuid.NewString(), "-", "")
+	missingRole := "mas_manager_missing_" + identity
+	if _, err := adminDB.ExecContext(ctx, `CREATE ROLE `+quoteIdent(missingRole)+` LOGIN CREATEDB PASSWORD `+quoteLiteral("missing-"+identity)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `GRANT CONNECT ON DATABASE postgres TO `+quoteIdent(missingRole)); err != nil {
+		t.Fatal(err)
+	}
+	missingConnection, err := adminConnection.WithIdentity("postgres", missingRole, "missing-"+identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewManager(ctx, missingConnection); err == nil || !strings.Contains(err.Error(), "CREATEDB + CREATEROLE") {
+		t.Fatalf("missing CREATEROLE preflight error=%v", err)
+	}
+	cleanupMinimalManagerProbe(t, adminConnection, missingRole, "")
+
+	role, password := "mas_manager_probe_"+identity, "probe-"+identity
+	if _, err := adminDB.ExecContext(ctx, `CREATE ROLE `+quoteIdent(role)+` LOGIN CREATEDB CREATEROLE PASSWORD `+quoteLiteral(password)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminDB.ExecContext(ctx, `GRANT CONNECT ON DATABASE postgres TO `+quoteIdent(role)); err != nil {
+		t.Fatal(err)
+	}
+	dmlRole := ""
+	defer func() { cleanupMinimalManagerProbe(t, adminConnection, role, dmlRole) }()
+	connection, err := adminConnection.WithIdentity("postgres", role, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := NewManager(ctx, connection)
+	if err != nil {
+		t.Fatalf("initialize minimally privileged manager: %v", err)
+	}
+	dmlRole = manager.dmlRole
+	lease, err := manager.AcquireRowState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.DB.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var nativeManagerAuthority bool
+	if err := adminDB.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_auth_members membership
+			JOIN pg_roles granted_role ON granted_role.oid=membership.roleid
+			JOIN pg_roles member_role ON member_role.oid=membership.member
+			WHERE granted_role.rolname=$1
+			  AND member_role.rolname=$2
+			  AND membership.admin_option
+		)`, lease.role, role).Scan(&nativeManagerAuthority); err != nil {
+		t.Fatal(err)
+	}
+	if !nativeManagerAuthority {
+		t.Fatal("PostgreSQL did not retain native ADMIN authority for the manager over the lease role")
+	}
+	if err := lease.Release(ctx); err != nil {
+		t.Fatal(err)
+	}
+	manager.rowPool.mu.Lock()
+	slots := append([]*rowStateSlot(nil), manager.rowPool.available...)
+	manager.rowPool.available = nil
+	manager.rowPool.mu.Unlock()
+	for _, slot := range slots {
+		manager.retireRowStateSlot(ctx, slot)
+	}
+}
+
+func cleanupMinimalManagerProbe(t *testing.T, admin Connection, role, dmlRole string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	db, err := admin.Open()
+	if err != nil {
+		t.Errorf("open cleanup admin: %v", err)
+		return
+	}
+	defer db.Close()
+	rows, err := db.QueryContext(ctx, `SELECT d.datname FROM pg_database d JOIN pg_roles r ON r.oid=d.datdba WHERE r.rolname=$1 ORDER BY d.datname`, role)
+	if err != nil {
+		t.Errorf("list probe databases: %v", err)
+		return
+	}
+	var databases []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Errorf("scan probe database: %v", err)
+		}
+		databases = append(databases, name)
+	}
+	_ = rows.Close()
+	for _, name := range databases {
+		if err := dropDatabase(ctx, db, name); err != nil {
+			t.Errorf("drop probe database %s: %v", name, err)
+		}
+	}
+	if dmlRole != "" {
+		if _, err := db.ExecContext(ctx, `DROP ROLE IF EXISTS `+quoteIdent(dmlRole)); err != nil {
+			t.Errorf("drop probe DML role: %v", err)
+		}
+	}
+	_, _ = db.ExecContext(ctx, `REVOKE CONNECT ON DATABASE postgres FROM `+quoteIdent(role))
+	if _, err := db.ExecContext(ctx, `DROP ROLE IF EXISTS `+quoteIdent(role)); err != nil {
+		t.Errorf("drop probe manager role: %v", err)
+	}
 }
 
 func assertDatabaseAbsent(t *testing.T, connection Connection, name string) {

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -701,6 +701,31 @@ func BenchmarkRowStateLeaseLifecycle(b *testing.B) {
 	}
 }
 
+func BenchmarkFreshPhysicalLifecycle(b *testing.B) {
+	manager := integrationManager(b)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	var acquireTime, releaseTime time.Duration
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		started := time.Now()
+		sandbox, err := manager.Acquire(ctx, true)
+		acquireTime += time.Since(started)
+		if err != nil {
+			b.Fatal(err)
+		}
+		started = time.Now()
+		if err := sandbox.Release(ctx); err != nil {
+			b.Fatal(err)
+		}
+		releaseTime += time.Since(started)
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(acquireTime.Nanoseconds())/float64(b.N), "acquire-ns/op")
+		b.ReportMetric(float64(releaseTime.Nanoseconds())/float64(b.N), "release-ns/op")
+	}
+}
+
 func TestRowStateLeaseProcessDeathReconciliationFencesRoleAndRetiresSlot(t *testing.T) {
 	manager := integrationManager(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/testpostgres/row_pool.go
+++ b/internal/testpostgres/row_pool.go
@@ -1,0 +1,630 @@
+package testpostgres
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const maxRowStateSlotsPerProcess = 4
+
+type rowStatePool struct {
+	mu        sync.Mutex
+	available []*rowStateSlot
+	total     int
+}
+
+type rowStateSlot struct {
+	name        string
+	identity    string
+	leaseKey    int64
+	leaseConn   *sql.Conn
+	fingerprint string
+}
+
+type RowStateLease struct {
+	Name       string
+	Connection Connection
+	DB         *sql.DB
+
+	manager *Manager
+	slot    *rowStateSlot
+	role    string
+	once    sync.Once
+	err     error
+}
+
+type leaseRoleMetadata struct {
+	Version  int    `json:"version"`
+	Manager  string `json:"manager"`
+	Slot     string `json:"slot"`
+	Identity string `json:"identity"`
+	LeaseKey int64  `json:"lease_key"`
+	MAC      string `json:"mac"`
+}
+
+func (m *Manager) AcquireRowState(ctx context.Context) (*RowStateLease, error) {
+	slot, err := m.takeRowStateSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	lease, err := m.beginRowStateLease(ctx, slot)
+	if err != nil {
+		m.retireRowStateSlot(context.Background(), slot)
+		return nil, err
+	}
+	return lease, nil
+}
+
+func (m *Manager) takeRowStateSlot(ctx context.Context) (*rowStateSlot, error) {
+	for {
+		m.rowPool.mu.Lock()
+		last := len(m.rowPool.available) - 1
+		if last >= 0 {
+			slot := m.rowPool.available[last]
+			m.rowPool.available = m.rowPool.available[:last]
+			m.rowPool.mu.Unlock()
+			return slot, nil
+		}
+		if m.rowPool.total < maxRowStateSlotsPerProcess {
+			m.rowPool.total++
+			m.rowPool.mu.Unlock()
+			slot, err := m.createRowStateSlot(ctx)
+			if err != nil {
+				m.rowPool.mu.Lock()
+				m.rowPool.total--
+				m.rowPool.mu.Unlock()
+				return nil, err
+			}
+			return slot, nil
+		}
+		m.rowPool.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("wait for reusable postgres row-state slot: %w", ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (m *Manager) createRowStateSlot(ctx context.Context) (*rowStateSlot, error) {
+	adminDB, err := m.admin.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open postgres admin for row-state slot: %w", err)
+	}
+	defer adminDB.Close()
+	if err := m.ensureTemplate(ctx, adminDB); err != nil {
+		return nil, err
+	}
+	identity := strings.ReplaceAll(uuid.NewString(), "-", "")
+	name := m.signedResourceName(poolNamePrefix, "pool", identity)
+	leaseKey := advisoryKey("pool:" + identity)
+	leaseConn, err := adminDB.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open row-state slot lease connection: %w", err)
+	}
+	if err := acquireAdvisoryLock(ctx, leaseConn, leaseKey, "row-state slot "+name); err != nil {
+		_ = leaseConn.Close()
+		return nil, err
+	}
+	cleanupLock := true
+	defer func() {
+		if cleanupLock {
+			releaseAdvisoryLock(leaseConn, leaseKey)
+		}
+	}()
+	intent := resourceIntent{Name: name, Kind: "pool", Identity: identity, LeaseKey: leaseKey, Template: m.templateName}
+	if err := m.putIntent(ctx, intent); err != nil {
+		return nil, err
+	}
+	if err := m.withDDLAdmission(ctx, adminDB, "clone row-state slot "+name, func(conn *sql.Conn) error {
+		if err := createDatabaseFromTemplate(ctx, conn, name, m.templateName); err != nil {
+			return err
+		}
+		return hardenManagedDatabase(ctx, conn, name)
+	}); err != nil {
+		cleanupErr := m.retireIntentIfDatabaseAbsent(context.Background(), adminDB, name)
+		return nil, errors.Join(fmt.Errorf("create postgres row-state slot %q: %w", name, err), cleanupErr)
+	}
+	metadata := resourceMetadata{Version: 1, Kind: "pool", Identity: identity, LeaseKey: leaseKey, Template: m.templateName}
+	if err := setDatabaseMetadata(ctx, adminDB, name, metadata); err != nil {
+		cleanupErr := m.dropIntendedDatabase(context.Background(), adminDB, name)
+		return nil, errors.Join(err, cleanupErr)
+	}
+	if err := m.deleteIntent(ctx, name); err != nil {
+		_ = m.dropSandbox(context.Background(), adminDB, name)
+		return nil, err
+	}
+	projected, err := m.admin.WithDatabase(name)
+	if err != nil {
+		return nil, err
+	}
+	db, err := projected.Open()
+	if err != nil {
+		return nil, err
+	}
+	fingerprint, err := postgresSchemaFingerprint(ctx, db)
+	_ = db.Close()
+	if err != nil {
+		return nil, err
+	}
+	cleanupLock = false
+	return &rowStateSlot{name: name, identity: identity, leaseKey: leaseKey, leaseConn: leaseConn, fingerprint: fingerprint}, nil
+}
+
+func (m *Manager) beginRowStateLease(ctx context.Context, slot *rowStateSlot) (*RowStateLease, error) {
+	identity := strings.ReplaceAll(uuid.NewString(), "-", "")
+	role := leaseRolePrefix + identity
+	password, err := randomLeasePassword()
+	if err != nil {
+		return nil, err
+	}
+	adminDB, err := m.admin.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer adminDB.Close()
+	tx, err := adminDB.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin postgres row-state lease role transaction: %w", err)
+	}
+	rollback := func(cause error) error {
+		return errors.Join(cause, tx.Rollback())
+	}
+	metadata := m.newLeaseRoleMetadata(role, slot.name, identity, slot.leaseKey)
+	rawMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, rollback(err)
+	}
+	statements := []string{
+		`CREATE ROLE ` + quoteIdent(role) + ` LOGIN PASSWORD ` + quoteLiteral(password),
+		`COMMENT ON ROLE ` + quoteIdent(role) + ` IS ` + quoteLiteral(resourceMetadataPrefix+string(rawMetadata)),
+		`GRANT ` + quoteIdent(m.dmlRole) + ` TO ` + quoteIdent(role),
+		`GRANT CONNECT ON DATABASE ` + quoteIdent(slot.name) + ` TO ` + quoteIdent(role),
+	}
+	for _, stmt := range statements {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return nil, rollback(fmt.Errorf("establish postgres row-state lease authority: %w", err))
+		}
+	}
+	databaseMetadata := resourceMetadata{Version: 1, Kind: "pool", Identity: slot.identity, LeaseKey: slot.leaseKey, Template: m.templateName, Role: role, Lease: identity}
+	rawDatabaseMetadata, err := json.Marshal(databaseMetadata)
+	if err != nil {
+		return nil, rollback(err)
+	}
+	if _, err := tx.ExecContext(ctx, `COMMENT ON DATABASE `+quoteIdent(slot.name)+` IS `+quoteLiteral(resourceMetadataPrefix+string(rawDatabaseMetadata))); err != nil {
+		return nil, rollback(fmt.Errorf("bind postgres row-state lease metadata: %w", err))
+	}
+	if m.beforeLeaseRoleCommit != nil {
+		if err := m.beforeLeaseRoleCommit(role); err != nil {
+			return nil, rollback(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit postgres row-state lease authority: %w", err)
+	}
+	connection, err := m.admin.WithIdentity(slot.name, role, password)
+	if err != nil {
+		_ = m.retireLeaseRole(context.Background(), adminDB, slot.name, role, identity, slot.leaseKey)
+		return nil, err
+	}
+	db, err := connection.Open()
+	if err != nil {
+		_ = m.retireLeaseRole(context.Background(), adminDB, slot.name, role, identity, slot.leaseKey)
+		return nil, err
+	}
+	if err := waitForDatabase(ctx, db, 30*time.Second); err != nil {
+		_ = db.Close()
+		_ = m.retireLeaseRole(context.Background(), adminDB, slot.name, role, identity, slot.leaseKey)
+		return nil, err
+	}
+	return &RowStateLease{Name: slot.name, Connection: connection, DB: db, manager: m, slot: slot, role: role}, nil
+}
+
+func (l *RowStateLease) Release(ctx context.Context) error {
+	l.once.Do(func() {
+		if l.DB != nil {
+			l.err = l.DB.Close()
+		}
+		adminDB, err := l.manager.admin.Open()
+		roleErr := err
+		if err == nil {
+			roleErr = l.manager.retireLeaseRole(ctx, adminDB, l.slot.name, l.role, strings.TrimPrefix(l.role, leaseRolePrefix), l.slot.leaseKey)
+		}
+		err = roleErr
+		if roleErr == nil {
+			err = l.manager.resetRowStateSlot(ctx, l.slot)
+		}
+		if adminDB != nil {
+			_ = adminDB.Close()
+		}
+		if l.err == nil {
+			l.err = err
+		}
+		if l.err != nil {
+			if roleErr != nil {
+				l.manager.quarantineRowStateSlot(l.slot)
+			} else {
+				l.manager.retireRowStateSlot(context.Background(), l.slot)
+			}
+			return
+		}
+		l.manager.rowPool.mu.Lock()
+		l.manager.rowPool.available = append(l.manager.rowPool.available, l.slot)
+		l.manager.rowPool.mu.Unlock()
+	})
+	return l.err
+}
+
+func (m *Manager) resetRowStateSlot(ctx context.Context, slot *rowStateSlot) error {
+	adminDB, err := m.admin.Open()
+	if err != nil {
+		return err
+	}
+	defer adminDB.Close()
+	connection, err := m.admin.WithDatabase(slot.name)
+	if err != nil {
+		return err
+	}
+	db, err := connection.Open()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	tables := make([]string, 0, len(m.ddlPlans))
+	for _, plan := range m.ddlPlans {
+		tables = append(tables, quoteIdent(plan.TableName))
+	}
+	if len(tables) > 0 {
+		if _, err := db.ExecContext(ctx, `TRUNCATE TABLE `+strings.Join(tables, ", ")+` RESTART IDENTITY CASCADE`); err != nil {
+			return fmt.Errorf("reset postgres row-state slot %q: %w", slot.name, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO runtime_store_metadata (id, swarm_version, platform_version, created_at) VALUES (1, $1, $2, $3)`, "test-harness", m.spec.Platform.Version, time.Now().UTC()); err != nil {
+		return fmt.Errorf("restore postgres row-state canonical seed: %w", err)
+	}
+	fingerprint, err := postgresSchemaFingerprint(ctx, db)
+	if err != nil {
+		return err
+	}
+	if fingerprint != slot.fingerprint {
+		return fmt.Errorf("row-state slot %q schema/object shape changed; retire instead of reuse", slot.name)
+	}
+	if err := db.Close(); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		var otherSessions int
+		if err := adminDB.QueryRowContext(ctx, `SELECT count(*) FROM pg_stat_activity WHERE datname=$1`, slot.name).Scan(&otherSessions); err != nil {
+			return fmt.Errorf("verify row-state slot sessions: %w", err)
+		}
+		if otherSessions == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("row-state slot %q retains %d active or dormant sessions", slot.name, otherSessions)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	metadata := resourceMetadata{Version: 1, Kind: "pool", Identity: slot.identity, LeaseKey: slot.leaseKey, Template: m.templateName}
+	return setDatabaseMetadata(ctx, adminDB, slot.name, metadata)
+}
+
+func (m *Manager) retireRowStateSlot(ctx context.Context, slot *rowStateSlot) {
+	adminDB, err := m.admin.Open()
+	if err == nil {
+		_ = m.dropSandbox(ctx, adminDB, slot.name)
+		_ = adminDB.Close()
+	}
+	releaseAdvisoryLock(slot.leaseConn, slot.leaseKey)
+	m.rowPool.mu.Lock()
+	m.rowPool.total--
+	m.rowPool.mu.Unlock()
+}
+
+func (m *Manager) quarantineRowStateSlot(slot *rowStateSlot) {
+	releaseAdvisoryLock(slot.leaseConn, slot.leaseKey)
+	m.rowPool.mu.Lock()
+	m.rowPool.total--
+	m.rowPool.mu.Unlock()
+}
+
+func (m *Manager) preflightCapabilities(ctx context.Context, db *sql.DB) error {
+	var version int
+	var superuser, createDB, createRole bool
+	if err := db.QueryRowContext(ctx, `SELECT current_setting('server_version_num')::int, rolsuper, rolcreatedb, rolcreaterole FROM pg_roles WHERE rolname=current_user`).Scan(&version, &superuser, &createDB, &createRole); err != nil {
+		return fmt.Errorf("inspect postgres test manager capabilities: %w", err)
+	}
+	if version < 160000 || (!superuser && (!createDB || !createRole)) {
+		return fmt.Errorf("postgres test manager requires PostgreSQL 16+ and CREATEDB + CREATEROLE (or superuser); see internal/testutil/POSTGRES.md")
+	}
+	return m.withExclusiveDDLAdmission(ctx, db, "test role capability preflight", func(conn *sql.Conn) error {
+		return m.probeConnectIsolation(ctx, conn)
+	})
+}
+
+func (m *Manager) probeConnectIsolation(ctx context.Context, conn *sql.Conn) error {
+	probe := leaseRolePrefix + "probe_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE ROLE `+quoteIdent(probe)+` NOLOGIN`); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("probe postgres test role authority: %w; see internal/testutil/POSTGRES.md", err)
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT datname FROM pg_database WHERE datallowconn AND has_database_privilege($1, datname, 'CONNECT') ORDER BY datname`, probe)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	var connectable []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			_ = tx.Rollback()
+			return err
+		}
+		connectable = append(connectable, name)
+	}
+	_ = rows.Close()
+	if err := tx.Rollback(); err != nil {
+		return err
+	}
+	if len(connectable) > 0 {
+		return fmt.Errorf("postgres test host grants untrusted roles CONNECT to %s; use a dedicated host and revoke PUBLIC CONNECT as documented in internal/testutil/POSTGRES.md", strings.Join(connectable, ", "))
+	}
+	return nil
+}
+
+func (m *Manager) ensureDMLRole(ctx context.Context, db *sql.DB) error {
+	lockConn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer lockConn.Close()
+	lockKey := advisoryKey("dml-role:" + m.dmlRole)
+	if err := acquireAdvisoryLock(ctx, lockConn, lockKey, "DML role "+m.dmlRole); err != nil {
+		return err
+	}
+	defer func() { _, _ = lockConn.ExecContext(context.Background(), `SELECT pg_advisory_unlock($1)`, lockKey) }()
+	var comment string
+	err = lockConn.QueryRowContext(ctx, `SELECT COALESCE(shobj_description(oid, 'pg_authid'), '') FROM pg_roles WHERE rolname=$1`, m.dmlRole).Scan(&comment)
+	if err == nil {
+		if comment != m.signedRoleComment(m.dmlRole, "dml-role") {
+			return fmt.Errorf("postgres test DML role %q has invalid ownership metadata; left untouched", m.dmlRole)
+		}
+		return nil
+	}
+	if err != sql.ErrNoRows {
+		return err
+	}
+	if _, err := lockConn.ExecContext(ctx, `CREATE ROLE `+quoteIdent(m.dmlRole)+` NOLOGIN`); err != nil {
+		return fmt.Errorf("create postgres test DML role: %w", err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `COMMENT ON ROLE `+quoteIdent(m.dmlRole)+` IS `+quoteLiteral(m.signedRoleComment(m.dmlRole, "dml-role"))); err != nil {
+		return fmt.Errorf("stamp postgres test DML role: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) retireLeaseRole(ctx context.Context, db *sql.DB, slot, role, identity string, leaseKey int64) error {
+	var comment string
+	err := db.QueryRowContext(ctx, `SELECT COALESCE(shobj_description(oid, 'pg_authid'), '') FROM pg_roles WHERE rolname=$1`, role).Scan(&comment)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !m.validLeaseRoleComment(comment, role, slot, identity, leaseKey) {
+		return fmt.Errorf("role metadata is invalid; role left untouched")
+	}
+	statements := []string{`ALTER ROLE ` + quoteIdent(role) + ` NOLOGIN`}
+	var slotExists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)`, slot).Scan(&slotExists); err != nil {
+		return err
+	}
+	if slotExists {
+		statements = append(statements, `REVOKE CONNECT ON DATABASE `+quoteIdent(slot)+` FROM `+quoteIdent(role))
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	if _, err := db.ExecContext(ctx, `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename=$1 AND datname=$2 AND pid<>pg_backend_pid()`, role, slot); err != nil {
+		return err
+	}
+	sessionDeadline := time.Now().Add(time.Second)
+	for {
+		var sessions int
+		if err := db.QueryRowContext(ctx, `SELECT count(*) FROM pg_stat_activity WHERE usename=$1 AND datname=$2`, role, slot).Scan(&sessions); err != nil {
+			return err
+		}
+		if sessions == 0 {
+			break
+		}
+		if time.Now().After(sessionDeadline) {
+			return fmt.Errorf("lease role %q retains %d sessions", role, sessions)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	for _, stmt := range []string{
+		`REVOKE ` + quoteIdent(m.dmlRole) + ` FROM ` + quoteIdent(role),
+		`DROP ROLE ` + quoteIdent(role),
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	var roleExists bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname=$1)`, role).Scan(&roleExists); err != nil {
+		return err
+	}
+	if roleExists {
+		return fmt.Errorf("lease role %q still exists after drop", role)
+	}
+	return nil
+}
+
+func (m *Manager) reconcileLeaseRoles(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, `SELECT rolname, COALESCE(shobj_description(oid, 'pg_authid'), '') FROM pg_roles WHERE rolname LIKE $1 ORDER BY rolname`, leaseRolePrefix+"%")
+	if err != nil {
+		return fmt.Errorf("list postgres test lease roles: %w", err)
+	}
+	type candidate struct{ role, comment string }
+	var candidates []candidate
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.role, &item.comment); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		candidates = append(candidates, item)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, item := range candidates {
+		metadata, err := m.parseLeaseRoleComment(item.comment, item.role)
+		if err != nil {
+			return fmt.Errorf("unprovable postgres test lease role %q left untouched: %w", item.role, err)
+		}
+		lockConn, acquired, err := tryAdvisoryLock(ctx, db, metadata.LeaseKey)
+		if err != nil {
+			return err
+		}
+		if !acquired {
+			continue
+		}
+		err = m.retireLeaseRole(ctx, db, metadata.Slot, item.role, metadata.Identity, metadata.LeaseKey)
+		if err == nil {
+			var slotExists bool
+			if queryErr := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname=$1)`, metadata.Slot).Scan(&slotExists); queryErr != nil {
+				err = queryErr
+			} else if slotExists {
+				err = m.dropSandbox(ctx, db, metadata.Slot)
+			}
+		}
+		releaseAdvisoryLock(lockConn, metadata.LeaseKey)
+		if err != nil {
+			return fmt.Errorf("reconcile postgres test lease role %q: %w", item.role, err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) newLeaseRoleMetadata(role, slot, identity string, leaseKey int64) leaseRoleMetadata {
+	metadata := leaseRoleMetadata{Version: 1, Manager: m.role, Slot: slot, Identity: identity, LeaseKey: leaseKey}
+	metadata.MAC = m.leaseRoleMAC(role, metadata)
+	return metadata
+}
+
+func (m *Manager) validLeaseRoleComment(comment, role, slot, identity string, leaseKey int64) bool {
+	if !strings.HasPrefix(comment, resourceMetadataPrefix) {
+		return false
+	}
+	var metadata leaseRoleMetadata
+	if json.Unmarshal([]byte(strings.TrimPrefix(comment, resourceMetadataPrefix)), &metadata) != nil {
+		return false
+	}
+	want := m.newLeaseRoleMetadata(role, slot, identity, leaseKey)
+	return metadata == want
+}
+
+func (m *Manager) parseLeaseRoleComment(comment, role string) (leaseRoleMetadata, error) {
+	if !strings.HasPrefix(comment, resourceMetadataPrefix) {
+		return leaseRoleMetadata{}, fmt.Errorf("missing signed metadata")
+	}
+	var metadata leaseRoleMetadata
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(comment, resourceMetadataPrefix)), &metadata); err != nil {
+		return leaseRoleMetadata{}, err
+	}
+	if metadata.Version != 1 || metadata.Manager != m.role || role != leaseRolePrefix+metadata.Identity {
+		return leaseRoleMetadata{}, fmt.Errorf("metadata identity mismatch")
+	}
+	slotIdentity, ok := m.verifyResourceName(metadata.Slot, poolNamePrefix, "pool")
+	if !ok || metadata.LeaseKey != advisoryKey("pool:"+slotIdentity) {
+		return leaseRoleMetadata{}, fmt.Errorf("slot ownership mismatch")
+	}
+	if !m.validLeaseRoleComment(comment, role, metadata.Slot, metadata.Identity, metadata.LeaseKey) {
+		return leaseRoleMetadata{}, fmt.Errorf("metadata signature mismatch")
+	}
+	return metadata, nil
+}
+
+func (m *Manager) leaseRoleMAC(role string, metadata leaseRoleMetadata) string {
+	value := strings.Join([]string{role, metadata.Manager, metadata.Slot, metadata.Identity, fmt.Sprint(metadata.LeaseKey)}, "\x00")
+	mac := hmac.New(sha256.New, m.ownershipKey)
+	_, _ = mac.Write([]byte(value))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (m *Manager) signedRoleComment(role, kind string) string {
+	mac := hmac.New(sha256.New, m.ownershipKey)
+	_, _ = mac.Write([]byte(kind + "\x00" + role))
+	return resourceMetadataPrefix + hex.EncodeToString(mac.Sum(nil))
+}
+
+func randomLeasePassword() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate postgres lease password: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func postgresSchemaFingerprint(ctx context.Context, db *sql.DB) (string, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT n.nspname, c.relkind::text, c.relname,
+		       COALESCE(pg_get_viewdef(c.oid, true), ''),
+		       COALESCE(string_agg(a.attname || ':' || format_type(a.atttypid,a.atttypmod) || ':' || a.attnotnull::text, ',' ORDER BY a.attnum) FILTER (WHERE a.attnum > 0 AND NOT a.attisdropped), '')
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid=c.relnamespace
+		LEFT JOIN pg_attribute a ON a.attrelid=c.oid
+		WHERE n.nspname='public' AND c.relkind IN ('r','p','v','m','S','f','i')
+		GROUP BY n.nspname,c.relkind,c.relname,c.oid
+		ORDER BY c.relkind,c.relname`)
+	if err != nil {
+		return "", fmt.Errorf("inspect postgres row-state schema shape: %w", err)
+	}
+	defer rows.Close()
+	var objects []string
+	for rows.Next() {
+		var schema, kind, name, definition, columns string
+		if err := rows.Scan(&schema, &kind, &name, &definition, &columns); err != nil {
+			return "", err
+		}
+		objects = append(objects, strings.Join([]string{schema, kind, name, definition, columns}, "\x00"))
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	sort.Strings(objects)
+	digest := sha256.Sum256([]byte(strings.Join(objects, "\x01")))
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/testpostgres/row_pool.go
+++ b/internal/testpostgres/row_pool.go
@@ -418,11 +418,26 @@ func (m *Manager) ensureDMLRole(ctx context.Context, db *sql.DB) error {
 	if err != sql.ErrNoRows {
 		return err
 	}
-	if _, err := lockConn.ExecContext(ctx, `CREATE ROLE `+quoteIdent(m.dmlRole)+` NOLOGIN`); err != nil {
-		return fmt.Errorf("create postgres test DML role: %w", err)
+	tx, err := lockConn.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin postgres test DML role transaction: %w", err)
 	}
-	if _, err := lockConn.ExecContext(ctx, `COMMENT ON ROLE `+quoteIdent(m.dmlRole)+` IS `+quoteLiteral(m.signedRoleComment(m.dmlRole, "dml-role"))); err != nil {
-		return fmt.Errorf("stamp postgres test DML role: %w", err)
+	rollback := func(cause error) error {
+		return errors.Join(cause, tx.Rollback())
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE ROLE `+quoteIdent(m.dmlRole)+` NOLOGIN`); err != nil {
+		return rollback(fmt.Errorf("create postgres test DML role: %w", err))
+	}
+	if _, err := tx.ExecContext(ctx, `COMMENT ON ROLE `+quoteIdent(m.dmlRole)+` IS `+quoteLiteral(m.signedRoleComment(m.dmlRole, "dml-role"))); err != nil {
+		return rollback(fmt.Errorf("stamp postgres test DML role: %w", err))
+	}
+	if m.beforeDMLRoleCommit != nil {
+		if err := m.beforeDMLRoleCommit(m.dmlRole); err != nil {
+			return rollback(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit postgres test DML role: %w", err)
 	}
 	return nil
 }

--- a/internal/testpostgres/service_registry.go
+++ b/internal/testpostgres/service_registry.go
@@ -238,6 +238,10 @@ func (r *ServiceRegistry) Provision(ctx context.Context, executable string) (*Se
 		_ = db.Close()
 		return nil, fmt.Errorf("wait for runner-owned Postgres: %w", err)
 	}
+	if err := hardenOwnedPostgres(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
 	if err := verifyOwnedPostgresSettings(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -251,6 +255,15 @@ func (r *ServiceRegistry) Provision(ctx context.Context, executable string) (*Se
 	service.Connection = connection
 	cleanupOnError = false
 	return service, nil
+}
+
+func hardenOwnedPostgres(ctx context.Context, db *sql.DB) error {
+	for _, name := range []string{"postgres", "template1"} {
+		if _, err := db.ExecContext(ctx, `REVOKE CONNECT, TEMPORARY ON DATABASE `+quoteIdent(name)+` FROM PUBLIC`); err != nil {
+			return fmt.Errorf("harden runner-owned Postgres database %q: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func (s *Service) MarkChildRunning() error {

--- a/internal/testutil/POSTGRES.md
+++ b/internal/testutil/POSTGRES.md
@@ -5,9 +5,10 @@ preferred local setup is a host Postgres instance selected explicitly with
 `SWARM_TEST_POSTGRES_DSN`; this avoids the Docker or Colima memory cost during
 normal test iteration.
 
-The test role must use password authentication and have `CREATEDB`. The harness
-creates isolated databases, initializes one canonical schema template, clones
-that template for each test, and removes the databases during cleanup. Custom
+The test role must use password authentication and have `CREATEDB` plus
+`CREATEROLE`. The harness creates fresh physical databases only for schema and
+database-level proofs; row-state proofs reuse fenced databases through a random,
+single-lease login role. Custom
 `pqgo-*` TLS registrations, GSS authentication, passfiles, service files, and
 empty passwords are intentionally unsupported because cleanup runs in a separate
 process and must receive a self-contained connection value.
@@ -21,19 +22,24 @@ intent are left untouched and block reconciliation.
 
 ## Existing Host Postgres
 
-For a local PostgreSQL 16 server whose current administrator can create roles:
+Only a dedicated PostgreSQL 16 test cluster is supported. The harness rejects a
+shared cluster where a newly created role inherits `CONNECT` to any database.
+As a cluster administrator:
 
 ```bash
 psql postgres <<'SQL'
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'swarm_test') THEN
-    CREATE ROLE swarm_test LOGIN CREATEDB PASSWORD 'swarm-test';
+    CREATE ROLE swarm_test LOGIN CREATEDB CREATEROLE PASSWORD 'swarm-test';
   ELSE
-    ALTER ROLE swarm_test LOGIN CREATEDB PASSWORD 'swarm-test';
+    ALTER ROLE swarm_test LOGIN CREATEDB CREATEROLE PASSWORD 'swarm-test';
   END IF;
 END
 $$;
+REVOKE CONNECT, TEMPORARY ON DATABASE postgres FROM PUBLIC;
+REVOKE CONNECT, TEMPORARY ON DATABASE template1 FROM PUBLIC;
+GRANT CONNECT ON DATABASE postgres TO swarm_test;
 SQL
 ```
 
@@ -56,7 +62,7 @@ URL DSNs are equally supported:
 
 ```bash
 SWARM_TEST_POSTGRES_DSN='postgres://swarm_test:swarm-test@127.0.0.1:5432/postgres?sslmode=disable' \
-  go test ./internal/testutil -run '^TestStartPostgres' -count=1
+  go test ./internal/testutil -run '^TestAcquirePostgres' -count=1
 ```
 
 A set but invalid DSN fails closed and never falls through to Docker.

--- a/internal/testutil/database.go
+++ b/internal/testutil/database.go
@@ -1,0 +1,125 @@
+package testutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type DatabaseBackend uint8
+
+const (
+	databaseBackendInvalid DatabaseBackend = iota
+	DatabaseBackendSQLite
+	DatabaseBackendPostgreSQL
+)
+
+type DatabaseIsolation uint8
+
+const (
+	databaseIsolationInvalid DatabaseIsolation = iota
+	databaseIsolationSQLiteTemp
+	databaseIsolationSQLiteFile
+	databaseIsolationSQLiteSharedFile
+	databaseIsolationPostgresRowState
+	databaseIsolationPostgresFreshPhysical
+	databaseIsolationPostgresEmptyPhysical
+)
+
+type DatabaseRequirement struct {
+	backend   DatabaseBackend
+	isolation DatabaseIsolation
+}
+
+func SQLiteDefaultTemp() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendSQLite, isolation: databaseIsolationSQLiteTemp}
+}
+
+func SQLiteFreshFile() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendSQLite, isolation: databaseIsolationSQLiteFile}
+}
+
+func SQLiteSharedFile() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendSQLite, isolation: databaseIsolationSQLiteSharedFile}
+}
+
+func PostgresRowState() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendPostgreSQL, isolation: databaseIsolationPostgresRowState}
+}
+
+func PostgresFreshPhysical() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendPostgreSQL, isolation: databaseIsolationPostgresFreshPhysical}
+}
+
+func PostgresEmptyPhysical() DatabaseRequirement {
+	return DatabaseRequirement{backend: DatabaseBackendPostgreSQL, isolation: databaseIsolationPostgresEmptyPhysical}
+}
+
+func (r DatabaseRequirement) validate() error {
+	switch {
+	case r.backend == DatabaseBackendSQLite && (r.isolation == databaseIsolationSQLiteTemp || r.isolation == databaseIsolationSQLiteFile || r.isolation == databaseIsolationSQLiteSharedFile):
+		return nil
+	case r.backend == DatabaseBackendPostgreSQL && (r.isolation == databaseIsolationPostgresRowState || r.isolation == databaseIsolationPostgresFreshPhysical || r.isolation == databaseIsolationPostgresEmptyPhysical):
+		return nil
+	default:
+		return fmt.Errorf("unsupported or omitted test database backend/isolation requirement (%d/%d)", r.backend, r.isolation)
+	}
+}
+
+func SQLitePath(t testing.TB, requirement DatabaseRequirement) string {
+	t.Helper()
+	if err := requirement.validate(); err != nil {
+		t.Fatal(err)
+	}
+	if requirement.backend != DatabaseBackendSQLite {
+		t.Fatalf("SQLite path requires SQLite backend, got %d", requirement.backend)
+	}
+	switch requirement.isolation {
+	case databaseIsolationSQLiteTemp:
+		return filepath.Join(t.TempDir(), ".swarm", "dev.db")
+	case databaseIsolationSQLiteFile:
+		return filepath.Join(t.TempDir(), "database.db")
+	case databaseIsolationSQLiteSharedFile:
+		return filepath.Join(t.TempDir(), "shared.db")
+	default:
+		t.Fatalf("unsupported SQLite isolation %d", requirement.isolation)
+		return ""
+	}
+}
+
+func SQLiteDeclaredPath(t testing.TB, requirement DatabaseRequirement, path string) string {
+	t.Helper()
+	declared, err := DeclareSQLitePath(requirement, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return declared
+}
+
+func DeclareSQLitePath(requirement DatabaseRequirement, path string) (string, error) {
+	if err := requirement.validate(); err != nil {
+		return "", err
+	}
+	if requirement.backend != DatabaseBackendSQLite {
+		return "", fmt.Errorf("explicit SQLite path requires SQLite backend, got %d/%d", requirement.backend, requirement.isolation)
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("explicit SQLite path is required")
+	}
+	return path, nil
+}
+
+func SQLiteDeclaredDSN(t testing.TB, requirement DatabaseRequirement, dsn string) string {
+	t.Helper()
+	if err := requirement.validate(); err != nil {
+		t.Fatal(err)
+	}
+	if requirement.backend != DatabaseBackendSQLite {
+		t.Fatalf("SQLite DSN requires SQLite backend, got %d", requirement.backend)
+	}
+	if strings.TrimSpace(dsn) == "" {
+		t.Fatal("SQLite DSN is required")
+	}
+	return dsn
+}

--- a/internal/testutil/database_guard_test.go
+++ b/internal/testutil/database_guard_test.go
@@ -1,0 +1,149 @@
+package testutil
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDatabaseAcquisitionRequiresTypedRequirement(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	var violations []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !databaseGuardScansFile(root, path) {
+			return err
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := databaseGuardCallName(call.Fun)
+			position := fset.Position(call.Pos())
+			fail := func(reason string) {
+				rel, _ := filepath.Rel(root, path)
+				violations = append(violations, fmt.Sprintf("%s:%d: %s", rel, position.Line, reason))
+			}
+			switch name {
+			case "StartPostgres", "StartEmptyPostgres":
+				fail("retired untyped PostgreSQL acquisition")
+			case "AcquirePostgres":
+				if len(call.Args) < 2 {
+					fail("PostgreSQL acquisition omits DatabaseRequirement")
+				}
+			case "StartSQLiteRuntimeStore":
+				if len(call.Args) < 2 {
+					fail("SQLite store acquisition omits DatabaseRequirement")
+				}
+			case "StartSQLiteRuntimeStoreWithContext":
+				if len(call.Args) < 3 {
+					fail("SQLite store acquisition omits DatabaseRequirement")
+				}
+			case "newBootstrappedSQLiteRuntimeStoreForTest":
+				if len(call.Args) < 2 {
+					fail("SQLite temp helper omits DatabaseRequirement")
+				}
+			case "newBootstrappedSQLiteRuntimeStoreForPath":
+				if len(call.Args) < 3 {
+					fail("SQLite path helper omits DatabaseRequirement")
+				}
+			case "NewSQLiteRuntimeStore":
+				if len(call.Args) == 0 || !databaseGuardTypedSQLitePath(call.Args[0], file) {
+					fail("SQLite runtime constructor bypasses typed path declaration")
+				}
+			case "Open":
+				if databaseGuardIsSQLiteOpen(call) && !databaseGuardCallIs(call.Args[1], "SQLiteDeclaredDSN") {
+					fail("direct SQLite open bypasses typed DSN declaration")
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("untyped test database acquisition bypasses:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func databaseGuardCallName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.SelectorExpr:
+		return value.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func databaseGuardCallIs(expr ast.Expr, name string) bool {
+	call, ok := expr.(*ast.CallExpr)
+	return ok && databaseGuardCallName(call.Fun) == name
+}
+
+func databaseGuardTypedSQLitePath(expr ast.Expr, file *ast.File) bool {
+	if databaseGuardCallIs(expr, "SQLiteDeclaredPath") || databaseGuardCallIs(expr, "SQLitePath") {
+		return true
+	}
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	typed := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) == 0 || len(assign.Rhs) == 0 {
+			return true
+		}
+		lhs, ok := assign.Lhs[0].(*ast.Ident)
+		if ok && lhs.Name == ident.Name && (databaseGuardCallIs(assign.Rhs[0], "DeclareSQLitePath") || databaseGuardCallIs(assign.Rhs[0], "SQLitePath")) {
+			typed = true
+			return false
+		}
+		return true
+	})
+	return typed
+}
+
+func databaseGuardScansFile(root, path string) bool {
+	if !strings.HasSuffix(path, ".go") {
+		return false
+	}
+	if strings.HasSuffix(path, "_test.go") {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(rel, filepath.Join("internal", "testutil")+string(filepath.Separator)) ||
+		strings.HasPrefix(rel, filepath.Join("internal", "store", "storetest")+string(filepath.Separator))
+}
+
+func databaseGuardIsSQLiteOpen(call *ast.CallExpr) bool {
+	if len(call.Args) < 2 {
+		return false
+	}
+	literal, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false
+	}
+	driver, err := strconv.Unquote(literal.Value)
+	return err == nil && driver == "sqlite"
+}

--- a/internal/testutil/database_guard_test.go
+++ b/internal/testutil/database_guard_test.go
@@ -8,15 +8,93 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 )
 
+var databaseRequirementConstructors = map[string]bool{
+	"SQLiteDefaultTemp":     true,
+	"SQLiteFreshFile":       true,
+	"SQLiteSharedFile":      true,
+	"PostgresRowState":      true,
+	"PostgresFreshPhysical": true,
+	"PostgresEmptyPhysical": true,
+}
+
+var databasePrimitiveRequirementIndex = map[string]int{
+	"AcquirePostgres":                          1,
+	"StartSQLiteRuntimeStore":                  1,
+	"StartSQLiteRuntimeStoreWithContext":       2,
+	"newBootstrappedSQLiteRuntimeStoreForTest": 1,
+	"newBootstrappedSQLiteRuntimeStoreForPath": 2,
+	"SQLitePath":         1,
+	"SQLiteDeclaredPath": 1,
+	"DeclareSQLitePath":  0,
+	"SQLiteDeclaredDSN":  1,
+}
+
+type databaseGuardSource struct {
+	path string
+	fset *token.FileSet
+	file *ast.File
+}
+
+type databaseGuardFunction struct {
+	name               string
+	path               string
+	fset               *token.FileSet
+	file               *ast.File
+	decl               *ast.FuncDecl
+	requirementParams  map[string]bool
+	requirementIndex   []int
+	calls              []*ast.CallExpr
+	directAcquisition  bool
+	reachesAcquisition bool
+}
+
 func TestDatabaseAcquisitionRequiresTypedRequirement(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
-	var violations []string
+	sources, err := databaseGuardLoadSources(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := databaseGuardViolations(root, sources)
+	if len(violations) > 0 {
+		t.Fatalf("untyped test database acquisition bypasses:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func TestDatabaseGuardRejectsHiddenWrapperDefaults(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	fixtureRoot := filepath.Join(filepath.Dir(thisFile), "testdata", "database_guard")
+	entries, err := os.ReadDir(fixtureRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		t.Run(strings.TrimSuffix(entry.Name(), ".go"), func(t *testing.T) {
+			path := filepath.Join(fixtureRoot, entry.Name())
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			violations := databaseGuardViolations(fixtureRoot, []databaseGuardSource{{path: path, fset: fset, file: file}})
+			if len(violations) == 0 || !strings.Contains(strings.Join(violations, "\n"), "hides database isolation") {
+				t.Fatalf("violations = %v, want hidden database isolation rejection", violations)
+			}
+		})
+	}
+}
+
+func databaseGuardLoadSources(root string) ([]databaseGuardSource, error) {
+	var sources []databaseGuardSource
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || !databaseGuardScansFile(root, path) {
 			return err
@@ -26,59 +104,157 @@ func TestDatabaseAcquisitionRequiresTypedRequirement(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
+		sources = append(sources, databaseGuardSource{path: path, fset: fset, file: file})
+		return nil
+	})
+	return sources, err
+}
+
+func databaseGuardViolations(root string, sources []databaseGuardSource) []string {
+	functionsByPackage := make(map[string]map[string][]*databaseGuardFunction)
+	var functions []*databaseGuardFunction
+	for _, source := range sources {
+		packageKey := filepath.Dir(source.path) + "\x00" + source.file.Name.Name
+		if functionsByPackage[packageKey] == nil {
+			functionsByPackage[packageKey] = make(map[string][]*databaseGuardFunction)
+		}
+		for _, declaration := range source.file.Decls {
+			decl, ok := declaration.(*ast.FuncDecl)
+			if !ok || decl.Body == nil {
+				continue
 			}
+			fn := &databaseGuardFunction{
+				name: decl.Name.Name, path: source.path, fset: source.fset, file: source.file, decl: decl,
+				requirementParams: make(map[string]bool),
+			}
+			fieldIndex := 0
+			if decl.Type.Params != nil {
+				for _, field := range decl.Type.Params.List {
+					count := len(field.Names)
+					if count == 0 {
+						count = 1
+					}
+					if databaseGuardTypeName(field.Type) == "DatabaseRequirement" {
+						for offset := 0; offset < count; offset++ {
+							fn.requirementIndex = append(fn.requirementIndex, fieldIndex+offset)
+						}
+						for _, name := range field.Names {
+							fn.requirementParams[name.Name] = true
+						}
+					}
+					fieldIndex += count
+				}
+			}
+			ast.Inspect(decl.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				fn.calls = append(fn.calls, call)
+				name := databaseGuardCallName(call.Fun)
+				if _, ok := databasePrimitiveRequirementIndex[name]; ok || name == "NewSQLiteRuntimeStore" || databaseGuardIsSQLiteOpen(call) {
+					fn.directAcquisition = true
+					fn.reachesAcquisition = true
+				}
+				return true
+			})
+			functions = append(functions, fn)
+			functionsByPackage[packageKey][fn.name] = append(functionsByPackage[packageKey][fn.name], fn)
+		}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for _, fn := range functions {
+			if fn.reachesAcquisition {
+				continue
+			}
+			packageFunctions := functionsByPackage[filepath.Dir(fn.path)+"\x00"+fn.file.Name.Name]
+			for _, call := range fn.calls {
+				targets := packageFunctions[databaseGuardCallName(call.Fun)]
+				if len(targets) == 1 && targets[0].reachesAcquisition {
+					fn.reachesAcquisition = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+
+	var violations []string
+	fail := func(fn *databaseGuardFunction, node ast.Node, reason string) {
+		rel, _ := filepath.Rel(root, fn.path)
+		violations = append(violations, fmt.Sprintf("%s:%d: %s", rel, fn.fset.Position(node.Pos()).Line, reason))
+	}
+	for _, fn := range functions {
+		rootDeclaration := databaseGuardRootDeclaration(fn.name)
+		if fn.reachesAcquisition && !rootDeclaration && len(fn.requirementIndex) == 0 {
+			fail(fn, fn.decl.Name, fmt.Sprintf("helper %s hides database isolation instead of accepting DatabaseRequirement", fn.name))
+		}
+		packageFunctions := functionsByPackage[filepath.Dir(fn.path)+"\x00"+fn.file.Name.Name]
+		for _, call := range fn.calls {
 			name := databaseGuardCallName(call.Fun)
-			position := fset.Position(call.Pos())
-			fail := func(reason string) {
-				rel, _ := filepath.Rel(root, path)
-				violations = append(violations, fmt.Sprintf("%s:%d: %s", rel, position.Line, reason))
+			if name == "StartPostgres" || name == "StartEmptyPostgres" {
+				fail(fn, call, "retired untyped PostgreSQL acquisition")
+				continue
+			}
+			if databaseRequirementConstructors[name] && !rootDeclaration {
+				fail(fn, call, fmt.Sprintf("helper %s hides database isolation with %s", fn.name, name))
+			}
+			if requirementIndex, ok := databasePrimitiveRequirementIndex[name]; ok {
+				databaseGuardRequireForwardedArgument(fn, call, requirementIndex, rootDeclaration, fail)
 			}
 			switch name {
-			case "StartPostgres", "StartEmptyPostgres":
-				fail("retired untyped PostgreSQL acquisition")
-			case "AcquirePostgres":
-				if len(call.Args) < 2 {
-					fail("PostgreSQL acquisition omits DatabaseRequirement")
-				}
-			case "StartSQLiteRuntimeStore":
-				if len(call.Args) < 2 {
-					fail("SQLite store acquisition omits DatabaseRequirement")
-				}
-			case "StartSQLiteRuntimeStoreWithContext":
-				if len(call.Args) < 3 {
-					fail("SQLite store acquisition omits DatabaseRequirement")
-				}
-			case "newBootstrappedSQLiteRuntimeStoreForTest":
-				if len(call.Args) < 2 {
-					fail("SQLite temp helper omits DatabaseRequirement")
-				}
-			case "newBootstrappedSQLiteRuntimeStoreForPath":
-				if len(call.Args) < 3 {
-					fail("SQLite path helper omits DatabaseRequirement")
-				}
 			case "NewSQLiteRuntimeStore":
-				if len(call.Args) == 0 || !databaseGuardTypedSQLitePath(call.Args[0], file) {
-					fail("SQLite runtime constructor bypasses typed path declaration")
+				if len(call.Args) == 0 || !databaseGuardTypedSQLitePath(call.Args[0]) {
+					fail(fn, call, "SQLite runtime constructor bypasses typed path declaration")
 				}
 			case "Open":
 				if databaseGuardIsSQLiteOpen(call) && !databaseGuardCallIs(call.Args[1], "SQLiteDeclaredDSN") {
-					fail("direct SQLite open bypasses typed DSN declaration")
+					fail(fn, call, "direct SQLite open bypasses typed DSN declaration")
 				}
 			}
-			return true
-		})
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+			targets := packageFunctions[name]
+			if len(targets) != 1 || !targets[0].reachesAcquisition {
+				continue
+			}
+			for _, requirementIndex := range targets[0].requirementIndex {
+				databaseGuardRequireForwardedArgument(fn, call, requirementIndex, rootDeclaration, fail)
+			}
+		}
 	}
-	if len(violations) > 0 {
-		t.Fatalf("untyped test database acquisition bypasses:\n%s", strings.Join(violations, "\n"))
+	sort.Strings(violations)
+	return violations
+}
+
+func databaseGuardRequireForwardedArgument(fn *databaseGuardFunction, call *ast.CallExpr, index int, rootDeclaration bool, fail func(*databaseGuardFunction, ast.Node, string)) {
+	if index >= len(call.Args) {
+		fail(fn, call, "database acquisition omits DatabaseRequirement")
+		return
 	}
+	if rootDeclaration {
+		return
+	}
+	ident, ok := call.Args[index].(*ast.Ident)
+	if !ok || !fn.requirementParams[ident.Name] {
+		fail(fn, call, fmt.Sprintf("helper %s does not forward its DatabaseRequirement parameter", fn.name))
+	}
+}
+
+func databaseGuardTypeName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.SelectorExpr:
+		return value.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func databaseGuardRootDeclaration(name string) bool {
+	return strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Benchmark") || strings.HasPrefix(name, "Fuzz") || strings.HasPrefix(name, "Example")
 }
 
 func databaseGuardCallName(expr ast.Expr) string {
@@ -97,32 +273,34 @@ func databaseGuardCallIs(expr ast.Expr, name string) bool {
 	return ok && databaseGuardCallName(call.Fun) == name
 }
 
-func databaseGuardTypedSQLitePath(expr ast.Expr, file *ast.File) bool {
+func databaseGuardTypedSQLitePath(expr ast.Expr) bool {
 	if databaseGuardCallIs(expr, "SQLiteDeclaredPath") || databaseGuardCallIs(expr, "SQLitePath") {
 		return true
 	}
 	ident, ok := expr.(*ast.Ident)
-	if !ok {
+	if !ok || ident.Obj == nil {
 		return false
 	}
-	typed := false
-	ast.Inspect(file, func(node ast.Node) bool {
-		assign, ok := node.(*ast.AssignStmt)
-		if !ok || len(assign.Lhs) == 0 || len(assign.Rhs) == 0 {
-			return true
+	switch declaration := ident.Obj.Decl.(type) {
+	case *ast.AssignStmt:
+		for index, lhs := range declaration.Lhs {
+			declared, ok := lhs.(*ast.Ident)
+			if ok && declared.Obj == ident.Obj && index < len(declaration.Rhs) {
+				return databaseGuardCallIs(declaration.Rhs[index], "DeclareSQLitePath") || databaseGuardCallIs(declaration.Rhs[index], "SQLitePath")
+			}
 		}
-		lhs, ok := assign.Lhs[0].(*ast.Ident)
-		if ok && lhs.Name == ident.Name && (databaseGuardCallIs(assign.Rhs[0], "DeclareSQLitePath") || databaseGuardCallIs(assign.Rhs[0], "SQLitePath")) {
-			typed = true
-			return false
+	case *ast.ValueSpec:
+		for index, declared := range declaration.Names {
+			if declared.Obj == ident.Obj && index < len(declaration.Values) {
+				return databaseGuardCallIs(declaration.Values[index], "DeclareSQLitePath") || databaseGuardCallIs(declaration.Values[index], "SQLitePath")
+			}
 		}
-		return true
-	})
-	return typed
+	}
+	return false
 }
 
 func databaseGuardScansFile(root, path string) bool {
-	if !strings.HasSuffix(path, ".go") {
+	if !strings.HasSuffix(path, ".go") || strings.Contains(path, string(filepath.Separator)+"testdata"+string(filepath.Separator)) {
 		return false
 	}
 	if strings.HasSuffix(path, "_test.go") {

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -20,21 +20,18 @@ var postgresManagers = struct {
 	bySource map[string]*testpostgres.Manager
 }{bySource: make(map[string]*testpostgres.Manager)}
 
-// StartPostgres returns a database-per-test sandbox cloned from the canonical
-// content-addressed platform template.
-func StartPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
+func AcquirePostgres(t *testing.T, requirement DatabaseRequirement) (dsn string, db *sql.DB, cleanup func()) {
 	t.Helper()
-	return startPostgresDatabase(t, true)
+	if err := requirement.validate(); err != nil {
+		t.Fatal(err)
+	}
+	if requirement.backend != DatabaseBackendPostgreSQL {
+		t.Fatalf("PostgreSQL acquisition requires PostgreSQL backend, got %d", requirement.backend)
+	}
+	return acquirePostgresDatabase(t, requirement)
 }
 
-// StartEmptyPostgres returns a database-per-test sandbox without platform
-// schema bootstrap.
-func StartEmptyPostgres(t *testing.T) (dsn string, db *sql.DB, cleanup func()) {
-	t.Helper()
-	return startPostgresDatabase(t, false)
-}
-
-func startPostgresDatabase(t *testing.T, useTemplate bool) (string, *sql.DB, func()) {
+func acquirePostgresDatabase(t *testing.T, requirement DatabaseRequirement) (string, *sql.DB, func()) {
 	t.Helper()
 	connection, err := testpostgres.ConnectionFromEnvironment()
 	if err != nil {
@@ -60,6 +57,32 @@ func startPostgresDatabase(t *testing.T, useTemplate bool) (string, *sql.DB, fun
 	postgresManagers.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	if requirement.isolation == databaseIsolationPostgresRowState {
+		lease, err := manager.AcquireRowState(ctx)
+		cancel()
+		if err != nil {
+			t.Fatalf("acquire reusable Postgres row-state lease: %v", err)
+		}
+		dsn, err := lease.Connection.String()
+		if err != nil {
+			_ = lease.Release(context.Background())
+			t.Fatalf("serialize Postgres row-state lease: %v", err)
+		}
+		release := func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			if err := lease.Release(ctx); err != nil {
+				t.Errorf("release Postgres row-state lease %q: %v", lease.Name, err)
+			}
+		}
+		t.Cleanup(release)
+		return dsn, lease.DB, release
+	}
+	useTemplate := requirement.isolation == databaseIsolationPostgresFreshPhysical
+	if !useTemplate && requirement.isolation != databaseIsolationPostgresEmptyPhysical {
+		cancel()
+		t.Fatalf("unsupported PostgreSQL isolation %d", requirement.isolation)
+	}
 	sandbox, err := manager.Acquire(ctx, useTemplate)
 	cancel()
 	if err != nil {

--- a/internal/testutil/postgres_test.go
+++ b/internal/testutil/postgres_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/testpostgres"
 	"github.com/division-sh/swarm/internal/yamlsource"
 )
 
-func TestStartPostgres_Smoke(t *testing.T) {
-	_, db, cleanup := StartPostgres(t)
+func TestAcquirePostgresFreshPhysicalSmoke(t *testing.T) {
+	_, db, cleanup := AcquirePostgres(t, PostgresFreshPhysical())
 	defer cleanup()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -38,7 +39,7 @@ func loadPlatformSpec() (runtimecontracts.PlatformSpecDocument, error) {
 	return spec, err
 }
 
-func TestStartPostgres_CanonicalSchemaTemplatePreservesIsolation(t *testing.T) {
+func TestAcquirePostgresFreshPhysicalPreservesIsolation(t *testing.T) {
 	spec, err := loadPlatformSpec()
 	if err != nil {
 		t.Fatalf("load platform spec: %v", err)
@@ -47,9 +48,9 @@ func TestStartPostgres_CanonicalSchemaTemplatePreservesIsolation(t *testing.T) {
 		t.Fatal("platform spec version is required")
 	}
 
-	_, firstDB, cleanupFirst := StartPostgres(t)
+	_, firstDB, cleanupFirst := AcquirePostgres(t, PostgresFreshPhysical())
 	defer cleanupFirst()
-	assertStartPostgresSchema(t, firstDB, spec.Platform.Version)
+	assertPostgresSchema(t, firstDB, spec.Platform.Version)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -57,20 +58,94 @@ func TestStartPostgres_CanonicalSchemaTemplatePreservesIsolation(t *testing.T) {
 		t.Fatalf("create isolation probe in first database: %v", err)
 	}
 
-	_, secondDB, cleanupSecond := StartPostgres(t)
+	_, secondDB, cleanupSecond := AcquirePostgres(t, PostgresFreshPhysical())
 	defer cleanupSecond()
-	assertStartPostgresSchema(t, secondDB, spec.Platform.Version)
+	assertPostgresSchema(t, secondDB, spec.Platform.Version)
 
 	var leaked bool
 	if err := secondDB.QueryRowContext(ctx, `SELECT to_regclass('public.start_postgres_isolation_probe') IS NOT NULL`).Scan(&leaked); err != nil {
 		t.Fatalf("check isolation probe in second database: %v", err)
 	}
 	if leaked {
-		t.Fatal("table created in one StartPostgres database leaked into another")
+		t.Fatal("table created in one fresh physical database leaked into another")
 	}
 }
 
-func assertStartPostgresSchema(t *testing.T, db *sql.DB, wantVersion string) {
+func TestAcquirePostgresRowStateReusesResetSlotAndFencesLease(t *testing.T) {
+	spec, err := loadPlatformSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dsnA, dbA, releaseA := AcquirePostgres(t, PostgresRowState())
+	var slotA string
+	if err := dbA.QueryRow(`SELECT current_database()`).Scan(&slotA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dbA.Exec(`UPDATE runtime_store_metadata SET platform_version='leaked' WHERE id=1`); err != nil {
+		t.Fatalf("lease DML authority: %v", err)
+	}
+	if _, err := dbA.Exec(`CREATE TABLE forbidden_lease_ddl (id bigint)`); err == nil {
+		t.Fatal("row-state lease unexpectedly acquired schema creation authority")
+	}
+	connectionA, err := testpostgres.ParseConnection(dsnA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := connectionA.WithDatabase("postgres")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDB, err := other.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := otherDB.Ping(); err == nil {
+		_ = otherDB.Close()
+		t.Fatal("lease role unexpectedly connected to another database")
+	}
+	_ = otherDB.Close()
+	dormant, err := connectionA.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dormant.Ping(); err != nil {
+		t.Fatalf("open dormant lease client: %v", err)
+	}
+	releaseA()
+	if err := dormant.Ping(); err == nil {
+		_ = dormant.Close()
+		t.Fatal("release did not fence a dormant external lease client")
+	}
+	_ = dormant.Close()
+
+	stale, err := connectionA.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stale.Ping(); err == nil {
+		_ = stale.Close()
+		t.Fatal("released lease DSN remained usable")
+	}
+	_ = stale.Close()
+
+	_, dbB, releaseB := AcquirePostgres(t, PostgresRowState())
+	defer releaseB()
+	var slotB, version string
+	if err := dbB.QueryRow(`SELECT current_database()`).Scan(&slotB); err != nil {
+		t.Fatal(err)
+	}
+	if slotB != slotA {
+		t.Fatalf("row-state slot was not reused: first=%s second=%s", slotA, slotB)
+	}
+	if err := dbB.QueryRow(`SELECT platform_version FROM runtime_store_metadata WHERE id=1`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != spec.Platform.Version {
+		t.Fatalf("row-state reset retained prior rows: platform_version=%q want=%q", version, spec.Platform.Version)
+	}
+}
+
+func assertPostgresSchema(t *testing.T, db *sql.DB, wantVersion string) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/testutil/testdata/database_guard/hidden_postgres_default.go
+++ b/internal/testutil/testdata/database_guard/hidden_postgres_default.go
@@ -1,0 +1,9 @@
+package guardfixture
+
+func hiddenPostgresDefault(t testing.TB) {
+	AcquirePostgres(t, PostgresRowState())
+}
+
+func TestCallsHiddenPostgresDefault(t *testing.T) {
+	hiddenPostgresDefault(t)
+}

--- a/internal/testutil/testdata/database_guard/hidden_sqlite_default.go
+++ b/internal/testutil/testdata/database_guard/hidden_sqlite_default.go
@@ -1,0 +1,9 @@
+package guardfixture
+
+func hiddenSQLiteDefault(t testing.TB) string {
+	return SQLitePath(t, SQLiteFreshFile())
+}
+
+func TestCallsHiddenSQLiteDefault(t *testing.T) {
+	_ = hiddenSQLiteDefault(t)
+}


### PR DESCRIPTION
## Summary

- replace every audited PostgreSQL and SQLite test acquisition with a closed typed backend/isolation requirement
- add a bounded reusable PostgreSQL row-state pool with per-lease revocable credentials, fail-closed reset, stale-DSN fencing, and crash reconciliation
- preserve physical databases for schema/database-identity proofs and enforce package-local transitive wrapper forwarding with a repo-wide AST guard
- make permanent DML-role creation/stamping atomic and prove rollback leaves no unstamped role
- document the PostgreSQL 16 `CREATEDB` + `CREATEROLE` dedicated-host contract

Part of #2015
Parent: #1196

## Governing context

No exact production platform-spec section governs test-harness database acquisition. Binding context is #2015's repaired Pre-Implementation Coverage Audit, generated inventory, [Gate B re-review 4 approval](https://github.com/division-sh/swarm/issues/2015#issuecomment-4952946837), and the recorded PostgreSQL 16 catalog amendments.

The rebase onto `origin/master` `43f1a2b7` introduced five new acquisition rows. Their classification and tracker repair were recorded before migration in [#2015 comment 4954102109](https://github.com/division-sh/swarm/issues/2015#issuecomment-4954102109). Current head `c14a0c0c` has 902 typed primitive/setup rows, 65 transitive wrapper definitions, and 333 wrapper-call rows in the [public generated inventory](https://gist.github.com/yazzaoui/b3b5669a47d424f0ab1d2951498d25d9).

This is test-harness architecture only; it does not change production platform/runtime semantics, so `platform-spec.yaml` is unchanged per Gate B condition 8.

## Semantic migration

- **Canonical owner:** `internal/testutil.DatabaseRequirement` plus `AcquirePostgres`; `internal/testpostgres.Manager` owns physical and reusable PostgreSQL lifecycle; typed SQLite declarations own file/temp setup intent.
- **Old paths invalid:** `StartPostgres`, `StartEmptyPostgres`, omitted/default helper choices, helper-local backend constructors, and direct undeclared SQLite opens/constructors.
- **Production/test paths checked:** all current generated primitive/setup rows, all package-local transitive wrappers, direct SQLite opens and constructors, Manager owner proofs, selected-DSN projections, schema/bootstrap tests, and catalog/runtime/API/CLI/store consumers.
- **Migration completeness:** complete for the approved database-acquisition class. Process-global env/chdir/resource authority and scheduling remain separate parent siblings under #2015/#1196.

## Proof

- latest rebased required matrix: [CI run 29221374287, attempt 3](https://github.com/division-sh/swarm/actions/runs/29221374287), all required checks green
- `go test ./internal/testutil -run 'TestDatabase(AcquisitionRequiresTypedRequirement|GuardRejectsHiddenWrapperDefaults)' -count=1`
- `go test ./... -run '^$' -count=1`
- managed permanent/lease-role rollback proofs, stale-DSN fencing, non-superuser capability, cross-database isolation, and lifecycle benchmarks
- newly introduced master acquisition tests pass on PostgreSQL and SQLite after typed migration

The exact local monolithic path remains load-sensitive. A semantically complete pre-benchmark head passed in 213.46s; current-head attempts repeatedly hit the existing join/fork replay flake, and a contaminated attempt hit shared Docker/PG timing. This is explicitly tracked in [#2015 comment 4954121697](https://github.com/division-sh/swarm/issues/2015#issuecomment-4954121697); the sharded required surface is green. No claim is made that this PR fixes local monolithic reliability.

## Performance evidence

The original single-sample `18.3% faster` claim is withdrawn. The valid three-run exact-base/head checkpoint showed median aggregate command time **417s -> 470s (+12.7%)** and median critical path **133s -> 147s (+10.5%)**. After rebase, successful samples were base `86/150/101/152/55s`, `65/119/83/113/45s` and head `69/135/72/126/44s`, `71/138/86/130/46s`; excluded reruns failed the same process-global unprovable-sandbox race on both base and head.

The structural database result is independent of shard noise: execution-reconciled physical create operations fall **1,070 -> 263 (75.4%)**; an isolated store proof records **390 -> 152 creates (61.0%)**, WAL bytes **-58.7%**, and FPIs **-52.1%**. Lifecycle medians are 54.9ms for row leases versus 80.9ms for fresh physical databases; role creation itself is about 9.3ms, so never-reused lease roles are retained for stale-DSN safety rather than replaced with credential reuse.
