### PR TITLE
[agent-f][issue #1962] Add pack-owned normalized trigger events

### DIFF
--- a/cmd/swarm/boot_floor_conformance_test.go
+++ b/cmd/swarm/boot_floor_conformance_test.go
@@ -131,12 +131,15 @@ func TestBootFloorExplicitHostRefusalAcrossServeVerifyDescribe(t *testing.T) {
 
 	t.Run("serve", func(t *testing.T) {
 		var out lockedBuffer
+		swarmDir := t.TempDir()
 		code := runServeRuntime(context.Background(), repoRoot(), serveOptions{
 			ConfigPath:           configPath,
 			ContractsPath:        contractsPath,
 			DataSource:           t.TempDir(),
 			PlatformSpecPath:     defaultPlatformSpecPath,
 			StoreMode:            storebackend.ActiveDefaultBackend().String(),
+			SwarmDir:             swarmDir,
+			SwarmDirSet:          true,
 			APIListenAddr:        "127.0.0.1:0",
 			MCPListenAddr:        "127.0.0.1:0",
 			SelfCheck:            true,

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -23,10 +23,13 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	workspace "github.com/division-sh/swarm/internal/runtime/workspace"
 	"github.com/division-sh/swarm/internal/store"
@@ -220,16 +223,21 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load standing fixture: %v", err)
 	}
+	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+	for _, flow := range bundle.FlowTree.ByID {
+		if flow != nil {
+			flow.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+		}
+	}
 	source := semanticview.Wrap(bundle)
 	catalog := testProviderTriggerCatalog(t)
-	makeContext := func(hash, alias, runID, entityID string) (runtimepkg.BundleContext, *processIngressProofStore, *processIngressEventStore) {
-		persistence := &processIngressProofStore{}
+	makeContext := func(hash, alias, runID, entityID string) (runtimepkg.BundleContext, *processIngressEventStore) {
 		eventsStore := &processIngressEventStore{}
 		bus, err := runtimebus.NewEventBus(eventsStore)
 		if err != nil {
 			t.Fatalf("NewEventBus(%s): %v", alias, err)
 		}
-		gateway := runtimepkg.NewInboundGateway(bus, nil, nil, persistence)
+		gateway := runtimepkg.NewInboundGateway(bus, nil, nil)
 		gateway.SetCredentialStore(processIngressCredentialStore{"webhook_signing.telegram": "telegram-secret"})
 		plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{Alias: alias, Provider: "telegram", SigningSecret: "webhook_signing.telegram"})
 		if err != nil {
@@ -242,12 +250,12 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 				RunID: runID, FlowInstance: "telegram-chat/" + strings.TrimPrefix(alias, "chat-"),
 				EntityID: entityID, SigningSecret: "webhook_signing.telegram", AdmissionPlan: plan,
 			}},
-		}, persistence, eventsStore
+		}, eventsStore
 	}
 	hashA := "bundle-v1:sha256:" + strings.Repeat("a", 64)
 	hashB := "bundle-v1:sha256:" + strings.Repeat("b", 64)
-	contextA, persistenceA, eventsA := makeContext(hashA, "chat-a", "41000000-0000-0000-0000-000000000001", "41000000-0000-0000-0000-000000000002")
-	contextB, persistenceB, eventsB := makeContext(hashB, "chat-b", "42000000-0000-0000-0000-000000000001", "42000000-0000-0000-0000-000000000002")
+	contextA, eventsA := makeContext(hashA, "chat-a", "41000000-0000-0000-0000-000000000001", "41000000-0000-0000-0000-000000000002")
+	contextB, eventsB := makeContext(hashB, "chat-b", "42000000-0000-0000-0000-000000000001", "42000000-0000-0000-0000-000000000002")
 	installed, err := catalog.InstalledCapabilitySubjects()
 	if err != nil {
 		t.Fatal(err)
@@ -257,18 +265,18 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 		t.Fatalf("NewRuntimeContextManager: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/chat-b/telegram", strings.NewReader(`{"update_id":99,"message":{"chat":{"id":42},"text":"hello"}}`))
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/chat-b/telegram", strings.NewReader(`{"update_id":99,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`))
 	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
 	rec := httptest.NewRecorder()
 	runtimeProcessInboundHandler{contexts: manager}.ServeHTTP(rec, req)
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("selected-context response = %d %q, want 202", rec.Code, rec.Body.String())
 	}
-	if persistenceA.recorded || len(eventsA.events) != 0 {
-		t.Fatalf("non-selected context A was touched: marker=%v events=%d", persistenceA.recorded, len(eventsA.events))
+	if eventsA.recorded || len(eventsA.events) != 0 {
+		t.Fatalf("non-selected context A was touched: marker=%v events=%d", eventsA.recorded, len(eventsA.events))
 	}
-	if !persistenceB.recorded || len(eventsB.events) != 1 {
-		t.Fatalf("selected context B marker/events = %v/%d, want true/1", persistenceB.recorded, len(eventsB.events))
+	if !eventsB.recorded || len(eventsB.events) != 2 {
+		t.Fatalf("selected context B marker/events = %v/%d, want true and raw plus normalized", eventsB.recorded, len(eventsB.events))
 	}
 	if got := eventsB.events[0].RunID(); got != contextB.StandingTargets[0].RunID {
 		t.Fatalf("selected event run_id = %q, want %q", got, contextB.StandingTargets[0].RunID)
@@ -1038,20 +1046,11 @@ func (processIngressCredentialStore) Set(context.Context, string, string) error 
 func (processIngressCredentialStore) List(context.Context) ([]string, error)    { return nil, nil }
 func (processIngressCredentialStore) Delete(context.Context, string) error      { return nil }
 
-type processIngressProofStore struct{ recorded bool }
-
-func (s *processIngressProofStore) RecordInboundEvent(context.Context, string, string, string) (bool, error) {
-	s.recorded = true
-	return true, nil
+type processIngressEventStore struct {
+	events   []events.Event
+	seen     map[string]struct{}
+	recorded bool
 }
-func (*processIngressProofStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
-	return 0, nil
-}
-func (*processIngressProofStore) DeleteInboundEvent(context.Context, string, string, string) error {
-	return nil
-}
-
-type processIngressEventStore struct{ events []events.Event }
 
 func (s *processIngressEventStore) AppendEvent(_ context.Context, event events.Event) error {
 	s.events = append(s.events, event)
@@ -1062,6 +1061,61 @@ func (*processIngressEventStore) InsertEventDeliveries(context.Context, string, 
 }
 func (*processIngressEventStore) ListEventDeliveryRecipients(context.Context, string) ([]string, error) {
 	return nil, nil
+}
+
+func (s *processIngressEventStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if s.seen == nil {
+		s.seen = map[string]struct{}{}
+	}
+	postCommit := make([]func(), 0, 4)
+	mutation := &processIngressEventMutation{store: s}
+	mutation.ctx = runtimebus.WithEventMutationContext(runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommit), mutation)
+	if err := fn(mutation); err != nil {
+		return err
+	}
+	if mutation.pendingKey != "" {
+		s.seen[mutation.pendingKey] = struct{}{}
+		s.recorded = true
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+type processIngressEventMutation struct {
+	ctx        context.Context
+	store      *processIngressEventStore
+	pendingKey string
+}
+
+func (m *processIngressEventMutation) Context() context.Context { return m.ctx }
+func (m *processIngressEventMutation) AppendEvent(ctx context.Context, event events.Event) error {
+	return m.store.AppendEvent(ctx, event)
+}
+func (*processIngressEventMutation) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*processIngressEventMutation) InsertEventDeliveriesWithTargets(context.Context, string, []string, map[string]events.RouteIdentity) error {
+	return nil
+}
+func (*processIngressEventMutation) InsertEventDeliveryRoutes(context.Context, string, []events.DeliveryRoute) error {
+	return nil
+}
+func (*processIngressEventMutation) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
+	return nil
+}
+func (*processIngressEventMutation) UpsertPipelineReceipt(context.Context, string, string, *runtimefailures.Envelope) error {
+	return nil
+}
+func (*processIngressEventMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
+	return nil
+}
+func (m *processIngressEventMutation) ClaimInboundEvent(_ context.Context, providerEventID, entityID, provider string) (bool, error) {
+	key := provider + "\x00" + entityID + "\x00" + providerEventID
+	if _, exists := m.store.seen[key]; exists {
+		return false, nil
+	}
+	m.pendingKey = key
+	return true, nil
 }
 
 func TestRuntimeProjectSupervisorCloseProjectWithShutdownOptionsUsesConfiguredGrace(t *testing.T) {

--- a/cmd/swarm/builder_project_supervisor_test.go
+++ b/cmd/swarm/builder_project_supervisor_test.go
@@ -233,9 +233,9 @@ func TestRuntimeProcessInboundHandlerSelectsExactLoadedContext(t *testing.T) {
 	catalog := testProviderTriggerCatalog(t)
 	makeContext := func(hash, alias, runID, entityID string) (runtimepkg.BundleContext, *processIngressEventStore) {
 		eventsStore := &processIngressEventStore{}
-		bus, err := runtimebus.NewEventBus(eventsStore)
+		bus, err := runtimebus.NewEventBusWithOptions(eventsStore, runtimebus.EventBusOptions{ProviderOutputVerifier: catalog})
 		if err != nil {
-			t.Fatalf("NewEventBus(%s): %v", alias, err)
+			t.Fatalf("NewEventBusWithOptions(%s): %v", alias, err)
 		}
 		gateway := runtimepkg.NewInboundGateway(bus, nil, nil)
 		gateway.SetCredentialStore(processIngressCredentialStore{"webhook_signing.telegram": "telegram-secret"})

--- a/cmd/swarm/describe_test.go
+++ b/cmd/swarm/describe_test.go
@@ -66,10 +66,16 @@ func TestDescribeCommandRendersStandingIngressDeclaration(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
 		t.Fatalf("decode standing describe json: %v\n%s", err, stdout.String())
 	}
-	if len(view.Flows) != 1 {
+	if len(view.Flows) != 2 {
 		t.Fatalf("standing describe flows = %#v", view.Flows)
 	}
-	flow := view.Flows[0]
+	var flow authoringview.FlowView
+	for _, candidate := range view.Flows {
+		if candidate.ID == "telegram-ingress" {
+			flow = candidate
+			break
+		}
+	}
 	if flow.Activation != "standing" || flow.Ingress == nil || flow.Ingress.Alias != "chat" || len(flow.Ingress.Providers) != 1 {
 		t.Fatalf("standing describe flow = %#v", flow)
 	}
@@ -81,7 +87,7 @@ func TestDescribeCommandRendersStandingIngressDeclaration(t *testing.T) {
 		t.Fatalf("standing root input sources = %#v", view.RoutingTopology.RootInputSources)
 	}
 	source := view.RoutingTopology.RootInputSources[0]
-	if source.Kind != routingtopology.RootInputSourceStandingIngress || source.Alias != "chat" || source.Provider != "telegram" || source.Target.FlowID != "telegram-chat" || source.Target.FlowPath != "telegram-chat" || source.Admission.Kind != "pack-required" || source.Admission.PackID != "" {
+	if source.Kind != routingtopology.RootInputSourceStandingIngress || source.Alias != "chat" || source.Provider != "telegram" || source.Target.FlowID != "telegram-ingress" || source.Target.FlowPath != "telegram-ingress" || source.Admission.Kind != "pack-required" || source.Admission.PackID != "" {
 		t.Fatalf("standing root input source = %#v", source)
 	}
 	for _, edge := range view.RoutingTopology.Edges {
@@ -109,7 +115,7 @@ func TestDescribeRoutesProjectsStandingIngressAsRootInputAdmission(t *testing.T)
 	if code := executeRootCommandWithOptions(context.Background(), repoRoot(), []string{"describe", "routes", "--contracts", contractsRoot}, &humanOut, &humanErr, defaultRootCommandOptions()); code != 0 {
 		t.Fatalf("describe routes code=%d stdout=%s stderr=%s", code, humanOut.String(), humanErr.String())
 	}
-	for _, want := range []string{"root input sources:", "[standing_ingress] chat/telegram -> flow telegram-chat admission=pack-required"} {
+	for _, want := range []string{"root input sources:", "[standing_ingress] chat/telegram -> flow telegram-ingress admission=pack-required"} {
 		if !strings.Contains(humanOut.String(), want) {
 			t.Fatalf("standing routes human output missing %q:\n%s", want, humanOut.String())
 		}

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -376,6 +376,13 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 	}
 	process := startServeRuntimeTestProcess(t, opts)
 	process.waitForReadyLine()
+	readbackDeadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(process.outputString(), ":matrix:telegram AVAILABLE") {
+		if time.Now().After(readbackDeadline) {
+			t.Fatalf("timed out waiting for complete standing ingress readback:\n%s", process.outputString())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	serveOutput := process.outputString()
 	var unsignedWarningLine string
 	for _, line := range strings.Split(serveOutput, "\n") {
@@ -577,7 +584,7 @@ pins:
 
 func inboundAdmissionMatrixEventsYAML() string {
 	var out strings.Builder
-	for _, event := range []string{"inbound.telegram", "inbound.intercom", "inbound.acme_public", "inbound.partner_auth", "inbound.partner_open", "inbound.partner_ack"} {
+	for _, event := range []string{"inbound.partner_auth", "inbound.partner_open", "inbound.partner_ack"} {
 		fmt.Fprintf(&out, "%s:\n  entity_id: text\n  provider: text\n  event_type: text\n  provider_event_type: text\n  provider_event_id: text\n  provider_delivery_id: text\n  headers: json\n  received_at: text\n", event)
 	}
 	return out.String()

--- a/cmd/swarm/inbound_admission_supported_surface_test.go
+++ b/cmd/swarm/inbound_admission_supported_surface_test.go
@@ -376,13 +376,6 @@ func runInboundAdmissionSupportedSurfacePolicyMatrix(t *testing.T, backend strin
 	}
 	process := startServeRuntimeTestProcess(t, opts)
 	process.waitForReadyLine()
-	readbackDeadline := time.Now().Add(2 * time.Second)
-	for !strings.Contains(process.outputString(), ":matrix:telegram AVAILABLE") {
-		if time.Now().After(readbackDeadline) {
-			t.Fatalf("timed out waiting for complete standing ingress readback:\n%s", process.outputString())
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 	serveOutput := process.outputString()
 	var unsignedWarningLine string
 	for _, line := range strings.Split(serveOutput, "\n") {

--- a/cmd/swarm/provider_ingress_proof_role_guard_test.go
+++ b/cmd/swarm/provider_ingress_proof_role_guard_test.go
@@ -50,7 +50,7 @@ func TestProviderIngressProofRoleRegistryRejectsHiddenAuthorityFromSupportedProo
 			"TestRuntimeProcessInboundHandlerTeachesUnknownStandingAlias",
 		},
 		"internal/runtime/standing_targets_test.go": {
-			"TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish",
+			"TestInboundGatewayConsumesCompiledGitHubRouteWithoutReinterpretingDynamicPins",
 		},
 	}
 	for path, tests := range supported {

--- a/cmd/swarm/provider_trigger_smoke_helpers_test.go
+++ b/cmd/swarm/provider_trigger_smoke_helpers_test.go
@@ -105,6 +105,9 @@ func startProviderTriggerSmokeServer(
 	if strings.TrimSpace(listenAddr) == "" {
 		listenAddr = "localhost:0"
 	}
+	if bus != nil {
+		bus.SetProviderOutputAuthorizationVerifier(testProviderTriggerCatalog(t))
+	}
 	gateway := runtimepkg.NewInboundGateway(bus, nil, nil)
 	gateway.SetCredentialStore(providerTriggerSmokeCredentialStore{target.SigningSecret: signingSecret})
 	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/swarm/provider_trigger_smoke_helpers_test.go
+++ b/cmd/swarm/provider_trigger_smoke_helpers_test.go
@@ -105,7 +105,7 @@ func startProviderTriggerSmokeServer(
 	if strings.TrimSpace(listenAddr) == "" {
 		listenAddr = "localhost:0"
 	}
-	gateway := runtimepkg.NewInboundGateway(bus, nil, nil, sqliteStore)
+	gateway := runtimepkg.NewInboundGateway(bus, nil, nil)
 	gateway.SetCredentialStore(providerTriggerSmokeCredentialStore{target.SigningSecret: signingSecret})
 	inboundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rec := &providerTriggerSmokeCaptureWriter{ResponseWriter: w, status: http.StatusOK}

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -156,6 +156,12 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "mutation log persistence is an explicit runtime SQL owner used from mutation transaction boundaries",
 		},
+		"internal/runtime/manager/flow_activation.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          1962,
+			SpecRef:        "platform-spec.yaml#tool_model.provider_trigger_adapters.pack_manifest_engine.provider_delivery_transaction",
+			Reason:         "flow activation observes the ambient selected-store transaction only to persist route authority in-unit and defer agent process startup until commit",
+		},
 		"internal/runtime/pipeline/accumulator_completion_diagnostics.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -130,7 +130,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	for _, want := range []string{
 		"swarm serve --dev · ",
 		"store                      sqlite · " + sqlitePath,
-		"workspace                  not required",
+		"workspace                  host · agent work runs on this machine",
 		"listeners                  api 127.0.0.1:",
 		"ready in ",
 		"telegram webhook",
@@ -144,7 +144,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if strings.Contains(firstOutput, "[1/22]") || strings.Contains(firstOutput, "telegram-secret") || strings.Contains(firstOutput, "\x1b[") {
 		t.Fatalf("concise supported serve output leaked verbose, secret, or terminal decoration:\n%s", firstOutput)
 	}
-	if strings.Count(firstOutput, "workspace                  not required") != 1 || strings.Count(firstOutput, "ready in ") != 1 {
+	if strings.Count(firstOutput, "workspace                  host · agent work runs on this machine") != 1 || strings.Count(firstOutput, "ready in ") != 1 {
 		t.Fatalf("concise supported serve output retained parallel lifecycle writers:\n%s", firstOutput)
 	}
 	for _, forbidden := range []string{"request_authentication=", "catalog_generation=", "manifest_hash=", "policy_source=", "provenance=", "source_path=", "standing ingress admitted:"} {

--- a/cmd/swarm/standing_ingress_supported_surface_test.go
+++ b/cmd/swarm/standing_ingress_supported_surface_test.go
@@ -16,11 +16,66 @@ import (
 
 	"github.com/division-sh/swarm/internal/config"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"github.com/division-sh/swarm/internal/testutil"
 )
+
+type telegramPhraseBotLLMRuntime struct{}
+
+func (telegramPhraseBotLLMRuntime) StartSession(_ context.Context, agentID, systemPrompt string, tools []runtimellm.ToolDefinition) (*runtimellm.Session, error) {
+	return &runtimellm.Session{
+		ID: agentID + "-session", AgentID: agentID, SystemPrompt: systemPrompt,
+		Tools: append([]runtimellm.ToolDefinition(nil), tools...),
+	}, nil
+}
+
+func (telegramPhraseBotLLMRuntime) ContinueSession(_ context.Context, session *runtimellm.Session, message runtimellm.Message) (*runtimellm.Response, error) {
+	if message.Role == "tool" {
+		return &runtimellm.Response{
+			Message:   runtimellm.Message{Role: "assistant", Content: "Telegram reply sent."},
+			SessionID: session.ID,
+		}, nil
+	}
+	const payloadPrefix = "- payload: "
+	start := strings.Index(message.Content, payloadPrefix)
+	if start < 0 {
+		return nil, fmt.Errorf("phrase-bot input has no event payload")
+	}
+	raw := message.Content[start+len(payloadPrefix):]
+	if end := strings.IndexByte(raw, '\n'); end >= 0 {
+		raw = raw[:end]
+	}
+	var payload map[string]any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode phrase-bot event payload: %w", err)
+	}
+	chatID := strings.TrimSpace(fmt.Sprint(payload["chat_id"]))
+	messageText := strings.TrimSpace(fmt.Sprint(payload["text"]))
+	if chatID == "" || messageText == "" {
+		return nil, fmt.Errorf("phrase-bot requires chat_id and text")
+	}
+	call := runtimellm.ToolCall{
+		ID:   "reply-" + chatID,
+		Name: "emit_telegram_reply_requested",
+		Arguments: map[string]any{
+			"chat_id": chatID,
+			"text":    "Swarm heard: " + messageText,
+		},
+	}
+	return &runtimellm.Response{
+		Message:   runtimellm.Message{Role: "assistant", ToolCalls: []runtimellm.ToolCall{call}},
+		ToolCalls: []runtimellm.ToolCall{call}, SessionID: session.ID,
+	}, nil
+}
+
+func (telegramPhraseBotLLMRuntime) PersistConversationSnapshot(context.Context, *runtimellm.Session) error {
+	return nil
+}
 
 func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplies(t *testing.T) {
 	isolateCLIAPIConfigEnv(t)
@@ -56,18 +111,18 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 		ConfigPath: configPath, ContractsPath: contractsRoot, PlatformSpecPath: defaultPlatformSpecPath,
 		StoreMode: "sqlite", APIListenAddr: "127.0.0.1:0", MCPListenAddr: "127.0.0.1:0",
 		SelfCheck: true, RequireBundleMatch: false, Dev: true,
-		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+		TestLLMRuntime: telegramPhraseBotLLMRuntime{}, TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
 	}
 
 	first := startServeRuntimeTestProcess(t, opts)
 	first.waitForReadyLine()
 	firstURL := "http://" + serveRuntimeAPIListenerFromOutput(t, first.outputString())
-	firstEntity := sendStandingTelegramUpdate(t, firstURL, 101)
-	secondEntity := sendStandingTelegramUpdate(t, firstURL, 102)
+	firstEntity := sendStandingTelegramUpdate(t, firstURL, 101, 42)
+	secondEntity := sendStandingTelegramUpdate(t, firstURL, 102, 42)
 	if firstEntity == "" || firstEntity != secondEntity {
 		t.Fatalf("delivery entities = %q and %q, want one standing entity", firstEntity, secondEntity)
 	}
-	requireStandingTelegramCalls(t, calls, 2, sqlitePath)
+	requireStandingTelegramCalls(t, calls, sqlitePath, 42, 42)
 	if code := first.stop(); code != 0 {
 		t.Fatalf("first serve exit = %d", code)
 	}
@@ -101,11 +156,11 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	second := startServeRuntimeTestProcess(t, opts)
 	second.waitForReadyLine()
 	secondURL := "http://" + serveRuntimeAPIListenerFromOutput(t, second.outputString())
-	restartedEntity := sendStandingTelegramUpdate(t, secondURL, 103)
+	restartedEntity := sendStandingTelegramUpdate(t, secondURL, 103, 84)
 	if restartedEntity != firstEntity {
 		t.Fatalf("restart entity = %q, want %q", restartedEntity, firstEntity)
 	}
-	requireStandingTelegramCalls(t, calls, 1, sqlitePath)
+	requireStandingTelegramCalls(t, calls, sqlitePath, 84)
 	if code := second.stop(); code != 0 {
 		t.Fatalf("second serve exit = %d", code)
 	}
@@ -124,7 +179,7 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
 		JOIN runs r ON r.run_id = es.run_id
 		WHERE es.entity_id = ?
-		  AND fi.flow_template = 'telegram-chat'
+		  AND fi.flow_template = 'telegram-ingress'
 		  AND json_extract(es.fields, '$.activation') = 'standing'
 		  AND r.status = 'running'
 		  AND r.bundle_hash IS NOT NULL
@@ -135,12 +190,12 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 		SELECT COUNT(DISTINCT es.run_id)
 		FROM entity_state es
 		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
-		WHERE fi.flow_template = 'telegram-chat'
+		WHERE fi.flow_template = 'telegram-ingress'
 		  AND json_extract(es.fields, '$.activation') = 'standing'
 	`).Scan(&runs); err != nil {
 		t.Fatalf("count standing run authorities: %v", err)
 	}
-	if err := sqliteStore.DB.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-chat'`).Scan(&instances); err != nil {
+	if err := sqliteStore.DB.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-ingress'`).Scan(&instances); err != nil {
 		t.Fatalf("count standing instances: %v", err)
 	}
 	if err := sqliteStore.DB.QueryRow(`SELECT COUNT(*) FROM entity_state WHERE entity_id = ?`, firstEntity).Scan(&entities); err != nil {
@@ -148,6 +203,19 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	}
 	if runs != 1 || instances != 1 || entities != 1 {
 		t.Fatalf("standing authority counts = runs:%d instances:%d entities:%d, want 1/1/1", runs, instances, entities)
+	}
+	var chatInstances, normalizedEvents, wrongNormalizedRuns int
+	if err := sqliteStore.DB.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-chat'`).Scan(&chatInstances); err != nil {
+		t.Fatalf("count per-chat instances: %v", err)
+	}
+	if err := sqliteStore.DB.QueryRow(`
+		SELECT COUNT(*), COALESCE(SUM(CASE WHEN run_id = ? THEN 0 ELSE 1 END), 0)
+		FROM events WHERE event_name = 'inbound.telegram.text_message'
+	`, standingRunID).Scan(&normalizedEvents, &wrongNormalizedRuns); err != nil {
+		t.Fatalf("inspect normalized event lineage: %v", err)
+	}
+	if chatInstances != 2 || normalizedEvents != 3 || wrongNormalizedRuns != 0 {
+		t.Fatalf("normalized routing = chat_instances:%d events:%d wrong_run:%d, want 2/3/0", chatInstances, normalizedEvents, wrongNormalizedRuns)
 	}
 	var entityEvents, wrongRunEvents int
 	if err := sqliteStore.DB.QueryRow(`
@@ -249,16 +317,16 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 		ConfigPath: writeServeRuntimeTestConfig(t), ContractsPath: contractsRoot, PlatformSpecPath: defaultPlatformSpecPath,
 		StoreMode: "postgres", APIListenAddr: "127.0.0.1:0", MCPListenAddr: "127.0.0.1:0",
 		SelfCheck: true, RequireBundleMatch: false, Dev: true, Verbose: true,
-		TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
+		TestLLMRuntime: telegramPhraseBotLLMRuntime{}, TestOutboxSweeperConfig: servedEventPublishProofOutboxSweeperConfig(),
 	}
 	first := startServeRuntimeTestProcess(t, opts)
 	first.waitForReadyLine()
 	baseURL := "http://" + serveRuntimeAPIListenerFromOutput(t, first.outputString())
-	entity := sendStandingTelegramUpdate(t, baseURL, 201)
-	if got := sendStandingTelegramUpdate(t, baseURL, 202); got != entity {
+	entity := sendStandingTelegramUpdate(t, baseURL, 201, 42)
+	if got := sendStandingTelegramUpdate(t, baseURL, 202, 42); got != entity {
 		t.Fatalf("second entity = %q, want %q", got, entity)
 	}
-	requireStandingTelegramCalls(t, calls, 2, "postgres:"+dsn)
+	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, 42, 42)
 	if code := first.stop(); code != 0 {
 		t.Fatalf("first serve exit = %d", code)
 	}
@@ -268,10 +336,10 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 	}
 	second := startServeRuntimeTestProcess(t, opts)
 	second.waitForReadyLine()
-	if got := sendStandingTelegramUpdate(t, "http://"+serveRuntimeAPIListenerFromOutput(t, second.outputString()), 203); got != entity {
+	if got := sendStandingTelegramUpdate(t, "http://"+serveRuntimeAPIListenerFromOutput(t, second.outputString()), 203, 84); got != entity {
 		t.Fatalf("restart entity = %q, want %q", got, entity)
 	}
-	requireStandingTelegramCalls(t, calls, 1, "postgres:"+dsn)
+	requireStandingTelegramCalls(t, calls, "postgres:"+dsn, 84)
 	if code := second.stop(); code != 0 {
 		t.Fatalf("second serve exit = %d", code)
 	}
@@ -296,7 +364,7 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
 		JOIN runs r ON r.run_id = es.run_id
 		WHERE es.entity_id = $1::uuid
-		  AND fi.flow_template = 'telegram-chat'
+		  AND fi.flow_template = 'telegram-ingress'
 		  AND es.fields->>'activation' = 'standing'
 		  AND r.status = 'running'
 		  AND r.bundle_hash IS NOT NULL
@@ -307,12 +375,12 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 		SELECT COUNT(DISTINCT es.run_id)
 		FROM entity_state es
 		JOIN flow_instances fi ON fi.instance_id = es.flow_instance
-		WHERE fi.flow_template = 'telegram-chat'
+		WHERE fi.flow_template = 'telegram-ingress'
 		  AND es.fields->>'activation' = 'standing'
 	`).Scan(&runs); err != nil {
 		t.Fatalf("count standing run authorities: %v", err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-chat'`).Scan(&instances); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-ingress'`).Scan(&instances); err != nil {
 		t.Fatalf("count standing instances: %v", err)
 	}
 	if err := db.QueryRow(`SELECT COUNT(*) FROM entity_state WHERE entity_id = $1::uuid`, entity).Scan(&entities); err != nil {
@@ -320,6 +388,19 @@ func TestStandingIngressSupportedSurfacePostgresRestartPreservesAuthorityAndRepl
 	}
 	if runs != 1 || instances != 1 || entities != 1 {
 		t.Fatalf("standing authority counts = runs:%d instances:%d entities:%d, want 1/1/1", runs, instances, entities)
+	}
+	var chatInstances, normalizedEvents, wrongNormalizedRuns int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM flow_instances WHERE flow_template = 'telegram-chat'`).Scan(&chatInstances); err != nil {
+		t.Fatalf("count per-chat instances: %v", err)
+	}
+	if err := db.QueryRow(`
+		SELECT COUNT(*), COALESCE(SUM(CASE WHEN run_id = $1::uuid THEN 0 ELSE 1 END), 0)
+		FROM events WHERE event_name = 'inbound.telegram.text_message'
+	`, standingRunID).Scan(&normalizedEvents, &wrongNormalizedRuns); err != nil {
+		t.Fatalf("inspect normalized event lineage: %v", err)
+	}
+	if chatInstances != 2 || normalizedEvents != 3 || wrongNormalizedRuns != 0 {
+		t.Fatalf("normalized routing = chat_instances:%d events:%d wrong_run:%d, want 2/3/0", chatInstances, normalizedEvents, wrongNormalizedRuns)
 	}
 	var entityEvents, wrongRunEvents int
 	if err := db.QueryRow(`
@@ -341,16 +422,11 @@ func requireChangedStandingColdStartMatrix(t *testing.T, opts serveOptions, cont
 	if err != nil {
 		t.Fatalf("read standing package: %v", err)
 	}
-	flowDir := filepath.Join(contractsRoot, "flows", "telegram-chat")
+	flowDir := filepath.Join(contractsRoot, "flows", "telegram-ingress")
 	flowSchemaPath := filepath.Join(flowDir, "schema.yaml")
 	baseFlowSchema, err := os.ReadFile(flowSchemaPath)
 	if err != nil {
 		t.Fatalf("read standing flow schema: %v", err)
-	}
-	nodesPath := filepath.Join(flowDir, "nodes.yaml")
-	baseNodes, err := os.ReadFile(nodesPath)
-	if err != nil {
-		t.Fatalf("read standing flow nodes: %v", err)
 	}
 	type candidateMutation struct {
 		name  string
@@ -368,29 +444,8 @@ func requireChangedStandingColdStartMatrix(t *testing.T, opts serveOptions, cont
 			}
 			writeStandingCandidateFile(t, packagePath, before[:start]+"flows: []\n")
 		}},
-		{name: "standing changed to non-standing", apply: func(t *testing.T) {
-			before := string(basePackage)
-			standingBlock := `    activation: standing
-    ingress:
-      alias: chat
-      providers:
-        - provider: telegram
-          signing_secret: webhook_signing.telegram
-`
-			changed := strings.Replace(before, standingBlock, "", 1)
-			if changed == before {
-				t.Fatal("standing activation block not found")
-			}
-			writeStandingCandidateFile(t, packagePath, changed)
-			changedNodes := strings.Replace(string(baseNodes), "    inbound.telegram:\n      activity:", "    inbound.telegram:\n      select_or_create_entity:\n        by:\n          service_id: payload.provider\n      activity:", 1)
-			if changedNodes == string(baseNodes) {
-				t.Fatal("standing handler marker not found")
-			}
-			writeStandingCandidateFile(t, nodesPath, changedNodes)
-			t.Cleanup(func() { _ = os.WriteFile(nodesPath, baseNodes, 0o600) })
-		}},
 		{name: "flow identity renamed", apply: func(t *testing.T) {
-			renamedDir := filepath.Join(contractsRoot, "flows", "telegram-chat-v2")
+			renamedDir := filepath.Join(contractsRoot, "flows", "telegram-ingress-v2")
 			if err := os.Rename(flowDir, renamedDir); err != nil {
 				t.Fatalf("rename flow directory: %v", err)
 			}
@@ -398,9 +453,8 @@ func requireChangedStandingColdStartMatrix(t *testing.T, opts serveOptions, cont
 				_ = os.Rename(renamedDir, flowDir)
 				_ = os.WriteFile(flowSchemaPath, baseFlowSchema, 0o600)
 			})
-			writeStandingCandidateFile(t, filepath.Join(renamedDir, "schema.yaml"), strings.Replace(string(baseFlowSchema), "name: telegram-chat", "name: telegram-chat-v2", 1))
-			writeStandingCandidateFile(t, filepath.Join(renamedDir, "nodes.yaml"), strings.ReplaceAll(string(baseNodes), "telegram-chat.telegram_send_message", "telegram-chat-v2.telegram_send_message"))
-			writeStandingCandidateFile(t, packagePath, strings.ReplaceAll(string(basePackage), "telegram-chat", "telegram-chat-v2"))
+			writeStandingCandidateFile(t, filepath.Join(renamedDir, "schema.yaml"), strings.Replace(string(baseFlowSchema), "name: telegram-ingress", "name: telegram-ingress-v2", 1))
+			writeStandingCandidateFile(t, packagePath, strings.ReplaceAll(string(basePackage), "telegram-ingress", "telegram-ingress-v2"))
 		}},
 	}
 	for _, mutation := range mutations {
@@ -442,9 +496,9 @@ func requireChangedStandingColdStartRejected(t *testing.T, opts serveOptions) {
 	}
 }
 
-func sendStandingTelegramUpdate(t testing.TB, baseURL string, updateID int) string {
+func sendStandingTelegramUpdate(t testing.TB, baseURL string, updateID, chatID int) string {
 	t.Helper()
-	body := []byte(fmt.Sprintf(`{"update_id":%d,"message":{"message_id":%d,"chat":{"id":42},"text":"hello %d"}}`, updateID, updateID, updateID))
+	body := []byte(fmt.Sprintf(`{"update_id":%d,"message":{"message_id":%d,"chat":{"id":%d},"text":"hello %d"}}`, updateID, updateID, chatID, updateID))
 	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(baseURL, "/")+"/webhooks/chat/telegram", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("new webhook request: %v", err)
@@ -466,13 +520,13 @@ func sendStandingTelegramUpdate(t testing.TB, baseURL string, updateID int) stri
 	return strings.TrimSpace(fmt.Sprint(payload["entity_id"]))
 }
 
-func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, count int, sqlitePath string) {
+func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, sqlitePath string, chatIDs ...int) {
 	t.Helper()
-	for i := 0; i < count; i++ {
+	for i, chatID := range chatIDs {
 		select {
 		case call := <-calls:
-			if strings.TrimSpace(fmt.Sprint(call["chat_id"])) != "42" {
-				t.Fatalf("Telegram chat_id = %v", call["chat_id"])
+			if got := strings.TrimSpace(fmt.Sprint(call["chat_id"])); got != fmt.Sprint(chatID) {
+				t.Fatalf("Telegram chat_id = %v, want %d", call["chat_id"], chatID)
 			}
 		case <-time.After(5 * time.Second):
 			diagnostics := "unavailable"
@@ -481,7 +535,7 @@ func requireStandingTelegramCalls(t testing.TB, calls <-chan map[string]any, cou
 			} else if strings.TrimSpace(sqlitePath) != "" {
 				diagnostics = standingSQLiteDiagnostics(sqlitePath)
 			}
-			t.Fatalf("timed out waiting for Telegram reply %d/%d; diagnostics: %s", i+1, count, diagnostics)
+			t.Fatalf("timed out waiting for Telegram reply %d/%d; diagnostics: %s", i+1, len(chatIDs), diagnostics)
 		}
 	}
 }
@@ -599,8 +653,8 @@ func writeStandingTelegramServeFixture(t testing.TB, telegramBaseURL string) str
 version: "1.0.0"
 platform_version: ">=0.7.0 <0.8.0"
 flows:
-  - id: telegram-chat
-    flow: telegram-chat
+  - id: telegram-ingress
+    flow: telegram-ingress
     mode: singleton
     activation: standing
     ingress:
@@ -608,6 +662,9 @@ flows:
       providers:
         - provider: telegram
           signing_secret: webhook_signing.telegram
+  - id: telegram-chat
+    flow: telegram-chat
+    mode: template
 `,
 		"schema.yaml": "name: standing-telegram-proof\n",
 		"policy.yaml": "{}\n",
@@ -615,7 +672,7 @@ flows:
 		"agents.yaml": "{}\n",
 		"events.yaml": "{}\n",
 		"nodes.yaml":  "{}\n",
-		"flows/telegram-chat/schema.yaml": `name: telegram-chat
+		"flows/telegram-ingress/schema.yaml": `name: telegram-ingress
 mode: singleton
 initial_state: active
 states: [active]
@@ -628,50 +685,75 @@ pins:
   outputs:
     events: []
 `,
-		"flows/telegram-chat/types.yaml": "{}\n",
-		"flows/telegram-chat/entities.yaml": `chat_service:
+		"flows/telegram-ingress/types.yaml": "{}\n",
+		"flows/telegram-ingress/entities.yaml": `telegram_service:
   service_id:
     type: text
     initial: standing
-  chats:
+  active_chats:
     type: map[text]json
     initial: {}
 `,
-		"flows/telegram-chat/events.yaml": `inbound.telegram:
-  entity_id: text
-  provider: text
-  event_type: text
-  provider_event_type: text
-  provider_event_id: text
-  provider_delivery_id: text
-  headers: json
-  received_at: text
+		"flows/telegram-ingress/events.yaml": "{}\n",
+		"flows/telegram-ingress/nodes.yaml":  "{}\n",
+		"flows/telegram-ingress/tools.yaml":  "{}\n",
+		"flows/telegram-ingress/policy.yaml": "{}\n",
+		"flows/telegram-ingress/agents.yaml": "{}\n",
+		"flows/telegram-chat/schema.yaml": `name: telegram-chat
+mode: template
+instance:
+  by: chat_id
+  on_missing: create
+  on_conflict: reuse
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events:
+      - name: telegram_text_message
+        event: inbound.telegram.text_message
+        source: external
+        resolution:
+          mode: select-or-create
+          instance_key: chat_id
+        carries:
+          chat_id:
+            from: payload.chat_id
+            type: text
+  outputs:
+    events: []
+`,
+		"flows/telegram-chat/types.yaml": "{}\n",
+		"flows/telegram-chat/entities.yaml": `chat:
+  chat_id:
+    type: text
+    indexed: true
+    _unused_reason: populated from the normalized input resolution carry
+  last_message:
+    type: text
+    initial: ""
+`,
+		"flows/telegram-chat/events.yaml": `telegram.reply_requested:
+  chat_id: text
+  text: text
 `,
 		"flows/telegram-chat/nodes.yaml": `telegram-responder:
   id: telegram-responder
   execution_type: system_node
-  subscribes_to: [inbound.telegram]
+  subscribes_to: [telegram.reply_requested]
   event_handlers:
-    inbound.telegram:
+    telegram.reply_requested:
       activity:
         id: telegram_send_message
         tool: telegram.send_message
         input:
           chat_id:
-            cel: payload.payload.message.chat.id
+            cel: payload.chat_id
           text:
-            cel: payload.payload.message.text
-telegram-outcome-observer:
-  id: telegram-outcome-observer
-  execution_type: system_node
-  subscribes_to: [telegram-chat.telegram_send_message.succeeded, telegram-chat.telegram_send_message.failed]
-  event_handlers:
-    telegram-chat.telegram_send_message.succeeded:
-      advances_to: active
-    telegram-chat.telegram_send_message.failed:
-      advances_to: active
+            cel: payload.text
 `,
 		"flows/telegram-chat/tools.yaml": fmt.Sprintf(`telegram.send_message:
+  category: provider_connector
   description: send Telegram messages
   handler_type: http
   effect_class: non_idempotent_write
@@ -692,7 +774,19 @@ telegram-outcome-observer:
       text: "{{input.text}}"
 `, strings.TrimRight(telegramBaseURL, "/")),
 		"flows/telegram-chat/policy.yaml": "{}\n",
-		"flows/telegram-chat/agents.yaml": "{}\n",
+		"flows/telegram-chat/agents.yaml": `phrase-bot:
+  id: phrase-bot-{instance_id}
+  role: phrase_bot
+  prompt_ref: phrase-bot
+  model: regular
+  mode: session_per_entity
+  subscriptions:
+    - inbound.telegram.text_message
+  emit_events:
+    - telegram.reply_requested
+`,
+		"flows/telegram-chat/prompts/phrase-bot.md": `Reply to each Telegram message by emitting telegram.reply_requested with the same chat_id.
+`,
 	}
 	for name, contents := range files {
 		path := filepath.Join(root, name)

--- a/internal/packs/capability_surface.go
+++ b/internal/packs/capability_surface.go
@@ -61,20 +61,34 @@ const (
 )
 
 type Subject struct {
-	ID               string            `json:"id"`
-	Kind             SubjectKind       `json:"kind"`
-	Provider         string            `json:"provider"`
-	Action           string            `json:"action,omitempty"`
-	Source           string            `json:"source"`
-	Provenance       string            `json:"provenance,omitempty"`
-	SourcePath       string            `json:"source_path,omitempty"`
-	Applicability    string            `json:"applicability"`
-	Status           SubjectStatus     `json:"status"`
-	Capabilities     []Capability      `json:"capabilities,omitempty"`
-	Guarantees       []Guarantee       `json:"guarantees,omitempty"`
-	Requirements     []Requirement     `json:"requirements,omitempty"`
-	Evidence         []Evidence        `json:"evidence,omitempty"`
-	TriggerAdmission *TriggerAdmission `json:"trigger_admission,omitempty"`
+	ID               string                   `json:"id"`
+	Kind             SubjectKind              `json:"kind"`
+	Provider         string                   `json:"provider"`
+	Action           string                   `json:"action,omitempty"`
+	Source           string                   `json:"source"`
+	Provenance       string                   `json:"provenance,omitempty"`
+	SourcePath       string                   `json:"source_path,omitempty"`
+	Applicability    string                   `json:"applicability"`
+	Status           SubjectStatus            `json:"status"`
+	Capabilities     []Capability             `json:"capabilities,omitempty"`
+	Guarantees       []Guarantee              `json:"guarantees,omitempty"`
+	Requirements     []Requirement            `json:"requirements,omitempty"`
+	Evidence         []Evidence               `json:"evidence,omitempty"`
+	TriggerAdmission *TriggerAdmission        `json:"trigger_admission,omitempty"`
+	TriggerEvents    []TriggerEventDescriptor `json:"trigger_events,omitempty"`
+}
+
+type TriggerEventDescriptor struct {
+	Event  string                        `json:"event"`
+	Kind   string                        `json:"kind"`
+	Fields []TriggerEventFieldDescriptor `json:"fields,omitempty"`
+}
+
+type TriggerEventFieldDescriptor struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Required      bool   `json:"required"`
+	CarryEligible bool   `json:"carry_eligible"`
 }
 
 type TriggerAdmission struct {
@@ -302,6 +316,11 @@ func CloneSubjects(subjects []Subject) []Subject {
 			out[i].Evidence[j] = evidence
 			out[i].Evidence[j].Fields = cloneStringMap(evidence.Fields)
 		}
+		out[i].TriggerEvents = make([]TriggerEventDescriptor, len(subject.TriggerEvents))
+		for j, descriptor := range subject.TriggerEvents {
+			out[i].TriggerEvents[j] = descriptor
+			out[i].TriggerEvents[j].Fields = append([]TriggerEventFieldDescriptor(nil), descriptor.Fields...)
+		}
 		if subject.TriggerAdmission != nil {
 			admission := *subject.TriggerAdmission
 			if subject.TriggerAdmission.Pack != nil {
@@ -432,6 +451,34 @@ func normalizeSubject(subject *Subject) error {
 }
 
 func normalizeProviderTriggerSubject(subject *Subject) error {
+	for i := range subject.TriggerEvents {
+		descriptor := &subject.TriggerEvents[i]
+		descriptor.Event = strings.TrimSpace(descriptor.Event)
+		descriptor.Kind = strings.TrimSpace(descriptor.Kind)
+		if descriptor.Event == "" || (descriptor.Kind != "raw" && descriptor.Kind != "normalized") {
+			return fmt.Errorf("provider trigger subject %q has invalid trigger event descriptor", subject.ID)
+		}
+		for j := range descriptor.Fields {
+			field := &descriptor.Fields[j]
+			field.Name = strings.TrimSpace(field.Name)
+			field.Type = strings.TrimSpace(field.Type)
+			if field.Name == "" || field.Type == "" {
+				return fmt.Errorf("provider trigger subject %q event %q has incomplete field descriptor", subject.ID, descriptor.Event)
+			}
+		}
+		sort.SliceStable(descriptor.Fields, func(a, b int) bool { return descriptor.Fields[a].Name < descriptor.Fields[b].Name })
+	}
+	sort.SliceStable(subject.TriggerEvents, func(i, j int) bool {
+		if subject.TriggerEvents[i].Event != subject.TriggerEvents[j].Event {
+			return subject.TriggerEvents[i].Event < subject.TriggerEvents[j].Event
+		}
+		return subject.TriggerEvents[i].Kind < subject.TriggerEvents[j].Kind
+	})
+	for i := 1; i < len(subject.TriggerEvents); i++ {
+		if subject.TriggerEvents[i-1].Event == subject.TriggerEvents[i].Event {
+			return fmt.Errorf("provider trigger subject %q has duplicate event descriptor %q", subject.ID, subject.TriggerEvents[i].Event)
+		}
+	}
 	switch subject.Applicability {
 	case "installed":
 		if subject.Source != "trigger_pack" || subject.TriggerAdmission != nil {
@@ -563,6 +610,25 @@ func RenderSubject(subject Subject, verbose bool) string {
 			phrase += " " + capability.Target
 		}
 		parts = append(parts, "CAN "+phrase)
+	}
+	for _, descriptor := range subject.TriggerEvents {
+		fields := make([]string, 0, len(descriptor.Fields))
+		for _, field := range descriptor.Fields {
+			required := "optional"
+			if field.Required {
+				required = "required"
+			}
+			carry := "not-carry-eligible"
+			if field.CarryEligible {
+				carry = "carry-eligible"
+			}
+			fields = append(fields, field.Name+":"+field.Type+":"+required+":"+carry)
+		}
+		text := "event_descriptor=" + descriptor.Event + " kind=" + descriptor.Kind
+		if len(fields) > 0 {
+			text += " fields=" + strings.Join(fields, ",")
+		}
+		parts = append(parts, text)
 	}
 	for _, guarantee := range subject.Guarantees {
 		phrase := userfacing.ProjectHumanCode(userfacing.HumanCodeProviderGuarantee, guarantee.Code)

--- a/internal/packs/capability_surface_test.go
+++ b/internal/packs/capability_surface_test.go
@@ -33,6 +33,10 @@ func TestNormalizeSubjectsOwnsEffectiveTriggerAdmissionShape(t *testing.T) {
 			Pack: &TriggerPackIdentity{ID: "provider.acme", Version: "1.0.0", ManifestHash: "sha256:" + strings.Repeat("c", 64), Provenance: "external"},
 		},
 		Requirements: []Requirement{TargetScopedRequirement(RequirementSecret, "webhook_signing.acme")},
+		TriggerEvents: []TriggerEventDescriptor{
+			{Event: "inbound.acme", Kind: "raw", Fields: []TriggerEventFieldDescriptor{{Name: "payload", Type: "json", Required: true}}},
+			{Event: "inbound.acme.record_created", Kind: "normalized", Fields: []TriggerEventFieldDescriptor{{Name: "record_id", Type: "text", Required: true, CarryEligible: true}}},
+		},
 	}
 	normalized, err := NormalizeSubjects([]Subject{base})
 	if err != nil {
@@ -216,6 +220,10 @@ func TestEffectiveTriggerTextAndJSONProjectTheSameTypedFacts(t *testing.T) {
 			Pack: &TriggerPackIdentity{ID: "provider.acme", Version: "1.2.3", ManifestHash: "sha256:" + strings.Repeat("f", 64), Provenance: "external"},
 		},
 		Requirements: []Requirement{TargetScopedRequirement(RequirementSecret, "webhook_signing.acme")},
+		TriggerEvents: []TriggerEventDescriptor{
+			{Event: "inbound.acme", Kind: "raw", Fields: []TriggerEventFieldDescriptor{{Name: "payload", Type: "json", Required: true}}},
+			{Event: "inbound.acme.record_created", Kind: "normalized", Fields: []TriggerEventFieldDescriptor{{Name: "record_id", Type: "text", Required: true, CarryEligible: true}}},
+		},
 	}
 	normalized, err := NormalizeSubjects([]Subject{subject})
 	if err != nil {
@@ -226,9 +234,12 @@ func TestEffectiveTriggerTextAndJSONProjectTheSameTypedFacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := RenderSubject(normalized[0], false)
-	for _, value := range []string{"chat", "verified_pack", "HMAC_SHA256", "inbound.acme", strings.Repeat("e", 64), "provider.acme", "1.2.3", "webhook_signing.acme"} {
+	for _, value := range []string{"chat", "verified_pack", "HMAC_SHA256", "inbound.acme", "inbound.acme.record_created", "record_id", strings.Repeat("e", 64), "provider.acme", "1.2.3", "webhook_signing.acme"} {
 		if !strings.Contains(string(body), value) || !strings.Contains(text, value) {
 			t.Fatalf("typed fact %q missing from JSON or text\njson=%s\ntext=%s", value, body, text)
 		}
+	}
+	if !strings.Contains(string(body), `"carry_eligible":true`) || !strings.Contains(text, "record_id:text:required:carry-eligible") {
+		t.Fatalf("normalized carry descriptor missing from JSON or text\njson=%s\ntext=%s", body, text)
 	}
 }

--- a/internal/providertriggers/admission.go
+++ b/internal/providertriggers/admission.go
@@ -14,6 +14,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/packs"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 )
 
 type AdmissionKind string
@@ -476,6 +477,19 @@ func (p InboundAdmissionPlan) Accept(req Request) (Delivery, error) {
 				return Delivery{}, badRequest(fmt.Sprintf("pack %s version=%s manifest_hash=%s normalized event %q path %q failed: %s", p.packIdentity.ID, p.packIdentity.Version, p.packIdentity.ManifestHash, normalizationErr.Event, normalizationErr.Path, normalizationErr.Cause))
 			}
 			return Delivery{}, err
+		}
+		if p.packIdentity == nil {
+			return Delivery{}, badRequest("compiled pack admission requires verified pack identity")
+		}
+		for index := range delivery.Events {
+			if delivery.Events[index].Kind != OutputKindNormalized {
+				continue
+			}
+			delivery.Events[index].Authorization = runtimeprovideroutput.Authorization{
+				Provider: p.provider, Event: string(delivery.Events[index].Name),
+				PackID: p.packIdentity.ID, PackVersion: p.packIdentity.Version,
+				ManifestHash: p.packIdentity.ManifestHash, GenerationID: p.generationID,
+			}.Normalized()
 		}
 		return delivery, nil
 	}

--- a/internal/providertriggers/admission.go
+++ b/internal/providertriggers/admission.go
@@ -6,12 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/packs"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
 type AdmissionKind string
@@ -86,7 +88,7 @@ type InboundAdmissionPlan struct {
 	manifest              *Manifest
 	raw                   *RawAdmissionPolicy
 	requiresSecret        bool
-	eventNames            EventNameManifest
+	outputs               []OutputManifest
 	acknowledgedUnsigned  bool
 }
 
@@ -162,7 +164,7 @@ func (s *CatalogSnapshot) compilePackAdmission(alias, provider, signingSecret st
 	return InboundAdmissionPlan{
 		generationID: s.GenerationID(), provider: provider, policySource: PolicySourceVerifiedPack,
 		requestAuthentication: auth, packIdentity: &identity, manifest: &manifest,
-		requiresSecret: requiresSecret, eventNames: manifest.EventName,
+		requiresSecret: requiresSecret, outputs: manifest.OutputManifest(),
 		acknowledgedUnsigned: ack == UnsignedWebhookAcknowledgement,
 	}, nil
 }
@@ -198,7 +200,7 @@ func (s *CatalogSnapshot) compileRawAdmission(alias, provider, signingSecret str
 	return InboundAdmissionPlan{
 		generationID: generationID, provider: provider, policySource: PolicySourceRawDeclaration,
 		requestAuthentication: auth, raw: &policy, requiresSecret: requiresSecret,
-		eventNames: EventNameManifest{Literal: policy.Event}, acknowledgedUnsigned: ack == UnsignedWebhookAcknowledgement,
+		outputs: []OutputManifest{{Kind: OutputKindRaw, EventName: EventNameManifest{Literal: policy.Event}}}, acknowledgedUnsigned: ack == UnsignedWebhookAcknowledgement,
 	}, nil
 }
 
@@ -315,8 +317,29 @@ func (p InboundAdmissionPlan) PolicySource() PolicySource { return p.policySourc
 func (p InboundAdmissionPlan) RequestAuthentication() RequestAuthentication {
 	return p.requestAuthentication
 }
-func (p InboundAdmissionPlan) RequiresSecret() bool          { return p.requiresSecret }
-func (p InboundAdmissionPlan) EventNames() EventNameManifest { return p.eventNames }
+func (p InboundAdmissionPlan) RequiresSecret() bool { return p.requiresSecret }
+func (p InboundAdmissionPlan) Outputs() []OutputManifest {
+	out := make([]OutputManifest, 0, len(p.outputs))
+	for _, output := range p.outputs {
+		fields := make(map[string]runtimecontracts.FieldProjection, len(output.Fields))
+		for name, field := range output.Fields {
+			fields[name] = field
+		}
+		output.Fields = fields
+		output.When.Exists = append([]string{}, output.When.Exists...)
+		output.When.Absent = append([]string{}, output.When.Absent...)
+		out = append(out, output)
+	}
+	return out
+}
+func (p InboundAdmissionPlan) RawOutput() (OutputManifest, bool) {
+	for _, output := range p.Outputs() {
+		if output.Kind == OutputKindRaw {
+			return output, true
+		}
+	}
+	return OutputManifest{}, false
+}
 func (p InboundAdmissionPlan) PackIdentity() (PackIdentity, bool) {
 	if p.packIdentity == nil {
 		return PackIdentity{}, false
@@ -361,10 +384,7 @@ func (p InboundAdmissionPlan) EffectiveCapabilitySubject(req EffectiveSubjectReq
 	if bundleHash == "" || alias == "" {
 		return packs.Subject{}, fmt.Errorf("effective inbound admission subject requires bundle_hash and alias")
 	}
-	eventName := strings.TrimSpace(p.eventNames.Literal)
-	if eventName == "" {
-		eventName = strings.TrimSpace(p.eventNames.Template)
-	}
+	eventName := rawOutputName(p.outputs)
 	source := "raw_declaration"
 	provenance := "project"
 	admission := &packs.TriggerAdmission{
@@ -397,6 +417,23 @@ func (p InboundAdmissionPlan) EffectiveCapabilitySubject(req EffectiveSubjectReq
 			{Code: packs.CapabilityEmitEvent, Target: eventName},
 			{Code: packs.CapabilityPersistDedupeMarkers},
 		},
+	}
+	if p.manifest != nil {
+		subject.TriggerEvents = triggerEventDescriptors(*p.manifest)
+	} else {
+		subject.TriggerEvents = []packs.TriggerEventDescriptor{{Event: eventName, Kind: string(OutputKindRaw)}}
+	}
+	for _, output := range p.outputs {
+		name := strings.TrimSpace(output.Event)
+		if output.Kind == OutputKindRaw {
+			name = strings.TrimSpace(output.EventName.Literal)
+			if name == "" {
+				name = strings.TrimSpace(output.EventName.Template)
+			}
+		}
+		if name != "" && name != eventName {
+			subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityEmitEvent, Target: name})
+		}
 	}
 	if p.requiresSecret {
 		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityVerifySecret, Target: strings.TrimSpace(req.SigningSecret)})
@@ -432,7 +469,15 @@ func (p InboundAdmissionPlan) Accept(req Request) (Delivery, error) {
 		return Delivery{}, unauthorized(provider + " webhook signing secret is required")
 	}
 	if p.manifest != nil {
-		return p.manifest.Accept(req)
+		delivery, err := p.manifest.Accept(req)
+		if err != nil {
+			var normalizationErr NormalizationError
+			if errors.As(err, &normalizationErr) && p.packIdentity != nil {
+				return Delivery{}, badRequest(fmt.Sprintf("pack %s version=%s manifest_hash=%s normalized event %q path %q failed: %s", p.packIdentity.ID, p.packIdentity.Version, p.packIdentity.ManifestHash, normalizationErr.Event, normalizationErr.Path, normalizationErr.Cause))
+			}
+			return Delivery{}, err
+		}
+		return delivery, nil
 	}
 	return p.acceptExplicitRaw(req)
 }
@@ -469,8 +514,21 @@ func (p InboundAdmissionPlan) acceptExplicitRaw(req Request) (Delivery, error) {
 	}
 	return Delivery{
 		ProviderEventID: deliveryID, ProviderEventType: NormalizeEventToken(policy.Event),
-		EventName: events.EventType(policy.Event), Payload: payload,
+		Events: []DeliveryEvent{{Name: events.EventType(policy.Event), Kind: OutputKindRaw, Payload: payload}},
 	}, nil
+}
+
+func rawOutputName(outputs []OutputManifest) string {
+	for _, output := range outputs {
+		if output.Kind != OutputKindRaw {
+			continue
+		}
+		if literal := strings.TrimSpace(output.EventName.Literal); literal != "" {
+			return literal
+		}
+		return strings.TrimSpace(output.EventName.Template)
+	}
+	return ""
 }
 
 func verifyRawAuthentication(auth RawAuthenticationDeclaration, secret string, headers http.Header, body []byte) error {

--- a/internal/providertriggers/admission_test.go
+++ b/internal/providertriggers/admission_test.go
@@ -202,7 +202,7 @@ func TestRawAdmissionConsumesOnlyDeclaredAuthenticationAndDeliverySources(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if delivery.ProviderEventID != "declared-id" || delivery.EventName != "inbound.partner" {
+	if delivery.ProviderEventID != "declared-id" || delivery.Events[0].Name != "inbound.partner" {
 		t.Fatalf("delivery = %+v", delivery)
 	}
 	headers["X-Partner-Delivery"] = []string{"one", "two"}
@@ -281,9 +281,9 @@ func TestRawAdmissionPreservesRawPayloadWhileResolvingJSONPathDeliveryID(t *test
 	if delivery.ProviderEventID != "evt-raw-json-path" {
 		t.Fatalf("delivery id = %q", delivery.ProviderEventID)
 	}
-	data, ok := delivery.Payload["data"].(string)
+	data, ok := delivery.Events[0].Payload["data"].(string)
 	if !ok || data != string(body) {
-		t.Fatalf("raw emitted payload = %#v, want exact body string", delivery.Payload["data"])
+		t.Fatalf("raw emitted payload = %#v, want exact body string", delivery.Events[0].Payload["data"])
 	}
 	if _, err := plan.Accept(Request{Provider: "partner-events", Body: []byte("not-json")}); err == nil || !strings.Contains(err.Error(), "requires a valid JSON request body") {
 		t.Fatalf("invalid JSON error = %v", err)

--- a/internal/providertriggers/normalized_events.go
+++ b/internal/providertriggers/normalized_events.go
@@ -1,0 +1,391 @@
+package providertriggers
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+)
+
+type OutputKind string
+
+const (
+	OutputKindRaw        OutputKind = "raw"
+	OutputKindNormalized OutputKind = "normalized"
+)
+
+type NormalizedEventManifest struct {
+	Event  string                                      `yaml:"event"`
+	Fields map[string]runtimecontracts.FieldProjection `yaml:"fields"`
+	When   NormalizedEventWhen                         `yaml:"when,omitempty"`
+}
+
+type NormalizedEventWhen struct {
+	Exists []string `yaml:"exists,omitempty"`
+	Absent []string `yaml:"absent,omitempty"`
+}
+
+type OutputManifest struct {
+	Kind      OutputKind
+	EventName EventNameManifest
+	Event     string
+	Fields    map[string]runtimecontracts.FieldProjection
+	When      NormalizedEventWhen
+}
+
+type NormalizationError struct {
+	Event string
+	Path  string
+	Cause string
+}
+
+func (e NormalizationError) Error() string {
+	return fmt.Sprintf("normalized event %q field path %q failed: %s", e.Event, e.Path, e.Cause)
+}
+
+var normalizedFieldNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func (m Manifest) OutputManifest() []OutputManifest {
+	out := []OutputManifest{{Kind: OutputKindRaw, EventName: m.EventName}}
+	for _, item := range m.NormalizedEvents {
+		fields := make(map[string]runtimecontracts.FieldProjection, len(item.Fields))
+		for name, field := range item.Fields {
+			fields[name] = field.Normalized()
+		}
+		out = append(out, OutputManifest{
+			Kind: OutputKindNormalized, Event: strings.TrimSpace(item.Event),
+			Fields: fields, When: item.When.normalized(fields),
+		})
+	}
+	return out
+}
+
+func (m Manifest) validateNormalizedEvents() error {
+	provider := NormalizeProviderName(m.Provider)
+	seen := map[string]struct{}{}
+	if literal := strings.TrimSpace(m.EventName.Literal); literal != "" {
+		seen[literal] = struct{}{}
+	}
+	branches := make([]OutputManifest, 0, len(m.NormalizedEvents))
+	for index, item := range m.NormalizedEvents {
+		eventName := strings.TrimSpace(item.Event)
+		if eventName == "" {
+			return fmt.Errorf("%s normalized_events[%d].event is required", provider, index)
+		}
+		if !strings.HasPrefix(eventName, "inbound."+provider+".") {
+			return fmt.Errorf("%s normalized event %q must use inbound.%s.* namespace", provider, eventName, provider)
+		}
+		if _, exists := seen[eventName]; exists {
+			return fmt.Errorf("%s normalized event %q duplicates another declared output", provider, eventName)
+		}
+		seen[eventName] = struct{}{}
+		if len(item.Fields) == 0 {
+			return fmt.Errorf("%s normalized event %q requires fields", provider, eventName)
+		}
+		fields := make(map[string]runtimecontracts.FieldProjection, len(item.Fields))
+		for name, field := range item.Fields {
+			name = strings.TrimSpace(name)
+			field = field.Normalized()
+			if !normalizedFieldNamePattern.MatchString(name) {
+				return fmt.Errorf("%s normalized event %q has invalid field name %q", provider, eventName, name)
+			}
+			if _, err := runtimepaths.ParseStrictRelative(field.From); err != nil {
+				return fmt.Errorf("%s normalized event %q field %q: %w", provider, eventName, name, err)
+			}
+			if err := runtimecontracts.ValidateWave1TypeReference(field.Type, "normalized event "+eventName+" field "+name); err != nil {
+				return err
+			}
+			switch field.Convert {
+			case "":
+			case runtimecontracts.FieldProjectionConvertNumberToText:
+				if field.Type != "text" && field.Type != "string" {
+					return fmt.Errorf("%s normalized event %q field %q conversion number_to_text requires type text", provider, eventName, name)
+				}
+			default:
+				return fmt.Errorf("%s normalized event %q field %q has unsupported conversion %q; use number_to_text or remove convert", provider, eventName, name, field.Convert)
+			}
+			fields[name] = field
+		}
+		when, err := validateNormalizedWhen(provider, eventName, item.When, fields)
+		if err != nil {
+			return err
+		}
+		branches = append(branches, OutputManifest{Kind: OutputKindNormalized, Event: eventName, Fields: fields, When: when})
+	}
+	for i := 0; i < len(branches); i++ {
+		for j := i + 1; j < len(branches); j++ {
+			if normalizedBranchesExclusive(branches[i].When, branches[j].When) {
+				continue
+			}
+			return fmt.Errorf("%s normalized events %q and %q can match the same payload; add when.absent to one branch so their exists/absent predicates are mutually exclusive", provider, branches[i].Event, branches[j].Event)
+		}
+	}
+	return nil
+}
+
+func validateNormalizedWhen(provider, eventName string, declared NormalizedEventWhen, fields map[string]runtimecontracts.FieldProjection) (NormalizedEventWhen, error) {
+	when := declared.normalized(fields)
+	for _, path := range append(append([]string{}, when.Exists...), when.Absent...) {
+		if _, err := runtimepaths.ParseStrictRelative(path); err != nil {
+			return NormalizedEventWhen{}, fmt.Errorf("%s normalized event %q when path: %w", provider, eventName, err)
+		}
+	}
+	for _, exists := range when.Exists {
+		for _, absent := range when.Absent {
+			if pathIsSameOrDescendant(exists, absent) {
+				return NormalizedEventWhen{}, fmt.Errorf("%s normalized event %q requires path %q while declaring ancestor %q absent", provider, eventName, exists, absent)
+			}
+		}
+	}
+	return when, nil
+}
+
+func (w NormalizedEventWhen) normalized(fields map[string]runtimecontracts.FieldProjection) NormalizedEventWhen {
+	exists := append([]string{}, w.Exists...)
+	for _, field := range fields {
+		if !field.Optional {
+			exists = append(exists, field.From)
+		}
+	}
+	return NormalizedEventWhen{Exists: normalizedPaths(exists), Absent: normalizedPaths(w.Absent)}
+}
+
+func normalizedPaths(in []string) []string {
+	seen := map[string]struct{}{}
+	for _, item := range in {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			seen[item] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for item := range seen {
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizedBranchesExclusive(left, right NormalizedEventWhen) bool {
+	for _, exists := range left.Exists {
+		for _, absent := range right.Absent {
+			if pathIsSameOrDescendant(exists, absent) {
+				return true
+			}
+		}
+	}
+	for _, exists := range right.Exists {
+		for _, absent := range left.Absent {
+			if pathIsSameOrDescendant(exists, absent) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pathIsSameOrDescendant(candidate, ancestor string) bool {
+	candidate = strings.TrimSpace(candidate)
+	ancestor = strings.TrimSpace(ancestor)
+	return candidate == ancestor || strings.HasPrefix(candidate, ancestor+".")
+}
+
+func (m Manifest) normalizedDeliveryEvents(payload any) ([]DeliveryEvent, error) {
+	var matched []OutputManifest
+	for _, output := range m.OutputManifest() {
+		if output.Kind != OutputKindNormalized || !normalizedWhenMatches(payload, output.When) {
+			continue
+		}
+		matched = append(matched, output)
+	}
+	if len(matched) > 1 {
+		names := make([]string, 0, len(matched))
+		for _, output := range matched {
+			names = append(names, output.Event)
+		}
+		sort.Strings(names)
+		return nil, badRequest("verified provider trigger normalized-event plan matched multiple branches: " + strings.Join(names, ", "))
+	}
+	if len(matched) == 0 {
+		return nil, nil
+	}
+	output := matched[0]
+	normalized := make(map[string]any, len(output.Fields))
+	fieldNames := make([]string, 0, len(output.Fields))
+	for name := range output.Fields {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+	for _, name := range fieldNames {
+		field := output.Fields[name]
+		value, ok := valueFromRelativePath(payload, field.From)
+		if !ok {
+			if field.Optional {
+				continue
+			}
+			return nil, NormalizationError{Event: output.Event, Path: field.From, Cause: "required value is missing"}
+		}
+		converted, err := normalizeProjectedValue(value, field)
+		if err != nil {
+			return nil, NormalizationError{Event: output.Event, Path: field.From, Cause: err.Error()}
+		}
+		normalized[name] = converted
+	}
+	return []DeliveryEvent{{Name: events.EventType(output.Event), Kind: OutputKindNormalized, Payload: normalized}}, nil
+}
+
+func normalizedWhenMatches(payload any, when NormalizedEventWhen) bool {
+	for _, path := range when.Exists {
+		if _, ok := valueFromRelativePath(payload, path); !ok {
+			return false
+		}
+	}
+	for _, path := range when.Absent {
+		if _, ok := valueFromRelativePath(payload, path); ok {
+			return false
+		}
+	}
+	return true
+}
+
+func valueFromRelativePath(value any, path string) (any, bool) {
+	parsed, err := runtimepaths.ParseStrictRelative(path)
+	if err != nil {
+		return nil, false
+	}
+	current := value
+	for _, segment := range parsed.Segments {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[segment]
+		if !ok || current == nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func normalizeProjectedValue(value any, field runtimecontracts.FieldProjection) (any, error) {
+	if field.Convert == runtimecontracts.FieldProjectionConvertNumberToText {
+		return exactNumberText(value)
+	}
+	if !projectedValueMatchesType(value, field.Type) {
+		return nil, fmt.Errorf("value type %T is incompatible with declared type %s and implicit conversion is forbidden", value, field.Type)
+	}
+	return value, nil
+}
+
+func exactNumberText(value any) (string, error) {
+	switch typed := value.(type) {
+	case json.Number:
+		text := typed.String()
+		if _, err := strconv.ParseInt(text, 10, 64); err != nil {
+			return "", fmt.Errorf("number_to_text requires an integer JSON number, got %q", text)
+		}
+		return text, nil
+	case int:
+		return strconv.Itoa(typed), nil
+	case int32:
+		return strconv.FormatInt(int64(typed), 10), nil
+	case int64:
+		return strconv.FormatInt(typed, 10), nil
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed || math.Abs(typed) > 1<<53 {
+			return "", fmt.Errorf("number_to_text requires an exact integer number")
+		}
+		return strconv.FormatInt(int64(typed), 10), nil
+	default:
+		return "", fmt.Errorf("number_to_text requires a numeric value, got %T", value)
+	}
+}
+
+func projectedValueMatchesType(value any, typeRef string) bool {
+	switch strings.TrimSpace(typeRef) {
+	case "text", "string", "uuid", "timestamp", "timestamptz":
+		_, ok := value.(string)
+		return ok
+	case "integer", "int", "bigint":
+		switch typed := value.(type) {
+		case json.Number:
+			_, err := strconv.ParseInt(typed.String(), 10, 64)
+			return err == nil
+		case int, int32, int64:
+			return true
+		case float64:
+			return math.Trunc(typed) == typed && math.Abs(typed) <= 1<<53
+		default:
+			return false
+		}
+	case "float", "double", "real", "numeric":
+		switch value.(type) {
+		case json.Number, int, int32, int64, float64:
+			return true
+		default:
+			return false
+		}
+	case "boolean", "bool":
+		_, ok := value.(bool)
+		return ok
+	case "json", "jsonb":
+		return true
+	default:
+		return true
+	}
+}
+
+func (m Manifest) eventCatalogEntries() map[string]runtimecontracts.EventCatalogEntry {
+	out := map[string]runtimecontracts.EventCatalogEntry{}
+	if literal := strings.TrimSpace(m.EventName.Literal); literal != "" {
+		out[literal] = RawEventCatalogEntry()
+	}
+	for _, normalized := range m.NormalizedEvents {
+		entry := runtimecontracts.EventCatalogEntry{
+			Source: "provider_trigger_pack_normalized", Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"},
+			Payload: runtimecontracts.EventPayloadSpec{Type: "object", Properties: map[string]runtimecontracts.EventFieldSpec{}},
+		}
+		for name, projection := range normalized.Fields {
+			projection = projection.Normalized()
+			entry.Payload.Properties[strings.TrimSpace(name)] = runtimecontracts.EventFieldSpec{Type: projection.Type}
+			if !projection.Optional {
+				entry.Required = append(entry.Required, strings.TrimSpace(name))
+			}
+		}
+		sort.Strings(entry.Required)
+		entry.Payload.Required = append([]string{}, entry.Required...)
+		out[strings.TrimSpace(normalized.Event)] = entry
+	}
+	return out
+}
+
+func RawEventCatalogEntry() runtimecontracts.EventCatalogEntry {
+	properties := map[string]runtimecontracts.EventFieldSpec{
+		"entity_id":            {Type: "text"},
+		"provider":             {Type: "text"},
+		"event_type":           {Type: "text"},
+		"provider_event_type":  {Type: "text"},
+		"provider_event_id":    {Type: "text"},
+		"provider_delivery_id": {Type: "text"},
+		"payload":              {Type: "json"},
+		"headers":              {Type: "json"},
+		"received_at":          {Type: "text"},
+	}
+	required := make([]string, 0, len(properties))
+	for name := range properties {
+		required = append(required, name)
+	}
+	sort.Strings(required)
+	return runtimecontracts.EventCatalogEntry{
+		Source: "provider_trigger_pack_raw", Swarm: runtimecontracts.EventSwarmMetadata{Source: "external"},
+		Payload:  runtimecontracts.EventPayloadSpec{Type: "object", Properties: properties, Required: append([]string{}, required...)},
+		Required: required,
+	}
+}

--- a/internal/providertriggers/normalized_events.go
+++ b/internal/providertriggers/normalized_events.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
 )
 
@@ -57,7 +58,7 @@ func (m Manifest) OutputManifest() []OutputManifest {
 	for _, item := range m.NormalizedEvents {
 		fields := make(map[string]runtimecontracts.FieldProjection, len(item.Fields))
 		for name, field := range item.Fields {
-			fields[name] = field.Normalized()
+			fields[strings.TrimSpace(name)] = field.Normalized()
 		}
 		out = append(out, OutputManifest{
 			Kind: OutputKindNormalized, Event: strings.TrimSpace(item.Event),
@@ -70,9 +71,6 @@ func (m Manifest) OutputManifest() []OutputManifest {
 func (m Manifest) validateNormalizedEvents() error {
 	provider := NormalizeProviderName(m.Provider)
 	seen := map[string]struct{}{}
-	if literal := strings.TrimSpace(m.EventName.Literal); literal != "" {
-		seen[literal] = struct{}{}
-	}
 	branches := make([]OutputManifest, 0, len(m.NormalizedEvents))
 	for index, item := range m.NormalizedEvents {
 		eventName := strings.TrimSpace(item.Event)
@@ -82,6 +80,12 @@ func (m Manifest) validateNormalizedEvents() error {
 		if !strings.HasPrefix(eventName, "inbound."+provider+".") {
 			return fmt.Errorf("%s normalized event %q must use inbound.%s.* namespace", provider, eventName, provider)
 		}
+		if !eventidentity.IsValidName(eventName) {
+			return fmt.Errorf("%s normalized event %q is not a valid canonical event name", provider, eventName)
+		}
+		if m.EventName.Accepts(eventName) {
+			return fmt.Errorf("%s normalized event %q collides with the raw event-name policy", provider, eventName)
+		}
 		if _, exists := seen[eventName]; exists {
 			return fmt.Errorf("%s normalized event %q duplicates another declared output", provider, eventName)
 		}
@@ -90,8 +94,14 @@ func (m Manifest) validateNormalizedEvents() error {
 			return fmt.Errorf("%s normalized event %q requires fields", provider, eventName)
 		}
 		fields := make(map[string]runtimecontracts.FieldProjection, len(item.Fields))
-		for name, field := range item.Fields {
-			name = strings.TrimSpace(name)
+		for declaredName, field := range item.Fields {
+			name := strings.TrimSpace(declaredName)
+			if declaredName != name {
+				return fmt.Errorf("%s normalized event %q field name %q is not canonical; remove surrounding whitespace", provider, eventName, declaredName)
+			}
+			if _, duplicate := fields[name]; duplicate {
+				return fmt.Errorf("%s normalized event %q field name %q duplicates another field after normalization", provider, eventName, declaredName)
+			}
 			field = field.Normalized()
 			if !normalizedFieldNamePattern.MatchString(name) {
 				return fmt.Errorf("%s normalized event %q has invalid field name %q", provider, eventName, name)
@@ -99,7 +109,7 @@ func (m Manifest) validateNormalizedEvents() error {
 			if _, err := runtimepaths.ParseStrictRelative(field.From); err != nil {
 				return fmt.Errorf("%s normalized event %q field %q: %w", provider, eventName, name, err)
 			}
-			if err := runtimecontracts.ValidateWave1TypeReference(field.Type, "normalized event "+eventName+" field "+name); err != nil {
+			if err := runtimecontracts.ValidateStandaloneWave1TypeReference(field.Type, "normalized event "+eventName+" field "+name); err != nil {
 				return err
 			}
 			switch field.Convert {
@@ -278,8 +288,8 @@ func normalizeProjectedValue(value any, field runtimecontracts.FieldProjection) 
 	if field.Convert == runtimecontracts.FieldProjectionConvertNumberToText {
 		return exactNumberText(value)
 	}
-	if !projectedValueMatchesType(value, field.Type) {
-		return nil, fmt.Errorf("value type %T is incompatible with declared type %s and implicit conversion is forbidden", value, field.Type)
+	if err := runtimecontracts.ValidateStandaloneWave1Value(field.Type, value); err != nil {
+		return nil, fmt.Errorf("%v and implicit conversion is forbidden", err)
 	}
 	return value, nil
 }
@@ -308,40 +318,6 @@ func exactNumberText(value any) (string, error) {
 	}
 }
 
-func projectedValueMatchesType(value any, typeRef string) bool {
-	switch strings.TrimSpace(typeRef) {
-	case "text", "string", "uuid", "timestamp", "timestamptz":
-		_, ok := value.(string)
-		return ok
-	case "integer", "int", "bigint":
-		switch typed := value.(type) {
-		case json.Number:
-			_, err := strconv.ParseInt(typed.String(), 10, 64)
-			return err == nil
-		case int, int32, int64:
-			return true
-		case float64:
-			return math.Trunc(typed) == typed && math.Abs(typed) <= 1<<53
-		default:
-			return false
-		}
-	case "float", "double", "real", "numeric":
-		switch value.(type) {
-		case json.Number, int, int32, int64, float64:
-			return true
-		default:
-			return false
-		}
-	case "boolean", "bool":
-		_, ok := value.(bool)
-		return ok
-	case "json", "jsonb":
-		return true
-	default:
-		return true
-	}
-}
-
 func (m Manifest) eventCatalogEntries() map[string]runtimecontracts.EventCatalogEntry {
 	out := map[string]runtimecontracts.EventCatalogEntry{}
 	if literal := strings.TrimSpace(m.EventName.Literal); literal != "" {
@@ -354,7 +330,8 @@ func (m Manifest) eventCatalogEntries() map[string]runtimecontracts.EventCatalog
 		}
 		for name, projection := range normalized.Fields {
 			projection = projection.Normalized()
-			entry.Payload.Properties[strings.TrimSpace(name)] = runtimecontracts.EventFieldSpec{Type: projection.Type}
+			name = strings.TrimSpace(name)
+			entry.Payload.Properties[name] = runtimecontracts.EventFieldSpec{Type: projection.Type}
 			if !projection.Optional {
 				entry.Required = append(entry.Required, strings.TrimSpace(name))
 			}

--- a/internal/providertriggers/normalized_events_test.go
+++ b/internal/providertriggers/normalized_events_test.go
@@ -48,6 +48,48 @@ func TestNormalizedEventManifestPublishesRawAndTypedFlatEvent(t *testing.T) {
 	}
 }
 
+func TestCompiledPackPlanOwnsNormalizedOutputAuthorization(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	identity := PackIdentity{
+		ID: "provider.telegram", Version: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("c", 64), Provenance: "platform",
+	}
+	catalog, err := NewCatalogSnapshot(CatalogEntry{Manifest: manifest, Identity: identity, Source: "test"})
+	if err != nil {
+		t.Fatalf("NewCatalogSnapshot: %v", err)
+	}
+	plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "chat", Provider: "telegram",
+		Declaration: AdmissionDeclaration{Acknowledge: UnsignedWebhookAcknowledgement},
+	})
+	if err != nil {
+		t.Fatalf("CompileAdmission: %v", err)
+	}
+	delivery, err := plan.Accept(Request{
+		Target: Target{EntityID: "entity-1"},
+		Payload: map[string]any{
+			"update_id": json.Number("123"),
+			"message": map[string]any{
+				"message_id": json.Number("7"),
+				"chat":       map[string]any{"id": json.Number("42")},
+				"text":       "hello",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if len(delivery.Events) != 2 || !delivery.Events[0].Authorization.Empty() {
+		t.Fatalf("raw output authorization = %#v, want empty", delivery.Events)
+	}
+	got := delivery.Events[1].Authorization
+	if !got.Valid() || got.Provider != "telegram" || got.Event != "inbound.telegram.text_message" ||
+		got.PackID != identity.ID || got.PackVersion != identity.Version ||
+		got.ManifestHash != identity.ManifestHash || got.GenerationID != catalog.GenerationID() {
+		t.Fatalf("normalized output authorization = %#v, want compiled pack identity/generation", got)
+	}
+}
+
 func TestNormalizedEventManifestUnmatchedPayloadPublishesRawOnly(t *testing.T) {
 	manifest := normalizedEventTestManifest()
 	delivery, err := manifest.Accept(Request{
@@ -91,6 +133,121 @@ func TestNormalizedEventManifestRejectsHostileProjectionSyntax(t *testing.T) {
 				t.Fatalf("Validate accepted hostile path %q", path)
 			}
 		})
+	}
+}
+
+func TestNormalizedEventManifestRejectsMalformedEventNamesAtLoad(t *testing.T) {
+	for _, eventName := range []string{
+		"inbound.telegram.",
+		"inbound.telegram.TextMessage",
+		"inbound.telegram.text-message",
+		"inbound.telegram..text_message",
+		"inbound.telegram.text message",
+	} {
+		t.Run(eventName, func(t *testing.T) {
+			manifest := normalizedEventTestManifest()
+			manifest.NormalizedEvents[0].Event = eventName
+			if err := manifest.Validate(); err == nil || !strings.Contains(err.Error(), "valid canonical event name") {
+				t.Fatalf("Validate(%q) error = %v, want canonical event-name rejection", eventName, err)
+			}
+		})
+	}
+}
+
+func TestNormalizedEventManifestRejectsRawTemplateCollision(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	manifest.Provider = "github"
+	manifest.EventName = EventNameManifest{Template: "inbound.github.{event_type}"}
+	manifest.NormalizedEvents[0].Event = "inbound.github.push"
+	err := manifest.Validate()
+	if err == nil || !strings.Contains(err.Error(), "collides with the raw event-name policy") {
+		t.Fatalf("Validate error = %v, want raw-template collision rejection", err)
+	}
+}
+
+func TestNormalizedEventManifestRejectsNonCanonicalFieldNames(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	manifest.NormalizedEvents[0].Fields[" text "] = manifest.NormalizedEvents[0].Fields["text"]
+	delete(manifest.NormalizedEvents[0].Fields, "text")
+	err := manifest.Validate()
+	if err == nil || !strings.Contains(err.Error(), "field name") || !strings.Contains(err.Error(), "not canonical") {
+		t.Fatalf("Validate error = %v, want non-canonical field-name rejection", err)
+	}
+}
+
+func TestNormalizedEventPlanRejectsCompositeTypeMismatchesWithPackProvenance(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		typeRef  string
+		value    any
+		wantPart string
+	}{
+		{name: "list", typeRef: "[text]", value: []any{"ok", json.Number("2")}, wantPart: "list item 1"},
+		{name: "map", typeRef: "map[text]integer", value: map[string]any{"key": "not-an-integer"}, wantPart: "map value at \"key\""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := normalizedEventTestManifest()
+			field := manifest.NormalizedEvents[0].Fields["raw"]
+			field.Type = tc.typeRef
+			field.From = "message.raw"
+			field.Optional = false
+			manifest.NormalizedEvents[0].Fields["raw"] = field
+			entry := CatalogEntry{
+				Manifest: manifest,
+				Identity: PackIdentity{
+					ID: "provider.telegram", Version: "1.0.0",
+					ManifestHash: "sha256:" + strings.Repeat("a", 64), Provenance: "platform",
+				},
+				Source: "test",
+			}
+			catalog, err := NewCatalogSnapshot(entry)
+			if err != nil {
+				t.Fatalf("NewCatalogSnapshot: %v", err)
+			}
+			plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+				Alias: "chat", Provider: "telegram",
+				Declaration: AdmissionDeclaration{Acknowledge: UnsignedWebhookAcknowledgement},
+			})
+			if err != nil {
+				t.Fatalf("CompileAdmission: %v", err)
+			}
+			_, err = plan.Accept(Request{
+				Target: Target{EntityID: "entity-1"},
+				Payload: map[string]any{
+					"update_id": json.Number("123"),
+					"message": map[string]any{
+						"message_id": json.Number("7"),
+						"chat":       map[string]any{"id": json.Number("42")},
+						"text":       "hello", "raw": tc.value,
+					},
+				},
+			})
+			for _, want := range []string{"provider.telegram", "version=1.0.0", "manifest_hash=sha256:", "inbound.telegram.text_message", "path \"message.raw\"", tc.wantPart} {
+				if err == nil || !strings.Contains(err.Error(), want) {
+					t.Fatalf("Accept error = %v, want %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizedEventManifestRejectsUnresolvableNamedTypeWithPackProvenance(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	field := manifest.NormalizedEvents[0].Fields["text"]
+	field.Type = "MessageText"
+	manifest.NormalizedEvents[0].Fields["text"] = field
+	_, err := NewCatalogSnapshot(CatalogEntry{
+		Manifest: manifest,
+		Identity: PackIdentity{
+			ID: "provider.telegram", Version: "1.0.0",
+			ManifestHash: "sha256:" + strings.Repeat("b", 64), Provenance: "platform",
+		},
+		Source: "test",
+	})
+	for _, want := range []string{"provider.telegram", "version=1.0.0", "manifest_hash=sha256:", "MessageText", "not standalone-resolvable"} {
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("NewCatalogSnapshot error = %v, want %q", err, want)
+		}
 	}
 }
 

--- a/internal/providertriggers/normalized_events_test.go
+++ b/internal/providertriggers/normalized_events_test.go
@@ -1,0 +1,153 @@
+package providertriggers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestNormalizedEventManifestPublishesRawAndTypedFlatEvent(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	delivery, err := manifest.Accept(Request{
+		Target: Target{EntityID: "entity-1"},
+		Payload: map[string]any{
+			"update_id": json.Number("123"),
+			"message": map[string]any{
+				"message_id": json.Number("7"),
+				"chat":       map[string]any{"id": json.Number("9007199254740993")},
+				"text":       "hello",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if len(delivery.Events) != 2 {
+		t.Fatalf("events = %#v, want raw plus normalized", delivery.Events)
+	}
+	if delivery.Events[0].Kind != OutputKindRaw || delivery.Events[0].Name != "inbound.telegram" {
+		t.Fatalf("raw event = %#v", delivery.Events[0])
+	}
+	normalized := delivery.Events[1]
+	if normalized.Kind != OutputKindNormalized || normalized.Name != "inbound.telegram.text_message" {
+		t.Fatalf("normalized event = %#v", normalized)
+	}
+	if got := normalized.Payload["chat_id"]; got != "9007199254740993" {
+		t.Fatalf("chat_id = %#v, want lossless text", got)
+	}
+	if got := normalized.Payload["message_id"]; got != json.Number("7") {
+		t.Fatalf("message_id = %#v, want JSON number", got)
+	}
+	if got := normalized.Payload["text"]; got != "hello" {
+		t.Fatalf("text = %#v", got)
+	}
+}
+
+func TestNormalizedEventManifestUnmatchedPayloadPublishesRawOnly(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	delivery, err := manifest.Accept(Request{
+		Target:  Target{EntityID: "entity-1"},
+		Payload: map[string]any{"update_id": json.Number("123"), "callback_query": map[string]any{"id": "callback-1"}},
+	})
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if len(delivery.Events) != 1 || delivery.Events[0].Kind != OutputKindRaw {
+		t.Fatalf("events = %#v, want raw only", delivery.Events)
+	}
+}
+
+func TestNormalizedEventManifestRejectsOverlappingBranchesAtLoad(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	manifest.NormalizedEvents = append(manifest.NormalizedEvents, NormalizedEventManifest{
+		Event: "inbound.telegram.message_copy",
+		Fields: map[string]runtimecontracts.FieldProjection{
+			"text": {From: "message.text", Type: "text"},
+		},
+	})
+	err := manifest.Validate()
+	if err == nil || !strings.Contains(err.Error(), "can match the same payload") || !strings.Contains(err.Error(), "when.absent") {
+		t.Fatalf("Validate error = %v, want overlap teaching error", err)
+	}
+	manifest.NormalizedEvents[1].When.Absent = []string{"message.chat"}
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("mutually exclusive manifest rejected: %v", err)
+	}
+}
+
+func TestNormalizedEventManifestRejectsHostileProjectionSyntax(t *testing.T) {
+	for _, path := range []string{"$.message.text", "message..text", "payload.message.text", "entity.id", "message[0].text", "message.text == 'x'"} {
+		t.Run(path, func(t *testing.T) {
+			manifest := normalizedEventTestManifest()
+			field := manifest.NormalizedEvents[0].Fields["text"]
+			field.From = path
+			manifest.NormalizedEvents[0].Fields["text"] = field
+			if err := manifest.Validate(); err == nil {
+				t.Fatalf("Validate accepted hostile path %q", path)
+			}
+		})
+	}
+}
+
+func TestNormalizedEventManifestRejectsImplicitAndUnknownConversions(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	field := manifest.NormalizedEvents[0].Fields["chat_id"]
+	field.Convert = "stringify"
+	manifest.NormalizedEvents[0].Fields["chat_id"] = field
+	if err := manifest.Validate(); err == nil || !strings.Contains(err.Error(), "unsupported conversion") {
+		t.Fatalf("Validate error = %v, want closed conversion rejection", err)
+	}
+
+	manifest = normalizedEventTestManifest()
+	field = manifest.NormalizedEvents[0].Fields["chat_id"]
+	field.Convert = ""
+	manifest.NormalizedEvents[0].Fields["chat_id"] = field
+	_, err := manifest.Accept(Request{
+		Target: Target{EntityID: "entity-1"},
+		Payload: map[string]any{"message": map[string]any{
+			"message_id": json.Number("7"), "chat": map[string]any{"id": json.Number("42")}, "text": "hello",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "implicit conversion is forbidden") {
+		t.Fatalf("Accept error = %v, want implicit conversion rejection", err)
+	}
+}
+
+func TestNormalizedEventCatalogDerivesSchemaAndCapabilities(t *testing.T) {
+	manifest := normalizedEventTestManifest()
+	entry := manifest.EventCatalogEntries()["inbound.telegram.text_message"]
+	if entry.Source != "provider_trigger_pack_normalized" || entry.Payload.Properties["chat_id"].Type != "text" {
+		t.Fatalf("catalog entry = %#v", entry)
+	}
+	if got := strings.Join(entry.Required, ","); got != "chat_id,message_id,text" {
+		t.Fatalf("required = %q", got)
+	}
+	capabilities := DerivedCapabilities(manifest)
+	if got := strings.Join(capabilities.Can.EmitEvents, ","); got != "inbound.telegram,inbound.telegram.text_message" {
+		t.Fatalf("emit events = %q", got)
+	}
+}
+
+func normalizedEventTestManifest() Manifest {
+	return Manifest{
+		Provider:              "telegram",
+		PayloadObjectRequired: true,
+		DeliveryID:            ValueSource{Literal: "delivery-1", Required: true},
+		EventType:             ValueSource{Literal: "update", Required: true},
+		EventName:             EventNameManifest{Literal: "inbound.telegram"},
+		NormalizedEvents: []NormalizedEventManifest{{
+			Event: "inbound.telegram.text_message",
+			Fields: map[string]runtimecontracts.FieldProjection{
+				"chat_id":    {From: "message.chat.id", Type: "text", Convert: runtimecontracts.FieldProjectionConvertNumberToText},
+				"text":       {From: "message.text", Type: "text"},
+				"message_id": {From: "message.message_id", Type: "integer"},
+				"raw":        {From: "message", Type: "json", Optional: true},
+			},
+		}},
+	}
+}

--- a/internal/providertriggers/normalized_events_test.go
+++ b/internal/providertriggers/normalized_events_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 )
 
 func TestNormalizedEventManifestPublishesRawAndTypedFlatEvent(t *testing.T) {
@@ -87,6 +88,28 @@ func TestCompiledPackPlanOwnsNormalizedOutputAuthorization(t *testing.T) {
 		got.PackID != identity.ID || got.PackVersion != identity.Version ||
 		got.ManifestHash != identity.ManifestHash || got.GenerationID != catalog.GenerationID() {
 		t.Fatalf("normalized output authorization = %#v, want compiled pack identity/generation", got)
+	}
+	if err := catalog.VerifyProviderOutputAuthorization(got); err != nil {
+		t.Fatalf("VerifyProviderOutputAuthorization: %v", err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*runtimeprovideroutput.Authorization)
+	}{
+		{name: "provider", mutate: func(a *runtimeprovideroutput.Authorization) { a.Provider = "telegram-stale" }},
+		{name: "event", mutate: func(a *runtimeprovideroutput.Authorization) { a.Event = "inbound.telegram.edited_message" }},
+		{name: "pack id", mutate: func(a *runtimeprovideroutput.Authorization) { a.PackID = "provider.telegram.stale" }},
+		{name: "pack version", mutate: func(a *runtimeprovideroutput.Authorization) { a.PackVersion = "0.9.0" }},
+		{name: "manifest hash", mutate: func(a *runtimeprovideroutput.Authorization) { a.ManifestHash = "sha256:" + strings.Repeat("d", 64) }},
+		{name: "catalog generation", mutate: func(a *runtimeprovideroutput.Authorization) { a.GenerationID = "generation-stale" }},
+	} {
+		t.Run("rejects "+tc.name+" mismatch", func(t *testing.T) {
+			stale := got
+			tc.mutate(&stale)
+			if err := catalog.VerifyProviderOutputAuthorization(stale); err == nil {
+				t.Fatalf("VerifyProviderOutputAuthorization(%s mismatch) error = nil", tc.name)
+			}
+		})
 	}
 }
 

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/packs"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	"gopkg.in/yaml.v3"
 )
 
@@ -73,9 +74,10 @@ type Delivery struct {
 }
 
 type DeliveryEvent struct {
-	Name    events.EventType
-	Kind    OutputKind
-	Payload map[string]any
+	Name          events.EventType
+	Kind          OutputKind
+	Payload       map[string]any
+	Authorization runtimeprovideroutput.Authorization
 }
 
 type Response struct {
@@ -151,7 +153,11 @@ func NewCatalogSnapshot(entries ...CatalogEntry) (*CatalogSnapshot, error) {
 	for _, entry := range entries {
 		manifest := entry.Manifest
 		if err := manifest.Validate(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf(
+				"validate provider trigger pack %q version=%s manifest_hash=%s: %w",
+				strings.TrimSpace(entry.Identity.ID), strings.TrimSpace(entry.Identity.Version),
+				strings.TrimSpace(entry.Identity.ManifestHash), err,
+			)
 		}
 		provider := NormalizeProviderName(manifest.Provider)
 		entry.Manifest.Provider = provider

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -538,6 +538,35 @@ func (s *CatalogSnapshot) GenerationID() string {
 	return s.generationID
 }
 
+func (s *CatalogSnapshot) VerifyProviderOutputAuthorization(authorization runtimeprovideroutput.Authorization) error {
+	authorization = authorization.Normalized()
+	if !authorization.Valid() {
+		return fmt.Errorf("provider-output authorization is incomplete")
+	}
+	if s == nil || strings.TrimSpace(s.generationID) == "" {
+		return fmt.Errorf("verified provider-trigger catalog is unavailable")
+	}
+	if authorization.GenerationID != s.generationID {
+		return fmt.Errorf("catalog generation %q does not match current generation %q", authorization.GenerationID, s.generationID)
+	}
+	entry, ok := s.byID[authorization.PackID]
+	if !ok {
+		return fmt.Errorf("pack %q is not present in the current verified catalog", authorization.PackID)
+	}
+	if entry.Identity.Version != authorization.PackVersion || entry.Identity.ManifestHash != authorization.ManifestHash {
+		return fmt.Errorf("pack %q version/hash does not match the current verified catalog", authorization.PackID)
+	}
+	if NormalizeProviderName(entry.Manifest.Provider) != authorization.Provider {
+		return fmt.Errorf("pack %q does not own provider %q", authorization.PackID, authorization.Provider)
+	}
+	for _, normalized := range entry.Manifest.NormalizedEvents {
+		if strings.TrimSpace(normalized.Event) == authorization.Event {
+			return nil
+		}
+	}
+	return fmt.Errorf("pack %q does not declare normalized event %q", authorization.PackID, authorization.Event)
+}
+
 func (s *CatalogSnapshot) EntryByProvider(provider string) (CatalogEntry, bool) {
 	if s == nil {
 		return CatalogEntry{}, false

--- a/internal/providertriggers/providertriggers.go
+++ b/internal/providertriggers/providertriggers.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/packs"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"gopkg.in/yaml.v3"
 )
 
@@ -66,10 +67,15 @@ type Request struct {
 type Delivery struct {
 	ProviderEventID           string
 	ProviderEventType         string
-	EventName                 events.EventType
-	Payload                   map[string]any
+	Events                    []DeliveryEvent
 	Response                  *Response
 	AcknowledgeBeforeDispatch bool
+}
+
+type DeliveryEvent struct {
+	Name    events.EventType
+	Kind    OutputKind
+	Payload map[string]any
 }
 
 type Response struct {
@@ -407,10 +413,20 @@ func LoadPackFS(fsys fs.FS, dir, runningPlatformVersion string) (LoadedPack, err
 
 func DerivedCapabilities(manifest Manifest) packs.Capabilities {
 	provider := NormalizeProviderName(manifest.Provider)
-	eventName := strings.TrimSpace(manifest.EventName.Literal)
-	if eventName == "" {
-		eventName = strings.TrimSpace(manifest.EventName.Template)
+	eventNames := make([]string, 0, 1+len(manifest.NormalizedEvents))
+	for _, output := range manifest.OutputManifest() {
+		name := strings.TrimSpace(output.Event)
+		if output.Kind == OutputKindRaw {
+			name = strings.TrimSpace(output.EventName.Literal)
+			if name == "" {
+				name = strings.TrimSpace(output.EventName.Template)
+			}
+		}
+		if name != "" {
+			eventNames = append(eventNames, name)
+		}
 	}
+	sort.Strings(eventNames)
 	verifySecret := ""
 	if manifest.Secret.Required {
 		verifySecret = "webhook_signing." + provider
@@ -419,7 +435,7 @@ func DerivedCapabilities(manifest Manifest) packs.Capabilities {
 		Can: packs.CanCapabilities{
 			ReceiveHTTPSRoute:    "/webhooks/{alias}/" + provider,
 			VerifySecret:         verifySecret,
-			EmitEvents:           []string{eventName},
+			EmitEvents:           eventNames,
 			PersistDedupeMarkers: true,
 		},
 		Cannot: []string{
@@ -448,6 +464,7 @@ func (p LoadedPack) CapabilitySubject() (packs.Subject, error) {
 		Provenance:    strings.TrimSpace(p.Envelope.Provenance.Source),
 		SourcePath:    strings.TrimSpace(p.SourcePath),
 		Applicability: "installed",
+		TriggerEvents: triggerEventDescriptors(p.Manifest),
 	}
 	if route := strings.TrimSpace(capabilities.Can.ReceiveHTTPSRoute); route != "" {
 		subject.Capabilities = append(subject.Capabilities, packs.Capability{Code: packs.CapabilityReceiveHTTPSRoute, Target: route})
@@ -476,6 +493,36 @@ func (p LoadedPack) CapabilitySubject() (packs.Subject, error) {
 		return packs.Subject{}, err
 	}
 	return normalized[0], nil
+}
+
+func triggerEventDescriptors(manifest Manifest) []packs.TriggerEventDescriptor {
+	entries := manifest.EventCatalogEntries()
+	out := make([]packs.TriggerEventDescriptor, 0, len(entries))
+	for _, output := range manifest.OutputManifest() {
+		name := strings.TrimSpace(output.Event)
+		if output.Kind == OutputKindRaw {
+			name = strings.TrimSpace(output.EventName.Literal)
+			if name == "" {
+				name = strings.TrimSpace(output.EventName.Template)
+			}
+		}
+		descriptor := packs.TriggerEventDescriptor{Event: name, Kind: string(output.Kind)}
+		if entry, ok := entries[name]; ok {
+			required := map[string]struct{}{}
+			for _, field := range entry.Required {
+				required[field] = struct{}{}
+			}
+			for fieldName, field := range entry.Payload.Properties {
+				_, isRequired := required[fieldName]
+				descriptor.Fields = append(descriptor.Fields, packs.TriggerEventFieldDescriptor{
+					Name: fieldName, Type: field.Type, Required: isRequired,
+					CarryEligible: output.Kind == OutputKindNormalized && isRequired,
+				})
+			}
+		}
+		out = append(out, descriptor)
+	}
+	return out
 }
 
 func (s *CatalogSnapshot) GenerationID() string {
@@ -563,20 +610,21 @@ func (req Request) withProvider(provider string) Request {
 }
 
 type Manifest struct {
-	Provider              string             `yaml:"provider"`
-	PayloadObjectRequired bool               `yaml:"payload_object_required"`
-	PayloadObjectError    string             `yaml:"payload_object_error"`
-	PayloadSource         string             `yaml:"payload_source"`
-	Secret                SecretManifest     `yaml:"secret"`
-	Signature             SignatureManifest  `yaml:"signature"`
-	Challenge             *ChallengeManifest `yaml:"challenge"`
-	DeliveryCondition     *ConditionManifest `yaml:"delivery_condition"`
-	DeliveryID            ValueSource        `yaml:"delivery_id"`
-	EventType             ValueSource        `yaml:"event_type"`
-	EventName             EventNameManifest  `yaml:"event_name"`
-	Ack                   AckManifest        `yaml:"ack"`
-	RedactKeys            []string           `yaml:"redact_keys"`
-	Metadata              map[string]string  `yaml:"metadata"`
+	Provider              string                    `yaml:"provider"`
+	PayloadObjectRequired bool                      `yaml:"payload_object_required"`
+	PayloadObjectError    string                    `yaml:"payload_object_error"`
+	PayloadSource         string                    `yaml:"payload_source"`
+	Secret                SecretManifest            `yaml:"secret"`
+	Signature             SignatureManifest         `yaml:"signature"`
+	Challenge             *ChallengeManifest        `yaml:"challenge"`
+	DeliveryCondition     *ConditionManifest        `yaml:"delivery_condition"`
+	DeliveryID            ValueSource               `yaml:"delivery_id"`
+	EventType             ValueSource               `yaml:"event_type"`
+	EventName             EventNameManifest         `yaml:"event_name"`
+	NormalizedEvents      []NormalizedEventManifest `yaml:"normalized_events,omitempty"`
+	Ack                   AckManifest               `yaml:"ack"`
+	RedactKeys            []string                  `yaml:"redact_keys"`
+	Metadata              map[string]string         `yaml:"metadata"`
 }
 
 type SecretManifest struct {
@@ -803,6 +851,9 @@ func (m Manifest) Validate() error {
 			return fmt.Errorf("%s manifest metadata %q has unsupported source %q", provider, key, source)
 		}
 	}
+	if err := m.validateNormalizedEvents(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -860,13 +911,25 @@ func (m Manifest) Accept(req Request) (Delivery, error) {
 	eventType := NormalizeEventToken(rawEventType)
 	entityID := req.Target.EffectiveEntityID()
 	payload := m.buildPublishPayload(provider, entityID, deliveryID, eventType, req)
+	normalized, err := m.normalizedDeliveryEvents(req.Payload)
+	if err != nil {
+		return Delivery{}, err
+	}
+	outputs := make([]DeliveryEvent, 0, 1+len(normalized))
+	outputs = append(outputs, DeliveryEvent{
+		Name: events.EventType(m.resolveEventName(eventType)), Kind: OutputKindRaw, Payload: payload,
+	})
+	outputs = append(outputs, normalized...)
 	return Delivery{
 		ProviderEventID:           deliveryID,
 		ProviderEventType:         eventType,
-		EventName:                 events.EventType(m.resolveEventName(eventType)),
-		Payload:                   payload,
+		Events:                    outputs,
 		AcknowledgeBeforeDispatch: strings.TrimSpace(m.Ack.Mode) == "durable_before_dispatch",
 	}, nil
+}
+
+func (m Manifest) EventCatalogEntries() map[string]runtimecontracts.EventCatalogEntry {
+	return m.eventCatalogEntries()
 }
 
 func (m Manifest) verifySignature(secret string, req Request) error {

--- a/internal/providertriggers/providertriggers_test.go
+++ b/internal/providertriggers/providertriggers_test.go
@@ -64,7 +64,8 @@ func TestPlatformPackInventoryIsCompleteFilesystemOnlyAndFreshlyStamped(t *testi
 		if err != nil {
 			t.Fatalf("capability subject %s: %v", dir, err)
 		}
-		if subject.Kind != packs.SubjectProviderTrigger || subject.Status != packs.StatusAvailable || subject.Provider != pack.Manifest.Provider || len(subject.Capabilities) != 4 || len(subject.Guarantees) != 3 {
+		wantCapabilityCount := 3 + len(DerivedCapabilities(pack.Manifest).Can.EmitEvents)
+		if subject.Kind != packs.SubjectProviderTrigger || subject.Status != packs.StatusAvailable || subject.Provider != pack.Manifest.Provider || len(subject.Capabilities) != wantCapabilityCount || len(subject.Guarantees) != 3 {
 			t.Fatalf("capability subject %s = %#v", dir, subject)
 		}
 		wantRoute := "/webhooks/{alias}/" + pack.Manifest.Provider
@@ -405,7 +406,7 @@ func TestExternalTelegramProviderTriggerPackUsesSameTokenEqualityVerifier(t *tes
 	if err != nil {
 		t.Fatalf("Accept external Telegram webhook: %v", err)
 	}
-	if delivery.ProviderEventID != "123456789" || delivery.ProviderEventType != "update" || delivery.EventName != "inbound.telegram" {
+	if delivery.ProviderEventID != "123456789" || delivery.ProviderEventType != "update" || delivery.Events[0].Name != "inbound.telegram" {
 		t.Fatalf("delivery = %+v, want Telegram manifest identity", delivery)
 	}
 }
@@ -431,8 +432,8 @@ func TestManifestInterpreterHostileProviderRejectsBoundaryAttacks(t *testing.T) 
 		if delivery.ProviderEventType != "safe_event" {
 			t.Fatalf("provider event type = %q, want manifest json path source", delivery.ProviderEventType)
 		}
-		if delivery.Payload["provider_event_id"] != "delivery-header" || delivery.Payload["provider_event_type"] != "safe_event" {
-			t.Fatalf("payload identity = %+v, want manifest-derived fields", delivery.Payload)
+		if delivery.Events[0].Payload["provider_event_id"] != "delivery-header" || delivery.Events[0].Payload["provider_event_type"] != "safe_event" {
+			t.Fatalf("payload identity = %+v, want manifest-derived fields", delivery.Events[0].Payload)
 		}
 	})
 
@@ -606,8 +607,8 @@ func TestStripeManifestAcceptsLiteralEventType(t *testing.T) {
 	if delivery.ProviderEventType != "event" {
 		t.Fatalf("ProviderEventType = %q, want event", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.stripe" {
-		t.Fatalf("EventName = %q, want inbound.stripe", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.stripe" {
+		t.Fatalf("EventName = %q, want inbound.stripe", delivery.Events[0].Name)
 	}
 }
 
@@ -651,27 +652,27 @@ func TestTwilioManifestAcceptsSignedFormWebhook(t *testing.T) {
 	if delivery.ProviderEventType != "message_received" {
 		t.Fatalf("ProviderEventType = %q, want message_received", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.twilio" {
-		t.Fatalf("EventName = %q, want inbound.twilio", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.twilio" {
+		t.Fatalf("EventName = %q, want inbound.twilio", delivery.Events[0].Name)
 	}
 	if !delivery.AcknowledgeBeforeDispatch {
 		t.Fatal("Twilio delivery did not request durable_before_dispatch acknowledgement")
 	}
-	payload, ok := delivery.Payload["payload"].(map[string]any)
+	payload, ok := delivery.Events[0].Payload["payload"].(map[string]any)
 	if !ok {
-		t.Fatalf("payload = %T, want form payload map", delivery.Payload["payload"])
+		t.Fatalf("payload = %T, want form payload map", delivery.Events[0].Payload["payload"])
 	}
 	if payload["Body"] != "hello from twilio" || payload["UnexpectedNew"] != "still signed" {
 		t.Fatalf("form payload = %+v, want Twilio form parameters without allowlist loss", payload)
 	}
-	headers, ok := delivery.Payload["headers"].(map[string]any)
+	headers, ok := delivery.Events[0].Payload["headers"].(map[string]any)
 	if !ok {
-		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+		t.Fatalf("headers = %T, want metadata map", delivery.Events[0].Payload["headers"])
 	}
 	if headers["twilio_message_sid"] != "SM1234567890abcdef" || headers["twilio_event_type"] != "message_received" {
 		t.Fatalf("headers = %+v, want Twilio manifest metadata", headers)
 	}
-	encoded := fmtPayload(delivery.Payload)
+	encoded := fmtPayload(delivery.Events[0].Payload)
 	if strings.Contains(encoded, "twilio-secret") {
 		t.Fatal("Twilio signing secret leaked into delivery payload")
 	}
@@ -809,20 +810,20 @@ func TestShopifyManifestAcceptsRawBodyBase64Signature(t *testing.T) {
 	if delivery.ProviderEventType != "orders_create" {
 		t.Fatalf("ProviderEventType = %q, want orders_create", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.shopify" {
-		t.Fatalf("EventName = %q, want inbound.shopify", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.shopify" {
+		t.Fatalf("EventName = %q, want inbound.shopify", delivery.Events[0].Name)
 	}
 	if !delivery.AcknowledgeBeforeDispatch {
 		t.Fatal("Shopify delivery did not request durable_before_dispatch acknowledgement")
 	}
-	headers, ok := delivery.Payload["headers"].(map[string]any)
+	headers, ok := delivery.Events[0].Payload["headers"].(map[string]any)
 	if !ok {
-		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+		t.Fatalf("headers = %T, want metadata map", delivery.Events[0].Payload["headers"])
 	}
 	if headers["shopify_webhook_id"] != "webhook-123" || headers["shopify_topic"] != "orders_create" {
 		t.Fatalf("headers = %+v, want Shopify manifest metadata", headers)
 	}
-	encoded := fmtPayload(delivery.Payload)
+	encoded := fmtPayload(delivery.Events[0].Payload)
 	if strings.Contains(encoded, "shopify-secret") {
 		t.Fatal("Shopify signing secret leaked into delivery payload")
 	}
@@ -939,20 +940,20 @@ func TestTypeformManifestAcceptsRawBodyBase64Signature(t *testing.T) {
 	if delivery.ProviderEventType != "form_response" {
 		t.Fatalf("ProviderEventType = %q, want form_response", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.typeform" {
-		t.Fatalf("EventName = %q, want inbound.typeform", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.typeform" {
+		t.Fatalf("EventName = %q, want inbound.typeform", delivery.Events[0].Name)
 	}
 	if !delivery.AcknowledgeBeforeDispatch {
 		t.Fatal("Typeform delivery did not request durable_before_dispatch acknowledgement")
 	}
-	headers, ok := delivery.Payload["headers"].(map[string]any)
+	headers, ok := delivery.Events[0].Payload["headers"].(map[string]any)
 	if !ok {
-		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+		t.Fatalf("headers = %T, want metadata map", delivery.Events[0].Payload["headers"])
 	}
 	if headers["typeform_event_id"] != "tf-evt-123" || headers["typeform_event_type"] != "form_response" {
 		t.Fatalf("headers = %+v, want Typeform manifest metadata", headers)
 	}
-	encoded := fmtPayload(delivery.Payload)
+	encoded := fmtPayload(delivery.Events[0].Payload)
 	if strings.Contains(encoded, "typeform-secret") {
 		t.Fatal("Typeform signing secret leaked into delivery payload")
 	}
@@ -1072,20 +1073,20 @@ func TestIntercomManifestAcceptsRawBodySHA1Signature(t *testing.T) {
 	if delivery.ProviderEventType != "conversation_user_created" {
 		t.Fatalf("ProviderEventType = %q, want conversation_user_created", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.intercom" {
-		t.Fatalf("EventName = %q, want inbound.intercom", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.intercom" {
+		t.Fatalf("EventName = %q, want inbound.intercom", delivery.Events[0].Name)
 	}
 	if !delivery.AcknowledgeBeforeDispatch {
 		t.Fatal("Intercom delivery did not request durable_before_dispatch acknowledgement")
 	}
-	headers, ok := delivery.Payload["headers"].(map[string]any)
+	headers, ok := delivery.Events[0].Payload["headers"].(map[string]any)
 	if !ok {
-		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+		t.Fatalf("headers = %T, want metadata map", delivery.Events[0].Payload["headers"])
 	}
 	if headers["intercom_notification_id"] != "notif_123" || headers["intercom_topic"] != "conversation_user_created" {
 		t.Fatalf("headers = %+v, want Intercom manifest metadata", headers)
 	}
-	encoded := fmtPayload(delivery.Payload)
+	encoded := fmtPayload(delivery.Events[0].Payload)
 	if strings.Contains(encoded, "intercom-secret") {
 		t.Fatal("Intercom signing secret leaked into delivery payload")
 	}
@@ -1195,20 +1196,20 @@ func TestTelegramManifestAcceptsHeaderTokenUpdate(t *testing.T) {
 	if delivery.ProviderEventType != "update" {
 		t.Fatalf("ProviderEventType = %q, want update", delivery.ProviderEventType)
 	}
-	if delivery.EventName != "inbound.telegram" {
-		t.Fatalf("EventName = %q, want inbound.telegram", delivery.EventName)
+	if delivery.Events[0].Name != "inbound.telegram" {
+		t.Fatalf("EventName = %q, want inbound.telegram", delivery.Events[0].Name)
 	}
 	if !delivery.AcknowledgeBeforeDispatch {
 		t.Fatal("Telegram delivery did not request durable_before_dispatch acknowledgement")
 	}
-	headers, ok := delivery.Payload["headers"].(map[string]any)
+	headers, ok := delivery.Events[0].Payload["headers"].(map[string]any)
 	if !ok {
-		t.Fatalf("headers = %T, want metadata map", delivery.Payload["headers"])
+		t.Fatalf("headers = %T, want metadata map", delivery.Events[0].Payload["headers"])
 	}
 	if headers["telegram_update_id"] != "123456789" || headers["telegram_update_type"] != "update" {
 		t.Fatalf("headers = %+v, want Telegram manifest metadata", headers)
 	}
-	encoded := fmtPayload(delivery.Payload)
+	encoded := fmtPayload(delivery.Events[0].Payload)
 	if strings.Contains(encoded, "telegram-secret") {
 		t.Fatal("Telegram secret token leaked into delivery payload")
 	}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -295,10 +295,25 @@ func validateInputPinResolutions(source semanticview.Source) []Finding {
 			continue
 		}
 		for _, pin := range source.FlowInputEventPins(flowID) {
+			findings = append(findings, validateFlowInputCarryProjectionPolicy(flowID, pin)...)
 			if pin.Resolution.Empty() {
 				continue
 			}
 			findings = append(findings, validateInputPinResolution(source, flowID, pin)...)
+		}
+	}
+	return findings
+}
+
+func validateFlowInputCarryProjectionPolicy(flowID string, pin runtimecontracts.FlowInputEventPin) []Finding {
+	var findings []Finding
+	for name, carry := range pin.Carries {
+		name = strings.TrimSpace(name)
+		if carry.Optional {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "carry_projection_unsupported", fmt.Sprintf("carry %s optional is reserved for provider normalized-event projections and is not supported on flow input carries", name), flowID))
+		}
+		if conversion := strings.TrimSpace(carry.Convert); conversion != "" {
+			findings = append(findings, inputPinResolutionFinding(flowID, pin, "carry_projection_unsupported", fmt.Sprintf("carry %s conversion %q is reserved for provider normalized-event projections and is not supported on flow input carries", name, conversion), flowID))
 		}
 	}
 	return findings

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -119,6 +119,28 @@ func TestRun_AllowsSelectOrCreateInputResolutionCompositionConnect(t *testing.T)
 	}
 }
 
+func TestRunRejectsProviderOnlyProjectionOptionsOnFlowInputCarries(t *testing.T) {
+	root := writeSelectResolutionCompositionConnectFixture(t, selectResolutionCompositionFixtureOptions{})
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+	pins := bundle.Semantics.FlowInputEventPins["account"]
+	if len(pins) == 0 {
+		t.Fatal("account input pin fixture is unavailable")
+	}
+	pin := &pins[0]
+	for name, carry := range pin.Carries {
+		carry.Optional = true
+		carry.Convert = runtimecontracts.FieldProjectionConvertNumberToText
+		pin.Carries[name] = carry
+		break
+	}
+	bundle.Semantics.FlowInputEventPins["account"] = pins
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "composition_connect_validation", "reserved for provider normalized-event projections") {
+		t.Fatalf("expected flow carry projection blocker, got %#v", report.Errors())
+	}
+}
+
 func TestRun_FailsClosedForInvalidSelectInputResolution(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
+++ b/internal/runtime/bootverify/workflow_dead_event_schema_checks.go
@@ -96,6 +96,9 @@ func deadEventDeclarations(source semanticview.Source) []deadEventDeclaration {
 			continue
 		}
 		for eventName, entry := range scope.Events {
+			if strings.TrimSpace(entry.Source) == "provider_trigger_pack_raw" {
+				continue
+			}
 			canonical := eventidentity.Normalize(eventName)
 			if canonical == "" {
 				continue

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
@@ -49,8 +50,10 @@ func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTa
 		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors, replyStore: replyStore}
 	}
 	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
-	if targetFree, ok := source.(interface{ ProviderTriggerTargetFreeEvents() []string }); ok {
-		directPlans, directIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, targetFree.ProviderTriggerTargetFreeEvents())
+	if targetFree, ok := source.(interface {
+		ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization
+	}); ok {
+		directPlans, directIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, targetFree.ProviderTriggerTargetFreeAuthorizations())
 		plans = append(plans, directPlans...)
 		issues = append(issues, directIssues...)
 	}
@@ -70,7 +73,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		return connectRoutePlanDispatch{}, nil
 	}
 	for _, issue := range r.issues {
-		if r.connectIssueMatchesEvent(issue, evt) {
+		if r.connectIssueMatchesEvent(ctx, issue, evt) {
 			return connectRoutePlanDispatch{
 				Matched: true,
 				Failure: connectRoutePlanTargetFailure(issue.Failure),
@@ -82,7 +85,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		}
 	}
 
-	matched := r.matchedPlans(evt)
+	matched := r.matchedPlans(ctx, evt)
 	if len(matched) == 0 {
 		return connectRoutePlanDispatch{}, nil
 	}
@@ -354,13 +357,13 @@ func (r connectRoutePlanResolver) installTemplateInstanceLifecyclePreview(decisi
 	}, nil
 }
 
-func (r connectRoutePlanResolver) matchedPlans(evt events.Event) []runtimepinrouting.ConnectRoutePlan {
+func (r connectRoutePlanResolver) matchedPlans(ctx context.Context, evt events.Event) []runtimepinrouting.ConnectRoutePlan {
 	if len(r.plans) == 0 {
 		return nil
 	}
 	out := make([]runtimepinrouting.ConnectRoutePlan, 0, len(r.plans))
 	for _, plan := range r.plans {
-		if connectEndpointMatchesEvent(plan.Source, evt) {
+		if connectRoutePlanMatchesEvent(ctx, plan, evt) {
 			out = append(out, plan)
 		}
 	}
@@ -443,7 +446,7 @@ func connectSubscriberMatchesPlanTarget(plan runtimepinrouting.ConnectRoutePlan,
 	return targetPath == receiverPath || strings.HasPrefix(targetPath, receiverPath+"/")
 }
 
-func (r connectRoutePlanResolver) connectIssueMatchesEvent(issue runtimepinrouting.ConnectRoutePlanIssue, evt events.Event) bool {
+func (r connectRoutePlanResolver) connectIssueMatchesEvent(ctx context.Context, issue runtimepinrouting.ConnectRoutePlanIssue, evt events.Event) bool {
 	if r.source == nil || issue.Failure == "" {
 		return false
 	}
@@ -463,7 +466,14 @@ func (r connectRoutePlanResolver) connectIssueMatchesEvent(issue runtimepinrouti
 		Event:         strings.TrimSpace(outputPin.EventType()),
 		ResolvedEvent: strings.TrimSpace(r.source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
 	}
-	return connectEndpointMatchesEvent(endpoint, evt)
+	if !connectEndpointMatchesEvent(endpoint, evt) {
+		return false
+	}
+	return providerOutputAuthorizationMatches(ctx, issue.ProviderOutputAuthorization)
+}
+
+func connectRoutePlanMatchesEvent(ctx context.Context, plan runtimepinrouting.ConnectRoutePlan, evt events.Event) bool {
+	return connectEndpointMatchesEvent(plan.Source, evt) && providerOutputAuthorizationMatches(ctx, plan.ProviderOutputAuthorization)
 }
 
 func connectEndpointMatchesEvent(endpoint runtimepinrouting.ConnectRoutePlanEndpoint, evt events.Event) bool {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -49,6 +49,11 @@ func newConnectRoutePlanResolver(source semanticview.Source, routeTable *RouteTa
 		return connectRoutePlanResolver{routeTable: routeTable, loadDescriptors: loadDescriptors, replyStore: replyStore}
 	}
 	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if targetFree, ok := source.(interface{ ProviderTriggerTargetFreeEvents() []string }); ok {
+		directPlans, directIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, targetFree.ProviderTriggerTargetFreeEvents())
+		plans = append(plans, directPlans...)
+		issues = append(issues, directIssues...)
+	}
 	return connectRoutePlanResolver{
 		source:          source,
 		routeTable:      routeTable,

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -132,7 +132,7 @@ func (s *connectRoutePlanLifecycleStore) Activate(ctx context.Context, req runti
 	for _, descriptor := range s.flowInstances {
 		descriptor = descriptor.Normalized()
 		if descriptor.InstanceID == req.Instance.InstanceID || descriptor.FlowInstance == req.Instance.InstancePath {
-			return errors.New("flow instance already exists")
+			return runtimefailures.New(runtimefailures.ClassConflictingDuplicate, "flow_instance_already_exists", "connect-route-plan-test", "activate", map[string]any{"flow_instance": req.Instance.InstancePath})
 		}
 	}
 	s.activations = append(s.activations, req)
@@ -168,7 +168,7 @@ func (s *connectRoutePlanConcurrentLifecycleStore) Activate(ctx context.Context,
 	for _, descriptor := range s.flowInstances {
 		descriptor = descriptor.Normalized()
 		if descriptor.InstanceID == req.Instance.InstanceID || descriptor.FlowInstance == req.Instance.InstancePath {
-			return errors.New("flow instance already exists")
+			return runtimefailures.New(runtimefailures.ClassConflictingDuplicate, "flow_instance_already_exists", "connect-route-plan-test", "activate", map[string]any{"flow_instance": req.Instance.InstancePath})
 		}
 	}
 	s.activations = append(s.activations, req)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -17,6 +17,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
@@ -34,6 +35,15 @@ type connectRoutePlanTestFlow struct {
 	outputs      []runtimecontracts.FlowOutputEventPin
 	nodes        map[string]runtimecontracts.SystemNodeContract
 	entityFields map[string]runtimecontracts.EntityFieldDecl
+}
+
+type providerOutputAuthorizedTestSource struct {
+	semanticview.Source
+	authorizations []runtimeprovideroutput.Authorization
+}
+
+func (s providerOutputAuthorizedTestSource) ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization {
+	return append([]runtimeprovideroutput.Authorization(nil), s.authorizations...)
 }
 
 type connectRoutePlanDescriptorStore struct {
@@ -2630,6 +2640,38 @@ func TestRoutePlanCanonicalFailClosedDropsExecutableRoutes(t *testing.T) {
 	}
 	if len(got.LiveRecipients) != 0 || len(got.DeliveryIntents) != 0 || len(got.DeliveryRoutes()) != 0 || len(got.PersistedRecipientIDs()) != 0 {
 		t.Fatalf("fail-closed plan exposed executable routes: live=%#v intents=%#v routes=%#v persisted=%#v", got.LiveRecipients, got.DeliveryIntents, got.DeliveryRoutes(), got.PersistedRecipientIDs())
+	}
+}
+
+func TestOrdinaryOperatorPublishCannotAcquireProviderTargetFreeAuthorityByEventName(t *testing.T) {
+	const eventName = "inbound.telegram.text_message"
+	authorization := runtimeprovideroutput.Authorization{
+		Provider: "telegram", Event: eventName, PackID: "provider.telegram", PackVersion: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "generation-1",
+	}
+	source := providerOutputAuthorizedTestSource{
+		Source: semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{{
+			id: "consumer", mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name: "telegram_text", Event: eventName, Source: "external",
+			}},
+			nodes: map[string]runtimecontracts.SystemNodeContract{
+				"consumer-node": {ID: "consumer-node", EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{eventName: {}}},
+			},
+		}}, nil)),
+		authorizations: []runtimeprovideroutput.Authorization{authorization},
+	}
+	resolver := newConnectRoutePlanResolver(source, nil, nil, nil)
+	evt := eventtest.RootIngress(
+		uuid.NewString(), events.EventType(eventName), "operator-api", "", json.RawMessage(`{"chat_id":"42"}`),
+		0, "run-1", "", events.EventEnvelope{}, time.Now().UTC(),
+	)
+	if matched := resolver.matchedPlans(context.Background(), evt); len(matched) != 0 {
+		t.Fatalf("ordinary operator event matched provider target-free plans = %#v", matched)
+	}
+	authorizedCtx := withProviderOutputAuthorization(context.Background(), authorization)
+	if matched := resolver.matchedPlans(authorizedCtx, evt); len(matched) != 1 {
+		t.Fatalf("verified provider output matched plans = %#v, want one", matched)
 	}
 }
 

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -61,6 +61,7 @@ type EventBus struct {
 	bundleFingerprint           string
 	bundleSourceFact            runtimecorrelation.BundleSourceFact
 	testLifecycleProbe          runtimelifecycleprobe.Observer
+	providerOutputVerifier      ProviderOutputAuthorizationVerifier
 	outboxSweeperActive         bool
 	inFlightPublishes           atomic.Int64
 }
@@ -110,6 +111,7 @@ type EventBusOptions struct {
 	BundleFingerprint           string
 	BundleSourceFact            runtimecorrelation.BundleSourceFact
 	TestLifecycleProbe          runtimelifecycleprobe.Observer
+	ProviderOutputVerifier      ProviderOutputAuthorizationVerifier
 }
 
 const deliverySendTimeout = 250 * time.Millisecond
@@ -174,9 +176,28 @@ func NewEventBusWithOptions(store EventStore, opts EventBusOptions) (*EventBus, 
 		bundleFingerprint:           strings.TrimSpace(opts.BundleFingerprint),
 		bundleSourceFact:            opts.BundleSourceFact.Normalized(),
 		testLifecycleProbe:          opts.TestLifecycleProbe,
+		providerOutputVerifier:      opts.ProviderOutputVerifier,
 	}
 	eb.rebuildRoutePlanners()
 	return eb, nil
+}
+
+func (eb *EventBus) SetProviderOutputAuthorizationVerifier(verifier ProviderOutputAuthorizationVerifier) {
+	if eb == nil {
+		return
+	}
+	eb.mu.Lock()
+	eb.providerOutputVerifier = verifier
+	eb.mu.Unlock()
+}
+
+func (eb *EventBus) providerOutputAuthorizationVerifier() ProviderOutputAuthorizationVerifier {
+	if eb == nil {
+		return nil
+	}
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	return eb.providerOutputVerifier
 }
 
 func (eb *EventBus) rebuildRoutePlanners() {

--- a/internal/runtime/bus/eventbus_publish.go
+++ b/internal/runtime/bus/eventbus_publish.go
@@ -425,7 +425,12 @@ func (eb *EventBus) PublishInMutation(ctx context.Context, evt events.Event) err
 		return nil
 	}
 	if !runtimepipeline.QueuePipelinePostCommitAction(txctx, func() {
-		eb.completeCommittedPublishDispatch(runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(txctx)), evt, inboundPlan)
+		dispatchCtx := runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(txctx))
+		if acknowledgedInboundMutation(txctx) {
+			eb.dispatchCommittedPublishAsync(dispatchCtx, evt, inboundPlan)
+			return
+		}
+		eb.completeCommittedPublishDispatch(dispatchCtx, evt, inboundPlan)
 	}) {
 		return errors.New("event mutation post-commit actions are required")
 	}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1822,6 +1822,134 @@ func TestEventBusPublish_ZeroRecipientsDoesNotEmitContradiction(t *testing.T) {
 	}
 }
 
+func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) {
+	testCases := []struct {
+		name  string
+		setup func(*testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner)
+		count func(*testing.T, context.Context, *sql.DB, string, string) (int, int)
+	}{
+		{
+			name: "postgres",
+			setup: func(t *testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				ctx := eventBusTestRunContext(t, db)
+				pg := &store.PostgresStore{DB: db}
+				return ctx, db, pg, pg
+			},
+			count: countPostgresInboundBatchRows,
+		},
+		{
+			name: "sqlite",
+			setup: func(t *testing.T) (context.Context, *sql.DB, runtimebus.EventStore, runtimebus.EventMutationRunner) {
+				sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+				ctx := runtimecorrelation.WithRunID(context.Background(), eventBusTestRunID)
+				if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, eventBusTestRunID); err != nil {
+					t.Fatalf("seed SQLite event bus test run: %v", err)
+				}
+				return ctx, sqliteStore.DB, sqliteStore, sqliteStore
+			},
+			count: countSQLiteInboundBatchRows,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, db, eventStore, runner := tc.setup(t)
+			proofStore := &failingInboundBatchStore{EventStore: eventStore, runner: runner, failAppend: 2}
+			eb, err := runtimebus.NewEventBus(proofStore)
+			if err != nil {
+				t.Fatalf("NewEventBus: %v", err)
+			}
+			rawID := uuid.NewString()
+			normalizedID := uuid.NewString()
+			entityID := uuid.NewString()
+			providerEventID := "provider-delivery-rollback"
+			batch := runtimebus.InboundDeliveryBatch{
+				Claim: runtimebus.InboundDeliveryClaim{
+					ProviderEventID: providerEventID,
+					EntityID:        entityID,
+					Provider:        "proof-provider",
+				},
+				Events: []events.Event{
+					eventtest.RootIngress(rawID, events.EventType("inbound.proof"), "inbound-gateway", "", []byte(`{"raw":true}`), 0, eventBusTestRunID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()),
+					eventtest.RootIngress(normalizedID, events.EventType("inbound.proof.normalized"), "inbound-gateway", "", []byte(`{"normalized":true}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+				},
+			}
+
+			if _, err := eb.PublishInboundDelivery(ctx, batch); err == nil || !strings.Contains(err.Error(), "injected normalized append failure") {
+				t.Fatalf("PublishInboundDelivery error = %v, want injected normalized append failure", err)
+			}
+			eventsCount, markerCount := tc.count(t, ctx, db, rawID, normalizedID)
+			if eventsCount != 0 || markerCount != 0 {
+				t.Fatalf("rolled-back provider batch retained events=%d markers=%d, want zero", eventsCount, markerCount)
+			}
+		})
+	}
+}
+
+type failingInboundBatchStore struct {
+	runtimebus.EventStore
+	runner     runtimebus.EventMutationRunner
+	failAppend int
+}
+
+func (s *failingInboundBatchStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	return s.runner.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		return fn(&failingInboundBatchMutation{EventMutation: mutation, failAppend: s.failAppend})
+	})
+}
+
+type failingInboundBatchMutation struct {
+	runtimebus.EventMutation
+	appendCount int
+	failAppend  int
+}
+
+func (m *failingInboundBatchMutation) Context() context.Context {
+	return runtimebus.WithEventMutationContext(m.EventMutation.Context(), m)
+}
+
+func (m *failingInboundBatchMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	m.appendCount++
+	if m.appendCount == m.failAppend {
+		return errors.New("injected normalized append failure")
+	}
+	return m.EventMutation.AppendEvent(ctx, evt)
+}
+
+func (m *failingInboundBatchMutation) ClaimInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	inbound, ok := m.EventMutation.(runtimebus.InboundDeliveryMutation)
+	if !ok {
+		return false, errors.New("selected-store mutation does not support inbound claims")
+	}
+	return inbound.ClaimInboundEvent(ctx, providerEventID, entityID, provider)
+}
+
+func countPostgresInboundBatchRows(t *testing.T, ctx context.Context, db *sql.DB, rawID, normalizedID string) (int, int) {
+	t.Helper()
+	var eventsCount, markerCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id IN ($1::uuid, $2::uuid)`, rawID, normalizedID).Scan(&eventsCount); err != nil {
+		t.Fatalf("count Postgres provider events: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'platform.inbound_recorded'`).Scan(&markerCount); err != nil {
+		t.Fatalf("count Postgres provider marker: %v", err)
+	}
+	return eventsCount, markerCount
+}
+
+func countSQLiteInboundBatchRows(t *testing.T, ctx context.Context, db *sql.DB, rawID, normalizedID string) (int, int) {
+	t.Helper()
+	var eventsCount, markerCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_id IN (?, ?)`, rawID, normalizedID).Scan(&eventsCount); err != nil {
+		t.Fatalf("count SQLite provider events: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE event_name = 'platform.inbound_recorded'`).Scan(&markerCount); err != nil {
+		t.Fatalf("count SQLite provider marker: %v", err)
+	}
+	return eventsCount, markerCount
+}
+
 func TestEventBusPublish_RuntimeLogBypassesContradictionRouting(t *testing.T) {
 	store := &recordingEventStore{}
 	eb, err := runtimebus.NewEventBus(store)

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1858,14 +1858,23 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, db, eventStore, runner := tc.setup(t)
 			proofStore := &failingInboundBatchStore{EventStore: eventStore, runner: runner, failAppend: 2}
-			eb, err := runtimebus.NewEventBus(proofStore)
-			if err != nil {
-				t.Fatalf("NewEventBus: %v", err)
-			}
 			rawID := uuid.NewString()
 			normalizedID := uuid.NewString()
 			entityID := uuid.NewString()
 			providerEventID := "provider-delivery-rollback"
+			authorization := runtimeprovideroutput.Authorization{
+				Provider: "proof-provider", Event: "inbound.proof.normalized", PackID: "provider.proof",
+				PackVersion: "1.0.0", ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "proof-generation",
+			}
+			source := inboundBatchAuthorizedSource{
+				Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}), authorizations: []runtimeprovideroutput.Authorization{authorization},
+			}
+			eb, err := runtimebus.NewEventBusWithOptions(proofStore, runtimebus.EventBusOptions{
+				ContractBundle: source, ProviderOutputVerifier: source,
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
 			batch := runtimebus.InboundDeliveryBatch{
 				Claim: runtimebus.InboundDeliveryClaim{
 					ProviderEventID: providerEventID,
@@ -1875,12 +1884,9 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 				Events: []runtimebus.InboundDeliveryEvent{
 					{Event: eventtest.RootIngress(rawID, events.EventType("inbound.proof"), "inbound-gateway", "", []byte(`{"raw":true}`), 0, eventBusTestRunID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()), Kind: runtimeprovideroutput.KindRaw},
 					{
-						Event: eventtest.RootIngress(normalizedID, events.EventType("inbound.proof.normalized"), "inbound-gateway", "", []byte(`{"normalized":true}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
-						Kind:  runtimeprovideroutput.KindNormalized,
-						Authorization: runtimeprovideroutput.Authorization{
-							Provider: "proof-provider", Event: "inbound.proof.normalized", PackID: "provider.proof",
-							PackVersion: "1.0.0", ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "proof-generation",
-						},
+						Event:         eventtest.RootIngress(normalizedID, events.EventType("inbound.proof.normalized"), "inbound-gateway", "", []byte(`{"normalized":true}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+						Kind:          runtimeprovideroutput.KindNormalized,
+						Authorization: authorization,
 					},
 				},
 			}
@@ -1894,6 +1900,24 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 			}
 		})
 	}
+}
+
+type inboundBatchAuthorizedSource struct {
+	semanticview.Source
+	authorizations []runtimeprovideroutput.Authorization
+}
+
+func (s inboundBatchAuthorizedSource) ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization {
+	return append([]runtimeprovideroutput.Authorization(nil), s.authorizations...)
+}
+
+func (s inboundBatchAuthorizedSource) VerifyProviderOutputAuthorization(actual runtimeprovideroutput.Authorization) error {
+	for _, expected := range s.authorizations {
+		if expected.Matches(actual) {
+			return nil
+		}
+	}
+	return errors.New("authorization does not match test catalog owner")
 }
 
 type failingInboundBatchStore struct {

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -18,6 +18,7 @@ import (
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/diaglog"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
@@ -1871,9 +1872,16 @@ func TestPublishInboundDeliveryRollsBackMarkerAndAllDerivedEvents(t *testing.T) 
 					EntityID:        entityID,
 					Provider:        "proof-provider",
 				},
-				Events: []events.Event{
-					eventtest.RootIngress(rawID, events.EventType("inbound.proof"), "inbound-gateway", "", []byte(`{"raw":true}`), 0, eventBusTestRunID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()),
-					eventtest.RootIngress(normalizedID, events.EventType("inbound.proof.normalized"), "inbound-gateway", "", []byte(`{"normalized":true}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+				Events: []runtimebus.InboundDeliveryEvent{
+					{Event: eventtest.RootIngress(rawID, events.EventType("inbound.proof"), "inbound-gateway", "", []byte(`{"raw":true}`), 0, eventBusTestRunID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()), Kind: runtimeprovideroutput.KindRaw},
+					{
+						Event: eventtest.RootIngress(normalizedID, events.EventType("inbound.proof.normalized"), "inbound-gateway", "", []byte(`{"normalized":true}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC()),
+						Kind:  runtimeprovideroutput.KindNormalized,
+						Authorization: runtimeprovideroutput.Authorization{
+							Provider: "proof-provider", Event: "inbound.proof.normalized", PackID: "provider.proof",
+							PackVersion: "1.0.0", ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "proof-generation",
+						},
+					},
 				},
 			}
 

--- a/internal/runtime/bus/inbound_batch.go
+++ b/internal/runtime/bus/inbound_batch.go
@@ -1,0 +1,81 @@
+package bus
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+)
+
+type InboundDeliveryClaim struct {
+	ProviderEventID string
+	EntityID        string
+	Provider        string
+}
+
+type InboundDeliveryBatch struct {
+	Claim                     InboundDeliveryClaim
+	Events                    []events.Event
+	AcknowledgeBeforeDispatch bool
+}
+
+type InboundDeliveryBatchResult struct {
+	Duplicate bool
+}
+
+type acknowledgedInboundMutationContextKey struct{}
+
+func withAcknowledgedInboundMutation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, acknowledgedInboundMutationContextKey{}, true)
+}
+
+func acknowledgedInboundMutation(ctx context.Context) bool {
+	value, _ := ctx.Value(acknowledgedInboundMutationContextKey{}).(bool)
+	return value
+}
+
+// PublishInboundDelivery persists one provider marker and every derived event
+// through one selected-store mutation. Route planning and template lifecycle
+// materialization therefore participate in the same transaction.
+func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDeliveryBatch) (InboundDeliveryBatchResult, error) {
+	result := InboundDeliveryBatchResult{}
+	if eb == nil || eb.store == nil {
+		return result, fmt.Errorf("event bus store is required")
+	}
+	if strings.TrimSpace(batch.Claim.ProviderEventID) == "" || strings.TrimSpace(batch.Claim.EntityID) == "" || strings.TrimSpace(batch.Claim.Provider) == "" {
+		return result, fmt.Errorf("inbound delivery claim requires provider_event_id, entity_id, and provider")
+	}
+	if len(batch.Events) == 0 {
+		return result, fmt.Errorf("inbound delivery batch requires at least one event")
+	}
+	runner, ok := eb.store.(EventMutationRunner)
+	if !ok || runner == nil {
+		return result, fmt.Errorf("typed event mutation runner is required for inbound delivery")
+	}
+	err := runner.RunEventMutation(ctx, func(mutation EventMutation) error {
+		inbound, ok := mutation.(InboundDeliveryMutation)
+		if !ok || inbound == nil {
+			return fmt.Errorf("selected-store event mutation does not support inbound delivery claims")
+		}
+		txctx := mutation.Context()
+		if batch.AcknowledgeBeforeDispatch {
+			txctx = withAcknowledgedInboundMutation(txctx)
+		}
+		inserted, err := inbound.ClaimInboundEvent(txctx, batch.Claim.ProviderEventID, batch.Claim.EntityID, batch.Claim.Provider)
+		if err != nil {
+			return err
+		}
+		if !inserted {
+			result.Duplicate = true
+			return nil
+		}
+		for _, event := range batch.Events {
+			if err := eb.PublishInMutation(txctx, event); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return result, err
+}

--- a/internal/runtime/bus/inbound_batch.go
+++ b/internal/runtime/bus/inbound_batch.go
@@ -31,6 +31,13 @@ type InboundDeliveryBatchResult struct {
 	Duplicate bool
 }
 
+// ProviderOutputAuthorizationVerifier is the current immutable verified-pack
+// catalog owner used to reject fabricated or stale normalized outputs before a
+// selected-store mutation begins.
+type ProviderOutputAuthorizationVerifier interface {
+	VerifyProviderOutputAuthorization(runtimeprovideroutput.Authorization) error
+}
+
 type acknowledgedInboundMutationContextKey struct{}
 
 func withAcknowledgedInboundMutation(ctx context.Context) context.Context {
@@ -50,17 +57,15 @@ func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDel
 	if eb == nil || eb.store == nil {
 		return result, fmt.Errorf("event bus store is required")
 	}
-	if strings.TrimSpace(batch.Claim.ProviderEventID) == "" || strings.TrimSpace(batch.Claim.EntityID) == "" || strings.TrimSpace(batch.Claim.Provider) == "" {
-		return result, fmt.Errorf("inbound delivery claim requires provider_event_id, entity_id, and provider")
-	}
-	if len(batch.Events) == 0 {
-		return result, fmt.Errorf("inbound delivery batch requires at least one event")
+	validated, err := preflightInboundDeliveryBatch(eb.providerOutputAuthorizationVerifier(), batch)
+	if err != nil {
+		return result, err
 	}
 	runner, ok := eb.store.(EventMutationRunner)
 	if !ok || runner == nil {
 		return result, fmt.Errorf("typed event mutation runner is required for inbound delivery")
 	}
-	err := runner.RunEventMutation(ctx, func(mutation EventMutation) error {
+	err = runner.RunEventMutation(ctx, func(mutation EventMutation) error {
 		inbound, ok := mutation.(InboundDeliveryMutation)
 		if !ok || inbound == nil {
 			return fmt.Errorf("selected-store event mutation does not support inbound delivery claims")
@@ -77,25 +82,12 @@ func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDel
 			result.Duplicate = true
 			return nil
 		}
-		for _, item := range batch.Events {
+		for _, item := range validated.Events {
 			event := item.Event
-			authorization := item.Authorization.Normalized()
-			switch item.Kind {
-			case runtimeprovideroutput.KindRaw:
-				if !authorization.Empty() {
-					return fmt.Errorf("raw provider output must not carry normalized-output authorization")
-				}
+			if item.Kind == runtimeprovideroutput.KindRaw {
 				txctx = withoutProviderOutputAuthorization(txctx)
-			case runtimeprovideroutput.KindNormalized:
-				if !authorization.Valid() {
-					return fmt.Errorf("normalized provider output requires complete verified-pack authorization")
-				}
-				if authorization.Provider != strings.TrimSpace(batch.Claim.Provider) || authorization.Event != strings.TrimSpace(string(event.Type())) {
-					return fmt.Errorf("normalized provider output authorization does not match delivery claim/event")
-				}
-				txctx = withProviderOutputAuthorization(txctx, authorization)
-			default:
-				return fmt.Errorf("inbound delivery event requires raw or normalized output kind")
+			} else {
+				txctx = withProviderOutputAuthorization(txctx, item.Authorization)
 			}
 			if err := eb.PublishInMutation(txctx, event); err != nil {
 				return err
@@ -104,6 +96,48 @@ func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDel
 		return nil
 	})
 	return result, err
+}
+
+func preflightInboundDeliveryBatch(verifier ProviderOutputAuthorizationVerifier, batch InboundDeliveryBatch) (InboundDeliveryBatch, error) {
+	claimProvider := strings.TrimSpace(batch.Claim.Provider)
+	if strings.TrimSpace(batch.Claim.ProviderEventID) == "" || strings.TrimSpace(batch.Claim.EntityID) == "" || claimProvider == "" {
+		return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery claim requires provider_event_id, entity_id, and provider")
+	}
+	if len(batch.Events) == 0 {
+		return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery batch requires at least one event")
+	}
+	validated := batch
+	validated.Claim.Provider = claimProvider
+	validated.Events = append([]InboundDeliveryEvent(nil), batch.Events...)
+	for index := range validated.Events {
+		item := &validated.Events[index]
+		authorization := item.Authorization.Normalized()
+		switch item.Kind {
+		case runtimeprovideroutput.KindRaw:
+			if !authorization.Empty() {
+				return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d raw provider output must not carry normalized-output authorization", index)
+			}
+			item.Authorization = runtimeprovideroutput.Authorization{}
+		case runtimeprovideroutput.KindNormalized:
+			if !authorization.Valid() {
+				return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d normalized provider output requires complete verified-pack authorization", index)
+			}
+			eventName := strings.TrimSpace(string(item.Event.Type()))
+			if authorization.Provider != claimProvider || authorization.Event != eventName {
+				return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d normalized provider output authorization does not match delivery claim/event", index)
+			}
+			if verifier == nil {
+				return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d normalized provider output has no current compiled authorization owner", index)
+			}
+			if err := verifier.VerifyProviderOutputAuthorization(authorization); err != nil {
+				return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d normalized provider output authorization is stale or mismatched against the current compiled owner: %w", index, err)
+			}
+			item.Authorization = authorization
+		default:
+			return InboundDeliveryBatch{}, fmt.Errorf("inbound delivery event %d requires raw or normalized output kind", index)
+		}
+	}
+	return validated, nil
 }
 
 type providerOutputAuthorizationContextKey struct{}

--- a/internal/runtime/bus/inbound_batch.go
+++ b/internal/runtime/bus/inbound_batch.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 )
 
 type InboundDeliveryClaim struct {
@@ -16,8 +17,14 @@ type InboundDeliveryClaim struct {
 
 type InboundDeliveryBatch struct {
 	Claim                     InboundDeliveryClaim
-	Events                    []events.Event
+	Events                    []InboundDeliveryEvent
 	AcknowledgeBeforeDispatch bool
+}
+
+type InboundDeliveryEvent struct {
+	Event         events.Event
+	Kind          runtimeprovideroutput.Kind
+	Authorization runtimeprovideroutput.Authorization
 }
 
 type InboundDeliveryBatchResult struct {
@@ -70,7 +77,26 @@ func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDel
 			result.Duplicate = true
 			return nil
 		}
-		for _, event := range batch.Events {
+		for _, item := range batch.Events {
+			event := item.Event
+			authorization := item.Authorization.Normalized()
+			switch item.Kind {
+			case runtimeprovideroutput.KindRaw:
+				if !authorization.Empty() {
+					return fmt.Errorf("raw provider output must not carry normalized-output authorization")
+				}
+				txctx = withoutProviderOutputAuthorization(txctx)
+			case runtimeprovideroutput.KindNormalized:
+				if !authorization.Valid() {
+					return fmt.Errorf("normalized provider output requires complete verified-pack authorization")
+				}
+				if authorization.Provider != strings.TrimSpace(batch.Claim.Provider) || authorization.Event != strings.TrimSpace(string(event.Type())) {
+					return fmt.Errorf("normalized provider output authorization does not match delivery claim/event")
+				}
+				txctx = withProviderOutputAuthorization(txctx, authorization)
+			default:
+				return fmt.Errorf("inbound delivery event requires raw or normalized output kind")
+			}
 			if err := eb.PublishInMutation(txctx, event); err != nil {
 				return err
 			}
@@ -78,4 +104,22 @@ func (eb *EventBus) PublishInboundDelivery(ctx context.Context, batch InboundDel
 		return nil
 	})
 	return result, err
+}
+
+type providerOutputAuthorizationContextKey struct{}
+
+func withProviderOutputAuthorization(ctx context.Context, authorization runtimeprovideroutput.Authorization) context.Context {
+	return context.WithValue(ctx, providerOutputAuthorizationContextKey{}, authorization.Normalized())
+}
+
+func withoutProviderOutputAuthorization(ctx context.Context) context.Context {
+	return context.WithValue(ctx, providerOutputAuthorizationContextKey{}, runtimeprovideroutput.Authorization{})
+}
+
+func providerOutputAuthorizationMatches(ctx context.Context, expected *runtimeprovideroutput.Authorization) bool {
+	if expected == nil {
+		return true
+	}
+	actual, _ := ctx.Value(providerOutputAuthorizationContextKey{}).(runtimeprovideroutput.Authorization)
+	return expected.Matches(actual)
 }

--- a/internal/runtime/bus/inbound_batch_test.go
+++ b/internal/runtime/bus/inbound_batch_test.go
@@ -1,0 +1,131 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
+)
+
+type inboundBatchPreflightProofStore struct {
+	InMemoryEventStore
+	mutationCalls int
+}
+
+func (s *inboundBatchPreflightProofStore) RunEventMutation(context.Context, func(EventMutation) error) error {
+	s.mutationCalls++
+	return errors.New("mutation must not start during authorization preflight proof")
+}
+
+type inboundBatchAuthorizationVerifier struct {
+	expected runtimeprovideroutput.Authorization
+}
+
+func (v inboundBatchAuthorizationVerifier) VerifyProviderOutputAuthorization(actual runtimeprovideroutput.Authorization) error {
+	if !v.expected.Matches(actual) {
+		return errors.New("authorization does not match current compiled owner")
+	}
+	return nil
+}
+
+func TestPublishInboundDeliveryRejectsInvalidProviderOutputAuthorizationBeforeMutation(t *testing.T) {
+	expected := runtimeprovideroutput.Authorization{
+		Provider: "telegram", Event: "inbound.telegram.text_message",
+		PackID: "provider.telegram", PackVersion: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "generation-current",
+	}
+	testCases := []struct {
+		name   string
+		mutate func(*InboundDeliveryBatch)
+	}{
+		{name: "missing authorization", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization = runtimeprovideroutput.Authorization{}
+		}},
+		{name: "partial authorization", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization.ManifestHash = ""
+		}},
+		{name: "provider mismatch", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Claim.Provider = "telegram-stale"
+			batch.Events[0].Authorization.Provider = "telegram-stale"
+		}},
+		{name: "event mismatch", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Event = inboundBatchPreflightEvent("inbound.telegram.edited_message")
+			batch.Events[0].Authorization.Event = "inbound.telegram.edited_message"
+		}},
+		{name: "pack id mismatch", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization.PackID = "provider.telegram.stale"
+		}},
+		{name: "pack version mismatch", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization.PackVersion = "0.9.0"
+		}},
+		{name: "manifest hash mismatch", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization.ManifestHash = "sha256:" + strings.Repeat("b", 64)
+		}},
+		{name: "stale generation", mutate: func(batch *InboundDeliveryBatch) {
+			batch.Events[0].Authorization.GenerationID = "generation-stale"
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &inboundBatchPreflightProofStore{}
+			bus, err := NewEventBusWithOptions(store, EventBusOptions{
+				ProviderOutputVerifier: inboundBatchAuthorizationVerifier{expected: expected},
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			batch := inboundBatchPreflightBatch(expected)
+			tc.mutate(&batch)
+			if _, err := bus.PublishInboundDelivery(context.Background(), batch); err == nil {
+				t.Fatal("PublishInboundDelivery error = nil, want fail-closed authorization rejection")
+			}
+			if store.mutationCalls != 0 {
+				t.Fatalf("RunEventMutation calls = %d, want zero", store.mutationCalls)
+			}
+		})
+	}
+}
+
+func TestPublishInboundDeliveryAcceptsOnlyExactCurrentProviderOutputAuthorizationIntoMutation(t *testing.T) {
+	expected := runtimeprovideroutput.Authorization{
+		Provider: "telegram", Event: "inbound.telegram.text_message",
+		PackID: "provider.telegram", PackVersion: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "generation-current",
+	}
+	store := &inboundBatchPreflightProofStore{}
+	bus, err := NewEventBusWithOptions(store, EventBusOptions{
+		ProviderOutputVerifier: inboundBatchAuthorizationVerifier{expected: expected},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	if _, err := bus.PublishInboundDelivery(context.Background(), inboundBatchPreflightBatch(expected)); err == nil || !strings.Contains(err.Error(), "mutation must not start") {
+		t.Fatalf("PublishInboundDelivery error = %v, want mutation sentinel", err)
+	}
+	if store.mutationCalls != 1 {
+		t.Fatalf("RunEventMutation calls = %d, want one", store.mutationCalls)
+	}
+}
+
+func inboundBatchPreflightBatch(authorization runtimeprovideroutput.Authorization) InboundDeliveryBatch {
+	return InboundDeliveryBatch{
+		Claim: InboundDeliveryClaim{ProviderEventID: "delivery-1", EntityID: "entity-1", Provider: "telegram"},
+		Events: []InboundDeliveryEvent{{
+			Event: inboundBatchPreflightEvent("inbound.telegram.text_message"), Kind: runtimeprovideroutput.KindNormalized,
+			Authorization: authorization,
+		}},
+	}
+}
+
+func inboundBatchPreflightEvent(eventName string) events.Event {
+	return eventtest.RootIngress(
+		"event-1", events.EventType(eventName), "inbound-gateway", "", []byte(`{"chat_id":"42"}`), 0,
+		"run-1", "", events.EventEnvelope{}, time.Unix(1, 0).UTC(),
+	)
+}

--- a/internal/runtime/bus/routing.go
+++ b/internal/runtime/bus/routing.go
@@ -1,15 +1,11 @@
 package bus
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 )
-
-var eventTypeTokenPattern = regexp.MustCompile(`^[a-z0-9_]+$`)
-var eventPathSegmentPattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 func RouteMatches(pattern, eventType string) bool {
 	return eventidentity.MatchPattern(pattern, eventType)
@@ -28,34 +24,7 @@ func AppendUniqueEventType(in []events.EventType, v events.EventType) []events.E
 }
 
 func IsValidEventTypeName(raw string) bool {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return false
-	}
-	segments := strings.Split(raw, "/")
-	for _, segment := range segments {
-		segment = strings.TrimSpace(segment)
-		if segment == "" || segment == "*" {
-			return false
-		}
-		if strings.Contains(segment, ".") {
-			parts := strings.Split(segment, ".")
-			if len(parts) == 0 {
-				return false
-			}
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				if p == "" || !eventTypeTokenPattern.MatchString(p) {
-					return false
-				}
-			}
-			continue
-		}
-		if !eventPathSegmentPattern.MatchString(segment) {
-			return false
-		}
-	}
-	return true
+	return eventidentity.IsValidName(raw)
 }
 
 func UniqueStrings(in []string) []string {

--- a/internal/runtime/bus/store.go
+++ b/internal/runtime/bus/store.go
@@ -240,6 +240,14 @@ type EventMutation interface {
 	RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error
 }
 
+// InboundDeliveryMutation extends the selected-store event mutation with the
+// external delivery identity claim. The marker and every event/lifecycle write
+// performed through the mutation commit or roll back together.
+type InboundDeliveryMutation interface {
+	EventMutation
+	ClaimInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error)
+}
+
 type EventMutationRunner interface {
 	RunEventMutation(ctx context.Context, fn func(EventMutation) error) error
 }
@@ -278,6 +286,10 @@ func WithoutEventMutationContext(ctx context.Context) context.Context {
 
 type TransactionalEventReplayScopePersistence interface {
 	UpsertCommittedReplayScopeTx(ctx context.Context, tx *sql.Tx, eventID string, scope runtimereplayclaim.CommittedReplayScope) error
+}
+
+type TransactionalInboundEventPersistence interface {
+	ClaimInboundEventTx(ctx context.Context, tx *sql.Tx, providerEventID, entityID, provider string) (bool, error)
 }
 
 // TransactionalEventStore is the backend-local raw-SQL helper used below

--- a/internal/runtime/bus/template_instance_lifecycle.go
+++ b/internal/runtime/bus/template_instance_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -185,7 +186,7 @@ func (o templateInstanceLifecycleOwner) Materialize(ctx context.Context, evt eve
 		return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: failure}, TemplateInstanceLifecycleDecision{}, true, nil
 	}
 	if err := o.activate(ctx, req); err != nil {
-		if templateInstanceLifecycleCanReuseAfterActivationError(plan, onMissing, onConflict) {
+		if templateInstanceLifecycleCanReuseAfterActivationError(plan, onMissing, onConflict, err) {
 			refreshed, refreshErr := o.reloadDescriptors(ctx)
 			if refreshErr != nil {
 				return runtimepinrouting.ConnectRoutePlanMaterialization{}, TemplateInstanceLifecycleDecision{}, true, refreshErr
@@ -344,11 +345,15 @@ func templateInstanceLifecycleExistingAction(onMissing, onConflict string) strin
 	return templateInstanceLifecycleActionSelectedExisting
 }
 
-func templateInstanceLifecycleCanReuseAfterActivationError(plan runtimepinrouting.ConnectRoutePlan, onMissing, onConflict string) bool {
+func templateInstanceLifecycleCanReuseAfterActivationError(plan runtimepinrouting.ConnectRoutePlan, onMissing, onConflict string, activationErr error) bool {
 	if plan.InstanceKey == nil || strings.TrimSpace(plan.InstanceKey.Mode) != runtimecontracts.FlowInputResolutionModeSelectOrCreate {
 		return false
 	}
-	return strings.TrimSpace(onMissing) == "create" && strings.TrimSpace(onConflict) == "reuse"
+	if strings.TrimSpace(onMissing) != "create" || strings.TrimSpace(onConflict) != "reuse" {
+		return false
+	}
+	failure, ok := runtimefailures.As(activationErr)
+	return ok && failure.Failure.Class == runtimefailures.ClassConflictingDuplicate
 }
 
 func templateInstanceLifecycleMatchIsRoutable(routeTable *RouteTable, plan runtimepinrouting.ConnectRoutePlan, target events.RouteIdentity) bool {

--- a/internal/runtime/contracts/field_projection.go
+++ b/internal/runtime/contracts/field_projection.go
@@ -1,0 +1,28 @@
+package contracts
+
+import "strings"
+
+const FieldProjectionConvertNumberToText = "number_to_text"
+
+// FieldProjection is the shared declaration model for a typed field selected
+// from another value. Consumers decide which optional/conversion combinations
+// are legal for their semantic context.
+type FieldProjection struct {
+	From     string `yaml:"from" json:"from"`
+	Type     string `yaml:"type" json:"type"`
+	Optional bool   `yaml:"optional,omitempty" json:"optional,omitempty"`
+	Convert  string `yaml:"convert,omitempty" json:"convert,omitempty"`
+}
+
+func (p FieldProjection) Normalized() FieldProjection {
+	return FieldProjection{
+		From:     strings.TrimSpace(p.From),
+		Type:     strings.TrimSpace(p.Type),
+		Optional: p.Optional,
+		Convert:  strings.ToLower(strings.TrimSpace(p.Convert)),
+	}
+}
+
+func ValidateWave1TypeReference(raw, context string) error {
+	return validateWave1TypeRef(raw, context)
+}

--- a/internal/runtime/contracts/standalone_projection_type.go
+++ b/internal/runtime/contracts/standalone_projection_type.go
@@ -1,0 +1,131 @@
+package contracts
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// ValidateStandaloneWave1TypeReference rejects references that require a
+// separate type catalog. Provider trigger manifests do not own such a catalog.
+func ValidateStandaloneWave1TypeReference(raw, context string) error {
+	if err := ValidateWave1TypeReference(raw, context); err != nil {
+		return err
+	}
+	if _, err := (CatalogTypeReference{Type: strings.TrimSpace(raw)}).Resolve(); err != nil {
+		return fmt.Errorf("%s type %q is not standalone-resolvable: %w", context, strings.TrimSpace(raw), err)
+	}
+	return nil
+}
+
+func ValidateStandaloneWave1Value(typeRef string, value any) error {
+	resolved, err := (CatalogTypeReference{Type: strings.TrimSpace(typeRef)}).Resolve()
+	if err != nil {
+		return err
+	}
+	return validateStandaloneWave1Value(resolved, value)
+}
+
+func validateStandaloneWave1Value(expected ResolvedCatalogType, value any) error {
+	switch expected.Kind {
+	case CatalogTypeDynamic:
+		return nil
+	case CatalogTypeText:
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("value type %T is incompatible with text", value)
+		}
+		return nil
+	case CatalogTypeInteger:
+		if !standaloneInteger(value) {
+			return fmt.Errorf("value type %T is incompatible with integer", value)
+		}
+		return nil
+	case CatalogTypeNumber:
+		if !standaloneNumber(value) {
+			return fmt.Errorf("value type %T is incompatible with numeric", value)
+		}
+		return nil
+	case CatalogTypeBoolean:
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("value type %T is incompatible with boolean", value)
+		}
+		return nil
+	case CatalogTypeList:
+		items, ok := standaloneList(value)
+		if !ok || expected.Element == nil {
+			return fmt.Errorf("value type %T is incompatible with list", value)
+		}
+		for index, item := range items {
+			if err := validateStandaloneWave1Value(*expected.Element, item); err != nil {
+				return fmt.Errorf("list item %d: %w", index, err)
+			}
+		}
+		return nil
+	case CatalogTypeMap:
+		object, ok := value.(map[string]any)
+		if !ok || expected.Key == nil || expected.Value == nil {
+			return fmt.Errorf("value type %T is incompatible with map", value)
+		}
+		for key, item := range object {
+			if err := validateStandaloneWave1Value(*expected.Key, key); err != nil {
+				return fmt.Errorf("map key %q: %w", key, err)
+			}
+			if err := validateStandaloneWave1Value(*expected.Value, item); err != nil {
+				return fmt.Errorf("map value at %q: %w", key, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("standalone projection cannot validate type kind %q", expected.Kind)
+	}
+}
+
+func standaloneInteger(value any) bool {
+	switch typed := value.(type) {
+	case json.Number:
+		_, err := typed.Int64()
+		return err == nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32:
+		value64 := float64(typed)
+		return !math.IsNaN(value64) && !math.IsInf(value64, 0) && typed == float32(int64(typed))
+	case float64:
+		return !math.IsNaN(typed) && !math.IsInf(typed, 0) && math.Trunc(typed) == typed && math.Abs(typed) <= 1<<53
+	default:
+		return false
+	}
+}
+
+func standaloneNumber(value any) bool {
+	switch typed := value.(type) {
+	case json.Number:
+		_, err := typed.Float64()
+		return err == nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32:
+		value64 := float64(typed)
+		return !math.IsNaN(value64) && !math.IsInf(value64, 0)
+	case float64:
+		return !math.IsNaN(typed) && !math.IsInf(typed, 0)
+	default:
+		return false
+	}
+}
+
+func standaloneList(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []string:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, item)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_connect.go
+++ b/internal/runtime/contracts/workflow_contract_connect.go
@@ -51,7 +51,7 @@ func (c FlowInputPinCarries) normalized() FlowInputPinCarries {
 			continue
 		}
 		carry := c[key].normalized()
-		if carry.From == "" && carry.Type == "" {
+		if carry.From == "" && carry.Type == "" && !carry.Optional && carry.Convert == "" {
 			continue
 		}
 		out[name] = carry
@@ -63,9 +63,12 @@ func (c FlowInputPinCarries) normalized() FlowInputPinCarries {
 }
 
 func (c FlowInputPinCarry) normalized() FlowInputPinCarry {
+	projection := (FieldProjection{
+		From: c.From, Type: c.Type, Optional: c.Optional, Convert: c.Convert,
+	}).Normalized()
 	return FlowInputPinCarry{
-		From: strings.TrimSpace(c.From),
-		Type: strings.TrimSpace(c.Type),
+		From: projection.From, Type: projection.Type,
+		Optional: projection.Optional, Convert: projection.Convert,
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1450,8 +1450,10 @@ type FlowOutputEventPin struct {
 }
 type FlowInputPinCarries map[string]FlowInputPinCarry
 type FlowInputPinCarry struct {
-	From string `yaml:"from"`
-	Type string `yaml:"type"`
+	From     string `yaml:"from"`
+	Type     string `yaml:"type"`
+	Optional bool   `yaml:"optional,omitempty"`
+	Convert  string `yaml:"convert,omitempty"`
 }
 type FlowInputPinAddress struct {
 	By          string `yaml:"by"`

--- a/internal/runtime/contracts/workflow_contract_yaml_flow.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_flow.go
@@ -265,8 +265,10 @@ var outputEventPinFieldOptions = map[string]struct{}{
 }
 
 var inputEventPinCarryFieldOptions = map[string]struct{}{
-	"from": {},
-	"type": {},
+	"from":     {},
+	"type":     {},
+	"optional": {},
+	"convert":  {},
 }
 
 var inputEventPinResolutionFieldOptions = map[string]struct{}{
@@ -491,6 +493,14 @@ func (c *FlowInputPinCarry) UnmarshalYAML(node *yaml.Node) error {
 		case "type":
 			if err := value.Decode(&out.Type); err != nil {
 				return fmt.Errorf("carry.type: %w", err)
+			}
+		case "optional":
+			if err := value.Decode(&out.Optional); err != nil {
+				return fmt.Errorf("carry.optional: %w", err)
+			}
+		case "convert":
+			if err := value.Decode(&out.Convert); err != nil {
+				return fmt.Errorf("carry.convert: %w", err)
 			}
 		default:
 			return NewUndefinedFieldDiagnostic("input event pin carry", key, inputEventPinCarryFieldOptions)

--- a/internal/runtime/core/eventidentity/eventidentity.go
+++ b/internal/runtime/core/eventidentity/eventidentity.go
@@ -2,8 +2,12 @@ package eventidentity
 
 import (
 	"path"
+	"regexp"
 	"strings"
 )
+
+var eventTypeTokenPattern = regexp.MustCompile("^[a-z0-9_]+$")
+var eventPathSegmentPattern = regexp.MustCompile("^[a-z0-9_-]+$")
 
 type Scope struct {
 	Path         string
@@ -19,6 +23,32 @@ type DescendantScope struct {
 
 func Normalize(raw string) string {
 	return strings.Trim(strings.TrimSpace(raw), "/")
+}
+
+func IsValidName(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	for _, segment := range strings.Split(raw, "/") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" || segment == "*" {
+			return false
+		}
+		if strings.Contains(segment, ".") {
+			for _, part := range strings.Split(segment, ".") {
+				part = strings.TrimSpace(part)
+				if part == "" || !eventTypeTokenPattern.MatchString(part) {
+					return false
+				}
+			}
+			continue
+		}
+		if !eventPathSegmentPattern.MatchString(segment) {
+			return false
+		}
+	}
+	return true
 }
 
 func LeafName(raw string) string {

--- a/internal/runtime/core/eventidentity/eventidentity_test.go
+++ b/internal/runtime/core/eventidentity/eventidentity_test.go
@@ -2,6 +2,19 @@ package eventidentity
 
 import "testing"
 
+func TestIsValidNameUsesCanonicalEventGrammar(t *testing.T) {
+	for _, name := range []string{"inbound.telegram.text_message", "flow/step.completed", "flow-instance/step.completed"} {
+		if !IsValidName(name) {
+			t.Fatalf("IsValidName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "inbound.telegram.", "Inbound.telegram.event", "inbound.telegram.text-message", "flow//event", "flow/*"} {
+		if IsValidName(name) {
+			t.Fatalf("IsValidName(%q) = true, want false", name)
+		}
+	}
+}
+
 func TestLeafName_LocalizesScopedEvent(t *testing.T) {
 	if got := LeafName("scoring/vertical.shortlisted"); got != "vertical.shortlisted" {
 		t.Fatalf("LeafName = %q, want %q", got, "vertical.shortlisted")

--- a/internal/runtime/core/paths/path.go
+++ b/internal/runtime/core/paths/path.go
@@ -1,6 +1,12 @@
 package paths
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var strictRelativeSegmentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
 
 type PathRoot uint8
 
@@ -79,6 +85,35 @@ func Parse(text string) Path {
 		return Path{Root: root, Segments: append([]string(nil), segments[1:]...), Raw: raw}
 	}
 	return Path{Root: RootUnknown, Segments: append([]string(nil), segments...), Raw: raw}
+}
+
+// ParseStrictRelative parses declaration-time paths that are relative to an
+// already selected value. Unlike Parse, it rejects empty segments and runtime
+// expression roots instead of silently normalizing them.
+func ParseStrictRelative(text string) (Path, error) {
+	raw := strings.TrimSpace(text)
+	if raw == "" {
+		return Path{}, fmt.Errorf("relative dotted path is required")
+	}
+	if strings.HasPrefix(raw, "$") {
+		return Path{}, fmt.Errorf("relative dotted path %q must not use JSONPath syntax", raw)
+	}
+	parts := strings.Split(raw, ".")
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return Path{}, fmt.Errorf("relative dotted path %q contains an empty segment", raw)
+		}
+		if !strictRelativeSegmentPattern.MatchString(part) {
+			return Path{}, fmt.Errorf("relative dotted path %q contains unsupported segment %q", raw, part)
+		}
+		segments = append(segments, part)
+	}
+	if root := parseRoot(segments[0]); root != RootUnknown {
+		return Path{}, fmt.Errorf("relative dotted path %q must not use runtime namespace %q", raw, segments[0])
+	}
+	return Path{Root: RootUnknown, Segments: segments, Raw: raw}, nil
 }
 
 func parseRoot(text string) PathRoot {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -204,6 +204,77 @@ func LowerCompositionConnectRoutePlans(source semanticview.Source) ([]ConnectRou
 	return plans, issues
 }
 
+// LowerTargetFreeInputRoutePlans lowers exact external input pins for the
+// explicitly authorized target-free event set. It reuses the same instance-key
+// materialization model as composition connect routes without inventing a
+// synthetic producer output pin.
+func LowerTargetFreeInputRoutePlans(source semanticview.Source, eventNames []string) ([]ConnectRoutePlan, []ConnectRoutePlanIssue) {
+	if source == nil || len(eventNames) == 0 {
+		return nil, nil
+	}
+	allowed := map[string]struct{}{}
+	for _, name := range eventNames {
+		if normalized := eventidentity.Normalize(name); normalized != "" {
+			allowed[normalized] = struct{}{}
+		}
+	}
+	plans := make([]ConnectRoutePlan, 0)
+	issues := make([]ConnectRoutePlanIssue, 0)
+	for _, scope := range source.FlowScopes() {
+		flowID := strings.TrimSpace(scope.ID)
+		for _, inputPin := range source.FlowInputEventPins(flowID) {
+			if strings.TrimSpace(inputPin.Source) != "external" {
+				continue
+			}
+			resolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, inputPin.EventType()))
+			if _, ok := allowed[resolved]; !ok {
+				continue
+			}
+			connect := runtimecontracts.FlowPackageConnect{To: flowID + "." + inputPin.PinName(), Delivery: string(ConnectDeliveryOne)}
+			var instanceKey *ConnectRoutePlanInstanceKey
+			if receiverRequiresRuntimeResolution(scope) {
+				var issue ConnectRoutePlanIssue
+				instanceKey, issue = connectResolutionInstanceKey(source, connect, inputPin, inputPin.Resolution, ConnectDeliveryOne, flowID)
+				if issue.Failure != "" {
+					issue.AuthoredLocation = flowID + "." + inputPin.PinName()
+					issues = append(issues, issue)
+					continue
+				}
+			}
+			plan := ConnectRoutePlan{
+				AuthoredLocation: flowID + "." + inputPin.PinName(),
+				Source: ConnectRoutePlanEndpoint{
+					Root: true, Pin: inputPin.PinName(), Event: resolved, ResolvedEvent: resolved, Mode: "external",
+				},
+				Receiver: ConnectRoutePlanEndpoint{
+					FlowID: flowID, FlowPath: strings.Trim(strings.TrimSpace(scope.Path), "/"), Mode: strings.TrimSpace(scope.Mode),
+					Pin: inputPin.PinName(), Event: eventidentity.Normalize(inputPin.EventType()), ResolvedEvent: resolved,
+				},
+				Delivery: ConnectDeliveryOne, TargetKind: ConnectTargetKindTarget,
+				ResolutionKind: connectResolutionKind(scope, ConnectDeliveryOne, nil, instanceKey),
+				InstanceKey:    instanceKey,
+			}
+			if receiverRequiresRuntimeResolution(scope) {
+				if instanceKey == nil {
+					issues = append(issues, ConnectRoutePlanIssue{Connect: connect, AuthoredLocation: plan.AuthoredLocation, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: flowID})
+					continue
+				}
+				plan.RequiresRuntimeResolution = true
+			} else {
+				plan.Target = staticConnectRoute(source, flowID)
+			}
+			plans = append(plans, plan)
+		}
+	}
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].Receiver.FlowID != plans[j].Receiver.FlowID {
+			return plans[i].Receiver.FlowID < plans[j].Receiver.FlowID
+		}
+		return plans[i].Receiver.Pin < plans[j].Receiver.Pin
+	})
+	return plans, issues
+}
+
 func LowerCompositionConnectRoutePlan(source semanticview.Source, connect runtimecontracts.FlowPackageConnect) (ConnectRoutePlan, ConnectRoutePlanIssue) {
 	plan, issue := lowerCompositionConnectRoutePlan(source, connect)
 	authoredLocation := connect.AuthoredLocation()

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -11,6 +11,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -132,30 +133,32 @@ const (
 )
 
 type ConnectRoutePlan struct {
-	PackageKey                string
-	AuthoredLocation          string
-	Source                    ConnectRoutePlanEndpoint
-	Receiver                  ConnectRoutePlanEndpoint
-	Adapter                   string
-	Delivery                  ConnectRoutePlanDelivery
-	TargetKind                ConnectRoutePlanTargetKind
-	ResolutionKind            ConnectRoutePlanResolutionKind
-	Address                   *ConnectRoutePlanAddress
-	InstanceKey               *ConnectRoutePlanInstanceKey
-	FanIn                     *ConnectRoutePlanFanIn
-	ReplyResolution           *ConnectRoutePlanReplyResolution
-	Map                       []ConnectRoutePlanMapEntry
-	Reply                     map[string]string
-	Target                    events.RouteIdentity
-	TargetSet                 []events.RouteIdentity
-	RequiresRuntimeResolution bool
+	PackageKey                  string
+	AuthoredLocation            string
+	Source                      ConnectRoutePlanEndpoint
+	Receiver                    ConnectRoutePlanEndpoint
+	Adapter                     string
+	Delivery                    ConnectRoutePlanDelivery
+	TargetKind                  ConnectRoutePlanTargetKind
+	ResolutionKind              ConnectRoutePlanResolutionKind
+	Address                     *ConnectRoutePlanAddress
+	InstanceKey                 *ConnectRoutePlanInstanceKey
+	FanIn                       *ConnectRoutePlanFanIn
+	ReplyResolution             *ConnectRoutePlanReplyResolution
+	Map                         []ConnectRoutePlanMapEntry
+	Reply                       map[string]string
+	Target                      events.RouteIdentity
+	TargetSet                   []events.RouteIdentity
+	RequiresRuntimeResolution   bool
+	ProviderOutputAuthorization *runtimeprovideroutput.Authorization
 }
 
 type ConnectRoutePlanIssue struct {
-	Connect          runtimecontracts.FlowPackageConnect
-	AuthoredLocation string
-	Failure          ConnectRoutePlanFailure
-	Detail           string
+	Connect                     runtimecontracts.FlowPackageConnect
+	AuthoredLocation            string
+	Failure                     ConnectRoutePlanFailure
+	Detail                      string
+	ProviderOutputAuthorization *runtimeprovideroutput.Authorization
 }
 
 type ConnectRoutePlanMaterializationInput struct {
@@ -208,14 +211,15 @@ func LowerCompositionConnectRoutePlans(source semanticview.Source) ([]ConnectRou
 // explicitly authorized target-free event set. It reuses the same instance-key
 // materialization model as composition connect routes without inventing a
 // synthetic producer output pin.
-func LowerTargetFreeInputRoutePlans(source semanticview.Source, eventNames []string) ([]ConnectRoutePlan, []ConnectRoutePlanIssue) {
-	if source == nil || len(eventNames) == 0 {
+func LowerTargetFreeInputRoutePlans(source semanticview.Source, authorizations []runtimeprovideroutput.Authorization) ([]ConnectRoutePlan, []ConnectRoutePlanIssue) {
+	if source == nil || len(authorizations) == 0 {
 		return nil, nil
 	}
-	allowed := map[string]struct{}{}
-	for _, name := range eventNames {
-		if normalized := eventidentity.Normalize(name); normalized != "" {
-			allowed[normalized] = struct{}{}
+	allowed := map[string]runtimeprovideroutput.Authorization{}
+	for _, authorization := range authorizations {
+		authorization = authorization.Normalized()
+		if authorization.Valid() {
+			allowed[eventidentity.Normalize(authorization.Event)] = authorization
 		}
 	}
 	plans := make([]ConnectRoutePlan, 0)
@@ -227,7 +231,8 @@ func LowerTargetFreeInputRoutePlans(source semanticview.Source, eventNames []str
 				continue
 			}
 			resolved := eventidentity.Normalize(source.ResolveFlowEventReference(flowID, inputPin.EventType()))
-			if _, ok := allowed[resolved]; !ok {
+			authorization, ok := allowed[resolved]
+			if !ok {
 				continue
 			}
 			connect := runtimecontracts.FlowPackageConnect{To: flowID + "." + inputPin.PinName(), Delivery: string(ConnectDeliveryOne)}
@@ -237,6 +242,7 @@ func LowerTargetFreeInputRoutePlans(source semanticview.Source, eventNames []str
 				instanceKey, issue = connectResolutionInstanceKey(source, connect, inputPin, inputPin.Resolution, ConnectDeliveryOne, flowID)
 				if issue.Failure != "" {
 					issue.AuthoredLocation = flowID + "." + inputPin.PinName()
+					issue.ProviderOutputAuthorization = &authorization
 					issues = append(issues, issue)
 					continue
 				}
@@ -251,12 +257,13 @@ func LowerTargetFreeInputRoutePlans(source semanticview.Source, eventNames []str
 					Pin: inputPin.PinName(), Event: eventidentity.Normalize(inputPin.EventType()), ResolvedEvent: resolved,
 				},
 				Delivery: ConnectDeliveryOne, TargetKind: ConnectTargetKindTarget,
-				ResolutionKind: connectResolutionKind(scope, ConnectDeliveryOne, nil, instanceKey),
-				InstanceKey:    instanceKey,
+				ResolutionKind:              connectResolutionKind(scope, ConnectDeliveryOne, nil, instanceKey),
+				InstanceKey:                 instanceKey,
+				ProviderOutputAuthorization: &authorization,
 			}
 			if receiverRequiresRuntimeResolution(scope) {
 				if instanceKey == nil {
-					issues = append(issues, ConnectRoutePlanIssue{Connect: connect, AuthoredLocation: plan.AuthoredLocation, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: flowID})
+					issues = append(issues, ConnectRoutePlanIssue{Connect: connect, AuthoredLocation: plan.AuthoredLocation, Failure: ConnectFailureReceiverAddressRuleMissing, Detail: flowID, ProviderOutputAuthorization: &authorization})
 					continue
 				}
 				plan.RequiresRuntimeResolution = true

--- a/internal/runtime/core/provideroutput/authorization.go
+++ b/internal/runtime/core/provideroutput/authorization.go
@@ -1,0 +1,47 @@
+package provideroutput
+
+import "strings"
+
+type Kind string
+
+const (
+	KindRaw        Kind = "raw"
+	KindNormalized Kind = "normalized"
+)
+
+// Authorization is the verified-pack provenance required to grant a
+// normalized provider output target-free input routing authority.
+type Authorization struct {
+	Provider     string
+	Event        string
+	PackID       string
+	PackVersion  string
+	ManifestHash string
+	GenerationID string
+}
+
+func (a Authorization) Normalized() Authorization {
+	return Authorization{
+		Provider:     strings.TrimSpace(a.Provider),
+		Event:        strings.TrimSpace(a.Event),
+		PackID:       strings.TrimSpace(a.PackID),
+		PackVersion:  strings.TrimSpace(a.PackVersion),
+		ManifestHash: strings.TrimSpace(a.ManifestHash),
+		GenerationID: strings.TrimSpace(a.GenerationID),
+	}
+}
+
+func (a Authorization) Valid() bool {
+	a = a.Normalized()
+	return a.Provider != "" && a.Event != "" && a.PackID != "" && a.PackVersion != "" && a.ManifestHash != "" && a.GenerationID != ""
+}
+
+func (a Authorization) Empty() bool {
+	return a.Normalized() == (Authorization{})
+}
+
+func (a Authorization) Matches(other Authorization) bool {
+	a = a.Normalized()
+	other = other.Normalized()
+	return a.Valid() && other.Valid() && a == other
+}

--- a/internal/runtime/eventbus_logger.go
+++ b/internal/runtime/eventbus_logger.go
@@ -18,7 +18,7 @@ import (
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
-func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator, templateInstanceActivator runtimepipeline.FlowInstanceActivator, testLifecycleProbe runtimelifecycleprobe.Observer) (*runtimebus.EventBus, error) {
+func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, source semanticview.Source, bundleFingerprint string, bundleSourceFact runtimecorrelation.BundleSourceFact, interceptorProvider func() []runtimebus.EventInterceptor, payloadValidator runtimebus.PayloadValidator, templateInstanceActivator runtimepipeline.FlowInstanceActivator, providerOutputVerifier runtimebus.ProviderOutputAuthorizationVerifier, testLifecycleProbe runtimelifecycleprobe.Observer) (*runtimebus.EventBus, error) {
 	var hook runtimebus.LoggerHook
 	if logger != nil {
 		hook = runtimeLoggerHook{logger: logger}
@@ -32,6 +32,7 @@ func newRuntimeEventBus(store runtimebus.EventStore, logger *RuntimeLogger, sour
 		BundleFingerprint:         bundleFingerprint,
 		BundleSourceFact:          bundleSourceFact,
 		TestLifecycleProbe:        testLifecycleProbe,
+		ProviderOutputVerifier:    providerOutputVerifier,
 	})
 }
 

--- a/internal/runtime/eventbus_logger_test.go
+++ b/internal/runtime/eventbus_logger_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestEventBusRejectsMalformedFailureBeforeRuntimeLog(t *testing.T) {
 	logger := NewRuntimeLogger(nil)
-	eventBus, err := newRuntimeEventBus(nil, logger, nil, "", runtimecorrelation.BundleSourceFact{}, nil, nil, nil, nil)
+	eventBus, err := newRuntimeEventBus(nil, logger, nil, "", runtimecorrelation.BundleSourceFact{}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newRuntimeEventBus: %v", err)
 	}

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -24,12 +25,7 @@ import (
 const inboundWebhookMaxBodyBytes = 1 << 20
 
 type InboundPersistence interface {
-	RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error)
 	PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error)
-}
-
-type InboundFailureRollback interface {
-	DeleteInboundEvent(ctx context.Context, providerEventID, entityID, provider string) error
 }
 
 type InboundTarget struct {
@@ -65,7 +61,6 @@ func (t *InboundTarget) NormalizeEntity() {
 
 type InboundGateway struct {
 	bus                     *runtimebus.EventBus
-	store                   InboundPersistence
 	logger                  *RuntimeLogger
 	shutdownAdmissionClosed func() bool
 	beginAdmission          func(context.Context) (context.Context, func(), bool)
@@ -79,14 +74,9 @@ func (g *InboundGateway) SetAdmissionGuard(begin func(context.Context) (context.
 	}
 }
 
-func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...InboundPersistence) *InboundGateway {
-	var store InboundPersistence
-	if len(stores) > 0 {
-		store = stores[0]
-	}
+func NewInboundGateway(bus *runtimebus.EventBus, logger *RuntimeLogger, shutdownAdmissionClosed func() bool) *InboundGateway {
 	g := &InboundGateway{
 		bus:                     bus,
-		store:                   store,
 		logger:                  logger,
 		shutdownAdmissionClosed: shutdownAdmissionClosed,
 	}
@@ -186,7 +176,9 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 	}
 	target.NormalizeEntity()
 	var payload any
-	if err := json.Unmarshal(body, &payload); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
 		payload = map[string]any{"raw": string(body)}
 	}
 	entityID := target.EffectiveEntityID()
@@ -235,68 +227,51 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 		_, _ = w.Write(delivery.Response.Body)
 		return
 	}
-	if source != nil && !standingInputPinAdmitted(source, target.FlowID, string(delivery.EventName)) {
-		http.Error(w, fmt.Sprintf("ingress target %q provider %q resolved event %q, but flow %q in bundle %s has no exact external input pin; add that pin", target.Alias, provider, delivery.EventName, target.FlowID, target.BundleHash), http.StatusUnprocessableEntity)
-		return
-	}
 	providerEventID := delivery.ProviderEventID
 	requestCtx := r.Context()
 	if strings.TrimSpace(target.RunID) != "" {
 		requestCtx = runtimecorrelation.WithRunID(requestCtx, target.RunID)
 	}
 
-	if g.store != nil {
-		inserted, err := g.store.RecordInboundEvent(requestCtx, providerEventID, entityID, provider)
-		if err != nil {
-			http.Error(w, "record inbound failed", http.StatusInternalServerError)
-			return
-		}
-		if !inserted {
-			writeJSON(w, http.StatusOK, map[string]any{
-				"status":              "duplicate",
-				"provider":            provider,
-				"provider_event_id":   providerEventID,
-				"provider_event_type": delivery.ProviderEventType,
-				"event_name":          string(delivery.EventName),
-			})
-			return
-		}
+	if g.bus == nil {
+		http.Error(w, "publish inbound unavailable", http.StatusServiceUnavailable)
+		return
 	}
-
-	pubType, pubPayload := delivery.EventName, delivery.Payload
-	envelopeBytes := mustJSON(pubPayload)
-	if g.bus != nil {
-		pubCtx := runtimebus.WithCurrentRuntimeEpoch(requestCtx)
-		envelope := events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: entityID, FlowInstance: target.FlowInstance})
-		published := events.NewRootIngressEvent(uuid.NewString(), pubType, "inbound-gateway", "", envelopeBytes, 0, target.RunID, "", envelope, now)
-		var err error
-		if delivery.AcknowledgeBeforeDispatch {
-			err = g.bus.PublishAcknowledged(pubCtx, published)
-		} else {
-			err = g.bus.Publish(pubCtx, published)
+	pubCtx := runtimebus.WithCurrentRuntimeEpoch(requestCtx)
+	published := make([]events.Event, 0, len(delivery.Events))
+	eventNames := make([]string, 0, len(delivery.Events))
+	for _, output := range delivery.Events {
+		envelope := events.EventEnvelope{}
+		if output.Kind == providertriggers.OutputKindRaw {
+			envelope = events.EnvelopeForTargetRoute(envelope, events.RouteIdentity{EntityID: entityID, FlowInstance: target.FlowInstance})
 		}
-		if err != nil {
-			if g.logger != nil {
-				handleRuntimeLogPersistenceError("inbound-gateway", "publish_failed", g.logger.Error(requestCtx, "inbound-gateway", "publish_failed", map[string]any{
-					"provider":          provider,
-					"entity_id":         entityID,
-					"provider_event_id": providerEventID,
-				}, err))
-			}
-			if rollback, ok := g.store.(InboundFailureRollback); ok && rollback != nil {
-				if rollbackErr := rollback.DeleteInboundEvent(requestCtx, providerEventID, entityID, provider); rollbackErr != nil {
-					if g.logger != nil {
-						handleRuntimeLogPersistenceError("inbound-gateway", "rollback_failed", g.logger.Error(requestCtx, "inbound-gateway", "rollback_failed", map[string]any{
-							"provider":          provider,
-							"entity_id":         entityID,
-							"provider_event_id": providerEventID,
-						}, rollbackErr))
-					}
-				}
-			}
-			http.Error(w, "publish inbound failed", http.StatusServiceUnavailable)
-			return
+		published = append(published, events.NewRootIngressEvent(
+			uuid.NewString(), output.Name, "inbound-gateway", "", mustJSON(output.Payload), 0,
+			target.RunID, "", envelope, now,
+		))
+		eventNames = append(eventNames, string(output.Name))
+	}
+	result, err := g.bus.PublishInboundDelivery(pubCtx, runtimebus.InboundDeliveryBatch{
+		Claim: runtimebus.InboundDeliveryClaim{
+			ProviderEventID: providerEventID, EntityID: entityID, Provider: provider,
+		},
+		Events: published, AcknowledgeBeforeDispatch: delivery.AcknowledgeBeforeDispatch,
+	})
+	if err != nil {
+		if g.logger != nil {
+			handleRuntimeLogPersistenceError("inbound-gateway", "publish_failed", g.logger.Error(requestCtx, "inbound-gateway", "publish_failed", map[string]any{
+				"provider": provider, "entity_id": entityID, "provider_event_id": providerEventID,
+			}, err))
 		}
+		http.Error(w, "publish inbound failed", http.StatusServiceUnavailable)
+		return
+	}
+	if result.Duplicate {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "duplicate", "provider": provider, "provider_event_id": providerEventID,
+			"provider_event_type": delivery.ProviderEventType, "event_names": eventNames,
+		})
+		return
 	}
 
 	writeJSON(w, http.StatusAccepted, map[string]any{
@@ -306,7 +281,7 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 		"provider":            provider,
 		"provider_event_id":   providerEventID,
 		"provider_event_type": delivery.ProviderEventType,
-		"event_name":          string(delivery.EventName),
+		"event_names":         eventNames,
 	})
 }
 

--- a/internal/runtime/inbound.go
+++ b/internal/runtime/inbound.go
@@ -15,6 +15,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
@@ -179,7 +180,9 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
 	if err := decoder.Decode(&payload); err != nil {
-		payload = map[string]any{"raw": string(body)}
+		payload = string(body)
+	} else if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		payload = string(body)
 	}
 	entityID := target.EffectiveEntityID()
 	entitySlug := target.EffectiveEntitySlug()
@@ -238,17 +241,20 @@ func (g *InboundGateway) handleResolvedWebhook(w http.ResponseWriter, r *http.Re
 		return
 	}
 	pubCtx := runtimebus.WithCurrentRuntimeEpoch(requestCtx)
-	published := make([]events.Event, 0, len(delivery.Events))
+	published := make([]runtimebus.InboundDeliveryEvent, 0, len(delivery.Events))
 	eventNames := make([]string, 0, len(delivery.Events))
 	for _, output := range delivery.Events {
 		envelope := events.EventEnvelope{}
 		if output.Kind == providertriggers.OutputKindRaw {
 			envelope = events.EnvelopeForTargetRoute(envelope, events.RouteIdentity{EntityID: entityID, FlowInstance: target.FlowInstance})
 		}
-		published = append(published, events.NewRootIngressEvent(
+		event := events.NewRootIngressEvent(
 			uuid.NewString(), output.Name, "inbound-gateway", "", mustJSON(output.Payload), 0,
 			target.RunID, "", envelope, now,
-		))
+		)
+		published = append(published, runtimebus.InboundDeliveryEvent{
+			Event: event, Kind: runtimeprovideroutput.Kind(output.Kind), Authorization: output.Authorization,
+		})
 		eventNames = append(eventNames, string(output.Name))
 	}
 	result, err := g.bus.PublishInboundDelivery(pubCtx, runtimebus.InboundDeliveryBatch{

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -2033,6 +2033,18 @@ func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *te
 			configure:  func(*http.Request, []byte) {},
 			wantStatus: http.StatusBadRequest,
 		},
+		{
+			name:       "trailing junk after object",
+			body:       []byte(`{"update_id":123456789}junk`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "second JSON value after object",
+			body:       []byte(`{"update_id":123456789} {"update_id":2}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			eventStore := &capturingInboundEventStore{}

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -112,6 +112,9 @@ func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *Runti
 	if err != nil {
 		t.Fatalf("load provider trigger registry: %v", err)
 	}
+	if bus != nil {
+		bus.SetProviderOutputAuthorizationVerifier(registry)
+	}
 	gateway := NewInboundGateway(bus, logger, shutdownAdmissionClosed)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	var resolver testInboundTargetResolver

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -26,7 +26,11 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -108,7 +112,7 @@ func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *Runti
 	if err != nil {
 		t.Fatalf("load provider trigger registry: %v", err)
 	}
-	gateway := NewInboundGateway(bus, logger, shutdownAdmissionClosed, stores...)
+	gateway := NewInboundGateway(bus, logger, shutdownAdmissionClosed)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	var resolver testInboundTargetResolver
 	if len(stores) > 0 {
@@ -140,8 +144,18 @@ func (failingInboundEventStore) ListEventDeliveryRecipients(context.Context, str
 	return []string{}, nil
 }
 
+func (s failingInboundEventStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	return runInboundTestMutation(ctx, s.AppendEvent, nil, fn)
+}
+
 type capturingInboundEventStore struct {
-	events []events.Event
+	events          []events.Event
+	seen            map[string]struct{}
+	duplicate       bool
+	recorded        bool
+	providerEventID string
+	entityID        string
+	provider        string
 }
 
 func (s *capturingInboundEventStore) AppendEvent(_ context.Context, evt events.Event) error {
@@ -157,6 +171,76 @@ func (*capturingInboundEventStore) ListEventDeliveryRecipients(context.Context, 
 	return []string{}, nil
 }
 
+func (s *capturingInboundEventStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	if s.seen == nil {
+		s.seen = map[string]struct{}{}
+	}
+	return runInboundTestMutation(ctx, s.AppendEvent, s, fn)
+}
+
+type inboundTestMutation struct {
+	ctx        context.Context
+	append     func(context.Context, events.Event) error
+	sink       *capturingInboundEventStore
+	pendingKey string
+	claim      runtimebus.InboundDeliveryClaim
+}
+
+func runInboundTestMutation(ctx context.Context, appendEvent func(context.Context, events.Event) error, sink *capturingInboundEventStore, fn func(runtimebus.EventMutation) error) error {
+	postCommit := make([]func(), 0, 4)
+	mutation := &inboundTestMutation{append: appendEvent, sink: sink}
+	mutation.ctx = runtimebus.WithEventMutationContext(runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommit), mutation)
+	if err := fn(mutation); err != nil {
+		return err
+	}
+	if mutation.pendingKey != "" && mutation.sink != nil {
+		mutation.sink.seen[mutation.pendingKey] = struct{}{}
+		mutation.sink.recorded = true
+		mutation.sink.providerEventID = mutation.claim.ProviderEventID
+		mutation.sink.entityID = mutation.claim.EntityID
+		mutation.sink.provider = mutation.claim.Provider
+	}
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	return nil
+}
+
+func (m *inboundTestMutation) Context() context.Context { return m.ctx }
+func (m *inboundTestMutation) AppendEvent(ctx context.Context, event events.Event) error {
+	return m.append(ctx, event)
+}
+func (*inboundTestMutation) InsertEventDeliveries(context.Context, string, []string) error {
+	return nil
+}
+func (*inboundTestMutation) InsertEventDeliveriesWithTargets(context.Context, string, []string, map[string]events.RouteIdentity) error {
+	return nil
+}
+func (*inboundTestMutation) InsertEventDeliveryRoutes(context.Context, string, []events.DeliveryRoute) error {
+	return nil
+}
+func (*inboundTestMutation) UpsertCommittedReplayScope(context.Context, string, runtimereplayclaim.CommittedReplayScope) error {
+	return nil
+}
+func (*inboundTestMutation) UpsertPipelineReceipt(context.Context, string, string, *runtimefailures.Envelope) error {
+	return nil
+}
+func (*inboundTestMutation) RecordDeadLetter(context.Context, runtimedeadletters.Record) error {
+	return nil
+}
+func (m *inboundTestMutation) ClaimInboundEvent(_ context.Context, providerEventID, entityID, provider string) (bool, error) {
+	key := provider + "\x00" + entityID + "\x00" + providerEventID
+	if m.sink != nil && m.sink.duplicate {
+		return false, nil
+	}
+	if m.sink != nil {
+		if _, exists := m.sink.seen[key]; exists {
+			return false, nil
+		}
+	}
+	m.pendingKey = key
+	m.claim = runtimebus.InboundDeliveryClaim{ProviderEventID: providerEventID, EntityID: entityID, Provider: provider}
+	return true, nil
+}
+
 func TestInboundGatewayResolvedTargetPreservesStandingAuthority(t *testing.T) {
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
@@ -165,7 +249,7 @@ func TestInboundGatewayResolvedTargetPreservesStandingAuthority(t *testing.T) {
 	}
 	store := &recordingInboundStore{inserted: true}
 	gateway := newTestInboundGateway(t, bus, nil, nil, store)
-	body := []byte(`{"update_id":123,"message":{"chat":{"id":42},"text":"hello"}}`)
+	body := []byte(`{"update_id":123,"message":{"message_id":7,"chat":{"id":42},"text":"hello"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/chat/telegram", strings.NewReader(string(body)))
 	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "telegram-secret")
 	rec := httptest.NewRecorder()
@@ -178,8 +262,8 @@ func TestInboundGatewayResolvedTargetPreservesStandingAuthority(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d body=%s, want 202", rec.Code, rec.Body.String())
 	}
-	if len(eventStore.events) != 1 {
-		t.Fatalf("persisted events = %d, want 1", len(eventStore.events))
+	if len(eventStore.events) != 2 {
+		t.Fatalf("persisted events = %d, want raw plus normalized", len(eventStore.events))
 	}
 	evt := eventStore.events[0]
 	if evt.RunID() != "41000000-0000-0000-0000-000000000001" || evt.FlowInstance() != "chat-flow/a" || evt.EntityID() != "41000000-0000-0000-0000-000000000002" {
@@ -189,7 +273,6 @@ func TestInboundGatewayResolvedTargetPreservesStandingAuthority(t *testing.T) {
 
 type rollbackTrackingInboundStore struct {
 	recorded bool
-	rolled   bool
 }
 
 func (s *rollbackTrackingInboundStore) RecordInboundEvent(context.Context, string, string, string) (bool, error) {
@@ -203,11 +286,6 @@ func (s *rollbackTrackingInboundStore) ResolveInboundTarget(context.Context, str
 
 func (s *rollbackTrackingInboundStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
 	return 0, nil
-}
-
-func (s *rollbackTrackingInboundStore) DeleteInboundEvent(context.Context, string, string, string) error {
-	s.rolled = true
-	return nil
 }
 
 type recordingInboundStore struct {
@@ -236,7 +314,7 @@ func (*recordingInboundStore) PurgeInboundEventsBefore(context.Context, time.Tim
 	return 0, nil
 }
 
-func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.T) {
+func TestInboundGateway_Returns503WithoutCompensatingMarkerPathWhenBatchFails(t *testing.T) {
 	bus, err := runtimebus.NewEventBus(failingInboundEventStore{})
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -251,11 +329,8 @@ func TestInboundGateway_Returns503AndRollsBackMarkerWhenPublishFails(t *testing.
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", rec.Code)
 	}
-	if !store.recorded {
-		t.Fatal("expected inbound event to be recorded before publish attempt")
-	}
-	if !store.rolled {
-		t.Fatal("expected inbound event marker rollback on publish failure")
+	if store.recorded {
+		t.Fatal("legacy marker recorder was called outside the event mutation")
 	}
 }
 
@@ -305,7 +380,8 @@ func TestInboundGateway_UnknownTargetFailsBeforeProviderAdmission(t *testing.T) 
 }
 
 func TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
@@ -329,16 +405,14 @@ func TestInboundGateway_PausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected inbound event to be recorded while paused")
-	}
-	if store.rolled {
-		t.Fatal("did not expect inbound marker rollback for queued paused ingress")
 	}
 }
 
 func TestInboundGateway_GitHubPausedRuntimeUsesIngressOwnerAndAcceptsQueueableWebhook(t *testing.T) {
-	bus, err := runtimebus.NewEventBus(nil)
+	eventStore := &capturingInboundEventStore{}
+	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
@@ -373,11 +447,11 @@ func TestInboundGateway_GitHubPausedRuntimeUsesIngressOwnerAndAcceptsQueueableWe
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected GitHub delivery to record inbound marker while paused")
 	}
-	if store.providerEventID != "delivery-123" {
-		t.Fatalf("providerEventID = %q, want delivery-123", store.providerEventID)
+	if eventStore.providerEventID != "delivery-123" {
+		t.Fatalf("providerEventID = %q, want delivery-123", eventStore.providerEventID)
 	}
 }
 
@@ -408,11 +482,11 @@ func TestInboundGateway_GitHubAdapterOwnsSignatureDeliveryIDAndEventMapping(t *t
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected GitHub delivery to record inbound marker")
 	}
-	if store.providerEventID != "delivery-123" {
-		t.Fatalf("providerEventID = %q, want delivery-123", store.providerEventID)
+	if eventStore.providerEventID != "delivery-123" {
+		t.Fatalf("providerEventID = %q, want delivery-123", eventStore.providerEventID)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -469,7 +543,7 @@ func TestInboundGateway_GitHubAdapterRejectsInvalidSignatureBeforeMarkerAndPubli
 }
 
 func TestInboundGateway_GitHubAdapterDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -715,14 +789,14 @@ func TestInboundGateway_SlackEventCallbackOwnsEventIDAndInnerEventMapping(t *tes
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Slack callback to record inbound marker")
 	}
-	if store.providerEventID != "Ev123ABC456" {
-		t.Fatalf("providerEventID = %q, want Ev123ABC456", store.providerEventID)
+	if eventStore.providerEventID != "Ev123ABC456" {
+		t.Fatalf("providerEventID = %q, want Ev123ABC456", eventStore.providerEventID)
 	}
-	if store.provider != "slack" {
-		t.Fatalf("provider = %q, want slack", store.provider)
+	if eventStore.provider != "slack" {
+		t.Fatalf("provider = %q, want slack", eventStore.provider)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -798,7 +872,7 @@ func TestInboundGateway_SlackEventCallbackAcknowledgesBeforePostCommitDispatchCo
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Slack callback response waited for post-commit dispatch completion")
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Slack callback to record inbound marker before acknowledgement")
 	}
 	if len(eventStore.events) != 1 {
@@ -846,7 +920,7 @@ func TestInboundGateway_SlackEventCallbackRequiresEventIDBeforeMarkerAndPublish(
 }
 
 func TestInboundGateway_SlackDuplicateEventDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -930,11 +1004,11 @@ func TestInboundGateway_StripeManifestOwnsSignatureReplayIDTypeAndAck(t *testing
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Stripe callback response waited for post-commit dispatch completion")
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Stripe callback to record inbound marker")
 	}
-	if store.providerEventID != "evt_123" {
-		t.Fatalf("providerEventID = %q, want evt_123", store.providerEventID)
+	if eventStore.providerEventID != "evt_123" {
+		t.Fatalf("providerEventID = %q, want evt_123", eventStore.providerEventID)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1 before dispatch release", len(eventStore.events))
@@ -1092,7 +1166,7 @@ func TestInboundGateway_StripeRejectsInvalidInputsBeforeMarkerAndPublish(t *test
 }
 
 func TestInboundGateway_StripeDuplicateEventDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -1156,14 +1230,14 @@ func TestInboundGateway_TwilioManifestOwnsURLFormSignatureAndLiteralEvent(t *tes
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Twilio delivery to record inbound marker")
 	}
-	if store.providerEventID != "SM1234567890abcdef" {
-		t.Fatalf("providerEventID = %q, want MessageSid", store.providerEventID)
+	if eventStore.providerEventID != "SM1234567890abcdef" {
+		t.Fatalf("providerEventID = %q, want MessageSid", eventStore.providerEventID)
 	}
-	if store.provider != "twilio" {
-		t.Fatalf("provider = %q, want twilio", store.provider)
+	if eventStore.provider != "twilio" {
+		t.Fatalf("provider = %q, want twilio", eventStore.provider)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -1286,7 +1360,7 @@ func TestInboundGateway_TwilioRejectsInvalidInputsBeforeMarkerAndPublish(t *test
 }
 
 func TestInboundGateway_TwilioDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -1344,14 +1418,14 @@ func TestInboundGateway_ShopifyManifestOwnsRawBodySignatureDeliveryIDAndTopic(t 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Shopify delivery to record inbound marker")
 	}
-	if store.providerEventID != "webhook-123" {
-		t.Fatalf("providerEventID = %q, want webhook-123", store.providerEventID)
+	if eventStore.providerEventID != "webhook-123" {
+		t.Fatalf("providerEventID = %q, want webhook-123", eventStore.providerEventID)
 	}
-	if store.provider != "shopify" {
-		t.Fatalf("provider = %q, want shopify", store.provider)
+	if eventStore.provider != "shopify" {
+		t.Fatalf("provider = %q, want shopify", eventStore.provider)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -1467,7 +1541,7 @@ func TestInboundGateway_ShopifyRejectsInvalidInputsBeforeMarkerAndPublish(t *tes
 }
 
 func TestInboundGateway_ShopifyDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -1561,14 +1635,14 @@ func TestInboundGateway_TypeformAndIntercomManifestsOwnRawBodySignatureDeliveryI
 			if rec.Code != http.StatusAccepted {
 				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
 			}
-			if !store.recorded {
+			if !eventStore.recorded {
 				t.Fatalf("expected %s delivery to record inbound marker", tc.provider)
 			}
-			if store.providerEventID != tc.wantProviderID {
-				t.Fatalf("providerEventID = %q, want %s", store.providerEventID, tc.wantProviderID)
+			if eventStore.providerEventID != tc.wantProviderID {
+				t.Fatalf("providerEventID = %q, want %s", eventStore.providerEventID, tc.wantProviderID)
 			}
-			if store.provider != tc.provider {
-				t.Fatalf("provider = %q, want %s", store.provider, tc.provider)
+			if eventStore.provider != tc.provider {
+				t.Fatalf("provider = %q, want %s", eventStore.provider, tc.provider)
 			}
 			if len(eventStore.events) != 1 {
 				t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -1781,7 +1855,7 @@ func TestInboundGateway_TypeformAndIntercomDuplicateDeliveryDoesNotPublishAgain(
 		},
 	} {
 		t.Run(tc.provider, func(t *testing.T) {
-			eventStore := &capturingInboundEventStore{}
+			eventStore := &capturingInboundEventStore{duplicate: true}
 			bus, err := runtimebus.NewEventBus(eventStore)
 			if err != nil {
 				t.Fatalf("NewEventBus: %v", err)
@@ -1867,17 +1941,17 @@ func TestInboundGateway_TelegramManifestOwnsTokenDeliveryIDLiteralEventAndAck(t 
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Telegram callback response waited for post-commit dispatch completion")
 	}
-	if !store.recorded {
+	if !eventStore.recorded {
 		t.Fatal("expected Telegram delivery to record inbound marker")
 	}
-	if store.providerEventID != "123456789" {
-		t.Fatalf("providerEventID = %q, want 123456789", store.providerEventID)
+	if eventStore.providerEventID != "123456789" {
+		t.Fatalf("providerEventID = %q, want 123456789", eventStore.providerEventID)
 	}
-	if store.provider != "telegram" {
-		t.Fatalf("provider = %q, want telegram", store.provider)
+	if eventStore.provider != "telegram" {
+		t.Fatalf("provider = %q, want telegram", eventStore.provider)
 	}
-	if len(eventStore.events) != 1 {
-		t.Fatalf("published events = %d, want 1 before dispatch release", len(eventStore.events))
+	if len(eventStore.events) != 2 {
+		t.Fatalf("published events = %d, want atomic raw plus normalized before dispatch release", len(eventStore.events))
 	}
 	evt := eventStore.events[0]
 	if evt.Type() != events.EventType("inbound.telegram") {
@@ -1999,7 +2073,7 @@ func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *te
 }
 
 func TestInboundGateway_TelegramDuplicateDeliveryDoesNotPublishAgain(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &capturingInboundEventStore{duplicate: true}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
@@ -2220,8 +2294,7 @@ func TestInboundGateway_ExecutesOnlyCompiledRawAdmissionPolicy(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			store := &recordingInboundStore{inserted: true}
-			gateway := NewInboundGateway(bus, nil, nil, store)
+			gateway := NewInboundGateway(bus, nil, nil)
 			gateway.SetCredentialStore(identityInboundCredentialStore{})
 			req := httptest.NewRequest(http.MethodPost, "/webhooks/partner/partner-events", strings.NewReader(string(body)))
 			req.Header.Set("X-Partner-Signature", tc.signature)
@@ -2238,12 +2311,12 @@ func TestInboundGateway_ExecutesOnlyCompiledRawAdmissionPolicy(t *testing.T) {
 			if rec.Code != tc.wantStatus {
 				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
 			}
-			if store.recorded != tc.wantRecorded {
-				t.Fatalf("marker recorded=%t, want %t", store.recorded, tc.wantRecorded)
+			if eventStore.recorded != tc.wantRecorded {
+				t.Fatalf("marker recorded=%t, want %t", eventStore.recorded, tc.wantRecorded)
 			}
 			if tc.wantRecorded {
-				if store.providerEventID != "declared-delivery" || len(eventStore.events) != 1 || eventStore.events[0].Type() != "inbound.partner" {
-					t.Fatalf("accepted raw delivery marker=%q events=%#v", store.providerEventID, eventStore.events)
+				if eventStore.providerEventID != "declared-delivery" || len(eventStore.events) != 1 || eventStore.events[0].Type() != "inbound.partner" {
+					t.Fatalf("accepted raw delivery marker=%q events=%#v", eventStore.providerEventID, eventStore.events)
 				}
 			} else if len(eventStore.events) != 0 {
 				t.Fatalf("rejected raw delivery published %d events", len(eventStore.events))
@@ -2275,8 +2348,7 @@ func TestInboundGateway_PreservesExactEmptyBodyForCompiledAdmission(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := &recordingInboundStore{inserted: true}
-	gateway := NewInboundGateway(bus, nil, nil, store)
+	gateway := NewInboundGateway(bus, nil, nil)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/partner/partner-events", nil)
 	req.Header.Set("X-Partner-Signature", signature)
@@ -2290,8 +2362,8 @@ func TestInboundGateway_PreservesExactEmptyBodyForCompiledAdmission(t *testing.T
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
 	wantID := hex.EncodeToString(sha256.New().Sum(nil))
-	if store.providerEventID != wantID {
-		t.Fatalf("body_sha256 delivery id = %q, want exact empty-body hash %q", store.providerEventID, wantID)
+	if eventStore.providerEventID != wantID {
+		t.Fatalf("body_sha256 delivery id = %q, want exact empty-body hash %q", eventStore.providerEventID, wantID)
 	}
 	if len(eventStore.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(eventStore.events))
@@ -2309,8 +2381,7 @@ func TestInboundGateway_PreservesExactEmptyBodyForCompiledAdmission(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	jsonStore := &recordingInboundStore{inserted: true}
-	jsonGateway := NewInboundGateway(bus, nil, nil, jsonStore)
+	jsonGateway := NewInboundGateway(bus, nil, nil)
 	jsonReq := httptest.NewRequest(http.MethodPost, "/webhooks/json/json-events", nil)
 	jsonRec := httptest.NewRecorder()
 	jsonGateway.HandleResolvedWebhook(jsonRec, jsonReq, InboundTarget{
@@ -2321,8 +2392,8 @@ func TestInboundGateway_PreservesExactEmptyBodyForCompiledAdmission(t *testing.T
 	if jsonRec.Code != http.StatusBadRequest || !strings.Contains(jsonRec.Body.String(), "must be valid JSON") {
 		t.Fatalf("empty JSON body response = %d %q", jsonRec.Code, jsonRec.Body.String())
 	}
-	if jsonStore.recorded {
-		t.Fatal("empty JSON body reached marker persistence")
+	if eventStore.providerEventID != wantID || len(eventStore.events) != 1 {
+		t.Fatal("empty JSON body mutated the previously recorded marker or events")
 	}
 }
 

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -115,7 +115,19 @@ func (am *AgentManager) ActivateFlowInstance(ctx context.Context, req runtimepip
 	}); err != nil {
 		return fmt.Errorf("persist flow instance %s: %w", flowPath, err)
 	}
-	if err := am.installFlowInstanceRuntime(ctx, req, schema, scope); err != nil {
+	if _, inMutation := runtimepipeline.PipelineSQLTxFromContext(ctx); inMutation {
+		if err := am.installFlowInstanceRoute(ctx, req); err != nil {
+			return err
+		}
+		if !runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
+			postCommitCtx := runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(ctx))
+			if err := am.installFlowInstanceAgents(postCommitCtx, req, schema, scope); err != nil {
+				am.logFlowInstanceActivationSideEffectFailure(req, err)
+			}
+		}) {
+			return fmt.Errorf("flow instance %s requires post-commit agent activation", flowPath)
+		}
+	} else if err := am.installFlowInstanceRuntime(ctx, req, schema, scope); err != nil {
 		return err
 	}
 	if strings.TrimSpace(autoEmitName) != "" {
@@ -180,6 +192,13 @@ func (am *AgentManager) EnsureFlowInstance(ctx context.Context, req runtimepipel
 }
 
 func (am *AgentManager) installFlowInstanceRuntime(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest, schema runtimecontracts.FlowSchemaDocument, scope semanticview.FlowScope) error {
+	if err := am.installFlowInstanceAgents(ctx, req, schema, scope); err != nil {
+		return err
+	}
+	return am.installFlowInstanceRoute(ctx, req)
+}
+
+func (am *AgentManager) installFlowInstanceAgents(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest, schema runtimecontracts.FlowSchemaDocument, scope semanticview.FlowScope) error {
 	instance := req.Instance
 	vars := flowActivationVars(req)
 	localEvents := flowLocalEventSet(schema, scope)
@@ -206,6 +225,12 @@ func (am *AgentManager) installFlowInstanceRuntime(ctx context.Context, req runt
 			return err
 		}
 	}
+	return nil
+}
+
+func (am *AgentManager) installFlowInstanceRoute(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+	instance := req.Instance
+	vars := flowActivationVars(req)
 	request := runtimebus.FlowInstanceRouteMaterializationRequest{Identity: instance.Route(), ActivationVariables: vars}
 	if installer, ok := am.bus.(flowInstanceRouteContextInstaller); ok && installer != nil {
 		return installer.AddFlowInstanceRouteContext(ctx, request)
@@ -214,6 +239,19 @@ func (am *AgentManager) installFlowInstanceRuntime(ctx context.Context, req runt
 		return installer.AddFlowInstanceRoute(request)
 	}
 	return fmt.Errorf("event bus does not support derived flow-instance routing for %s", instance.InstancePath)
+}
+
+func (am *AgentManager) logFlowInstanceActivationSideEffectFailure(req runtimepipeline.FlowInstanceActivationRequest, err error) {
+	if am == nil || am.bus == nil || err == nil {
+		return
+	}
+	_ = am.bus.LogRuntime(context.Background(), runtimepipeline.RuntimeLogEntry{
+		Level: "error", Message: "Flow instance agent activation failed after commit",
+		Component: "flow_activation", Action: "agent_activation_failed",
+		EntityID: strings.TrimSpace(req.Instance.EntityID),
+		Detail:   map[string]any{"flow_path": strings.TrimSpace(req.Instance.InstancePath)},
+		Failure:  failureEnvelope(err, "flow_activation", "install_agents"),
+	})
 }
 
 func flowInstanceActivationMetadata(instance runtimeflowidentity.Instance, flowEntityID, instanceID, flowPath, parentEntityID string) map[string]any {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"os"
@@ -435,6 +436,33 @@ func TestActivateFlowInstanceAddsDerivedRouteTableInstance(t *testing.T) {
 	cfg, _ := am.GetAgentConfig("reviewer-inst-1")
 	if got := strings.TrimSpace(cfg.EntityID); got != runtimepipeline.FlowInstanceEntityID("review/inst-1") {
 		t.Fatalf("agent entity_id = %q, want %q", got, runtimepipeline.FlowInstanceEntityID("review/inst-1"))
+	}
+}
+
+func TestActivateFlowInstanceDefersAgentStartupUntilMutationCommit(t *testing.T) {
+	bus := &flowActivationTestBus{}
+	am := newFlowActivationManager(bus, &flowActivationTestInstanceStore{})
+	bundle := testFlowBundle("")
+	postCommit := make([]func(), 0, 1)
+	ctx := runtimepipeline.WithPipelineSQLTxContext(context.Background(), &sql.Tx{})
+	ctx = runtimepipeline.WithPipelinePostCommitActions(ctx, &postCommit)
+
+	if err := am.ActivateFlowInstance(ctx, testActivationRequest(bundle, "review", "inst-1", "ent-1", "review/inst-1")); err != nil {
+		t.Fatalf("ActivateFlowInstance: %v", err)
+	}
+	if len(bus.addedPaths) != 1 || bus.addedPaths[0] != "review/inst-1" {
+		t.Fatalf("transactional route materialization = %#v, want review/inst-1", bus.addedPaths)
+	}
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); ok {
+		t.Fatal("flow agent started before the activation transaction committed")
+	}
+	if len(postCommit) != 1 {
+		t.Fatalf("post-commit actions = %d, want deferred agent startup", len(postCommit))
+	}
+
+	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
+	if _, ok := am.GetAgentConfig("reviewer-inst-1"); !ok {
+		t.Fatal("flow agent did not start after activation commit")
 	}
 }
 

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -692,7 +692,7 @@ func runTelegramConnectorRoundTripThroughInboundDelivery(t *testing.T, ctx conte
 	defer server.Close()
 
 	delivery, inboundEvent := acceptedTelegramInboundDeliveryEvent(t, entityID, runID)
-	chatID, incomingText := telegramInboundChatAndText(t, delivery.Payload)
+	chatID, incomingText := telegramInboundChatAndText(t, delivery.Events[0].Payload)
 	credentialStore := testActivityCredentialStore(t, "telegram_bot_token", "provider-secret")
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Tools: map[string]runtimecontracts.ToolSchemaEntry{
@@ -1352,16 +1352,16 @@ func acceptedTelegramInboundDeliveryEvent(t *testing.T, entityID, runID string) 
 	if err != nil {
 		t.Fatalf("Accept Telegram inbound delivery: %v", err)
 	}
-	if delivery.EventName != "inbound.telegram" || delivery.ProviderEventID != "123456789" {
+	if delivery.Events[0].Name != "inbound.telegram" || delivery.ProviderEventID != "123456789" {
 		t.Fatalf("delivery = %+v, want inbound.telegram update", delivery)
 	}
-	raw, err := json.Marshal(delivery.Payload)
+	raw, err := json.Marshal(delivery.Events[0].Payload)
 	if err != nil {
 		t.Fatalf("marshal inbound delivery payload: %v", err)
 	}
 	evt := eventtest.RootIngress(
 		uuid.NewSHA1(uuid.NameSpaceURL, []byte("swarm:telegram-inbound:"+delivery.ProviderEventID)).String(),
-		delivery.EventName,
+		delivery.Events[0].Name,
 		"telegram",
 		"telegram-update-7",
 		raw,

--- a/internal/runtime/provider_trigger_registry_external_test.go
+++ b/internal/runtime/provider_trigger_registry_external_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 )
 
 type boundedProviderCredentialStore struct{}
@@ -106,16 +107,19 @@ func handleBoundedProviderDelivery(t *testing.T, gateway *runtimepkg.InboundGate
 		return
 	}
 	_ = store
-	batchEvents := make([]events.Event, 0, len(delivery.Events))
+	batchEvents := make([]runtimebus.InboundDeliveryEvent, 0, len(delivery.Events))
 	for _, output := range delivery.Events {
 		envelope := events.EventEnvelope{}
 		if output.Kind == providertriggers.OutputKindRaw {
 			envelope = events.EventEnvelope{EntityID: entityID}
 		}
-		batchEvents = append(batchEvents, eventtest.RootIngress(
+		event := eventtest.RootIngress(
 			"", output.Name, "bounded-provider-integration", "",
 			mustBoundedJSON(t, output.Payload), 0, runID, "", envelope, time.Now().UTC(),
-		))
+		)
+		batchEvents = append(batchEvents, runtimebus.InboundDeliveryEvent{
+			Event: event, Kind: runtimeprovideroutput.Kind(output.Kind), Authorization: output.Authorization,
+		})
 	}
 	result, err := bus.PublishInboundDelivery(r.Context(), runtimebus.InboundDeliveryBatch{
 		Claim: runtimebus.InboundDeliveryClaim{

--- a/internal/runtime/provider_trigger_registry_external_test.go
+++ b/internal/runtime/provider_trigger_registry_external_test.go
@@ -52,7 +52,7 @@ func testProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot 
 
 func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *runtimepkg.RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...runtimepkg.InboundPersistence) *runtimepkg.InboundGateway {
 	t.Helper()
-	gateway := runtimepkg.NewInboundGateway(bus, logger, shutdownAdmissionClosed, stores...)
+	gateway := runtimepkg.NewInboundGateway(bus, logger, shutdownAdmissionClosed)
 	gateway.SetCredentialStore(boundedProviderCredentialStore{})
 	return gateway
 }
@@ -105,23 +105,33 @@ func handleBoundedProviderDelivery(t *testing.T, gateway *runtimepkg.InboundGate
 		_, _ = w.Write(delivery.Response.Body)
 		return
 	}
-	if store != nil {
-		inserted, err := store.RecordInboundEvent(r.Context(), delivery.ProviderEventID, entityID, provider)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+	_ = store
+	batchEvents := make([]events.Event, 0, len(delivery.Events))
+	for _, output := range delivery.Events {
+		envelope := events.EventEnvelope{}
+		if output.Kind == providertriggers.OutputKindRaw {
+			envelope = events.EventEnvelope{EntityID: entityID}
 		}
-		if !inserted {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
+		batchEvents = append(batchEvents, eventtest.RootIngress(
+			"", output.Name, "bounded-provider-integration", "",
+			mustBoundedJSON(t, output.Payload), 0, runID, "", envelope, time.Now().UTC(),
+		))
 	}
-	event := eventtest.RootIngress(
-		"", delivery.EventName, "bounded-provider-integration", "",
-		mustBoundedJSON(t, delivery.Payload), 0, runID, "", events.EventEnvelope{EntityID: entityID}, time.Now().UTC(),
-	)
-	if err := bus.Publish(r.Context(), event); err != nil {
+	result, err := bus.PublishInboundDelivery(r.Context(), runtimebus.InboundDeliveryBatch{
+		Claim: runtimebus.InboundDeliveryClaim{
+			ProviderEventID: delivery.ProviderEventID,
+			EntityID:        entityID,
+			Provider:        provider,
+		},
+		Events:                    batchEvents,
+		AcknowledgeBeforeDispatch: delivery.AcknowledgeBeforeDispatch,
+	})
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	if result.Duplicate {
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/runtime/provider_trigger_registry_external_test.go
+++ b/internal/runtime/provider_trigger_registry_external_test.go
@@ -53,6 +53,9 @@ func testProviderTriggerCatalog(t *testing.T) *providertriggers.CatalogSnapshot 
 
 func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *runtimepkg.RuntimeLogger, shutdownAdmissionClosed func() bool, stores ...runtimepkg.InboundPersistence) *runtimepkg.InboundGateway {
 	t.Helper()
+	if bus != nil {
+		bus.SetProviderOutputAuthorizationVerifier(testProviderTriggerCatalog(t))
+	}
 	gateway := runtimepkg.NewInboundGateway(bus, logger, shutdownAdmissionClosed)
 	gateway.SetCredentialStore(boundedProviderCredentialStore{})
 	return gateway

--- a/internal/runtime/provider_trigger_source.go
+++ b/internal/runtime/provider_trigger_source.go
@@ -1,0 +1,188 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/providertriggers"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type providerTriggerEventSourceMarker interface {
+	ProviderTriggerEventsApplied() bool
+	ProviderTriggerEventGeneration() string
+	BaseSemanticSource() semanticview.Source
+}
+
+type providerTriggerTargetFreeEventSource interface {
+	ProviderTriggerTargetFreeEvents() []string
+}
+
+func SourceWithProviderTriggerEvents(source semanticview.Source, catalog *providertriggers.CatalogSnapshot) (semanticview.Source, error) {
+	if source == nil {
+		return nil, fmt.Errorf("semantic source is required")
+	}
+	if marked, ok := source.(providerTriggerEventSourceMarker); ok && marked.ProviderTriggerEventsApplied() {
+		if catalog != nil && marked.ProviderTriggerEventGeneration() == catalog.GenerationID() {
+			return source, nil
+		}
+		source = marked.BaseSemanticSource()
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || bundle == nil {
+		return nil, fmt.Errorf("provider trigger event import requires a bundle-backed semantic source")
+	}
+	if catalog == nil {
+		return source, nil
+	}
+
+	imported := map[string]runtimecontracts.EventCatalogEntry{}
+	owners := map[string]string{}
+	byProject := map[string]map[string]runtimecontracts.EventCatalogEntry{}
+	for _, pkg := range bundle.PackageTree {
+		for _, ref := range pkg.Manifest.Flows {
+			if ref.Ingress == nil {
+				continue
+			}
+			alias := strings.TrimSpace(ref.Ingress.Alias)
+			if alias == "" {
+				alias = strings.TrimSpace(ref.ID)
+			}
+			for _, binding := range ref.Ingress.Providers {
+				plan, err := catalog.CompileAdmission(providertriggers.CompileAdmissionRequest{
+					Alias: alias, Provider: binding.Provider, SigningSecret: binding.SigningSecret,
+					Declaration: providerAdmissionDeclaration(binding.Admission),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("%s: %w", standingDeclarationLocation(pkg, ref.ID), err)
+				}
+				identity, packBacked := plan.PackIdentity()
+				if !packBacked {
+					continue
+				}
+				entry, exists := catalog.EntryByID(identity.ID)
+				if !exists {
+					return nil, fmt.Errorf("effective ingress pack %q disappeared from verified catalog generation %s", identity.ID, catalog.GenerationID())
+				}
+				entries := entry.Manifest.EventCatalogEntries()
+				for _, output := range plan.Outputs() {
+					if output.Kind != providertriggers.OutputKindRaw || strings.TrimSpace(output.EventName.Template) == "" {
+						continue
+					}
+					for _, pin := range source.FlowInputEventPins(strings.TrimSpace(ref.ID)) {
+						name := strings.TrimSpace(pin.EventType())
+						if output.EventName.Accepts(name) {
+							entries[name] = providertriggers.RawEventCatalogEntry()
+						}
+					}
+				}
+				for eventName, eventEntry := range entries {
+					eventName = strings.TrimSpace(eventName)
+					owner := fmt.Sprintf("trigger pack %s version=%s manifest_hash=%s", identity.ID, identity.Version, identity.ManifestHash)
+					if existingOwner, duplicate := owners[eventName]; duplicate {
+						if existingOwner != owner {
+							return nil, fmt.Errorf("provider trigger event %q collision between %s and %s; remove one ingress binding", eventName, existingOwner, owner)
+						}
+						continue
+					}
+					if existing, collision := source.EventEntry(eventName); collision {
+						existingOwner := strings.TrimSpace(existing.Source)
+						if existingOwner == "" {
+							existingOwner = "authored event catalog"
+						}
+						return nil, fmt.Errorf("provider trigger event %q collision between %s and %s; remove the local redeclaration and inspect the pack with `swarm describe pack %s`", eventName, existingOwner, owner, identity.ID)
+					}
+					imported[eventName] = eventEntry
+					owners[eventName] = owner
+					if byProject[strings.TrimSpace(pkg.Key)] == nil {
+						byProject[strings.TrimSpace(pkg.Key)] = map[string]runtimecontracts.EventCatalogEntry{}
+					}
+					byProject[strings.TrimSpace(pkg.Key)][eventName] = eventEntry
+				}
+			}
+		}
+	}
+	if len(imported) == 0 {
+		return source, nil
+	}
+	return providerTriggerEventSource{Source: source, generation: catalog.GenerationID(), imported: imported, owners: owners, byProject: byProject}, nil
+}
+
+type providerTriggerEventSource struct {
+	semanticview.Source
+	generation string
+	imported   map[string]runtimecontracts.EventCatalogEntry
+	owners     map[string]string
+	byProject  map[string]map[string]runtimecontracts.EventCatalogEntry
+}
+
+func (s providerTriggerEventSource) BaseSemanticSource() semanticview.Source { return s.Source }
+func (s providerTriggerEventSource) ProviderTriggerEventsApplied() bool      { return true }
+func (s providerTriggerEventSource) ProviderTriggerEventGeneration() string  { return s.generation }
+
+func (s providerTriggerEventSource) ProviderTriggerTargetFreeEvents() []string {
+	out := make([]string, 0)
+	for name, entry := range s.imported {
+		if strings.TrimSpace(entry.Source) == "provider_trigger_pack_normalized" {
+			out = append(out, strings.TrimSpace(name))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s providerTriggerEventSource) ResolvedEventCatalog() map[string]runtimecontracts.EventCatalogEntry {
+	out := cloneEventCatalog(s.Source.ResolvedEventCatalog())
+	for name, entry := range s.imported {
+		out[name] = entry
+	}
+	return out
+}
+
+func (s providerTriggerEventSource) ResolveFlowEventCatalogEntry(flowID, eventType string) (runtimecontracts.EventCatalogEntry, string, bool) {
+	if entry, resolved, ok := s.Source.ResolveFlowEventCatalogEntry(flowID, eventType); ok {
+		return entry, resolved, true
+	}
+	eventType = strings.TrimSpace(eventType)
+	entry, ok := s.imported[eventType]
+	return entry, eventType, ok
+}
+
+func (s providerTriggerEventSource) EventEntries() map[string]runtimecontracts.EventCatalogEntry {
+	out := cloneEventCatalog(s.Source.EventEntries())
+	for name, entry := range s.imported {
+		out[name] = entry
+	}
+	return out
+}
+
+func (s providerTriggerEventSource) EventEntry(eventType string) (runtimecontracts.EventCatalogEntry, bool) {
+	if entry, ok := s.Source.EventEntry(eventType); ok {
+		return entry, true
+	}
+	entry, ok := s.imported[strings.TrimSpace(eventType)]
+	return entry, ok
+}
+
+func (s providerTriggerEventSource) ProjectScopes() []semanticview.ProjectScope {
+	scopes := s.Source.ProjectScopes()
+	out := make([]semanticview.ProjectScope, 0, len(scopes))
+	for _, scope := range scopes {
+		scope.Events = cloneEventCatalog(scope.Events)
+		for name, entry := range s.byProject[strings.TrimSpace(scope.Key)] {
+			scope.Events[name] = entry
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func cloneEventCatalog(in map[string]runtimecontracts.EventCatalogEntry) map[string]runtimecontracts.EventCatalogEntry {
+	out := make(map[string]runtimecontracts.EventCatalogEntry, len(in))
+	for name, entry := range in {
+		out[name] = entry
+	}
+	return out
+}

--- a/internal/runtime/provider_trigger_source.go
+++ b/internal/runtime/provider_trigger_source.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -17,7 +18,7 @@ type providerTriggerEventSourceMarker interface {
 }
 
 type providerTriggerTargetFreeEventSource interface {
-	ProviderTriggerTargetFreeEvents() []string
+	ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization
 }
 
 func SourceWithProviderTriggerEvents(source semanticview.Source, catalog *providertriggers.CatalogSnapshot) (semanticview.Source, error) {
@@ -41,6 +42,7 @@ func SourceWithProviderTriggerEvents(source semanticview.Source, catalog *provid
 	imported := map[string]runtimecontracts.EventCatalogEntry{}
 	owners := map[string]string{}
 	byProject := map[string]map[string]runtimecontracts.EventCatalogEntry{}
+	targetFree := map[string]runtimeprovideroutput.Authorization{}
 	for _, pkg := range bundle.PackageTree {
 		for _, ref := range pkg.Manifest.Flows {
 			if ref.Ingress == nil {
@@ -96,6 +98,13 @@ func SourceWithProviderTriggerEvents(source semanticview.Source, catalog *provid
 					}
 					imported[eventName] = eventEntry
 					owners[eventName] = owner
+					if strings.TrimSpace(eventEntry.Source) == "provider_trigger_pack_normalized" {
+						targetFree[eventName] = runtimeprovideroutput.Authorization{
+							Provider: providertriggers.NormalizeProviderName(binding.Provider), Event: eventName,
+							PackID: identity.ID, PackVersion: identity.Version, ManifestHash: identity.ManifestHash,
+							GenerationID: catalog.GenerationID(),
+						}.Normalized()
+					}
 					if byProject[strings.TrimSpace(pkg.Key)] == nil {
 						byProject[strings.TrimSpace(pkg.Key)] = map[string]runtimecontracts.EventCatalogEntry{}
 					}
@@ -107,7 +116,7 @@ func SourceWithProviderTriggerEvents(source semanticview.Source, catalog *provid
 	if len(imported) == 0 {
 		return source, nil
 	}
-	return providerTriggerEventSource{Source: source, generation: catalog.GenerationID(), imported: imported, owners: owners, byProject: byProject}, nil
+	return providerTriggerEventSource{Source: source, generation: catalog.GenerationID(), imported: imported, owners: owners, byProject: byProject, targetFree: targetFree}, nil
 }
 
 type providerTriggerEventSource struct {
@@ -116,20 +125,23 @@ type providerTriggerEventSource struct {
 	imported   map[string]runtimecontracts.EventCatalogEntry
 	owners     map[string]string
 	byProject  map[string]map[string]runtimecontracts.EventCatalogEntry
+	targetFree map[string]runtimeprovideroutput.Authorization
 }
 
 func (s providerTriggerEventSource) BaseSemanticSource() semanticview.Source { return s.Source }
 func (s providerTriggerEventSource) ProviderTriggerEventsApplied() bool      { return true }
 func (s providerTriggerEventSource) ProviderTriggerEventGeneration() string  { return s.generation }
 
-func (s providerTriggerEventSource) ProviderTriggerTargetFreeEvents() []string {
-	out := make([]string, 0)
-	for name, entry := range s.imported {
-		if strings.TrimSpace(entry.Source) == "provider_trigger_pack_normalized" {
-			out = append(out, strings.TrimSpace(name))
-		}
+func (s providerTriggerEventSource) ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization {
+	names := make([]string, 0, len(s.targetFree))
+	for name := range s.targetFree {
+		names = append(names, name)
 	}
-	sort.Strings(out)
+	sort.Strings(names)
+	out := make([]runtimeprovideroutput.Authorization, 0, len(names))
+	for _, name := range names {
+		out = append(out, s.targetFree[name].Normalized())
+	}
 	return out
 }
 

--- a/internal/runtime/provider_trigger_source_test.go
+++ b/internal/runtime/provider_trigger_source_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -65,11 +66,13 @@ func TestProviderTriggerNormalizedEventLowersThroughExactExternalInputPin(t *tes
 	if err != nil {
 		t.Fatalf("SourceWithProviderTriggerEvents: %v", err)
 	}
-	authorized, ok := wrapped.(interface{ ProviderTriggerTargetFreeEvents() []string })
+	authorized, ok := wrapped.(interface {
+		ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization
+	})
 	if !ok {
 		t.Fatal("provider trigger source does not expose its target-free event authority")
 	}
-	plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, authorized.ProviderTriggerTargetFreeEvents())
+	plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, authorized.ProviderTriggerTargetFreeAuthorizations())
 	if len(issues) != 0 {
 		t.Fatalf("target-free route plan issues = %#v", issues)
 	}
@@ -81,7 +84,10 @@ func TestProviderTriggerNormalizedEventLowersThroughExactExternalInputPin(t *tes
 		t.Fatalf("target-free normalized route plan = %#v", plan)
 	}
 
-	rawPlans, rawIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, []string{"inbound.telegram"})
+	rawPlans, rawIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, []runtimeprovideroutput.Authorization{{
+		Provider: "telegram", Event: "inbound.telegram", PackID: "provider.telegram", PackVersion: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: catalog.GenerationID(),
+	}})
 	if len(rawIssues) != 0 || len(rawPlans) != 0 {
 		t.Fatalf("raw standing event acquired target-free route plans=%#v issues=%#v", rawPlans, rawIssues)
 	}

--- a/internal/runtime/provider_trigger_source_test.go
+++ b/internal/runtime/provider_trigger_source_test.go
@@ -1,0 +1,123 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/providertriggers"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestSourceWithProviderTriggerEventsImportsEffectivePackSchemasWithoutAuthoredOwnership(t *testing.T) {
+	source, catalog := standingTelegramDeclarationSource(t, "inbound.telegram")
+	wrapped, err := SourceWithProviderTriggerEvents(source, catalog)
+	if err != nil {
+		t.Fatalf("SourceWithProviderTriggerEvents: %v", err)
+	}
+	entry, ok := wrapped.EventEntry("inbound.telegram.text_message")
+	if !ok || entry.Source != "provider_trigger_pack_normalized" {
+		t.Fatalf("normalized event entry = (%#v, %v)", entry, ok)
+	}
+	if _, authored := wrapped.AuthoredEventEntries()["inbound.telegram.text_message"]; authored {
+		t.Fatal("pack event was misclassified as authored")
+	}
+	resolved, name, ok := wrapped.ResolveFlowEventCatalogEntry("coordinator", "inbound.telegram.text_message")
+	if !ok || name != "inbound.telegram.text_message" || resolved.Payload.Properties["chat_id"].Type != "text" {
+		t.Fatalf("flow catalog resolution = (%#v, %q, %v)", resolved, name, ok)
+	}
+	if _, err := ResolveStandingTargetDeclarations(wrapped, catalog); err != nil {
+		t.Fatalf("standing declarations rejected pack-composed source: %v", err)
+	}
+}
+
+func TestSourceWithProviderTriggerEventsRejectsLocalPackEventRedeclaration(t *testing.T) {
+	source, catalog := standingTelegramDeclarationSource(t, "inbound.telegram")
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("bundle source missing")
+	}
+	bundle.Events["inbound.telegram.text_message"] = runtimecontracts.EventCatalogEntry{
+		Source: "events.yaml", Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{"chat_id": {Type: "text"}}},
+	}
+	_, err := SourceWithProviderTriggerEvents(source, catalog)
+	if err == nil || !strings.Contains(err.Error(), "collision between events.yaml and trigger pack provider.telegram") || !strings.Contains(err.Error(), "describe pack") {
+		t.Fatalf("collision error = %v", err)
+	}
+}
+
+func TestProviderTriggerNormalizedEventLowersThroughExactExternalInputPin(t *testing.T) {
+	source, catalog := standingTelegramDeclarationSource(t, "inbound.telegram.text_message")
+	bundle, ok := semanticview.Bundle(source)
+	if !ok || len(bundle.PackageTree) == 0 || len(bundle.PackageTree[0].Manifest.Flows) == 0 {
+		t.Fatal("fixture bundle flow declaration is unavailable")
+	}
+	// This unit proof isolates lowering for a non-template receiver. The served
+	// proof covers target-free select-or-create materialization.
+	bundle.PackageTree[0].Manifest.Flows[0].Mode = "static"
+	flow, ok := bundle.FlowViewByID("coordinator")
+	if !ok {
+		t.Fatal("fixture coordinator flow is unavailable")
+	}
+	flow.Schema.Mode = runtimecontracts.FlowModeStatic
+	wrapped, err := SourceWithProviderTriggerEvents(source, catalog)
+	if err != nil {
+		t.Fatalf("SourceWithProviderTriggerEvents: %v", err)
+	}
+	authorized, ok := wrapped.(interface{ ProviderTriggerTargetFreeEvents() []string })
+	if !ok {
+		t.Fatal("provider trigger source does not expose its target-free event authority")
+	}
+	plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, authorized.ProviderTriggerTargetFreeEvents())
+	if len(issues) != 0 {
+		t.Fatalf("target-free route plan issues = %#v", issues)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("target-free route plans = %#v, want one normalized input plan", plans)
+	}
+	plan := plans[0]
+	if plan.Source.ResolvedEvent != "inbound.telegram.text_message" || plan.Receiver.FlowID != "coordinator" || plan.Receiver.Pin == "" {
+		t.Fatalf("target-free normalized route plan = %#v", plan)
+	}
+
+	rawPlans, rawIssues := runtimepinrouting.LowerTargetFreeInputRoutePlans(wrapped, []string{"inbound.telegram"})
+	if len(rawIssues) != 0 || len(rawPlans) != 0 {
+		t.Fatalf("raw standing event acquired target-free route plans=%#v issues=%#v", rawPlans, rawIssues)
+	}
+}
+
+func TestSourceWithProviderTriggerEventsRebuildsOnCatalogGenerationChange(t *testing.T) {
+	source, catalog := standingTelegramDeclarationSource(t, "inbound.telegram")
+	first, err := SourceWithProviderTriggerEvents(source, catalog)
+	if err != nil {
+		t.Fatalf("first SourceWithProviderTriggerEvents: %v", err)
+	}
+	entry, ok := catalog.EntryByProvider("telegram")
+	if !ok {
+		t.Fatal("Telegram catalog entry missing")
+	}
+	entry.Identity.ManifestHash = "sha256:" + strings.Repeat("a", 64)
+	changed, err := providertriggers.NewCatalogSnapshot(entry)
+	if err != nil {
+		t.Fatalf("NewCatalogSnapshot: %v", err)
+	}
+	if changed.GenerationID() == catalog.GenerationID() {
+		t.Fatal("changed pack identity retained catalog generation")
+	}
+
+	second, err := SourceWithProviderTriggerEvents(first, changed)
+	if err != nil {
+		t.Fatalf("reload SourceWithProviderTriggerEvents: %v", err)
+	}
+	marker, ok := second.(providerTriggerEventSourceMarker)
+	if !ok || marker.ProviderTriggerEventGeneration() != changed.GenerationID() {
+		t.Fatalf("reloaded provider trigger source generation = %T %#v", second, marker)
+	}
+	if _, nested := marker.BaseSemanticSource().(providerTriggerEventSourceMarker); nested {
+		t.Fatal("reload stacked a provider trigger wrapper instead of rebuilding from the base source")
+	}
+	if entry, ok := second.EventEntry("inbound.telegram.text_message"); !ok || entry.Source != "provider_trigger_pack_normalized" {
+		t.Fatalf("reloaded normalized event entry = (%#v, %v)", entry, ok)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -445,11 +445,15 @@ func (m connectorPackWorkflowModule) SemanticSource() semanticview.Source {
 	return m.source
 }
 
-func workflowModuleWithConnectorPacks(module runtimepipeline.WorkflowModule) (runtimepipeline.WorkflowModule, semanticview.Source, error) {
+func workflowModuleWithProviderPacks(module runtimepipeline.WorkflowModule, triggerCatalog *providertriggers.CatalogSnapshot) (runtimepipeline.WorkflowModule, semanticview.Source, error) {
 	if module == nil {
 		return nil, nil, nil
 	}
 	source, err := providerconnectors.SourceWithConnectorPackImports(module.SemanticSource())
+	if err != nil {
+		return nil, nil, err
+	}
+	source, err = SourceWithProviderTriggerEvents(source, triggerCatalog)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -509,7 +513,7 @@ func (deps RuntimeDeps) validated() (validatedRuntimeDeps, error) {
 	}
 	var source semanticview.Source
 	if opts.WorkflowModule != nil {
-		workflowModule, wrappedSource, err := workflowModuleWithConnectorPacks(opts.WorkflowModule)
+		workflowModule, wrappedSource, err := workflowModuleWithProviderPacks(opts.WorkflowModule, opts.ProviderTriggerCatalog)
 		if err != nil {
 			return validatedRuntimeDeps{}, fmt.Errorf("provider connector pack import failed: %w", err)
 		}
@@ -855,7 +859,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	managerRef = rt.Manager
 
 	if stores.InboundStore != nil {
-		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed, stores.InboundStore)
+		rt.InboundGateway = NewInboundGateway(rt.Bus, rt.Logger, rt.shutdownAdmissionClosed)
 		rt.InboundGateway.SetAdmissionGuard(rt.shutdownGate.BeginContext)
 		rt.InboundGateway.SetRuntimeIngress(rt.RuntimeIngress)
 		rt.InboundGateway.SetCredentialStore(opts.ProviderCredentials)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -621,7 +621,7 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 			return fmt.Errorf("flow instance activator is required")
 		}
 		return managerRef.ActivateFlowInstance(ctx, req)
-	}, opts.TestLifecycleProbe)
+	}, opts.ProviderTriggerCatalog, opts.TestLifecycleProbe)
 	if err != nil {
 		return nil, fmt.Errorf("build event bus: %w", err)
 	}

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -69,21 +69,18 @@ type runtimeShutdownInboundStore struct {
 	recorded bool
 }
 
-type cancellationBlockingInboundStore struct {
+type cancellationBlockingInboundEventStore struct {
+	*capturingInboundEventStore
 	entered chan struct{}
 }
 
-func (s *cancellationBlockingInboundStore) RecordInboundEvent(ctx context.Context, _, _, _ string) (bool, error) {
+func (s *cancellationBlockingInboundEventStore) RunEventMutation(ctx context.Context, _ func(runtimebus.EventMutation) error) error {
 	select {
 	case s.entered <- struct{}{}:
 	default:
 	}
 	<-ctx.Done()
-	return false, ctx.Err()
-}
-
-func (*cancellationBlockingInboundStore) PurgeInboundEventsBefore(context.Context, time.Time, int) (int, error) {
-	return 0, nil
+	return ctx.Err()
 }
 
 func (s *runtimeShutdownInboundStore) RecordInboundEvent(context.Context, string, string, string) (bool, error) {
@@ -262,14 +259,16 @@ func TestRuntimeShutdownWithOptions_PropagatesConfiguredGraceToManagerDrain(t *t
 }
 
 func TestRuntimeContextDeactivationCancelsStuckWebhookWithoutPublishing(t *testing.T) {
-	eventStore := &capturingInboundEventStore{}
+	eventStore := &cancellationBlockingInboundEventStore{
+		capturingInboundEventStore: &capturingInboundEventStore{},
+		entered:                    make(chan struct{}, 1),
+	}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	store := &cancellationBlockingInboundStore{entered: make(chan struct{}, 1)}
 	rt := &Runtime{Bus: bus}
-	gateway := newTestInboundGateway(t, bus, nil, rt.shutdownAdmissionClosed, store)
+	gateway := newTestInboundGateway(t, bus, nil, rt.shutdownAdmissionClosed)
 	gateway.SetAdmissionGuard(rt.shutdownGate.BeginContext)
 	rt.InboundGateway = gateway.InboundGateway
 	hash := "bundle-v1:sha256:" + strings.Repeat("7", 64)
@@ -293,7 +292,7 @@ func TestRuntimeContextDeactivationCancelsStuckWebhookWithoutPublishing(t *testi
 		response <- rec
 	}()
 	select {
-	case <-store.entered:
+	case <-eventStore.entered:
 	case <-time.After(time.Second):
 		t.Fatal("webhook did not enter blocking persistence")
 	}

--- a/internal/runtime/standing_targets.go
+++ b/internal/runtime/standing_targets.go
@@ -16,11 +16,11 @@ import (
 )
 
 type StandingIngressBinding struct {
-	Provider      string
-	SigningSecret string
-	EventLiteral  string
-	EventTemplate string
-	AdmissionPlan providertriggers.InboundAdmissionPlan
+	Provider         string
+	SigningSecret    string
+	RawEventLiteral  string
+	RawEventTemplate string
+	AdmissionPlan    providertriggers.InboundAdmissionPlan
 }
 
 type StandingTargetDeclaration struct {
@@ -173,14 +173,17 @@ func ResolveStandingTargetDeclarations(source semanticview.Source, catalog *prov
 					if err != nil {
 						return nil, fmt.Errorf("%s: %w", location, err)
 					}
-					eventNames := plan.EventNames()
-					literal := strings.TrimSpace(eventNames.Literal)
-					template := strings.TrimSpace(eventNames.Template)
-					if err := validateStandingIngressPins(source, flowID, provider, eventNames); err != nil {
+					rawOutput, ok := plan.RawOutput()
+					if !ok {
+						return nil, fmt.Errorf("%s: ingress provider %q compiled no raw output", location, provider)
+					}
+					literal := strings.TrimSpace(rawOutput.EventName.Literal)
+					template := strings.TrimSpace(rawOutput.EventName.Template)
+					if err := validateStandingIngressRawPin(source, flowID, provider, rawOutput.EventName); err != nil {
 						return nil, fmt.Errorf("%s: %w", location, err)
 					}
 					decl.Ingress = append(decl.Ingress, StandingIngressBinding{
-						Provider: provider, SigningSecret: secret, EventLiteral: literal, EventTemplate: template, AdmissionPlan: plan,
+						Provider: provider, SigningSecret: secret, RawEventLiteral: literal, RawEventTemplate: template, AdmissionPlan: plan,
 					})
 				}
 			}
@@ -313,7 +316,7 @@ func standingDeclarationLocation(pkg runtimecontracts.LoadedProjectPackage, flow
 	return fmt.Sprintf("%s flows[%s]", path, firstNonEmpty(flowID, "<missing>"))
 }
 
-func validateStandingIngressPins(source semanticview.Source, flowID, provider string, eventNames providertriggers.EventNameManifest) error {
+func validateStandingIngressRawPin(source semanticview.Source, flowID, provider string, eventNames providertriggers.EventNameManifest) error {
 	literal := strings.TrimSpace(eventNames.Literal)
 	template := strings.TrimSpace(eventNames.Template)
 	if literal != "" {

--- a/internal/runtime/standing_targets_test.go
+++ b/internal/runtime/standing_targets_test.go
@@ -196,7 +196,7 @@ func TestRuntimeContextManagerLookupIngressDistinguishesAliasAndProvider(t *test
 	}
 }
 
-func TestInboundGatewayRejectsMappedEventBeforeMarkerOrPublish(t *testing.T) {
+func TestInboundGatewayConsumesCompiledTelegramRouteWithoutReinterpretingStandingPins(t *testing.T) {
 	source, catalog := standingTelegramDeclarationSource(t, "lead.observed")
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
@@ -219,23 +219,22 @@ func TestInboundGatewayRejectsMappedEventBeforeMarkerOrPublish(t *testing.T) {
 		SigningSecret: "telegram-secret",
 		AdmissionPlan: plan,
 	}, source)
-	if rec.Code != http.StatusUnprocessableEntity || !strings.Contains(rec.Body.String(), "no exact external input pin") {
-		t.Fatalf("response = %d %q, want exact-pin rejection", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("response = %d %q, want compiled-plan acceptance", rec.Code, rec.Body.String())
 	}
-	if store.recorded || len(eventStore.events) != 0 {
-		t.Fatalf("rejected mapped event persisted marker=%v events=%d", store.recorded, len(eventStore.events))
+	if !eventStore.recorded || len(eventStore.events) != 1 {
+		t.Fatalf("compiled mapped event persisted marker=%v events=%d", eventStore.recorded, len(eventStore.events))
 	}
 }
 
-func TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish(t *testing.T) {
+func TestInboundGatewayConsumesCompiledGitHubRouteWithoutReinterpretingDynamicPins(t *testing.T) {
 	source, catalog := standingProviderDeclarationSource(t, "github", "inbound.github.issues")
 	eventStore := &capturingInboundEventStore{}
 	bus, err := runtimebus.NewEventBus(eventStore)
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	store := &recordingInboundStore{inserted: true}
-	gateway := NewInboundGateway(bus, nil, nil, store)
+	gateway := NewInboundGateway(bus, nil, nil)
 	gateway.SetCredentialStore(identityInboundCredentialStore{})
 	body := []byte(`{"action":"created","issue":{"number":7}}`)
 	mac := hmac.New(sha256.New, []byte("github-secret"))
@@ -256,11 +255,11 @@ func TestInboundGatewayRejectsUnboundGitHubDynamicEventBeforeMarkerOrPublish(t *
 		SigningSecret: "github-secret",
 		AdmissionPlan: plan,
 	}, source)
-	if rec.Code != http.StatusUnprocessableEntity || !strings.Contains(rec.Body.String(), `resolved event "inbound.github.issue_comment"`) || !strings.Contains(rec.Body.String(), "has no exact external input pin") {
-		t.Fatalf("response = %d %q, want exact mapped dynamic-event rejection", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("response = %d %q, want compiled-plan acceptance", rec.Code, rec.Body.String())
 	}
-	if store.recorded || len(eventStore.events) != 0 {
-		t.Fatalf("rejected dynamic event persisted marker=%v events=%d", store.recorded, len(eventStore.events))
+	if !eventStore.recorded || len(eventStore.events) != 1 {
+		t.Fatalf("compiled dynamic event persisted marker=%v events=%d", eventStore.recorded, len(eventStore.events))
 	}
 }
 

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,13 +17,19 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
+	storetest "github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
 )
 
 const templateInstanceDeliveryRunID = "99999999-9999-4999-8999-999999999901"
@@ -887,6 +894,424 @@ pins:
   event_handlers:
     deploy.done: {}
 `,
+	}
+}
+
+func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
+	checkpoints := []struct {
+		name           string
+		databaseTable  string
+		mutation       providerRollbackMutationCheckpoint
+		withoutCarrier bool
+		retry          bool
+	}{
+		{name: "after receiver flow-instance creation", databaseTable: "flow_instances"},
+		{name: "after receiver entity creation", databaseTable: "entity_state"},
+		{name: "after receiver route materialization", databaseTable: "routing_rules"},
+		{name: "after raw append", mutation: providerRollbackAfterRawAppend},
+		{name: "after raw replay before normalized append", mutation: providerRollbackBeforeNormalizedAppend},
+		{name: "after normalized append before delivery", mutation: providerRollbackBeforeDelivery},
+		{name: "after delivery before normalized replay", mutation: providerRollbackBeforeNormalizedReplay},
+		{name: "after normalized replay before receipt", mutation: providerRollbackBeforeReceipt, withoutCarrier: true},
+		{name: "after receipt before dead letter", mutation: providerRollbackBeforeDeadLetter, withoutCarrier: true},
+		{name: "immediately before commit", mutation: providerRollbackBeforeCommit, retry: true},
+	}
+	backends := []struct {
+		name  string
+		setup func(*testing.T, providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore)
+	}{
+		{
+			name: "postgres",
+			setup: func(t *testing.T, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				ctx := seedRuntimeTestRun(t, db)
+				return ctx, db, &providerRollbackPostgresStore{
+					PostgresStore: &store.PostgresStore{DB: db},
+					proof:         &providerRollbackProof{checkpoint: checkpoint},
+				}
+			},
+		},
+		{
+			name: "sqlite",
+			setup: func(t *testing.T, checkpoint providerRollbackMutationCheckpoint) (context.Context, *sql.DB, runtimebus.EventStore) {
+				sqliteStore := storetest.StartSQLiteRuntimeStore(t)
+				ctx := runtimecorrelation.WithRunID(context.Background(), templateInstanceDeliveryRunID)
+				if _, err := sqliteStore.DB.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES (?, 'running')`, templateInstanceDeliveryRunID); err != nil {
+					t.Fatalf("seed SQLite rollback run: %v", err)
+				}
+				return ctx, sqliteStore.DB, &providerRollbackSQLiteStore{
+					SQLiteRuntimeStore: sqliteStore,
+					proof:              &providerRollbackProof{checkpoint: checkpoint},
+				}
+			},
+		},
+	}
+
+	for _, backend := range backends {
+		for _, checkpoint := range checkpoints {
+			t.Run(backend.name+"/"+checkpoint.name, func(t *testing.T) {
+				ctx, db, eventStore := backend.setup(t, checkpoint.mutation)
+				if checkpoint.databaseTable != "" {
+					installProviderRollbackTrigger(t, ctx, db, backend.name, checkpoint.databaseTable)
+				}
+				source := providerRollbackSemanticSource(t, !checkpoint.withoutCarrier)
+				plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, []runtimeprovideroutput.Authorization{providerRollbackAuthorization()})
+				if len(issues) != 0 || len(plans) != 1 {
+					t.Fatalf("target-free rollback fixture plans=%#v issues=%#v, want one plan", plans, issues)
+				}
+				workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+				if backend.name == "sqlite" {
+					workflowStore = runtimepipeline.NewSQLiteWorkflowInstanceStore(db)
+				}
+				var manager *runtimemanager.AgentManager
+				bus, err := runtimebus.NewEventBusWithOptions(eventStore, runtimebus.EventBusOptions{
+					ContractBundle: source,
+					TemplateInstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
+						if manager == nil {
+							return errors.New("agent manager is required")
+						}
+						return manager.ActivateFlowInstance(ctx, req)
+					},
+				})
+				if err != nil {
+					t.Fatalf("NewEventBusWithOptions: %v", err)
+				}
+				manager = runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+					WorkflowInstances: workflowStore,
+				})
+
+				batch := providerRollbackInboundBatch()
+				if _, err := bus.PublishInboundDelivery(ctx, batch); err == nil || !strings.Contains(err.Error(), "injected provider rollback checkpoint") {
+					t.Fatalf("PublishInboundDelivery error = %v, want injected checkpoint", err)
+				}
+				assertProviderRollbackTablesEmpty(t, ctx, db)
+
+				if checkpoint.retry {
+					result, err := bus.PublishInboundDelivery(ctx, batch)
+					if err != nil {
+						t.Fatalf("retry PublishInboundDelivery: %v", err)
+					}
+					if result.Duplicate {
+						t.Fatal("retry was classified duplicate after rolled-back pre-commit failure")
+					}
+					assertProviderRollbackRetryCommitted(t, ctx, db)
+				}
+			})
+		}
+	}
+}
+
+type providerRollbackMutationCheckpoint string
+
+const (
+	providerRollbackAfterRawAppend         providerRollbackMutationCheckpoint = "after_raw_append"
+	providerRollbackBeforeNormalizedAppend providerRollbackMutationCheckpoint = "before_normalized_append"
+	providerRollbackBeforeDelivery         providerRollbackMutationCheckpoint = "before_delivery"
+	providerRollbackBeforeNormalizedReplay providerRollbackMutationCheckpoint = "before_normalized_replay"
+	providerRollbackBeforeReceipt          providerRollbackMutationCheckpoint = "before_receipt"
+	providerRollbackBeforeDeadLetter       providerRollbackMutationCheckpoint = "before_dead_letter"
+	providerRollbackBeforeCommit           providerRollbackMutationCheckpoint = "before_commit"
+)
+
+type providerRollbackProof struct {
+	checkpoint providerRollbackMutationCheckpoint
+	failed     bool
+	appends    int
+	replays    int
+}
+
+func (p *providerRollbackProof) fail(checkpoint providerRollbackMutationCheckpoint) error {
+	if p == nil || p.failed || p.checkpoint != checkpoint {
+		return nil
+	}
+	p.failed = true
+	return fmt.Errorf("injected provider rollback checkpoint %s", checkpoint)
+}
+
+type providerRollbackPostgresStore struct {
+	*store.PostgresStore
+	proof *providerRollbackProof
+}
+
+func (s *providerRollbackPostgresStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	return s.PostgresStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		if err := fn(newProviderRollbackMutation(mutation, s.proof)); err != nil {
+			return err
+		}
+		return s.proof.fail(providerRollbackBeforeCommit)
+	})
+}
+
+type providerRollbackSQLiteStore struct {
+	*store.SQLiteRuntimeStore
+	proof *providerRollbackProof
+}
+
+func (s *providerRollbackSQLiteStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
+	return s.SQLiteRuntimeStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		if err := fn(newProviderRollbackMutation(mutation, s.proof)); err != nil {
+			return err
+		}
+		return s.proof.fail(providerRollbackBeforeCommit)
+	})
+}
+
+type providerRollbackMutation struct {
+	runtimebus.EventMutation
+	proof *providerRollbackProof
+}
+
+func newProviderRollbackMutation(mutation runtimebus.EventMutation, proof *providerRollbackProof) *providerRollbackMutation {
+	return &providerRollbackMutation{EventMutation: mutation, proof: proof}
+}
+
+func (m *providerRollbackMutation) Context() context.Context {
+	return runtimebus.WithEventMutationContext(m.EventMutation.Context(), m)
+}
+
+func (m *providerRollbackMutation) ClaimInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	inbound, ok := m.EventMutation.(runtimebus.InboundDeliveryMutation)
+	if !ok {
+		return false, errors.New("selected-store mutation does not support inbound claims")
+	}
+	return inbound.ClaimInboundEvent(ctx, providerEventID, entityID, provider)
+}
+
+func (m *providerRollbackMutation) AppendEvent(ctx context.Context, evt events.Event) error {
+	m.proof.appends++
+	if m.proof.appends == 2 {
+		if err := m.proof.fail(providerRollbackBeforeNormalizedAppend); err != nil {
+			return err
+		}
+	}
+	return m.EventMutation.AppendEvent(ctx, evt)
+}
+
+func (m *providerRollbackMutation) InsertEventDeliveries(ctx context.Context, eventID string, agentIDs []string) error {
+	if err := m.proof.fail(providerRollbackBeforeDelivery); err != nil {
+		return err
+	}
+	return m.EventMutation.InsertEventDeliveries(ctx, eventID, agentIDs)
+}
+
+func (m *providerRollbackMutation) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, targets map[string]events.RouteIdentity) error {
+	if err := m.proof.fail(providerRollbackBeforeDelivery); err != nil {
+		return err
+	}
+	return m.EventMutation.InsertEventDeliveriesWithTargets(ctx, eventID, agentIDs, targets)
+}
+
+func (m *providerRollbackMutation) InsertEventDeliveryRoutes(ctx context.Context, eventID string, routes []events.DeliveryRoute) error {
+	if err := m.proof.fail(providerRollbackBeforeDelivery); err != nil {
+		return err
+	}
+	return m.EventMutation.InsertEventDeliveryRoutes(ctx, eventID, routes)
+}
+
+func (m *providerRollbackMutation) UpsertCommittedReplayScope(ctx context.Context, eventID string, scope runtimereplayclaim.CommittedReplayScope) error {
+	m.proof.replays++
+	if m.proof.replays == 1 {
+		if err := m.proof.fail(providerRollbackAfterRawAppend); err != nil {
+			return err
+		}
+	}
+	if m.proof.replays == 2 {
+		if err := m.proof.fail(providerRollbackBeforeNormalizedReplay); err != nil {
+			return err
+		}
+	}
+	return m.EventMutation.UpsertCommittedReplayScope(ctx, eventID, scope)
+}
+
+func (m *providerRollbackMutation) UpsertPipelineReceipt(ctx context.Context, eventID, status string, failure *runtimefailures.Envelope) error {
+	if err := m.proof.fail(providerRollbackBeforeReceipt); err != nil {
+		return err
+	}
+	return m.EventMutation.UpsertPipelineReceipt(ctx, eventID, status, failure)
+}
+
+func (m *providerRollbackMutation) RecordDeadLetter(ctx context.Context, record runtimedeadletters.Record) error {
+	if err := m.proof.fail(providerRollbackBeforeDeadLetter); err != nil {
+		return err
+	}
+	return m.EventMutation.RecordDeadLetter(ctx, record)
+}
+
+type providerRollbackSource struct {
+	semanticview.Source
+	authorization runtimeprovideroutput.Authorization
+}
+
+func (s providerRollbackSource) ProviderTriggerTargetFreeAuthorizations() []runtimeprovideroutput.Authorization {
+	return []runtimeprovideroutput.Authorization{s.authorization}
+}
+
+func (s providerRollbackSource) BaseSemanticSource() semanticview.Source {
+	return s.Source
+}
+
+func providerRollbackSemanticSource(t *testing.T, withCarrier bool) semanticview.Source {
+	t.Helper()
+	bundle := loadRuntimeTempBundle(t, providerRollbackFixtureFiles(withCarrier))
+	return providerRollbackSource{Source: semanticview.Wrap(bundle), authorization: providerRollbackAuthorization()}
+}
+
+func providerRollbackAuthorization() runtimeprovideroutput.Authorization {
+	return runtimeprovideroutput.Authorization{
+		Provider: "telegram", Event: "inbound.telegram.text_message",
+		PackID: "provider.telegram", PackVersion: "1.0.0",
+		ManifestHash: "sha256:" + strings.Repeat("a", 64), GenerationID: "rollback-generation",
+	}
+}
+
+func providerRollbackInboundBatch() runtimebus.InboundDeliveryBatch {
+	entityID := "22222222-2222-4222-8222-222222222222"
+	now := time.Now().UTC()
+	return runtimebus.InboundDeliveryBatch{
+		Claim: runtimebus.InboundDeliveryClaim{
+			ProviderEventID: "provider-rollback-delivery", EntityID: entityID, Provider: "telegram",
+		},
+		Events: []runtimebus.InboundDeliveryEvent{
+			{Event: eventtest.RootIngress(
+				uuid.NewString(), "inbound.telegram", "inbound-gateway", "", []byte(`{"raw":true}`), 0,
+				templateInstanceDeliveryRunID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), now,
+			), Kind: runtimeprovideroutput.KindRaw},
+			{Event: eventtest.RootIngress(
+				uuid.NewString(), "inbound.telegram.text_message", "inbound-gateway", "", []byte(`{"chat_id":"42"}`), 0,
+				templateInstanceDeliveryRunID, "", events.EventEnvelope{}, now,
+			), Kind: runtimeprovideroutput.KindNormalized, Authorization: providerRollbackAuthorization()},
+		},
+		AcknowledgeBeforeDispatch: true,
+	}
+}
+
+func installProviderRollbackTrigger(t *testing.T, ctx context.Context, db *sql.DB, backend, table string) {
+	t.Helper()
+	if backend == "sqlite" {
+		statement := fmt.Sprintf(`
+			CREATE TRIGGER provider_rollback_checkpoint
+			AFTER INSERT ON %s
+			BEGIN
+				SELECT RAISE(ABORT, 'injected provider rollback checkpoint after %s creation');
+			END
+		`, table, table)
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("install SQLite rollback trigger on %s: %v", table, err)
+		}
+		return
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE OR REPLACE FUNCTION provider_rollback_checkpoint() RETURNS trigger AS $$
+		BEGIN
+			RAISE EXCEPTION 'injected provider rollback checkpoint after creation';
+		END;
+		$$ LANGUAGE plpgsql
+	`); err != nil {
+		t.Fatalf("install Postgres rollback function: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TRIGGER provider_rollback_checkpoint
+		AFTER INSERT ON %s
+		FOR EACH ROW EXECUTE FUNCTION provider_rollback_checkpoint()
+	`, table)); err != nil {
+		t.Fatalf("install Postgres rollback trigger on %s: %v", table, err)
+	}
+}
+
+func assertProviderRollbackTablesEmpty(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for _, table := range []string{"events", "event_deliveries", "event_receipts", "flow_instances", "entity_state", "routing_rules"} {
+		var count int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil {
+			t.Fatalf("count %s after rollback: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows after rollback = %d, want 0", table, count)
+		}
+	}
+	var runs int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM runs").Scan(&runs); err != nil {
+		t.Fatalf("count runs after rollback: %v", err)
+	}
+	if runs != 1 {
+		t.Fatalf("runs after rollback = %d, want seeded standing run only", runs)
+	}
+}
+
+func assertProviderRollbackRetryCommitted(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	for table, minimum := range map[string]int{
+		"events": 3, "event_deliveries": 1, "flow_instances": 1, "entity_state": 1, "routing_rules": 1,
+	} {
+		var count int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil {
+			t.Fatalf("count %s after retry: %v", table, err)
+		}
+		if count < minimum {
+			t.Fatalf("%s rows after retry = %d, want at least %d", table, count, minimum)
+		}
+	}
+}
+
+func providerRollbackFixtureFiles(withCarrier bool) map[string]string {
+	nodes := "{}\n"
+	if withCarrier {
+		nodes = `consumer-node:
+  id: consumer-node-{instance_id}
+  execution_type: system_node
+  event_handlers:
+    inbound.telegram.text_message: {}
+`
+	}
+	return map[string]string{
+		"package.yaml": `name: provider-rollback-proof
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: consumer
+    flow: consumer
+    mode: template
+`,
+		"schema.yaml": "name: provider-rollback-proof\n",
+		"policy.yaml": "{}\n",
+		"tools.yaml":  "{}\n",
+		"agents.yaml": "{}\n",
+		"events.yaml": `inbound.telegram:
+  raw: boolean
+inbound.telegram.text_message:
+  chat_id: text
+`,
+		"nodes.yaml": "{}\n",
+		"flows/consumer/schema.yaml": `name: consumer
+mode: template
+instance:
+  by: chat_id
+  on_missing: create
+  on_conflict: reuse
+pins:
+  inputs:
+    events:
+      - name: telegram_text
+        event: inbound.telegram.text_message
+        source: external
+        resolution:
+          mode: select-or-create
+          instance_key: chat_id
+        carries:
+          chat_id:
+            from: payload.chat_id
+            type: text
+`,
+		"flows/consumer/policy.yaml": "{}\n",
+		"flows/consumer/agents.yaml": "{}\n",
+		"flows/consumer/events.yaml": "{}\n",
+		"flows/consumer/entities.yaml": `chat:
+  chat_id:
+    type: text
+    indexed: true
+`,
+		"flows/consumer/nodes.yaml": nodes,
 	}
 }
 

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -900,14 +900,13 @@ pins:
 func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 	checkpoints := []struct {
 		name           string
-		databaseTable  string
 		mutation       providerRollbackMutationCheckpoint
 		withoutCarrier bool
 		retry          bool
 	}{
-		{name: "after receiver flow-instance creation", databaseTable: "flow_instances"},
-		{name: "after receiver entity creation", databaseTable: "entity_state"},
-		{name: "after receiver route materialization", databaseTable: "routing_rules"},
+		{name: "after receiver flow-instance creation", mutation: providerRollbackAfterFlowInstanceCreation},
+		{name: "after receiver entity creation", mutation: providerRollbackAfterEntityCreation},
+		{name: "after receiver route materialization", mutation: providerRollbackAfterRouteMaterialization},
 		{name: "after raw append", mutation: providerRollbackAfterRawAppend},
 		{name: "after raw replay before normalized append", mutation: providerRollbackBeforeNormalizedAppend},
 		{name: "after normalized append before delivery", mutation: providerRollbackBeforeDelivery},
@@ -952,9 +951,6 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 		for _, checkpoint := range checkpoints {
 			t.Run(backend.name+"/"+checkpoint.name, func(t *testing.T) {
 				ctx, db, eventStore := backend.setup(t, checkpoint.mutation)
-				if checkpoint.databaseTable != "" {
-					installProviderRollbackTrigger(t, ctx, db, backend.name, checkpoint.databaseTable)
-				}
 				source := providerRollbackSemanticSource(t, !checkpoint.withoutCarrier)
 				plans, issues := runtimepinrouting.LowerTargetFreeInputRoutePlans(source, []runtimeprovideroutput.Authorization{providerRollbackAuthorization()})
 				if len(issues) != 0 || len(plans) != 1 {
@@ -966,7 +962,7 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 				}
 				var manager *runtimemanager.AgentManager
 				bus, err := runtimebus.NewEventBusWithOptions(eventStore, runtimebus.EventBusOptions{
-					ContractBundle: source,
+					ContractBundle: source, ProviderOutputVerifier: source.(runtimebus.ProviderOutputAuthorizationVerifier),
 					TemplateInstanceActivator: func(ctx context.Context, req runtimepipeline.FlowInstanceActivationRequest) error {
 						if manager == nil {
 							return errors.New("agent manager is required")
@@ -1005,13 +1001,16 @@ func TestProviderNormalizedLifecycleRollbackMatrix(t *testing.T) {
 type providerRollbackMutationCheckpoint string
 
 const (
-	providerRollbackAfterRawAppend         providerRollbackMutationCheckpoint = "after_raw_append"
-	providerRollbackBeforeNormalizedAppend providerRollbackMutationCheckpoint = "before_normalized_append"
-	providerRollbackBeforeDelivery         providerRollbackMutationCheckpoint = "before_delivery"
-	providerRollbackBeforeNormalizedReplay providerRollbackMutationCheckpoint = "before_normalized_replay"
-	providerRollbackBeforeReceipt          providerRollbackMutationCheckpoint = "before_receipt"
-	providerRollbackBeforeDeadLetter       providerRollbackMutationCheckpoint = "before_dead_letter"
-	providerRollbackBeforeCommit           providerRollbackMutationCheckpoint = "before_commit"
+	providerRollbackAfterFlowInstanceCreation providerRollbackMutationCheckpoint = "after_flow_instance_creation"
+	providerRollbackAfterEntityCreation       providerRollbackMutationCheckpoint = "after_entity_creation"
+	providerRollbackAfterRouteMaterialization providerRollbackMutationCheckpoint = "after_route_materialization"
+	providerRollbackAfterRawAppend            providerRollbackMutationCheckpoint = "after_raw_append"
+	providerRollbackBeforeNormalizedAppend    providerRollbackMutationCheckpoint = "before_normalized_append"
+	providerRollbackBeforeDelivery            providerRollbackMutationCheckpoint = "before_delivery"
+	providerRollbackBeforeNormalizedReplay    providerRollbackMutationCheckpoint = "before_normalized_replay"
+	providerRollbackBeforeReceipt             providerRollbackMutationCheckpoint = "before_receipt"
+	providerRollbackBeforeDeadLetter          providerRollbackMutationCheckpoint = "before_dead_letter"
+	providerRollbackBeforeCommit              providerRollbackMutationCheckpoint = "before_commit"
 )
 
 type providerRollbackProof struct {
@@ -1034,6 +1033,10 @@ type providerRollbackPostgresStore struct {
 	proof *providerRollbackProof
 }
 
+func (s *providerRollbackPostgresStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
+	return upsertProviderRollbackFlowInstanceRoute(ctx, route, s.proof, s.PostgresStore.UpsertFlowInstanceRoute)
+}
+
 func (s *providerRollbackPostgresStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
 	return s.PostgresStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
 		if err := fn(newProviderRollbackMutation(mutation, s.proof)); err != nil {
@@ -1048,6 +1051,10 @@ type providerRollbackSQLiteStore struct {
 	proof *providerRollbackProof
 }
 
+func (s *providerRollbackSQLiteStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
+	return upsertProviderRollbackFlowInstanceRoute(ctx, route, s.proof, s.SQLiteRuntimeStore.UpsertFlowInstanceRoute)
+}
+
 func (s *providerRollbackSQLiteStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
 	return s.SQLiteRuntimeStore.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
 		if err := fn(newProviderRollbackMutation(mutation, s.proof)); err != nil {
@@ -1055,6 +1062,54 @@ func (s *providerRollbackSQLiteStore) RunEventMutation(ctx context.Context, fn f
 		}
 		return s.proof.fail(providerRollbackBeforeCommit)
 	})
+}
+
+func upsertProviderRollbackFlowInstanceRoute(
+	ctx context.Context,
+	route runtimebus.FlowInstanceRouteRecord,
+	proof *providerRollbackProof,
+	upsert func(context.Context, runtimebus.FlowInstanceRouteRecord) error,
+) error {
+	switch proof.checkpoint {
+	case providerRollbackAfterFlowInstanceCreation:
+		if err := requireProviderRollbackRowVisible(ctx, "flow_instances"); err != nil {
+			return err
+		}
+		return proof.fail(providerRollbackAfterFlowInstanceCreation)
+	case providerRollbackAfterEntityCreation:
+		if err := requireProviderRollbackRowVisible(ctx, "entity_state"); err != nil {
+			return err
+		}
+		return proof.fail(providerRollbackAfterEntityCreation)
+	}
+	if err := upsert(ctx, route); err != nil {
+		return err
+	}
+	if proof.checkpoint == providerRollbackAfterRouteMaterialization {
+		if err := requireProviderRollbackRowVisible(ctx, "routing_rules"); err != nil {
+			return err
+		}
+		return proof.fail(providerRollbackAfterRouteMaterialization)
+	}
+	return nil
+}
+
+func requireProviderRollbackRowVisible(ctx context.Context, table string) error {
+	if table != "flow_instances" && table != "entity_state" && table != "routing_rules" {
+		return fmt.Errorf("unsupported provider rollback proof table %q", table)
+	}
+	tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx)
+	if !ok || tx == nil {
+		return fmt.Errorf("provider rollback proof requires ambient selected-store transaction")
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil {
+		return fmt.Errorf("inspect %s before injected later failure: %w", table, err)
+	}
+	if count == 0 {
+		return fmt.Errorf("%s row was not visible before injected later failure", table)
+	}
+	return nil
 }
 
 type providerRollbackMutation struct {
@@ -1147,6 +1202,13 @@ func (s providerRollbackSource) ProviderTriggerTargetFreeAuthorizations() []runt
 	return []runtimeprovideroutput.Authorization{s.authorization}
 }
 
+func (s providerRollbackSource) VerifyProviderOutputAuthorization(actual runtimeprovideroutput.Authorization) error {
+	if !s.authorization.Matches(actual) {
+		return errors.New("authorization does not match rollback catalog owner")
+	}
+	return nil
+}
+
 func (s providerRollbackSource) BaseSemanticSource() semanticview.Source {
 	return s.Source
 }
@@ -1183,39 +1245,6 @@ func providerRollbackInboundBatch() runtimebus.InboundDeliveryBatch {
 			), Kind: runtimeprovideroutput.KindNormalized, Authorization: providerRollbackAuthorization()},
 		},
 		AcknowledgeBeforeDispatch: true,
-	}
-}
-
-func installProviderRollbackTrigger(t *testing.T, ctx context.Context, db *sql.DB, backend, table string) {
-	t.Helper()
-	if backend == "sqlite" {
-		statement := fmt.Sprintf(`
-			CREATE TRIGGER provider_rollback_checkpoint
-			AFTER INSERT ON %s
-			BEGIN
-				SELECT RAISE(ABORT, 'injected provider rollback checkpoint after %s creation');
-			END
-		`, table, table)
-		if _, err := db.ExecContext(ctx, statement); err != nil {
-			t.Fatalf("install SQLite rollback trigger on %s: %v", table, err)
-		}
-		return
-	}
-	if _, err := db.ExecContext(ctx, `
-		CREATE OR REPLACE FUNCTION provider_rollback_checkpoint() RETURNS trigger AS $$
-		BEGIN
-			RAISE EXCEPTION 'injected provider rollback checkpoint after creation';
-		END;
-		$$ LANGUAGE plpgsql
-	`); err != nil {
-		t.Fatalf("install Postgres rollback function: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(`
-		CREATE TRIGGER provider_rollback_checkpoint
-		AFTER INSERT ON %s
-		FOR EACH ROW EXECUTE FUNCTION provider_rollback_checkpoint()
-	`, table)); err != nil {
-		t.Fatalf("install Postgres rollback trigger on %s: %v", table, err)
 	}
 }
 

--- a/internal/runtime/workflow_validation.go
+++ b/internal/runtime/workflow_validation.go
@@ -65,6 +65,10 @@ func ValidateWorkflowContractSurface(ctx context.Context, source semanticview.So
 	if err != nil {
 		return result, fmt.Errorf("provider connector pack import failed: %w", err)
 	}
+	source, err = SourceWithProviderTriggerEvents(source, opts.ProviderTriggerCatalog)
+	if err != nil {
+		return result, fmt.Errorf("provider trigger event import failed: %w", err)
+	}
 
 	result.BootReport = runtimebootverify.Run(ctx, source, runtimebootverify.Options{
 		Credentials:             opts.Credentials,

--- a/internal/store/event_mutation.go
+++ b/internal/store/event_mutation.go
@@ -124,6 +124,20 @@ func (m *sqlEventMutation) RecordDeadLetter(ctx context.Context, rec runtimedead
 	return recorder.RecordDeadLetterTx(m.operationContext(ctx), m.tx, rec)
 }
 
+func (m *sqlEventMutation) ClaimInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	if m == nil {
+		return false, fmt.Errorf("event mutation store is required")
+	}
+	if err := m.validatePipelineTransaction(ctx); err != nil {
+		return false, err
+	}
+	writer, ok := m.store.(runtimebus.TransactionalInboundEventPersistence)
+	if !ok || writer == nil {
+		return false, fmt.Errorf("event mutation store does not support inbound delivery claims")
+	}
+	return writer.ClaimInboundEventTx(m.operationContext(ctx), m.tx, providerEventID, entityID, provider)
+}
+
 func (s *SQLiteRuntimeStore) RunEventMutation(ctx context.Context, fn func(runtimebus.EventMutation) error) error {
 	if fn == nil {
 		return nil

--- a/internal/store/flow_instance_routes.go
+++ b/internal/store/flow_instance_routes.go
@@ -205,6 +205,193 @@ func (s *PostgresStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimefl
 	return out, nil
 }
 
+func (s *SQLiteRuntimeStore) UpsertFlowInstanceRoute(ctx context.Context, route runtimebus.FlowInstanceRouteRecord) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required for flow instance routes")
+	}
+	return s.runRuntimeMutation(ctx, "upsert flow instance route", func(txctx context.Context, tx *sql.Tx) error {
+		return upsertSQLiteFlowInstanceRouteTx(txctx, tx, route)
+	})
+}
+
+func upsertSQLiteFlowInstanceRouteTx(ctx context.Context, tx *sql.Tx, route runtimebus.FlowInstanceRouteRecord) error {
+	if tx == nil {
+		return fmt.Errorf("sqlite flow instance route transaction is required")
+	}
+	route.Identity = runtimeflowidentity.StoredRoute(route.Identity.ScopeKey, route.Identity.InstanceID, route.Identity.InstancePath)
+	if !route.Identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
+	}
+	sourceFlow := strings.TrimSpace(route.SourceFlow)
+	if sourceFlow == "" {
+		sourceFlow = route.Identity.ScopeKey
+	}
+	var materializedFrom sql.NullString
+	if strings.TrimSpace(route.EventPattern) != "" && strings.TrimSpace(route.SubscriberType) != "" && strings.TrimSpace(route.SubscriberID) != "" {
+		_ = tx.QueryRowContext(ctx, `
+			SELECT CAST(rule_id AS TEXT)
+			FROM routing_rules
+			WHERE event_pattern = ?
+			  AND subscriber_type = ?
+			  AND subscriber_id = ?
+			  AND COALESCE(source_flow, '') = ?
+			  AND is_wildcard = true
+			  AND is_materialized = false
+			  AND status = 'active'
+			ORDER BY created_at ASC
+			LIMIT 1
+		`, route.EventPattern, route.SubscriberType, route.SubscriberID, sourceFlow).Scan(&materializedFrom)
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE routing_rules
+		SET source_flow = NULLIF(?, ''),
+		    materialized_from = ?,
+		    status = 'active'
+		WHERE event_pattern = ?
+		  AND subscriber_type = ?
+		  AND subscriber_id = ?
+		  AND COALESCE(flow_instance, '') = ?
+		  AND is_materialized = true
+	`, sourceFlow, nullableFlowInstanceRouteID(materializedFrom), route.EventPattern, route.SubscriberType, route.SubscriberID, route.Identity.InstancePath)
+	if err != nil {
+		return fmt.Errorf("update SQLite flow instance route %s/%s: %w", route.Identity.ScopeKey, route.Identity.InstanceID, err)
+	}
+	if rows, rowsErr := res.RowsAffected(); rowsErr == nil && rows > 0 {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO routing_rules (
+			event_pattern, subscriber_type, subscriber_id, flow_instance,
+			source_flow, is_wildcard, is_materialized, materialized_from,
+			status, created_at
+		)
+		VALUES (?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), false, true, ?, 'active', CURRENT_TIMESTAMP)
+	`, route.EventPattern, route.SubscriberType, route.SubscriberID, route.Identity.InstancePath, sourceFlow, nullableFlowInstanceRouteID(materializedFrom)); err != nil {
+		return fmt.Errorf("insert SQLite flow instance route %s/%s: %w", route.Identity.ScopeKey, route.Identity.InstanceID, err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) DeleteFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required for flow instance routes")
+	}
+	return s.runRuntimeMutation(ctx, "delete flow instance route", func(txctx context.Context, tx *sql.Tx) error {
+		return deleteSQLiteFlowInstanceRouteTx(txctx, tx, identity)
+	})
+}
+
+func deleteSQLiteFlowInstanceRouteTx(ctx context.Context, tx *sql.Tx, identity runtimeflowidentity.Route) error {
+	if tx == nil {
+		return fmt.Errorf("sqlite flow instance route transaction is required")
+	}
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
+	}
+	var status string
+	err := tx.QueryRowContext(ctx, `
+		SELECT status
+		FROM flow_instances
+		WHERE instance_id = ?
+	`, identity.InstancePath).Scan(&status)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("flow instance not found for route removal: %s", identity.InstancePath)
+		}
+		return fmt.Errorf("load SQLite flow instance for route removal %s: %w", identity.InstancePath, err)
+	}
+	if strings.TrimSpace(status) != "terminated" {
+		return fmt.Errorf("flow instance route removal requires terminal flow_instances status for %s", identity.InstancePath)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE routing_rules
+		SET status = 'inactive'
+		WHERE flow_instance = ?
+		  AND is_materialized = true
+		  AND status = 'active'
+	`, identity.InstancePath); err != nil {
+		return fmt.Errorf("delete SQLite flow instance route %s/%s: %w", identity.ScopeKey, identity.InstanceID, err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) RollbackFlowInstanceRoute(ctx context.Context, identity runtimeflowidentity.Route) error {
+	if s == nil || s.DB == nil {
+		return fmt.Errorf("sqlite runtime store is required for flow instance routes")
+	}
+	return s.runRuntimeMutation(ctx, "rollback flow instance route", func(txctx context.Context, tx *sql.Tx) error {
+		return rollbackSQLiteFlowInstanceRouteTx(txctx, tx, identity)
+	})
+}
+
+func rollbackSQLiteFlowInstanceRouteTx(ctx context.Context, tx *sql.Tx, identity runtimeflowidentity.Route) error {
+	if tx == nil {
+		return fmt.Errorf("sqlite flow instance route transaction is required")
+	}
+	identity = runtimeflowidentity.StoredRoute(identity.ScopeKey, identity.InstanceID, identity.InstancePath)
+	if !identity.Valid() {
+		return fmt.Errorf("scope_key, instance_id, and instance_path are required")
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE routing_rules
+		SET status = 'inactive'
+		WHERE flow_instance = ?
+		  AND is_materialized = true
+		  AND status = 'active'
+	`, identity.InstancePath); err != nil {
+		return fmt.Errorf("rollback SQLite flow instance route %s/%s: %w", identity.ScopeKey, identity.InstanceID, err)
+	}
+	return nil
+}
+
+func (s *SQLiteRuntimeStore) ListFlowInstanceRoutes(ctx context.Context) ([]runtimeflowidentity.Route, error) {
+	if s == nil || s.DB == nil {
+		return nil, fmt.Errorf("sqlite runtime store is required for flow instance routes")
+	}
+	q := flowInstanceDescriptorQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		q = tx
+	}
+	rows, err := q.QueryContext(ctx, `
+		SELECT COALESCE(NULLIF(source_flow, ''), ''), flow_instance
+		FROM routing_rules
+		JOIN flow_instances fi ON fi.instance_id = routing_rules.flow_instance
+		WHERE is_materialized = true
+		  AND routing_rules.status = 'active'
+		  AND fi.status = 'active'
+		  AND flow_instance IS NOT NULL
+		GROUP BY flow_instance, source_flow
+		ORDER BY flow_instance ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list SQLite flow instance routes: %w", err)
+	}
+	defer rows.Close()
+	out := []runtimeflowidentity.Route{}
+	for rows.Next() {
+		var sourceFlow, instancePath string
+		if err := rows.Scan(&sourceFlow, &instancePath); err != nil {
+			return nil, fmt.Errorf("scan SQLite flow instance route: %w", err)
+		}
+		route := runtimeflowidentity.StoredRoute(sourceFlow, "", instancePath)
+		if route.Valid() {
+			out = append(out, route)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate SQLite flow instance routes: %w", err)
+	}
+	return out, nil
+}
+
+func nullableFlowInstanceRouteID(value sql.NullString) any {
+	if !value.Valid || strings.TrimSpace(value.String) == "" {
+		return nil
+	}
+	return strings.TrimSpace(value.String)
+}
+
 func (s *PostgresStore) ListActiveFlowInstanceDescriptors(ctx context.Context) ([]runtimebus.ActiveFlowInstanceDescriptor, error) {
 	if s == nil || s.DB == nil {
 		return nil, fmt.Errorf("postgres store is required for active flow instance descriptors")

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -2,36 +2,29 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 )
 
 func (s *PostgresStore) RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return false, err
-	}
-	if strings.TrimSpace(providerEventID) == "" {
-		return false, fmt.Errorf("provider_event_id is required")
-	}
-	if strings.TrimSpace(entityID) == "" {
-		return false, fmt.Errorf("entity_id is required")
-	}
-	if strings.TrimSpace(provider) == "" {
-		return false, fmt.Errorf("provider is required")
-	}
-	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
-		if caps.Events.Log != SchemaFlavorCanonical {
-			return false, unsupportedSchemaCapability("events", caps.Events.Log)
+	inserted := false
+	err := s.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		inbound, ok := mutation.(runtimebus.InboundDeliveryMutation)
+		if !ok {
+			return fmt.Errorf("selected-store event mutation does not support inbound delivery claims")
 		}
-		return false, fmt.Errorf("store: inbound event recording requires canonical events.idempotency_key support")
-	}
-	return s.recordInboundEventSpec(ctx, providerEventID, entityID, provider)
+		var err error
+		inserted, err = inbound.ClaimInboundEvent(mutation.Context(), providerEventID, entityID, provider)
+		return err
+	})
+	return inserted, err
 }
 
 func (s *PostgresStore) PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error) {
@@ -48,55 +41,29 @@ func (s *PostgresStore) PurgeInboundEventsBefore(ctx context.Context, before tim
 	return s.purgeInboundEventsSpec(ctx, before, limit)
 }
 
-func (s *PostgresStore) DeleteInboundEvent(ctx context.Context, providerEventID, entityID, provider string) error {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
-	}
-	if strings.TrimSpace(providerEventID) == "" {
-		return fmt.Errorf("provider_event_id is required")
-	}
-	if strings.TrimSpace(entityID) == "" {
-		return fmt.Errorf("entity_id is required")
-	}
-	if strings.TrimSpace(provider) == "" {
-		return fmt.Errorf("provider is required")
-	}
-	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
-		if caps.Events.Log != SchemaFlavorCanonical {
-			return unsupportedSchemaCapability("events", caps.Events.Log)
-		}
-		return fmt.Errorf("store: inbound event deletion requires canonical events.idempotency_key support")
-	}
-	idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
-	_, err = s.DB.ExecContext(ctx, `
-		DELETE FROM events
-		WHERE idempotency_key = $1
-		  AND event_name = 'platform.inbound_recorded'
-		  AND entity_id IS NOT DISTINCT FROM NULLIF($2,'')::uuid
-	`, idempotencyKey, entityID)
-	if err != nil {
-		return fmt.Errorf("delete inbound event marker: %w", err)
-	}
-	return nil
-}
-
-func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+func (s *PostgresStore) ClaimInboundEventTx(ctx context.Context, tx *sql.Tx, providerEventID, entityID, provider string) (bool, error) {
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return false, err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return false, fmt.Errorf("begin inbound event tx: %w", err)
+	if tx == nil {
+		return false, fmt.Errorf("inbound delivery claim transaction is required")
 	}
-	committed := false
-	defer func() {
-		if committed {
-			return
+	if strings.TrimSpace(providerEventID) == "" {
+		return false, fmt.Errorf("provider_event_id is required")
+	}
+	if strings.TrimSpace(entityID) == "" {
+		return false, fmt.Errorf("entity_id is required")
+	}
+	if strings.TrimSpace(provider) == "" {
+		return false, fmt.Errorf("provider is required")
+	}
+	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
+		if caps.Events.Log != SchemaFlavorCanonical {
+			return false, unsupportedSchemaCapability("events", caps.Events.Log)
 		}
-		_ = tx.Rollback()
-	}()
+		return false, fmt.Errorf("store: inbound event recording requires canonical events.idempotency_key support")
+	}
 
 	idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
 	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, idempotencyKey); err != nil {
@@ -116,10 +83,6 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 		return false, fmt.Errorf("check inbound event dedupe: %w", err)
 	}
 	if exists {
-		if err := tx.Commit(); err != nil {
-			return false, fmt.Errorf("commit inbound event dedupe tx: %w", err)
-		}
-		committed = true
 		return false, nil
 	}
 
@@ -183,10 +146,6 @@ func (s *PostgresStore) recordInboundEventSpec(ctx context.Context, providerEven
 	if _, err := tx.ExecContext(ctx, insertQ, args...); err != nil {
 		return false, fmt.Errorf("record inbound event in events: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("commit inbound event tx: %w", err)
-	}
-	committed = true
 	return true, nil
 }
 

--- a/internal/store/inbound_sqlite_test.go
+++ b/internal/store/inbound_sqlite_test.go
@@ -44,24 +44,6 @@ func TestSQLiteRuntimeStore_RecordInboundEvent_DedupesWithCanonicalMarker(t *tes
 	}
 }
 
-func TestSQLiteRuntimeStore_DeleteInboundEventRemovesRollbackMarker(t *testing.T) {
-	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
-	ctx := context.Background()
-	runID := uuid.NewString()
-	entityID := uuid.NewString()
-	seedSQLiteInboundRunAndEntity(t, ctx, sqliteStore, runID, entityID, "customer-a")
-
-	if inserted, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil || !inserted {
-		t.Fatalf("RecordInboundEvent inserted=%v err=%v, want first insert", inserted, err)
-	}
-	if err := sqliteStore.DeleteInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil {
-		t.Fatalf("DeleteInboundEvent: %v", err)
-	}
-	if inserted, err := sqliteStore.RecordInboundEvent(ctx, "delivery-123", entityID, "github"); err != nil || !inserted {
-		t.Fatalf("RecordInboundEvent after delete inserted=%v err=%v, want fresh insert", inserted, err)
-	}
-}
-
 func seedSQLiteInboundRunAndEntity(t *testing.T, ctx context.Context, sqliteStore *SQLiteRuntimeStore, runID, entityID, slug string) {
 	t.Helper()
 	now := time.Now().UTC()

--- a/internal/store/runtime_log_persistence.go
+++ b/internal/store/runtime_log_persistence.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/google/uuid"
 )
 
@@ -46,8 +47,12 @@ func (s *PostgresStore) RuntimeLogLineageParentEventID(ctx context.Context, runI
 	if _, err := uuid.Parse(subjectEventID); err != nil {
 		return "", nil
 	}
+	queryer := rowQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		queryer = tx
+	}
 	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
+	if err := queryer.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM events
@@ -82,9 +87,16 @@ func (s *PostgresStore) PersistRuntimeLog(ctx context.Context, record runtimepkg
 		return err
 	}
 	if strings.TrimSpace(record.RunID) != "" {
+		if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+			return s.AppendEventTx(ctx, tx, evt)
+		}
 		return s.AppendEvent(ctx, evt)
 	}
-	_, err = s.DB.ExecContext(ctx, `
+	execer := execQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		execer = tx
+	}
+	_, err = execer.ExecContext(ctx, `
 		INSERT INTO events (
 			event_id, event_name, entity_id, flow_instance, scope, payload,
 			chain_depth, produced_by, produced_by_type, source_event_id, created_at
@@ -116,8 +128,12 @@ func (s *SQLiteRuntimeStore) RuntimeLogLineageParentEventID(ctx context.Context,
 	if _, err := uuid.Parse(subjectEventID); err != nil {
 		return "", nil
 	}
+	queryer := rowQueryer(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		queryer = tx
+	}
 	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
+	if err := queryer.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM events

--- a/internal/store/runtime_log_persistence_test.go
+++ b/internal/store/runtime_log_persistence_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -364,5 +365,45 @@ func TestPostgresRuntimeLogPersistencePreservesRunSourceAndLineage(t *testing.T)
 	}
 	if sourceEventID != subjectEventID {
 		t.Fatalf("postgres source_event_id = %q, want %q", sourceEventID, subjectEventID)
+	}
+}
+
+func TestPostgresRuntimeLogPersistenceReusesAmbientEventTransaction(t *testing.T) {
+	ctx := context.Background()
+	_, db, cleanup := testutil.StartPostgres(t)
+	defer cleanup()
+	pg := &PostgresStore{DB: db}
+	if _, err := pg.BindSchemaCapabilities(ctx); err != nil {
+		t.Fatalf("BindSchemaCapabilities: %v", err)
+	}
+	runID := uuid.NewString()
+	subjectEventID := uuid.NewString()
+	ctx = runtimecorrelation.WithRunID(ctx, runID)
+	logger := runtimepkg.NewRuntimeLogger(pg)
+
+	if err := pg.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		if err := pg.AppendEventTx(txctx, tx, eventtest.PersistedProjection(
+			subjectEventID, events.EventType("validation/validation.package_ready"),
+			"agent-1", "", json.RawMessage(`{"ready":true}`), 0, runID, "", events.EventEnvelope{}, time.Now().UTC())); err != nil {
+			return err
+		}
+		return logger.Log(txctx, runtimepkg.RuntimeLogEntry{
+			Level: "warn", Message: "transactional diagnostic", Component: "eventbus",
+			Action: "ambient_transaction", EventID: subjectEventID, EventType: "validation/validation.package_ready",
+		})
+	}); err != nil {
+		t.Fatalf("RunEventTransaction: %v", err)
+	}
+
+	var sourceEventID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(source_event_id::text, '')
+		FROM events
+		WHERE event_name = 'platform.runtime_log'
+	`).Scan(&sourceEventID); err != nil {
+		t.Fatalf("load transactional runtime log: %v", err)
+	}
+	if sourceEventID != subjectEventID {
+		t.Fatalf("transactional runtime log source_event_id = %q, want %q", sourceEventID, subjectEventID)
 	}
 }

--- a/internal/store/sqlite_inbound.go
+++ b/internal/store/sqlite_inbound.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/google/uuid"
 )
@@ -17,6 +18,20 @@ import (
 var _ runtime.InboundPersistence = (*SQLiteRuntimeStore)(nil)
 
 func (s *SQLiteRuntimeStore) RecordInboundEvent(ctx context.Context, providerEventID, entityID, provider string) (bool, error) {
+	inserted := false
+	err := s.RunEventMutation(ctx, func(mutation runtimebus.EventMutation) error {
+		inbound, ok := mutation.(runtimebus.InboundDeliveryMutation)
+		if !ok {
+			return fmt.Errorf("selected-store event mutation does not support inbound delivery claims")
+		}
+		var err error
+		inserted, err = inbound.ClaimInboundEvent(mutation.Context(), providerEventID, entityID, provider)
+		return err
+	})
+	return inserted, err
+}
+
+func (s *SQLiteRuntimeStore) ClaimInboundEventTx(ctx context.Context, tx *sql.Tx, providerEventID, entityID, provider string) (bool, error) {
 	if strings.TrimSpace(providerEventID) == "" {
 		return false, fmt.Errorf("provider_event_id is required")
 	}
@@ -36,11 +51,12 @@ func (s *SQLiteRuntimeStore) RecordInboundEvent(ctx context.Context, providerEve
 		}
 		return false, fmt.Errorf("store: inbound event recording requires canonical events.idempotency_key support")
 	}
-	inserted := false
-	err = s.runRuntimeMutation(ctx, "sqlite record inbound event", func(txctx context.Context, tx *sql.Tx) error {
-		idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
-		var exists bool
-		if err := tx.QueryRowContext(txctx, `
+	if tx == nil {
+		return false, fmt.Errorf("inbound delivery claim transaction is required")
+	}
+	idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
 			SELECT EXISTS(
 				SELECT 1
 				FROM events
@@ -49,62 +65,58 @@ func (s *SQLiteRuntimeStore) RecordInboundEvent(ctx context.Context, providerEve
 				  AND entity_id IS ?
 			)
 		`, idempotencyKey, sqliteNullUUID(entityID)).Scan(&exists); err != nil {
-			return fmt.Errorf("check sqlite inbound event dedupe: %w", err)
-		}
-		if exists {
-			inserted = false
-			return nil
-		}
+		return false, fmt.Errorf("check sqlite inbound event dedupe: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
 
-		payload, err := json.Marshal(map[string]any{
-			"provider":          provider,
-			"provider_event_id": providerEventID,
-			"entity_id":         entityID,
-		})
-		if err != nil {
-			return fmt.Errorf("marshal inbound event payload: %w", err)
+	payload, err := json.Marshal(map[string]any{
+		"provider":          provider,
+		"provider_event_id": providerEventID,
+		"entity_id":         entityID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("marshal inbound event payload: %w", err)
+	}
+	if err := s.validateEventPayload("platform.inbound_recorded", payload); err != nil {
+		return false, err
+	}
+	runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(ctx))
+	evt, err := events.AdmitForPersistence(
+		events.NewDiagnosticDirectEvent(
+			uuid.NewString(),
+			events.EventType("platform.inbound_recorded"),
+			provider,
+			"",
+			payload,
+			0,
+			runID,
+			"",
+			events.EventEnvelope{EntityID: entityID},
+			time.Time{},
+		),
+		events.AdmissionOptions{},
+	)
+	if err != nil {
+		return false, err
+	}
+	if caps.Events.LogRunID {
+		if err := sqliteEnsureRunRow(ctx, tx, evt.RunID(), "", "", evt.CreatedAt()); err != nil {
+			return false, err
 		}
-		if err := s.validateEventPayload("platform.inbound_recorded", payload); err != nil {
-			return err
-		}
-		runID := strings.TrimSpace(runtimecorrelation.RunIDFromContext(txctx))
-		evt, err := events.AdmitForPersistence(
-			events.NewDiagnosticDirectEvent(
-				uuid.NewString(),
-				events.EventType("platform.inbound_recorded"),
-				provider,
-				"",
-				payload,
-				0,
-				runID,
-				"",
-				events.EventEnvelope{EntityID: entityID},
-				time.Time{},
-			),
-			events.AdmissionOptions{},
-		)
-		if err != nil {
-			return err
-		}
-		if caps.Events.LogRunID {
-			if err := sqliteEnsureRunRow(txctx, tx, evt.RunID(), "", "", evt.CreatedAt()); err != nil {
-				return err
-			}
-		}
-		_, err = tx.ExecContext(txctx, `
+	}
+	_, err = tx.ExecContext(ctx, `
 			INSERT INTO events (
 				event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
 				scope, payload, chain_depth, produced_by, produced_by_type, idempotency_key, created_at
 			)
 			VALUES (?, ?, 'platform.inbound_recorded', ?, NULL, '{}', '{}', '[]', 'entity', ?, 0, ?, 'external', ?, ?)
 		`, evt.ID(), sqliteNullUUID(evt.RunID()), sqliteNullUUID(entityID), string(evt.Payload()), provider, idempotencyKey, evt.CreatedAt().UTC())
-		if err != nil {
-			return fmt.Errorf("record sqlite inbound event in events: %w", err)
-		}
-		inserted = true
-		return nil
-	})
-	return inserted, err
+	if err != nil {
+		return false, fmt.Errorf("record sqlite inbound event in events: %w", err)
+	}
+	return true, nil
 }
 
 func (s *SQLiteRuntimeStore) PurgeInboundEventsBefore(ctx context.Context, before time.Time, limit int) (int, error) {
@@ -140,38 +152,4 @@ func (s *SQLiteRuntimeStore) PurgeInboundEventsBefore(ctx context.Context, befor
 		return nil
 	})
 	return deleted, err
-}
-
-func (s *SQLiteRuntimeStore) DeleteInboundEvent(ctx context.Context, providerEventID, entityID, provider string) error {
-	if strings.TrimSpace(providerEventID) == "" {
-		return fmt.Errorf("provider_event_id is required")
-	}
-	if strings.TrimSpace(entityID) == "" {
-		return fmt.Errorf("entity_id is required")
-	}
-	if strings.TrimSpace(provider) == "" {
-		return fmt.Errorf("provider is required")
-	}
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
-	}
-	if caps.Events.Log != SchemaFlavorCanonical || !caps.Events.LogIdempotencyKey {
-		if caps.Events.Log != SchemaFlavorCanonical {
-			return unsupportedSchemaCapability("events", caps.Events.Log)
-		}
-		return fmt.Errorf("store: inbound event deletion requires canonical events.idempotency_key support")
-	}
-	return s.runRuntimeMutation(ctx, "sqlite delete inbound event", func(txctx context.Context, tx *sql.Tx) error {
-		idempotencyKey := inboundEventIdempotencyKey(providerEventID, entityID, provider)
-		if _, err := tx.ExecContext(txctx, `
-			DELETE FROM events
-			WHERE idempotency_key = ?
-			  AND event_name = 'platform.inbound_recorded'
-			  AND entity_id IS ?
-		`, idempotencyKey, sqliteNullUUID(entityID)); err != nil {
-			return fmt.Errorf("delete sqlite inbound event marker: %w", err)
-		}
-		return nil
-	})
 }

--- a/packs/provider-triggers/telegram/pack.yaml
+++ b/packs/provider-triggers/telegram/pack.yaml
@@ -2,7 +2,7 @@ id: provider.telegram
 version: 0.1.0
 platform_version: '>=0.7.0 <0.8.0'
 type: trigger
-manifest_hash: sha256:5e3c264b31da7a2d2cba83ab97d9f9af6005c8f35f1fcc25e538e1c9bd5fb638
+manifest_hash: sha256:bd52afaa81475c451b41de343c8c70b6f5f397cfaec6423f0cab8cae410eeeec
 provenance:
     source: platform
 capabilities:
@@ -11,6 +11,7 @@ capabilities:
         verify_secret: webhook_signing.telegram
         emit_events:
             - inbound.telegram
+            - inbound.telegram.text_message
         persist_dedupe_markers: true
     cannot:
         - emit_undeclared_events

--- a/packs/provider-triggers/telegram/trigger.yaml
+++ b/packs/provider-triggers/telegram/trigger.yaml
@@ -17,6 +17,23 @@ event_type:
   required: true
 event_name:
   literal: inbound.telegram
+normalized_events:
+  - event: inbound.telegram.text_message
+    fields:
+      chat_id:
+        from: message.chat.id
+        type: text
+        convert: number_to_text
+      text:
+        from: message.text
+        type: text
+      message_id:
+        from: message.message_id
+        type: integer
+      raw:
+        from: message
+        type: json
+        optional: true
 ack:
   mode: durable_before_dispatch
 metadata:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7966,8 +7966,10 @@ tool_model:
       normalized_events:
         shape: >
           Optional list entries use `{event, fields, when}`. `event` must be an exact `inbound.<provider>.*` literal.
-          `fields` is the same carry-style typed projection vocabulary: each field declares `from`, Wave-1 `type`, optional
-          `optional`, and optional closed conversion. The event payload schema, required set, extraction plan, carry
+          `fields` is the same carry-style typed projection vocabulary: each field declares `from`, a standalone-resolvable
+          Wave-1 `type`, optional `optional`, and optional closed conversion. Because trigger manifests do not declare a
+          type catalog, unresolved named types fail pack load; built-in, list, and map references are validated recursively.
+          The event payload schema, required set, extraction plan, carry
           eligibility, and capability descriptor derive mechanically from this one block.
         paths: >
           `from` and `when.exists/absent` use strict dotted paths relative to the decoded raw provider object. Empty
@@ -7986,8 +7988,11 @@ tool_model:
           text. There is no implicit coercion and unknown conversions fail pack load.
         output_route: >
           Raw and normalized outputs are explicit compiled kinds. Raw is exact-standing-target. Normalized is target-free
-          but inherits the standing run. Only composed pack-owned normalized events may enter the target-free external
-          input-plan lowering path; ordinary events cannot gain this authority by name or catalog presence.
+          but inherits the standing run. The provider-delivery batch carries the normalized kind plus the exact verified
+          pack id/version/manifest_hash/catalog-generation authorization into route planning, which must match the composed
+          plan authorization byte-for-byte. Missing, partial, stale, or mismatched authorization fails before mutation.
+          Only composed pack-owned normalized events may enter the target-free external input-plan lowering path; ordinary
+          events cannot gain this authority by event name, catalog presence, source-agent label, or payload shape.
         source_composition: >
           Before boot verification, packs selected by effective standing ingress bindings import raw and normalized schemas
           into the semantic source. These are imported facts, not authored declarations. Local redeclaration fails closed

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7726,6 +7726,8 @@ tool_model:
     - provider-specific signature policy and signing-secret lookup
     - provider delivery-id extraction and dedupe-key authority
     - provider event-type extraction and canonical Swarm event mapping
+    - pack-declared typed normalized events and target-free template input routing
+    - atomic provider marker, raw/normalized publication, receiver lifecycle, routes, deliveries, replay scopes, and receipts
     - redacted per-request delivery readback in webhook responses and persisted `platform.inbound_recorded` markers
     non_goals:
     - creating a second generic webhook gateway
@@ -7738,7 +7740,10 @@ tool_model:
       provider through the loaded `RuntimeContextManager` standing-target registry. `internal/runtime/inbound.go` remains the
       generic HTTP ingress executor only after that exact target and its immutable InboundAdmissionPlan are resolved. It
       consumes `runtime_ingress.queueable_ingress.inbound.webhook`, executes only that plan, persists the inbound dedupe
-      marker before publish for delivery callbacks, and publishes the normalized root ingress event returned by the plan.
+      marker and every raw/normalized output through one selected-store provider-delivery transaction, and publishes only
+      the typed outputs returned by the plan. The raw output retains the exact standing target. Normalized outputs retain
+      the standing RunID but carry no fixed FlowInstance target, so exact external input-pin resolution owns template
+      select-or-create. The gateway never reinterprets standing pins or normalized paths at request time.
       Provider manifests may also return an authenticated response-only result when the provider protocol requires a
       challenge response that is not a delivery. The gateway MUST NOT inspect catalog presence, provider-specific headers,
       or payload shape to select an interpreter at request time.
@@ -7804,7 +7809,7 @@ tool_model:
         Verification compiles every standing ingress binding into one immutable InboundAdmissionPlan containing the exact
         catalog generation, normalized provider, policy_source (`verified_pack` or `raw_declaration`), exact
         request_authentication, resolved pack id/version/manifest_hash/provenance when applicable, copied executable policy,
-        secret requirement, event-name policy, and unsigned acknowledgement fact. Runtime targets and effective capability
+        secret requirement, typed raw-versus-normalized output manifest, event-name policy, and unsigned acknowledgement fact. Runtime targets and effective capability
         subjects carry this plan; a target without a valid plan is unavailable and the gateway fails before credential
         lookup, body interpretation, marker persistence, or publish.
       process_generation: >
@@ -7819,6 +7824,13 @@ tool_model:
         effective subjects from the compiled owner. Basic describe and routing topology remain declaration-only and show
         authored admission kind/pin/auth/event/acknowledgement facts without claiming resolved pack identity, generation,
         request authentication, or readiness.
+      provider_delivery_transaction: >
+        `runtime/bus.EventBus.PublishInboundDelivery` is the sole provider-delivery mutation owner. In one selected-store
+        transaction it claims `platform.inbound_recorded`, appends the raw event and every matched normalized event, plans
+        exact routes, materializes select-or-create run/entity/flow-instance/route state, and persists delivery, replay, and
+        receipt rows. Any failure rolls back the complete set; no compensating marker deletion path exists. Commit precedes
+        durable webhook acknowledgement. Runtime agent process startup is a post-commit side effect queued before event
+        dispatch; persisted flow-instance and route authority remain transaction participants.
     pack_envelope_source_authority:
       owner: internal/packs universal envelope plus body-specific verifiers such as internal/providertriggers and internal/providerconnectors
       status: >
@@ -7951,6 +7963,40 @@ tool_model:
         Source for the provider payload embedded in the published normalized event. The default `payload` uses the decoded
         JSON object or raw-body wrapper. `form` uses the gateway-parsed `application/x-www-form-urlencoded` parameter set
         and requires the relevant signed-payload recipe to fail closed on malformed form input.
+      normalized_events:
+        shape: >
+          Optional list entries use `{event, fields, when}`. `event` must be an exact `inbound.<provider>.*` literal.
+          `fields` is the same carry-style typed projection vocabulary: each field declares `from`, Wave-1 `type`, optional
+          `optional`, and optional closed conversion. The event payload schema, required set, extraction plan, carry
+          eligibility, and capability descriptor derive mechanically from this one block.
+        paths: >
+          `from` and `when.exists/absent` use strict dotted paths relative to the decoded raw provider object. Empty
+          segments, rooted JSONPath, CEL, runtime namespaces, expression syntax, and unsupported segments fail pack load.
+        predicates: >
+          Omitted `when` means every required field path exists. Authored `when` may add closed `exists` and `absent`
+          constraints. Verification proves every branch pair mutually exclusive; an overlap fails pack load with the two
+          events and a remediation naming `when.absent`. Runtime multi-match rejection remains a fail-closed unreachable
+          backstop. No match publishes the raw event only.
+        extraction: >
+          A matched branch must extract every required field with its declared type. Missing optional fields are omitted.
+          Missing required fields, type mismatch, or conversion failure rejects the provider delivery with pack
+          id/version/manifest_hash, normalized event, field, and path provenance; no marker or output survives.
+        conversion: >
+          The v1 closed enum contains exactly `number_to_text`. It converts a lossless JSON integer to canonical decimal
+          text. There is no implicit coercion and unknown conversions fail pack load.
+        output_route: >
+          Raw and normalized outputs are explicit compiled kinds. Raw is exact-standing-target. Normalized is target-free
+          but inherits the standing run. Only composed pack-owned normalized events may enter the target-free external
+          input-plan lowering path; ordinary events cannot gain this authority by name or catalog presence.
+        source_composition: >
+          Before boot verification, packs selected by effective standing ingress bindings import raw and normalized schemas
+          into the semantic source. These are imported facts, not authored declarations. Local redeclaration fails closed
+          naming both owners. Normalized events retain ordinary exact-consumer and chain checks; an unused raw escape-hatch
+          declaration is legal.
+        capability_surface: >
+          Installed and effective trigger subjects carry structured event descriptors with event, raw|normalized kind,
+          field names/types/requiredness, carry eligibility, and pack provenance. Singular event-name or prose-only
+          capability views are non-authoritative.
       secret.required: require a configured signing secret before accepting the provider callback
       signature: >
         Configured-provider authenticity verification. HMAC-SHA256 and HMAC-SHA1 verify a manifest-selected signed payload,


### PR DESCRIPTION
## Summary

- add a generic pack-declared normalized-event engine with strict dotted projections, derived Wave-1 schemas, default required-path predicates, static overlap exclusion, and the closed `number_to_text` conversion
- compose effective trigger-pack event schemas into the canonical semantic source and route normalized events target-free within the standing run through ordinary exact input-pin/template lifecycle ownership
- publish the provider marker, raw/normalized events, route/lifecycle state, deliveries, replay scopes, and receipts through one selected-store transaction on SQLite and Postgres
- express Telegram `inbound.telegram.text_message` as manifest data and prove the served standing-ingress -> per-chat agent/transcript -> journaled connector-reply journey

Closes #1962
Closes #2009
Part of #1770

#2009 closes only because prerequisite PR #2018 removed wall 1 and this PR removes walls 2/3 by importing pack schemas and eliminating the authored normalizer from the common path.

## Governing refs

There was no exact authoritative spec section for normalized trigger branches or atomic raw+normalized provider delivery before this work. Binding context is the full #1962 thread, its approved Pre-Implementation Coverage Audit and Gate Repair 1, and the independent approved gate outcome. Adjacent contracts are `contract_formats.event_schema`, `tool_model.provider_trigger_adapters`, `tool_model.provider_capability_surface`, standing ingress run authority, exact external input-pin resolution, and selected-store event mutation ownership.

This PR updates authoritative `platform-spec.yaml` under `tool_model.provider_trigger_adapters`, including `compiled_admission_plan`, `provider_delivery_transaction`, and `normalized_events` declaration/path/predicate/extraction/conversion/route/source/capability rules.

## Semantic migration

- **New canonical owners:** `contracts.FieldProjection` for typed path metadata; the immutable `providertriggers.CatalogSnapshot`/`InboundAdmissionPlan` typed output manifest for raw-vs-normalized execution; composed semantic source imports for pack-owned schemas; `EventBus.PublishInboundDelivery` for the complete provider-delivery transaction.
- **Old producer/reader/writer paths now invalid:** singular `EventNames()` / singular delivery ownership; gateway re-interpretation of standing pins per emitted event; marker-before-publish plus compensating `DeleteInboundEvent`; local `events.yaml` redeclaration of pack-owned events; lifecycle writes outside the provider transaction.
- **Production paths checked:** platform/external pack load and generation reload; verify/boot/serve capability projection; standing target compilation; gateway authentication/extraction; event-bus routing and template select-or-create; manager activation; SQLite/Postgres marker/event/delivery/replay/receipt/runtime-log persistence; all existing GitHub/Slack/Stripe/Twilio/Shopify/Typeform/Intercom/Telegram regressions.
- **Migration completeness:** complete for the approved #1962 normalized-event engine and Telegram text-message capability. The broader E5 unified-pack parent #1770 remains open.

## Proof

- `go test ./...` with host Postgres via `SWARM_TEST_POSTGRES_DSN` and `PGPASSWORD`
- served SQLite and Postgres restart journeys prove one standing run, per-chat select-or-create reuse, agent transcript, and Telegram connector reply
- selected-store failure injection proves marker and raw event roll back when normalized append fails on both backends
- existing Postgres template lifecycle failure injection proves entity, flow-instance, persisted route, route-table, event, and delivery rollback
- reload-generation, source collision, static branch overlap, path/conversion/type, capability text/JSON parity, exact input lowering, and deferred agent-start proofs
