### PR TITLE
[agent-f][issue #2038] Prove selected Telegram text contract

### DIFF
--- a/internal/providertriggers/telegram_contract_test.go
+++ b/internal/providertriggers/telegram_contract_test.go
@@ -1,0 +1,267 @@
+package providertriggers
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/packs"
+)
+
+const telegramBotAPIUpdateContract = "Bot API 10.1 (2026-06-11) https://core.telegram.org/bots/api#update"
+
+var telegramBotAPI101UpdateRoots = []string{
+	"message",
+	"edited_message",
+	"channel_post",
+	"edited_channel_post",
+	"business_connection",
+	"business_message",
+	"edited_business_message",
+	"deleted_business_messages",
+	"guest_message",
+	"message_reaction",
+	"message_reaction_count",
+	"inline_query",
+	"chosen_inline_result",
+	"callback_query",
+	"shipping_query",
+	"pre_checkout_query",
+	"purchased_paid_media",
+	"poll",
+	"poll_answer",
+	"my_chat_member",
+	"chat_member",
+	"chat_join_request",
+	"chat_boost",
+	"removed_chat_boost",
+	"managed_bot",
+}
+
+func TestTelegramSelectedTextMessageContractUsesShippedPack(t *testing.T) {
+	_, catalog, plan := telegramPlatformContract(t)
+	delivery, err := plan.Accept(telegramContractRequest(t, map[string]any{
+		"update_id": 101,
+		"message": map[string]any{
+			"message_id": 7,
+			"chat":       map[string]any{"id": -1001234567890},
+			"text":       "hello",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("Accept selected Telegram text message: %v", err)
+	}
+	if len(delivery.Events) != 2 {
+		t.Fatalf("events = %#v, want exactly raw plus text_message", delivery.Events)
+	}
+	if raw := delivery.Events[0]; raw.Kind != OutputKindRaw || raw.Name != "inbound.telegram" || !raw.Authorization.Empty() {
+		t.Fatalf("raw event = %#v", raw)
+	}
+	normalized := delivery.Events[1]
+	if normalized.Kind != OutputKindNormalized || normalized.Name != "inbound.telegram.text_message" {
+		t.Fatalf("normalized event = %#v", normalized)
+	}
+	wantPayload := map[string]any{
+		"chat_id": "-1001234567890", "message_id": json.Number("7"), "text": "hello",
+		"raw": map[string]any{
+			"message_id": json.Number("7"),
+			"chat":       map[string]any{"id": json.Number("-1001234567890")},
+			"text":       "hello",
+		},
+	}
+	if !reflect.DeepEqual(normalized.Payload, wantPayload) {
+		t.Fatalf("normalized payload = %#v, want %#v", normalized.Payload, wantPayload)
+	}
+	if err := catalog.VerifyProviderOutputAuthorization(normalized.Authorization); err != nil {
+		t.Fatalf("VerifyProviderOutputAuthorization: %v", err)
+	}
+}
+
+func TestTelegramBotAPI101ResidualUpdateUnionRemainsRawOnly(t *testing.T) {
+	_, _, plan := telegramPlatformContract(t)
+	fixtures := []struct {
+		name  string
+		root  string
+		value any
+	}{
+		{name: "message missing text", root: "message", value: map[string]any{"message_id": 1, "chat": map[string]any{"id": 42}, "photo": []any{map[string]any{"file_id": "photo"}}}},
+		{name: "message missing chat id", root: "message", value: map[string]any{"message_id": 1, "text": "hello"}},
+		{name: "message missing message id", root: "message", value: map[string]any{"chat": map[string]any{"id": 42}, "text": "hello"}},
+		{name: "edited message", root: "edited_message", value: map[string]any{"message_id": 1}},
+		{name: "channel post", root: "channel_post", value: map[string]any{"message_id": 1}},
+		{name: "edited channel post", root: "edited_channel_post", value: map[string]any{"message_id": 1}},
+		{name: "business connection", root: "business_connection", value: map[string]any{"id": "business"}},
+		{name: "business message", root: "business_message", value: map[string]any{"message_id": 1}},
+		{name: "edited business message", root: "edited_business_message", value: map[string]any{"message_id": 1}},
+		{name: "deleted business messages", root: "deleted_business_messages", value: map[string]any{"business_connection_id": "business"}},
+		{name: "guest message", root: "guest_message", value: map[string]any{"message_id": 1}},
+		{name: "message reaction", root: "message_reaction", value: map[string]any{"date": 1}},
+		{name: "message reaction count", root: "message_reaction_count", value: map[string]any{"date": 1}},
+		{name: "inline query", root: "inline_query", value: map[string]any{"id": "inline"}},
+		{name: "chosen inline result", root: "chosen_inline_result", value: map[string]any{"result_id": "result"}},
+		{name: "callback message data", root: "callback_query", value: telegramCallbackFixture(map[string]any{"message": telegramCallbackMessage(), "data": "choice"})},
+		{name: "callback message game", root: "callback_query", value: telegramCallbackFixture(map[string]any{"message": telegramCallbackMessage(), "game_short_name": "game"})},
+		{name: "callback inline data", root: "callback_query", value: telegramCallbackFixture(map[string]any{"inline_message_id": "inline", "data": "choice"})},
+		{name: "callback inline game", root: "callback_query", value: telegramCallbackFixture(map[string]any{"inline_message_id": "inline", "game_short_name": "game"})},
+		{name: "shipping query", root: "shipping_query", value: map[string]any{"id": "shipping"}},
+		{name: "pre-checkout query", root: "pre_checkout_query", value: map[string]any{"id": "checkout"}},
+		{name: "purchased paid media", root: "purchased_paid_media", value: map[string]any{"payload": "purchase"}},
+		{name: "poll", root: "poll", value: map[string]any{"id": "poll"}},
+		{name: "poll answer", root: "poll_answer", value: map[string]any{"poll_id": "poll"}},
+		{name: "my chat member", root: "my_chat_member", value: map[string]any{"date": 1}},
+		{name: "chat member", root: "chat_member", value: map[string]any{"date": 1}},
+		{name: "chat join request", root: "chat_join_request", value: map[string]any{"date": 1}},
+		{name: "chat boost", root: "chat_boost", value: map[string]any{"boost": map[string]any{"boost_id": "boost"}}},
+		{name: "removed chat boost", root: "removed_chat_boost", value: map[string]any{"boost_id": "boost"}},
+		{name: "managed bot", root: "managed_bot", value: map[string]any{"bot": map[string]any{"id": 1}}},
+	}
+
+	covered := make(map[string]int, len(telegramBotAPI101UpdateRoots))
+	for index, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			covered[fixture.root]++
+			delivery, err := plan.Accept(telegramContractRequest(t, map[string]any{
+				"update_id":  1000 + index,
+				fixture.root: fixture.value,
+			}))
+			if err != nil {
+				t.Fatalf("Accept %s fixture (%s): %v", fixture.root, telegramBotAPIUpdateContract, err)
+			}
+			if len(delivery.Events) != 1 || delivery.Events[0].Kind != OutputKindRaw || delivery.Events[0].Name != "inbound.telegram" || !delivery.Events[0].Authorization.Empty() {
+				t.Fatalf("events = %#v, want exactly raw for %s under %s", delivery.Events, fixture.root, telegramBotAPIUpdateContract)
+			}
+		})
+	}
+	if len(telegramBotAPI101UpdateRoots) != 25 {
+		t.Fatalf("recorded Update roots = %d, want 25 for %s", len(telegramBotAPI101UpdateRoots), telegramBotAPIUpdateContract)
+	}
+	for _, root := range telegramBotAPI101UpdateRoots {
+		if covered[root] == 0 {
+			t.Errorf("Update root %q has no disposition proof for %s", root, telegramBotAPIUpdateContract)
+		}
+	}
+	if covered["callback_query"] != 4 {
+		t.Errorf("callback_query variants covered = %d, want message/inline x data/game", covered["callback_query"])
+	}
+}
+
+func TestTelegramInstalledAndEffectiveSubjectsCarryExactSelectedDescriptors(t *testing.T) {
+	pack, catalog, plan := telegramPlatformContract(t)
+	installed, err := catalog.InstalledCapabilitySubjects()
+	if err != nil {
+		t.Fatalf("InstalledCapabilitySubjects: %v", err)
+	}
+	if len(installed) != 1 {
+		t.Fatalf("installed subjects = %#v, want Telegram only", installed)
+	}
+	effective, err := plan.EffectiveCapabilitySubject(EffectiveSubjectRequest{
+		BundleHash: strings.Repeat("a", 64), Alias: "chat",
+		SigningSecret: "webhook_signing.telegram", SourcePath: "package.yaml",
+	})
+	if err != nil {
+		t.Fatalf("EffectiveCapabilitySubject: %v", err)
+	}
+	wantDescriptors := telegramSelectedTriggerDescriptors()
+	for name, subject := range map[string]packs.Subject{"installed": installed[0], "effective": effective} {
+		if !reflect.DeepEqual(subject.TriggerEvents, wantDescriptors) {
+			t.Errorf("%s trigger descriptors = %#v, want %#v", name, subject.TriggerEvents, wantDescriptors)
+		}
+		if subject.Provider != "telegram" || subject.Provenance != packs.ProvenancePlatform {
+			t.Errorf("%s subject provider/provenance = %q/%q", name, subject.Provider, subject.Provenance)
+		}
+	}
+	if installed[0].ID != "provider.telegram" || installed[0].Source != "trigger_pack" || installed[0].Applicability != "installed" || installed[0].SourcePath != pack.SourcePath {
+		t.Fatalf("installed subject identity = %#v", installed[0])
+	}
+	identity := effective.TriggerAdmission
+	if effective.Source != "trigger_pack_binding" || effective.Applicability != "effective" || identity == nil || identity.Pack == nil ||
+		identity.Pack.ID != pack.Envelope.ID || identity.Pack.Version != pack.Envelope.Version ||
+		identity.Pack.ManifestHash != pack.Envelope.ManifestHash || identity.Pack.Provenance != packs.ProvenancePlatform {
+		t.Fatalf("effective subject pack provenance = %#v", effective)
+	}
+}
+
+func telegramPlatformContract(t *testing.T) (LoadedPack, *CatalogSnapshot, InboundAdmissionPlan) {
+	t.Helper()
+	dir := filepath.Join(testPlatformPackRoot(), "telegram")
+	loaded, err := LoadPlatformPackDirs("0.7.0", dir)
+	if err != nil {
+		t.Fatalf("LoadPlatformPackDirs Telegram: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded Telegram packs = %d, want 1", len(loaded))
+	}
+	catalog, err := NewCatalogSnapshot(CatalogEntriesFromLoadedPacks(loaded...)...)
+	if err != nil {
+		t.Fatalf("NewCatalogSnapshot Telegram: %v", err)
+	}
+	plan, err := catalog.CompileAdmission(CompileAdmissionRequest{
+		Alias: "chat", Provider: "telegram", SigningSecret: "webhook_signing.telegram",
+	})
+	if err != nil {
+		t.Fatalf("CompileAdmission Telegram: %v", err)
+	}
+	return loaded[0], catalog, plan
+}
+
+func telegramContractRequest(t *testing.T, payload map[string]any) Request {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal Telegram fixture: %v", err)
+	}
+	var decoded map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatalf("decode Telegram fixture: %v", err)
+	}
+	return telegramRequest("telegram-secret", body, decoded)
+}
+
+func telegramCallbackFixture(variant map[string]any) map[string]any {
+	out := map[string]any{
+		"id": "callback", "from": map[string]any{"id": 1, "is_bot": false, "first_name": "User"},
+		"chat_instance": "chat-instance",
+	}
+	for key, value := range variant {
+		out[key] = value
+	}
+	return out
+}
+
+func telegramCallbackMessage() map[string]any {
+	return map[string]any{"message_id": 1, "chat": map[string]any{"id": 42}}
+}
+
+func telegramSelectedTriggerDescriptors() []packs.TriggerEventDescriptor {
+	return []packs.TriggerEventDescriptor{
+		{
+			Event: "inbound.telegram", Kind: "raw",
+			Fields: []packs.TriggerEventFieldDescriptor{
+				{Name: "entity_id", Type: "text", Required: true},
+				{Name: "event_type", Type: "text", Required: true},
+				{Name: "headers", Type: "json", Required: true},
+				{Name: "payload", Type: "json", Required: true},
+				{Name: "provider", Type: "text", Required: true},
+				{Name: "provider_delivery_id", Type: "text", Required: true},
+				{Name: "provider_event_id", Type: "text", Required: true},
+				{Name: "provider_event_type", Type: "text", Required: true},
+				{Name: "received_at", Type: "text", Required: true},
+			},
+		},
+		{
+			Event: "inbound.telegram.text_message", Kind: "normalized",
+			Fields: []packs.TriggerEventFieldDescriptor{
+				{Name: "chat_id", Type: "text", Required: true, CarryEligible: true},
+				{Name: "message_id", Type: "integer", Required: true, CarryEligible: true},
+				{Name: "raw", Type: "json"},
+				{Name: "text", Type: "text", Required: true, CarryEligible: true},
+			},
+		},
+	}
+}

