### PR TITLE
[agent-g][issue #2050] Lock PostgreSQL temporal frontier design

### DIFF
--- a/internal/runtime/conformance/temporal_frontier_design_record_test.go
+++ b/internal/runtime/conformance/temporal_frontier_design_record_test.go
@@ -1,0 +1,443 @@
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const temporalFrontierDesignRecordPath = "internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml"
+
+type temporalFrontierDesignRecord struct {
+	Version             int                             `yaml:"version"`
+	Kind                string                          `yaml:"kind"`
+	Issue               int                             `yaml:"issue"`
+	ParentIssue         int                             `yaml:"parent_issue"`
+	ImplementationIssue int                             `yaml:"implementation_issue"`
+	SourceRefs          temporalFrontierSourceRefs      `yaml:"source_refs"`
+	Policy              temporalFrontierPolicy          `yaml:"policy"`
+	Selectors           temporalFrontierSelectors       `yaml:"selectors"`
+	Transaction         temporalFrontierTransaction     `yaml:"transaction"`
+	Objects             temporalFrontierObjects         `yaml:"objects"`
+	Roles               map[string]temporalFrontierRole `yaml:"roles"`
+	Grants              temporalFrontierGrants          `yaml:"grants"`
+	FactFamilies        []temporalFrontierFactFamily    `yaml:"fact_families"`
+	Operations          map[string]string               `yaml:"operations"`
+	Migration           temporalFrontierMigration       `yaml:"migration"`
+	Prototype           temporalFrontierPrototype       `yaml:"prototype"`
+	Manifestations      []temporalFrontierManifestation `yaml:"manifestations"`
+}
+
+type temporalFrontierSourceRefs struct {
+	ParentPreAudit   string `yaml:"parent_pre_audit"`
+	FinalAuditRepair string `yaml:"final_audit_repair"`
+	Gate             string `yaml:"gate"`
+	PlatformSpec     string `yaml:"platform_spec"`
+}
+
+type temporalFrontierPolicy struct {
+	ClosureLevel                       string `yaml:"closure_level"`
+	ClaimsRuntimeBehaviorChange        bool   `yaml:"claims_runtime_behavior_change"`
+	ClaimsProductionFailureClassClosed bool   `yaml:"claims_production_failure_class_closed"`
+	ProductionActivationAllowed        bool   `yaml:"production_activation_allowed"`
+	ProductionActivationIssue          int    `yaml:"production_activation_issue"`
+	SQLiteSemanticsChanged             bool   `yaml:"sqlite_semantics_changed"`
+}
+
+type temporalFrontierSelectors struct {
+	Supported     []string `yaml:"supported"`
+	Invalid       []string `yaml:"invalid"`
+	BookmarkOwner string   `yaml:"bookmark_owner"`
+}
+
+type temporalFrontierTransaction struct {
+	DeclarationTable                     string   `yaml:"declaration_table"`
+	XIDType                              string   `yaml:"xid_type"`
+	Modes                                []string `yaml:"modes"`
+	SealedFields                         []string `yaml:"sealed_fields"`
+	LockOrder                            []string `yaml:"lock_order"`
+	OrdinaryRevisionOnDestructiveCleanup bool     `yaml:"ordinary_revision_on_destructive_cleanup"`
+	OrdinalStart                         int      `yaml:"ordinal_start"`
+	HeaderRetention                      string   `yaml:"header_retention"`
+}
+
+type temporalFrontierObjects struct {
+	Tables            []string `yaml:"tables"`
+	HistoryTables     []string `yaml:"history_tables"`
+	Functions         []string `yaml:"functions"`
+	TriggerProperties []string `yaml:"trigger_properties"`
+}
+
+type temporalFrontierRole struct {
+	Kind                string   `yaml:"kind"`
+	DistinctFromRuntime bool     `yaml:"distinct_from_runtime"`
+	Invocation          string   `yaml:"invocation"`
+	Attributes          []string `yaml:"attributes"`
+}
+
+type temporalFrontierGrants struct {
+	RuntimeExecute                []string `yaml:"runtime_execute"`
+	RuntimeDeniedExecute          []string `yaml:"runtime_denied_execute"`
+	RuntimeInsertOnly             []string `yaml:"runtime_insert_only"`
+	RuntimeGuardedInsertUpdate    []string `yaml:"runtime_guarded_insert_update"`
+	RuntimeGuardedDML             []string `yaml:"runtime_guarded_dml"`
+	RuntimeDeniedDML              []string `yaml:"runtime_denied_dml"`
+	RuntimeDeniedDirectOperations []string `yaml:"runtime_denied_direct_operations"`
+}
+
+type temporalFrontierFactFamily struct {
+	Name        string `yaml:"name"`
+	Disposition string `yaml:"disposition"`
+}
+
+type temporalFrontierMigration struct {
+	Generation                      string   `yaml:"generation"`
+	MigrationID                     string   `yaml:"migration_id"`
+	RecognizedLegacyPlatformVersion string   `yaml:"recognized_legacy_platform_version"`
+	ActiveStatuses                  []string `yaml:"active_statuses"`
+	LegacyRunDisposition            string   `yaml:"legacy_run_disposition"`
+	UnknownShape                    string   `yaml:"unknown_shape"`
+	HeuristicBackfill               string   `yaml:"heuristic_backfill"`
+	Isolation                       string   `yaml:"isolation"`
+	DeploymentLocks                 []string `yaml:"deployment_locks"`
+	MetadataUpdatedLast             bool     `yaml:"metadata_updated_last"`
+	RollbackIsAtomic                bool     `yaml:"rollback_is_atomic"`
+	Reapply                         string   `yaml:"reapply"`
+	ServeSchemaMutation             string   `yaml:"serve_schema_mutation"`
+}
+
+type temporalFrontierPrototype struct {
+	Test            string   `yaml:"test"`
+	RunnerOwner     string   `yaml:"runner_owner"`
+	ProofProjection string   `yaml:"proof_projection"`
+	Assertions      []string `yaml:"assertions"`
+}
+
+type temporalFrontierManifestation struct {
+	ID     string `yaml:"id"`
+	Issue  int    `yaml:"issue"`
+	Status string `yaml:"status"`
+}
+
+type temporalFrontierSpecDocument struct {
+	PlatformTables struct {
+		Tables map[string]yaml.Node `yaml:"tables"`
+	} `yaml:"platform_tables"`
+	RunModel struct {
+		Fork struct {
+			TemporalFrontier temporalFrontierSpec `yaml:"temporal_frontier"`
+		} `yaml:"fork"`
+	} `yaml:"run_model"`
+}
+
+type temporalFrontierSpec struct {
+	PromotedBy                string `yaml:"promoted_by"`
+	ParentTracker             string `yaml:"parent_tracker"`
+	ProductionActivationOwner string `yaml:"production_activation_owner"`
+	Status                    string `yaml:"status"`
+	ClosureLevel              string `yaml:"closure_level"`
+	CanonicalOwner            string `yaml:"canonical_owner"`
+	Selectors                 struct {
+		Public  []string `yaml:"public"`
+		Invalid []string `yaml:"invalid"`
+	} `yaml:"selectors"`
+	TransactionContract struct {
+		XIDType          string   `yaml:"xid_type"`
+		DeclarationOwner string   `yaml:"declaration_owner"`
+		LockOrder        []string `yaml:"lock_order"`
+	} `yaml:"transaction_contract"`
+	SchemaContract struct {
+		Generation string `yaml:"generation"`
+		DDLStatus  string `yaml:"ddl_status"`
+		Tables     map[string]struct {
+			DDL string `yaml:"ddl"`
+		} `yaml:"tables"`
+	} `yaml:"schema_contract"`
+	TriggerContract struct {
+		Functions  []string `yaml:"functions"`
+		Properties []string `yaml:"properties"`
+	} `yaml:"trigger_contract"`
+	RequiredConformance struct {
+		CommittedRecord string `yaml:"committed_record"`
+		PostgresTest    string `yaml:"postgres_test"`
+		Runner          string `yaml:"runner"`
+	} `yaml:"required_conformance"`
+}
+
+func TestTemporalFrontierDesignRecordLocksCompleteInactiveContract(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	record := loadTemporalFrontierDesignRecord(t, root)
+	spec := loadTemporalFrontierSpec(t, root)
+	if problems := validateTemporalFrontierDesignRecord(root, record, spec); len(problems) > 0 {
+		t.Fatalf("temporal frontier design validation failed:\n- %s", strings.Join(problems, "\n- "))
+	}
+}
+
+func TestTemporalFrontierDesignRecordRejectsClosureAndGuardDrift(t *testing.T) {
+	root := conformanceRepoRoot(t)
+	base := loadTemporalFrontierDesignRecord(t, root)
+	spec := loadTemporalFrontierSpec(t, root)
+	tests := []struct {
+		name   string
+		mutate func(*temporalFrontierDesignRecord)
+		want   string
+	}{
+		{name: "runtime behavior claim", mutate: func(r *temporalFrontierDesignRecord) { r.Policy.ClaimsRuntimeBehaviorChange = true }, want: "claims runtime behavior change"},
+		{name: "production activation", mutate: func(r *temporalFrontierDesignRecord) { r.Policy.ProductionActivationAllowed = true }, want: "permits production activation"},
+		{name: "missing event delete denial", mutate: func(r *temporalFrontierDesignRecord) {
+			r.Grants.RuntimeDeniedDirectOperations = []string{"events.UPDATE"}
+		}, want: "runtime denied direct operations"},
+		{name: "missing old new guard", mutate: func(r *temporalFrontierDesignRecord) { delete(r.Operations, "mutable_update") }, want: "operations missing mutable_update"},
+		{name: "destructive ordinary revision", mutate: func(r *temporalFrontierDesignRecord) { r.Transaction.OrdinaryRevisionOnDestructiveCleanup = true }, want: "destructive cleanup fabricates an ordinary revision"},
+		{name: "truncated xid", mutate: func(r *temporalFrontierDesignRecord) { r.Transaction.XIDType = "bigint" }, want: "transaction xid_type"},
+		{name: "missing history family", mutate: func(r *temporalFrontierDesignRecord) {
+			r.Objects.HistoryTables = stringsExcept(r.Objects.HistoryTables, "event_delivery_history")
+		}, want: "history tables missing event_delivery_history"},
+		{name: "missing proof", mutate: func(r *temporalFrontierDesignRecord) {
+			r.Prototype.Assertions = stringsExcept(r.Prototype.Assertions, "update_move_requires_old_and_new_runs")
+		}, want: "prototype assertions missing update_move_requires_old_and_new_runs"},
+		{name: "heuristic backfill", mutate: func(r *temporalFrontierDesignRecord) { r.Migration.HeuristicBackfill = "allowed" }, want: "heuristic backfill"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := cloneTemporalFrontierRecord(t, base)
+			tc.mutate(&record)
+			problems := validateTemporalFrontierDesignRecord(root, record, spec)
+			if !problemsContain(problems, tc.want) {
+				t.Fatalf("validation problems missing %q:\n- %s", tc.want, strings.Join(problems, "\n- "))
+			}
+		})
+	}
+}
+
+func loadTemporalFrontierDesignRecord(t *testing.T, root string) temporalFrontierDesignRecord {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, temporalFrontierDesignRecordPath))
+	if err != nil {
+		t.Fatalf("read temporal frontier design record: %v", err)
+	}
+	var record temporalFrontierDesignRecord
+	if err := yaml.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("parse temporal frontier design record: %v", err)
+	}
+	return record
+}
+
+func loadTemporalFrontierSpec(t *testing.T, root string) temporalFrontierSpecDocument {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, "platform-spec.yaml"))
+	if err != nil {
+		t.Fatalf("read platform spec: %v", err)
+	}
+	var spec temporalFrontierSpecDocument
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse platform spec: %v", err)
+	}
+	return spec
+}
+
+func cloneTemporalFrontierRecord(t *testing.T, record temporalFrontierDesignRecord) temporalFrontierDesignRecord {
+	t.Helper()
+	raw, err := yaml.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal temporal frontier record: %v", err)
+	}
+	var cloned temporalFrontierDesignRecord
+	if err := yaml.Unmarshal(raw, &cloned); err != nil {
+		t.Fatalf("clone temporal frontier record: %v", err)
+	}
+	return cloned
+}
+
+func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDesignRecord, specDoc temporalFrontierSpecDocument) []string {
+	var problems []string
+	if record.Version != 1 || record.Kind != "temporal_frontier_design_record" {
+		problems = append(problems, fmt.Sprintf("record identity = version %d kind %q", record.Version, record.Kind))
+	}
+	if record.Issue != 2050 || record.ParentIssue != 2049 || record.ImplementationIssue != 2051 {
+		problems = append(problems, fmt.Sprintf("issue chain = #%d/#%d/#%d, want #2050/#2049/#2051", record.Issue, record.ParentIssue, record.ImplementationIssue))
+	}
+	for name, ref := range map[string]string{"parent_pre_audit": record.SourceRefs.ParentPreAudit, "final_audit_repair": record.SourceRefs.FinalAuditRepair, "gate": record.SourceRefs.Gate} {
+		if !strings.Contains(ref, "github.com/division-sh/swarm/issues/2049#issuecomment-") {
+			problems = append(problems, "source ref "+name+" does not resolve to a #2049 comment")
+		}
+	}
+	if record.SourceRefs.PlatformSpec != "platform-spec.yaml#run_model.fork.temporal_frontier" {
+		problems = append(problems, "source_refs platform_spec is not the canonical temporal owner")
+	}
+	if record.Policy.ClosureLevel != "spec_schema_design_locked" {
+		problems = append(problems, "closure level is not spec_schema_design_locked")
+	}
+	if record.Policy.ClaimsRuntimeBehaviorChange {
+		problems = append(problems, "policy claims runtime behavior change")
+	}
+	if record.Policy.ClaimsProductionFailureClassClosed {
+		problems = append(problems, "policy claims production failure class closed")
+	}
+	if record.Policy.ProductionActivationAllowed {
+		problems = append(problems, "policy permits production activation")
+	}
+	if record.Policy.ProductionActivationIssue != 2051 || record.Policy.SQLiteSemanticsChanged {
+		problems = append(problems, "policy activation boundary is not #2051 with unchanged SQLite semantics")
+	}
+
+	problems = append(problems, requireExactSet("supported selectors", record.Selectors.Supported, []string{"default_latest_event", "explicit_event_uuid"})...)
+	problems = append(problems, requireSet("invalid selectors", record.Selectors.Invalid, []string{"rfc3339_timestamp", "created_at_event_id_cutoff", "caller_supplied_revision"})...)
+	if record.Selectors.BookmarkOwner != "event_uuid_resolves_temporal_revision" {
+		problems = append(problems, "selector bookmark owner is not event UUID to temporal revision")
+	}
+	if record.Transaction.DeclarationTable != "run_temporal_transactions" || record.Transaction.XIDType != "xid8" {
+		problems = append(problems, "transaction xid_type/declaration owner is not xid8/run_temporal_transactions")
+	}
+	if record.Transaction.OrdinaryRevisionOnDestructiveCleanup {
+		problems = append(problems, "destructive cleanup fabricates an ordinary revision")
+	}
+	if record.Transaction.OrdinalStart != 1 || record.Transaction.HeaderRetention != "referenced_by_revision_or_tombstone" {
+		problems = append(problems, "transaction ordinal/header retention contract drifted")
+	}
+	problems = append(problems, requireExactSet("transaction modes", record.Transaction.Modes, []string{"normal", "destructive"})...)
+	problems = append(problems, requireExactOrder("transaction lock order", record.Transaction.LockOrder, []string{"nonlocking_identity_snapshot", "sealed_frontier_declaration", "sorted_frontier_locks", "deterministic_fact_locks", "identity_revalidation", "captured_fact_mutation"})...)
+
+	requiredTables := []string{"run_temporal_transactions", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_deletion_tombstones"}
+	requiredHistory := []string{"run_lifecycle_history", "event_delivery_history", "event_receipt_history", "timer_history", "entity_state_history", "agent_session_history", "conversation_audit_history", "reply_context_history", "activity_attempt_history"}
+	requiredFunctions := []string{"swarm_declare_temporal_runs", "swarm_claim_temporal_runs", "swarm_next_temporal_ordinal", "swarm_guard_events", "swarm_guard_event_deliveries", "swarm_guard_event_receipts", "swarm_destroy_run"}
+	problems = append(problems, requireExactSet("tables", record.Objects.Tables, requiredTables)...)
+	problems = append(problems, requireExactSet("history tables", record.Objects.HistoryTables, requiredHistory)...)
+	problems = append(problems, requireExactSet("functions", record.Objects.Functions, requiredFunctions)...)
+	problems = append(problems, requireSet("trigger properties", record.Objects.TriggerProperties, []string{"security_definer", "owner_controlled", "schema_qualified", "pinned_search_path", "public_execute_revoked", "enable_always"})...)
+
+	migrationRole, migrationOK := record.Roles["migration"]
+	runtimeRole, runtimeOK := record.Roles["runtime"]
+	if !migrationOK || migrationRole.Kind != "schema_owner_login" || !migrationRole.DistinctFromRuntime || !strings.HasPrefix(migrationRole.Invocation, "swarm schema apply ") {
+		problems = append(problems, "migration role/invocation contract is incomplete")
+	}
+	if !runtimeOK || runtimeRole.Kind != "restricted_login" || runtimeRole.Invocation != "swarm serve --config <runtime-config>" {
+		problems = append(problems, "runtime role/invocation contract is incomplete")
+	}
+	problems = append(problems, requireExactSet("runtime denied direct operations", record.Grants.RuntimeDeniedDirectOperations, []string{"events.UPDATE", "events.DELETE", "runs.DELETE"})...)
+	problems = append(problems, requireExactSet("runtime guarded insert update", record.Grants.RuntimeGuardedInsertUpdate, []string{"runs"})...)
+	problems = append(problems, requireExactSet("runtime execute", record.Grants.RuntimeExecute, []string{"swarm_claim_temporal_runs", "swarm_destroy_run"})...)
+	problems = append(problems, requireSet("runtime denied execute", record.Grants.RuntimeDeniedExecute, []string{"swarm_declare_temporal_runs", "swarm_next_temporal_ordinal", "swarm_guard_events", "swarm_guard_event_deliveries", "swarm_guard_event_receipts"})...)
+
+	requiredFacts := []string{"runs", "events", "event_deliveries", "event_receipts", "dead_letters", "entity_mutations", "entity_state", "timers", "agent_sessions", "agent_turns", "agent_conversation_audits", "reply_contexts", "activity_attempts", "selected_fork_lineage", "routing_rules", "runless_events"}
+	facts := make([]string, 0, len(record.FactFamilies))
+	for _, family := range record.FactFamilies {
+		facts = append(facts, family.Name)
+		if strings.TrimSpace(family.Disposition) == "" {
+			problems = append(problems, "fact family "+family.Name+" has no disposition")
+		}
+	}
+	problems = append(problems, requireExactSet("fact families", facts, requiredFacts)...)
+	for _, operation := range []string{"event_insert", "event_update", "event_delete", "mutable_insert", "mutable_update", "mutable_delete", "whole_run_delete"} {
+		if strings.TrimSpace(record.Operations[operation]) == "" {
+			problems = append(problems, "operations missing "+operation)
+		}
+	}
+	if record.Operations["mutable_update"] != "every_distinct_old_and_new_nonnull_run_declared" {
+		problems = append(problems, "mutable_update does not require OLD and NEW non-null runs")
+	}
+
+	if record.Migration.Generation != "temporal-frontier-v1" || record.Migration.MigrationID != "temporal-frontier-v1" || record.Migration.RecognizedLegacyPlatformVersion != "0.7.0" {
+		problems = append(problems, "migration generation/edge drifted")
+	}
+	if record.Migration.HeuristicBackfill != "forbidden" {
+		problems = append(problems, "migration heuristic backfill is not forbidden")
+	}
+	if record.Migration.Isolation != "SERIALIZABLE" || !record.Migration.MetadataUpdatedLast || !record.Migration.RollbackIsAtomic || record.Migration.ServeSchemaMutation != "forbidden" {
+		problems = append(problems, "migration atomicity/admission contract drifted")
+	}
+	problems = append(problems, requireExactSet("active statuses", record.Migration.ActiveStatuses, []string{"running", "paused"})...)
+	problems = append(problems, requireExactSet("deployment locks", record.Migration.DeploymentLocks, []string{"runtime_shared_session_advisory", "migration_exclusive_advisory", "first_upgrade_access_exclusive_tables"})...)
+
+	requiredAssertions := []string{"fresh_schema_creation", "active_legacy_run_rejected_without_ddl", "failed_migration_rolls_back_schema_and_metadata", "exact_reapply_is_idempotent", "runtime_shared_lock_excludes_migration", "runtime_cannot_assume_owner_or_disable_trigger", "runtime_cannot_mutate_authority_or_history_tables", "undeclared_insert_update_delete_rejected", "declared_delete_writes_typed_history", "destructive_declaration_not_runtime_callable", "event_delivery_receipt_share_revision_and_ordinals", "rollback_publishes_no_revision", "update_move_requires_old_and_new_runs", "runless_lineage_remains_unversioned", "unversioned_destructive_cleanup_creates_no_revision", "reverse_order_claims_serialize_frontier_first", "trigger_functions_are_not_runtime_bypass_surfaces", "second_runtime_boot_is_read_only"}
+	if record.Prototype.Test != "TestTemporalFrontierPostgresDesignConformance" || record.Prototype.RunnerOwner != "platform-spec.yaml#run_model.fork.temporal_frontier.required_conformance.runner" || record.Prototype.ProofProjection != "required-full" {
+		problems = append(problems, "prototype test/runner owner/proof projection does not match the dedicated supported command")
+	}
+	problems = append(problems, requireExactSet("prototype assertions", record.Prototype.Assertions, requiredAssertions)...)
+
+	spec := specDoc.RunModel.Fork.TemporalFrontier
+	if spec.PromotedBy != "#2050" || spec.ParentTracker != "#2049" || spec.ProductionActivationOwner != "#2051" || spec.Status != "design_locked_not_activated" || spec.ClosureLevel != "spec_schema_design_locked" {
+		problems = append(problems, "platform spec issue/status boundary drifted")
+	}
+	if strings.TrimSpace(spec.CanonicalOwner) == "" || spec.SchemaContract.Generation != record.Migration.Generation || spec.SchemaContract.DDLStatus != "exact_target_ddl_inactive_until_2051" {
+		problems = append(problems, "platform spec canonical owner/schema generation drifted")
+	}
+	problems = append(problems, requireExactSet("spec supported selectors", spec.Selectors.Public, record.Selectors.Supported)...)
+	problems = append(problems, requireExactSet("spec invalid selectors", spec.Selectors.Invalid, record.Selectors.Invalid)...)
+	if spec.TransactionContract.XIDType != "xid8" || spec.TransactionContract.DeclarationOwner != record.Transaction.DeclarationTable {
+		problems = append(problems, "platform spec transaction owner/xid drifted")
+	}
+	for _, table := range append(append([]string(nil), requiredTables...), requiredHistory...) {
+		entry, ok := spec.SchemaContract.Tables[table]
+		if !ok || strings.TrimSpace(entry.DDL) == "" {
+			problems = append(problems, "platform spec exact DDL missing "+table)
+		}
+		if strings.HasSuffix(table, "_history") && (!strings.Contains(entry.DDL, "FOREIGN KEY (run_id, revision)") || !strings.Contains(entry.DDL, "REFERENCES run_temporal_revisions(run_id, revision)")) {
+			problems = append(problems, "platform spec history DDL missing revision foreign key "+table)
+		}
+		if _, active := specDoc.PlatformTables.Tables[table]; active {
+			problems = append(problems, "inactive temporal table appears in production platform_tables: "+table)
+		}
+	}
+	problems = append(problems, requireExactSet("spec trigger functions", spec.TriggerContract.Functions, record.Objects.Functions)...)
+	if spec.RequiredConformance.CommittedRecord != temporalFrontierDesignRecordPath || spec.RequiredConformance.PostgresTest != record.Prototype.Test || strings.TrimSpace(spec.RequiredConformance.Runner) == "" {
+		problems = append(problems, "platform spec required conformance drifted from record")
+	}
+	if _, err := os.Stat(filepath.Join(root, temporalFrontierDesignRecordPath)); err != nil {
+		problems = append(problems, "committed temporal frontier design record is missing")
+	}
+
+	sort.Strings(problems)
+	return problems
+}
+
+func requireExactSet(label string, got, want []string) []string {
+	problems := requireSet(label, got, want)
+	problems = append(problems, requireSet(label+" unexpected", want, got)...)
+	return problems
+}
+
+func requireSet(label string, got, want []string) []string {
+	present := make(map[string]bool, len(got))
+	for _, value := range got {
+		present[value] = true
+	}
+	var problems []string
+	for _, value := range want {
+		if !present[value] {
+			problems = append(problems, label+" missing "+value)
+		}
+	}
+	return problems
+}
+
+func requireExactOrder(label string, got, want []string) []string {
+	if strings.Join(got, "\x00") == strings.Join(want, "\x00") {
+		return nil
+	}
+	return []string{fmt.Sprintf("%s = %v, want %v", label, got, want)}
+}
+
+func stringsExcept(values []string, excluded string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != excluded {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func problemsContain(problems []string, want string) bool {
+	for _, problem := range problems {
+		if strings.Contains(problem, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/conformance/temporal_frontier_design_record_test.go
+++ b/internal/runtime/conformance/temporal_frontier_design_record_test.go
@@ -28,6 +28,7 @@ type temporalFrontierDesignRecord struct {
 	Grants              temporalFrontierGrants          `yaml:"grants"`
 	FactFamilies        []temporalFrontierFactFamily    `yaml:"fact_families"`
 	Operations          map[string]string               `yaml:"operations"`
+	OperationMatrix     []temporalFrontierOperationRow  `yaml:"operation_matrix"`
 	Migration           temporalFrontierMigration       `yaml:"migration"`
 	Prototype           temporalFrontierPrototype       `yaml:"prototype"`
 	Manifestations      []temporalFrontierManifestation `yaml:"manifestations"`
@@ -84,6 +85,7 @@ type temporalFrontierGrants struct {
 	RuntimeExecute                []string `yaml:"runtime_execute"`
 	RuntimeDeniedExecute          []string `yaml:"runtime_denied_execute"`
 	CleanupAuthorizerExecute      []string `yaml:"cleanup_authorizer_execute"`
+	CleanupAuthorizerRead         []string `yaml:"cleanup_authorizer_read"`
 	RuntimeInsertOnly             []string `yaml:"runtime_insert_only"`
 	RuntimeGuardedUpdate          []string `yaml:"runtime_guarded_update"`
 	RuntimeGuardedDML             []string `yaml:"runtime_guarded_dml"`
@@ -94,6 +96,14 @@ type temporalFrontierGrants struct {
 type temporalFrontierFactFamily struct {
 	Name        string `yaml:"name"`
 	Disposition string `yaml:"disposition"`
+}
+
+type temporalFrontierOperationRow struct {
+	Family string `yaml:"family"`
+	Insert string `yaml:"insert"`
+	Update string `yaml:"update"`
+	Delete string `yaml:"delete"`
+	Proof  string `yaml:"proof"`
 }
 
 type temporalFrontierMigration struct {
@@ -203,6 +213,9 @@ func TestTemporalFrontierDesignRecordRejectsClosureAndGuardDrift(t *testing.T) {
 		{name: "missing proof", mutate: func(r *temporalFrontierDesignRecord) {
 			r.Prototype.Assertions = stringsExcept(r.Prototype.Assertions, "update_move_requires_old_and_new_runs")
 		}, want: "prototype assertions missing update_move_requires_old_and_new_runs"},
+		{name: "missing operation row", mutate: func(r *temporalFrontierDesignRecord) {
+			r.OperationMatrix = r.OperationMatrix[1:]
+		}, want: "operation matrix missing runs"},
 		{name: "heuristic backfill", mutate: func(r *temporalFrontierDesignRecord) { r.Migration.HeuristicBackfill = "allowed" }, want: "heuristic backfill"},
 	}
 	for _, tc := range tests {
@@ -330,6 +343,7 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	problems = append(problems, requireExactSet("runtime execute", record.Grants.RuntimeExecute, []string{"swarm_create_run", "swarm_claim_temporal_runs", "swarm_claim_authorized_run_cleanup", "swarm_delete_authorized_runs"})...)
 	problems = append(problems, requireSet("runtime denied execute", record.Grants.RuntimeDeniedExecute, []string{"swarm_declare_temporal_runs", "swarm_authorize_run_cleanup", "swarm_next_temporal_ordinal", "swarm_resolve_temporal_run", "swarm_guard_append_fact", "swarm_guard_mutable_fact"})...)
 	problems = append(problems, requireExactSet("cleanup authorizer execute", record.Grants.CleanupAuthorizerExecute, []string{"swarm_authorize_run_cleanup"})...)
+	problems = append(problems, requireExactSet("cleanup authorizer read", record.Grants.CleanupAuthorizerRead, []string{"runtime_store_metadata", "runtime_store_migrations"})...)
 
 	requiredFacts := []string{"runs", "events", "event_deliveries", "event_receipts", "dead_letters", "entity_mutations", "entity_state", "timers", "agent_sessions", "agent_turns", "agent_conversation_audits", "reply_contexts", "activity_attempts", "selected_fork_lineage", "routing_rules", "runless_events"}
 	facts := make([]string, 0, len(record.FactFamilies))
@@ -348,6 +362,42 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	if record.Operations["mutable_update"] != "every_distinct_old_and_new_nonnull_run_declared" {
 		problems = append(problems, "mutable_update does not require OLD and NEW non-null runs")
 	}
+	expectedOperationMatrix := map[string][3]string{
+		"runs":                      {"owner_function", "typed_history", "authorized_wrapper_cascade"},
+		"events":                    {"revisioned_insert", "rejected_immutable", "authorized_wrapper_cascade"},
+		"event_deliveries":          {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"event_receipts":            {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"dead_letters":              {"revisioned_insert", "rejected_immutable", "authorized_wrapper_cascade"},
+		"entity_mutations":          {"revisioned_insert", "rejected_immutable", "authorized_wrapper_cascade"},
+		"entity_state":              {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"timers":                    {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"agent_sessions":            {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"agent_turns":               {"revisioned_insert", "rejected_immutable", "authorized_wrapper_cascade"},
+		"agent_conversation_audits": {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"reply_contexts":            {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"activity_attempts":         {"typed_history", "typed_history", "typed_history_or_authorized_wrapper_cascade"},
+		"selected_fork_lineage":     {"revisioned_insert", "rejected_immutable", "authorized_wrapper_cascade"},
+	}
+	seenOperationRows := make(map[string]bool, len(record.OperationMatrix))
+	for _, row := range record.OperationMatrix {
+		expected, ok := expectedOperationMatrix[row.Family]
+		if !ok {
+			problems = append(problems, "operation matrix has unexpected family "+row.Family)
+			continue
+		}
+		if seenOperationRows[row.Family] {
+			problems = append(problems, "operation matrix duplicates "+row.Family)
+		}
+		seenOperationRows[row.Family] = true
+		if row.Insert != expected[0] || row.Update != expected[1] || row.Delete != expected[2] || strings.TrimSpace(row.Proof) == "" {
+			problems = append(problems, "operation matrix row drifted for "+row.Family)
+		}
+	}
+	for family := range expectedOperationMatrix {
+		if !seenOperationRows[family] {
+			problems = append(problems, "operation matrix missing "+family)
+		}
+	}
 
 	if record.Migration.Generation != "temporal-frontier-v1" || record.Migration.MigrationID != "temporal-frontier-v1" || record.Migration.RecognizedLegacyPlatformVersion != "0.7.0" {
 		problems = append(problems, "migration generation/edge drifted")
@@ -355,7 +405,7 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	if record.Migration.HeuristicBackfill != "forbidden" {
 		problems = append(problems, "migration heuristic backfill is not forbidden")
 	}
-	if record.Migration.LegacyAdmission != "complete_registered_catalog_checksum" || record.Migration.Reapply != "full_catalog_revalidation_then_exact_checksum_noop_else_fail_closed" {
+	if record.Migration.LegacyAdmission != "complete_registered_catalog_checksum_and_delivery_event_lineage" || record.Migration.Reapply != "full_catalog_revalidation_then_exact_checksum_noop_else_fail_closed" {
 		problems = append(problems, "migration catalog admission/reapply contract drifted")
 	}
 	if record.Migration.Isolation != "SERIALIZABLE" || !record.Migration.MetadataUpdatedLast || !record.Migration.RollbackIsAtomic || record.Migration.ServeSchemaMutation != "forbidden" {
@@ -364,7 +414,7 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	problems = append(problems, requireExactSet("active statuses", record.Migration.ActiveStatuses, []string{"running", "paused"})...)
 	problems = append(problems, requireExactSet("deployment locks", record.Migration.DeploymentLocks, []string{"runtime_shared_session_advisory", "migration_exclusive_advisory", "first_upgrade_access_exclusive_tables"})...)
 
-	requiredAssertions := []string{"fresh_schema_creation", "restricted_runtime_atomic_run_creation", "active_legacy_run_rejected_without_ddl", "complete_legacy_catalog_drift_rejected", "failed_migration_rolls_back_schema_and_metadata", "exact_reapply_is_idempotent", "drifted_target_reapply_rejected", "runtime_shared_lock_excludes_migration", "runtime_cannot_assume_owner_or_disable_trigger", "runtime_cannot_mutate_authority_or_history_tables", "undeclared_insert_update_delete_rejected", "every_guarded_fact_family_insert_update_delete_proven", "derived_lineage_mismatch_rejected", "destructive_declaration_not_runtime_callable", "event_delivery_receipt_share_revision_and_ordinals", "rollback_publishes_no_revision", "update_move_requires_old_and_new_runs", "runless_lineage_remains_unversioned", "authorized_unversioned_destructive_cleanup_creates_no_revision", "arbitrary_run_deletion_rejected", "cleanup_authorization_is_not_runtime_mintable", "cleanup_authorizer_has_no_fact_or_schema_privileges", "mixed_cleanup_revisions_survivors_and_tombstones_deleted_runs", "reverse_order_claims_serialize_frontier_first", "trigger_functions_are_not_runtime_bypass_surfaces", "second_runtime_boot_is_read_only"}
+	requiredAssertions := []string{"fresh_schema_creation", "restricted_runtime_atomic_run_creation", "active_legacy_run_rejected_without_ddl", "complete_legacy_catalog_drift_rejected", "legacy_delivery_lineage_mismatch_rejected_without_ddl", "failed_migration_rolls_back_schema_and_metadata", "exact_reapply_is_idempotent", "drifted_target_reapply_rejected", "exact_runtime_and_cleanup_admission", "post_migration_admission_drift_rejected", "runtime_shared_lock_excludes_migration", "runtime_cannot_assume_owner_or_disable_trigger", "runtime_cannot_mutate_authority_or_history_tables", "undeclared_insert_update_delete_rejected", "explicit_fact_family_operation_matrix_executed", "append_family_update_delete_rejected", "every_fact_family_authorized_destructive_cascade", "delivery_update_and_delete_history_proven", "receipt_update_and_delete_history_proven", "derived_lineage_mismatch_rejected", "destructive_declaration_not_runtime_callable", "partial_destructive_fact_delete_cannot_commit", "event_delivery_receipt_share_revision_and_ordinals", "rollback_publishes_no_revision", "update_move_requires_old_and_new_runs", "runless_lineage_remains_unversioned", "authorized_unversioned_destructive_cleanup_creates_no_revision", "arbitrary_run_deletion_rejected", "cleanup_authorization_is_not_runtime_mintable", "cleanup_authorizer_has_no_fact_or_schema_privileges", "mixed_cleanup_revisions_survivors_and_tombstones_deleted_runs", "reverse_order_claims_serialize_frontier_first", "trigger_functions_are_not_runtime_bypass_surfaces", "second_runtime_boot_is_read_only"}
 	if record.Prototype.Test != "TestTemporalFrontierPostgresDesignConformance" || record.Prototype.RunnerOwner != "platform-spec.yaml#run_model.fork.temporal_frontier.required_conformance.runner" || record.Prototype.ProofProjection != "required-full" {
 		problems = append(problems, "prototype test/runner owner/proof projection does not match the dedicated supported command")
 	}

--- a/internal/runtime/conformance/temporal_frontier_design_record_test.go
+++ b/internal/runtime/conformance/temporal_frontier_design_record_test.go
@@ -58,7 +58,7 @@ type temporalFrontierSelectors struct {
 type temporalFrontierTransaction struct {
 	DeclarationTable                     string   `yaml:"declaration_table"`
 	XIDType                              string   `yaml:"xid_type"`
-	Modes                                []string `yaml:"modes"`
+	Dispositions                         []string `yaml:"dispositions"`
 	SealedFields                         []string `yaml:"sealed_fields"`
 	LockOrder                            []string `yaml:"lock_order"`
 	OrdinaryRevisionOnDestructiveCleanup bool     `yaml:"ordinary_revision_on_destructive_cleanup"`
@@ -83,8 +83,9 @@ type temporalFrontierRole struct {
 type temporalFrontierGrants struct {
 	RuntimeExecute                []string `yaml:"runtime_execute"`
 	RuntimeDeniedExecute          []string `yaml:"runtime_denied_execute"`
+	CleanupAuthorizerExecute      []string `yaml:"cleanup_authorizer_execute"`
 	RuntimeInsertOnly             []string `yaml:"runtime_insert_only"`
-	RuntimeGuardedInsertUpdate    []string `yaml:"runtime_guarded_insert_update"`
+	RuntimeGuardedUpdate          []string `yaml:"runtime_guarded_update"`
 	RuntimeGuardedDML             []string `yaml:"runtime_guarded_dml"`
 	RuntimeDeniedDML              []string `yaml:"runtime_denied_dml"`
 	RuntimeDeniedDirectOperations []string `yaml:"runtime_denied_direct_operations"`
@@ -108,6 +109,7 @@ type temporalFrontierMigration struct {
 	MetadataUpdatedLast             bool     `yaml:"metadata_updated_last"`
 	RollbackIsAtomic                bool     `yaml:"rollback_is_atomic"`
 	Reapply                         string   `yaml:"reapply"`
+	LegacyAdmission                 string   `yaml:"legacy_admission"`
 	ServeSchemaMutation             string   `yaml:"serve_schema_mutation"`
 }
 
@@ -300,12 +302,12 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	if record.Transaction.OrdinalStart != 1 || record.Transaction.HeaderRetention != "referenced_by_revision_or_tombstone" {
 		problems = append(problems, "transaction ordinal/header retention contract drifted")
 	}
-	problems = append(problems, requireExactSet("transaction modes", record.Transaction.Modes, []string{"normal", "destructive"})...)
+	problems = append(problems, requireExactSet("transaction dispositions", record.Transaction.Dispositions, []string{"normal", "destructive"})...)
 	problems = append(problems, requireExactOrder("transaction lock order", record.Transaction.LockOrder, []string{"nonlocking_identity_snapshot", "sealed_frontier_declaration", "sorted_frontier_locks", "deterministic_fact_locks", "identity_revalidation", "captured_fact_mutation"})...)
 
-	requiredTables := []string{"run_temporal_transactions", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_deletion_tombstones"}
+	requiredTables := []string{"run_temporal_transactions", "run_temporal_transaction_runs", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_cleanup_authorizations", "run_deletion_tombstones"}
 	requiredHistory := []string{"run_lifecycle_history", "event_delivery_history", "event_receipt_history", "timer_history", "entity_state_history", "agent_session_history", "conversation_audit_history", "reply_context_history", "activity_attempt_history"}
-	requiredFunctions := []string{"swarm_declare_temporal_runs", "swarm_claim_temporal_runs", "swarm_next_temporal_ordinal", "swarm_guard_events", "swarm_guard_event_deliveries", "swarm_guard_event_receipts", "swarm_destroy_run"}
+	requiredFunctions := []string{"swarm_declare_temporal_runs", "swarm_create_run", "swarm_claim_temporal_runs", "swarm_authorize_run_cleanup", "swarm_claim_authorized_run_cleanup", "swarm_delete_authorized_runs", "swarm_next_temporal_ordinal", "swarm_resolve_temporal_run", "swarm_guard_append_fact", "swarm_guard_mutable_fact"}
 	problems = append(problems, requireExactSet("tables", record.Objects.Tables, requiredTables)...)
 	problems = append(problems, requireExactSet("history tables", record.Objects.HistoryTables, requiredHistory)...)
 	problems = append(problems, requireExactSet("functions", record.Objects.Functions, requiredFunctions)...)
@@ -313,16 +315,21 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 
 	migrationRole, migrationOK := record.Roles["migration"]
 	runtimeRole, runtimeOK := record.Roles["runtime"]
+	cleanupAuthorizerRole, cleanupAuthorizerOK := record.Roles["cleanup_authorizer"]
 	if !migrationOK || migrationRole.Kind != "schema_owner_login" || !migrationRole.DistinctFromRuntime || !strings.HasPrefix(migrationRole.Invocation, "swarm schema apply ") {
 		problems = append(problems, "migration role/invocation contract is incomplete")
 	}
 	if !runtimeOK || runtimeRole.Kind != "restricted_login" || runtimeRole.Invocation != "swarm serve --config <runtime-config>" {
 		problems = append(problems, "runtime role/invocation contract is incomplete")
 	}
-	problems = append(problems, requireExactSet("runtime denied direct operations", record.Grants.RuntimeDeniedDirectOperations, []string{"events.UPDATE", "events.DELETE", "runs.DELETE"})...)
-	problems = append(problems, requireExactSet("runtime guarded insert update", record.Grants.RuntimeGuardedInsertUpdate, []string{"runs"})...)
-	problems = append(problems, requireExactSet("runtime execute", record.Grants.RuntimeExecute, []string{"swarm_claim_temporal_runs", "swarm_destroy_run"})...)
-	problems = append(problems, requireSet("runtime denied execute", record.Grants.RuntimeDeniedExecute, []string{"swarm_declare_temporal_runs", "swarm_next_temporal_ordinal", "swarm_guard_events", "swarm_guard_event_deliveries", "swarm_guard_event_receipts"})...)
+	if !cleanupAuthorizerOK || cleanupAuthorizerRole.Kind != "restricted_cleanup_authorizer_login" || !cleanupAuthorizerRole.DistinctFromRuntime || cleanupAuthorizerRole.Invocation != "canonical destructive-reset plan/quiescence/directive owner" {
+		problems = append(problems, "cleanup authorizer role/invocation contract is incomplete")
+	}
+	problems = append(problems, requireExactSet("runtime denied direct operations", record.Grants.RuntimeDeniedDirectOperations, []string{"events.UPDATE", "events.DELETE", "runs.INSERT", "runs.DELETE"})...)
+	problems = append(problems, requireExactSet("runtime guarded update", record.Grants.RuntimeGuardedUpdate, []string{"runs"})...)
+	problems = append(problems, requireExactSet("runtime execute", record.Grants.RuntimeExecute, []string{"swarm_create_run", "swarm_claim_temporal_runs", "swarm_claim_authorized_run_cleanup", "swarm_delete_authorized_runs"})...)
+	problems = append(problems, requireSet("runtime denied execute", record.Grants.RuntimeDeniedExecute, []string{"swarm_declare_temporal_runs", "swarm_authorize_run_cleanup", "swarm_next_temporal_ordinal", "swarm_resolve_temporal_run", "swarm_guard_append_fact", "swarm_guard_mutable_fact"})...)
+	problems = append(problems, requireExactSet("cleanup authorizer execute", record.Grants.CleanupAuthorizerExecute, []string{"swarm_authorize_run_cleanup"})...)
 
 	requiredFacts := []string{"runs", "events", "event_deliveries", "event_receipts", "dead_letters", "entity_mutations", "entity_state", "timers", "agent_sessions", "agent_turns", "agent_conversation_audits", "reply_contexts", "activity_attempts", "selected_fork_lineage", "routing_rules", "runless_events"}
 	facts := make([]string, 0, len(record.FactFamilies))
@@ -333,7 +340,7 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 		}
 	}
 	problems = append(problems, requireExactSet("fact families", facts, requiredFacts)...)
-	for _, operation := range []string{"event_insert", "event_update", "event_delete", "mutable_insert", "mutable_update", "mutable_delete", "whole_run_delete"} {
+	for _, operation := range []string{"run_insert", "event_insert", "event_update", "event_delete", "mutable_insert", "mutable_update", "mutable_delete", "whole_run_delete", "mixed_cleanup", "derived_lineage"} {
 		if strings.TrimSpace(record.Operations[operation]) == "" {
 			problems = append(problems, "operations missing "+operation)
 		}
@@ -348,13 +355,16 @@ func validateTemporalFrontierDesignRecord(root string, record temporalFrontierDe
 	if record.Migration.HeuristicBackfill != "forbidden" {
 		problems = append(problems, "migration heuristic backfill is not forbidden")
 	}
+	if record.Migration.LegacyAdmission != "complete_registered_catalog_checksum" || record.Migration.Reapply != "full_catalog_revalidation_then_exact_checksum_noop_else_fail_closed" {
+		problems = append(problems, "migration catalog admission/reapply contract drifted")
+	}
 	if record.Migration.Isolation != "SERIALIZABLE" || !record.Migration.MetadataUpdatedLast || !record.Migration.RollbackIsAtomic || record.Migration.ServeSchemaMutation != "forbidden" {
 		problems = append(problems, "migration atomicity/admission contract drifted")
 	}
 	problems = append(problems, requireExactSet("active statuses", record.Migration.ActiveStatuses, []string{"running", "paused"})...)
 	problems = append(problems, requireExactSet("deployment locks", record.Migration.DeploymentLocks, []string{"runtime_shared_session_advisory", "migration_exclusive_advisory", "first_upgrade_access_exclusive_tables"})...)
 
-	requiredAssertions := []string{"fresh_schema_creation", "active_legacy_run_rejected_without_ddl", "failed_migration_rolls_back_schema_and_metadata", "exact_reapply_is_idempotent", "runtime_shared_lock_excludes_migration", "runtime_cannot_assume_owner_or_disable_trigger", "runtime_cannot_mutate_authority_or_history_tables", "undeclared_insert_update_delete_rejected", "declared_delete_writes_typed_history", "destructive_declaration_not_runtime_callable", "event_delivery_receipt_share_revision_and_ordinals", "rollback_publishes_no_revision", "update_move_requires_old_and_new_runs", "runless_lineage_remains_unversioned", "unversioned_destructive_cleanup_creates_no_revision", "reverse_order_claims_serialize_frontier_first", "trigger_functions_are_not_runtime_bypass_surfaces", "second_runtime_boot_is_read_only"}
+	requiredAssertions := []string{"fresh_schema_creation", "restricted_runtime_atomic_run_creation", "active_legacy_run_rejected_without_ddl", "complete_legacy_catalog_drift_rejected", "failed_migration_rolls_back_schema_and_metadata", "exact_reapply_is_idempotent", "drifted_target_reapply_rejected", "runtime_shared_lock_excludes_migration", "runtime_cannot_assume_owner_or_disable_trigger", "runtime_cannot_mutate_authority_or_history_tables", "undeclared_insert_update_delete_rejected", "every_guarded_fact_family_insert_update_delete_proven", "derived_lineage_mismatch_rejected", "destructive_declaration_not_runtime_callable", "event_delivery_receipt_share_revision_and_ordinals", "rollback_publishes_no_revision", "update_move_requires_old_and_new_runs", "runless_lineage_remains_unversioned", "authorized_unversioned_destructive_cleanup_creates_no_revision", "arbitrary_run_deletion_rejected", "cleanup_authorization_is_not_runtime_mintable", "cleanup_authorizer_has_no_fact_or_schema_privileges", "mixed_cleanup_revisions_survivors_and_tombstones_deleted_runs", "reverse_order_claims_serialize_frontier_first", "trigger_functions_are_not_runtime_bypass_surfaces", "second_runtime_boot_is_read_only"}
 	if record.Prototype.Test != "TestTemporalFrontierPostgresDesignConformance" || record.Prototype.RunnerOwner != "platform-spec.yaml#run_model.fork.temporal_frontier.required_conformance.runner" || record.Prototype.ProofProjection != "required-full" {
 		problems = append(problems, "prototype test/runner owner/proof projection does not match the dedicated supported command")
 	}

--- a/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
+++ b/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
@@ -6,13 +6,14 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/testpostgres"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
@@ -47,25 +48,29 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	suffix := fmt.Sprintf("%x", time.Now().UnixNano())
 	ownerRole := "tf_owner_" + suffix
 	runtimeRole := "tf_runtime_" + suffix
+	cleanupAuthorizerRole := "tf_cleanup_authorizer_" + suffix
 	upgradeSchema := "tf_upgrade_" + suffix
 	freshSchema := "tf_fresh_" + suffix
 	runtimePassword := "tf-runtime-" + suffix
+	cleanupAuthorizerPassword := "tf-cleanup-authorizer-" + suffix
 
 	mustExecTemporal(t, ctx, admin, `CREATE ROLE `+quoteTemporalIdent(ownerRole)+` LOGIN PASSWORD 'owner-not-used' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS`)
 	mustExecTemporal(t, ctx, admin, `CREATE ROLE `+quoteTemporalIdent(runtimeRole)+` LOGIN PASSWORD `+quoteTemporalLiteral(runtimePassword)+` NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS`)
+	mustExecTemporal(t, ctx, admin, `CREATE ROLE `+quoteTemporalIdent(cleanupAuthorizerRole)+` LOGIN PASSWORD `+quoteTemporalLiteral(cleanupAuthorizerPassword)+` NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS`)
 	defer func() {
 		_, _ = admin.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+quoteTemporalIdent(freshSchema)+` CASCADE`)
 		_, _ = admin.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+quoteTemporalIdent(upgradeSchema)+` CASCADE`)
 		_, _ = admin.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+quoteTemporalIdent(runtimeRole))
+		_, _ = admin.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+quoteTemporalIdent(cleanupAuthorizerRole))
 		_, _ = admin.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+quoteTemporalIdent(ownerRole))
 	}()
 
 	mustExecTemporal(t, ctx, admin, `CREATE SCHEMA `+quoteTemporalIdent(freshSchema)+` AUTHORIZATION `+quoteTemporalIdent(ownerRole))
-	if err := applyTemporalPrototype(ctx, admin, freshSchema, ownerRole, runtimeRole, true, false); err != nil {
+	if err := applyTemporalPrototype(ctx, admin, freshSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, true, false); err != nil {
 		t.Fatalf("fresh temporal schema apply: %v", err)
 	}
-	assertTemporalTargetMetadata(t, ctx, admin, freshSchema, ownerRole, runtimeRole)
-	for _, table := range []string{"run_temporal_transactions", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_deletion_tombstones", "event_delivery_history", "event_receipt_history"} {
+	assertTemporalTargetMetadata(t, ctx, admin, freshSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
+	for _, table := range []string{"run_temporal_transactions", "run_temporal_transaction_runs", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_cleanup_authorizations", "run_deletion_tombstones", "event_delivery_history", "event_receipt_history"} {
 		assertTemporalTableExists(t, ctx, admin, freshSchema, table, true)
 	}
 
@@ -80,14 +85,21 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status) VALUES ($1,$2,$3,'pending')`, quoteTemporalIdent(upgradeSchema)), legacyDelivery, legacyRun, legacyEvent)
 	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.event_receipts(receipt_id,event_id,outcome) VALUES ($1,$2,'success')`, quoteTemporalIdent(upgradeSchema)), legacyReceipt, legacyEvent)
 
-	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false)
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false)
 	if err == nil || !strings.Contains(err.Error(), legacyRun) {
 		t.Fatalf("active legacy migration error = %v, want exact active run", err)
 	}
 	assertTemporalTableExists(t, ctx, admin, upgradeSchema, "run_temporal_frontiers", false)
 	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`UPDATE %s.runs SET status='completed' WHERE run_id=$1`, quoteTemporalIdent(upgradeSchema)), legacyRun)
 
-	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, true)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`ALTER TABLE %s.events ADD COLUMN unregistered_drift TEXT`, quoteTemporalIdent(upgradeSchema)))
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false)
+	if err == nil || !strings.Contains(err.Error(), "legacy catalog checksum mismatch") {
+		t.Fatalf("drifted legacy migration error = %v, want catalog checksum rejection", err)
+	}
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`ALTER TABLE %s.events DROP COLUMN unregistered_drift`, quoteTemporalIdent(upgradeSchema)))
+
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, true)
 	if err == nil || !strings.Contains(err.Error(), "forced temporal migration rollback") {
 		t.Fatalf("forced migration error = %v", err)
 	}
@@ -100,11 +112,11 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 		t.Fatalf("rolled-back platform version = %q, want 0.7.0", legacyVersion)
 	}
 
-	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false); err != nil {
+	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false); err != nil {
 		t.Fatalf("recognized temporal upgrade: %v", err)
 	}
-	assertTemporalTargetMetadata(t, ctx, admin, upgradeSchema, ownerRole, runtimeRole)
-	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false); err != nil {
+	assertTemporalTargetMetadata(t, ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
+	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false); err != nil {
 		t.Fatalf("idempotent temporal reapply: %v", err)
 	}
 	var migrationCount int
@@ -113,6 +125,15 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	}
 	if migrationCount != 1 {
 		t.Fatalf("temporal migration rows = %d, want 1", migrationCount)
+	}
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`ALTER TABLE %s.event_deliveries DISABLE TRIGGER temporal_event_deliveries_guard`, quoteTemporalIdent(upgradeSchema)))
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false)
+	if err == nil || !strings.Contains(err.Error(), "target catalog checksum mismatch") {
+		t.Fatalf("drifted target reapply error = %v, want full catalog rejection", err)
+	}
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`ALTER TABLE %s.event_deliveries ENABLE ALWAYS TRIGGER temporal_event_deliveries_guard`, quoteTemporalIdent(upgradeSchema)))
+	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false); err != nil {
+		t.Fatalf("reapply after restoring target catalog: %v", err)
 	}
 
 	runtimeDSN := temporalRoleDSN(connection.Parameters(), runtimeRole, runtimePassword)
@@ -123,6 +144,15 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	defer runtimeDB.Close()
 	if err := runtimeDB.PingContext(ctx); err != nil {
 		t.Fatalf("ping restricted runtime connection: %v", err)
+	}
+	cleanupAuthorizerDSN := temporalRoleDSN(connection.Parameters(), cleanupAuthorizerRole, cleanupAuthorizerPassword)
+	cleanupAuthorizerDB, err := sql.Open("postgres", cleanupAuthorizerDSN)
+	if err != nil {
+		t.Fatalf("open cleanup authorizer connection: %v", err)
+	}
+	defer cleanupAuthorizerDB.Close()
+	if err := cleanupAuthorizerDB.PingContext(ctx); err != nil {
+		t.Fatalf("ping cleanup authorizer connection: %v", err)
 	}
 
 	lockKey := temporalSchemaLockKey(upgradeSchema)
@@ -142,20 +172,24 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	mustExecTemporal(t, ctx, runtimeLockConn, `SELECT pg_advisory_unlock_shared($1)`, lockKey)
 	runtimeLockConn.Close()
 
-	assertTemporalRuntimeAdmission(t, ctx, runtimeDB, upgradeSchema, ownerRole, runtimeRole)
+	assertTemporalRuntimeAdmission(t, ctx, runtimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
 	secondRuntimeDB, err := sql.Open("postgres", runtimeDSN)
 	if err != nil {
 		t.Fatalf("open second runtime connection: %v", err)
 	}
-	assertTemporalRuntimeAdmission(t, ctx, secondRuntimeDB, upgradeSchema, ownerRole, runtimeRole)
+	assertTemporalRuntimeAdmission(t, ctx, secondRuntimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
 	secondRuntimeDB.Close()
 
 	assertTemporalPrivilegeDenials(t, ctx, runtimeDB, upgradeSchema, ownerRole)
+	assertTemporalCleanupAuthorizerAdmission(t, ctx, cleanupAuthorizerDB, upgradeSchema)
 
 	runA := "10000000-0000-0000-0000-000000000001"
 	runB := "20000000-0000-0000-0000-000000000002"
 	runC := "30000000-0000-0000-0000-000000000003"
-	seedTemporalVersionedRuns(t, ctx, admin, upgradeSchema, ownerRole, runA, runB, runC)
+	for _, runID := range []string{runA, runB, runC} {
+		mustExecTemporal(t, ctx, runtimeDB, fmt.Sprintf(`SELECT %s.swarm_create_run($1,'running')`, quoteTemporalIdent(upgradeSchema)), runID)
+	}
+	assertTemporalCreatedRuns(t, ctx, runtimeDB, upgradeSchema, runA, runB, runC)
 
 	eventID := "a0000000-0000-0000-0000-000000000001"
 	deliveryID := "d0000000-0000-0000-0000-000000000001"
@@ -166,11 +200,13 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	assertTemporalDirectEventMutationRejected(t, ctx, runtimeDB, upgradeSchema, eventID)
 	assertTemporalEventTriggerDefendsGrantDrift(t, ctx, admin, upgradeSchema, ownerRole, runA, eventID)
 	assertTemporalUndeclaredDeliveryMutationRejected(t, ctx, runtimeDB, upgradeSchema, deliveryID)
-	assertTemporalOwnershipMove(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA, runB)
-	assertTemporalDeclaredDeliveryDelete(t, ctx, runtimeDB, upgradeSchema, deliveryID, runB)
+	assertTemporalDeliveryLineageMismatchRejected(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA, runB)
+	assertTemporalDeclaredDeliveryDelete(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA)
+	assertTemporalAllGuardedFamilies(t, ctx, runtimeDB, upgradeSchema, runA, eventID)
 	assertTemporalRollbackPublishesNothing(t, ctx, runtimeDB, upgradeSchema, runC)
 	assertTemporalRunlessLineage(t, ctx, runtimeDB, upgradeSchema)
-	assertTemporalUnversionedDestruction(t, ctx, runtimeDB, upgradeSchema, legacyRun, legacyEvent, legacyDelivery, legacyReceipt)
+	assertTemporalAuthorizedMixedCleanup(t, ctx, cleanupAuthorizerDB, runtimeDB, upgradeSchema, runA, runC)
+	assertTemporalUnversionedDestruction(t, ctx, cleanupAuthorizerDB, runtimeDB, upgradeSchema, legacyRun, legacyEvent, legacyDelivery, legacyReceipt)
 	assertTemporalReverseClaimsSerialize(t, ctx, admin, runtimeDB, upgradeSchema, runA, runB)
 }
 
@@ -188,7 +224,7 @@ func createTemporalLegacySchema(t *testing.T, ctx context.Context, db *sql.DB, s
 	}
 }
 
-func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runtimeRole string, fresh, forceRollback bool) error {
+func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string, fresh, forceRollback bool) error {
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return fmt.Errorf("begin temporal schema apply: %w", err)
@@ -230,22 +266,29 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 		SELECT count(*)
 		FROM information_schema.columns
 		WHERE table_schema=$1 AND table_name='runtime_store_metadata'
-		  AND column_name IN ('schema_generation','schema_ddl_sha256','schema_owner_role','runtime_role')
+		  AND column_name IN ('schema_generation','schema_ddl_sha256','schema_catalog_sha256','schema_owner_role','runtime_role','cleanup_authorizer_role')
 	`, schema).Scan(&targetColumns); err != nil {
 		return fmt.Errorf("inspect temporal metadata generation: %w", err)
 	}
 	checksum := temporalPrototypeChecksum()
-	if targetColumns == 4 {
-		var generation, storedChecksum, storedOwner, storedRuntime string
-		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_owner_role,runtime_role FROM %s.runtime_store_metadata WHERE id=1`, qSchema)).Scan(&generation, &storedChecksum, &storedOwner, &storedRuntime); err != nil {
+	if targetColumns == 6 {
+		var generation, storedChecksum, storedCatalogChecksum, storedOwner, storedRuntime, storedCleanupAuthorizer string
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_catalog_sha256,schema_owner_role,runtime_role,cleanup_authorizer_role FROM %s.runtime_store_metadata WHERE id=1`, qSchema)).Scan(&generation, &storedChecksum, &storedCatalogChecksum, &storedOwner, &storedRuntime, &storedCleanupAuthorizer); err != nil {
 			return fmt.Errorf("read temporal target metadata: %w", err)
 		}
-		if generation != "temporal-frontier-v1" || storedChecksum != checksum || storedOwner != owner || storedRuntime != runtimeRole {
+		if generation != "temporal-frontier-v1" || storedChecksum != checksum || storedOwner != owner || storedRuntime != runtimeRole || storedCleanupAuthorizer != cleanupAuthorizerRole {
 			return fmt.Errorf("temporal target metadata drift")
 		}
 		var ledgerCount int
-		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.runtime_store_migrations WHERE migration_id='temporal-frontier-v1' AND ddl_sha256=$1`, qSchema), checksum).Scan(&ledgerCount); err != nil || ledgerCount != 1 {
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.runtime_store_migrations WHERE migration_id='temporal-frontier-v1' AND ddl_sha256=$1 AND catalog_sha256=$2 AND cleanup_authorizer_role=$3`, qSchema), checksum, storedCatalogChecksum, cleanupAuthorizerRole).Scan(&ledgerCount); err != nil || ledgerCount != 1 {
 			return fmt.Errorf("temporal migration ledger drift: count=%d err=%v", ledgerCount, err)
+		}
+		actualCatalogChecksum, err := temporalCatalogChecksum(ctx, tx, schema, owner, runtimeRole)
+		if err != nil {
+			return fmt.Errorf("revalidate temporal target catalog: %w", err)
+		}
+		if actualCatalogChecksum != storedCatalogChecksum {
+			return fmt.Errorf("target catalog checksum mismatch: got %s want %s", actualCatalogChecksum, storedCatalogChecksum)
 		}
 		return tx.Commit()
 	}
@@ -256,7 +299,7 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 	if _, err := tx.ExecContext(ctx, `SET LOCAL ROLE `+quoteTemporalIdent(owner)); err != nil {
 		return fmt.Errorf("assume temporal schema owner: %w", err)
 	}
-	for _, table := range []string{"event_deliveries", "event_receipts", "events", "runs", "runtime_store_metadata"} {
+	for _, table := range []string{"activity_attempts", "agent_conversation_audits", "agent_sessions", "agent_turns", "dead_letters", "entity_mutations", "entity_state", "event_deliveries", "event_receipts", "events", "reply_contexts", "runs", "runtime_store_metadata", "selected_fork_lineage", "timers"} {
 		if _, err := tx.ExecContext(ctx, `LOCK TABLE `+qSchema+`.`+quoteTemporalIdent(table)+` IN ACCESS EXCLUSIVE MODE`); err != nil {
 			return fmt.Errorf("lock legacy table %s: %w", table, err)
 		}
@@ -288,6 +331,13 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 	if platformVersion != "0.7.0" {
 		return fmt.Errorf("unrecognized legacy platform version %q", platformVersion)
 	}
+	legacyCatalogChecksum, err := temporalCatalogChecksum(ctx, tx, schema, owner, runtimeRole)
+	if err != nil {
+		return fmt.Errorf("inspect legacy catalog checksum: %w", err)
+	}
+	if legacyCatalogChecksum != temporalRegisteredLegacyCatalogChecksum {
+		return fmt.Errorf("legacy catalog checksum mismatch: got %s want %s", legacyCatalogChecksum, temporalRegisteredLegacyCatalogChecksum)
+	}
 	if _, err := tx.ExecContext(ctx, temporalTargetDDL(qSchema)); err != nil {
 		return fmt.Errorf("create temporal target schema: %w", err)
 	}
@@ -300,24 +350,28 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 	`, qSchema)); err != nil {
 		return fmt.Errorf("mark retained legacy runs unversioned: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, temporalGrantDDL(qSchema, quoteTemporalIdent(runtimeRole))); err != nil {
+	if _, err := tx.ExecContext(ctx, temporalGrantDDL(qSchema, quoteTemporalIdent(runtimeRole), quoteTemporalIdent(cleanupAuthorizerRole))); err != nil {
 		return fmt.Errorf("apply temporal grants: %w", err)
 	}
 	if forceRollback {
 		return fmt.Errorf("forced temporal migration rollback")
 	}
+	targetCatalogChecksum, err := temporalCatalogChecksum(ctx, tx, schema, owner, runtimeRole)
+	if err != nil {
+		return fmt.Errorf("compute installed temporal catalog checksum: %w", err)
+	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s.runtime_store_migrations(migration_id,from_generation,to_generation,ddl_sha256,schema_owner_role,runtime_role)
-		VALUES ('temporal-frontier-v1','pre-temporal-v0','temporal-frontier-v1',$1,$2,$3)
-	`, qSchema), checksum, owner, runtimeRole); err != nil {
+		INSERT INTO %s.runtime_store_migrations(migration_id,from_generation,to_generation,ddl_sha256,catalog_sha256,schema_owner_role,runtime_role,cleanup_authorizer_role)
+		VALUES ('temporal-frontier-v1','pre-temporal-v0','temporal-frontier-v1',$1,$2,$3,$4,$5)
+	`, qSchema), checksum, targetCatalogChecksum, owner, runtimeRole, cleanupAuthorizerRole); err != nil {
 		return fmt.Errorf("write temporal migration ledger: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s.runtime_store_metadata
 		SET platform_version='0.7.0', schema_generation='temporal-frontier-v1', schema_ddl_sha256=$1,
-		    schema_owner_role=$2, runtime_role=$3
+		    schema_catalog_sha256=$2, schema_owner_role=$3, runtime_role=$4, cleanup_authorizer_role=$5
 		WHERE id=1
-	`, qSchema), checksum, owner, runtimeRole); err != nil {
+	`, qSchema), checksum, targetCatalogChecksum, owner, runtimeRole, cleanupAuthorizerRole); err != nil {
 		return fmt.Errorf("commit temporal metadata authority: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -326,14 +380,14 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 	return nil
 }
 
-func assertTemporalTargetMetadata(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole string) {
+func assertTemporalTargetMetadata(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string) {
 	t.Helper()
-	var generation, checksum, gotOwner, gotRuntime string
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_owner_role,runtime_role FROM %s.runtime_store_metadata WHERE id=1`, quoteTemporalIdent(schema))).Scan(&generation, &checksum, &gotOwner, &gotRuntime); err != nil {
+	var generation, checksum, catalogChecksum, gotOwner, gotRuntime, gotCleanupAuthorizer string
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_catalog_sha256,schema_owner_role,runtime_role,cleanup_authorizer_role FROM %s.runtime_store_metadata WHERE id=1`, quoteTemporalIdent(schema))).Scan(&generation, &checksum, &catalogChecksum, &gotOwner, &gotRuntime, &gotCleanupAuthorizer); err != nil {
 		t.Fatalf("read temporal target metadata: %v", err)
 	}
-	if generation != "temporal-frontier-v1" || checksum != temporalPrototypeChecksum() || gotOwner != owner || gotRuntime != runtimeRole {
-		t.Fatalf("temporal metadata = generation:%q checksum:%q owner:%q runtime:%q", generation, checksum, gotOwner, gotRuntime)
+	if generation != "temporal-frontier-v1" || checksum != temporalPrototypeChecksum() || len(catalogChecksum) != 64 || gotOwner != owner || gotRuntime != runtimeRole || gotCleanupAuthorizer != cleanupAuthorizerRole {
+		t.Fatalf("temporal metadata = generation:%q checksum:%q catalog:%q owner:%q runtime:%q cleanup_authorizer:%q", generation, checksum, catalogChecksum, gotOwner, gotRuntime, gotCleanupAuthorizer)
 	}
 }
 
@@ -348,16 +402,18 @@ func assertTemporalTableExists(t *testing.T, ctx context.Context, db *sql.DB, sc
 	}
 }
 
-func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole string) {
+func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
-	var currentUser, generation, metadataRuntime string
-	var ownerMember, superuser, bypassRLS, createRole, schemaCreate bool
+	var currentUser, generation, metadataRuntime, metadataCleanupAuthorizer string
+	var ownerMember, cleanupAuthorizerMember, superuser, bypassRLS, createRole, schemaCreate bool
 	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT current_user,
 		       m.schema_generation,
 		       m.runtime_role,
+		       m.cleanup_authorizer_role,
 		       pg_has_role(current_user,$1,'MEMBER'),
+		       pg_has_role(current_user,$3,'MEMBER'),
 		       r.rolsuper,
 		       r.rolbypassrls,
 		       r.rolcreaterole,
@@ -365,11 +421,11 @@ func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.D
 		FROM %[1]s.runtime_store_metadata m
 		JOIN pg_roles r ON r.rolname=current_user
 		WHERE m.id=1
-	`, qSchema), owner, schema).Scan(&currentUser, &generation, &metadataRuntime, &ownerMember, &superuser, &bypassRLS, &createRole, &schemaCreate); err != nil {
+	`, qSchema), owner, schema, cleanupAuthorizerRole).Scan(&currentUser, &generation, &metadataRuntime, &metadataCleanupAuthorizer, &ownerMember, &cleanupAuthorizerMember, &superuser, &bypassRLS, &createRole, &schemaCreate); err != nil {
 		t.Fatalf("read temporal runtime admission: %v", err)
 	}
-	if currentUser != runtimeRole || metadataRuntime != runtimeRole || generation != "temporal-frontier-v1" || ownerMember || superuser || bypassRLS || createRole || schemaCreate {
-		t.Fatalf("runtime admission drift: user=%q metadata=%q generation=%q owner_member=%v super=%v bypass=%v createrole=%v schema_create=%v", currentUser, metadataRuntime, generation, ownerMember, superuser, bypassRLS, createRole, schemaCreate)
+	if currentUser != runtimeRole || metadataRuntime != runtimeRole || metadataCleanupAuthorizer != cleanupAuthorizerRole || generation != "temporal-frontier-v1" || ownerMember || cleanupAuthorizerMember || superuser || bypassRLS || createRole || schemaCreate {
+		t.Fatalf("runtime admission drift: user=%q metadata=%q cleanup_authorizer=%q generation=%q owner_member=%v cleanup_member=%v super=%v bypass=%v createrole=%v schema_create=%v", currentUser, metadataRuntime, metadataCleanupAuthorizer, generation, ownerMember, cleanupAuthorizerMember, superuser, bypassRLS, createRole, schemaCreate)
 	}
 
 	var triggerCount int
@@ -381,7 +437,7 @@ func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.D
 		JOIN pg_proc p ON p.oid=t.tgfoid
 		JOIN pg_roles owner_role ON owner_role.oid=p.proowner
 		WHERE n.nspname=$1
-		  AND c.relname IN ('events','event_deliveries','event_receipts')
+		  AND c.relname IN ('runs','events','event_deliveries','event_receipts','dead_letters','entity_mutations','entity_state','timers','agent_sessions','agent_turns','agent_conversation_audits','reply_contexts','activity_attempts','selected_fork_lineage')
 		  AND NOT t.tgisinternal
 		  AND t.tgenabled='A'
 		  AND p.prosecdef
@@ -390,34 +446,38 @@ func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.D
 	`, schema, owner).Scan(&triggerCount); err != nil {
 		t.Fatalf("inspect temporal triggers: %v", err)
 	}
-	if triggerCount != 3 {
-		t.Fatalf("admitted temporal trigger count = %d, want 3", triggerCount)
+	if triggerCount != 14 {
+		t.Fatalf("admitted temporal trigger count = %d, want 14", triggerCount)
 	}
 
-	var eventInsert, eventUpdate, eventDelete, historyDML, helperExecute bool
+	var eventInsert, eventUpdate, eventDelete, runInsert, historyDML, helperExecute bool
 	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT has_table_privilege(current_user,'%[1]s.events','INSERT'),
 		       has_table_privilege(current_user,'%[1]s.events','UPDATE'),
 		       has_table_privilege(current_user,'%[1]s.events','DELETE'),
+		       has_table_privilege(current_user,'%[1]s.runs','INSERT'),
 		       has_table_privilege(current_user,'%[1]s.event_delivery_history','INSERT,UPDATE,DELETE'),
 		       has_function_privilege(current_user,'%[1]s.swarm_next_temporal_ordinal(uuid)','EXECUTE')
-	`, qSchema)).Scan(&eventInsert, &eventUpdate, &eventDelete, &historyDML, &helperExecute); err != nil {
+	`, qSchema)).Scan(&eventInsert, &eventUpdate, &eventDelete, &runInsert, &historyDML, &helperExecute); err != nil {
 		t.Fatalf("inspect temporal grants: %v", err)
 	}
-	if !eventInsert || eventUpdate || eventDelete || historyDML || helperExecute {
-		t.Fatalf("runtime grant drift: event_insert=%v event_update=%v event_delete=%v history_dml=%v helper_execute=%v", eventInsert, eventUpdate, eventDelete, historyDML, helperExecute)
+	if !eventInsert || eventUpdate || eventDelete || runInsert || historyDML || helperExecute {
+		t.Fatalf("runtime grant drift: event_insert=%v event_update=%v event_delete=%v run_insert=%v history_dml=%v helper_execute=%v", eventInsert, eventUpdate, eventDelete, runInsert, historyDML, helperExecute)
 	}
 	functionGrants := []struct {
 		signature string
 		want      bool
 	}{
 		{signature: "swarm_claim_temporal_runs(uuid[])", want: true},
-		{signature: "swarm_destroy_run(uuid,text)", want: true},
-		{signature: "swarm_declare_temporal_runs(uuid[],text)", want: false},
+		{signature: "swarm_create_run(uuid,text)", want: true},
+		{signature: "swarm_authorize_run_cleanup(uuid,text,text,uuid[],uuid[])", want: false},
+		{signature: "swarm_claim_authorized_run_cleanup(uuid)", want: true},
+		{signature: "swarm_delete_authorized_runs(uuid)", want: true},
+		{signature: "swarm_declare_temporal_runs(uuid[],uuid[])", want: false},
 		{signature: "swarm_next_temporal_ordinal(uuid)", want: false},
-		{signature: "swarm_guard_events()", want: false},
-		{signature: "swarm_guard_event_deliveries()", want: false},
-		{signature: "swarm_guard_event_receipts()", want: false},
+		{signature: "swarm_resolve_temporal_run(jsonb,text,text)", want: false},
+		{signature: "swarm_guard_append_fact()", want: false},
+		{signature: "swarm_guard_mutable_fact()", want: false},
 	}
 	for _, grant := range functionGrants {
 		var got bool
@@ -430,37 +490,62 @@ func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.D
 	}
 }
 
+func assertTemporalCleanupAuthorizerAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	var schemaCreate, factInsert, authorityDML, authorizeExecute, claimExecute bool
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT has_schema_privilege(current_user,$1,'CREATE'),
+		       has_table_privilege(current_user,'%[1]s.events','INSERT,UPDATE,DELETE'),
+		       has_table_privilege(current_user,'%[1]s.run_cleanup_authorizations','INSERT,UPDATE,DELETE'),
+		       has_function_privilege(current_user,'%[1]s.swarm_authorize_run_cleanup(uuid,text,text,uuid[],uuid[])','EXECUTE'),
+		       has_function_privilege(current_user,'%[1]s.swarm_claim_authorized_run_cleanup(uuid)','EXECUTE')
+	`, qSchema), schema).Scan(&schemaCreate, &factInsert, &authorityDML, &authorizeExecute, &claimExecute); err != nil {
+		t.Fatalf("inspect cleanup authorizer admission: %v", err)
+	}
+	if schemaCreate || factInsert || authorityDML || !authorizeExecute || claimExecute {
+		t.Fatalf("cleanup authorizer grant drift: schema_create=%v fact_insert=%v authority_dml=%v authorize=%v claim=%v", schemaCreate, factInsert, authorityDML, authorizeExecute, claimExecute)
+	}
+}
+
 func assertTemporalPrivilegeDenials(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
 	assertTemporalExecFails(t, ctx, db, `SET ROLE `+quoteTemporalIdent(owner), "assume schema owner")
 	assertTemporalExecFails(t, ctx, db, `ALTER TABLE `+qSchema+`.events DISABLE TRIGGER ALL`, "disable temporal trigger")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.event_delivery_history(run_id,revision,ordinal,operation,fact_id) VALUES ('00000000-0000-0000-0000-000000000000',1,1,'insert','forged')`, qSchema), "write temporal history")
-	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.run_temporal_transactions(transaction_id,run_ids,mode) VALUES (pg_current_xact_id(),ARRAY['00000000-0000-0000-0000-000000000000'::uuid],'normal')`, qSchema), "write temporal transaction authority")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.run_temporal_transactions(transaction_id) VALUES (pg_current_xact_id())`, qSchema), "write temporal transaction authority")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.run_temporal_transaction_runs(transaction_id,run_id,disposition) VALUES (pg_current_xact_id(),'00000000-0000-0000-0000-000000000000','normal')`, qSchema), "write temporal transaction run authority")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.run_temporal_frontiers SET current_revision=current_revision+1`, qSchema), "write temporal frontier authority")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.run_temporal_revisions`, qSchema), "write temporal revision authority")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.runtime_store_migrations`, qSchema), "write temporal migration ledger")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.runtime_store_metadata SET schema_generation='forged'`, qSchema), "write temporal metadata")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.run_deletion_tombstones`, qSchema), "write temporal deletion evidence")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.run_cleanup_authorizations(authorization_id,operation_id,actor_evidence,destructive_run_ids) VALUES (gen_random_uuid(),'forged','forged',ARRAY['00000000-0000-0000-0000-000000000000'::uuid])`, qSchema), "write cleanup authorization")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.runs(run_id,status) VALUES ('00000000-0000-0000-0000-000000000000','running')`, qSchema), "insert run outside creation owner")
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT * FROM %s.swarm_next_temporal_ordinal('00000000-0000-0000-0000-000000000000'::uuid)`, qSchema), "invoke ordinal bypass")
-	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_declare_temporal_runs(ARRAY['00000000-0000-0000-0000-000000000000'::uuid],'destructive')`, qSchema), "invoke destructive declaration bypass")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_declare_temporal_runs('{}'::uuid[],ARRAY['00000000-0000-0000-0000-000000000000'::uuid])`, qSchema), "invoke destructive declaration bypass")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_authorize_run_cleanup(gen_random_uuid(),'forged','forged','{}'::uuid[],ARRAY['00000000-0000-0000-0000-000000000000'::uuid])`, qSchema), "mint cleanup authorization from runtime")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_claim_authorized_run_cleanup('00000000-0000-0000-0000-000000000000')`, qSchema), "claim unknown cleanup authorization")
 }
 
-func seedTemporalVersionedRuns(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string, runIDs ...string) {
+func assertTemporalCreatedRuns(t *testing.T, ctx context.Context, db *sql.DB, schema string, runIDs ...string) {
 	t.Helper()
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin temporal run seed: %v", err)
-	}
-	defer tx.Rollback()
-	mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
 	qSchema := quoteTemporalIdent(schema)
 	for _, runID := range runIDs {
-		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.runs(run_id,status) VALUES ($1,'running')`, qSchema), runID)
-		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.run_temporal_frontiers(run_id,model_version,current_revision,history_complete) VALUES ($1,1,0,true)`, qSchema), runID)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit temporal run seed: %v", err)
+		var model int
+		var revision int64
+		var historyCount int
+		if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT f.model_version,f.current_revision,
+			       (SELECT count(*) FROM %[1]s.run_lifecycle_history h WHERE h.run_id=f.run_id AND h.operation='insert')
+			FROM %[1]s.run_temporal_frontiers f WHERE f.run_id=$1
+		`, qSchema), runID).Scan(&model, &revision, &historyCount); err != nil {
+			t.Fatalf("read restricted-runtime-created run %s: %v", runID, err)
+		}
+		if model != 1 || revision != 1 || historyCount != 1 {
+			t.Fatalf("created run %s = model:%d revision:%d history:%d, want 1/1/1", runID, model, revision, historyCount)
+		}
 	}
 }
 
@@ -553,35 +638,82 @@ func assertTemporalUndeclaredDeliveryMutationRejected(t *testing.T, ctx context.
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), "undeclared delivery delete", deliveryID)
 }
 
-func assertTemporalOwnershipMove(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID, runA, runB string) {
+func assertTemporalDeliveryLineageMismatchRejected(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID, runA, runB string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
+	eventB := "b0000000-0000-0000-0000-000000000002"
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		t.Fatalf("begin incomplete ownership move: %v", err)
+		t.Fatalf("begin second-run event insert: %v", err)
 	}
 	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runB)
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s.event_deliveries SET run_id=$1 WHERE delivery_id=$2`, qSchema), runB, deliveryID); err == nil {
-		t.Fatal("ownership move with NEW run only unexpectedly succeeded")
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ($1,$2)`, qSchema), eventB, runB)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit second-run event insert: %v", err)
+	}
+
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin delivery lineage mismatch insert: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runA)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status) VALUES ('d0000000-0000-0000-0000-000000000099',$1,$2,'pending')`, qSchema), runA, eventB); err == nil {
+		t.Fatal("delivery insert with mismatched event lineage unexpectedly succeeded")
 	}
 	_ = tx.Rollback()
 
 	tx, err = db.BeginTx(ctx, nil)
 	if err != nil {
-		t.Fatalf("begin complete ownership move: %v", err)
+		t.Fatalf("begin delivery lineage mismatch update: %v", err)
 	}
-	defer tx.Rollback()
-	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runB, runA)
-	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.event_deliveries SET run_id=$1 WHERE delivery_id=$2`, qSchema), runB, deliveryID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runA, runB)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s.event_deliveries SET run_id=$1 WHERE delivery_id=$2`, qSchema), runB, deliveryID); err == nil {
+		t.Fatal("delivery moved away from authoritative event lineage")
+	}
+	_ = tx.Rollback()
+
+	entityID := "b0000000-0000-0000-0000-000000000003"
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin direct mutable fixture: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runA)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.entity_state(entity_id,run_id,value) VALUES ($1,$2,'owned-a')`, qSchema), entityID, runA)
 	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit complete ownership move: %v", err)
+		t.Fatalf("commit direct mutable fixture: %v", err)
 	}
-	var gotRun string
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT run_id::text FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), deliveryID).Scan(&gotRun); err != nil {
-		t.Fatalf("read moved delivery: %v", err)
+
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin incomplete direct ownership move: %v", err)
 	}
-	if gotRun != runB {
-		t.Fatalf("moved delivery run = %s, want %s", gotRun, runB)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runB)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s.entity_state SET run_id=$1 WHERE entity_id=$2`, qSchema), runB, entityID); err == nil {
+		t.Fatal("direct ownership move with only NEW run unexpectedly succeeded")
+	}
+	_ = tx.Rollback()
+
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin complete direct ownership move: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runB, runA)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.entity_state SET run_id=$1,value='owned-b' WHERE entity_id=$2`, qSchema), runB, entityID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit complete direct ownership move: %v", err)
+	}
+	var movedRun string
+	var oldRunHistory, newRunHistory int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT e.run_id::text,
+		       (SELECT count(*) FROM %[1]s.entity_state_history WHERE fact_id=$1 AND run_id=$2::uuid),
+		       (SELECT count(*) FROM %[1]s.entity_state_history WHERE fact_id=$1 AND run_id=$3::uuid)
+		FROM %[1]s.entity_state e WHERE entity_id=$1::uuid
+	`, qSchema), entityID, runA, runB).Scan(&movedRun, &oldRunHistory, &newRunHistory); err != nil {
+		t.Fatalf("read complete direct ownership move: %v", err)
+	}
+	if movedRun != runB || oldRunHistory == 0 || newRunHistory == 0 {
+		t.Fatalf("direct ownership move = run:%s old_history:%d new_history:%d", movedRun, oldRunHistory, newRunHistory)
 	}
 }
 
@@ -611,9 +743,146 @@ func assertTemporalDeclaredDeliveryDelete(t *testing.T, ctx context.Context, db 
 	}
 }
 
+func assertTemporalAllGuardedFamilies(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, eventID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin all-family restricted runtime proof: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+
+	appendStatements := []struct {
+		query string
+		arg   string
+	}{
+		{query: fmt.Sprintf(`INSERT INTO %s.entity_mutations(mutation_id,run_id,value) VALUES ('41000000-0000-0000-0000-000000000001',$1,'inserted')`, qSchema), arg: runID},
+		{query: fmt.Sprintf(`INSERT INTO %s.dead_letters(dead_letter_id,original_event_id,value) VALUES ('42000000-0000-0000-0000-000000000001',$1,'inserted')`, qSchema), arg: eventID},
+		{query: fmt.Sprintf(`INSERT INTO %s.agent_turns(turn_id,run_id,value) VALUES ('43000000-0000-0000-0000-000000000001',$1,'inserted')`, qSchema), arg: runID},
+		{query: fmt.Sprintf(`INSERT INTO %s.selected_fork_lineage(lineage_id,run_id,value) VALUES ('44000000-0000-0000-0000-000000000001',$1,'inserted')`, qSchema), arg: runID},
+	}
+	for _, stmt := range appendStatements {
+		mustExecTemporal(t, ctx, tx, stmt.query, stmt.arg)
+	}
+
+	mutableFamilies := []struct {
+		table        string
+		idColumn     string
+		id           string
+		historyTable string
+	}{
+		{table: "timers", idColumn: "timer_id", id: "51000000-0000-0000-0000-000000000001", historyTable: "timer_history"},
+		{table: "entity_state", idColumn: "entity_id", id: "52000000-0000-0000-0000-000000000001", historyTable: "entity_state_history"},
+		{table: "agent_sessions", idColumn: "session_id", id: "53000000-0000-0000-0000-000000000001", historyTable: "agent_session_history"},
+		{table: "agent_conversation_audits", idColumn: "audit_id", id: "54000000-0000-0000-0000-000000000001", historyTable: "conversation_audit_history"},
+		{table: "reply_contexts", idColumn: "reply_context_id", id: "55000000-0000-0000-0000-000000000001", historyTable: "reply_context_history"},
+		{table: "activity_attempts", idColumn: "attempt_id", id: "56000000-0000-0000-0000-000000000001", historyTable: "activity_attempt_history"},
+	}
+	for _, family := range mutableFamilies {
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.%s(%s,run_id,value) VALUES ($1,$2,'inserted')`, qSchema, quoteTemporalIdent(family.table), quoteTemporalIdent(family.idColumn)), family.id, runID)
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.%s SET value='updated' WHERE %s=$1`, qSchema, quoteTemporalIdent(family.table), quoteTemporalIdent(family.idColumn)), family.id)
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`DELETE FROM %s.%s WHERE %s=$1`, qSchema, quoteTemporalIdent(family.table), quoteTemporalIdent(family.idColumn)), family.id)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.runs SET status='paused' WHERE run_id=$1`, qSchema), runID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit all-family restricted runtime proof: %v", err)
+	}
+
+	for _, family := range mutableFamilies {
+		var count int
+		if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.%s WHERE fact_id=$1 AND operation IN ('insert','update','delete')`, qSchema, quoteTemporalIdent(family.historyTable)), family.id).Scan(&count); err != nil {
+			t.Fatalf("count %s typed history: %v", family.table, err)
+		}
+		if count != 3 {
+			t.Fatalf("%s typed history count = %d, want 3", family.table, count)
+		}
+	}
+	for _, family := range []struct {
+		table string
+		idCol string
+		id    string
+	}{
+		{table: "entity_mutations", idCol: "mutation_id", id: "41000000-0000-0000-0000-000000000001"},
+		{table: "dead_letters", idCol: "dead_letter_id", id: "42000000-0000-0000-0000-000000000001"},
+		{table: "agent_turns", idCol: "turn_id", id: "43000000-0000-0000-0000-000000000001"},
+		{table: "selected_fork_lineage", idCol: "lineage_id", id: "44000000-0000-0000-0000-000000000001"},
+	} {
+		var revision int64
+		if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT temporal_revision FROM %s.%s WHERE %s=$1`, qSchema, quoteTemporalIdent(family.table), quoteTemporalIdent(family.idCol)), family.id).Scan(&revision); err != nil {
+			t.Fatalf("read %s temporal stamp: %v", family.table, err)
+		}
+		if revision <= 0 {
+			t.Fatalf("%s temporal revision = %d, want positive", family.table, revision)
+		}
+	}
+}
+
+func authorizeTemporalCleanup(t *testing.T, ctx context.Context, db *sql.DB, schema, authorizationID, operationID, actor string, normalRuns, destructiveRuns []string) {
+	t.Helper()
+	if normalRuns == nil {
+		normalRuns = []string{}
+	}
+	mustExecTemporal(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_authorize_run_cleanup($1,$2,$3,$4::uuid[],$5::uuid[])`, quoteTemporalIdent(schema)), authorizationID, operationID, actor, pq.Array(normalRuns), pq.Array(destructiveRuns))
+}
+
+func assertTemporalAuthorizedMixedCleanup(t *testing.T, ctx context.Context, cleanupAuthorizerDB, runtimeDB *sql.DB, schema, survivorRun, deletedRun string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	authorizationID := "61000000-0000-0000-0000-000000000001"
+	timerID := "61000000-0000-0000-0000-000000000002"
+	tx, err := runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin mixed-cleanup fixture: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), survivorRun, deletedRun)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.timers(timer_id,run_id,value) VALUES ($1,$2,'before-cleanup')`, qSchema), timerID, survivorRun)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ('61000000-0000-0000-0000-000000000003',$1)`, qSchema), deletedRun)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit mixed-cleanup fixture: %v", err)
+	}
+	authorizeTemporalCleanup(t, ctx, cleanupAuthorizerDB, schema, authorizationID, "runtime.nuke/operation-1", "operator-token:7", []string{survivorRun}, []string{deletedRun})
+
+	tx, err = runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin authorized mixed cleanup: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_authorized_run_cleanup($1)`, qSchema), authorizationID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.timers SET value='reference-severed' WHERE timer_id=$1`, qSchema), timerID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_delete_authorized_runs($1)`, qSchema), authorizationID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit authorized mixed cleanup: %v", err)
+	}
+
+	var deletedCount, survivorHistory int
+	var actor string
+	if err := runtimeDB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT (SELECT count(*) FROM %[1]s.runs WHERE run_id=$1),
+		       (SELECT count(*) FROM %[1]s.timer_history WHERE fact_id=$2 AND operation='update'),
+		       (SELECT deleted_by FROM %[1]s.run_deletion_tombstones WHERE run_id=$1)
+	`, qSchema), deletedRun, timerID).Scan(&deletedCount, &survivorHistory, &actor); err != nil {
+		t.Fatalf("read authorized mixed cleanup proof: %v", err)
+	}
+	var authorizer string
+	if err := cleanupAuthorizerDB.QueryRowContext(ctx, `SELECT current_user`).Scan(&authorizer); err != nil {
+		t.Fatalf("read cleanup authorizer identity: %v", err)
+	}
+	if deletedCount != 0 || survivorHistory != 1 || actor != authorizer+":operator-token:7" {
+		t.Fatalf("mixed cleanup = deleted:%d survivor_history:%d actor:%q", deletedCount, survivorHistory, actor)
+	}
+}
+
 func assertTemporalRollbackPublishesNothing(t *testing.T, ctx context.Context, db *sql.DB, schema, runID string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
+	var beforeFrontier, beforeRevisions int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT current_revision,(SELECT count(*) FROM %[1]s.run_temporal_revisions WHERE run_id=$1)
+		FROM %[1]s.run_temporal_frontiers WHERE run_id=$1
+	`, qSchema), runID).Scan(&beforeFrontier, &beforeRevisions); err != nil {
+		t.Fatalf("read pre-rollback temporal authority: %v", err)
+	}
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatalf("begin temporal rollback proof: %v", err)
@@ -632,8 +901,8 @@ func assertTemporalRollbackPublishesNothing(t *testing.T, ctx context.Context, d
 	`, qSchema), runID).Scan(&frontier, &revisionCount, &eventCount); err != nil {
 		t.Fatalf("read rollback temporal authority: %v", err)
 	}
-	if frontier != 0 || revisionCount != 0 || eventCount != 0 {
-		t.Fatalf("rollback published frontier=%d revisions=%d events=%d", frontier, revisionCount, eventCount)
+	if frontier != beforeFrontier || revisionCount != beforeRevisions || eventCount != 0 {
+		t.Fatalf("rollback published frontier=%d/%d revisions=%d/%d events=%d", frontier, beforeFrontier, revisionCount, beforeRevisions, eventCount)
 	}
 }
 
@@ -659,7 +928,7 @@ func assertTemporalRunlessLineage(t *testing.T, ctx context.Context, db *sql.DB,
 	}
 }
 
-func assertTemporalUnversionedDestruction(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, eventID, deliveryID, receiptID string) {
+func assertTemporalUnversionedDestruction(t *testing.T, ctx context.Context, cleanupAuthorizerDB, db *sql.DB, schema, runID, eventID, deliveryID, receiptID string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
 	tx, err := db.BeginTx(ctx, nil)
@@ -671,7 +940,17 @@ func assertTemporalUnversionedDestruction(t *testing.T, ctx context.Context, db 
 	}
 	_ = tx.Rollback()
 
-	mustExecTemporal(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_destroy_run($1,'conformance')`, qSchema), runID)
+	authorizationID := "62000000-0000-0000-0000-000000000001"
+	authorizeTemporalCleanup(t, ctx, cleanupAuthorizerDB, schema, authorizationID, "runtime.nuke/legacy", "operator-token:legacy", nil, []string{runID})
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin authorized unversioned cleanup: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_authorized_run_cleanup($1)`, qSchema), authorizationID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_delete_authorized_runs($1)`, qSchema), authorizationID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit authorized unversioned cleanup: %v", err)
+	}
 	var tombstoneVersion int
 	var lastRevision sql.NullInt64
 	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT source_model_version,last_revision FROM %s.run_deletion_tombstones WHERE run_id=$1`, qSchema), runID).Scan(&tombstoneVersion, &lastRevision); err != nil {
@@ -809,6 +1088,84 @@ func temporalPrototypeChecksum() string {
 	return hex.EncodeToString(digest[:])
 }
 
+const temporalRegisteredLegacyCatalogChecksum = "12323dcc1333b52314fe166dbf5db811560e287ca4b247beac2bab766b46e01e"
+
+func temporalCatalogChecksum(ctx context.Context, db interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, schema, owner, runtimeRole string) (string, error) {
+	queries := []string{
+		`SELECT 'relation',c.relkind::text,c.relname,r.rolname,COALESCE(c.relacl::text,'')
+		 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace JOIN pg_roles r ON r.oid=c.relowner
+		 WHERE n.nspname=$1 AND c.relkind IN ('r','S','i')`,
+		`SELECT 'column',c.relname,a.attnum::text,a.attname,
+		        format_type(a.atttypid,a.atttypmod),a.attnotnull::text,
+		        COALESCE(pg_get_expr(d.adbin,d.adrelid),'')
+		 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+		 JOIN pg_attribute a ON a.attrelid=c.oid AND a.attnum>0 AND NOT a.attisdropped
+		 LEFT JOIN pg_attrdef d ON d.adrelid=c.oid AND d.adnum=a.attnum
+		 WHERE n.nspname=$1 AND c.relkind IN ('r','S')`,
+		`SELECT 'constraint',c.relname,con.contype::text,con.conname,pg_get_constraintdef(con.oid,true)
+		 FROM pg_constraint con JOIN pg_class c ON c.oid=con.conrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+		 WHERE n.nspname=$1`,
+		`SELECT 'index',tablename,indexname,indexdef
+		 FROM pg_indexes WHERE schemaname=$1`,
+		`SELECT 'trigger',c.relname,t.tgname,t.tgenabled::text,p.proname,pg_get_triggerdef(t.oid,true)
+		 FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+		 JOIN pg_proc p ON p.oid=t.tgfoid WHERE n.nspname=$1 AND NOT t.tgisinternal`,
+		`SELECT 'function',p.proname,pg_get_function_identity_arguments(p.oid),p.prosecdef::text,r.rolname,
+		        COALESCE(array_to_string(p.proconfig,','),''),COALESCE(p.proacl::text,''),pg_get_functiondef(p.oid)
+		 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace JOIN pg_roles r ON r.oid=p.proowner
+		 WHERE n.nspname=$1`,
+		`SELECT 'schema',n.nspname,r.rolname,COALESCE(n.nspacl::text,'')
+		 FROM pg_namespace n JOIN pg_roles r ON r.oid=n.nspowner WHERE n.nspname=$1`,
+	}
+	var entries []string
+	for _, query := range queries {
+		rows, err := db.QueryContext(ctx, query, schema)
+		if err != nil {
+			return "", err
+		}
+		columns, err := rows.Columns()
+		if err != nil {
+			rows.Close()
+			return "", err
+		}
+		for rows.Next() {
+			values := make([]sql.NullString, len(columns))
+			dest := make([]any, len(columns))
+			for i := range values {
+				dest[i] = &values[i]
+			}
+			if err := rows.Scan(dest...); err != nil {
+				rows.Close()
+				return "", err
+			}
+			parts := make([]string, len(values))
+			for i, value := range values {
+				if value.Valid {
+					parts[i] = value.String
+				}
+			}
+			entry := strings.Join(parts, "\x1f")
+			entry = strings.ReplaceAll(entry, quoteTemporalIdent(schema), "<schema>")
+			entry = strings.ReplaceAll(entry, schema+".", "<schema>.")
+			entry = strings.ReplaceAll(entry, schema, "<schema>")
+			entry = strings.ReplaceAll(entry, owner, "<owner>")
+			entry = strings.ReplaceAll(entry, runtimeRole, "<runtime>")
+			entries = append(entries, entry)
+		}
+		if err := rows.Close(); err != nil {
+			return "", err
+		}
+		if err := rows.Err(); err != nil {
+			return "", err
+		}
+	}
+	sort.Strings(entries)
+	digest := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return hex.EncodeToString(digest[:]), nil
+}
+
 func temporalLegacyDDL(schema string) string {
 	return fmt.Sprintf(temporalLegacySchemaTemplate, schema)
 }
@@ -821,8 +1178,8 @@ func temporalFunctionsDDL(schema string) string {
 	return fmt.Sprintf(temporalPrototypeFunctionsTemplate, schema)
 }
 
-func temporalGrantDDL(schema, runtimeRole string) string {
-	return fmt.Sprintf(temporalPrototypeGrantTemplate, schema, runtimeRole)
+func temporalGrantDDL(schema, runtimeRole, cleanupAuthorizerRole string) string {
+	return fmt.Sprintf(temporalPrototypeGrantTemplate, schema, runtimeRole, cleanupAuthorizerRole)
 }
 
 const temporalLegacySchemaTemplate = `
@@ -835,11 +1192,12 @@ const temporalLegacySchemaTemplate = `
 	INSERT INTO %[1]s.runtime_store_metadata(id,swarm_version,platform_version) VALUES (1,'conformance','0.7.0');
 	CREATE TABLE %[1]s.runs (
 		run_id UUID PRIMARY KEY,
-		status TEXT NOT NULL CHECK (status IN ('running','paused','completed','failed','cancelled','forked'))
+		status TEXT NOT NULL CHECK (status IN ('running','paused','completed','failed','cancelled','forked')),
+		value TEXT NOT NULL DEFAULT ''
 	);
 	CREATE TABLE %[1]s.events (
 		event_id UUID PRIMARY KEY,
-		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
 		created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
 	);
 	CREATE TABLE %[1]s.event_deliveries (
@@ -853,24 +1211,83 @@ const temporalLegacySchemaTemplate = `
 		event_id UUID NOT NULL REFERENCES %[1]s.events(event_id) ON DELETE CASCADE,
 		outcome TEXT NOT NULL
 	);
+	CREATE TABLE %[1]s.dead_letters (
+		dead_letter_id UUID PRIMARY KEY,
+		original_event_id UUID NOT NULL REFERENCES %[1]s.events(event_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.entity_mutations (
+		mutation_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.entity_state (
+		entity_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.timers (
+		timer_id UUID PRIMARY KEY,
+		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.agent_sessions (
+		session_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.agent_turns (
+		turn_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.agent_conversation_audits (
+		audit_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.reply_contexts (
+		reply_context_id UUID PRIMARY KEY,
+		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.activity_attempts (
+		attempt_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
+	CREATE TABLE %[1]s.selected_fork_lineage (
+		lineage_id UUID PRIMARY KEY,
+		run_id UUID NOT NULL REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		value TEXT NOT NULL DEFAULT ''
+	);
 `
 
 const temporalPrototypeSchemaTemplate = `
 	ALTER TABLE %[1]s.runtime_store_metadata
 		ADD COLUMN schema_generation TEXT,
 		ADD COLUMN schema_ddl_sha256 TEXT,
+		ADD COLUMN schema_catalog_sha256 TEXT,
 		ADD COLUMN schema_owner_role TEXT,
-		ADD COLUMN runtime_role TEXT;
-	ALTER TABLE %[1]s.events
-		ADD COLUMN temporal_revision BIGINT,
-		ADD COLUMN temporal_ordinal INTEGER;
-	ALTER TABLE %[1]s.event_deliveries
-		ADD COLUMN temporal_revision BIGINT,
-		ADD COLUMN temporal_ordinal INTEGER;
+		ADD COLUMN runtime_role TEXT,
+		ADD COLUMN cleanup_authorizer_role TEXT;
+	ALTER TABLE %[1]s.runs ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.events ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.event_deliveries ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
 	ALTER TABLE %[1]s.event_receipts
 		ADD COLUMN temporal_run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
 		ADD COLUMN temporal_revision BIGINT,
 		ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.dead_letters ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.entity_mutations ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.entity_state ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.timers ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.agent_sessions ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.agent_turns ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.agent_conversation_audits ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.reply_contexts ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.activity_attempts ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.selected_fork_lineage ADD COLUMN temporal_revision BIGINT, ADD COLUMN temporal_ordinal INTEGER;
 	UPDATE %[1]s.event_receipts AS receipt
 	SET temporal_run_id=event.run_id
 	FROM %[1]s.events AS event
@@ -878,13 +1295,16 @@ const temporalPrototypeSchemaTemplate = `
 
 	CREATE TABLE %[1]s.run_temporal_transactions (
 		transaction_id XID8 PRIMARY KEY,
-		run_ids UUID[] NOT NULL,
-		mode TEXT NOT NULL CHECK (mode IN ('normal','destructive')),
-		declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-		CHECK (cardinality(run_ids) > 0)
+		declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+	);
+	CREATE TABLE %[1]s.run_temporal_transaction_runs (
+		transaction_id XID8 NOT NULL REFERENCES %[1]s.run_temporal_transactions(transaction_id) ON DELETE CASCADE,
+		run_id UUID NOT NULL,
+		disposition TEXT NOT NULL CHECK (disposition IN ('normal','destructive')),
+		PRIMARY KEY (transaction_id,run_id)
 	);
 	CREATE TABLE %[1]s.run_temporal_frontiers (
-		run_id UUID PRIMARY KEY REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		run_id UUID PRIMARY KEY REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
 		model_version INTEGER NOT NULL CHECK (model_version IN (0,1)),
 		current_revision BIGINT NOT NULL DEFAULT 0 CHECK (current_revision >= 0),
 		history_complete BOOLEAN NOT NULL DEFAULT FALSE,
@@ -905,10 +1325,23 @@ const temporalPrototypeSchemaTemplate = `
 		from_generation TEXT NOT NULL,
 		to_generation TEXT NOT NULL,
 		ddl_sha256 TEXT NOT NULL CHECK (ddl_sha256 ~ '^[0-9a-f]{64}$'),
+		catalog_sha256 TEXT NOT NULL CHECK (catalog_sha256 ~ '^[0-9a-f]{64}$'),
 		schema_owner_role TEXT NOT NULL,
 		runtime_role TEXT NOT NULL,
+		cleanup_authorizer_role TEXT NOT NULL,
 		applied_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-		CHECK (schema_owner_role <> runtime_role)
+		CHECK (schema_owner_role<>runtime_role AND schema_owner_role<>cleanup_authorizer_role AND runtime_role<>cleanup_authorizer_role)
+	);
+	CREATE TABLE %[1]s.run_cleanup_authorizations (
+		authorization_id UUID PRIMARY KEY,
+		operation_id TEXT NOT NULL UNIQUE,
+		actor_evidence TEXT NOT NULL CHECK (btrim(actor_evidence)<>''),
+		authorized_by TEXT NOT NULL CHECK (btrim(authorized_by)<>''),
+		normal_run_ids UUID[] NOT NULL DEFAULT '{}',
+		destructive_run_ids UUID[] NOT NULL,
+		authorized_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+		claimed_transaction_id XID8 UNIQUE,
+		CHECK (cardinality(destructive_run_ids)>0)
 	);
 	CREATE TABLE %[1]s.run_deletion_tombstones (
 		deletion_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -952,7 +1385,7 @@ const temporalPrototypeSchemaTemplate = `
 `
 
 const temporalPrototypeFunctionsTemplate = `
-	CREATE FUNCTION %[1]s.swarm_declare_temporal_runs(requested_run_ids UUID[], requested_mode TEXT)
+	CREATE FUNCTION %[1]s.swarm_declare_temporal_runs(normal_run_ids UUID[], destructive_run_ids UUID[])
 	RETURNS VOID
 	LANGUAGE plpgsql
 	SECURITY DEFINER
@@ -960,36 +1393,53 @@ const temporalPrototypeFunctionsTemplate = `
 	AS $function$
 	DECLARE
 		current_xid XID8 := pg_current_xact_id();
-		normalized UUID[];
-		existing_run_ids UUID[];
-		existing_mode TEXT;
+		normalized_normal UUID[];
+		normalized_destructive UUID[];
+		existing_normal UUID[];
+		existing_destructive UUID[];
 		target_run UUID;
+		target_disposition TEXT;
 		target_model INTEGER;
 		target_history_complete BOOLEAN;
 		next_revision BIGINT;
 	BEGIN
-		IF requested_mode NOT IN ('normal','destructive') THEN
-			RAISE EXCEPTION 'unsupported temporal declaration mode %%', requested_mode;
-		END IF;
 		SELECT array_agg(run_id ORDER BY run_id)
-		INTO normalized
-		FROM (SELECT DISTINCT unnest(requested_run_ids) AS run_id) declared
+		INTO normalized_normal
+		FROM (SELECT DISTINCT unnest(COALESCE(normal_run_ids,'{}'::uuid[])) AS run_id) declared
 		WHERE run_id IS NOT NULL;
-		IF normalized IS NULL OR cardinality(normalized)=0 THEN
+		SELECT array_agg(run_id ORDER BY run_id)
+		INTO normalized_destructive
+		FROM (SELECT DISTINCT unnest(COALESCE(destructive_run_ids,'{}'::uuid[])) AS run_id) declared
+		WHERE run_id IS NOT NULL;
+		normalized_normal=COALESCE(normalized_normal,'{}'::uuid[]);
+		normalized_destructive=COALESCE(normalized_destructive,'{}'::uuid[]);
+		IF cardinality(normalized_normal)+cardinality(normalized_destructive)=0 THEN
 			RAISE EXCEPTION 'temporal declaration requires at least one run';
 		END IF;
-		SELECT run_ids,mode INTO existing_run_ids,existing_mode
-		FROM %[1]s.run_temporal_transactions
+		IF EXISTS (SELECT 1 FROM unnest(normalized_normal) n JOIN unnest(normalized_destructive) d ON n=d) THEN
+			RAISE EXCEPTION 'temporal declaration dispositions overlap';
+		END IF;
+		SELECT COALESCE(array_agg(run_id ORDER BY run_id) FILTER (WHERE disposition='normal'),'{}'::uuid[]),
+		       COALESCE(array_agg(run_id ORDER BY run_id) FILTER (WHERE disposition='destructive'),'{}'::uuid[])
+		INTO existing_normal,existing_destructive
+		FROM %[1]s.run_temporal_transaction_runs
 		WHERE transaction_id=current_xid;
+		PERFORM 1 FROM %[1]s.run_temporal_transactions WHERE transaction_id=current_xid;
 		IF FOUND THEN
-			IF existing_run_ids<>normalized OR existing_mode<>requested_mode THEN
+			IF existing_normal<>normalized_normal OR existing_destructive<>normalized_destructive THEN
 				RAISE EXCEPTION 'temporal declaration is sealed for this transaction';
 			END IF;
 			RETURN;
 		END IF;
-		INSERT INTO %[1]s.run_temporal_transactions(transaction_id,run_ids,mode)
-		VALUES (current_xid,normalized,requested_mode);
-		FOREACH target_run IN ARRAY normalized LOOP
+		INSERT INTO %[1]s.run_temporal_transactions(transaction_id) VALUES (current_xid);
+		INSERT INTO %[1]s.run_temporal_transaction_runs(transaction_id,run_id,disposition)
+		SELECT current_xid,run_id,'normal' FROM unnest(normalized_normal) AS normal_runs(run_id)
+		UNION ALL
+		SELECT current_xid,run_id,'destructive' FROM unnest(normalized_destructive) AS destructive_runs(run_id);
+		FOR target_run,target_disposition IN
+			SELECT run_id,disposition FROM %[1]s.run_temporal_transaction_runs
+			WHERE transaction_id=current_xid ORDER BY run_id
+		LOOP
 			SELECT model_version,history_complete
 			INTO target_model,target_history_complete
 			FROM %[1]s.run_temporal_frontiers
@@ -998,7 +1448,7 @@ const temporalPrototypeFunctionsTemplate = `
 			IF NOT FOUND THEN
 				RAISE EXCEPTION 'run %% has no temporal frontier', target_run;
 			END IF;
-			IF requested_mode='normal' THEN
+			IF target_disposition='normal' THEN
 				IF target_model<>1 OR NOT target_history_complete THEN
 					RAISE EXCEPTION 'run %% temporal history is unproven', target_run;
 				END IF;
@@ -1013,6 +1463,32 @@ const temporalPrototypeFunctionsTemplate = `
 	END
 	$function$;
 
+	CREATE FUNCTION %[1]s.swarm_create_run(target_run UUID, initial_status TEXT)
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		stamp RECORD;
+		created_row JSONB;
+	BEGIN
+		IF initial_status NOT IN ('running','paused') THEN
+			RAISE EXCEPTION 'unsupported initial run status %%', initial_status;
+		END IF;
+		INSERT INTO %[1]s.run_temporal_frontiers(run_id,model_version,current_revision,history_complete)
+		VALUES (target_run,1,0,true);
+		PERFORM %[1]s.swarm_declare_temporal_runs(ARRAY[target_run],'{}'::uuid[]);
+		SELECT * INTO stamp FROM %[1]s.swarm_next_temporal_ordinal(target_run);
+		INSERT INTO %[1]s.runs(run_id,status,temporal_revision,temporal_ordinal)
+		VALUES (target_run,initial_status,stamp.temporal_revision,stamp.temporal_ordinal);
+		SELECT to_jsonb(run_row) INTO STRICT created_row
+		FROM %[1]s.runs AS run_row WHERE run_id=target_run;
+		INSERT INTO %[1]s.run_lifecycle_history(run_id,revision,ordinal,operation,fact_id,after_state)
+		VALUES (target_run,stamp.temporal_revision,stamp.temporal_ordinal,'insert',target_run::text,created_row);
+	END
+	$function$;
+
 	CREATE FUNCTION %[1]s.swarm_claim_temporal_runs(requested_run_ids UUID[])
 	RETURNS VOID
 	LANGUAGE plpgsql
@@ -1020,7 +1496,102 @@ const temporalPrototypeFunctionsTemplate = `
 	SET search_path = pg_catalog, %[1]s
 	AS $function$
 	BEGIN
-		PERFORM %[1]s.swarm_declare_temporal_runs(requested_run_ids,'normal');
+		PERFORM %[1]s.swarm_declare_temporal_runs(requested_run_ids,'{}'::uuid[]);
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_authorize_run_cleanup(target_authorization UUID, target_operation TEXT, target_actor TEXT, requested_normal UUID[], requested_destructive UUID[])
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		normalized_normal UUID[];
+		normalized_destructive UUID[];
+	BEGIN
+		IF btrim(COALESCE(target_operation,''))='' OR btrim(COALESCE(target_actor,''))='' THEN
+			RAISE EXCEPTION 'cleanup authorization requires operation and actor evidence';
+		END IF;
+		SELECT COALESCE(array_agg(run_id ORDER BY run_id),'{}'::uuid[])
+		INTO normalized_normal
+		FROM (SELECT DISTINCT unnest(COALESCE(requested_normal,'{}'::uuid[])) AS run_id) declared
+		WHERE run_id IS NOT NULL;
+		SELECT COALESCE(array_agg(run_id ORDER BY run_id),'{}'::uuid[])
+		INTO normalized_destructive
+		FROM (SELECT DISTINCT unnest(COALESCE(requested_destructive,'{}'::uuid[])) AS run_id) declared
+		WHERE run_id IS NOT NULL;
+		IF cardinality(normalized_destructive)=0
+		   OR EXISTS (SELECT 1 FROM unnest(normalized_normal) n JOIN unnest(normalized_destructive) d ON n=d) THEN
+			RAISE EXCEPTION 'cleanup authorization requires disjoint sets and at least one destructive run';
+		END IF;
+		INSERT INTO %[1]s.run_cleanup_authorizations(
+			authorization_id,operation_id,actor_evidence,authorized_by,normal_run_ids,destructive_run_ids
+		) VALUES (
+			target_authorization,target_operation,target_actor,session_user,normalized_normal,normalized_destructive
+		);
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_claim_authorized_run_cleanup(target_authorization UUID)
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		normalized_normal UUID[];
+		normalized_destructive UUID[];
+		claimed XID8;
+		current_xid XID8 := pg_current_xact_id();
+	BEGIN
+		SELECT normal_run_ids,destructive_run_ids,claimed_transaction_id
+		INTO STRICT normalized_normal,normalized_destructive,claimed
+		FROM %[1]s.run_cleanup_authorizations
+		WHERE authorization_id=target_authorization
+		FOR UPDATE;
+		IF normalized_normal<>ARRAY(SELECT DISTINCT x FROM unnest(normalized_normal) x ORDER BY x)
+		   OR normalized_destructive<>ARRAY(SELECT DISTINCT x FROM unnest(normalized_destructive) x ORDER BY x)
+		   OR EXISTS (SELECT 1 FROM unnest(normalized_normal) n JOIN unnest(normalized_destructive) d ON n=d) THEN
+			RAISE EXCEPTION 'cleanup authorization run sets are not sealed canonical sets';
+		END IF;
+		IF claimed IS NOT NULL AND claimed<>current_xid THEN
+			RAISE EXCEPTION 'cleanup authorization already consumed';
+		END IF;
+		UPDATE %[1]s.run_cleanup_authorizations
+		SET claimed_transaction_id=current_xid
+		WHERE authorization_id=target_authorization;
+		PERFORM %[1]s.swarm_declare_temporal_runs(normalized_normal,normalized_destructive);
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_delete_authorized_runs(target_authorization UUID)
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		cleanup_runs UUID[];
+		actor TEXT;
+		authorizer TEXT;
+		target_run UUID;
+		model INTEGER;
+		frontier BIGINT;
+	BEGIN
+		SELECT destructive_run_ids,actor_evidence,authorized_by
+		INTO STRICT cleanup_runs,actor,authorizer
+		FROM %[1]s.run_cleanup_authorizations
+		WHERE authorization_id=target_authorization
+		  AND claimed_transaction_id=pg_current_xact_id();
+		FOREACH target_run IN ARRAY cleanup_runs LOOP
+			SELECT model_version,current_revision INTO STRICT model,frontier
+			FROM %[1]s.run_temporal_frontiers WHERE run_id=target_run;
+			INSERT INTO %[1]s.run_deletion_tombstones(run_id,source_model_version,last_revision,transaction_id,deleted_by)
+			VALUES (target_run,model,CASE WHEN model=0 THEN NULL ELSE frontier END,pg_current_xact_id(),authorizer||':'||actor);
+			DELETE FROM %[1]s.runs WHERE run_id=target_run;
+			IF NOT FOUND THEN RAISE EXCEPTION 'authorized cleanup run %% does not exist', target_run; END IF;
+		END LOOP;
 	END
 	$function$;
 
@@ -1032,12 +1603,12 @@ const temporalPrototypeFunctionsTemplate = `
 	AS $function$
 	DECLARE
 		current_xid XID8 := pg_current_xact_id();
-		declared_mode TEXT;
+		declared_disposition TEXT;
 	BEGIN
-		SELECT mode INTO declared_mode
-		FROM %[1]s.run_temporal_transactions
-		WHERE transaction_id=current_xid AND target_run=ANY(run_ids);
-		IF NOT FOUND OR declared_mode<>'normal' THEN
+		SELECT disposition INTO declared_disposition
+		FROM %[1]s.run_temporal_transaction_runs
+		WHERE transaction_id=current_xid AND run_id=target_run;
+		IF NOT FOUND OR declared_disposition<>'normal' THEN
 			RAISE EXCEPTION 'run %% is not in the sealed normal temporal declaration', target_run;
 		END IF;
 		UPDATE %[1]s.run_temporal_revisions
@@ -1051,7 +1622,27 @@ const temporalPrototypeFunctionsTemplate = `
 	END
 	$function$;
 
-	CREATE FUNCTION %[1]s.swarm_guard_events()
+	CREATE FUNCTION %[1]s.swarm_resolve_temporal_run(row_data JSONB, lineage_kind TEXT, lineage_field TEXT)
+	RETURNS UUID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		resolved UUID;
+	BEGIN
+		IF lineage_kind='direct' THEN
+			RETURN NULLIF(row_data->>lineage_field,'')::uuid;
+		ELSIF lineage_kind='event' THEN
+			SELECT run_id INTO STRICT resolved FROM %[1]s.events
+			WHERE event_id=NULLIF(row_data->>lineage_field,'')::uuid;
+			RETURN resolved;
+		END IF;
+		RAISE EXCEPTION 'unsupported temporal lineage kind %%', lineage_kind;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_guard_append_fact()
 	RETURNS TRIGGER
 	LANGUAGE plpgsql
 	SECURITY DEFINER
@@ -1059,98 +1650,34 @@ const temporalPrototypeFunctionsTemplate = `
 	AS $function$
 	DECLARE
 		stamp RECORD;
-		allowed BOOLEAN;
-	BEGIN
-		IF TG_OP='UPDATE' THEN
-			RAISE EXCEPTION 'events are immutable';
-		ELSIF TG_OP='DELETE' THEN
-			IF OLD.run_id IS NULL THEN
-				RAISE EXCEPTION 'runless event deletion has no destructive authority';
-			END IF;
-			SELECT EXISTS (
-				SELECT 1 FROM %[1]s.run_temporal_transactions
-				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND OLD.run_id=ANY(run_ids)
-			) INTO allowed;
-			IF NOT allowed THEN
-				RAISE EXCEPTION 'event deletion requires sealed destructive run authority';
-			END IF;
-			RETURN OLD;
-		END IF;
-		IF NEW.run_id IS NULL THEN
-			NEW.temporal_revision=NULL;
-			NEW.temporal_ordinal=NULL;
-			RETURN NEW;
-		END IF;
-		SELECT * INTO stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
-		NEW.temporal_revision=stamp.temporal_revision;
-		NEW.temporal_ordinal=stamp.temporal_ordinal;
-		RETURN NEW;
-	END
-	$function$;
-
-	CREATE FUNCTION %[1]s.swarm_guard_event_deliveries()
-	RETURNS TRIGGER
-	LANGUAGE plpgsql
-	SECURITY DEFINER
-	SET search_path = pg_catalog, %[1]s
-	AS $function$
-	DECLARE
-		old_stamp RECORD;
-		new_stamp RECORD;
+		fact_run UUID;
 		destructive BOOLEAN;
 	BEGIN
+		IF TG_OP='UPDATE' THEN
+			RAISE EXCEPTION 'append-only temporal fact %% is immutable', TG_TABLE_NAME;
+		END IF;
 		IF TG_OP='DELETE' THEN
-			IF OLD.run_id IS NULL THEN RETURN OLD; END IF;
+			fact_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(OLD),TG_ARGV[1],TG_ARGV[2]);
+			IF fact_run IS NULL THEN RAISE EXCEPTION 'runless append-only fact cannot be deleted'; END IF;
 			SELECT EXISTS (
-				SELECT 1 FROM %[1]s.run_temporal_transactions
-				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND OLD.run_id=ANY(run_ids)
+				SELECT 1 FROM %[1]s.run_temporal_transaction_runs
+				WHERE transaction_id=pg_current_xact_id() AND run_id=fact_run AND disposition='destructive'
 			) INTO destructive;
-			IF destructive THEN RETURN OLD; END IF;
-			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(OLD.run_id);
-			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state)
-			VALUES (OLD.run_id,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'delete',OLD.delivery_id::text,to_jsonb(OLD));
+			IF NOT destructive THEN RAISE EXCEPTION 'append-only fact deletion requires authorized destructive disposition'; END IF;
 			RETURN OLD;
-		ELSIF TG_OP='INSERT' THEN
-			IF NEW.run_id IS NULL THEN
-				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
-			END IF;
-			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,after_state)
-			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'insert',NEW.delivery_id::text,to_jsonb(NEW));
+		END IF;
+		fact_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(NEW),TG_ARGV[1],TG_ARGV[2]);
+		IF fact_run IS NULL THEN
+			NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',NULL,'temporal_ordinal',NULL));
 			RETURN NEW;
 		END IF;
-		IF OLD.run_id IS NOT DISTINCT FROM NEW.run_id THEN
-			IF NEW.run_id IS NULL THEN
-				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
-			END IF;
-			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
-			RETURN NEW;
-		END IF;
-		IF OLD.run_id IS NOT NULL THEN
-			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(OLD.run_id);
-			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (OLD.run_id,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'update',OLD.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
-		END IF;
-		IF NEW.run_id IS NOT NULL THEN
-			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
-		ELSE
-			NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL;
-		END IF;
+		SELECT * INTO stamp FROM %[1]s.swarm_next_temporal_ordinal(fact_run);
+		NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',stamp.temporal_revision,'temporal_ordinal',stamp.temporal_ordinal));
 		RETURN NEW;
 	END
 	$function$;
 
-	CREATE FUNCTION %[1]s.swarm_guard_event_receipts()
+	CREATE FUNCTION %[1]s.swarm_guard_mutable_fact()
 	RETURNS TRIGGER
 	LANGUAGE plpgsql
 	SECURITY DEFINER
@@ -1159,95 +1686,118 @@ const temporalPrototypeFunctionsTemplate = `
 	DECLARE
 		old_run UUID;
 		new_run UUID;
+		asserted_run UUID;
 		old_stamp RECORD;
 		new_stamp RECORD;
 		destructive BOOLEAN;
+		fact_id TEXT;
+		history_table TEXT := TG_ARGV[3];
 	BEGIN
-		IF TG_OP<>'INSERT' THEN old_run=OLD.temporal_run_id; END IF;
+		IF TG_OP<>'INSERT' THEN
+			fact_id=COALESCE(to_jsonb(OLD)->>TG_ARGV[0],'');
+			IF TG_ARGV[1]='event' THEN
+				old_run=NULLIF(to_jsonb(OLD)->>'temporal_run_id','')::uuid;
+			ELSIF TG_ARGV[1]='asserted_event' THEN
+				asserted_run=NULLIF(to_jsonb(OLD)->>'run_id','')::uuid;
+				IF TG_OP='DELETE' THEN
+					old_run=asserted_run;
+				ELSE
+					old_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(OLD),'event',TG_ARGV[2]);
+					IF old_run IS DISTINCT FROM asserted_run THEN RAISE EXCEPTION 'stored run identity disagrees with event lineage'; END IF;
+				END IF;
+			ELSE
+				old_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(OLD),'direct',TG_ARGV[2]);
+			END IF;
+		END IF;
 		IF TG_OP<>'DELETE' THEN
-			SELECT run_id INTO STRICT new_run FROM %[1]s.events WHERE event_id=NEW.event_id;
-			NEW.temporal_run_id=new_run;
+			fact_id=COALESCE(to_jsonb(NEW)->>TG_ARGV[0],'');
+			IF TG_ARGV[1]='event' THEN
+				new_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(NEW),'event',TG_ARGV[2]);
+				NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_run_id',new_run));
+			ELSIF TG_ARGV[1]='asserted_event' THEN
+				new_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(NEW),'event',TG_ARGV[2]);
+				asserted_run=NULLIF(to_jsonb(NEW)->>'run_id','')::uuid;
+				IF new_run IS DISTINCT FROM asserted_run THEN RAISE EXCEPTION 'stored run identity disagrees with event lineage'; END IF;
+			ELSE
+				new_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(NEW),'direct',TG_ARGV[2]);
+			END IF;
 		END IF;
 		IF TG_OP='DELETE' THEN
 			IF old_run IS NULL THEN RETURN OLD; END IF;
 			SELECT EXISTS (
-				SELECT 1 FROM %[1]s.run_temporal_transactions
-				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND old_run=ANY(run_ids)
+				SELECT 1 FROM %[1]s.run_temporal_transaction_runs
+				WHERE transaction_id=pg_current_xact_id() AND run_id=old_run AND disposition='destructive'
 			) INTO destructive;
 			IF destructive THEN RETURN OLD; END IF;
 			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(old_run);
-			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state)
-			VALUES (old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'delete',OLD.receipt_id::text,to_jsonb(OLD));
+			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,before_state) VALUES ($1,$2,$3,''delete'',$4,$5)',TG_TABLE_SCHEMA,history_table)
+			USING old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,fact_id,to_jsonb(OLD);
 			RETURN OLD;
 		ELSIF TG_OP='INSERT' THEN
 			IF new_run IS NULL THEN
-				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+				NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',NULL,'temporal_ordinal',NULL)); RETURN NEW;
 			END IF;
 			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,after_state)
-			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'insert',NEW.receipt_id::text,to_jsonb(NEW));
+			NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',new_stamp.temporal_revision,'temporal_ordinal',new_stamp.temporal_ordinal));
+			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,after_state) VALUES ($1,$2,$3,''insert'',$4,$5)',TG_TABLE_SCHEMA,history_table)
+			USING new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,fact_id,to_jsonb(NEW);
 			RETURN NEW;
 		END IF;
 		IF old_run IS NOT DISTINCT FROM new_run THEN
 			IF new_run IS NULL THEN
-				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+				NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',NULL,'temporal_ordinal',NULL)); RETURN NEW;
 			END IF;
 			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+			NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',new_stamp.temporal_revision,'temporal_ordinal',new_stamp.temporal_ordinal));
+			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,before_state,after_state) VALUES ($1,$2,$3,''update'',$4,$5,$6)',TG_TABLE_SCHEMA,history_table)
+			USING new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,fact_id,to_jsonb(OLD),to_jsonb(NEW);
 			RETURN NEW;
 		END IF;
 		IF old_run IS NOT NULL THEN
 			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(old_run);
-			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'update',OLD.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,before_state,after_state) VALUES ($1,$2,$3,''update'',$4,$5,$6)',TG_TABLE_SCHEMA,history_table)
+			USING old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,fact_id,to_jsonb(OLD),to_jsonb(NEW);
 		END IF;
 		IF new_run IS NOT NULL THEN
 			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
-			NEW.temporal_revision=new_stamp.temporal_revision;
-			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
-			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
-			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+			NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',new_stamp.temporal_revision,'temporal_ordinal',new_stamp.temporal_ordinal));
+			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,before_state,after_state) VALUES ($1,$2,$3,''update'',$4,$5,$6)',TG_TABLE_SCHEMA,history_table)
+			USING new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,fact_id,to_jsonb(OLD),to_jsonb(NEW);
 		ELSE
-			NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL;
+			NEW=jsonb_populate_record(NEW,jsonb_build_object('temporal_revision',NULL,'temporal_ordinal',NULL));
 		END IF;
 		RETURN NEW;
 	END
 	$function$;
 
-	CREATE FUNCTION %[1]s.swarm_destroy_run(target_run UUID, deletion_actor TEXT)
-	RETURNS VOID
-	LANGUAGE plpgsql
-	SECURITY DEFINER
-	SET search_path = pg_catalog, %[1]s
-	AS $function$
-	DECLARE
-		model INTEGER;
-		frontier BIGINT;
-	BEGIN
-		PERFORM %[1]s.swarm_declare_temporal_runs(ARRAY[target_run],'destructive');
-		SELECT model_version,current_revision INTO STRICT model,frontier
-		FROM %[1]s.run_temporal_frontiers WHERE run_id=target_run;
-		INSERT INTO %[1]s.run_deletion_tombstones(run_id,source_model_version,last_revision,transaction_id,deleted_by)
-		VALUES (target_run,model,CASE WHEN model=0 THEN NULL ELSE frontier END,pg_current_xact_id(),deletion_actor);
-		DELETE FROM %[1]s.runs WHERE run_id=target_run;
-		IF NOT FOUND THEN RAISE EXCEPTION 'run %% does not exist', target_run; END IF;
-	END
-	$function$;
-
-	CREATE TRIGGER temporal_events_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.events
-	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_events();
-	CREATE TRIGGER temporal_event_deliveries_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_deliveries
-	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_event_deliveries();
-	CREATE TRIGGER temporal_event_receipts_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_receipts
-	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_event_receipts();
+	CREATE TRIGGER temporal_runs_guard BEFORE UPDATE OR DELETE ON %[1]s.runs FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('run_id','direct','run_id','run_lifecycle_history');
+	CREATE TRIGGER temporal_events_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.events FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_append_fact('event_id','direct','run_id');
+	CREATE TRIGGER temporal_event_deliveries_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_deliveries FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('delivery_id','asserted_event','event_id','event_delivery_history');
+	CREATE TRIGGER temporal_event_receipts_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_receipts FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('receipt_id','event','event_id','event_receipt_history');
+	CREATE TRIGGER temporal_dead_letters_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.dead_letters FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_append_fact('dead_letter_id','event','original_event_id');
+	CREATE TRIGGER temporal_entity_mutations_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.entity_mutations FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_append_fact('mutation_id','direct','run_id');
+	CREATE TRIGGER temporal_entity_state_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.entity_state FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('entity_id','direct','run_id','entity_state_history');
+	CREATE TRIGGER temporal_timers_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.timers FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('timer_id','direct','run_id','timer_history');
+	CREATE TRIGGER temporal_agent_sessions_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.agent_sessions FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('session_id','direct','run_id','agent_session_history');
+	CREATE TRIGGER temporal_agent_turns_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.agent_turns FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_append_fact('turn_id','direct','run_id');
+	CREATE TRIGGER temporal_agent_conversation_audits_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.agent_conversation_audits FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('audit_id','direct','run_id','conversation_audit_history');
+	CREATE TRIGGER temporal_reply_contexts_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.reply_contexts FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('reply_context_id','direct','run_id','reply_context_history');
+	CREATE TRIGGER temporal_activity_attempts_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.activity_attempts FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_mutable_fact('attempt_id','direct','run_id','activity_attempt_history');
+	CREATE TRIGGER temporal_selected_fork_lineage_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.selected_fork_lineage FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_append_fact('lineage_id','direct','run_id');
+	ALTER TABLE %[1]s.runs ENABLE ALWAYS TRIGGER temporal_runs_guard;
 	ALTER TABLE %[1]s.events ENABLE ALWAYS TRIGGER temporal_events_guard;
 	ALTER TABLE %[1]s.event_deliveries ENABLE ALWAYS TRIGGER temporal_event_deliveries_guard;
 	ALTER TABLE %[1]s.event_receipts ENABLE ALWAYS TRIGGER temporal_event_receipts_guard;
+	ALTER TABLE %[1]s.dead_letters ENABLE ALWAYS TRIGGER temporal_dead_letters_guard;
+	ALTER TABLE %[1]s.entity_mutations ENABLE ALWAYS TRIGGER temporal_entity_mutations_guard;
+	ALTER TABLE %[1]s.entity_state ENABLE ALWAYS TRIGGER temporal_entity_state_guard;
+	ALTER TABLE %[1]s.timers ENABLE ALWAYS TRIGGER temporal_timers_guard;
+	ALTER TABLE %[1]s.agent_sessions ENABLE ALWAYS TRIGGER temporal_agent_sessions_guard;
+	ALTER TABLE %[1]s.agent_turns ENABLE ALWAYS TRIGGER temporal_agent_turns_guard;
+	ALTER TABLE %[1]s.agent_conversation_audits ENABLE ALWAYS TRIGGER temporal_agent_conversation_audits_guard;
+	ALTER TABLE %[1]s.reply_contexts ENABLE ALWAYS TRIGGER temporal_reply_contexts_guard;
+	ALTER TABLE %[1]s.activity_attempts ENABLE ALWAYS TRIGGER temporal_activity_attempts_guard;
+	ALTER TABLE %[1]s.selected_fork_lineage ENABLE ALWAYS TRIGGER temporal_selected_fork_lineage_guard;
 `
 
 const temporalPrototypeGrantTemplate = `
@@ -1256,6 +1806,7 @@ const temporalPrototypeGrantTemplate = `
 	REVOKE ALL ON ALL SEQUENCES IN SCHEMA %[1]s FROM PUBLIC;
 	REVOKE ALL ON ALL FUNCTIONS IN SCHEMA %[1]s FROM PUBLIC;
 	GRANT USAGE ON SCHEMA %[1]s TO %[2]s;
+	GRANT USAGE ON SCHEMA %[1]s TO %[3]s;
 	GRANT SELECT ON
 		%[1]s.runtime_store_metadata,
 		%[1]s.runtime_store_migrations,
@@ -1263,7 +1814,18 @@ const temporalPrototypeGrantTemplate = `
 		%[1]s.events,
 		%[1]s.event_deliveries,
 		%[1]s.event_receipts,
+		%[1]s.dead_letters,
+		%[1]s.entity_mutations,
+		%[1]s.entity_state,
+		%[1]s.timers,
+		%[1]s.agent_sessions,
+		%[1]s.agent_turns,
+		%[1]s.agent_conversation_audits,
+		%[1]s.reply_contexts,
+		%[1]s.activity_attempts,
+		%[1]s.selected_fork_lineage,
 		%[1]s.run_temporal_transactions,
+		%[1]s.run_temporal_transaction_runs,
 		%[1]s.run_temporal_frontiers,
 		%[1]s.run_temporal_revisions,
 		%[1]s.run_deletion_tombstones,
@@ -1277,8 +1839,12 @@ const temporalPrototypeGrantTemplate = `
 		%[1]s.reply_context_history,
 		%[1]s.activity_attempt_history
 	TO %[2]s;
-	GRANT INSERT ON %[1]s.events TO %[2]s;
-	GRANT INSERT,UPDATE,DELETE ON %[1]s.event_deliveries,%[1]s.event_receipts TO %[2]s;
+	GRANT INSERT ON %[1]s.events,%[1]s.dead_letters,%[1]s.entity_mutations,%[1]s.agent_turns,%[1]s.selected_fork_lineage TO %[2]s;
+	GRANT UPDATE ON %[1]s.runs TO %[2]s;
+	GRANT INSERT,UPDATE,DELETE ON %[1]s.event_deliveries,%[1]s.event_receipts,%[1]s.entity_state,%[1]s.timers,%[1]s.agent_sessions,%[1]s.agent_conversation_audits,%[1]s.reply_contexts,%[1]s.activity_attempts TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_create_run(UUID,TEXT) TO %[2]s;
 	GRANT EXECUTE ON FUNCTION %[1]s.swarm_claim_temporal_runs(UUID[]) TO %[2]s;
-	GRANT EXECUTE ON FUNCTION %[1]s.swarm_destroy_run(UUID,TEXT) TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_claim_authorized_run_cleanup(UUID) TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_delete_authorized_runs(UUID) TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_authorize_run_cleanup(UUID,TEXT,TEXT,UUID[],UUID[]) TO %[3]s;
 `

--- a/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
+++ b/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
@@ -1,0 +1,1284 @@
+package conformance
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/testpostgres"
+	_ "github.com/lib/pq"
+)
+
+func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	connection, err := testpostgres.ConnectionFromEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin, err := connection.Open()
+	if err != nil {
+		t.Fatalf("open PostgreSQL conformance connection: %v", err)
+	}
+	defer admin.Close()
+	if err := admin.PingContext(ctx); err != nil {
+		t.Fatalf("ping PostgreSQL conformance connection: %v", err)
+	}
+
+	var canCreateRoles bool
+	if err := admin.QueryRowContext(ctx, `
+		SELECT rolsuper OR rolcreaterole
+		FROM pg_roles
+		WHERE rolname = current_user
+	`).Scan(&canCreateRoles); err != nil {
+		t.Fatalf("inspect PostgreSQL conformance role: %v", err)
+	}
+	if !canCreateRoles {
+		t.Skip("temporal frontier privilege conformance requires CREATEROLE; use the dedicated cmd/swarm-test-postgres runner")
+	}
+
+	suffix := fmt.Sprintf("%x", time.Now().UnixNano())
+	ownerRole := "tf_owner_" + suffix
+	runtimeRole := "tf_runtime_" + suffix
+	upgradeSchema := "tf_upgrade_" + suffix
+	freshSchema := "tf_fresh_" + suffix
+	runtimePassword := "tf-runtime-" + suffix
+
+	mustExecTemporal(t, ctx, admin, `CREATE ROLE `+quoteTemporalIdent(ownerRole)+` LOGIN PASSWORD 'owner-not-used' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS`)
+	mustExecTemporal(t, ctx, admin, `CREATE ROLE `+quoteTemporalIdent(runtimeRole)+` LOGIN PASSWORD `+quoteTemporalLiteral(runtimePassword)+` NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS`)
+	defer func() {
+		_, _ = admin.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+quoteTemporalIdent(freshSchema)+` CASCADE`)
+		_, _ = admin.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+quoteTemporalIdent(upgradeSchema)+` CASCADE`)
+		_, _ = admin.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+quoteTemporalIdent(runtimeRole))
+		_, _ = admin.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+quoteTemporalIdent(ownerRole))
+	}()
+
+	mustExecTemporal(t, ctx, admin, `CREATE SCHEMA `+quoteTemporalIdent(freshSchema)+` AUTHORIZATION `+quoteTemporalIdent(ownerRole))
+	if err := applyTemporalPrototype(ctx, admin, freshSchema, ownerRole, runtimeRole, true, false); err != nil {
+		t.Fatalf("fresh temporal schema apply: %v", err)
+	}
+	assertTemporalTargetMetadata(t, ctx, admin, freshSchema, ownerRole, runtimeRole)
+	for _, table := range []string{"run_temporal_transactions", "run_temporal_frontiers", "run_temporal_revisions", "runtime_store_migrations", "run_deletion_tombstones", "event_delivery_history", "event_receipt_history"} {
+		assertTemporalTableExists(t, ctx, admin, freshSchema, table, true)
+	}
+
+	mustExecTemporal(t, ctx, admin, `CREATE SCHEMA `+quoteTemporalIdent(upgradeSchema)+` AUTHORIZATION `+quoteTemporalIdent(ownerRole))
+	createTemporalLegacySchema(t, ctx, admin, upgradeSchema, ownerRole)
+	legacyRun := "00000000-0000-0000-0000-000000000001"
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.runs(run_id,status) VALUES ($1,'running')`, quoteTemporalIdent(upgradeSchema)), legacyRun)
+	legacyEvent := "00000000-0000-0000-0000-000000000011"
+	legacyDelivery := "00000000-0000-0000-0000-000000000012"
+	legacyReceipt := "00000000-0000-0000-0000-000000000013"
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ($1,$2)`, quoteTemporalIdent(upgradeSchema)), legacyEvent, legacyRun)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status) VALUES ($1,$2,$3,'pending')`, quoteTemporalIdent(upgradeSchema)), legacyDelivery, legacyRun, legacyEvent)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.event_receipts(receipt_id,event_id,outcome) VALUES ($1,$2,'success')`, quoteTemporalIdent(upgradeSchema)), legacyReceipt, legacyEvent)
+
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false)
+	if err == nil || !strings.Contains(err.Error(), legacyRun) {
+		t.Fatalf("active legacy migration error = %v, want exact active run", err)
+	}
+	assertTemporalTableExists(t, ctx, admin, upgradeSchema, "run_temporal_frontiers", false)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`UPDATE %s.runs SET status='completed' WHERE run_id=$1`, quoteTemporalIdent(upgradeSchema)), legacyRun)
+
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, true)
+	if err == nil || !strings.Contains(err.Error(), "forced temporal migration rollback") {
+		t.Fatalf("forced migration error = %v", err)
+	}
+	assertTemporalTableExists(t, ctx, admin, upgradeSchema, "run_temporal_frontiers", false)
+	var legacyVersion string
+	if err := admin.QueryRowContext(ctx, fmt.Sprintf(`SELECT platform_version FROM %s.runtime_store_metadata WHERE id=1`, quoteTemporalIdent(upgradeSchema))).Scan(&legacyVersion); err != nil {
+		t.Fatalf("read rolled-back metadata: %v", err)
+	}
+	if legacyVersion != "0.7.0" {
+		t.Fatalf("rolled-back platform version = %q, want 0.7.0", legacyVersion)
+	}
+
+	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false); err != nil {
+		t.Fatalf("recognized temporal upgrade: %v", err)
+	}
+	assertTemporalTargetMetadata(t, ctx, admin, upgradeSchema, ownerRole, runtimeRole)
+	if err := applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, false, false); err != nil {
+		t.Fatalf("idempotent temporal reapply: %v", err)
+	}
+	var migrationCount int
+	if err := admin.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.runtime_store_migrations WHERE migration_id='temporal-frontier-v1'`, quoteTemporalIdent(upgradeSchema))).Scan(&migrationCount); err != nil {
+		t.Fatalf("count temporal migrations: %v", err)
+	}
+	if migrationCount != 1 {
+		t.Fatalf("temporal migration rows = %d, want 1", migrationCount)
+	}
+
+	runtimeDSN := temporalRoleDSN(connection.Parameters(), runtimeRole, runtimePassword)
+	runtimeDB, err := sql.Open("postgres", runtimeDSN)
+	if err != nil {
+		t.Fatalf("open restricted runtime connection: %v", err)
+	}
+	defer runtimeDB.Close()
+	if err := runtimeDB.PingContext(ctx); err != nil {
+		t.Fatalf("ping restricted runtime connection: %v", err)
+	}
+
+	lockKey := temporalSchemaLockKey(upgradeSchema)
+	runtimeLockConn, err := runtimeDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("open runtime lock connection: %v", err)
+	}
+	mustExecTemporal(t, ctx, runtimeLockConn, `SELECT pg_advisory_lock_shared($1)`, lockKey)
+	var migrationLockAvailable bool
+	if err := admin.QueryRowContext(ctx, `SELECT pg_try_advisory_lock($1)`, lockKey).Scan(&migrationLockAvailable); err != nil {
+		t.Fatalf("try migration lock: %v", err)
+	}
+	if migrationLockAvailable {
+		_, _ = admin.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, lockKey)
+		t.Fatal("migration exclusive lock succeeded while runtime held shared lock")
+	}
+	mustExecTemporal(t, ctx, runtimeLockConn, `SELECT pg_advisory_unlock_shared($1)`, lockKey)
+	runtimeLockConn.Close()
+
+	assertTemporalRuntimeAdmission(t, ctx, runtimeDB, upgradeSchema, ownerRole, runtimeRole)
+	secondRuntimeDB, err := sql.Open("postgres", runtimeDSN)
+	if err != nil {
+		t.Fatalf("open second runtime connection: %v", err)
+	}
+	assertTemporalRuntimeAdmission(t, ctx, secondRuntimeDB, upgradeSchema, ownerRole, runtimeRole)
+	secondRuntimeDB.Close()
+
+	assertTemporalPrivilegeDenials(t, ctx, runtimeDB, upgradeSchema, ownerRole)
+
+	runA := "10000000-0000-0000-0000-000000000001"
+	runB := "20000000-0000-0000-0000-000000000002"
+	runC := "30000000-0000-0000-0000-000000000003"
+	seedTemporalVersionedRuns(t, ctx, admin, upgradeSchema, ownerRole, runA, runB, runC)
+
+	eventID := "a0000000-0000-0000-0000-000000000001"
+	deliveryID := "d0000000-0000-0000-0000-000000000001"
+	receiptID := "e0000000-0000-0000-0000-000000000001"
+	assertTemporalUndeclaredDMLRejected(t, ctx, runtimeDB, upgradeSchema, runA, eventID)
+	writeTemporalEventDeliveryReceipt(t, ctx, runtimeDB, upgradeSchema, runA, eventID, deliveryID, receiptID)
+	assertTemporalSharedRevision(t, ctx, runtimeDB, upgradeSchema, eventID, deliveryID, receiptID)
+	assertTemporalDirectEventMutationRejected(t, ctx, runtimeDB, upgradeSchema, eventID)
+	assertTemporalEventTriggerDefendsGrantDrift(t, ctx, admin, upgradeSchema, ownerRole, runA, eventID)
+	assertTemporalUndeclaredDeliveryMutationRejected(t, ctx, runtimeDB, upgradeSchema, deliveryID)
+	assertTemporalOwnershipMove(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA, runB)
+	assertTemporalDeclaredDeliveryDelete(t, ctx, runtimeDB, upgradeSchema, deliveryID, runB)
+	assertTemporalRollbackPublishesNothing(t, ctx, runtimeDB, upgradeSchema, runC)
+	assertTemporalRunlessLineage(t, ctx, runtimeDB, upgradeSchema)
+	assertTemporalUnversionedDestruction(t, ctx, runtimeDB, upgradeSchema, legacyRun, legacyEvent, legacyDelivery, legacyReceipt)
+	assertTemporalReverseClaimsSerialize(t, ctx, admin, runtimeDB, upgradeSchema, runA, runB)
+}
+
+func createTemporalLegacySchema(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin legacy schema: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
+	mustExecTemporal(t, ctx, tx, temporalLegacyDDL(quoteTemporalIdent(schema)))
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit legacy schema: %v", err)
+	}
+}
+
+func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runtimeRole string, fresh, forceRollback bool) error {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("begin temporal schema apply: %w", err)
+	}
+	defer tx.Rollback()
+
+	lockKey := temporalSchemaLockKey(schema)
+	var locked bool
+	if err := tx.QueryRowContext(ctx, `SELECT pg_try_advisory_xact_lock($1)`, lockKey).Scan(&locked); err != nil {
+		return fmt.Errorf("acquire temporal migration lock: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("temporal schema migration blocked by an active runtime")
+	}
+
+	qSchema := quoteTemporalIdent(schema)
+	var metadataExists bool
+	if err := tx.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, schema+`.runtime_store_metadata`).Scan(&metadataExists); err != nil {
+		return fmt.Errorf("inspect temporal metadata table: %w", err)
+	}
+	if fresh {
+		if metadataExists {
+			return fmt.Errorf("fresh temporal apply requires an empty schema")
+		}
+		if _, err := tx.ExecContext(ctx, `SET LOCAL ROLE `+quoteTemporalIdent(owner)); err != nil {
+			return fmt.Errorf("assume temporal schema owner: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, temporalLegacyDDL(qSchema)); err != nil {
+			return fmt.Errorf("create fresh platform base: %w", err)
+		}
+		metadataExists = true
+	}
+	if !metadataExists {
+		return fmt.Errorf("recognized runtime_store_metadata is required")
+	}
+
+	var targetColumns int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM information_schema.columns
+		WHERE table_schema=$1 AND table_name='runtime_store_metadata'
+		  AND column_name IN ('schema_generation','schema_ddl_sha256','schema_owner_role','runtime_role')
+	`, schema).Scan(&targetColumns); err != nil {
+		return fmt.Errorf("inspect temporal metadata generation: %w", err)
+	}
+	checksum := temporalPrototypeChecksum()
+	if targetColumns == 4 {
+		var generation, storedChecksum, storedOwner, storedRuntime string
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_owner_role,runtime_role FROM %s.runtime_store_metadata WHERE id=1`, qSchema)).Scan(&generation, &storedChecksum, &storedOwner, &storedRuntime); err != nil {
+			return fmt.Errorf("read temporal target metadata: %w", err)
+		}
+		if generation != "temporal-frontier-v1" || storedChecksum != checksum || storedOwner != owner || storedRuntime != runtimeRole {
+			return fmt.Errorf("temporal target metadata drift")
+		}
+		var ledgerCount int
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.runtime_store_migrations WHERE migration_id='temporal-frontier-v1' AND ddl_sha256=$1`, qSchema), checksum).Scan(&ledgerCount); err != nil || ledgerCount != 1 {
+			return fmt.Errorf("temporal migration ledger drift: count=%d err=%v", ledgerCount, err)
+		}
+		return tx.Commit()
+	}
+	if targetColumns != 0 {
+		return fmt.Errorf("partial temporal metadata shape is unsupported")
+	}
+
+	if _, err := tx.ExecContext(ctx, `SET LOCAL ROLE `+quoteTemporalIdent(owner)); err != nil {
+		return fmt.Errorf("assume temporal schema owner: %w", err)
+	}
+	for _, table := range []string{"event_deliveries", "event_receipts", "events", "runs", "runtime_store_metadata"} {
+		if _, err := tx.ExecContext(ctx, `LOCK TABLE `+qSchema+`.`+quoteTemporalIdent(table)+` IN ACCESS EXCLUSIVE MODE`); err != nil {
+			return fmt.Errorf("lock legacy table %s: %w", table, err)
+		}
+	}
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`SELECT run_id::text FROM %s.runs WHERE status IN ('running','paused') ORDER BY run_id::text`, qSchema))
+	if err != nil {
+		return fmt.Errorf("query active legacy runs: %w", err)
+	}
+	var active []string
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan active legacy run: %w", err)
+		}
+		active = append(active, runID)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close active legacy runs: %w", err)
+	}
+	if len(active) > 0 {
+		return fmt.Errorf("active legacy runs block temporal migration: %s", strings.Join(active, ","))
+	}
+
+	var platformVersion string
+	if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT platform_version FROM %s.runtime_store_metadata WHERE id=1`, qSchema)).Scan(&platformVersion); err != nil {
+		return fmt.Errorf("read legacy platform version: %w", err)
+	}
+	if platformVersion != "0.7.0" {
+		return fmt.Errorf("unrecognized legacy platform version %q", platformVersion)
+	}
+	if _, err := tx.ExecContext(ctx, temporalTargetDDL(qSchema)); err != nil {
+		return fmt.Errorf("create temporal target schema: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, temporalFunctionsDDL(qSchema)); err != nil {
+		return fmt.Errorf("create temporal functions and triggers: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %[1]s.run_temporal_frontiers(run_id,model_version,current_revision,history_complete)
+		SELECT run_id,0,0,false FROM %[1]s.runs;
+	`, qSchema)); err != nil {
+		return fmt.Errorf("mark retained legacy runs unversioned: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, temporalGrantDDL(qSchema, quoteTemporalIdent(runtimeRole))); err != nil {
+		return fmt.Errorf("apply temporal grants: %w", err)
+	}
+	if forceRollback {
+		return fmt.Errorf("forced temporal migration rollback")
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s.runtime_store_migrations(migration_id,from_generation,to_generation,ddl_sha256,schema_owner_role,runtime_role)
+		VALUES ('temporal-frontier-v1','pre-temporal-v0','temporal-frontier-v1',$1,$2,$3)
+	`, qSchema), checksum, owner, runtimeRole); err != nil {
+		return fmt.Errorf("write temporal migration ledger: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s.runtime_store_metadata
+		SET platform_version='0.7.0', schema_generation='temporal-frontier-v1', schema_ddl_sha256=$1,
+		    schema_owner_role=$2, runtime_role=$3
+		WHERE id=1
+	`, qSchema), checksum, owner, runtimeRole); err != nil {
+		return fmt.Errorf("commit temporal metadata authority: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit temporal schema apply: %w", err)
+	}
+	return nil
+}
+
+func assertTemporalTargetMetadata(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole string) {
+	t.Helper()
+	var generation, checksum, gotOwner, gotRuntime string
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT schema_generation,schema_ddl_sha256,schema_owner_role,runtime_role FROM %s.runtime_store_metadata WHERE id=1`, quoteTemporalIdent(schema))).Scan(&generation, &checksum, &gotOwner, &gotRuntime); err != nil {
+		t.Fatalf("read temporal target metadata: %v", err)
+	}
+	if generation != "temporal-frontier-v1" || checksum != temporalPrototypeChecksum() || gotOwner != owner || gotRuntime != runtimeRole {
+		t.Fatalf("temporal metadata = generation:%q checksum:%q owner:%q runtime:%q", generation, checksum, gotOwner, gotRuntime)
+	}
+}
+
+func assertTemporalTableExists(t *testing.T, ctx context.Context, db *sql.DB, schema, table string, want bool) {
+	t.Helper()
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`, schema+`.`+table).Scan(&exists); err != nil {
+		t.Fatalf("inspect temporal table %s.%s: %v", schema, table, err)
+	}
+	if exists != want {
+		t.Fatalf("temporal table %s.%s exists = %v, want %v", schema, table, exists, want)
+	}
+}
+
+func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	var currentUser, generation, metadataRuntime string
+	var ownerMember, superuser, bypassRLS, createRole, schemaCreate bool
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT current_user,
+		       m.schema_generation,
+		       m.runtime_role,
+		       pg_has_role(current_user,$1,'MEMBER'),
+		       r.rolsuper,
+		       r.rolbypassrls,
+		       r.rolcreaterole,
+		       has_schema_privilege(current_user,$2,'CREATE')
+		FROM %[1]s.runtime_store_metadata m
+		JOIN pg_roles r ON r.rolname=current_user
+		WHERE m.id=1
+	`, qSchema), owner, schema).Scan(&currentUser, &generation, &metadataRuntime, &ownerMember, &superuser, &bypassRLS, &createRole, &schemaCreate); err != nil {
+		t.Fatalf("read temporal runtime admission: %v", err)
+	}
+	if currentUser != runtimeRole || metadataRuntime != runtimeRole || generation != "temporal-frontier-v1" || ownerMember || superuser || bypassRLS || createRole || schemaCreate {
+		t.Fatalf("runtime admission drift: user=%q metadata=%q generation=%q owner_member=%v super=%v bypass=%v createrole=%v schema_create=%v", currentUser, metadataRuntime, generation, ownerMember, superuser, bypassRLS, createRole, schemaCreate)
+	}
+
+	var triggerCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM pg_trigger t
+		JOIN pg_class c ON c.oid=t.tgrelid
+		JOIN pg_namespace n ON n.oid=c.relnamespace
+		JOIN pg_proc p ON p.oid=t.tgfoid
+		JOIN pg_roles owner_role ON owner_role.oid=p.proowner
+		WHERE n.nspname=$1
+		  AND c.relname IN ('events','event_deliveries','event_receipts')
+		  AND NOT t.tgisinternal
+		  AND t.tgenabled='A'
+		  AND p.prosecdef
+		  AND owner_role.rolname=$2
+		  AND EXISTS (SELECT 1 FROM unnest(p.proconfig) cfg WHERE cfg LIKE 'search_path=pg_catalog,%')
+	`, schema, owner).Scan(&triggerCount); err != nil {
+		t.Fatalf("inspect temporal triggers: %v", err)
+	}
+	if triggerCount != 3 {
+		t.Fatalf("admitted temporal trigger count = %d, want 3", triggerCount)
+	}
+
+	var eventInsert, eventUpdate, eventDelete, historyDML, helperExecute bool
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT has_table_privilege(current_user,'%[1]s.events','INSERT'),
+		       has_table_privilege(current_user,'%[1]s.events','UPDATE'),
+		       has_table_privilege(current_user,'%[1]s.events','DELETE'),
+		       has_table_privilege(current_user,'%[1]s.event_delivery_history','INSERT,UPDATE,DELETE'),
+		       has_function_privilege(current_user,'%[1]s.swarm_next_temporal_ordinal(uuid)','EXECUTE')
+	`, qSchema)).Scan(&eventInsert, &eventUpdate, &eventDelete, &historyDML, &helperExecute); err != nil {
+		t.Fatalf("inspect temporal grants: %v", err)
+	}
+	if !eventInsert || eventUpdate || eventDelete || historyDML || helperExecute {
+		t.Fatalf("runtime grant drift: event_insert=%v event_update=%v event_delete=%v history_dml=%v helper_execute=%v", eventInsert, eventUpdate, eventDelete, historyDML, helperExecute)
+	}
+	functionGrants := []struct {
+		signature string
+		want      bool
+	}{
+		{signature: "swarm_claim_temporal_runs(uuid[])", want: true},
+		{signature: "swarm_destroy_run(uuid,text)", want: true},
+		{signature: "swarm_declare_temporal_runs(uuid[],text)", want: false},
+		{signature: "swarm_next_temporal_ordinal(uuid)", want: false},
+		{signature: "swarm_guard_events()", want: false},
+		{signature: "swarm_guard_event_deliveries()", want: false},
+		{signature: "swarm_guard_event_receipts()", want: false},
+	}
+	for _, grant := range functionGrants {
+		var got bool
+		if err := db.QueryRowContext(ctx, `SELECT has_function_privilege(current_user,$1,'EXECUTE')`, schema+`.`+grant.signature).Scan(&got); err != nil {
+			t.Fatalf("inspect temporal function grant %s: %v", grant.signature, err)
+		}
+		if got != grant.want {
+			t.Fatalf("runtime EXECUTE on %s = %v, want %v", grant.signature, got, grant.want)
+		}
+	}
+}
+
+func assertTemporalPrivilegeDenials(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	assertTemporalExecFails(t, ctx, db, `SET ROLE `+quoteTemporalIdent(owner), "assume schema owner")
+	assertTemporalExecFails(t, ctx, db, `ALTER TABLE `+qSchema+`.events DISABLE TRIGGER ALL`, "disable temporal trigger")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.event_delivery_history(run_id,revision,ordinal,operation,fact_id) VALUES ('00000000-0000-0000-0000-000000000000',1,1,'insert','forged')`, qSchema), "write temporal history")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.run_temporal_transactions(transaction_id,run_ids,mode) VALUES (pg_current_xact_id(),ARRAY['00000000-0000-0000-0000-000000000000'::uuid],'normal')`, qSchema), "write temporal transaction authority")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.run_temporal_frontiers SET current_revision=current_revision+1`, qSchema), "write temporal frontier authority")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.run_temporal_revisions`, qSchema), "write temporal revision authority")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.runtime_store_migrations`, qSchema), "write temporal migration ledger")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.runtime_store_metadata SET schema_generation='forged'`, qSchema), "write temporal metadata")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.run_deletion_tombstones`, qSchema), "write temporal deletion evidence")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT * FROM %s.swarm_next_temporal_ordinal('00000000-0000-0000-0000-000000000000'::uuid)`, qSchema), "invoke ordinal bypass")
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_declare_temporal_runs(ARRAY['00000000-0000-0000-0000-000000000000'::uuid],'destructive')`, qSchema), "invoke destructive declaration bypass")
+}
+
+func seedTemporalVersionedRuns(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string, runIDs ...string) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin temporal run seed: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
+	qSchema := quoteTemporalIdent(schema)
+	for _, runID := range runIDs {
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.runs(run_id,status) VALUES ($1,'running')`, qSchema), runID)
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.run_temporal_frontiers(run_id,model_version,current_revision,history_complete) VALUES ($1,1,0,true)`, qSchema), runID)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit temporal run seed: %v", err)
+	}
+}
+
+func assertTemporalUndeclaredDMLRejected(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, eventID string) {
+	t.Helper()
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id,temporal_revision,temporal_ordinal) VALUES ($1,$2,999,999)`, quoteTemporalIdent(schema)), "undeclared event insert", eventID, runID)
+}
+
+func writeTemporalEventDeliveryReceipt(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, eventID, deliveryID, receiptID string) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin event/delivery/receipt transaction: %v", err)
+	}
+	defer tx.Rollback()
+	qSchema := quoteTemporalIdent(schema)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id,temporal_revision,temporal_ordinal) VALUES ($1,$2,999,999)`, qSchema), eventID, runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status,temporal_revision,temporal_ordinal) VALUES ($1,$2,$3,'pending',999,999)`, qSchema), deliveryID, runID, eventID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.event_receipts(receipt_id,event_id,outcome,temporal_revision,temporal_ordinal) VALUES ($1,$2,'success',999,999)`, qSchema), receiptID, eventID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit event/delivery/receipt transaction: %v", err)
+	}
+}
+
+func assertTemporalSharedRevision(t *testing.T, ctx context.Context, db *sql.DB, schema, eventID, deliveryID, receiptID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	var eventRev, deliveryRev, receiptRev int64
+	var eventOrdinal, deliveryOrdinal, receiptOrdinal int
+	var receiptRun string
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT e.temporal_revision,e.temporal_ordinal,
+		       d.temporal_revision,d.temporal_ordinal,
+		       r.temporal_revision,r.temporal_ordinal,r.temporal_run_id::text
+		FROM %[1]s.events e
+		JOIN %[1]s.event_deliveries d ON d.delivery_id=$2
+		JOIN %[1]s.event_receipts r ON r.receipt_id=$3
+		WHERE e.event_id=$1
+	`, qSchema), eventID, deliveryID, receiptID).Scan(&eventRev, &eventOrdinal, &deliveryRev, &deliveryOrdinal, &receiptRev, &receiptOrdinal, &receiptRun); err != nil {
+		t.Fatalf("read event/delivery/receipt temporal stamps: %v", err)
+	}
+	if eventRev != deliveryRev || eventRev != receiptRev || eventOrdinal != 1 || deliveryOrdinal != 2 || receiptOrdinal != 3 || receiptRun == "" {
+		t.Fatalf("shared revision = %d/%d/%d ordinals=%d/%d/%d receipt_run=%q", eventRev, deliveryRev, receiptRev, eventOrdinal, deliveryOrdinal, receiptOrdinal, receiptRun)
+	}
+	var deliveryHistory, receiptHistory int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT (SELECT count(*) FROM %[1]s.event_delivery_history),(SELECT count(*) FROM %[1]s.event_receipt_history)`, qSchema)).Scan(&deliveryHistory, &receiptHistory); err != nil {
+		t.Fatalf("count typed temporal history: %v", err)
+	}
+	if deliveryHistory != 1 || receiptHistory != 1 {
+		t.Fatalf("typed temporal history counts = delivery:%d receipt:%d, want 1/1", deliveryHistory, receiptHistory)
+	}
+}
+
+func assertTemporalDirectEventMutationRejected(t *testing.T, ctx context.Context, db *sql.DB, schema, eventID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.events SET created_at=clock_timestamp() WHERE event_id=$1`, qSchema), "runtime event update", eventID)
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.events WHERE event_id=$1`, qSchema), "runtime event delete", eventID)
+}
+
+func assertTemporalEventTriggerDefendsGrantDrift(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runID, eventID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	for _, mutation := range []struct {
+		name string
+		sql  string
+	}{
+		{name: "update", sql: fmt.Sprintf(`UPDATE %s.events SET created_at=clock_timestamp() WHERE event_id=$1`, qSchema)},
+		{name: "normal delete", sql: fmt.Sprintf(`DELETE FROM %s.events WHERE event_id=$1`, qSchema)},
+	} {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin owner event %s proof: %v", mutation.name, err)
+		}
+		mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
+		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+		if _, err := tx.ExecContext(ctx, mutation.sql, eventID); err == nil {
+			_ = tx.Rollback()
+			t.Fatalf("owner event %s bypassed ENABLE ALWAYS trigger", mutation.name)
+		}
+		_ = tx.Rollback()
+	}
+}
+
+func assertTemporalUndeclaredDeliveryMutationRejected(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.event_deliveries SET status='delivered' WHERE delivery_id=$1`, qSchema), "undeclared delivery update", deliveryID)
+	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), "undeclared delivery delete", deliveryID)
+}
+
+func assertTemporalOwnershipMove(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID, runA, runB string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin incomplete ownership move: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runB)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s.event_deliveries SET run_id=$1 WHERE delivery_id=$2`, qSchema), runB, deliveryID); err == nil {
+		t.Fatal("ownership move with NEW run only unexpectedly succeeded")
+	}
+	_ = tx.Rollback()
+
+	tx, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin complete ownership move: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runB, runA)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.event_deliveries SET run_id=$1 WHERE delivery_id=$2`, qSchema), runB, deliveryID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit complete ownership move: %v", err)
+	}
+	var gotRun string
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT run_id::text FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), deliveryID).Scan(&gotRun); err != nil {
+		t.Fatalf("read moved delivery: %v", err)
+	}
+	if gotRun != runB {
+		t.Fatalf("moved delivery run = %s, want %s", gotRun, runB)
+	}
+}
+
+func assertTemporalDeclaredDeliveryDelete(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID, runID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	var before int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.event_delivery_history WHERE operation='delete' AND fact_id=$1`, qSchema), deliveryID).Scan(&before); err != nil {
+		t.Fatalf("count delivery delete history before mutation: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin declared delivery delete: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`DELETE FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), deliveryID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit declared delivery delete: %v", err)
+	}
+	var after int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.event_delivery_history WHERE operation='delete' AND fact_id=$1`, qSchema), deliveryID).Scan(&after); err != nil {
+		t.Fatalf("count delivery delete history after mutation: %v", err)
+	}
+	if after != before+1 {
+		t.Fatalf("declared delivery delete history count = %d, want %d", after, before+1)
+	}
+}
+
+func assertTemporalRollbackPublishesNothing(t *testing.T, ctx context.Context, db *sql.DB, schema, runID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin temporal rollback proof: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ('c0000000-0000-0000-0000-000000000001',$1)`, qSchema), runID)
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback temporal transaction: %v", err)
+	}
+	var frontier, revisionCount, eventCount int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT f.current_revision,
+		       (SELECT count(*) FROM %[1]s.run_temporal_revisions r WHERE r.run_id=f.run_id),
+		       (SELECT count(*) FROM %[1]s.events e WHERE e.run_id=f.run_id)
+		FROM %[1]s.run_temporal_frontiers f WHERE f.run_id=$1
+	`, qSchema), runID).Scan(&frontier, &revisionCount, &eventCount); err != nil {
+		t.Fatalf("read rollback temporal authority: %v", err)
+	}
+	if frontier != 0 || revisionCount != 0 || eventCount != 0 {
+		t.Fatalf("rollback published frontier=%d revisions=%d events=%d", frontier, revisionCount, eventCount)
+	}
+}
+
+func assertTemporalRunlessLineage(t *testing.T, ctx context.Context, db *sql.DB, schema string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	eventID := "f0000000-0000-0000-0000-000000000001"
+	receiptID := "f0000000-0000-0000-0000-000000000002"
+	mustExecTemporal(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ($1,NULL)`, qSchema), eventID)
+	mustExecTemporal(t, ctx, db, fmt.Sprintf(`INSERT INTO %s.event_receipts(receipt_id,event_id,outcome) VALUES ($1,$2,'success')`, qSchema), receiptID, eventID)
+	var eventRevision, receiptRevision sql.NullInt64
+	var receiptRun sql.NullString
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT e.temporal_revision,r.temporal_run_id::text,r.temporal_revision
+		FROM %[1]s.events e JOIN %[1]s.event_receipts r ON r.event_id=e.event_id
+		WHERE e.event_id=$1
+	`, qSchema), eventID).Scan(&eventRevision, &receiptRun, &receiptRevision); err == nil {
+	} else {
+		t.Fatalf("read runless temporal lineage: %v", err)
+	}
+	if eventRevision.Valid || receiptRun.Valid || receiptRevision.Valid {
+		t.Fatalf("runless temporal stamps = event:%v receipt_run:%v receipt:%v, want NULL", eventRevision, receiptRun, receiptRevision)
+	}
+}
+
+func assertTemporalUnversionedDestruction(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, eventID, deliveryID, receiptID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin unversioned normal claim: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID); err == nil {
+		t.Fatal("normal claim for unversioned run unexpectedly succeeded")
+	}
+	_ = tx.Rollback()
+
+	mustExecTemporal(t, ctx, db, fmt.Sprintf(`SELECT %s.swarm_destroy_run($1,'conformance')`, qSchema), runID)
+	var tombstoneVersion int
+	var lastRevision sql.NullInt64
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT source_model_version,last_revision FROM %s.run_deletion_tombstones WHERE run_id=$1`, qSchema), runID).Scan(&tombstoneVersion, &lastRevision); err != nil {
+		t.Fatalf("read unversioned deletion tombstone: %v", err)
+	}
+	if tombstoneVersion != 0 || lastRevision.Valid {
+		t.Fatalf("unversioned tombstone = version:%d revision:%v, want 0/NULL", tombstoneVersion, lastRevision)
+	}
+	var revisionCount int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.run_temporal_revisions WHERE run_id=$1`, qSchema), runID).Scan(&revisionCount); err != nil {
+		t.Fatalf("count unversioned destructive revisions: %v", err)
+	}
+	if revisionCount != 0 {
+		t.Fatalf("unversioned destructive cleanup created %d ordinary revisions", revisionCount)
+	}
+	var remainingFacts int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT (SELECT count(*) FROM %[1]s.events WHERE event_id=$1)
+		     + (SELECT count(*) FROM %[1]s.event_deliveries WHERE delivery_id=$2)
+		     + (SELECT count(*) FROM %[1]s.event_receipts WHERE receipt_id=$3)
+	`, qSchema), eventID, deliveryID, receiptID).Scan(&remainingFacts); err != nil {
+		t.Fatalf("count destructively cascaded legacy facts: %v", err)
+	}
+	if remainingFacts != 0 {
+		t.Fatalf("destructive legacy cascade left %d facts", remainingFacts)
+	}
+}
+
+func assertTemporalReverseClaimsSerialize(t *testing.T, ctx context.Context, admin, runtimeDB *sql.DB, schema, runA, runB string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx1, err := runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin first reverse claim: %v", err)
+	}
+	defer tx1.Rollback()
+	mustExecTemporal(t, ctx, tx1, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runB, runA)
+
+	conn2, err := runtimeDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("open second reverse claim connection: %v", err)
+	}
+	defer conn2.Close()
+	tx2, err := conn2.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin second reverse claim: %v", err)
+	}
+	defer tx2.Rollback()
+	var pid int
+	if err := tx2.QueryRowContext(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+		t.Fatalf("read second reverse claim pid: %v", err)
+	}
+
+	result := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := tx2.ExecContext(ctx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), runA, runB)
+		result <- err
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	waiting := false
+	for time.Now().Before(deadline) {
+		if err := admin.QueryRowContext(ctx, `SELECT wait_event_type='Lock' FROM pg_stat_activity WHERE pid=$1`, pid).Scan(&waiting); err == nil && waiting {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !waiting {
+		t.Fatal("reverse-order temporal claim did not block on sorted frontier lock")
+	}
+	if err := tx1.Commit(); err != nil {
+		t.Fatalf("commit first reverse claim: %v", err)
+	}
+	if err := <-result; err != nil {
+		t.Fatalf("second reverse claim after serialization: %v", err)
+	}
+	if err := tx2.Commit(); err != nil {
+		t.Fatalf("commit second reverse claim: %v", err)
+	}
+	wg.Wait()
+}
+
+func assertTemporalExecFails(t *testing.T, ctx context.Context, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, query, label string, args ...any) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, query, args...); err == nil {
+		t.Fatalf("%s unexpectedly succeeded", label)
+	}
+}
+
+func mustExecTemporal(t *testing.T, ctx context.Context, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, query string, args ...any) {
+	t.Helper()
+	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		t.Fatalf("execute temporal conformance SQL: %v\n%s", err, query)
+	}
+}
+
+func temporalRoleDSN(params testpostgres.Parameters, user, password string) string {
+	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=%s",
+		quoteTemporalDSNValue(params.Host), params.Port, quoteTemporalDSNValue(params.Database),
+		quoteTemporalDSNValue(user), quoteTemporalDSNValue(password), quoteTemporalDSNValue(params.SSLMode))
+}
+
+func quoteTemporalDSNValue(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `'`, `\'`)
+	return `'` + value + `'`
+}
+
+func quoteTemporalIdent(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func quoteTemporalLiteral(value string) string {
+	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
+}
+
+func temporalSchemaLockKey(schema string) int64 {
+	digest := sha256.Sum256([]byte("swarm:temporal-schema:" + schema))
+	var key int64
+	for _, b := range digest[:8] {
+		key = key<<8 | int64(b)
+	}
+	return key
+}
+
+func temporalPrototypeChecksum() string {
+	digest := sha256.Sum256([]byte(temporalPrototypeSchemaTemplate + "\x00" + temporalPrototypeFunctionsTemplate + "\x00" + temporalPrototypeGrantTemplate))
+	return hex.EncodeToString(digest[:])
+}
+
+func temporalLegacyDDL(schema string) string {
+	return fmt.Sprintf(temporalLegacySchemaTemplate, schema)
+}
+
+func temporalTargetDDL(schema string) string {
+	return fmt.Sprintf(temporalPrototypeSchemaTemplate, schema)
+}
+
+func temporalFunctionsDDL(schema string) string {
+	return fmt.Sprintf(temporalPrototypeFunctionsTemplate, schema)
+}
+
+func temporalGrantDDL(schema, runtimeRole string) string {
+	return fmt.Sprintf(temporalPrototypeGrantTemplate, schema, runtimeRole)
+}
+
+const temporalLegacySchemaTemplate = `
+	CREATE TABLE %[1]s.runtime_store_metadata (
+		id INTEGER PRIMARY KEY CHECK (id=1),
+		swarm_version TEXT NOT NULL,
+		platform_version TEXT NOT NULL,
+		created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+	);
+	INSERT INTO %[1]s.runtime_store_metadata(id,swarm_version,platform_version) VALUES (1,'conformance','0.7.0');
+	CREATE TABLE %[1]s.runs (
+		run_id UUID PRIMARY KEY,
+		status TEXT NOT NULL CHECK (status IN ('running','paused','completed','failed','cancelled','forked'))
+	);
+	CREATE TABLE %[1]s.events (
+		event_id UUID PRIMARY KEY,
+		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+	);
+	CREATE TABLE %[1]s.event_deliveries (
+		delivery_id UUID PRIMARY KEY,
+		run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		event_id UUID NOT NULL REFERENCES %[1]s.events(event_id) ON DELETE CASCADE,
+		status TEXT NOT NULL CHECK (status IN ('pending','in_progress','delivered','failed','dead_letter'))
+	);
+	CREATE TABLE %[1]s.event_receipts (
+		receipt_id UUID PRIMARY KEY,
+		event_id UUID NOT NULL REFERENCES %[1]s.events(event_id) ON DELETE CASCADE,
+		outcome TEXT NOT NULL
+	);
+`
+
+const temporalPrototypeSchemaTemplate = `
+	ALTER TABLE %[1]s.runtime_store_metadata
+		ADD COLUMN schema_generation TEXT,
+		ADD COLUMN schema_ddl_sha256 TEXT,
+		ADD COLUMN schema_owner_role TEXT,
+		ADD COLUMN runtime_role TEXT;
+	ALTER TABLE %[1]s.events
+		ADD COLUMN temporal_revision BIGINT,
+		ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.event_deliveries
+		ADD COLUMN temporal_revision BIGINT,
+		ADD COLUMN temporal_ordinal INTEGER;
+	ALTER TABLE %[1]s.event_receipts
+		ADD COLUMN temporal_run_id UUID REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		ADD COLUMN temporal_revision BIGINT,
+		ADD COLUMN temporal_ordinal INTEGER;
+	UPDATE %[1]s.event_receipts AS receipt
+	SET temporal_run_id=event.run_id
+	FROM %[1]s.events AS event
+	WHERE event.event_id=receipt.event_id;
+
+	CREATE TABLE %[1]s.run_temporal_transactions (
+		transaction_id XID8 PRIMARY KEY,
+		run_ids UUID[] NOT NULL,
+		mode TEXT NOT NULL CHECK (mode IN ('normal','destructive')),
+		declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+		CHECK (cardinality(run_ids) > 0)
+	);
+	CREATE TABLE %[1]s.run_temporal_frontiers (
+		run_id UUID PRIMARY KEY REFERENCES %[1]s.runs(run_id) ON DELETE CASCADE,
+		model_version INTEGER NOT NULL CHECK (model_version IN (0,1)),
+		current_revision BIGINT NOT NULL DEFAULT 0 CHECK (current_revision >= 0),
+		history_complete BOOLEAN NOT NULL DEFAULT FALSE,
+		CHECK ((model_version=0 AND history_complete=FALSE AND current_revision=0)
+		    OR (model_version=1 AND history_complete=TRUE))
+	);
+	CREATE TABLE %[1]s.run_temporal_revisions (
+		run_id UUID NOT NULL REFERENCES %[1]s.run_temporal_frontiers(run_id) ON DELETE CASCADE,
+		revision BIGINT NOT NULL CHECK (revision > 0),
+		transaction_id XID8 NOT NULL REFERENCES %[1]s.run_temporal_transactions(transaction_id),
+		next_ordinal INTEGER NOT NULL DEFAULT 0 CHECK (next_ordinal >= 0),
+		recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+		PRIMARY KEY (run_id,revision),
+		UNIQUE (run_id,transaction_id)
+	);
+	CREATE TABLE %[1]s.runtime_store_migrations (
+		migration_id TEXT PRIMARY KEY,
+		from_generation TEXT NOT NULL,
+		to_generation TEXT NOT NULL,
+		ddl_sha256 TEXT NOT NULL CHECK (ddl_sha256 ~ '^[0-9a-f]{64}$'),
+		schema_owner_role TEXT NOT NULL,
+		runtime_role TEXT NOT NULL,
+		applied_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+		CHECK (schema_owner_role <> runtime_role)
+	);
+	CREATE TABLE %[1]s.run_deletion_tombstones (
+		deletion_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		run_id UUID NOT NULL UNIQUE,
+		source_model_version INTEGER NOT NULL CHECK (source_model_version IN (0,1)),
+		last_revision BIGINT CHECK (last_revision IS NULL OR last_revision >= 0),
+		transaction_id XID8 NOT NULL REFERENCES %[1]s.run_temporal_transactions(transaction_id),
+		deleted_by TEXT NOT NULL,
+		deleted_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+		CHECK ((source_model_version=0 AND last_revision IS NULL)
+		    OR (source_model_version=1 AND last_revision IS NOT NULL))
+	);
+	CREATE TABLE %[1]s.run_lifecycle_history (
+		history_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+		run_id UUID NOT NULL,
+		revision BIGINT NOT NULL,
+		ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+		operation TEXT NOT NULL CHECK (operation IN ('insert','update','delete')),
+		fact_id TEXT NOT NULL,
+		before_state JSONB,
+		after_state JSONB,
+		FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE,
+		UNIQUE (run_id,revision,ordinal)
+	);
+	CREATE TABLE %[1]s.event_delivery_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.event_receipt_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.timer_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.entity_state_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.agent_session_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.conversation_audit_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.reply_context_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	CREATE TABLE %[1]s.activity_attempt_history (LIKE %[1]s.run_lifecycle_history INCLUDING ALL);
+	ALTER TABLE %[1]s.event_delivery_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.event_receipt_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.timer_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.entity_state_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.agent_session_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.conversation_audit_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.reply_context_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+	ALTER TABLE %[1]s.activity_attempt_history ADD FOREIGN KEY (run_id,revision) REFERENCES %[1]s.run_temporal_revisions(run_id,revision) ON DELETE CASCADE;
+`
+
+const temporalPrototypeFunctionsTemplate = `
+	CREATE FUNCTION %[1]s.swarm_declare_temporal_runs(requested_run_ids UUID[], requested_mode TEXT)
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		current_xid XID8 := pg_current_xact_id();
+		normalized UUID[];
+		existing_run_ids UUID[];
+		existing_mode TEXT;
+		target_run UUID;
+		target_model INTEGER;
+		target_history_complete BOOLEAN;
+		next_revision BIGINT;
+	BEGIN
+		IF requested_mode NOT IN ('normal','destructive') THEN
+			RAISE EXCEPTION 'unsupported temporal declaration mode %%', requested_mode;
+		END IF;
+		SELECT array_agg(run_id ORDER BY run_id)
+		INTO normalized
+		FROM (SELECT DISTINCT unnest(requested_run_ids) AS run_id) declared
+		WHERE run_id IS NOT NULL;
+		IF normalized IS NULL OR cardinality(normalized)=0 THEN
+			RAISE EXCEPTION 'temporal declaration requires at least one run';
+		END IF;
+		SELECT run_ids,mode INTO existing_run_ids,existing_mode
+		FROM %[1]s.run_temporal_transactions
+		WHERE transaction_id=current_xid;
+		IF FOUND THEN
+			IF existing_run_ids<>normalized OR existing_mode<>requested_mode THEN
+				RAISE EXCEPTION 'temporal declaration is sealed for this transaction';
+			END IF;
+			RETURN;
+		END IF;
+		INSERT INTO %[1]s.run_temporal_transactions(transaction_id,run_ids,mode)
+		VALUES (current_xid,normalized,requested_mode);
+		FOREACH target_run IN ARRAY normalized LOOP
+			SELECT model_version,history_complete
+			INTO target_model,target_history_complete
+			FROM %[1]s.run_temporal_frontiers
+			WHERE run_id=target_run
+			FOR UPDATE;
+			IF NOT FOUND THEN
+				RAISE EXCEPTION 'run %% has no temporal frontier', target_run;
+			END IF;
+			IF requested_mode='normal' THEN
+				IF target_model<>1 OR NOT target_history_complete THEN
+					RAISE EXCEPTION 'run %% temporal history is unproven', target_run;
+				END IF;
+				UPDATE %[1]s.run_temporal_frontiers
+				SET current_revision=current_revision+1
+				WHERE run_id=target_run
+				RETURNING current_revision INTO next_revision;
+				INSERT INTO %[1]s.run_temporal_revisions(run_id,revision,transaction_id)
+				VALUES (target_run,next_revision,current_xid);
+			END IF;
+		END LOOP;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_claim_temporal_runs(requested_run_ids UUID[])
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	BEGIN
+		PERFORM %[1]s.swarm_declare_temporal_runs(requested_run_ids,'normal');
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_next_temporal_ordinal(target_run UUID)
+	RETURNS TABLE(temporal_revision BIGINT, temporal_ordinal INTEGER)
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		current_xid XID8 := pg_current_xact_id();
+		declared_mode TEXT;
+	BEGIN
+		SELECT mode INTO declared_mode
+		FROM %[1]s.run_temporal_transactions
+		WHERE transaction_id=current_xid AND target_run=ANY(run_ids);
+		IF NOT FOUND OR declared_mode<>'normal' THEN
+			RAISE EXCEPTION 'run %% is not in the sealed normal temporal declaration', target_run;
+		END IF;
+		UPDATE %[1]s.run_temporal_revisions
+		SET next_ordinal=next_ordinal+1
+		WHERE run_id=target_run AND transaction_id=current_xid
+		RETURNING revision,next_ordinal INTO temporal_revision,temporal_ordinal;
+		IF NOT FOUND THEN
+			RAISE EXCEPTION 'run %% has no revision for the current transaction', target_run;
+		END IF;
+		RETURN NEXT;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_guard_events()
+	RETURNS TRIGGER
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		stamp RECORD;
+		allowed BOOLEAN;
+	BEGIN
+		IF TG_OP='UPDATE' THEN
+			RAISE EXCEPTION 'events are immutable';
+		ELSIF TG_OP='DELETE' THEN
+			IF OLD.run_id IS NULL THEN
+				RAISE EXCEPTION 'runless event deletion has no destructive authority';
+			END IF;
+			SELECT EXISTS (
+				SELECT 1 FROM %[1]s.run_temporal_transactions
+				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND OLD.run_id=ANY(run_ids)
+			) INTO allowed;
+			IF NOT allowed THEN
+				RAISE EXCEPTION 'event deletion requires sealed destructive run authority';
+			END IF;
+			RETURN OLD;
+		END IF;
+		IF NEW.run_id IS NULL THEN
+			NEW.temporal_revision=NULL;
+			NEW.temporal_ordinal=NULL;
+			RETURN NEW;
+		END IF;
+		SELECT * INTO stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
+		NEW.temporal_revision=stamp.temporal_revision;
+		NEW.temporal_ordinal=stamp.temporal_ordinal;
+		RETURN NEW;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_guard_event_deliveries()
+	RETURNS TRIGGER
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		old_stamp RECORD;
+		new_stamp RECORD;
+		destructive BOOLEAN;
+	BEGIN
+		IF TG_OP='DELETE' THEN
+			IF OLD.run_id IS NULL THEN RETURN OLD; END IF;
+			SELECT EXISTS (
+				SELECT 1 FROM %[1]s.run_temporal_transactions
+				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND OLD.run_id=ANY(run_ids)
+			) INTO destructive;
+			IF destructive THEN RETURN OLD; END IF;
+			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(OLD.run_id);
+			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state)
+			VALUES (OLD.run_id,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'delete',OLD.delivery_id::text,to_jsonb(OLD));
+			RETURN OLD;
+		ELSIF TG_OP='INSERT' THEN
+			IF NEW.run_id IS NULL THEN
+				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+			END IF;
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,after_state)
+			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'insert',NEW.delivery_id::text,to_jsonb(NEW));
+			RETURN NEW;
+		END IF;
+		IF OLD.run_id IS NOT DISTINCT FROM NEW.run_id THEN
+			IF NEW.run_id IS NULL THEN
+				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+			END IF;
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
+			RETURN NEW;
+		END IF;
+		IF OLD.run_id IS NOT NULL THEN
+			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(OLD.run_id);
+			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (OLD.run_id,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'update',OLD.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
+		END IF;
+		IF NEW.run_id IS NOT NULL THEN
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(NEW.run_id);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_delivery_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (NEW.run_id,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.delivery_id::text,to_jsonb(OLD),to_jsonb(NEW));
+		ELSE
+			NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL;
+		END IF;
+		RETURN NEW;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_guard_event_receipts()
+	RETURNS TRIGGER
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		old_run UUID;
+		new_run UUID;
+		old_stamp RECORD;
+		new_stamp RECORD;
+		destructive BOOLEAN;
+	BEGIN
+		IF TG_OP<>'INSERT' THEN old_run=OLD.temporal_run_id; END IF;
+		IF TG_OP<>'DELETE' THEN
+			SELECT run_id INTO STRICT new_run FROM %[1]s.events WHERE event_id=NEW.event_id;
+			NEW.temporal_run_id=new_run;
+		END IF;
+		IF TG_OP='DELETE' THEN
+			IF old_run IS NULL THEN RETURN OLD; END IF;
+			SELECT EXISTS (
+				SELECT 1 FROM %[1]s.run_temporal_transactions
+				WHERE transaction_id=pg_current_xact_id() AND mode='destructive' AND old_run=ANY(run_ids)
+			) INTO destructive;
+			IF destructive THEN RETURN OLD; END IF;
+			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(old_run);
+			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state)
+			VALUES (old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'delete',OLD.receipt_id::text,to_jsonb(OLD));
+			RETURN OLD;
+		ELSIF TG_OP='INSERT' THEN
+			IF new_run IS NULL THEN
+				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+			END IF;
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,after_state)
+			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'insert',NEW.receipt_id::text,to_jsonb(NEW));
+			RETURN NEW;
+		END IF;
+		IF old_run IS NOT DISTINCT FROM new_run THEN
+			IF new_run IS NULL THEN
+				NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL; RETURN NEW;
+			END IF;
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+			RETURN NEW;
+		END IF;
+		IF old_run IS NOT NULL THEN
+			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(old_run);
+			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,'update',OLD.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+		END IF;
+		IF new_run IS NOT NULL THEN
+			SELECT * INTO new_stamp FROM %[1]s.swarm_next_temporal_ordinal(new_run);
+			NEW.temporal_revision=new_stamp.temporal_revision;
+			NEW.temporal_ordinal=new_stamp.temporal_ordinal;
+			INSERT INTO %[1]s.event_receipt_history(run_id,revision,ordinal,operation,fact_id,before_state,after_state)
+			VALUES (new_run,new_stamp.temporal_revision,new_stamp.temporal_ordinal,'update',NEW.receipt_id::text,to_jsonb(OLD),to_jsonb(NEW));
+		ELSE
+			NEW.temporal_revision=NULL; NEW.temporal_ordinal=NULL;
+		END IF;
+		RETURN NEW;
+	END
+	$function$;
+
+	CREATE FUNCTION %[1]s.swarm_destroy_run(target_run UUID, deletion_actor TEXT)
+	RETURNS VOID
+	LANGUAGE plpgsql
+	SECURITY DEFINER
+	SET search_path = pg_catalog, %[1]s
+	AS $function$
+	DECLARE
+		model INTEGER;
+		frontier BIGINT;
+	BEGIN
+		PERFORM %[1]s.swarm_declare_temporal_runs(ARRAY[target_run],'destructive');
+		SELECT model_version,current_revision INTO STRICT model,frontier
+		FROM %[1]s.run_temporal_frontiers WHERE run_id=target_run;
+		INSERT INTO %[1]s.run_deletion_tombstones(run_id,source_model_version,last_revision,transaction_id,deleted_by)
+		VALUES (target_run,model,CASE WHEN model=0 THEN NULL ELSE frontier END,pg_current_xact_id(),deletion_actor);
+		DELETE FROM %[1]s.runs WHERE run_id=target_run;
+		IF NOT FOUND THEN RAISE EXCEPTION 'run %% does not exist', target_run; END IF;
+	END
+	$function$;
+
+	CREATE TRIGGER temporal_events_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.events
+	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_events();
+	CREATE TRIGGER temporal_event_deliveries_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_deliveries
+	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_event_deliveries();
+	CREATE TRIGGER temporal_event_receipts_guard BEFORE INSERT OR UPDATE OR DELETE ON %[1]s.event_receipts
+	FOR EACH ROW EXECUTE FUNCTION %[1]s.swarm_guard_event_receipts();
+	ALTER TABLE %[1]s.events ENABLE ALWAYS TRIGGER temporal_events_guard;
+	ALTER TABLE %[1]s.event_deliveries ENABLE ALWAYS TRIGGER temporal_event_deliveries_guard;
+	ALTER TABLE %[1]s.event_receipts ENABLE ALWAYS TRIGGER temporal_event_receipts_guard;
+`
+
+const temporalPrototypeGrantTemplate = `
+	REVOKE ALL ON SCHEMA %[1]s FROM PUBLIC;
+	REVOKE ALL ON ALL TABLES IN SCHEMA %[1]s FROM PUBLIC;
+	REVOKE ALL ON ALL SEQUENCES IN SCHEMA %[1]s FROM PUBLIC;
+	REVOKE ALL ON ALL FUNCTIONS IN SCHEMA %[1]s FROM PUBLIC;
+	GRANT USAGE ON SCHEMA %[1]s TO %[2]s;
+	GRANT SELECT ON
+		%[1]s.runtime_store_metadata,
+		%[1]s.runtime_store_migrations,
+		%[1]s.runs,
+		%[1]s.events,
+		%[1]s.event_deliveries,
+		%[1]s.event_receipts,
+		%[1]s.run_temporal_transactions,
+		%[1]s.run_temporal_frontiers,
+		%[1]s.run_temporal_revisions,
+		%[1]s.run_deletion_tombstones,
+		%[1]s.run_lifecycle_history,
+		%[1]s.event_delivery_history,
+		%[1]s.event_receipt_history,
+		%[1]s.timer_history,
+		%[1]s.entity_state_history,
+		%[1]s.agent_session_history,
+		%[1]s.conversation_audit_history,
+		%[1]s.reply_context_history,
+		%[1]s.activity_attempt_history
+	TO %[2]s;
+	GRANT INSERT ON %[1]s.events TO %[2]s;
+	GRANT INSERT,UPDATE,DELETE ON %[1]s.event_deliveries,%[1]s.event_receipts TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_claim_temporal_runs(UUID[]) TO %[2]s;
+	GRANT EXECUTE ON FUNCTION %[1]s.swarm_destroy_run(UUID,TEXT) TO %[2]s;
+`

--- a/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
+++ b/internal/runtime/conformance/temporal_frontier_postgres_design_test.go
@@ -99,6 +99,18 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	}
 	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`ALTER TABLE %s.events DROP COLUMN unregistered_drift`, quoteTemporalIdent(upgradeSchema)))
 
+	legacyMismatchRun := "00000000-0000-0000-0000-000000000002"
+	legacyMismatchDelivery := "00000000-0000-0000-0000-000000000014"
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.runs(run_id,status) VALUES ($1,'completed')`, quoteTemporalIdent(upgradeSchema)), legacyMismatchRun)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status) VALUES ($1,$2,$3,'pending')`, quoteTemporalIdent(upgradeSchema)), legacyMismatchDelivery, legacyMismatchRun, legacyEvent)
+	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, false)
+	if err == nil || !strings.Contains(err.Error(), legacyMismatchDelivery) || !strings.Contains(err.Error(), legacyMismatchRun) || !strings.Contains(err.Error(), legacyRun) {
+		t.Fatalf("legacy lineage migration error = %v, want delivery/stored/event run diagnostic", err)
+	}
+	assertTemporalTableExists(t, ctx, admin, upgradeSchema, "run_temporal_frontiers", false)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`DELETE FROM %s.event_deliveries WHERE delivery_id=$1`, quoteTemporalIdent(upgradeSchema)), legacyMismatchDelivery)
+	mustExecTemporal(t, ctx, admin, fmt.Sprintf(`DELETE FROM %s.runs WHERE run_id=$1`, quoteTemporalIdent(upgradeSchema)), legacyMismatchRun)
+
 	err = applyTemporalPrototype(ctx, admin, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, false, true)
 	if err == nil || !strings.Contains(err.Error(), "forced temporal migration rollback") {
 		t.Fatalf("forced migration error = %v", err)
@@ -172,16 +184,17 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	mustExecTemporal(t, ctx, runtimeLockConn, `SELECT pg_advisory_unlock_shared($1)`, lockKey)
 	runtimeLockConn.Close()
 
-	assertTemporalRuntimeAdmission(t, ctx, runtimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
+	assertTemporalReadOnlyAdmission(t, ctx, runtimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, temporalAdmissionRuntime)
 	secondRuntimeDB, err := sql.Open("postgres", runtimeDSN)
 	if err != nil {
 		t.Fatalf("open second runtime connection: %v", err)
 	}
-	assertTemporalRuntimeAdmission(t, ctx, secondRuntimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
+	assertTemporalReadOnlyAdmission(t, ctx, secondRuntimeDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, temporalAdmissionRuntime)
 	secondRuntimeDB.Close()
 
 	assertTemporalPrivilegeDenials(t, ctx, runtimeDB, upgradeSchema, ownerRole)
-	assertTemporalCleanupAuthorizerAdmission(t, ctx, cleanupAuthorizerDB, upgradeSchema)
+	assertTemporalReadOnlyAdmission(t, ctx, cleanupAuthorizerDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole, temporalAdmissionCleanupAuthorizer)
+	assertTemporalAdmissionRejectsCommittedDrift(t, ctx, admin, runtimeDB, cleanupAuthorizerDB, upgradeSchema, ownerRole, runtimeRole, cleanupAuthorizerRole)
 
 	runA := "10000000-0000-0000-0000-000000000001"
 	runB := "20000000-0000-0000-0000-000000000002"
@@ -198,15 +211,17 @@ func TestTemporalFrontierPostgresDesignConformance(t *testing.T) {
 	writeTemporalEventDeliveryReceipt(t, ctx, runtimeDB, upgradeSchema, runA, eventID, deliveryID, receiptID)
 	assertTemporalSharedRevision(t, ctx, runtimeDB, upgradeSchema, eventID, deliveryID, receiptID)
 	assertTemporalDirectEventMutationRejected(t, ctx, runtimeDB, upgradeSchema, eventID)
-	assertTemporalEventTriggerDefendsGrantDrift(t, ctx, admin, upgradeSchema, ownerRole, runA, eventID)
+	assertTemporalAllGuardedFamilies(t, ctx, runtimeDB, upgradeSchema, runA, eventID)
+	assertTemporalAppendFamilyImmutability(t, ctx, admin, upgradeSchema, ownerRole, runA)
 	assertTemporalUndeclaredDeliveryMutationRejected(t, ctx, runtimeDB, upgradeSchema, deliveryID)
+	assertTemporalEventDerivedMutableOperations(t, ctx, runtimeDB, upgradeSchema, runA, deliveryID, receiptID)
 	assertTemporalDeliveryLineageMismatchRejected(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA, runB)
 	assertTemporalDeclaredDeliveryDelete(t, ctx, runtimeDB, upgradeSchema, deliveryID, runA)
-	assertTemporalAllGuardedFamilies(t, ctx, runtimeDB, upgradeSchema, runA, eventID)
 	assertTemporalRollbackPublishesNothing(t, ctx, runtimeDB, upgradeSchema, runC)
 	assertTemporalRunlessLineage(t, ctx, runtimeDB, upgradeSchema)
 	assertTemporalAuthorizedMixedCleanup(t, ctx, cleanupAuthorizerDB, runtimeDB, upgradeSchema, runA, runC)
 	assertTemporalUnversionedDestruction(t, ctx, cleanupAuthorizerDB, runtimeDB, upgradeSchema, legacyRun, legacyEvent, legacyDelivery, legacyReceipt)
+	assertTemporalEveryFamilyDestructiveCascade(t, ctx, cleanupAuthorizerDB, runtimeDB, upgradeSchema)
 	assertTemporalReverseClaimsSerialize(t, ctx, admin, runtimeDB, upgradeSchema, runA, runB)
 }
 
@@ -338,6 +353,40 @@ func applyTemporalPrototype(ctx context.Context, db *sql.DB, schema, owner, runt
 	if legacyCatalogChecksum != temporalRegisteredLegacyCatalogChecksum {
 		return fmt.Errorf("legacy catalog checksum mismatch: got %s want %s", legacyCatalogChecksum, temporalRegisteredLegacyCatalogChecksum)
 	}
+	rows, err = tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT delivery.delivery_id::text,delivery.run_id::text,event.run_id::text
+		FROM %s.event_deliveries delivery
+		LEFT JOIN %s.events event ON event.event_id=delivery.event_id
+		WHERE event.event_id IS NULL OR delivery.run_id IS DISTINCT FROM event.run_id
+		ORDER BY delivery.delivery_id::text
+	`, qSchema, qSchema))
+	if err != nil {
+		return fmt.Errorf("inspect legacy delivery lineage: %w", err)
+	}
+	var lineageMismatches []string
+	for rows.Next() {
+		var deliveryID, storedRun string
+		var eventRun sql.NullString
+		if err := rows.Scan(&deliveryID, &storedRun, &eventRun); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan legacy delivery lineage: %w", err)
+		}
+		resolvedEventRun := "<missing-event>"
+		if eventRun.Valid {
+			resolvedEventRun = eventRun.String
+		}
+		lineageMismatches = append(lineageMismatches, fmt.Sprintf("delivery=%s stored_run=%s event_run=%s", deliveryID, storedRun, resolvedEventRun))
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate legacy delivery lineage: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close legacy delivery lineage: %w", err)
+	}
+	if len(lineageMismatches) > 0 {
+		return fmt.Errorf("legacy delivery/event lineage mismatch: %s", strings.Join(lineageMismatches, ";"))
+	}
 	if _, err := tx.ExecContext(ctx, temporalTargetDDL(qSchema)); err != nil {
 		return fmt.Errorf("create temporal target schema: %w", err)
 	}
@@ -402,110 +451,324 @@ func assertTemporalTableExists(t *testing.T, ctx context.Context, db *sql.DB, sc
 	}
 }
 
-func assertTemporalRuntimeAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string) {
+type temporalAdmissionIdentity string
+
+const (
+	temporalAdmissionRuntime           temporalAdmissionIdentity = "runtime"
+	temporalAdmissionCleanupAuthorizer temporalAdmissionIdentity = "cleanup_authorizer"
+)
+
+func assertTemporalReadOnlyAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string, identity temporalAdmissionIdentity) {
 	t.Helper()
-	qSchema := quoteTemporalIdent(schema)
-	var currentUser, generation, metadataRuntime, metadataCleanupAuthorizer string
-	var ownerMember, cleanupAuthorizerMember, superuser, bypassRLS, createRole, schemaCreate bool
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT current_user,
-		       m.schema_generation,
-		       m.runtime_role,
-		       m.cleanup_authorizer_role,
-		       pg_has_role(current_user,$1,'MEMBER'),
-		       pg_has_role(current_user,$3,'MEMBER'),
-		       r.rolsuper,
-		       r.rolbypassrls,
-		       r.rolcreaterole,
-		       has_schema_privilege(current_user,$2,'CREATE')
-		FROM %[1]s.runtime_store_metadata m
-		JOIN pg_roles r ON r.rolname=current_user
-		WHERE m.id=1
-	`, qSchema), owner, schema, cleanupAuthorizerRole).Scan(&currentUser, &generation, &metadataRuntime, &metadataCleanupAuthorizer, &ownerMember, &cleanupAuthorizerMember, &superuser, &bypassRLS, &createRole, &schemaCreate); err != nil {
-		t.Fatalf("read temporal runtime admission: %v", err)
-	}
-	if currentUser != runtimeRole || metadataRuntime != runtimeRole || metadataCleanupAuthorizer != cleanupAuthorizerRole || generation != "temporal-frontier-v1" || ownerMember || cleanupAuthorizerMember || superuser || bypassRLS || createRole || schemaCreate {
-		t.Fatalf("runtime admission drift: user=%q metadata=%q cleanup_authorizer=%q generation=%q owner_member=%v cleanup_member=%v super=%v bypass=%v createrole=%v schema_create=%v", currentUser, metadataRuntime, metadataCleanupAuthorizer, generation, ownerMember, cleanupAuthorizerMember, superuser, bypassRLS, createRole, schemaCreate)
-	}
-
-	var triggerCount int
-	if err := db.QueryRowContext(ctx, `
-		SELECT count(*)
-		FROM pg_trigger t
-		JOIN pg_class c ON c.oid=t.tgrelid
-		JOIN pg_namespace n ON n.oid=c.relnamespace
-		JOIN pg_proc p ON p.oid=t.tgfoid
-		JOIN pg_roles owner_role ON owner_role.oid=p.proowner
-		WHERE n.nspname=$1
-		  AND c.relname IN ('runs','events','event_deliveries','event_receipts','dead_letters','entity_mutations','entity_state','timers','agent_sessions','agent_turns','agent_conversation_audits','reply_contexts','activity_attempts','selected_fork_lineage')
-		  AND NOT t.tgisinternal
-		  AND t.tgenabled='A'
-		  AND p.prosecdef
-		  AND owner_role.rolname=$2
-		  AND EXISTS (SELECT 1 FROM unnest(p.proconfig) cfg WHERE cfg LIKE 'search_path=pg_catalog,%')
-	`, schema, owner).Scan(&triggerCount); err != nil {
-		t.Fatalf("inspect temporal triggers: %v", err)
-	}
-	if triggerCount != 14 {
-		t.Fatalf("admitted temporal trigger count = %d, want 14", triggerCount)
-	}
-
-	var eventInsert, eventUpdate, eventDelete, runInsert, historyDML, helperExecute bool
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT has_table_privilege(current_user,'%[1]s.events','INSERT'),
-		       has_table_privilege(current_user,'%[1]s.events','UPDATE'),
-		       has_table_privilege(current_user,'%[1]s.events','DELETE'),
-		       has_table_privilege(current_user,'%[1]s.runs','INSERT'),
-		       has_table_privilege(current_user,'%[1]s.event_delivery_history','INSERT,UPDATE,DELETE'),
-		       has_function_privilege(current_user,'%[1]s.swarm_next_temporal_ordinal(uuid)','EXECUTE')
-	`, qSchema)).Scan(&eventInsert, &eventUpdate, &eventDelete, &runInsert, &historyDML, &helperExecute); err != nil {
-		t.Fatalf("inspect temporal grants: %v", err)
-	}
-	if !eventInsert || eventUpdate || eventDelete || runInsert || historyDML || helperExecute {
-		t.Fatalf("runtime grant drift: event_insert=%v event_update=%v event_delete=%v run_insert=%v history_dml=%v helper_execute=%v", eventInsert, eventUpdate, eventDelete, runInsert, historyDML, helperExecute)
-	}
-	functionGrants := []struct {
-		signature string
-		want      bool
-	}{
-		{signature: "swarm_claim_temporal_runs(uuid[])", want: true},
-		{signature: "swarm_create_run(uuid,text)", want: true},
-		{signature: "swarm_authorize_run_cleanup(uuid,text,text,uuid[],uuid[])", want: false},
-		{signature: "swarm_claim_authorized_run_cleanup(uuid)", want: true},
-		{signature: "swarm_delete_authorized_runs(uuid)", want: true},
-		{signature: "swarm_declare_temporal_runs(uuid[],uuid[])", want: false},
-		{signature: "swarm_next_temporal_ordinal(uuid)", want: false},
-		{signature: "swarm_resolve_temporal_run(jsonb,text,text)", want: false},
-		{signature: "swarm_guard_append_fact()", want: false},
-		{signature: "swarm_guard_mutable_fact()", want: false},
-	}
-	for _, grant := range functionGrants {
-		var got bool
-		if err := db.QueryRowContext(ctx, `SELECT has_function_privilege(current_user,$1,'EXECUTE')`, schema+`.`+grant.signature).Scan(&got); err != nil {
-			t.Fatalf("inspect temporal function grant %s: %v", grant.signature, err)
-		}
-		if got != grant.want {
-			t.Fatalf("runtime EXECUTE on %s = %v, want %v", grant.signature, got, grant.want)
-		}
+	if err := temporalReadOnlyAdmissionError(ctx, db, schema, owner, runtimeRole, cleanupAuthorizerRole, identity); err != nil {
+		t.Fatalf("%s temporal admission rejected: %v", identity, err)
 	}
 }
 
-func assertTemporalCleanupAuthorizerAdmission(t *testing.T, ctx context.Context, db *sql.DB, schema string) {
+func temporalReadOnlyAdmissionError(ctx context.Context, db *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string, identity temporalAdmissionIdentity) error {
+	expectedCurrentUser := runtimeRole
+	if identity == temporalAdmissionCleanupAuthorizer {
+		expectedCurrentUser = cleanupAuthorizerRole
+	} else if identity != temporalAdmissionRuntime {
+		return fmt.Errorf("unknown temporal admission identity %q", identity)
+	}
+	if owner == runtimeRole || owner == cleanupAuthorizerRole || runtimeRole == cleanupAuthorizerRole {
+		return fmt.Errorf("temporal database identities are not distinct")
+	}
+
+	qSchema := quoteTemporalIdent(schema)
+	var currentUser, platformVersion, generation, ddlChecksum, catalogChecksum, metadataOwner, metadataRuntime, metadataCleanupAuthorizer string
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT current_user,platform_version,schema_generation,schema_ddl_sha256,schema_catalog_sha256,
+		       schema_owner_role,runtime_role,cleanup_authorizer_role
+		FROM %s.runtime_store_metadata WHERE id=1
+	`, qSchema)).Scan(&currentUser, &platformVersion, &generation, &ddlChecksum, &catalogChecksum, &metadataOwner, &metadataRuntime, &metadataCleanupAuthorizer); err != nil {
+		return fmt.Errorf("read temporal metadata: %w", err)
+	}
+	if currentUser != expectedCurrentUser || platformVersion != "0.7.0" || generation != "temporal-frontier-v1" || ddlChecksum != temporalPrototypeChecksum() || metadataOwner != owner || metadataRuntime != runtimeRole || metadataCleanupAuthorizer != cleanupAuthorizerRole {
+		return fmt.Errorf("metadata/identity drift: current=%q platform=%q generation=%q ddl=%q owner=%q runtime=%q cleanup=%q", currentUser, platformVersion, generation, ddlChecksum, metadataOwner, metadataRuntime, metadataCleanupAuthorizer)
+	}
+	actualCatalogChecksum, err := temporalCatalogChecksum(ctx, db, schema, owner, runtimeRole)
+	if err != nil {
+		return fmt.Errorf("recompute installed catalog: %w", err)
+	}
+	if actualCatalogChecksum != catalogChecksum {
+		return fmt.Errorf("installed catalog checksum drift: got %s want %s", actualCatalogChecksum, catalogChecksum)
+	}
+
+	var ledgerCount int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT count(*) FROM %s.runtime_store_migrations
+		WHERE migration_id='temporal-frontier-v1'
+		  AND from_generation='pre-temporal-v0'
+		  AND to_generation='temporal-frontier-v1'
+		  AND ddl_sha256=$1 AND catalog_sha256=$2
+		  AND schema_owner_role=$3 AND runtime_role=$4 AND cleanup_authorizer_role=$5
+	`, qSchema), ddlChecksum, catalogChecksum, owner, runtimeRole, cleanupAuthorizerRole).Scan(&ledgerCount); err != nil {
+		return fmt.Errorf("read temporal migration ledger: %w", err)
+	}
+	if ledgerCount != 1 {
+		return fmt.Errorf("temporal migration ledger exact rows = %d, want 1", ledgerCount)
+	}
+
+	var schemaOwner string
+	if err := db.QueryRowContext(ctx, `
+		SELECT role.rolname FROM pg_namespace namespace
+		JOIN pg_roles role ON role.oid=namespace.nspowner
+		WHERE namespace.nspname=$1
+	`, schema).Scan(&schemaOwner); err != nil {
+		return fmt.Errorf("read temporal schema owner: %w", err)
+	}
+	if schemaOwner != owner {
+		return fmt.Errorf("temporal schema owner = %q, want %q", schemaOwner, owner)
+	}
+	for _, roleName := range []string{owner, runtimeRole, cleanupAuthorizerRole} {
+		var superuser, inherit, createRole, createDB, canLogin, replication, bypassRLS bool
+		var connectionLimit int
+		if err := db.QueryRowContext(ctx, `
+			SELECT rolsuper,rolinherit,rolcreaterole,rolcreatedb,rolcanlogin,rolreplication,rolbypassrls,rolconnlimit
+			FROM pg_roles WHERE rolname=$1
+		`, roleName).Scan(&superuser, &inherit, &createRole, &createDB, &canLogin, &replication, &bypassRLS, &connectionLimit); err != nil {
+			return fmt.Errorf("read temporal role %s: %w", roleName, err)
+		}
+		if superuser || inherit || createRole || createDB || !canLogin || replication || bypassRLS || connectionLimit != -1 {
+			return fmt.Errorf("temporal role %s attributes drifted", roleName)
+		}
+	}
+	var membershipCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM pg_auth_members membership
+		JOIN pg_roles granted_role ON granted_role.oid=membership.roleid
+		JOIN pg_roles member_role ON member_role.oid=membership.member
+		WHERE granted_role.rolname=ANY($1::text[]) OR member_role.rolname=ANY($1::text[])
+	`, pq.Array([]string{owner, runtimeRole, cleanupAuthorizerRole})).Scan(&membershipCount); err != nil {
+		return fmt.Errorf("read temporal role memberships: %w", err)
+	}
+	if membershipCount != 0 {
+		return fmt.Errorf("temporal role membership rows = %d, want 0", membershipCount)
+	}
+
+	var schemaUsage, schemaCreate bool
+	if err := db.QueryRowContext(ctx, `SELECT has_schema_privilege(current_user,$1,'USAGE'),has_schema_privilege(current_user,$1,'CREATE')`, schema).Scan(&schemaUsage, &schemaCreate); err != nil {
+		return fmt.Errorf("read temporal schema grants: %w", err)
+	}
+	if !schemaUsage || schemaCreate {
+		return fmt.Errorf("%s schema grants drifted: usage=%v create=%v", identity, schemaUsage, schemaCreate)
+	}
+
+	actualTableGrants, err := temporalAdmissionGrantRows(ctx, db, `
+		SELECT table_name,privilege_type
+		FROM information_schema.role_table_grants
+		WHERE table_schema=$1 AND grantee=current_user
+		ORDER BY table_name,privilege_type
+	`, schema)
+	if err != nil {
+		return fmt.Errorf("read temporal table grants: %w", err)
+	}
+	if err := requireTemporalExactRows("table grants", actualTableGrants, temporalExpectedTableGrants(identity)); err != nil {
+		return err
+	}
+
+	actualFunctionGrants, err := temporalAdmissionGrantRows(ctx, db, `
+		SELECT routine_name,privilege_type
+		FROM information_schema.role_routine_grants
+		WHERE specific_schema=$1 AND grantee=current_user
+		ORDER BY routine_name,privilege_type
+	`, schema)
+	if err != nil {
+		return fmt.Errorf("read temporal function grants: %w", err)
+	}
+	expectedFunctionGrants := []string{"swarm_create_run|EXECUTE", "swarm_claim_temporal_runs|EXECUTE", "swarm_claim_authorized_run_cleanup|EXECUTE", "swarm_delete_authorized_runs|EXECUTE"}
+	if identity == temporalAdmissionCleanupAuthorizer {
+		expectedFunctionGrants = []string{"swarm_authorize_run_cleanup|EXECUTE"}
+	}
+	if err := requireTemporalExactRows("function grants", actualFunctionGrants, expectedFunctionGrants); err != nil {
+		return err
+	}
+
+	functionRows, err := db.QueryContext(ctx, `
+		SELECT function.proname,oidvectortypes(function.proargtypes),function.prosecdef,owner_role.rolname,
+		       COALESCE(array_to_string(function.proconfig,','),'')
+		FROM pg_proc function
+		JOIN pg_namespace namespace ON namespace.oid=function.pronamespace
+		JOIN pg_roles owner_role ON owner_role.oid=function.proowner
+		WHERE namespace.nspname=$1
+		ORDER BY function.proname,oidvectortypes(function.proargtypes)
+	`, schema)
+	if err != nil {
+		return fmt.Errorf("read temporal function mapping: %w", err)
+	}
+	var actualFunctions []string
+	for functionRows.Next() {
+		var name, arguments, functionOwner, config string
+		var securityDefiner bool
+		if err := functionRows.Scan(&name, &arguments, &securityDefiner, &functionOwner, &config); err != nil {
+			functionRows.Close()
+			return fmt.Errorf("scan temporal function mapping: %w", err)
+		}
+		actualFunctions = append(actualFunctions, fmt.Sprintf("%s|%s|%t|%s|%s", name, arguments, securityDefiner, functionOwner, config))
+	}
+	if err := functionRows.Err(); err != nil {
+		functionRows.Close()
+		return fmt.Errorf("iterate temporal function mapping: %w", err)
+	}
+	if err := functionRows.Close(); err != nil {
+		return fmt.Errorf("close temporal function mapping: %w", err)
+	}
+	if err := requireTemporalExactRows("function mapping", actualFunctions, temporalExpectedFunctions(owner, schema)); err != nil {
+		return err
+	}
+
+	triggerRows, err := db.QueryContext(ctx, `
+		SELECT relation.relname,trigger.tgname,function.proname,trigger.tgenabled::text
+		FROM pg_trigger trigger
+		JOIN pg_class relation ON relation.oid=trigger.tgrelid
+		JOIN pg_namespace namespace ON namespace.oid=relation.relnamespace
+		JOIN pg_proc function ON function.oid=trigger.tgfoid
+		WHERE namespace.nspname=$1 AND NOT trigger.tgisinternal
+		ORDER BY relation.relname,trigger.tgname
+	`, schema)
+	if err != nil {
+		return fmt.Errorf("read temporal trigger mapping: %w", err)
+	}
+	var actualTriggers []string
+	for triggerRows.Next() {
+		var table, trigger, function, enabled string
+		if err := triggerRows.Scan(&table, &trigger, &function, &enabled); err != nil {
+			triggerRows.Close()
+			return fmt.Errorf("scan temporal trigger mapping: %w", err)
+		}
+		actualTriggers = append(actualTriggers, table+"|"+trigger+"|"+function+"|"+enabled)
+	}
+	if err := triggerRows.Err(); err != nil {
+		triggerRows.Close()
+		return fmt.Errorf("iterate temporal trigger mapping: %w", err)
+	}
+	if err := triggerRows.Close(); err != nil {
+		return fmt.Errorf("close temporal trigger mapping: %w", err)
+	}
+	return requireTemporalExactRows("trigger mapping", actualTriggers, temporalExpectedTriggers())
+}
+
+func temporalAdmissionGrantRows(ctx context.Context, db *sql.DB, query, schema string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, query, schema)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var grants []string
+	for rows.Next() {
+		var object, privilege string
+		if err := rows.Scan(&object, &privilege); err != nil {
+			return nil, err
+		}
+		grants = append(grants, object+"|"+privilege)
+	}
+	return grants, rows.Err()
+}
+
+func temporalExpectedTableGrants(identity temporalAdmissionIdentity) []string {
+	readTables := []string{"runtime_store_metadata", "runtime_store_migrations"}
+	if identity == temporalAdmissionCleanupAuthorizer {
+		return []string{"runtime_store_metadata|SELECT", "runtime_store_migrations|SELECT"}
+	}
+	readTables = append(readTables,
+		"runs", "events", "event_deliveries", "event_receipts", "dead_letters", "entity_mutations", "entity_state", "timers",
+		"agent_sessions", "agent_turns", "agent_conversation_audits", "reply_contexts", "activity_attempts", "selected_fork_lineage",
+		"run_temporal_transactions", "run_temporal_transaction_runs", "run_temporal_frontiers", "run_temporal_revisions", "run_deletion_tombstones",
+		"run_lifecycle_history", "event_delivery_history", "event_receipt_history", "timer_history", "entity_state_history", "agent_session_history",
+		"conversation_audit_history", "reply_context_history", "activity_attempt_history",
+	)
+	var grants []string
+	for _, table := range readTables {
+		grants = append(grants, table+"|SELECT")
+	}
+	for _, table := range []string{"events", "dead_letters", "entity_mutations", "agent_turns", "selected_fork_lineage"} {
+		grants = append(grants, table+"|INSERT")
+	}
+	grants = append(grants, "runs|UPDATE")
+	for _, table := range []string{"event_deliveries", "event_receipts", "entity_state", "timers", "agent_sessions", "agent_conversation_audits", "reply_contexts", "activity_attempts"} {
+		for _, privilege := range []string{"INSERT", "UPDATE", "DELETE"} {
+			grants = append(grants, table+"|"+privilege)
+		}
+	}
+	return grants
+}
+
+func temporalExpectedFunctions(owner, schema string) []string {
+	config := "search_path=pg_catalog, " + schema
+	rows := []struct {
+		name      string
+		arguments string
+	}{
+		{name: "swarm_declare_temporal_runs", arguments: "uuid[], uuid[]"},
+		{name: "swarm_create_run", arguments: "uuid, text"},
+		{name: "swarm_claim_temporal_runs", arguments: "uuid[]"},
+		{name: "swarm_authorize_run_cleanup", arguments: "uuid, text, text, uuid[], uuid[]"},
+		{name: "swarm_claim_authorized_run_cleanup", arguments: "uuid"},
+		{name: "swarm_delete_authorized_runs", arguments: "uuid"},
+		{name: "swarm_next_temporal_ordinal", arguments: "uuid"},
+		{name: "swarm_resolve_temporal_run", arguments: "jsonb, text, text"},
+		{name: "swarm_guard_append_fact", arguments: ""},
+		{name: "swarm_guard_mutable_fact", arguments: ""},
+	}
+	result := make([]string, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, fmt.Sprintf("%s|%s|true|%s|%s", row.name, row.arguments, owner, config))
+	}
+	return result
+}
+
+func temporalExpectedTriggers() []string {
+	return []string{
+		"runs|temporal_runs_guard|swarm_guard_mutable_fact|A",
+		"events|temporal_events_guard|swarm_guard_append_fact|A",
+		"event_deliveries|temporal_event_deliveries_guard|swarm_guard_mutable_fact|A",
+		"event_receipts|temporal_event_receipts_guard|swarm_guard_mutable_fact|A",
+		"dead_letters|temporal_dead_letters_guard|swarm_guard_append_fact|A",
+		"entity_mutations|temporal_entity_mutations_guard|swarm_guard_append_fact|A",
+		"entity_state|temporal_entity_state_guard|swarm_guard_mutable_fact|A",
+		"timers|temporal_timers_guard|swarm_guard_mutable_fact|A",
+		"agent_sessions|temporal_agent_sessions_guard|swarm_guard_mutable_fact|A",
+		"agent_turns|temporal_agent_turns_guard|swarm_guard_append_fact|A",
+		"agent_conversation_audits|temporal_agent_conversation_audits_guard|swarm_guard_mutable_fact|A",
+		"reply_contexts|temporal_reply_contexts_guard|swarm_guard_mutable_fact|A",
+		"activity_attempts|temporal_activity_attempts_guard|swarm_guard_mutable_fact|A",
+		"selected_fork_lineage|temporal_selected_fork_lineage_guard|swarm_guard_append_fact|A",
+	}
+}
+
+func requireTemporalExactRows(label string, got, want []string) error {
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		return fmt.Errorf("temporal %s drift: got %v want %v", label, got, want)
+	}
+	return nil
+}
+
+func assertTemporalAdmissionRejectsCommittedDrift(t *testing.T, ctx context.Context, admin, runtimeDB, cleanupAuthorizerDB *sql.DB, schema, owner, runtimeRole, cleanupAuthorizerRole string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
-	var schemaCreate, factInsert, authorityDML, authorizeExecute, claimExecute bool
-	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT has_schema_privilege(current_user,$1,'CREATE'),
-		       has_table_privilege(current_user,'%[1]s.events','INSERT,UPDATE,DELETE'),
-		       has_table_privilege(current_user,'%[1]s.run_cleanup_authorizations','INSERT,UPDATE,DELETE'),
-		       has_function_privilege(current_user,'%[1]s.swarm_authorize_run_cleanup(uuid,text,text,uuid[],uuid[])','EXECUTE'),
-		       has_function_privilege(current_user,'%[1]s.swarm_claim_authorized_run_cleanup(uuid)','EXECUTE')
-	`, qSchema), schema).Scan(&schemaCreate, &factInsert, &authorityDML, &authorizeExecute, &claimExecute); err != nil {
-		t.Fatalf("inspect cleanup authorizer admission: %v", err)
+	mustExecTemporal(t, ctx, admin, `GRANT UPDATE ON `+qSchema+`.events TO `+quoteTemporalIdent(runtimeRole))
+	for _, probe := range []struct {
+		name     string
+		db       *sql.DB
+		identity temporalAdmissionIdentity
+	}{
+		{name: "runtime", db: runtimeDB, identity: temporalAdmissionRuntime},
+		{name: "cleanup authorizer", db: cleanupAuthorizerDB, identity: temporalAdmissionCleanupAuthorizer},
+	} {
+		if err := temporalReadOnlyAdmissionError(ctx, probe.db, schema, owner, runtimeRole, cleanupAuthorizerRole, probe.identity); err == nil || !strings.Contains(err.Error(), "catalog checksum drift") {
+			t.Fatalf("%s boot admission after committed grant drift = %v, want catalog rejection", probe.name, err)
+		}
 	}
-	if schemaCreate || factInsert || authorityDML || !authorizeExecute || claimExecute {
-		t.Fatalf("cleanup authorizer grant drift: schema_create=%v fact_insert=%v authority_dml=%v authorize=%v claim=%v", schemaCreate, factInsert, authorityDML, authorizeExecute, claimExecute)
-	}
+	mustExecTemporal(t, ctx, admin, `REVOKE UPDATE ON `+qSchema+`.events FROM `+quoteTemporalIdent(runtimeRole))
+	assertTemporalReadOnlyAdmission(t, ctx, runtimeDB, schema, owner, runtimeRole, cleanupAuthorizerRole, temporalAdmissionRuntime)
+	assertTemporalReadOnlyAdmission(t, ctx, cleanupAuthorizerDB, schema, owner, runtimeRole, cleanupAuthorizerRole, temporalAdmissionCleanupAuthorizer)
 }
 
 func assertTemporalPrivilegeDenials(t *testing.T, ctx context.Context, db *sql.DB, schema, owner string) {
@@ -607,27 +870,42 @@ func assertTemporalDirectEventMutationRejected(t *testing.T, ctx context.Context
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.events WHERE event_id=$1`, qSchema), "runtime event delete", eventID)
 }
 
-func assertTemporalEventTriggerDefendsGrantDrift(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runID, eventID string) {
+func assertTemporalAppendFamilyImmutability(t *testing.T, ctx context.Context, db *sql.DB, schema, owner, runID string) {
 	t.Helper()
 	qSchema := quoteTemporalIdent(schema)
-	for _, mutation := range []struct {
-		name string
-		sql  string
+	appendFamilies := []struct {
+		name      string
+		table     string
+		idColumn  string
+		id        string
+		updateSQL string
 	}{
-		{name: "update", sql: fmt.Sprintf(`UPDATE %s.events SET created_at=clock_timestamp() WHERE event_id=$1`, qSchema)},
-		{name: "normal delete", sql: fmt.Sprintf(`DELETE FROM %s.events WHERE event_id=$1`, qSchema)},
-	} {
-		tx, err := db.BeginTx(ctx, nil)
-		if err != nil {
-			t.Fatalf("begin owner event %s proof: %v", mutation.name, err)
-		}
-		mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
-		mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
-		if _, err := tx.ExecContext(ctx, mutation.sql, eventID); err == nil {
+		{name: "events", table: "events", idColumn: "event_id", id: "a0000000-0000-0000-0000-000000000001", updateSQL: "created_at=clock_timestamp()"},
+		{name: "entity_mutations", table: "entity_mutations", idColumn: "mutation_id", id: "41000000-0000-0000-0000-000000000001", updateSQL: "value='forged'"},
+		{name: "dead_letters", table: "dead_letters", idColumn: "dead_letter_id", id: "42000000-0000-0000-0000-000000000001", updateSQL: "value='forged'"},
+		{name: "agent_turns", table: "agent_turns", idColumn: "turn_id", id: "43000000-0000-0000-0000-000000000001", updateSQL: "value='forged'"},
+		{name: "selected_fork_lineage", table: "selected_fork_lineage", idColumn: "lineage_id", id: "44000000-0000-0000-0000-000000000001", updateSQL: "value='forged'"},
+	}
+	for _, family := range appendFamilies {
+		for _, mutation := range []struct {
+			name string
+			sql  string
+		}{
+			{name: "update", sql: fmt.Sprintf(`UPDATE %s.%s SET %s WHERE %s=$1`, qSchema, quoteTemporalIdent(family.table), family.updateSQL, quoteTemporalIdent(family.idColumn))},
+			{name: "delete", sql: fmt.Sprintf(`DELETE FROM %s.%s WHERE %s=$1`, qSchema, quoteTemporalIdent(family.table), quoteTemporalIdent(family.idColumn))},
+		} {
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("begin owner %s %s proof: %v", family.name, mutation.name, err)
+			}
+			mustExecTemporal(t, ctx, tx, `SET LOCAL ROLE `+quoteTemporalIdent(owner))
+			mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+			if _, err := tx.ExecContext(ctx, mutation.sql, family.id); err == nil {
+				_ = tx.Rollback()
+				t.Fatalf("owner %s %s bypassed ENABLE ALWAYS append guard", family.name, mutation.name)
+			}
 			_ = tx.Rollback()
-			t.Fatalf("owner event %s bypassed ENABLE ALWAYS trigger", mutation.name)
 		}
-		_ = tx.Rollback()
 	}
 }
 
@@ -636,6 +914,35 @@ func assertTemporalUndeclaredDeliveryMutationRejected(t *testing.T, ctx context.
 	qSchema := quoteTemporalIdent(schema)
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`UPDATE %s.event_deliveries SET status='delivered' WHERE delivery_id=$1`, qSchema), "undeclared delivery update", deliveryID)
 	assertTemporalExecFails(t, ctx, db, fmt.Sprintf(`DELETE FROM %s.event_deliveries WHERE delivery_id=$1`, qSchema), "undeclared delivery delete", deliveryID)
+}
+
+func assertTemporalEventDerivedMutableOperations(t *testing.T, ctx context.Context, db *sql.DB, schema, runID, deliveryID, receiptID string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin delivery/receipt operation matrix: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.event_deliveries SET status='delivered' WHERE delivery_id=$1`, qSchema), deliveryID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`UPDATE %s.event_receipts SET outcome='retry' WHERE receipt_id=$1`, qSchema), receiptID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`DELETE FROM %s.event_receipts WHERE receipt_id=$1`, qSchema), receiptID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit delivery/receipt operation matrix: %v", err)
+	}
+	var deliveryUpdates, receiptUpdates, receiptDeletes, receiptRows int
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT (SELECT count(*) FROM %[1]s.event_delivery_history WHERE fact_id=$1::text AND operation='update'),
+		       (SELECT count(*) FROM %[1]s.event_receipt_history WHERE fact_id=$2::text AND operation='update'),
+		       (SELECT count(*) FROM %[1]s.event_receipt_history WHERE fact_id=$2::text AND operation='delete'),
+		       (SELECT count(*) FROM %[1]s.event_receipts WHERE receipt_id=$2::uuid)
+	`, qSchema), deliveryID, receiptID).Scan(&deliveryUpdates, &receiptUpdates, &receiptDeletes, &receiptRows); err != nil {
+		t.Fatalf("read delivery/receipt operation matrix: %v", err)
+	}
+	if deliveryUpdates != 1 || receiptUpdates != 1 || receiptDeletes != 1 || receiptRows != 0 {
+		t.Fatalf("delivery/receipt operations = delivery_update:%d receipt_update:%d receipt_delete:%d receipt_rows:%d", deliveryUpdates, receiptUpdates, receiptDeletes, receiptRows)
+	}
 }
 
 func assertTemporalDeliveryLineageMismatchRejected(t *testing.T, ctx context.Context, db *sql.DB, schema, deliveryID, runA, runB string) {
@@ -831,6 +1138,7 @@ func assertTemporalAuthorizedMixedCleanup(t *testing.T, ctx context.Context, cle
 	qSchema := quoteTemporalIdent(schema)
 	authorizationID := "61000000-0000-0000-0000-000000000001"
 	timerID := "61000000-0000-0000-0000-000000000002"
+	cleanupTimerID := "61000000-0000-0000-0000-000000000004"
 	tx, err := runtimeDB.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatalf("begin mixed-cleanup fixture: %v", err)
@@ -838,10 +1146,34 @@ func assertTemporalAuthorizedMixedCleanup(t *testing.T, ctx context.Context, cle
 	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid,$2::uuid])`, qSchema), survivorRun, deletedRun)
 	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.timers(timer_id,run_id,value) VALUES ($1,$2,'before-cleanup')`, qSchema), timerID, survivorRun)
 	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ('61000000-0000-0000-0000-000000000003',$1)`, qSchema), deletedRun)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.timers(timer_id,run_id,value) VALUES ($1,$2,'must-delete-with-run')`, qSchema), cleanupTimerID, deletedRun)
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("commit mixed-cleanup fixture: %v", err)
 	}
 	authorizeTemporalCleanup(t, ctx, cleanupAuthorizerDB, schema, authorizationID, "runtime.nuke/operation-1", "operator-token:7", []string{survivorRun}, []string{deletedRun})
+
+	tx, err = runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin partial destructive cleanup rejection: %v", err)
+	}
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_authorized_run_cleanup($1)`, qSchema), authorizationID)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s.timers WHERE timer_id=$1`, qSchema), cleanupTimerID); err == nil || !strings.Contains(err.Error(), "current-xid whole-run tombstone") {
+		_ = tx.Rollback()
+		t.Fatalf("partial destructive fact deletion error = %v, want tombstone refusal", err)
+	}
+	if err := tx.Commit(); err == nil {
+		t.Fatal("claim plus partial destructive fact deletion unexpectedly committed")
+	}
+	var cleanupTimerCount, prematureTombstones int
+	if err := runtimeDB.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT (SELECT count(*) FROM %[1]s.timers WHERE timer_id=$1),
+		       (SELECT count(*) FROM %[1]s.run_deletion_tombstones WHERE run_id=$2)
+	`, qSchema), cleanupTimerID, deletedRun).Scan(&cleanupTimerCount, &prematureTombstones); err != nil {
+		t.Fatalf("read rolled-back partial cleanup proof: %v", err)
+	}
+	if cleanupTimerCount != 1 || prematureTombstones != 0 {
+		t.Fatalf("partial cleanup rollback = timer:%d tombstones:%d", cleanupTimerCount, prematureTombstones)
+	}
 
 	tx, err = runtimeDB.BeginTx(ctx, nil)
 	if err != nil {
@@ -855,21 +1187,22 @@ func assertTemporalAuthorizedMixedCleanup(t *testing.T, ctx context.Context, cle
 		t.Fatalf("commit authorized mixed cleanup: %v", err)
 	}
 
-	var deletedCount, survivorHistory int
+	var deletedCount, survivorHistory, cleanupFactCount int
 	var actor string
 	if err := runtimeDB.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT (SELECT count(*) FROM %[1]s.runs WHERE run_id=$1),
 		       (SELECT count(*) FROM %[1]s.timer_history WHERE fact_id=$2 AND operation='update'),
+		       (SELECT count(*) FROM %[1]s.timers WHERE timer_id=$3),
 		       (SELECT deleted_by FROM %[1]s.run_deletion_tombstones WHERE run_id=$1)
-	`, qSchema), deletedRun, timerID).Scan(&deletedCount, &survivorHistory, &actor); err != nil {
+	`, qSchema), deletedRun, timerID, cleanupTimerID).Scan(&deletedCount, &survivorHistory, &cleanupFactCount, &actor); err != nil {
 		t.Fatalf("read authorized mixed cleanup proof: %v", err)
 	}
 	var authorizer string
 	if err := cleanupAuthorizerDB.QueryRowContext(ctx, `SELECT current_user`).Scan(&authorizer); err != nil {
 		t.Fatalf("read cleanup authorizer identity: %v", err)
 	}
-	if deletedCount != 0 || survivorHistory != 1 || actor != authorizer+":operator-token:7" {
-		t.Fatalf("mixed cleanup = deleted:%d survivor_history:%d actor:%q", deletedCount, survivorHistory, actor)
+	if deletedCount != 0 || survivorHistory != 1 || cleanupFactCount != 0 || actor != authorizer+":operator-token:7" {
+		t.Fatalf("mixed cleanup = deleted:%d survivor_history:%d cleanup_facts:%d actor:%q", deletedCount, survivorHistory, cleanupFactCount, actor)
 	}
 }
 
@@ -976,6 +1309,89 @@ func assertTemporalUnversionedDestruction(t *testing.T, ctx context.Context, cle
 	}
 	if remainingFacts != 0 {
 		t.Fatalf("destructive legacy cascade left %d facts", remainingFacts)
+	}
+}
+
+func assertTemporalEveryFamilyDestructiveCascade(t *testing.T, ctx context.Context, cleanupAuthorizerDB, runtimeDB *sql.DB, schema string) {
+	t.Helper()
+	qSchema := quoteTemporalIdent(schema)
+	runID := "70000000-0000-0000-0000-000000000001"
+	eventID := "70000000-0000-0000-0000-000000000002"
+	deliveryID := "70000000-0000-0000-0000-000000000003"
+	receiptID := "70000000-0000-0000-0000-000000000004"
+
+	mustExecTemporal(t, ctx, runtimeDB, fmt.Sprintf(`SELECT %s.swarm_create_run($1,'running')`, qSchema), runID)
+	tx, err := runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin every-family destructive fixture: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_temporal_runs(ARRAY[$1::uuid])`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.events(event_id,run_id) VALUES ($1,$2)`, qSchema), eventID, runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.event_deliveries(delivery_id,run_id,event_id,status) VALUES ($1,$2,$3,'pending')`, qSchema), deliveryID, runID, eventID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.event_receipts(receipt_id,event_id,outcome) VALUES ($1,$2,'success')`, qSchema), receiptID, eventID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.dead_letters(dead_letter_id,original_event_id,value) VALUES ('70000000-0000-0000-0000-000000000005',$1,'fixture')`, qSchema), eventID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.entity_mutations(mutation_id,run_id,value) VALUES ('70000000-0000-0000-0000-000000000006',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.entity_state(entity_id,run_id,value) VALUES ('70000000-0000-0000-0000-000000000007',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.timers(timer_id,run_id,value) VALUES ('70000000-0000-0000-0000-000000000008',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.agent_sessions(session_id,run_id,value) VALUES ('70000000-0000-0000-0000-000000000009',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.agent_turns(turn_id,run_id,value) VALUES ('70000000-0000-0000-0000-00000000000a',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.agent_conversation_audits(audit_id,run_id,value) VALUES ('70000000-0000-0000-0000-00000000000b',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.reply_contexts(reply_context_id,run_id,value) VALUES ('70000000-0000-0000-0000-00000000000c',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.activity_attempts(attempt_id,run_id,value) VALUES ('70000000-0000-0000-0000-00000000000d',$1,'fixture')`, qSchema), runID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`INSERT INTO %s.selected_fork_lineage(lineage_id,run_id,value) VALUES ('70000000-0000-0000-0000-00000000000e',$1,'fixture')`, qSchema), runID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit every-family destructive fixture: %v", err)
+	}
+
+	authorizationID := "70000000-0000-0000-0000-00000000000f"
+	authorizeTemporalCleanup(t, ctx, cleanupAuthorizerDB, schema, authorizationID, "runtime.nuke/every-family", "operator-token:every-family", nil, []string{runID})
+	tx, err = runtimeDB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin every-family destructive cleanup: %v", err)
+	}
+	defer tx.Rollback()
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_claim_authorized_run_cleanup($1)`, qSchema), authorizationID)
+	mustExecTemporal(t, ctx, tx, fmt.Sprintf(`SELECT %s.swarm_delete_authorized_runs($1)`, qSchema), authorizationID)
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit every-family destructive cleanup: %v", err)
+	}
+
+	checks := []struct {
+		table    string
+		idColumn string
+		id       string
+	}{
+		{table: "runs", idColumn: "run_id", id: runID},
+		{table: "events", idColumn: "event_id", id: eventID},
+		{table: "event_deliveries", idColumn: "delivery_id", id: deliveryID},
+		{table: "event_receipts", idColumn: "receipt_id", id: receiptID},
+		{table: "dead_letters", idColumn: "dead_letter_id", id: "70000000-0000-0000-0000-000000000005"},
+		{table: "entity_mutations", idColumn: "mutation_id", id: "70000000-0000-0000-0000-000000000006"},
+		{table: "entity_state", idColumn: "entity_id", id: "70000000-0000-0000-0000-000000000007"},
+		{table: "timers", idColumn: "timer_id", id: "70000000-0000-0000-0000-000000000008"},
+		{table: "agent_sessions", idColumn: "session_id", id: "70000000-0000-0000-0000-000000000009"},
+		{table: "agent_turns", idColumn: "turn_id", id: "70000000-0000-0000-0000-00000000000a"},
+		{table: "agent_conversation_audits", idColumn: "audit_id", id: "70000000-0000-0000-0000-00000000000b"},
+		{table: "reply_contexts", idColumn: "reply_context_id", id: "70000000-0000-0000-0000-00000000000c"},
+		{table: "activity_attempts", idColumn: "attempt_id", id: "70000000-0000-0000-0000-00000000000d"},
+		{table: "selected_fork_lineage", idColumn: "lineage_id", id: "70000000-0000-0000-0000-00000000000e"},
+	}
+	for _, check := range checks {
+		var count int
+		if err := runtimeDB.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.%s WHERE %s=$1`, qSchema, quoteTemporalIdent(check.table), quoteTemporalIdent(check.idColumn)), check.id).Scan(&count); err != nil {
+			t.Fatalf("count destructively cascaded %s: %v", check.table, err)
+		}
+		if count != 0 {
+			t.Fatalf("authorized destructive cascade left %s row %s", check.table, check.id)
+		}
+	}
+	var tombstones int
+	if err := runtimeDB.QueryRowContext(ctx, fmt.Sprintf(`SELECT count(*) FROM %s.run_deletion_tombstones WHERE run_id=$1 AND transaction_id IS NOT NULL`, qSchema), runID).Scan(&tombstones); err != nil {
+		t.Fatalf("read every-family deletion tombstone: %v", err)
+	}
+	if tombstones != 1 {
+		t.Fatalf("every-family destructive tombstones = %d, want 1", tombstones)
 	}
 }
 
@@ -1589,6 +2005,13 @@ const temporalPrototypeFunctionsTemplate = `
 			FROM %[1]s.run_temporal_frontiers WHERE run_id=target_run;
 			INSERT INTO %[1]s.run_deletion_tombstones(run_id,source_model_version,last_revision,transaction_id,deleted_by)
 			VALUES (target_run,model,CASE WHEN model=0 THEN NULL ELSE frontier END,pg_current_xact_id(),authorizer||':'||actor);
+			DELETE FROM %[1]s.event_receipts receipt
+			USING %[1]s.events event
+			WHERE receipt.event_id=event.event_id AND event.run_id=target_run;
+			DELETE FROM %[1]s.dead_letters dead_letter
+			USING %[1]s.events event
+			WHERE dead_letter.original_event_id=event.event_id AND event.run_id=target_run;
+			DELETE FROM %[1]s.event_deliveries WHERE run_id=target_run;
 			DELETE FROM %[1]s.runs WHERE run_id=target_run;
 			IF NOT FOUND THEN RAISE EXCEPTION 'authorized cleanup run %% does not exist', target_run; END IF;
 		END LOOP;
@@ -1660,10 +2083,16 @@ const temporalPrototypeFunctionsTemplate = `
 			fact_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(OLD),TG_ARGV[1],TG_ARGV[2]);
 			IF fact_run IS NULL THEN RAISE EXCEPTION 'runless append-only fact cannot be deleted'; END IF;
 			SELECT EXISTS (
-				SELECT 1 FROM %[1]s.run_temporal_transaction_runs
-				WHERE transaction_id=pg_current_xact_id() AND run_id=fact_run AND disposition='destructive'
+				SELECT 1
+				FROM %[1]s.run_temporal_transaction_runs declared
+				JOIN %[1]s.run_deletion_tombstones tombstone
+				  ON tombstone.run_id=declared.run_id
+				 AND tombstone.transaction_id=declared.transaction_id
+				WHERE declared.transaction_id=pg_current_xact_id()
+				  AND declared.run_id=fact_run
+				  AND declared.disposition='destructive'
 			) INTO destructive;
-			IF NOT destructive THEN RAISE EXCEPTION 'append-only fact deletion requires authorized destructive disposition'; END IF;
+			IF NOT destructive THEN RAISE EXCEPTION 'append-only fact deletion requires current-xid whole-run tombstone'; END IF;
 			RETURN OLD;
 		END IF;
 		fact_run=%[1]s.swarm_resolve_temporal_run(to_jsonb(NEW),TG_ARGV[1],TG_ARGV[2]);
@@ -1690,6 +2119,7 @@ const temporalPrototypeFunctionsTemplate = `
 		old_stamp RECORD;
 		new_stamp RECORD;
 		destructive BOOLEAN;
+		declared_destructive BOOLEAN;
 		fact_id TEXT;
 		history_table TEXT := TG_ARGV[3];
 	BEGIN
@@ -1727,8 +2157,21 @@ const temporalPrototypeFunctionsTemplate = `
 			SELECT EXISTS (
 				SELECT 1 FROM %[1]s.run_temporal_transaction_runs
 				WHERE transaction_id=pg_current_xact_id() AND run_id=old_run AND disposition='destructive'
+			) INTO declared_destructive;
+			SELECT EXISTS (
+				SELECT 1
+				FROM %[1]s.run_temporal_transaction_runs declared
+				JOIN %[1]s.run_deletion_tombstones tombstone
+				  ON tombstone.run_id=declared.run_id
+				 AND tombstone.transaction_id=declared.transaction_id
+				WHERE declared.transaction_id=pg_current_xact_id()
+				  AND declared.run_id=old_run
+				  AND declared.disposition='destructive'
 			) INTO destructive;
-			IF destructive THEN RETURN OLD; END IF;
+			IF declared_destructive THEN
+				IF NOT destructive THEN RAISE EXCEPTION 'mutable fact destructive deletion requires current-xid whole-run tombstone'; END IF;
+				RETURN OLD;
+			END IF;
 			SELECT * INTO old_stamp FROM %[1]s.swarm_next_temporal_ordinal(old_run);
 			EXECUTE format('INSERT INTO %%I.%%I(run_id,revision,ordinal,operation,fact_id,before_state) VALUES ($1,$2,$3,''delete'',$4,$5)',TG_TABLE_SCHEMA,history_table)
 			USING old_run,old_stamp.temporal_revision,old_stamp.temporal_ordinal,fact_id,to_jsonb(OLD);
@@ -1807,6 +2250,7 @@ const temporalPrototypeGrantTemplate = `
 	REVOKE ALL ON ALL FUNCTIONS IN SCHEMA %[1]s FROM PUBLIC;
 	GRANT USAGE ON SCHEMA %[1]s TO %[2]s;
 	GRANT USAGE ON SCHEMA %[1]s TO %[3]s;
+	GRANT SELECT ON %[1]s.runtime_store_metadata,%[1]s.runtime_store_migrations TO %[3]s;
 	GRANT SELECT ON
 		%[1]s.runtime_store_metadata,
 		%[1]s.runtime_store_migrations,

--- a/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
+++ b/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
@@ -90,6 +90,7 @@ grants:
   runtime_execute: [swarm_create_run, swarm_claim_temporal_runs, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs]
   runtime_denied_execute: [swarm_declare_temporal_runs, swarm_authorize_run_cleanup, swarm_next_temporal_ordinal, swarm_resolve_temporal_run, swarm_guard_append_fact, swarm_guard_mutable_fact]
   cleanup_authorizer_execute: [swarm_authorize_run_cleanup]
+  cleanup_authorizer_read: [runtime_store_metadata, runtime_store_migrations]
   runtime_insert_only: [events, entity_mutations, dead_letters, agent_turns, selected_fork_lineage]
   runtime_guarded_update: [runs]
   runtime_guarded_dml: [event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
@@ -123,6 +124,21 @@ operations:
   whole_run_delete: sealed_authorization_claim_then_owner_delete_wrapper
   mixed_cleanup: normal_survivors_revisioned_and_destructive_runs_tombstoned_in_one_transaction
   derived_lineage: persisted_and_derived_run_identity_must_agree
+operation_matrix:
+  - {family: runs, insert: owner_function, update: typed_history, delete: authorized_wrapper_cascade, proof: restricted runtime creation + guarded update + every-family cascade}
+  - {family: events, insert: revisioned_insert, update: rejected_immutable, delete: authorized_wrapper_cascade, proof: shared revision + append immutability + every-family cascade}
+  - {family: event_deliveries, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: delivery operation matrix + declared delete + every-family cascade}
+  - {family: event_receipts, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: receipt operation matrix + every-family cascade}
+  - {family: dead_letters, insert: revisioned_insert, update: rejected_immutable, delete: authorized_wrapper_cascade, proof: all-family insert + append immutability + every-family cascade}
+  - {family: entity_mutations, insert: revisioned_insert, update: rejected_immutable, delete: authorized_wrapper_cascade, proof: all-family insert + append immutability + every-family cascade}
+  - {family: entity_state, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + ownership move + every-family cascade}
+  - {family: timers, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + partial-delete refusal + every-family cascade}
+  - {family: agent_sessions, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + every-family cascade}
+  - {family: agent_turns, insert: revisioned_insert, update: rejected_immutable, delete: authorized_wrapper_cascade, proof: all-family insert + append immutability + every-family cascade}
+  - {family: agent_conversation_audits, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + every-family cascade}
+  - {family: reply_contexts, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + every-family cascade}
+  - {family: activity_attempts, insert: typed_history, update: typed_history, delete: typed_history_or_authorized_wrapper_cascade, proof: all-family typed history + every-family cascade}
+  - {family: selected_fork_lineage, insert: revisioned_insert, update: rejected_immutable, delete: authorized_wrapper_cascade, proof: all-family insert + append immutability + every-family cascade}
 migration:
   generation: temporal-frontier-v1
   migration_id: temporal-frontier-v1
@@ -136,7 +152,7 @@ migration:
   metadata_updated_last: true
   rollback_is_atomic: true
   reapply: full_catalog_revalidation_then_exact_checksum_noop_else_fail_closed
-  legacy_admission: complete_registered_catalog_checksum
+  legacy_admission: complete_registered_catalog_checksum_and_delivery_event_lineage
   serve_schema_mutation: forbidden
 prototype:
   test: TestTemporalFrontierPostgresDesignConformance
@@ -147,16 +163,24 @@ prototype:
     - restricted_runtime_atomic_run_creation
     - active_legacy_run_rejected_without_ddl
     - complete_legacy_catalog_drift_rejected
+    - legacy_delivery_lineage_mismatch_rejected_without_ddl
     - failed_migration_rolls_back_schema_and_metadata
     - exact_reapply_is_idempotent
     - drifted_target_reapply_rejected
+    - exact_runtime_and_cleanup_admission
+    - post_migration_admission_drift_rejected
     - runtime_shared_lock_excludes_migration
     - runtime_cannot_assume_owner_or_disable_trigger
     - runtime_cannot_mutate_authority_or_history_tables
     - undeclared_insert_update_delete_rejected
-    - every_guarded_fact_family_insert_update_delete_proven
+    - explicit_fact_family_operation_matrix_executed
+    - append_family_update_delete_rejected
+    - every_fact_family_authorized_destructive_cascade
+    - delivery_update_and_delete_history_proven
+    - receipt_update_and_delete_history_proven
     - derived_lineage_mismatch_rejected
     - destructive_declaration_not_runtime_callable
+    - partial_destructive_fact_delete_cannot_commit
     - event_delivery_receipt_share_revision_and_ordinals
     - rollback_publishes_no_revision
     - update_move_requires_old_and_new_runs
@@ -184,3 +208,7 @@ manifestations:
   - {id: delivery_event_lineage_mismatch, issue: 2050, status: design_locked_and_prototyped_here}
   - {id: drifted_target_reapply_accepted, issue: 2050, status: design_locked_and_prototyped_here}
   - {id: incomplete_legacy_catalog_admitted, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: partial_history_free_fact_deletion, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: incomplete_runtime_admission, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: legacy_delivery_event_data_mismatch, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: generic_fact_family_coverage_overclaim, issue: 2050, status: design_locked_and_prototyped_here}

--- a/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
+++ b/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
@@ -22,8 +22,8 @@ selectors:
 transaction:
   declaration_table: run_temporal_transactions
   xid_type: xid8
-  modes: [normal, destructive]
-  sealed_fields: [transaction_id, sorted_unique_run_ids, mode]
+  dispositions: [normal, destructive]
+  sealed_fields: [transaction_id, sorted_unique_normal_run_ids, sorted_unique_destructive_run_ids, per_run_disposition]
   lock_order:
     - nonlocking_identity_snapshot
     - sealed_frontier_declaration
@@ -37,9 +37,11 @@ transaction:
 objects:
   tables:
     - run_temporal_transactions
+    - run_temporal_transaction_runs
     - run_temporal_frontiers
     - run_temporal_revisions
     - runtime_store_migrations
+    - run_cleanup_authorizations
     - run_deletion_tombstones
   history_tables:
     - run_lifecycle_history
@@ -53,12 +55,15 @@ objects:
     - activity_attempt_history
   functions:
     - swarm_declare_temporal_runs
+    - swarm_create_run
     - swarm_claim_temporal_runs
+    - swarm_authorize_run_cleanup
+    - swarm_claim_authorized_run_cleanup
+    - swarm_delete_authorized_runs
     - swarm_next_temporal_ordinal
-    - swarm_guard_events
-    - swarm_guard_event_deliveries
-    - swarm_guard_event_receipts
-    - swarm_destroy_run
+    - swarm_resolve_temporal_run
+    - swarm_guard_append_fact
+    - swarm_guard_mutable_fact
   trigger_properties:
     - security_definer
     - owner_controlled
@@ -70,20 +75,26 @@ roles:
   migration:
     kind: schema_owner_login
     distinct_from_runtime: true
-    invocation: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+    invocation: swarm schema apply --runtime-role <postgres-role> --cleanup-authorizer-role <postgres-role> --config <explicit-migration-config>
     attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS]
   runtime:
     kind: restricted_login
     invocation: swarm serve --config <runtime-config>
     attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner]
+  cleanup_authorizer:
+    kind: restricted_cleanup_authorizer_login
+    distinct_from_runtime: true
+    invocation: canonical destructive-reset plan/quiescence/directive owner
+    attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner]
 grants:
-  runtime_execute: [swarm_claim_temporal_runs, swarm_destroy_run]
-  runtime_denied_execute: [swarm_declare_temporal_runs, swarm_next_temporal_ordinal, swarm_guard_events, swarm_guard_event_deliveries, swarm_guard_event_receipts]
-  runtime_insert_only: [events]
-  runtime_guarded_insert_update: [runs]
+  runtime_execute: [swarm_create_run, swarm_claim_temporal_runs, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs]
+  runtime_denied_execute: [swarm_declare_temporal_runs, swarm_authorize_run_cleanup, swarm_next_temporal_ordinal, swarm_resolve_temporal_run, swarm_guard_append_fact, swarm_guard_mutable_fact]
+  cleanup_authorizer_execute: [swarm_authorize_run_cleanup]
+  runtime_insert_only: [events, entity_mutations, dead_letters, agent_turns, selected_fork_lineage]
+  runtime_guarded_update: [runs]
   runtime_guarded_dml: [event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
-  runtime_denied_dml: [run_temporal_transactions, run_temporal_frontiers, run_temporal_revisions, runtime_store_migrations, run_deletion_tombstones, temporal_history, runtime_store_metadata]
-  runtime_denied_direct_operations: [events.UPDATE, events.DELETE, runs.DELETE]
+  runtime_denied_dml: [run_temporal_transactions, run_temporal_transaction_runs, run_temporal_frontiers, run_temporal_revisions, runtime_store_migrations, run_cleanup_authorizations, run_deletion_tombstones, temporal_history, runtime_store_metadata]
+  runtime_denied_direct_operations: [events.UPDATE, events.DELETE, runs.INSERT, runs.DELETE]
 fact_families:
   - {name: runs, disposition: typed_transition_history}
   - {name: events, disposition: immutable_append_revision}
@@ -102,13 +113,16 @@ fact_families:
   - {name: routing_rules, disposition: global_current_config_not_run_history}
   - {name: runless_events, disposition: null_revision_and_ordinal}
 operations:
+  run_insert: owner_function_creates_run_frontier_revision_and_history_atomically
   event_insert: declared_normal_run_overwrites_caller_stamp
   event_update: always_rejected
   event_delete: destructive_whole_run_only
   mutable_insert: every_nonnull_derived_run_declared
   mutable_update: every_distinct_old_and_new_nonnull_run_declared
   mutable_delete: old_nonnull_run_declared_and_typed_history_written
-  whole_run_delete: destructive_declaration_tombstone_then_cascade
+  whole_run_delete: sealed_authorization_claim_then_owner_delete_wrapper
+  mixed_cleanup: normal_survivors_revisioned_and_destructive_runs_tombstoned_in_one_transaction
+  derived_lineage: persisted_and_derived_run_identity_must_agree
 migration:
   generation: temporal-frontier-v1
   migration_id: temporal-frontier-v1
@@ -121,7 +135,8 @@ migration:
   deployment_locks: [runtime_shared_session_advisory, migration_exclusive_advisory, first_upgrade_access_exclusive_tables]
   metadata_updated_last: true
   rollback_is_atomic: true
-  reapply: exact_checksum_noop_else_fail_closed
+  reapply: full_catalog_revalidation_then_exact_checksum_noop_else_fail_closed
+  legacy_admission: complete_registered_catalog_checksum
   serve_schema_mutation: forbidden
 prototype:
   test: TestTemporalFrontierPostgresDesignConformance
@@ -129,20 +144,28 @@ prototype:
   proof_projection: required-full
   assertions:
     - fresh_schema_creation
+    - restricted_runtime_atomic_run_creation
     - active_legacy_run_rejected_without_ddl
+    - complete_legacy_catalog_drift_rejected
     - failed_migration_rolls_back_schema_and_metadata
     - exact_reapply_is_idempotent
+    - drifted_target_reapply_rejected
     - runtime_shared_lock_excludes_migration
     - runtime_cannot_assume_owner_or_disable_trigger
     - runtime_cannot_mutate_authority_or_history_tables
     - undeclared_insert_update_delete_rejected
-    - declared_delete_writes_typed_history
+    - every_guarded_fact_family_insert_update_delete_proven
+    - derived_lineage_mismatch_rejected
     - destructive_declaration_not_runtime_callable
     - event_delivery_receipt_share_revision_and_ordinals
     - rollback_publishes_no_revision
     - update_move_requires_old_and_new_runs
     - runless_lineage_remains_unversioned
-    - unversioned_destructive_cleanup_creates_no_revision
+    - authorized_unversioned_destructive_cleanup_creates_no_revision
+    - arbitrary_run_deletion_rejected
+    - cleanup_authorization_is_not_runtime_mintable
+    - cleanup_authorizer_has_no_fact_or_schema_privileges
+    - mixed_cleanup_revisions_survivors_and_tombstones_deleted_runs
     - reverse_order_claims_serialize_frontier_first
     - trigger_functions_are_not_runtime_bypass_surfaces
     - second_runtime_boot_is_read_only
@@ -154,3 +177,10 @@ manifestations:
   - {id: owner_is_runtime_bypass, issue: 2049, status: design_locked_here}
   - {id: unguarded_temporal_delete, issue: 2050, status: design_locked_and_prototyped_here}
   - {id: new_only_ownership_move_guard, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: restricted_runtime_run_bootstrap_cycle, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: transaction_wide_destructive_mode_conflict, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: unrestricted_runtime_run_deletion, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: partial_fact_family_guards, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: delivery_event_lineage_mismatch, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: drifted_target_reapply_accepted, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: incomplete_legacy_catalog_admitted, issue: 2050, status: design_locked_and_prototyped_here}

--- a/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
+++ b/internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
@@ -1,0 +1,156 @@
+version: 1
+kind: temporal_frontier_design_record
+issue: 2050
+parent_issue: 2049
+implementation_issue: 2051
+source_refs:
+  parent_pre_audit: https://github.com/division-sh/swarm/issues/2049#issuecomment-4961704596
+  final_audit_repair: https://github.com/division-sh/swarm/issues/2049#issuecomment-4962244013
+  gate: https://github.com/division-sh/swarm/issues/2049#issuecomment-4962277948
+  platform_spec: platform-spec.yaml#run_model.fork.temporal_frontier
+policy:
+  closure_level: spec_schema_design_locked
+  claims_runtime_behavior_change: false
+  claims_production_failure_class_closed: false
+  production_activation_allowed: false
+  production_activation_issue: 2051
+  sqlite_semantics_changed: false
+selectors:
+  supported: [default_latest_event, explicit_event_uuid]
+  invalid: [rfc3339_timestamp, created_at_event_id_cutoff, caller_supplied_revision]
+  bookmark_owner: event_uuid_resolves_temporal_revision
+transaction:
+  declaration_table: run_temporal_transactions
+  xid_type: xid8
+  modes: [normal, destructive]
+  sealed_fields: [transaction_id, sorted_unique_run_ids, mode]
+  lock_order:
+    - nonlocking_identity_snapshot
+    - sealed_frontier_declaration
+    - sorted_frontier_locks
+    - deterministic_fact_locks
+    - identity_revalidation
+    - captured_fact_mutation
+  ordinary_revision_on_destructive_cleanup: false
+  ordinal_start: 1
+  header_retention: referenced_by_revision_or_tombstone
+objects:
+  tables:
+    - run_temporal_transactions
+    - run_temporal_frontiers
+    - run_temporal_revisions
+    - runtime_store_migrations
+    - run_deletion_tombstones
+  history_tables:
+    - run_lifecycle_history
+    - event_delivery_history
+    - event_receipt_history
+    - timer_history
+    - entity_state_history
+    - agent_session_history
+    - conversation_audit_history
+    - reply_context_history
+    - activity_attempt_history
+  functions:
+    - swarm_declare_temporal_runs
+    - swarm_claim_temporal_runs
+    - swarm_next_temporal_ordinal
+    - swarm_guard_events
+    - swarm_guard_event_deliveries
+    - swarm_guard_event_receipts
+    - swarm_destroy_run
+  trigger_properties:
+    - security_definer
+    - owner_controlled
+    - schema_qualified
+    - pinned_search_path
+    - public_execute_revoked
+    - enable_always
+roles:
+  migration:
+    kind: schema_owner_login
+    distinct_from_runtime: true
+    invocation: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+    attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS]
+  runtime:
+    kind: restricted_login
+    invocation: swarm serve --config <runtime-config>
+    attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner]
+grants:
+  runtime_execute: [swarm_claim_temporal_runs, swarm_destroy_run]
+  runtime_denied_execute: [swarm_declare_temporal_runs, swarm_next_temporal_ordinal, swarm_guard_events, swarm_guard_event_deliveries, swarm_guard_event_receipts]
+  runtime_insert_only: [events]
+  runtime_guarded_insert_update: [runs]
+  runtime_guarded_dml: [event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
+  runtime_denied_dml: [run_temporal_transactions, run_temporal_frontiers, run_temporal_revisions, runtime_store_migrations, run_deletion_tombstones, temporal_history, runtime_store_metadata]
+  runtime_denied_direct_operations: [events.UPDATE, events.DELETE, runs.DELETE]
+fact_families:
+  - {name: runs, disposition: typed_transition_history}
+  - {name: events, disposition: immutable_append_revision}
+  - {name: event_deliveries, disposition: typed_transition_history}
+  - {name: event_receipts, disposition: typed_transition_history_derived_from_event}
+  - {name: dead_letters, disposition: append_revision_derived_from_event}
+  - {name: entity_mutations, disposition: append_revision}
+  - {name: entity_state, disposition: typed_transition_history_current_projection}
+  - {name: timers, disposition: typed_transition_history_current_projection}
+  - {name: agent_sessions, disposition: typed_transition_history_current_projection}
+  - {name: agent_turns, disposition: append_revision}
+  - {name: agent_conversation_audits, disposition: typed_transition_history}
+  - {name: reply_contexts, disposition: typed_transition_history_current_projection}
+  - {name: activity_attempts, disposition: typed_transition_history_current_projection}
+  - {name: selected_fork_lineage, disposition: append_revision_on_fork_run}
+  - {name: routing_rules, disposition: global_current_config_not_run_history}
+  - {name: runless_events, disposition: null_revision_and_ordinal}
+operations:
+  event_insert: declared_normal_run_overwrites_caller_stamp
+  event_update: always_rejected
+  event_delete: destructive_whole_run_only
+  mutable_insert: every_nonnull_derived_run_declared
+  mutable_update: every_distinct_old_and_new_nonnull_run_declared
+  mutable_delete: old_nonnull_run_declared_and_typed_history_written
+  whole_run_delete: destructive_declaration_tombstone_then_cascade
+migration:
+  generation: temporal-frontier-v1
+  migration_id: temporal-frontier-v1
+  recognized_legacy_platform_version: 0.7.0
+  active_statuses: [running, paused]
+  legacy_run_disposition: model_version_0_history_incomplete
+  unknown_shape: fail_closed
+  heuristic_backfill: forbidden
+  isolation: SERIALIZABLE
+  deployment_locks: [runtime_shared_session_advisory, migration_exclusive_advisory, first_upgrade_access_exclusive_tables]
+  metadata_updated_last: true
+  rollback_is_atomic: true
+  reapply: exact_checksum_noop_else_fail_closed
+  serve_schema_mutation: forbidden
+prototype:
+  test: TestTemporalFrontierPostgresDesignConformance
+  runner_owner: platform-spec.yaml#run_model.fork.temporal_frontier.required_conformance.runner
+  proof_projection: required-full
+  assertions:
+    - fresh_schema_creation
+    - active_legacy_run_rejected_without_ddl
+    - failed_migration_rolls_back_schema_and_metadata
+    - exact_reapply_is_idempotent
+    - runtime_shared_lock_excludes_migration
+    - runtime_cannot_assume_owner_or_disable_trigger
+    - runtime_cannot_mutate_authority_or_history_tables
+    - undeclared_insert_update_delete_rejected
+    - declared_delete_writes_typed_history
+    - destructive_declaration_not_runtime_callable
+    - event_delivery_receipt_share_revision_and_ordinals
+    - rollback_publishes_no_revision
+    - update_move_requires_old_and_new_runs
+    - runless_lineage_remains_unversioned
+    - unversioned_destructive_cleanup_creates_no_revision
+    - reverse_order_claims_serialize_frontier_first
+    - trigger_functions_are_not_runtime_bypass_surfaces
+    - second_runtime_boot_is_read_only
+manifestations:
+  - {id: wrong_two_event_success, issue: 2017, status: split_to_2051}
+  - {id: non_agent_delivery_replay_internal_failure, issue: 2017, status: split_to_2051}
+  - {id: catalog_future_timestamp_workaround, issue: 2049, status: split_to_2051}
+  - {id: mixed_clock_planner_predicates, issue: 2049, status: split_to_2051}
+  - {id: owner_is_runtime_bypass, issue: 2049, status: design_locked_here}
+  - {id: unguarded_temporal_delete, issue: 2050, status: design_locked_and_prototyped_here}
+  - {id: new_only_ownership_move_guard, issue: 2050, status: design_locked_and_prototyped_here}

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12034,6 +12034,21 @@ run_model:
             deterministically projects that existing FK lineage; this is identity normalization, not historical backfill.
           dead_letters: original event lineage
           runless_events: explicit NULL revision and ordinal
+        operation_matrix:
+          runs: {insert: owner function, update: typed history, delete: authorized wrapper cascade}
+          events: {insert: revisioned insert, update: rejected immutable, delete: authorized wrapper cascade}
+          event_deliveries: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          event_receipts: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          dead_letters: {insert: revisioned insert, update: rejected immutable, delete: authorized wrapper cascade}
+          entity_mutations: {insert: revisioned insert, update: rejected immutable, delete: authorized wrapper cascade}
+          entity_state: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          timers: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          agent_sessions: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          agent_turns: {insert: revisioned insert, update: rejected immutable, delete: authorized wrapper cascade}
+          agent_conversation_audits: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          reply_contexts: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          activity_attempts: {insert: typed history, update: typed history, delete: typed history or authorized wrapper cascade}
+          selected_fork_lineage: {insert: revisioned insert, update: rejected immutable, delete: authorized wrapper cascade}
       trigger_contract:
         functions: [swarm_declare_temporal_runs, swarm_create_run, swarm_claim_temporal_runs, swarm_authorize_run_cleanup, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs, swarm_next_temporal_ordinal, swarm_resolve_temporal_run, swarm_guard_append_fact, swarm_guard_mutable_fact]
         exact_trigger_families:
@@ -12057,7 +12072,11 @@ run_model:
         - Mutable UPDATE and DELETE guard OLD run identity before mutation; ownership moves independently guard every
           distinct OLD and NEW non-NULL run and write typed evidence for each. Event-derived and asserted-event families
           derive through events.run_id and reject missing or disagreeing lineage before allocating an ordinal.
-        - Cascade-triggered fact deletion accepts only the same sealed destructive transaction that owns the run tombstone.
+        - History-free fact deletion accepts only a destructive declaration paired with a matching run_deletion_tombstones
+          row for the current xid. Only swarm_delete_authorized_runs writes that tombstone before deleting the run; a cleanup
+          claim followed by direct or partial fact deletion aborts and cannot commit. The wrapper deletes event receipts,
+          dead letters, and deliveries while their immutable event lineage remains resolvable, then deletes the run so
+          direct-run foreign-key cascades complete without introducing a second deletion authority.
       privilege_contract:
         schema_owner_migration_login:
           attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS]
@@ -12066,7 +12085,9 @@ run_model:
         cleanup_authorizer_login:
           attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner, distinct_from_runtime]
           schema: USAGE only; no CREATE
-          tables: no direct privileges
+          tables:
+            read: [runtime_store_metadata, runtime_store_migrations]
+            mutate: none
           functions:
             execute: [swarm_authorize_run_cleanup]
             denied: [all other temporal functions]
@@ -12085,9 +12106,11 @@ run_model:
             execute: [swarm_create_run, swarm_claim_temporal_runs, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs]
             denied: [swarm_declare_temporal_runs, swarm_authorize_run_cleanup, swarm_resolve_temporal_run, all trigger functions, swarm_next_temporal_ordinal]
         admission: >
-          Serve verifies current_user equals metadata.runtime_role, differs from metadata.schema_owner_role, is not a
-          member of that role, and lacks SUPERUSER, BYPASSRLS, CREATEROLE, schema CREATE, table ownership, trigger/history/
-          metadata DML, and forbidden function EXECUTE. Any missing required grant or extra forbidden grant fails boot.
+          One exact read-only checker is used by runtime boot and cleanup-authorizer admission. It verifies the caller's
+          identity-specific grant matrix plus metadata, migration ledger, complete installed-catalog checksum, all three
+          role attributes and pairwise lack of membership, schema owner and privileges, table grants, function signatures,
+          owners, SECURITY DEFINER/search_path configuration and grants, and the exact table/trigger/function ENABLE ALWAYS
+          mapping. Any missing required grant, extra grant, metadata mismatch, or post-migration catalog drift fails closed.
       schema_apply:
         command: swarm schema apply --runtime-role <postgres-role> --cleanup-authorizer-role <postgres-role> --config <explicit-migration-config>
         authority: >
@@ -12098,8 +12121,9 @@ run_model:
         migration_id: temporal-frontier-v1
         recognized_legacy: >
           Only a runtime_store_metadata platform_version=0.7.0 store whose complete catalog checksum matches the registered
-          pre-temporal shape is eligible. Missing/unknown metadata, partial temporal objects, checksum drift, or an
-          unregistered shape fails closed; there is no heuristic repair or timestamp-derived backfill.
+          pre-temporal shape and whose stored event_deliveries.run_id agrees with the referenced events.run_id is eligible.
+          Missing/unknown metadata, partial temporal objects, checksum drift, missing event lineage, stored/derived run
+          disagreement, or an unregistered shape fails closed before DDL; there is no heuristic repair or timestamp-derived backfill.
         active_run_gate: >
           Before DDL, report every runs row in running or paused status and abort with no mutation. Operators must drain or
           terminate those runs explicitly. Terminal legacy runs are retained as model_version=0/history_complete=false.
@@ -12108,7 +12132,8 @@ run_model:
           order:
           - Acquire the temporal-schema exclusive advisory lock.
           - Lock recognized legacy tables ACCESS EXCLUSIVE in deterministic name order so first upgrade excludes old binaries.
-          - Re-read metadata, the registered complete catalog checksum, active runs, owner identity, and migration edge.
+          - Re-read metadata, the registered complete catalog checksum, every delivery/event run-lineage invariant, active runs,
+            owner identity, and migration edge.
           - Normalize only the registered legacy shape; create the temporal model and guarded functions/triggers.
           - Insert model_version=0 frontiers for retained legacy runs without synthesizing revisions or histories.
           - Apply exact ownership, revocations, grants, ENABLE ALWAYS triggers, and catalog validation.
@@ -12125,13 +12150,14 @@ run_model:
         first_upgrade: ACCESS EXCLUSIVE legacy table locks cover old binaries that do not yet hold the shared advisory lock.
       runtime_admission:
         schema_mutation: forbidden
-        checks: [platform version, schema generation, canonical DDL checksum, installed catalog checksum, migration ledger, schema owner, runtime role, role attributes and membership, exact grants, temporal columns and constraints, trigger/function OIDs and checksums, ENABLE ALWAYS state]
-        second_boot: Two independent runtime-login boots must pass the same read-only admission without executing DDL, DML, GRANT, REVOKE, ALTER, or role changes.
+        checker: one exact read-only checker shared by runtime and cleanup-authorizer identities
+        checks: [platform version, schema generation, canonical DDL checksum, installed catalog checksum, migration ledger, schema owner, owner/runtime/cleanup-authorizer role attributes and memberships, identity-specific exact table/function/schema grants, exact function signatures/owners/configuration/checksums, exact table/trigger/function mapping, ENABLE ALWAYS state]
+        second_boot: Two independent runtime-login boots and cleanup-authorizer admission must pass the same read-only checker without executing DDL, DML, GRANT, REVOKE, ALTER, or role changes; committed catalog drift must reject both identities.
       required_conformance:
         committed_record: internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
         postgres_test: TestTemporalFrontierPostgresDesignConformance
         runner: go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/conformance -run '^TestTemporalFrontierPostgresDesignConformance$' -count=1
-        compact_path: restricted runtime creates a run, mutates every guarded fact family, rejects lineage mismatch, consumes authorized mixed cleanup, and passes read-only second boot after complete migration/reapply validation
+        compact_path: restricted runtime creates a run; executes the explicit insert/update/delete disposition for every guarded fact family; rejects append mutation, lineage mismatch, and claim-plus-partial destructive deletion; proves authorized mixed and every-family destructive cascades; admits complete legacy lineage; rejects drifted reapply and post-migration drift; and passes runtime second boot plus cleanup-authorizer admission through one exact read-only checker
         scope: Design/schema/privilege feasibility only; passing does not prove production writer or reader migration.
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
       point, reconstructs provable state, classifies replay candidates, optionally loads selected contracts

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4516,6 +4516,19 @@ engine:
         a literal "postgres" password as hardcoded fallback. Operators may use legacy env names only by explicitly naming
         them through database.password_env. Plaintext database.password is unsupported and MUST fail closed with migration
         guidance. DSN construction MUST receive already-resolved password material and MUST NOT resolve password sources.
+    postgres_temporal_schema_authority:
+      promoted_by: '#2050'
+      activation_owner: '#2051'
+      status: design_locked_not_activated
+      owner: run_model.fork.temporal_frontier.schema_apply and privilege_contract
+      migration_invocation: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+      runtime_invocation: swarm serve --config <runtime-config>
+      rules:
+      - The migration invocation and runtime invocation use the same typed database config shape but distinct PostgreSQL logins.
+      - The explicit migration config authenticates as the schema-owning migration login and is never loaded by serve.
+      - Runtime config authenticates as the restricted metadata-declared runtime role and cannot own or migrate schema.
+      - Login creation, passwords, and role provisioning remain operator/DBA work; Swarm does not mint or persist them.
+      - #2050 does not add the command or alter startup behavior. #2051 activates both surfaces atomically with the temporal generation.
     runtime_backend_rule:
     - Unsupported backend ids fail closed with supported backend guidance.
     - >
@@ -4560,6 +4573,11 @@ engine:
         - Postgres remains authoritative when the canonical backend selector resolves to postgres.
         - Postgres bootstrap may use pgcrypto, Postgres compatibility migrations, Postgres DDL execution, and Postgres
           catalog inspection.
+        - >
+          The temporal-frontier target is the explicit exception design-locked at
+          run_model.fork.temporal_frontier. When #2051 activates that generation, `swarm schema apply` becomes the only
+          PostgreSQL temporal schema/migration writer and `swarm serve` becomes read-only schema/privilege admission.
+          #2050 records that target only; current production bootstrap remains unchanged until the atomic cutover.
       sqlite:
         status: explicit_local_runtime_schema_bootstrap
         owner: internal/store.SQLiteSchemaStore and SQLite dialect translation
@@ -11480,7 +11498,9 @@ platform_tables:
     runtime_store_metadata:
       description: 'Immutable creation-origin evidence for a selected runtime store. The stored versions explain which Swarm
         build and exact platform specification created the store; they never decide whether a later build may open it.
-        Products never read or write this table.'
+        Products never read or write this table. The inactive temporal-frontier-v1 target adds schema_generation,
+        schema_ddl_sha256, schema_owner_role, and runtime_role through the one-shot migration owned by
+        run_model.fork.temporal_frontier; normal boot does not add those columns in #2050.'
       ddl: "CREATE TABLE runtime_store_metadata (\n    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),\n    swarm_version\
         \     TEXT NOT NULL,\n    platform_version  TEXT NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL\n);"
   notes:
@@ -11490,7 +11510,9 @@ platform_tables:
     migrations: 'Pre-1.0 selected stores are not migrated or adopted at boot. Boot derives the complete required platform
       shape from this specification, probes the actual selected-backend catalog before persistent mutation, and accepts only
       a fresh empty namespace or an exactly compatible store carrying immutable runtime_store_metadata origin evidence.
-      Partial, un-stamped, conflicting, or drifted stores fail closed with backend-specific fresh-store remediation.'
+      Partial, un-stamped, conflicting, or drifted stores fail closed with backend-specific fresh-store remediation. The
+      design-locked temporal-frontier-v1 exception is not a boot migration: after #2051 activation only the explicit
+      `swarm schema apply` owner may perform its one recognized catalog-checksummed edge.'
     index_syntax: INDEX declarations are logical — the implementer may use CREATE INDEX statements or database-specific syntax.
       The spec declares intent, not SQL dialect.
   diagnostics_encoding:
@@ -11561,7 +11583,7 @@ platform_tables:
     digest_queries: Digest/reporting code should query entity_state for current metrics and spend_ledger for cost aggregates.
       No entity_metrics table.
   migration_policy:
-    status: pre_1_0_no_migration
+    status: pre_1_0_no_boot_migration_with_inactive_temporal_frontier_design
     compatibility_authority: actual_selected_backend_catalog_shape
     origin_evidence: runtime_store_metadata
     origin_validity: >
@@ -11579,6 +11601,11 @@ platform_tables:
     fresh_bootstrap: >
       Fresh platform creation is backend-serialized and atomically commits the complete platform schema plus exactly one
       immutable runtime_store_metadata row. Failed or concurrent creation cannot leave a successful stamp over partial DDL.
+    temporal_frontier_target: >
+      run_model.fork.temporal_frontier design-locks the only recognized existing-store migration exception. #2050 does not
+      activate it. #2051 must move fresh PostgreSQL creation and recognized upgrade to explicit `swarm schema apply`, remove
+      temporal DDL from serve, and admit runtime only after exact generation/checksum/owner/grant validation. SQLite keeps
+      its separately governed local bootstrap behavior.
     generated_node_state: >
       Contract-generated node-state tables are classified only after platform acceptance. Missing tables may be created;
       existing incompatible tables fail before node-state mutation through the same typed backend-specific compatibility
@@ -11601,6 +11628,10 @@ platform_tables:
       are not supported entity current-state read authority.
     bootstrap_function: BootstrapPlatformTables(spec PlatformSpec) — reads platform_tables.tables, generates DDL, executes.
       Called by both production boot and test setup. Single code path.
+    temporal_frontier_design_exception: >
+      #2050's PostgreSQL conformance prototype executes only in
+      TestTemporalFrontierPostgresDesignConformance. Generic store bootstrap MUST NOT create the inactive temporal schema;
+      production and generic-test activation belongs atomically to #2051.
   credentials_policy:
     description: Webhook secrets, API keys, and other credentials are NOT stored in platform tables. The platform provides
       a config surface; products choose their storage strategy.
@@ -11718,6 +11749,318 @@ run_model:
     dry_run_command: 'retired in v1 CLI; historical `swarm fork --dry-run` is not a supported operator command'
     materialize_only_command: 'retired in v1 CLI; historical `swarm fork --materialize-only` is not a supported operator command'
     activation_command: 'retired in v1 CLI; historical `swarm fork --activate` is not a supported operator command'
+    temporal_frontier:
+      promoted_by: '#2050'
+      parent_tracker: '#2049'
+      production_activation_owner: '#2051'
+      status: design_locked_not_activated
+      closure_level: spec_schema_design_locked
+      canonical_owner: PostgreSQL run-scoped transactional persistence revision
+      activation_boundary: >
+        This section is the authoritative target contract, but #2050 MUST NOT add these objects to
+        platform_tables.tables, execute this DDL during runtime boot, install production triggers, migrate production
+        writers/readers, or accept the new metadata generation. #2051 must activate the complete writer-plus-reader
+        migration atomically after a fresh independent pre-audit. Until then, current production behavior remains
+        unchanged and this design MUST NOT be cited as proof that timestamp-fork correctness is fixed.
+      semantics:
+        event_occurrence_time: >
+          events.created_at is occurrence/admission data only. Caller-supplied, backfilled, future, and mixed-clock
+          timestamps remain valid facts but never decide persisted frontier membership or transition order.
+        membership: >
+          A committed run-scoped fact belongs to the one revision allocated for its persistence transaction. A
+          transaction touching multiple runs declares the complete run set first, locks frontiers in ascending UUID
+          order, and allocates one revision per declared run. All facts for one run in that transaction share that
+          revision; monotonically allocated ordinals provide deterministic within-revision rendering only. Rollback
+          publishes neither the transaction declaration, revision, ordinals, nor history.
+        isolation: >
+          Historical planning reads one read-only REPEATABLE READ snapshot and classifies by revision. Activation then
+          performs a fresh source-frontier revalidation inside its mutation transaction. A historical workset never
+          substitutes for activation-time source advancement safety.
+        runless: >
+          A fact with no direct run derives its run through its declared immutable lineage owner (for example, a receipt
+          through its event). If derivation yields no run, temporal revision and ordinal remain NULL. Derivation failure,
+          ambiguity, or disagreement fails closed; writers never guess from timestamps or ambient current-run state.
+        mutable_projection: >
+          Mutable rows are current projections, not historical truth. Every admitted INSERT, UPDATE, and DELETE writes
+          typed before/after transition evidence under the same run revision. An ownership-moving UPDATE requires every
+          distinct non-NULL OLD.run_id and NEW.run_id in the sealed declaration and records evidence for both runs.
+        immutable_events: >
+          Run-scoped events are immutable after insertion. Runtime receives INSERT but not UPDATE or DELETE authority.
+          Trigger enforcement rejects UPDATE even if a grant drifts and permits DELETE only through whole-run destructive
+          authority with a sealed destructive declaration.
+        destructive_cleanup: >
+          Whole-run deletion declares destructive mode, locks the frontier before run-owned facts, records one durable
+          run_deletion_tombstone outside the run cascade, and then deletes the run. It never allocates an ordinary
+          revision. An unversioned legacy run therefore remains destructible without fabricating normal history.
+      selectors:
+        public:
+        - default_latest_event
+        - explicit_event_uuid
+        resolution: >
+          Default/latest resolves the last persisted source-run event and uses its temporal revision. Explicit selection
+          resolves that exact source-run event UUID and uses its temporal revision. Event UUID is the bookmark; displayed
+          occurrence/recorded timestamps are diagnostics only.
+        invalid:
+        - rfc3339_timestamp
+        - created_at_event_id_cutoff
+        - caller_supplied_revision
+        migration: >
+          #2051 deletes the internal RFC3339 branch in resolveRunForkPoint and all timestamp planner/advancement
+          predicates. There is no compatibility parser, timestamp fallback, or dual selector authority.
+      transaction_contract:
+        xid_type: xid8
+        declaration_owner: run_temporal_transactions
+        declaration_rule: >
+          Owner-only swarm_declare_temporal_runs(uuid[], mode) inserts exactly one durable header for
+          pg_current_xact_id(). Runtime can call only swarm_claim_temporal_runs(uuid[]), which delegates with normal mode;
+          swarm_destroy_run is the only runtime surface that may delegate with destructive mode. The sorted,
+          duplicate-free run_ids array and mode are sealed: a second declaration must match byte-for-byte or fail. Full
+          xid8 is retained; txid_current() bigint truncation and xid32 storage are forbidden.
+        modes:
+          normal: Requires model_version=1 and history_complete=true for every run; allocates revisions.
+          destructive: Permits versioned or unversioned whole-run cleanup; allocates no ordinary revision.
+        ordinal_rule: >
+          run_temporal_revisions.next_ordinal starts at zero. Each guarded fact/history operation atomically increments it
+          and receives the resulting positive integer. A multi-run ownership move receives one ordinal in each run.
+        retention: >
+          Transaction headers are committed audit authority and survive while referenced by a revision or deletion
+          tombstone. Compaction may remove an unreferenced header only after the configured audit-retention floor and may
+          never renumber, truncate, or reuse xid8 values.
+        lock_order:
+        - Take a non-locking identity snapshot sufficient to derive every affected run.
+        - Call swarm_claim_temporal_runs with the complete set; its private declaration owner locks frontiers in ascending UUID order.
+        - Lock temporal fact rows in deterministic table-name then primary-key order.
+        - Revalidate identities and the affected run set; drift rolls back and retries from the beginning.
+        - Mutate only the captured primary keys. No temporal fact FOR UPDATE, UPDATE, or DELETE may precede declaration.
+      schema_contract:
+        generation: temporal-frontier-v1
+        ddl_status: exact_target_ddl_inactive_until_2051
+        tables:
+          run_temporal_transactions:
+            ddl: |
+              CREATE TABLE run_temporal_transactions (
+                  transaction_id XID8 PRIMARY KEY,
+                  run_ids UUID[] NOT NULL,
+                  mode TEXT NOT NULL CHECK (mode IN ('normal', 'destructive')),
+                  declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+                  CHECK (cardinality(run_ids) > 0)
+              );
+          run_temporal_frontiers:
+            ddl: |
+              CREATE TABLE run_temporal_frontiers (
+                  run_id UUID PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE,
+                  model_version INTEGER NOT NULL CHECK (model_version IN (0, 1)),
+                  current_revision BIGINT NOT NULL DEFAULT 0 CHECK (current_revision >= 0),
+                  history_complete BOOLEAN NOT NULL DEFAULT FALSE,
+                  CHECK ((model_version = 0 AND history_complete = FALSE AND current_revision = 0)
+                      OR (model_version = 1 AND history_complete = TRUE))
+              );
+          run_temporal_revisions:
+            ddl: |
+              CREATE TABLE run_temporal_revisions (
+                  run_id UUID NOT NULL REFERENCES run_temporal_frontiers(run_id) ON DELETE CASCADE,
+                  revision BIGINT NOT NULL CHECK (revision > 0),
+                  transaction_id XID8 NOT NULL REFERENCES run_temporal_transactions(transaction_id),
+                  next_ordinal INTEGER NOT NULL DEFAULT 0 CHECK (next_ordinal >= 0),
+                  recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+                  PRIMARY KEY (run_id, revision),
+                  UNIQUE (run_id, transaction_id)
+              );
+          runtime_store_migrations:
+            ddl: |
+              CREATE TABLE runtime_store_migrations (
+                  migration_id TEXT PRIMARY KEY,
+                  from_generation TEXT NOT NULL,
+                  to_generation TEXT NOT NULL,
+                  ddl_sha256 TEXT NOT NULL CHECK (ddl_sha256 ~ '^[0-9a-f]{64}$'),
+                  schema_owner_role TEXT NOT NULL,
+                  runtime_role TEXT NOT NULL,
+                  applied_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+                  CHECK (schema_owner_role <> runtime_role)
+              );
+          run_deletion_tombstones:
+            ddl: |
+              CREATE TABLE run_deletion_tombstones (
+                  deletion_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                  run_id UUID NOT NULL UNIQUE,
+                  source_model_version INTEGER NOT NULL CHECK (source_model_version IN (0, 1)),
+                  last_revision BIGINT CHECK (last_revision IS NULL OR last_revision >= 0),
+                  transaction_id XID8 NOT NULL REFERENCES run_temporal_transactions(transaction_id),
+                  deleted_by TEXT NOT NULL,
+                  deleted_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+                  CHECK ((source_model_version = 0 AND last_revision IS NULL)
+                      OR (source_model_version = 1 AND last_revision IS NOT NULL))
+              );
+          run_lifecycle_history:
+            ddl: |
+              CREATE TABLE run_lifecycle_history (
+                  history_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                  run_id UUID NOT NULL,
+                  revision BIGINT NOT NULL,
+                  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+                  operation TEXT NOT NULL CHECK (operation IN ('insert', 'update', 'delete')),
+                  fact_id TEXT NOT NULL,
+                  before_state JSONB,
+                  after_state JSONB,
+                  FOREIGN KEY (run_id, revision) REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE,
+                  UNIQUE (run_id, revision, ordinal)
+              );
+          event_delivery_history:
+            ddl: |
+              CREATE TABLE event_delivery_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE event_delivery_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          event_receipt_history:
+            ddl: |
+              CREATE TABLE event_receipt_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE event_receipt_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          timer_history:
+            ddl: |
+              CREATE TABLE timer_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE timer_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          entity_state_history:
+            ddl: |
+              CREATE TABLE entity_state_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE entity_state_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          agent_session_history:
+            ddl: |
+              CREATE TABLE agent_session_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE agent_session_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          conversation_audit_history:
+            ddl: |
+              CREATE TABLE conversation_audit_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE conversation_audit_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          reply_context_history:
+            ddl: |
+              CREATE TABLE reply_context_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE reply_context_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+          activity_attempt_history:
+            ddl: |
+              CREATE TABLE activity_attempt_history (LIKE run_lifecycle_history INCLUDING ALL);
+              ALTER TABLE activity_attempt_history ADD FOREIGN KEY (run_id, revision)
+                  REFERENCES run_temporal_revisions(run_id, revision) ON DELETE CASCADE;
+        existing_table_columns:
+          runtime_store_metadata:
+            ddl: |
+              ALTER TABLE runtime_store_metadata
+                  ADD COLUMN schema_generation TEXT,
+                  ADD COLUMN schema_ddl_sha256 TEXT,
+                  ADD COLUMN schema_owner_role TEXT,
+                  ADD COLUMN runtime_role TEXT;
+          immutable_append_facts:
+            tables: [events, entity_mutations, dead_letters, agent_turns]
+            columns: temporal_revision BIGINT, temporal_ordinal INTEGER
+          event_receipts_derived_identity:
+            ddl: |
+              ALTER TABLE event_receipts
+                  ADD COLUMN temporal_run_id UUID REFERENCES runs(run_id) ON DELETE CASCADE,
+                  ADD COLUMN temporal_revision BIGINT,
+                  ADD COLUMN temporal_ordinal INTEGER;
+              UPDATE event_receipts AS receipt
+              SET temporal_run_id = event.run_id
+              FROM events AS event
+              WHERE event.event_id = receipt.event_id;
+          mutable_projection_facts:
+            tables: [runs, event_deliveries, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
+            columns: temporal_revision BIGINT, temporal_ordinal INTEGER
+        history_shape_rule: >
+          LIKE is notation for the exact common history shape above, not shared storage. #2051 may spell each CREATE TABLE
+          out after canonical SQL rendering, but every table must retain its own primary key, unique run/revision/ordinal
+          key, foreign key, operation check, fact identity, and typed before/after JSON projection. Generic catch-all
+          history and mutable current rows as history are forbidden.
+      fact_family_contract:
+        append_only_with_revision: [events, entity_mutations, dead_letters, agent_turns, selected fork lineage rows]
+        typed_transition_history: [runs, event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
+        current_projection_only: [runs, event_deliveries, timers, entity_state, agent_sessions, reply_contexts, activity_attempts]
+        global_not_run_historical: [routing_rules, bundles, runtime_store_metadata, runtime_store_migrations]
+        derived_run_identity:
+          event_receipts: >
+            events.run_id through immutable event_id, persisted as trigger-owned temporal_run_id. The recognized migration
+            deterministically projects that existing FK lineage; this is identity normalization, not historical backfill.
+          dead_letters: original event lineage
+          runless_events: explicit NULL revision and ordinal
+      trigger_contract:
+        functions: [swarm_declare_temporal_runs, swarm_claim_temporal_runs, swarm_next_temporal_ordinal, swarm_guard_events, swarm_guard_event_deliveries, swarm_guard_event_receipts, swarm_destroy_run]
+        properties:
+        - Every function is owned by the schema-owner/migration login, is SECURITY DEFINER, schema-qualifies all objects,
+          and pins search_path to pg_catalog plus the runtime schema.
+        - PUBLIC receives no EXECUTE. Runtime receives EXECUTE only on the normal-only swarm_claim_temporal_runs(uuid[])
+          wrapper and swarm_destroy_run; the mode-bearing declaration function, trigger functions, and ordinal helpers are
+          unavailable as direct bypass surfaces.
+        - Every temporal trigger is ENABLE ALWAYS. Runtime admission verifies trigger name, table/function OIDs,
+          tgenabled='A', function owner, prosecdef=true, proconfig search_path, and function checksum.
+        - Event INSERT overwrites caller revision/ordinal. Event UPDATE always rejects. Event DELETE requires destructive
+          mode and never writes ordinary history.
+        - Mutable UPDATE and DELETE guard OLD.run_id before mutation; ownership moves independently guard every distinct
+          OLD and NEW non-NULL run and write typed evidence for each.
+        - Cascade-triggered fact deletion accepts only the same sealed destructive transaction that owns the run tombstone.
+      privilege_contract:
+        schema_owner_migration_login:
+          attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS]
+          owns: [runtime schema, temporal tables, temporal functions, temporal triggers, runtime_store_metadata, runtime_store_migrations]
+          use: one-shot swarm schema apply only
+        runtime_login:
+          attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner]
+          schema: USAGE only; no CREATE
+          tables:
+            read: [runtime_store_metadata, runtime_store_migrations, run_temporal_frontiers, run_temporal_revisions, temporal history, runtime fact tables]
+            insert_only: [events, append-only run fact tables]
+            guarded_insert_update: [runs]
+            guarded_insert_update_delete: [event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
+            denied_all_dml: [run_temporal_transactions, run_temporal_frontiers, run_temporal_revisions, temporal history, run_deletion_tombstones, runtime_store_metadata, runtime_store_migrations]
+            denied_direct_mutation: [events.UPDATE, events.DELETE, runs.DELETE]
+          functions:
+            execute: [swarm_claim_temporal_runs, swarm_destroy_run]
+            denied: [swarm_declare_temporal_runs, all trigger functions, swarm_next_temporal_ordinal]
+        admission: >
+          Serve verifies current_user equals metadata.runtime_role, differs from metadata.schema_owner_role, is not a
+          member of that role, and lacks SUPERUSER, BYPASSRLS, CREATEROLE, schema CREATE, table ownership, trigger/history/
+          metadata DML, and forbidden function EXECUTE. Any missing required grant or extra forbidden grant fails boot.
+      schema_apply:
+        command: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+        authority: >
+          The explicit config uses the same typed database connection shape as serve but authenticates as the migration
+          owner. The runtime role is named separately and must already exist. Login provisioning is operator/DBA work.
+          Serve never loads, discovers, or falls back to migration credentials.
+        migration_id: temporal-frontier-v1
+        recognized_legacy: >
+          Only a runtime_store_metadata platform_version=0.7.0 store whose complete catalog checksum matches the registered
+          pre-temporal shape is eligible. Missing/unknown metadata, partial temporal objects, checksum drift, or an
+          unregistered shape fails closed; there is no heuristic repair or timestamp-derived backfill.
+        active_run_gate: >
+          Before DDL, report every runs row in running or paused status and abort with no mutation. Operators must drain or
+          terminate those runs explicitly. Terminal legacy runs are retained as model_version=0/history_complete=false.
+        transaction:
+          isolation: SERIALIZABLE
+          order:
+          - Acquire the temporal-schema exclusive advisory lock.
+          - Lock recognized legacy tables ACCESS EXCLUSIVE in deterministic name order so first upgrade excludes old binaries.
+          - Re-read metadata, catalog checksum, active runs, owner identity, and migration edge.
+          - Normalize only the registered legacy shape; create the temporal model and guarded functions/triggers.
+          - Insert model_version=0 frontiers for retained legacy runs without synthesizing revisions or histories.
+          - Apply exact ownership, revocations, grants, ENABLE ALWAYS triggers, and catalog validation.
+          - Insert migration ledger and update metadata generation/DDL checksum/roles last, then commit.
+        rollback: Any failure rolls back DDL, grants, ledger, and metadata. Reapply of the exact committed migration is a no-op after full revalidation; a different checksum fails closed.
+      deployment_exclusion:
+        lock_key: hashtextextended('swarm:temporal-schema:' || current_database() || ':' || runtime_schema, 0)::bigint
+        runtime: New temporal-aware serve holds the shared session advisory lock for its database connection lifetime.
+        migration: schema apply requires the exclusive lock and emits a visible active-runtime diagnostic when unavailable.
+        first_upgrade: ACCESS EXCLUSIVE legacy table locks cover old binaries that do not yet hold the shared advisory lock.
+      runtime_admission:
+        schema_mutation: forbidden
+        checks: [platform version, schema generation, canonical DDL checksum, migration ledger, schema owner, runtime role, role attributes and membership, exact grants, temporal columns and constraints, trigger/function OIDs and checksums, ENABLE ALWAYS state]
+        second_boot: Two independent runtime-login boots must pass the same read-only admission without executing DDL, DML, GRANT, REVOKE, ALTER, or role changes.
+      required_conformance:
+        committed_record: internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
+        postgres_test: TestTemporalFrontierPostgresDesignConformance
+        runner: go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/conformance -run '^TestTemporalFrontierPostgresDesignConformance$' -count=1
+        scope: Design/schema/privilege feasibility only; passing does not prove production writer or reader migration.
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
       point, reconstructs provable state, classifies replay candidates, optionally loads selected contracts
       for non-mutating contract/frontier/route admission, and returns execution_ready=false
@@ -12434,17 +12777,17 @@ run_model:
         delivery_event_replay_ready primitive, selected-contract frontier execution when independently admitted, and
         timer reconstruction where the timer owner has proven active-at-T lineage. Unsupported historical fact families
         fail closed with typed blockers; the platform never infers unfinished source work from current rows.'
-    parallel_safety: 'Timestamp-based fork handles parallel agent execution naturally. At timestamp T, all
-      concurrent branches either committed their mutations or did not. No DAG traversal, no branch
-      classification, no sibling carry-over logic. The reconstructed state is simply "what was the world at T."'
+    parallel_safety: 'Parallel fork membership is owned by run_model.fork.temporal_frontier, not wall-clock order.
+      Competing persistence transactions serialize per affected run, and a committed revision is either wholly visible
+      or absent from the planner snapshot. Cross-run transactions declare and lock runs in deterministic UUID order.'
     contract_swap: 'When --contracts specifies a new contract path, any admitted fork-local delivery/event work must use
       the selected handler logic uniformly with no mixed-version state. This intent is not itself an execution owner.
       Runtime/store readiness for selected-contract boot/resume is governed by
       runtime.run_fork.contract_swap_boot_resume_admission, and mutation remains limited to separately approved bounded
       owners for admitted fork work.'
-    timestamp_precision: 'Events committed in the same millisecond are disambiguated by (created_at, event_id)
-      composite ordering. The fork point is inclusive: mutations from the target moment are included in
-      reconstructed state. Only mutations strictly after T are undone.'
+    timestamp_precision: 'Timestamps have no frontier precision semantics. The explicit/default fork event resolves an
+      inclusive temporal revision; all same-run facts in that revision are included and facts in later revisions are
+      excluded. temporal_ordinal is a deterministic rendering order inside one revision, never a membership boundary.'
     isolation: 'Forked runs are fully isolated. They get their own event stream, their own entity state copies,
       and their own agent sessions. Fork state materialization writes entity_state rows under the fork run_id while
       preserving entity_id from the source run. Results can be compared side-by-side with the original run.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -4521,12 +4521,14 @@ engine:
       activation_owner: '#2051'
       status: design_locked_not_activated
       owner: run_model.fork.temporal_frontier.schema_apply and privilege_contract
-      migration_invocation: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+      migration_invocation: swarm schema apply --runtime-role <postgres-role> --cleanup-authorizer-role <postgres-role> --config <explicit-migration-config>
       runtime_invocation: swarm serve --config <runtime-config>
       rules:
-      - The migration invocation and runtime invocation use the same typed database config shape but distinct PostgreSQL logins.
+      - The migration invocation, ordinary runtime store, and destructive-reset cleanup authorizer use three distinct PostgreSQL logins.
       - The explicit migration config authenticates as the schema-owning migration login and is never loaded by serve.
       - Runtime config authenticates as the restricted metadata-declared runtime role and cannot own or migrate schema.
+      - Runtime config also declares one typed `database.cleanup_authorizer` connection with the same host/database/SSL shape and its own explicit password-source authority. It is delivered only to the canonical destructive-reset plan/quiescence/directive owner; ordinary store, SQL helpers, and other runtime consumers cannot obtain it.
+      - A temporal-generation serve fails admission when either runtime or cleanup-authorizer credentials are absent, name the same role, disagree with metadata, or hold broader privileges than their exact grant matrices. No ambient PG* or SWARM_DB_* fallback is allowed for either identity.
       - Login creation, passwords, and role provisioning remain operator/DBA work; Swarm does not mint or persist them.
       - #2050 does not add the command or alter startup behavior. #2051 activates both surfaces atomically with the temporal generation.
     runtime_backend_rule:
@@ -11499,7 +11501,7 @@ platform_tables:
       description: 'Immutable creation-origin evidence for a selected runtime store. The stored versions explain which Swarm
         build and exact platform specification created the store; they never decide whether a later build may open it.
         Products never read or write this table. The inactive temporal-frontier-v1 target adds schema_generation,
-        schema_ddl_sha256, schema_owner_role, and runtime_role through the one-shot migration owned by
+        schema_ddl_sha256, schema_catalog_sha256, schema_owner_role, runtime_role, and cleanup_authorizer_role through the one-shot migration owned by
         run_model.fork.temporal_frontier; normal boot does not add those columns in #2050.'
       ddl: "CREATE TABLE runtime_store_metadata (\n    id                INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),\n    swarm_version\
         \     TEXT NOT NULL,\n    platform_version  TEXT NOT NULL,\n    created_at        TIMESTAMPTZ NOT NULL\n);"
@@ -11783,15 +11785,23 @@ run_model:
         mutable_projection: >
           Mutable rows are current projections, not historical truth. Every admitted INSERT, UPDATE, and DELETE writes
           typed before/after transition evidence under the same run revision. An ownership-moving UPDATE requires every
-          distinct non-NULL OLD.run_id and NEW.run_id in the sealed declaration and records evidence for both runs.
+          distinct non-NULL OLD.run_id and NEW.run_id in the sealed declaration with normal disposition and records
+          evidence for both runs. A stored run identity that is derived from immutable lineage must agree with that
+          lineage on every INSERT and UPDATE; changing both is admitted only when the new lineage resolves to the new run.
         immutable_events: >
           Run-scoped events are immutable after insertion. Runtime receives INSERT but not UPDATE or DELETE authority.
           Trigger enforcement rejects UPDATE even if a grant drifts and permits DELETE only through whole-run destructive
           authority with a sealed destructive declaration.
         destructive_cleanup: >
-          Whole-run deletion declares destructive mode, locks the frontier before run-owned facts, records one durable
-          run_deletion_tombstone outside the run cascade, and then deletes the run. It never allocates an ordinary
-          revision. An unversioned legacy run therefore remains destructible without fabricating normal history.
+          Whole-run deletion consumes a sealed run_cleanup_authorizations row produced by the canonical destructive-reset
+          plan/quiescence/directive owner. Restricted runtime cannot create, alter, or select that evidence and cannot
+          choose the deleted runs or actor. Claiming the authorization declares a disposition per run: destructive for
+          cleanup runs and normal for surviving runs whose references are severed in the same transaction. Normal runs
+          receive typed history and ordinary revisions; destructive runs receive tombstones and no ordinary revision.
+          The authorization-consuming delete wrapper records one durable run_deletion_tombstone outside each run cascade
+          and then deletes exactly the authorized cleanup set. An unversioned legacy run therefore remains destructible without
+          fabricating normal history, while an arbitrary active/source run cannot be deleted through a generic runtime
+          function.
       selectors:
         public:
         - default_latest_event
@@ -11811,14 +11821,29 @@ run_model:
         xid_type: xid8
         declaration_owner: run_temporal_transactions
         declaration_rule: >
-          Owner-only swarm_declare_temporal_runs(uuid[], mode) inserts exactly one durable header for
-          pg_current_xact_id(). Runtime can call only swarm_claim_temporal_runs(uuid[]), which delegates with normal mode;
-          swarm_destroy_run is the only runtime surface that may delegate with destructive mode. The sorted,
-          duplicate-free run_ids array and mode are sealed: a second declaration must match byte-for-byte or fail. Full
-          xid8 is retained; txid_current() bigint truncation and xid32 storage are forbidden.
-        modes:
-          normal: Requires model_version=1 and history_complete=true for every run; allocates revisions.
-          destructive: Permits versioned or unversioned whole-run cleanup; allocates no ordinary revision.
+          Owner-only swarm_declare_temporal_runs(normal_run_ids uuid[], destructive_run_ids uuid[]) inserts one durable
+          header for pg_current_xact_id() plus one run_temporal_transaction_runs row per run. Sorted, duplicate-free,
+          disjoint run sets and each per-run disposition are sealed; a second declaration must match exactly or fail.
+          Runtime can call swarm_claim_temporal_runs(uuid[]) for normal work or claim one persisted cleanup authorization;
+          it cannot call the mode-bearing declaration directly. Full xid8 is retained; txid_current() bigint truncation
+          and xid32 storage are forbidden.
+        dispositions:
+          normal: Requires model_version=1 and history_complete=true; allocates one revision for that run.
+          destructive: Permits versioned or unversioned whole-run cleanup; allocates no ordinary revision for that run.
+        run_creation: >
+          Runtime has no direct runs INSERT grant. SECURITY DEFINER swarm_create_run(uuid,text) is the sole creation
+          primitive: it validates the initial status, inserts a version-1 frontier under a deferred run foreign key,
+          declares that run normal, allocates revision/ordinal one, inserts the run, and writes run_lifecycle_history in
+          one transaction. Failure publishes none of those rows.
+        cleanup_authorization: >
+          run_cleanup_authorizations is a sealed handoff from the canonical destructive-reset plan/quiescence/directive
+          owner through a dedicated cleanup-authorizer login. That login can execute only
+          swarm_authorize_run_cleanup(uuid,text,text,uuid[],uuid[]); the function persists session_user as non-spoofable
+          authorizer evidence and seals the operation identity, actor evidence, sorted normal survivor set, and sorted
+          destructive cleanup set. It cannot mutate runtime facts, temporal authority, history, or schema. Ordinary
+          runtime can execute only claim/delete wrappers by authorization UUID and has no direct table privileges. The
+          claim wrapper consumes the row once in the current xid and declares both sets; the delete wrapper requires that
+          same claimed xid and deletes exactly the destructive set.
         ordinal_rule: >
           run_temporal_revisions.next_ordinal starts at zero. Each guarded fact/history operation atomically increments it
           and receives the resulting positive integer. A multi-run ownership move receives one ordinal in each run.
@@ -11840,15 +11865,20 @@ run_model:
             ddl: |
               CREATE TABLE run_temporal_transactions (
                   transaction_id XID8 PRIMARY KEY,
-                  run_ids UUID[] NOT NULL,
-                  mode TEXT NOT NULL CHECK (mode IN ('normal', 'destructive')),
-                  declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-                  CHECK (cardinality(run_ids) > 0)
+                  declared_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+              );
+          run_temporal_transaction_runs:
+            ddl: |
+              CREATE TABLE run_temporal_transaction_runs (
+                  transaction_id XID8 NOT NULL REFERENCES run_temporal_transactions(transaction_id) ON DELETE CASCADE,
+                  run_id UUID NOT NULL,
+                  disposition TEXT NOT NULL CHECK (disposition IN ('normal', 'destructive')),
+                  PRIMARY KEY (transaction_id, run_id)
               );
           run_temporal_frontiers:
             ddl: |
               CREATE TABLE run_temporal_frontiers (
-                  run_id UUID PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE,
+                  run_id UUID PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
                   model_version INTEGER NOT NULL CHECK (model_version IN (0, 1)),
                   current_revision BIGINT NOT NULL DEFAULT 0 CHECK (current_revision >= 0),
                   history_complete BOOLEAN NOT NULL DEFAULT FALSE,
@@ -11873,10 +11903,27 @@ run_model:
                   from_generation TEXT NOT NULL,
                   to_generation TEXT NOT NULL,
                   ddl_sha256 TEXT NOT NULL CHECK (ddl_sha256 ~ '^[0-9a-f]{64}$'),
+                  catalog_sha256 TEXT NOT NULL CHECK (catalog_sha256 ~ '^[0-9a-f]{64}$'),
                   schema_owner_role TEXT NOT NULL,
                   runtime_role TEXT NOT NULL,
+                  cleanup_authorizer_role TEXT NOT NULL,
                   applied_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-                  CHECK (schema_owner_role <> runtime_role)
+                  CHECK (schema_owner_role <> runtime_role
+                      AND schema_owner_role <> cleanup_authorizer_role
+                      AND runtime_role <> cleanup_authorizer_role)
+              );
+          run_cleanup_authorizations:
+            ddl: |
+              CREATE TABLE run_cleanup_authorizations (
+                  authorization_id UUID PRIMARY KEY,
+                  operation_id TEXT NOT NULL UNIQUE,
+                  actor_evidence TEXT NOT NULL CHECK (BTRIM(actor_evidence) <> ''),
+                  authorized_by TEXT NOT NULL CHECK (BTRIM(authorized_by) <> ''),
+                  normal_run_ids UUID[] NOT NULL DEFAULT '{}',
+                  destructive_run_ids UUID[] NOT NULL,
+                  authorized_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+                  claimed_transaction_id XID8 UNIQUE,
+                  CHECK (cardinality(destructive_run_ids) > 0)
               );
           run_deletion_tombstones:
             ddl: |
@@ -11951,10 +11998,12 @@ run_model:
               ALTER TABLE runtime_store_metadata
                   ADD COLUMN schema_generation TEXT,
                   ADD COLUMN schema_ddl_sha256 TEXT,
+                  ADD COLUMN schema_catalog_sha256 TEXT,
                   ADD COLUMN schema_owner_role TEXT,
-                  ADD COLUMN runtime_role TEXT;
+                  ADD COLUMN runtime_role TEXT,
+                  ADD COLUMN cleanup_authorizer_role TEXT;
           immutable_append_facts:
-            tables: [events, entity_mutations, dead_letters, agent_turns]
+            tables: [events, entity_mutations, dead_letters, agent_turns, selected fork lineage rows]
             columns: temporal_revision BIGINT, temporal_ordinal INTEGER
           event_receipts_derived_identity:
             ddl: |
@@ -11986,47 +12035,65 @@ run_model:
           dead_letters: original event lineage
           runless_events: explicit NULL revision and ordinal
       trigger_contract:
-        functions: [swarm_declare_temporal_runs, swarm_claim_temporal_runs, swarm_next_temporal_ordinal, swarm_guard_events, swarm_guard_event_deliveries, swarm_guard_event_receipts, swarm_destroy_run]
+        functions: [swarm_declare_temporal_runs, swarm_create_run, swarm_claim_temporal_runs, swarm_authorize_run_cleanup, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs, swarm_next_temporal_ordinal, swarm_resolve_temporal_run, swarm_guard_append_fact, swarm_guard_mutable_fact]
+        exact_trigger_families:
+          append_guard:
+            direct_run: [events, entity_mutations, agent_turns, selected fork lineage rows]
+            event_derived_run: [dead_letters]
+          mutable_guard:
+            direct_run: [runs, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
+            event_derived_run: [event_receipts]
+            asserted_event_run: [event_deliveries]
         properties:
         - Every function is owned by the schema-owner/migration login, is SECURITY DEFINER, schema-qualifies all objects,
           and pins search_path to pg_catalog plus the runtime schema.
-        - PUBLIC receives no EXECUTE. Runtime receives EXECUTE only on the normal-only swarm_claim_temporal_runs(uuid[])
-          wrapper and swarm_destroy_run; the mode-bearing declaration function, trigger functions, and ordinal helpers are
-          unavailable as direct bypass surfaces.
+        - PUBLIC receives no EXECUTE. Runtime receives EXECUTE only on swarm_create_run, the normal-only claim wrapper, and
+          the authorization-ID cleanup claim/delete wrappers. The per-disposition declaration function, lineage resolver,
+          trigger functions, and ordinal helper are unavailable as direct bypass surfaces.
         - Every temporal trigger is ENABLE ALWAYS. Runtime admission verifies trigger name, table/function OIDs,
           tgenabled='A', function owner, prosecdef=true, proconfig search_path, and function checksum.
         - Event INSERT overwrites caller revision/ordinal. Event UPDATE always rejects. Event DELETE requires destructive
           mode and never writes ordinary history.
-        - Mutable UPDATE and DELETE guard OLD.run_id before mutation; ownership moves independently guard every distinct
-          OLD and NEW non-NULL run and write typed evidence for each.
+        - Mutable UPDATE and DELETE guard OLD run identity before mutation; ownership moves independently guard every
+          distinct OLD and NEW non-NULL run and write typed evidence for each. Event-derived and asserted-event families
+          derive through events.run_id and reject missing or disagreeing lineage before allocating an ordinal.
         - Cascade-triggered fact deletion accepts only the same sealed destructive transaction that owns the run tombstone.
       privilege_contract:
         schema_owner_migration_login:
           attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS]
           owns: [runtime schema, temporal tables, temporal functions, temporal triggers, runtime_store_metadata, runtime_store_migrations]
           use: one-shot swarm schema apply only
+        cleanup_authorizer_login:
+          attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner, distinct_from_runtime]
+          schema: USAGE only; no CREATE
+          tables: no direct privileges
+          functions:
+            execute: [swarm_authorize_run_cleanup]
+            denied: [all other temporal functions]
+          use: canonical destructive-reset plan/quiescence/directive owner only
         runtime_login:
           attributes: [LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOBYPASSRLS, not_member_of_schema_owner]
           schema: USAGE only; no CREATE
           tables:
             read: [runtime_store_metadata, runtime_store_migrations, run_temporal_frontiers, run_temporal_revisions, temporal history, runtime fact tables]
             insert_only: [events, append-only run fact tables]
-            guarded_insert_update: [runs]
+            guarded_update: [runs]
             guarded_insert_update_delete: [event_deliveries, event_receipts, timers, entity_state, agent_sessions, agent_conversation_audits, reply_contexts, activity_attempts]
-            denied_all_dml: [run_temporal_transactions, run_temporal_frontiers, run_temporal_revisions, temporal history, run_deletion_tombstones, runtime_store_metadata, runtime_store_migrations]
-            denied_direct_mutation: [events.UPDATE, events.DELETE, runs.DELETE]
+            denied_all_dml: [run_temporal_transactions, run_temporal_transaction_runs, run_temporal_frontiers, run_temporal_revisions, temporal history, run_cleanup_authorizations, run_deletion_tombstones, runtime_store_metadata, runtime_store_migrations]
+            denied_direct_mutation: [events.UPDATE, events.DELETE, runs.INSERT, runs.DELETE]
           functions:
-            execute: [swarm_claim_temporal_runs, swarm_destroy_run]
-            denied: [swarm_declare_temporal_runs, all trigger functions, swarm_next_temporal_ordinal]
+            execute: [swarm_create_run, swarm_claim_temporal_runs, swarm_claim_authorized_run_cleanup, swarm_delete_authorized_runs]
+            denied: [swarm_declare_temporal_runs, swarm_authorize_run_cleanup, swarm_resolve_temporal_run, all trigger functions, swarm_next_temporal_ordinal]
         admission: >
           Serve verifies current_user equals metadata.runtime_role, differs from metadata.schema_owner_role, is not a
           member of that role, and lacks SUPERUSER, BYPASSRLS, CREATEROLE, schema CREATE, table ownership, trigger/history/
           metadata DML, and forbidden function EXECUTE. Any missing required grant or extra forbidden grant fails boot.
       schema_apply:
-        command: swarm schema apply --runtime-role <postgres-role> --config <explicit-migration-config>
+        command: swarm schema apply --runtime-role <postgres-role> --cleanup-authorizer-role <postgres-role> --config <explicit-migration-config>
         authority: >
           The explicit config uses the same typed database connection shape as serve but authenticates as the migration
-          owner. The runtime role is named separately and must already exist. Login provisioning is operator/DBA work.
+          owner. The runtime and cleanup-authorizer roles are named separately, differ from each other and the schema
+          owner, and must already exist. Login provisioning is operator/DBA work.
           Serve never loads, discovers, or falls back to migration credentials.
         migration_id: temporal-frontier-v1
         recognized_legacy: >
@@ -12041,12 +12108,16 @@ run_model:
           order:
           - Acquire the temporal-schema exclusive advisory lock.
           - Lock recognized legacy tables ACCESS EXCLUSIVE in deterministic name order so first upgrade excludes old binaries.
-          - Re-read metadata, catalog checksum, active runs, owner identity, and migration edge.
+          - Re-read metadata, the registered complete catalog checksum, active runs, owner identity, and migration edge.
           - Normalize only the registered legacy shape; create the temporal model and guarded functions/triggers.
           - Insert model_version=0 frontiers for retained legacy runs without synthesizing revisions or histories.
           - Apply exact ownership, revocations, grants, ENABLE ALWAYS triggers, and catalog validation.
           - Insert migration ledger and update metadata generation/DDL checksum/roles last, then commit.
-        rollback: Any failure rolls back DDL, grants, ledger, and metadata. Reapply of the exact committed migration is a no-op after full revalidation; a different checksum fails closed.
+        rollback: >
+          Any failure rolls back DDL, grants, ledger, and metadata. The migration stores both the canonical DDL checksum
+          and a deterministic installed-catalog checksum covering relations, columns, constraints, indexes, functions,
+          ALWAYS triggers, owners, and grants. Reapply recomputes the complete target catalog and is a no-op only when both
+          checksums and all admission invariants match; any drift fails closed.
       deployment_exclusion:
         lock_key: hashtextextended('swarm:temporal-schema:' || current_database() || ':' || runtime_schema, 0)::bigint
         runtime: New temporal-aware serve holds the shared session advisory lock for its database connection lifetime.
@@ -12054,12 +12125,13 @@ run_model:
         first_upgrade: ACCESS EXCLUSIVE legacy table locks cover old binaries that do not yet hold the shared advisory lock.
       runtime_admission:
         schema_mutation: forbidden
-        checks: [platform version, schema generation, canonical DDL checksum, migration ledger, schema owner, runtime role, role attributes and membership, exact grants, temporal columns and constraints, trigger/function OIDs and checksums, ENABLE ALWAYS state]
+        checks: [platform version, schema generation, canonical DDL checksum, installed catalog checksum, migration ledger, schema owner, runtime role, role attributes and membership, exact grants, temporal columns and constraints, trigger/function OIDs and checksums, ENABLE ALWAYS state]
         second_boot: Two independent runtime-login boots must pass the same read-only admission without executing DDL, DML, GRANT, REVOKE, ALTER, or role changes.
       required_conformance:
         committed_record: internal/runtime/conformance/testdata/temporal_frontier_design_record.yaml
         postgres_test: TestTemporalFrontierPostgresDesignConformance
         runner: go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/conformance -run '^TestTemporalFrontierPostgresDesignConformance$' -count=1
+        compact_path: restricted runtime creates a run, mutates every guarded fact family, rejects lineage mismatch, consumes authorized mixed cleanup, and passes read-only second boot after complete migration/reapply validation
         scope: Design/schema/privilege feasibility only; passing does not prove production writer or reader migration.
     planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
       point, reconstructs provable state, classifies replay candidates, optionally loads selected contracts


### PR DESCRIPTION
## Summary

- define `platform-spec.yaml#run_model.fork.temporal_frontier` as the canonical PostgreSQL run-scoped persistence-revision authority
- lock a three-identity privilege model: schema-owner migration, restricted runtime, and narrowly scoped cleanup authorizer
- define per-run normal/destructive transaction dispositions, atomic restricted-runtime run creation, lineage-derived guards for every declared temporal fact family, and authorization-bound whole-run cleanup
- fail closed on unknown legacy catalogs and drifted target catalogs, including owners, grants, functions, constraints, indexes, and `ENABLE ALWAYS` triggers
- add one compact PostgreSQL conformance path covering run creation, every guarded family, lineage mismatch rejection, authorized deletion, mixed cleanup, complete legacy admission, drifted reapply rejection, and a second restricted-runtime boot

## Closure Boundary

This PR closes only **spec/schema design locked**. It does not add temporal objects to production bootstrap, activate production triggers, migrate a production writer/reader, remove the live timestamp interpreter, or change SQLite/runtime behavior. The atomic production cutover remains blocked in #2051 and requires a fresh pre-audit against this merged contract.

Closes #2050

## Governing References

- `platform-spec.yaml#run_model.fork.temporal_frontier` and adjacent runtime-store bootstrap/config sections
- Parent pre-audit: https://github.com/division-sh/swarm/issues/2049#issuecomment-4961704596
- Final audit repair: https://github.com/division-sh/swarm/issues/2049#issuecomment-4962244013
- Gate B approval: https://github.com/division-sh/swarm/issues/2049#issuecomment-4962277948
- Review repair instruction: https://github.com/division-sh/swarm/pull/2052#issuecomment-4963616381

## Semantic Migration Record

- New canonical owner: PostgreSQL run-scoped transactional persistence revision plus sealed per-run disposition rows.
- New restricted authorities: `swarm_create_run`; normal claim; cleanup-authorizer handoff; authorization-ID claim/delete wrappers; generic append/mutable trigger guards; complete legacy/target catalog checksums.
- Invalid old paths: timestamp lifecycle comparisons, caller-selected destructive mode/run/actor, runtime-as-schema-owner bootstrap, direct run creation, unguarded temporal DML, metadata-only reapply, and platform-version-only legacy admission.
- Production paths checked for accidental activation: schema bootstrap, store writers, fork planner/activation readers, CLI selector, serve construction, and SQLite remain untouched.
- Migration completeness: design complete and executable in the disposable conformance schema; production migration remains intentionally incomplete under #2051.

## Validation

- `go test ./internal/runtime/conformance -run '^TestTemporalFrontierDesignRecord' -count=1`
- `go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/conformance -run '^TestTemporalFrontierPostgresDesignConformance$' -count=1`
- `go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/conformance -count=1`
- `go test ./internal/testtiming -run '^TestCommittedPolicyModelAndProjectionConsumersAreCanonical$' -count=1`
- `go run ./cmd/swarm-test-postgres -- go test ./...` ran from a clean generated-fixture state. The only failure was the tracked #2017 `TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer` manifestation; every other reported package passed.
- `go run ./cmd/swarm-test-postgres -- go test ./... -skip '^TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer$'`