--- a/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
+++ b/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
@@ -188,7 +188,7 @@ func TestNotifyAllChildrenRuntimeConformance_MixedValidAndStaleRoutesPersistAndR
 			deleteNotifyAllChildrenReceipts(t, ctx, backend, db, originalA)
 			eventCountBefore := countNotifyAllChildrenItemEvents(t, ctx, backend, db, runID)
 			restarted := newNotifyAllChildrenRuntime(t, backend, db, source, func() time.Time { return fixedEngineNow })
-			missing, err := backend.ListEventsMissingPipelineReceipt(ctx, time.Now().Add(-24*time.Hour), 20)
+			missing, err := backend.ListEventsMissingPipelineReceipt(ctx, fixedEngineNow.Add(-24*time.Hour), 20)
 			if err != nil {
 				t.Fatalf("ListEventsMissingPipelineReceipt: %v", err)
 			}

--- a/internal/runtime/inbound_test.go
+++ b/internal/runtime/inbound_test.go
@@ -1989,11 +1989,12 @@ func TestInboundGateway_TelegramManifestOwnsTokenDeliveryIDLiteralEventAndAck(t 
 
 func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *testing.T) {
 	for _, tc := range []struct {
-		name       string
-		body       []byte
-		target     InboundTarget
-		configure  func(*http.Request, []byte)
-		wantStatus int
+		name          string
+		body          []byte
+		target        InboundTarget
+		configure     func(*http.Request, []byte)
+		wantStatus    int
+		wantBodyParts []string
 	}{
 		{
 			name:       "missing configured secret",
@@ -2029,6 +2030,39 @@ func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *te
 			body:       []byte(`{"message":{"message_id":7,"text":"hello"}}`),
 			configure:  func(*http.Request, []byte) {},
 			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "chat id conversion failure",
+			body:       []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":"not-a-number"},"text":"hello"}}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+			wantBodyParts: []string{
+				"provider.telegram", "version=0.1.0", "manifest_hash=sha256:",
+				`normalized event "inbound.telegram.text_message"`, `path "message.chat.id"`,
+				"number_to_text requires a numeric value",
+			},
+		},
+		{
+			name:       "message id type failure",
+			body:       []byte(`{"update_id":123456789,"message":{"message_id":"seven","chat":{"id":42},"text":"hello"}}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+			wantBodyParts: []string{
+				"provider.telegram", "version=0.1.0", "manifest_hash=sha256:",
+				`normalized event "inbound.telegram.text_message"`, `path "message.message_id"`,
+				"value type string is incompatible with integer and implicit conversion is forbidden",
+			},
+		},
+		{
+			name:       "message text type failure",
+			body:       []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":99}}`),
+			configure:  func(*http.Request, []byte) {},
+			wantStatus: http.StatusBadRequest,
+			wantBodyParts: []string{
+				"provider.telegram", "version=0.1.0", "manifest_hash=sha256:",
+				`normalized event "inbound.telegram.text_message"`, `path "message.text"`,
+				"value type json.Number is incompatible with text and implicit conversion is forbidden",
+			},
 		},
 		{
 			name:       "non object payload",
@@ -2076,6 +2110,11 @@ func TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish(t *te
 
 			if rec.Code != tc.wantStatus {
 				t.Fatalf("status = %d, want %d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			for _, want := range tc.wantBodyParts {
+				if !strings.Contains(rec.Body.String(), want) {
+					t.Errorf("body = %q, want containing %q", rec.Body.String(), want)
+				}
 			}
 			if store.recorded {
 				t.Fatal("invalid Telegram request recorded inbound marker")


### PR DESCRIPTION
## Summary

- prove the shipped Telegram pack emits exactly raw plus `inbound.telegram.text_message` for the selected #2036 contract
- pin Telegram Bot API 10.1 (2026-06-11) Update-union coverage: all 25 roots remain raw-only outside the selected branch, including callback message/inline x data/game
- prove exact installed/effective capability descriptors and fail-closed projection diagnostics before marker/event mutation
- repair an unrelated full-suite fixed-clock cutoff time bomb found during mandatory verification

Closes #2038
Part of #2040

## Governing context

Binding authoritative spec:
- `platform-spec.yaml` → `provider_trigger_manifests.manifest_vocabulary.normalized_events.{shape,paths,predicates,extraction,conversion,output_route,source_composition,capability_surface}`

Binding tracker/provider context:
- approved first-slice gate on #2038
- merged #1962 implementation and PR #2027
- Telegram Bot API 10.1 Update contract (2026-06-11): https://core.telegram.org/bots/api#update
- #2036 is the selected consumer; #2040 owns every residual normalized-adoption branch

## Semantic ownership / migration

No runtime semantic migration is performed. The canonical owner remains `packs/provider-triggers/telegram/trigger.yaml`, consumed through the existing verified catalog, compiled admission plan, semantic-source import, selected-store batch, and capability Subject paths.

No old producer, reader, or writer path is preserved or replaced because production behavior is unchanged. Production paths checked for surviving alternate behavior: manifest parsing, normalized matching/extraction/conversion, output authorization, gateway pre-mutation rejection, semantic-source routing, selected-store persistence, template instance selection/reuse, restart authority, and connector reply. No Telegram-specific Go interpreter or authored normalizer exists.

## Proof

- `go test ./internal/providertriggers -count=1`
- `go test ./internal/runtime -run 'TestInboundGateway_TelegramRejectsInvalidInputsBeforeMarkerAndPublish' -count=1`
- SQLite and Postgres `TestStandingIngressSupportedSurface*RestartPreservesAuthorityAndReplies`
- Postgres-enabled `go test ./internal/providertriggers ./internal/packs ./internal/runtime ./internal/runtime/bus -count=1`
- fixed-clock conformance regression on SQLite/Postgres, `-count=3`
- full Postgres-enabled `go test ./...`

All pass locally.