### PR TITLE
[agent-b][issue #2049] Stabilize fixed-event fork worksets

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -1811,7 +1811,7 @@ func runForkRuntimeOwnerHarness(ctx context.Context, repo string, args []string,
 	platformSpecPath := fs.String("platform-spec", defaultPlatformSpecPath, "Path to platform spec yaml")
 	storeMode := fs.String("store", storebackend.ActiveDefaultBackend().String(), runtimeStoreBackendHelp)
 	runID := fs.String("run", "", "Source run ID to plan from")
-	at := fs.String("at", "", "Fork point event UUID or RFC3339 timestamp")
+	at := fs.String("at", "", "Fork point event UUID")
 	dryRun := fs.Bool("dry-run", false, "Plan the fork without mutating runtime state")
 	materializeOnly := fs.Bool("materialize-only", false, "Create fork run and materialize state snapshot without resuming execution")
 	activate := fs.Bool("activate", false, "Activate an already materialized state-only fork")

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	runtimerunforkexecution "github.com/division-sh/swarm/internal/runtime/runforkexecution"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
@@ -3949,6 +3950,7 @@ func TestRunServeRuntimeDBLoadedRunForkSupportedSurfaceExecutesAndStampsPersiste
 		BundleHash:         projection.BundleHash,
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
+		StoreModeSet:       true,
 		APIListenAddr:      "127.0.0.1:0",
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
@@ -4127,6 +4129,12 @@ func TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer(t *testing.T) 
 		t.Fatalf("wait for join source quiescence before fork frontier: %v", err)
 	}
 	forkEventID := seedServedJoinForkFrontier(t, db, initial.RunID, entityID, arrival.EventID)
+	if _, err := (&store.PostgresStore{DB: db}).PlanRunFork(context.Background(), store.RunForkPlanRequest{
+		SourceRunID: initial.RunID,
+		At:          forkEventID,
+	}); err != nil {
+		t.Fatalf("plan served join fork frontier: %v", err)
+	}
 
 	var fork apiv1.RunForkExecutionResult
 	requireServedJSONRPCResult(t, endpoint, "run.fork", map[string]any{
@@ -4240,6 +4248,7 @@ func TestRunServeRuntimeDBLoadedRunForkCrossBundleTargetExecutesAndStampsTargetI
 		BundleHashes:       []string{targetProjection.BundleHash},
 		PlatformSpecPath:   defaultPlatformSpecPath,
 		StoreMode:          "postgres",
+		StoreModeSet:       true,
 		APIListenAddr:      "127.0.0.1:0",
 		MCPListenAddr:      "127.0.0.1:0",
 		SelfCheck:          true,
@@ -7576,8 +7585,13 @@ func servedJoinEntityID(t *testing.T, db *sql.DB, runID string) string {
 
 func seedServedJoinForkFrontier(t *testing.T, db *sql.DB, runID, entityID, sourceEventID string) string {
 	t.Helper()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin served join fork frontier: %v", err)
+	}
+	defer tx.Rollback()
 	var flowInstance string
-	if err := db.QueryRowContext(context.Background(), `
+	if err := tx.QueryRowContext(context.Background(), `
 		SELECT COALESCE(flow_instance, '')
 		FROM entity_state
 		WHERE run_id = $1::uuid
@@ -7588,10 +7602,10 @@ func seedServedJoinForkFrontier(t *testing.T, db *sql.DB, runID, entityID, sourc
 	eventID := uuid.NewString()
 	deliveryID := uuid.NewString()
 	var createdAt time.Time
-	if err := db.QueryRowContext(context.Background(), `SELECT clock_timestamp()`).Scan(&createdAt); err != nil {
+	if err := tx.QueryRowContext(context.Background(), `SELECT clock_timestamp()`).Scan(&createdAt); err != nil {
 		t.Fatalf("load served join fork frontier timestamp: %v", err)
 	}
-	if _, err := db.ExecContext(context.Background(), `
+	if _, err := tx.ExecContext(context.Background(), `
 		INSERT INTO events (
 			event_id, run_id, event_name, entity_id, flow_instance, scope, source_event_id,
 			payload, produced_by, produced_by_type, created_at
@@ -7603,7 +7617,7 @@ func seedServedJoinForkFrontier(t *testing.T, db *sql.DB, runID, entityID, sourc
 	`, eventID, runID, entityID, flowInstance, sourceEventID, createdAt); err != nil {
 		t.Fatalf("seed served join fork event: %v", err)
 	}
-	if _, err := db.ExecContext(context.Background(), `
+	if _, err := tx.ExecContext(context.Background(), `
 		INSERT INTO event_deliveries (
 			delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, reason_code, created_at
 		)
@@ -7611,11 +7625,22 @@ func seedServedJoinForkFrontier(t *testing.T, db *sql.DB, runID, entityID, sourc
 	`, deliveryID, runID, eventID, createdAt); err != nil {
 		t.Fatalf("seed served join fork delivery: %v", err)
 	}
-	if _, err := db.ExecContext(context.Background(), `
+	if _, err := tx.ExecContext(context.Background(), `
 		INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects)
 		VALUES ($1::uuid, 'platform', 'pipeline', 'success', 'pipeline_persisted', '{}'::jsonb)
 	`, eventID); err != nil {
 		t.Fatalf("seed served join fork pipeline receipt: %v", err)
+	}
+	if _, err := runforkrevision.Capture(
+		context.Background(), tx, runID,
+		runforkrevision.FamilyEvents,
+		runforkrevision.FamilyEventDeliveries,
+		runforkrevision.FamilyEventReceipts,
+	); err != nil {
+		t.Fatalf("capture served join fork frontier revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit served join fork frontier: %v", err)
 	}
 	return eventID
 }
@@ -10662,6 +10687,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunUsesCanonicalPlannerJSON(t *testing.T)
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
 		"--store", "postgres",
@@ -10726,6 +10752,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunJSONReportsDeliveryEventReplayReady(t 
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed pending delivery: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(ctx, t.TempDir(), []string{
@@ -10779,6 +10806,7 @@ func TestRunForkRuntimeOwnerHarness_DryRunContractsAddsContractFrontierAdmission
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed pending node delivery: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 
 	repo := repoRoot()
 	var buf bytes.Buffer
@@ -11098,6 +11126,7 @@ func TestRunForkRuntimeOwnerHarness_SelectedContractsExecuteReportsSourceAdvance
 	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
 		t.Fatalf("seed post-fork source event: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, sourceRunID, runforkrevision.FamilyEvents)
 
 	var buf bytes.Buffer
 	code := runForkRuntimeOwnerHarness(context.Background(), repo, []string{
@@ -11148,7 +11177,7 @@ func TestRunForkRuntimeOwnerHarness_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.cli.materialize', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli.materialize', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, runID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -11176,6 +11205,7 @@ func TestRunForkRuntimeOwnerHarness_MaterializeOnlyUsesCanonicalStoreOwnerJSON(t
 	`, runID, entityID, at); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 	repo := repoRoot()
 	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
 	var buf bytes.Buffer
@@ -11380,7 +11410,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingConsumesRuntimeAdmiss
 	}
 }
 
-func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSelectedRecipientPlan(t *testing.T) {
+func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingRejectsDeliveryReplayWithoutPersistedRouteRecovery(t *testing.T) {
 	dsn, db, _ := testutil.StartPostgres(t)
 	setPostgresEnvFromDSN(t, dsn)
 	runID := uuid.NewString()
@@ -11388,7 +11418,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSe
 	eventID := uuid.NewString()
 	at := time.Unix(1700000340, 0).UTC()
 	ctx := context.Background()
-	seedRunForkCLIActivationSource(t, db, runID, entityID, eventID, at)
+	seedRunForkCLIActivationSourceWithoutRevision(t, db, runID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, created_at
@@ -11397,6 +11427,7 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSe
 	`, runID, eventID, at); err != nil {
 		t.Fatalf("seed safe pending delivery: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 	repo := repoRoot()
 	contractsRoot := filepath.Join(repo, "tests", "tier11-flow-composition", "test-sibling-both-instantiated-isolated")
 
@@ -11427,8 +11458,8 @@ func TestRunForkRuntimeOwnerHarness_ActivateSelectedBindingBlocksReplayWithoutSe
 	if activateCode != 1 {
 		t.Fatalf("activate code=%d, want 1; output=%s", activateCode, activateOut.String())
 	}
-	if !strings.Contains(activateOut.String(), "no selected recipients") {
-		t.Fatalf("activate output = %q, want selected recipient-plan blocker", activateOut.String())
+	if !strings.Contains(activateOut.String(), "requires persisted route recovery before delivery replay") {
+		t.Fatalf("activate output = %q, want persisted route-recovery blocker", activateOut.String())
 	}
 	var sourceStatus, forkStatus string
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, runID).Scan(&sourceStatus); err != nil {
@@ -11469,9 +11500,13 @@ func TestRunForkRuntimeOwnerHarness_NonDryRunWithoutMaterializeOnlyStaysFailClos
 	}
 }
 
-func seedRunForkCLIActivationSource(t *testing.T, db interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, runID, entityID, eventID string, at time.Time) {
+func seedRunForkCLIActivationSource(t *testing.T, db *sql.DB, runID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	seedRunForkCLIActivationSourceWithoutRevision(t, db, runID, entityID, eventID, at)
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
+}
+
+func seedRunForkCLIActivationSourceWithoutRevision(t *testing.T, db *sql.DB, runID, entityID, eventID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -11484,7 +11519,7 @@ func seedRunForkCLIActivationSource(t *testing.T, db interface {
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.cli.activate', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+		VALUES ($1::uuid, $2::uuid, 'fork.cli.activate', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, runID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -11514,16 +11549,12 @@ func seedRunForkCLIActivationSource(t *testing.T, db interface {
 	}
 }
 
-func seedRunForkCLISelectedExecutionSource(t *testing.T, db interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, runID, entityID, eventID string, at time.Time) {
+func seedRunForkCLISelectedExecutionSource(t *testing.T, db *sql.DB, runID, entityID, eventID string, at time.Time) {
 	t.Helper()
 	seedRunForkSelectedExecutionSourceEvent(t, db, runID, entityID, eventID, "item.received", "test-node", "pending", "CLI Selected Execution Entity", "cli-selected-execution-test", at)
 }
 
-func seedRunForkSelectedExecutionSourceEvent(t *testing.T, db interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, runID, entityID, eventID, eventName, subscriberID, currentState, entityName, writerID string, at time.Time) {
+func seedRunForkSelectedExecutionSourceEvent(t *testing.T, db *sql.DB, runID, entityID, eventID, eventName, subscriberID, currentState, entityName, writerID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -11572,11 +11603,10 @@ func seedRunForkSelectedExecutionSourceEvent(t *testing.T, db interface {
 	`, runID, entityID, at, entityName, currentState); err != nil {
 		t.Fatalf("seed entity_state: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.AllFamilies()...)
 }
 
-func seedRunForkCLISelectedExecutionDiagnosticPlatformDeadLetter(t *testing.T, db interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, runID, eventID string, at time.Time) {
+func seedRunForkCLISelectedExecutionDiagnosticPlatformDeadLetter(t *testing.T, db *sql.DB, runID, eventID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -11602,6 +11632,24 @@ func seedRunForkCLISelectedExecutionDiagnosticPlatformDeadLetter(t *testing.T, d
 	`, eventID, at); err != nil {
 		t.Fatalf("seed diagnostic platform receipt: %v", err)
 	}
+	captureRunForkCLIRevision(t, db, runID, runforkrevision.FamilyEvents, runforkrevision.FamilyEventReceipts)
+}
+
+func captureRunForkCLIRevision(t *testing.T, db *sql.DB, runID string, families ...runforkrevision.Family) int64 {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin run-fork revision fixture: %v", err)
+	}
+	revision, err := runforkrevision.Capture(context.Background(), tx, runID, families...)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("capture run-fork revision fixture: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit run-fork revision fixture: %v", err)
+	}
+	return revision
 }
 
 func runForkPlanHasBlocker(blockers []store.RunForkUnsupportedBlocker, code string) bool {

--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -192,6 +192,12 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "system node runner delivery receipt/settlement writes are explicit pipeline unit-of-work primitives",
 		},
+		"internal/runtime/pipeline/run_fork_revision_context.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          2049,
+			SpecRef:        "platform-spec.yaml#run_model.fork.fixed_event_revision_and_workset",
+			Reason:         "pipeline transactions collect changed fork-reader families and publish them only at the existing unit-of-work commit boundary",
+		},
 		"internal/runtime/pipeline/runtime_interfaces.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,
@@ -211,6 +217,12 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Classification: rawSQLOptionalProductBoundary,
 			SpecRef:        "platform-spec.yaml#engine.runtime_core_persistence_store_contracts.optional_public_mutating_backend_support.run_fork",
 			Reason:         "selected-contract fork-local runtime container uses the Postgres store DB for optional run.fork logging/pipeline support and remains a spec-classified optional product split",
+		},
+		"internal/runtime/runforkrevision/revision.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          2049,
+			SpecRef:        "platform-spec.yaml#run_model.fork.fixed_event_revision_and_workset",
+			Reason:         "the bounded eleven-family revision registry is the canonical fixed-event persistence owner and runs inside existing PostgreSQL transactions",
 		},
 		"internal/runtime/pipeline/runtime_support.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,

--- a/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
+++ b/internal/runtime/cataloge2e/tier12_runtime_fork_e2e_test.go
@@ -46,7 +46,7 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 	_ = h.rt.Bus.Subscribe("test-agent", events.EventType("task.ready"))
 	h.seedInitialState(runtimepipeline.FlowInstanceEntityID(catalogRuntimeRunID))
 	pauseCatalogRun(t, h)
-	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], 10*time.Second)
+	sourceEventID := publishCatalogTrigger(t, h, expected.triggerSequence()[0], 10*time.Second)
 	sourceRunID := catalogRuntimeRunID
 	assertSourcePendingAgentDelivery(t, h.db, sourceRunID, sourceEventID, "test-agent")
 	forkAt := sourceEventID
@@ -54,11 +54,7 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 	sourceRowsBefore := selectedContractSourceRowSnapshot(t, h.db, sourceRunID, sourceEventID)
 
 	loader, selection := selectedContractForkFixtureSelection(t, h.ctx, repoRoot, fixtureRoot)
-	materialized, err := h.pg.MaterializeRunForkForSelectedContractExecution(h.ctx, store.RunForkSelectedContractExecutionMaterializeRequest{
-		SourceRunID:       sourceRunID,
-		At:                forkAt,
-		ContractSelection: selection,
-	})
+	materialized, err := materializeSelectedContractForkCleanupProbe(t, h.ctx, h.pg, loader, selection, sourceRunID, forkAt)
 	if err != nil {
 		t.Fatalf("MaterializeRunForkForSelectedContractExecution cleanup probe: %v", err)
 	}
@@ -128,7 +124,11 @@ func TestTier12RuntimeFork_SelectedContractForkExecutionFixture(t *testing.T) {
 	assertSelectedContractForkSourceIsolation(t, h.db, sourceRunID, forkRunID, sourceEventID, forkEventID)
 	assertRunCountsUnchanged(t, sourceBefore, selectedContractSourceRunCounts(t, h.db, sourceRunID), "source run after selected execution")
 	assertSourceRowsFrozen(t, sourceRowsBefore, selectedContractSourceRowSnapshot(t, h.db, sourceRunID, sourceEventID), "source rows after selected execution")
-	assertSourceRunLifecycle(t, h.db, sourceRunID, "forked", true)
+	if result.Activation.SourceFrozen || !result.Activation.SourceAdvancedAfterFork || result.Activation.BranchDivergence == nil ||
+		!containsTier12String(result.Activation.BranchDivergence.SourceAdvancedFacts, "source_events_advanced_after_fork_point") {
+		t.Fatalf("selected-contract source-advanced branch activation = %#v", result.Activation)
+	}
+	assertSourceRunLifecycle(t, h.db, sourceRunID, "paused", false)
 	negativeFixtureRoot := filepath.Join(repoRoot, "tests", "tier12-runtime-fork", "test-non-agent-replay-fail-closed")
 	assertUnsupportedHistoricalReplayFailsClosed(t, negativeFixtureRoot)
 }
@@ -171,6 +171,77 @@ func selectedContractForkFixtureSelection(t testing.TB, ctx context.Context, rep
 		t.Fatalf("LoadRunForkSelectedContractSource: %v", err)
 	}
 	return loader, runforkadmission.SelectedContractSelection(loaded.Source, fixtureRoot)
+}
+
+func materializeSelectedContractForkCleanupProbe(
+	t testing.TB,
+	ctx context.Context,
+	pg *store.PostgresStore,
+	loader runtimerunforkexecution.SelectedContractSourceLoader,
+	selection store.RunForkContractSelection,
+	sourceRunID,
+	forkAt string,
+) (store.RunForkMaterialization, error) {
+	t.Helper()
+	loaded, err := loader.LoadRunForkSelectedContractSource(ctx, selection)
+	if err != nil {
+		t.Fatalf("load cleanup-probe selected source: %v", err)
+	}
+	if loaded.Cleanup != nil {
+		defer func() {
+			if err := loaded.Cleanup(); err != nil {
+				t.Errorf("cleanup cleanup-probe selected source: %v", err)
+			}
+		}()
+	}
+	selection = loaded.Selection
+	plan, err := pg.PlanRunFork(ctx, store.RunForkPlanRequest{SourceRunID: sourceRunID, At: forkAt})
+	if err != nil {
+		t.Fatalf("plan cleanup-probe fork: %v", err)
+	}
+	frontier, err := runforkadmission.AdmitContractFrontier(runforkadmission.ContractFrontierRequest{
+		Plan:              plan,
+		Source:            loaded.Source,
+		ContractSelection: selection,
+	})
+	if err != nil {
+		t.Fatalf("admit cleanup-probe frontier: %v", err)
+	}
+	routeAdmission, err := runforkadmission.AdmitSelectedContractRouteHistory(runforkadmission.SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            loaded.Source,
+		ContractSelection: selection,
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("admit cleanup-probe route history: %v", err)
+	}
+	topology, err := runtimerunforkexecution.BuildSelectedContractRouteTopology(runtimerunforkexecution.SelectedContractRouteTopologyRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("build cleanup-probe route topology: %v", err)
+	}
+	model, err := runtimerunforkexecution.BuildSelectedContractExecutionModel(runtimerunforkexecution.SelectedContractExecutionModelRequest{
+		Admission:      frontier,
+		RouteAdmission: routeAdmission,
+		RouteTopology:  topology,
+	})
+	if err != nil {
+		t.Fatalf("build cleanup-probe execution model: %v", err)
+	}
+	if model.RecipientPlanning == nil {
+		t.Fatal("cleanup-probe execution model has no recipient planning")
+	}
+	return pg.MaterializeRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID:       sourceRunID,
+		At:                forkAt,
+		ContractSelection: selection,
+		FrontierAdmission: frontier,
+		RouteTopology:     topology,
+		RecipientPlanning: *model.RecipientPlanning,
+	})
 }
 
 func assertSourcePendingAgentDelivery(t testing.TB, db *sql.DB, runID, eventID, agentID string) {
@@ -401,7 +472,7 @@ func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot stri
 	h := newRuntimeHarness(t, fixtureRoot, true)
 	pauseCatalogRun(t, h)
 	h.seedEntityFields(expected)
-	sourceEventID := publishCatalogTriggerAtFuture(t, h, expected.triggerSequence()[0], catalogRuntimePublishTimeout)
+	sourceEventID := publishCatalogTrigger(t, h, expected.triggerSequence()[0], catalogRuntimePublishTimeout)
 	plan, err := h.pg.PlanRunFork(h.ctx, store.RunForkPlanRequest{
 		SourceRunID: catalogRuntimeRunID,
 		At:          sourceEventID,
@@ -425,7 +496,7 @@ func assertUnsupportedHistoricalReplayFailsClosed(t *testing.T, fixtureRoot stri
 	}
 }
 
-func publishCatalogTriggerAtFuture(t testing.TB, h *runtimeHarness, step catalogTriggerStep, timeout time.Duration) string {
+func publishCatalogTrigger(t testing.TB, h *runtimeHarness, step catalogTriggerStep, timeout time.Duration) string {
 	t.Helper()
 	payload := cloneStringAnyMap(step.Payload)
 	raw, err := json.Marshal(payload)
@@ -433,19 +504,27 @@ func publishCatalogTriggerAtFuture(t testing.TB, h *runtimeHarness, step catalog
 		t.Fatalf("marshal trigger payload: %v", err)
 	}
 	eventID := uuid.NewString()
-	future := timeout + time.Second
-	if future <= time.Second {
-		future = time.Second
-	}
 	eventEnvelope := events.EventEnvelope{}
-	if entityID := triggerPayloadEntityID(payload); entityID != "" {
-		eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, entityID)
-	} else {
-		eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, runtimepipeline.FlowInstanceEntityID(catalogRuntimeRunID))
+	entityID := triggerPayloadEntityID(payload)
+	if entityID == "" {
+		entityID = runtimepipeline.FlowInstanceEntityID(catalogRuntimeRunID)
+	}
+	eventEnvelope = events.EnvelopeForEntityID(eventEnvelope, entityID)
+	var flowInstance string
+	err = h.db.QueryRowContext(h.ctx, `
+		SELECT COALESCE(flow_instance, '')
+		FROM entity_state
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, catalogRuntimeRunID, entityID).Scan(&flowInstance)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatalf("load catalog trigger flow instance: %v", err)
+	}
+	if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
+		eventEnvelope = events.EnvelopeForFlowInstance(eventEnvelope, flowInstance)
 	}
 	evt := eventtest.RootIngress(eventID,
 		events.EventType(strings.TrimSpace(step.Event)),
-		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", eventEnvelope, time.Now().UTC().Add(future))
+		"cataloge2e", "", raw, 0, catalogRuntimeRunID, "", eventEnvelope, time.Now().UTC())
 	ctx, cancel := context.WithTimeout(h.ctx, timeout)
 	defer cancel()
 	if err := h.publishBusEvent(ctx, evt); err != nil {

--- a/internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml
+++ b/internal/runtime/conformance/testdata/fork_replay_resume_design_record.yaml
@@ -92,7 +92,7 @@ rows:
     blocker_codes: [delivery_history_unproven]
     enforcement_point: internal/store/run_fork_replay_resume_admission.go
     proof_refs:
-      - {kind: go_test, name: TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage}
+      - {kind: go_test, name: TestRunForkActivation_FailsClosedForDeliveryAdvancementAndMissingLineage}
       - {kind: go_test, name: TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers}
     rationale: "In-progress delivery state is not append-only replay truth and cannot be resumed from current rows."
 
@@ -125,7 +125,7 @@ rows:
     proof_refs:
       - {kind: go_test, name: TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker}
       - {kind: go_test, name: TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersAsLineage}
-    rationale: "Committed same-run replay markers are proof lineage, not timestamp-fork executable work."
+    rationale: "Committed same-run replay markers are proof lineage, not fixed-event fork executable work."
 
   - id: timer_history
     fact: timer_history
@@ -195,7 +195,7 @@ rows:
     enforcement_point: internal/store/run_fork_selected_contract_execution_mutation.go
     proof_refs:
       - {kind: go_test, name: TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint}
-      - {kind: go_test, name: TestPostTSourceTimerFailsClosedForSelectedContractActivation}
+      - {kind: go_test, name: TestPostTSourceTimerActivatesAsSelectedBranchDivergence}
       - {kind: go_test, name: TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation}
     rationale: "Post-T source advancement is branch-divergence lineage only where a selected owner admits it; otherwise it blocks."
 

--- a/internal/runtime/deadletters/record.go
+++ b/internal/runtime/deadletters/record.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 )
 
@@ -33,17 +34,35 @@ func Insert(ctx context.Context, db *sql.DB, rec Record) error {
 	if db == nil {
 		return fmt.Errorf("dead letter db is required")
 	}
-	return insert(ctx, db, rec)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin dead letter transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	changed, err := insert(ctx, tx, rec)
+	if err != nil {
+		return err
+	}
+	if changed {
+		if _, err := runforkrevision.CaptureForEvent(ctx, tx, rec.OriginalEventID, runforkrevision.FamilyDeadLetters); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit dead letter transaction: %w", err)
+	}
+	return nil
 }
 
 func InsertTx(ctx context.Context, tx *sql.Tx, rec Record) error {
 	if tx == nil {
 		return fmt.Errorf("dead letter tx is required")
 	}
-	return insert(ctx, tx, rec)
+	_, err := insert(ctx, tx, rec)
+	return err
 }
 
-func insert(ctx context.Context, db execer, rec Record) error {
+func insert(ctx context.Context, db execer, rec Record) (bool, error) {
 	rec.OriginalEventID = strings.TrimSpace(rec.OriginalEventID)
 	rec.OriginalEvent = strings.TrimSpace(rec.OriginalEvent)
 	rec.EntityID = strings.TrimSpace(rec.EntityID)
@@ -51,7 +70,7 @@ func insert(ctx context.Context, db execer, rec Record) error {
 	rec.HandlerNode = strings.TrimSpace(rec.HandlerNode)
 	rec.Timestamp = strings.TrimSpace(rec.Timestamp)
 	if rec.OriginalEventID == "" {
-		return fmt.Errorf("dead letter original event id is required")
+		return false, fmt.Errorf("dead letter original event id is required")
 	}
 	if rec.EntityID != "" {
 		if _, err := uuid.Parse(rec.EntityID); err != nil {
@@ -60,7 +79,7 @@ func insert(ctx context.Context, db execer, rec Record) error {
 	}
 	failureJSON, err := runtimefailures.MarshalEnvelope(rec.Failure)
 	if err != nil {
-		return fmt.Errorf("dead letter failure is invalid: %w", err)
+		return false, fmt.Errorf("dead letter failure is invalid: %w", err)
 	}
 	if len(rec.OriginalPayload) == 0 {
 		rec.OriginalPayload = json.RawMessage(`{}`)
@@ -114,11 +133,11 @@ func insert(ctx context.Context, db execer, rec Record) error {
 		rec.Timestamp,
 	)
 	if err != nil {
-		return fmt.Errorf("insert dead letter: %w", err)
+		return false, fmt.Errorf("insert dead letter: %w", err)
 	}
 	rows, err := result.RowsAffected()
-	if err == nil && rows >= 0 {
-		return nil
+	if err != nil {
+		return false, fmt.Errorf("read inserted dead letter rows: %w", err)
 	}
-	return nil
+	return rows > 0, nil
 }

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -21,6 +21,9 @@ type CleanupPolicy struct {
 
 func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 	return []CleanupCatalogEntry{
+		{Table: "run_fork_fact_revisions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_fact_revisions.run_id", DeleteOrderGroup: 1},
+		{Table: "run_fork_revisions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_revisions.run_id", DeleteOrderGroup: 2},
+		{Table: "run_fork_revision_heads", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_revision_heads.run_id", DeleteOrderGroup: 3},
 		{Table: "event_receipts", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByEventJoin, PredicateOwner: "events.run_id", DeleteOrderGroup: 1},
 		{Table: "dead_letters", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByEventJoin, PredicateOwner: "dead_letters.original_event_id -> events.run_id", DeleteOrderGroup: 1},
 		{Table: "run_fork_delivery_event_replays", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunLineage, PredicateOwner: "fork_run_id|source_run_id|source_event_id|fork_event_id -> events.run_id|source_delivery_id|fork_delivery_id -> event_deliveries/events.run_id", DeleteOrderGroup: 2},

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -55,6 +55,10 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	if db == nil {
 		return ErrInvalidMutationLogWriter("mutation log DB is required")
 	}
+	tx, ok := db.(*sql.Tx)
+	if !ok {
+		return ErrInvalidMutationLogWriter("PostgreSQL mutation log writes require the existing persistence transaction")
+	}
 	entityID := strings.TrimSpace(rec.EntityID)
 	field := strings.TrimSpace(rec.Field)
 	writerType := strings.TrimSpace(rec.WriterType)
@@ -96,7 +100,7 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 		}
 	}
 
-	_, err = db.ExecContext(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
 			run_id, entity_id, field, old_value, new_value,
 			caused_by_event, writer_type, writer_id, handler_step
@@ -106,7 +110,10 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 			NULLIF($6, '')::uuid, $7, $8, NULLIF($9, '')
 		)
 	`, runID, entityID, field, oldValue, newValue, causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep))
-	return err
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func BuildEntityStateDiffRecords(entityID string, before, after EntityStateProjection, writer Writer) ([]Record, error) {

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -97,7 +98,7 @@ func TestInsertStampsBundleSourceFactOnEnsuredRunRow(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
 
-	if err := Insert(ctx, db, Record{
+	if err := insertMutationLogRecord(t, ctx, db, Record{
 		EntityID:   uuid.NewString(),
 		Field:      "status",
 		OldValue:   nil,
@@ -136,7 +137,7 @@ func TestInsertRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
 	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
 	ctx = runtimecorrelation.WithBundleSourceFact(ctx, sourceFact)
 
-	err := Insert(ctx, db, Record{
+	err := insertMutationLogRecord(t, ctx, db, Record{
 		EntityID:   uuid.NewString(),
 		Field:      "status",
 		OldValue:   nil,
@@ -153,6 +154,22 @@ func TestInsertRejectsDeletedPersistedBundleSourceFact(t *testing.T) {
 	if count := countMutationRowsForRun(t, db, runID); count != 0 {
 		t.Fatalf("entity_mutations rows for %s = %d, want 0", runID, count)
 	}
+}
+
+func insertMutationLogRecord(t *testing.T, ctx context.Context, db *sql.DB, record Record) error {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin mutation log transaction: %v", err)
+	}
+	defer tx.Rollback()
+	if err := Insert(ctx, tx, record); err != nil {
+		return err
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func seedMutationLogBundleRow(t *testing.T, db *sql.DB, bundleHash string) {

--- a/internal/runtime/pipeline/activity_journal_test.go
+++ b/internal/runtime/pipeline/activity_journal_test.go
@@ -83,6 +83,15 @@ func TestActivityAttemptJournalSQLiteAndPostgres(t *testing.T) {
 			if inserted || terminalAgain.Status != ActivityAttemptStatusSucceeded {
 				t.Fatalf("terminal duplicate = (%v, %q), want existing succeeded", inserted, terminalAgain.Status)
 			}
+			if !sqlite {
+				var revisions int
+				if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_revisions WHERE run_id = $1::uuid`, runID).Scan(&revisions); err != nil {
+					t.Fatalf("count activity-only run fork revisions: %v", err)
+				}
+				if revisions != 0 {
+					t.Fatalf("activity-only run fork revisions = %d, want 0 for post-frontier selected-execution evidence", revisions)
+				}
+			}
 		})
 	}
 }

--- a/internal/runtime/pipeline/coordinator_recovery_test.go
+++ b/internal/runtime/pipeline/coordinator_recovery_test.go
@@ -15,6 +15,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/runforkexecution"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -140,7 +141,7 @@ func seedHistoricalReplayRecoverySourceRun(t *testing.T, db *sql.DB, sourceRunID
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+		VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, NULL, 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, sourceRunID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed source event: %v", err)
 	}
@@ -300,6 +301,17 @@ func TestRecoveryManager_ReplaysHistoricalForkDeliveryEventReplayRows(t *testing
 		RETURNING delivery_id::text
 	`, sourceRunID, sourceEventID, at).Scan(&sourceDeliveryID); err != nil {
 		t.Fatalf("seed source pending delivery: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin historical replay source revision: %v", err)
+	}
+	if _, err := runforkrevision.Capture(ctx, tx, sourceRunID, runforkrevision.AllFamilies()...); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("capture historical replay source revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit historical replay source revision: %v", err)
 	}
 
 	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -15,6 +15,7 @@ import (
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 )
 
@@ -692,7 +693,7 @@ func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db 
 	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx, tx, nodeID, eventID, sideEffects); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit system node processed receipt tx: %w", err)
 	}
 	committed = true
@@ -728,7 +729,7 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx context.Con
 	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx, tx, nodeID, eventID, target, sideEffects); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit targeted system node processed receipt tx: %w", err)
 	}
 	committed = true
@@ -885,7 +886,7 @@ func markPostgresSystemNodeDeliveryInProgress(ctx context.Context, db *sql.DB, n
 	if err := markPostgresSystemNodeDeliveryInProgressTx(ctx, tx, nodeID, eventID, retryLimit); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit system node delivery start tx: %w", err)
 	}
 	committed = true
@@ -922,7 +923,7 @@ func markPostgresSystemNodeDeliveryInProgressForTarget(ctx context.Context, db *
 	if err := markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit targeted system node delivery start tx: %w", err)
 	}
 	committed = true
@@ -1035,7 +1036,7 @@ func markPostgresSystemNodeDeliveryFailed(ctx context.Context, db *sql.DB, nodeI
 	if err := markPostgresSystemNodeDeliveryFailedTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit system node delivery failure tx: %w", err)
 	}
 	committed = true
@@ -1072,7 +1073,7 @@ func markPostgresSystemNodeDeliveryFailedForTarget(ctx context.Context, db *sql.
 	if err := markPostgresSystemNodeDeliveryFailedForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit targeted system node delivery failure tx: %w", err)
 	}
 	committed = true
@@ -1190,7 +1191,7 @@ func markPostgresSystemNodeDeliveryDeadLetter(ctx context.Context, db *sql.DB, n
 	if err := markPostgresSystemNodeDeliveryDeadLetterTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit system node delivery dead-letter tx: %w", err)
 	}
 	committed = true
@@ -1226,11 +1227,18 @@ func markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, db *
 	if err := markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit targeted system node delivery dead-letter tx: %w", err)
 	}
 	committed = true
 	return nil
+}
+
+func commitSystemNodeRevisionTx(ctx context.Context, tx *sql.Tx) error {
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func markPostgresSystemNodeDeliveryDeadLetterTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, reasonCode string, failure *runtimefailures.Envelope, retryCount int, sideEffects string) error {

--- a/internal/runtime/pipeline/run_fork_revision_context.go
+++ b/internal/runtime/pipeline/run_fork_revision_context.go
@@ -1,0 +1,78 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+)
+
+type pipelineRunForkRevisionChangesKey struct{}
+
+type pipelineRunForkRevisionChanges struct {
+	byRun map[string]map[runforkrevision.Family]struct{}
+}
+
+func withPipelineRunForkRevisionChanges(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(pipelineRunForkRevisionChangesKey{}).(*pipelineRunForkRevisionChanges); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, pipelineRunForkRevisionChangesKey{}, &pipelineRunForkRevisionChanges{
+		byRun: map[string]map[runforkrevision.Family]struct{}{},
+	})
+}
+
+func declarePipelineRunForkRevisionChange(ctx context.Context, runID string, families ...runforkrevision.Family) error {
+	changes, ok := ctx.Value(pipelineRunForkRevisionChangesKey{}).(*pipelineRunForkRevisionChanges)
+	if !ok || changes == nil {
+		return fmt.Errorf("pipeline transaction is missing its run fork revision owner")
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return fmt.Errorf("pipeline run fork revision change requires run_id")
+	}
+	if changes.byRun[runID] == nil {
+		changes.byRun[runID] = map[runforkrevision.Family]struct{}{}
+	}
+	for _, family := range families {
+		if !runforkrevision.ValidFamily(family) {
+			return fmt.Errorf("pipeline run fork revision change has unsupported family %q", family)
+		}
+		changes.byRun[runID][family] = struct{}{}
+	}
+	return nil
+}
+
+// CapturePipelineRunForkRevisionChanges publishes every bounded fact changed
+// by the current transaction, including explicitly declared deletion-sensitive
+// projections that PostgreSQL row writer stamps cannot discover.
+func CapturePipelineRunForkRevisionChanges(ctx context.Context, tx *sql.Tx) error {
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		return err
+	}
+	changes, ok := ctx.Value(pipelineRunForkRevisionChangesKey{}).(*pipelineRunForkRevisionChanges)
+	if !ok || changes == nil || len(changes.byRun) == 0 {
+		return nil
+	}
+	runIDs := make([]string, 0, len(changes.byRun))
+	for runID := range changes.byRun {
+		runIDs = append(runIDs, runID)
+	}
+	sort.Strings(runIDs)
+	declared := make([]runforkrevision.Change, 0, len(runIDs))
+	for _, runID := range runIDs {
+		families := make([]runforkrevision.Family, 0, len(changes.byRun[runID]))
+		for family := range changes.byRun[runID] {
+			families = append(families, family)
+		}
+		declared = append(declared, runforkrevision.Change{RunID: runID, Families: families})
+	}
+	_, err := runforkrevision.CaptureChanges(ctx, tx, declared...)
+	return err
+}

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -381,7 +381,7 @@ func withSQLTxContext(ctx context.Context, tx *sql.Tx) context.Context {
 }
 
 func WithPipelineSQLTxContext(ctx context.Context, tx *sql.Tx) context.Context {
-	return withSQLTxContext(ctx, tx)
+	return withPipelineRunForkRevisionChanges(withSQLTxContext(ctx, tx))
 }
 
 func WithPipelineSQLConnContext(ctx context.Context, conn *sql.Conn) context.Context {

--- a/internal/runtime/pipeline/workflow_entity_type_repair.go
+++ b/internal/runtime/pipeline/workflow_entity_type_repair.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store/runbundle"
 )
@@ -115,6 +116,13 @@ func (pc *PipelineCoordinator) RepairContractEntityTypes(ctx context.Context) (i
 		if affected, err := res.RowsAffected(); err == nil {
 			repaired += int(affected)
 		}
+	}
+	changes := make([]runforkrevision.Change, 0, len(repairs))
+	for _, repair := range repairs {
+		changes = append(changes, runforkrevision.Change{RunID: repair.RunID, Families: []runforkrevision.Family{runforkrevision.FamilyEntityMetadata}})
+	}
+	if _, err := runforkrevision.CaptureChanges(ctx, tx, changes...); err != nil {
+		return 0, err
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("commit contract entity type repair: %w", err)

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimemutationlog "github.com/division-sh/swarm/internal/runtime/mutationlog"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -394,7 +395,7 @@ func (s *WorkflowInstanceStore) MutateE(ctx context.Context, instanceID string, 
 			}
 		}()
 	}
-	ctx = withSQLTxContext(ctx, tx)
+	ctx = WithPipelineSQLTxContext(ctx, tx)
 	if err := lockWorkflowInstanceMutation(ctx, tx, instanceID); err != nil {
 		return err
 	}
@@ -412,6 +413,13 @@ func (s *WorkflowInstanceStore) MutateE(ctx context.Context, instanceID string, 
 		return err
 	}
 	if ownedTx {
+		runID, err := runtimecurrentstate.RequireRunID(ctx)
+		if err != nil {
+			return err
+		}
+		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
+			return err
+		}
 		if err := tx.Commit(); err != nil {
 			return err
 		}
@@ -771,10 +779,15 @@ func (s *WorkflowInstanceStore) runInPipelineTransactionOnce(ctx context.Context
 	postCommit := make([]func(), 0, 4)
 	rollbackActions := make([]func(), 0, 4)
 	txctx := WithPipelineSQLConnContext(ctx, conn)
-	txctx = withSQLTxContext(txctx, tx)
+	txctx = WithPipelineSQLTxContext(txctx, tx)
 	txctx = withPipelinePostCommitActions(txctx, &postCommit)
 	txctx = withPipelineRollbackActions(txctx, &rollbackActions)
 	if err := fn(txctx, tx); err != nil {
+		_ = tx.Rollback()
+		flushPipelineRollbackActions(rollbackActions)
+		return err
+	}
+	if err := CapturePipelineRunForkRevisionChanges(txctx, tx); err != nil {
 		_ = tx.Rollback()
 		flushPipelineRollbackActions(rollbackActions)
 		return err
@@ -1237,6 +1250,11 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	}); err != nil {
 		return err
 	}
+	if !ownedTx {
+		if err := declarePipelineRunForkRevisionChange(ctx, runID, runforkrevision.FamilyTimers); err != nil {
+			return err
+		}
+	}
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM timers
 		WHERE run_id = $1::uuid
@@ -1275,6 +1293,9 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 		}
 	}
 	if ownedTx {
+		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
+			return err
+		}
 		if err := tx.Commit(); err != nil {
 			return err
 		}
@@ -1408,6 +1429,9 @@ func (s *WorkflowInstanceStore) createSpec(ctx context.Context, rowID, storageRe
 		}
 	}
 	if ownedTx {
+		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
+			return err
+		}
 		if err := tx.Commit(); err != nil {
 			return err
 		}
@@ -1452,6 +1476,14 @@ func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, er
 		return nil, false, err
 	}
 	return tx, true, nil
+}
+
+func captureWorkflowInstanceRevision(ctx context.Context, tx *sql.Tx, runID string) error {
+	if err := CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+		return err
+	}
+	_, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyTimers)
+	return err
 }
 
 func lockWorkflowInstanceMutation(ctx context.Context, tx *sql.Tx, instanceID string) error {

--- a/internal/runtime/pipeline/workflow_transitions.go
+++ b/internal/runtime/pipeline/workflow_transitions.go
@@ -11,6 +11,7 @@ import (
 
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 )
 
@@ -198,7 +199,15 @@ func recordPipelineTransitionReceipt(ctx context.Context, db *sql.DB, eventID, h
 		}
 		failureJSON = string(raw)
 	}
-	_, err = db.ExecContext(ctx, `
+	tx, borrowed := PipelineSQLTxFromContext(ctx)
+	if !borrowed || tx == nil {
+		tx, err = db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin pipeline transition receipt: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+	}
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, state_before, state_after, side_effects, failure, duration_ms, processed_at
@@ -218,5 +227,17 @@ func recordPipelineTransitionReceipt(ctx context.Context, db *sql.DB, eventID, h
 			duration_ms = EXCLUDED.duration_ms,
 			processed_at = now()
 	`, eventID, "pipeline:"+pipelineID, outcome, reasonCode, string(before), string(after), string(sideEffects), failureJSON, durationMS)
-	return err
+	if err != nil {
+		return err
+	}
+	if borrowed {
+		return nil
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit pipeline transition receipt: %w", err)
+	}
+	return nil
 }

--- a/internal/runtime/pipeline/workflow_transitions_test.go
+++ b/internal/runtime/pipeline/workflow_transitions_test.go
@@ -24,9 +24,13 @@ func TestRecordPipelineTransition_PersistsViaCanonicalCapabilityOwner(t *testing
 	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM events WHERE event_id = \$1::uuid\)`).
 		WithArgs(eventID).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO event_receipts").
 		WithArgs(eventID, "pipeline:"+pipelineID, "success", "pipeline_transition_applied", "", "", sqlmock.AnyArg(), nil, 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("FROM information_schema.columns").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name"}))
+	mock.ExpectCommit()
 
 	pg := &store.PostgresStore{DB: db}
 	err = runtimepipeline.RecordPipelineTransition(context.Background(), db, pg.CanonicalEventReceiptsCapability, runtimepipeline.PipelineTransitionInput{

--- a/internal/runtime/runforkexecution/activation_gate.go
+++ b/internal/runtime/runforkexecution/activation_gate.go
@@ -138,18 +138,26 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 	}
 	if ok {
 		routeRecovery = &recoveredRoute
+		if err := validateContractSwapRouteRecovery(admission, recoveredRoute); err != nil {
+			return SelectedContractActivationGateResult{}, err
+		}
+		replayAdmission = store.RunForkReplayResumeAdmissionWithSelectedRouteResolution(replayAdmission)
+		plan.ReplayResumeAdmission = replayAdmission
+		plan.UnsupportedBlockers = replayAdmission.UnsupportedBlockers
+		plan.UnsupportedBlockerCount = len(replayAdmission.UnsupportedBlockers)
+		plan.ExecutionReady = replayAdmission.StateOnlyExecutionReady || replayAdmission.DeliveryEventReplayReady
 	}
 	pgStore, _ := req.Store.(*store.PostgresStore)
 	contractSwapAdmission, err := BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
 		SelectedExecutionAdmission: admission,
-		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+		ReplayResumeAdmission:      replayAdmission,
 		RouteRecovery:              routeRecovery,
 	})
 	if err != nil {
 		return SelectedContractActivationGateResult{}, err
 	}
 	historicalReplayAdmission, err := BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
-		ReplayResumeAdmission:      plan.ReplayResumeAdmission,
+		ReplayResumeAdmission:      replayAdmission,
 		SelectedExecutionAdmission: admission,
 		ContractSwapAdmission:      contractSwapAdmission,
 		RouteRecovery:              routeRecovery,
@@ -163,45 +171,15 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		ContractSwapBootResumeAdmission:    &contractSwapAdmission,
 		HistoricalReplayExecutionAdmission: &historicalReplayAdmission,
 	}
+	if replayAdmission.DeliveryEventReplayReady && routeRecovery == nil {
+		return result, fmt.Errorf("selected-contract activation gate requires persisted route recovery before delivery replay")
+	}
 	if !plan.ExecutionReady {
 		return result, fmt.Errorf("selected-contract activation gate requires execution-ready plan before mutation; blockers: %s", selectedContractBlockerCodes(plan.UnsupportedBlockers))
 	}
 	if plan.ReplayResumeAdmission.DeliveryEventReplayReady {
 		if pgStore == nil {
 			return result, fmt.Errorf("%s requires postgres store", store.RunForkHistoricalReplayContractSwapBootResumeOwner)
-		}
-		if routeRecovery == nil {
-			record, err := pgStore.RecordRunForkSelectedContractRouteRecovery(ctx, store.RunForkSelectedContractRouteRecoveryRequest{
-				ForkRunID:         forkRunID,
-				SourceRunID:       binding.SourceRunID,
-				ForkEventID:       binding.ForkEventID,
-				ContractSelection: binding.ContractSelection,
-				RouteTopology:     routeTopology,
-				RecipientPlanning: *model.RecipientPlanning,
-			})
-			if err != nil {
-				return result, fmt.Errorf("record selected-contract route recovery for contract-swap execution: %w", err)
-			}
-			routeRecovery = &record
-			contractSwapAdmission, err = BuildContractSwapBootResumeAdmission(ContractSwapBootResumeAdmissionRequest{
-				SelectedExecutionAdmission: admission,
-				ReplayResumeAdmission:      plan.ReplayResumeAdmission,
-				RouteRecovery:              routeRecovery,
-			})
-			if err != nil {
-				return result, err
-			}
-			historicalReplayAdmission, err = BuildHistoricalReplayExecutionAdmission(HistoricalReplayExecutionAdmissionRequest{
-				ReplayResumeAdmission:      plan.ReplayResumeAdmission,
-				SelectedExecutionAdmission: admission,
-				ContractSwapAdmission:      contractSwapAdmission,
-				RouteRecovery:              routeRecovery,
-			})
-			if err != nil {
-				return result, err
-			}
-			result.ContractSwapBootResumeAdmission = &contractSwapAdmission
-			result.HistoricalReplayExecutionAdmission = &historicalReplayAdmission
 		}
 		historicalReplayExecution, err := BuildHistoricalReplayExecution(HistoricalReplayExecutionRequest{
 			Admission:             historicalReplayAdmission,
@@ -231,7 +209,6 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 			SourceRunID:       binding.SourceRunID,
 			ForkRunID:         forkRunID,
 			ForkEventID:       plan.ForkPoint.EventID,
-			ForkTime:          plan.ForkPoint.Timestamp,
 			SourceEvents:      sourceEventIDs,
 			ExecutionOwner:    store.RunForkHistoricalReplayContractSwapBootResumeOwner,
 		})
@@ -260,6 +237,9 @@ func ActivateSelectedContractRunFork(ctx context.Context, req SelectedContractAc
 		activation, err := pgStore.ActivateRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionActivateRequest{
 			ForkRunID:             forkRunID,
 			AllowedSourceEventIDs: sourceEventIDs,
+			FrontierAdmission:     frontier,
+			RouteTopology:         routeTopology,
+			RecipientPlanning:     *model.RecipientPlanning,
 		})
 		result.RunForkActivation = activation
 		if err != nil {

--- a/internal/runtime/runforkexecution/activation_gate_test.go
+++ b/internal/runtime/runforkexecution/activation_gate_test.go
@@ -115,8 +115,33 @@ func TestActivateSelectedContractRunForkRequiresConcreteStoreForReplayMutation(t
 		DeliveryEventReplayReady: true,
 		ReplayResumeFactsPresent: true,
 		BoundedReplaySupported:   true,
+		Dispositions: []store.RunForkReplayResumeDisposition{{
+			Fact:           store.RunForkReplayResumeFactDeliveryPendingHistory,
+			Disposition:    store.RunForkReplayResumeDispositionForkReplay,
+			Classification: store.RunForkPendingClassificationPending,
+			EventID:        plan.PendingWork[0].EventID,
+			DeliveryID:     plan.PendingWork[0].DeliveryID,
+			SubscriberType: plan.PendingWork[0].SubscriberType,
+			SubscriberID:   plan.PendingWork[0].SubscriberID,
+			Message:        "test pending source delivery is replayable fork-local work",
+		}},
 	}
-	fakeStore := &fakeSelectedContractActivationStore{binding: binding, bindingOK: true, plan: plan}
+	fakeStore := &fakeSelectedContractActivationStore{
+		binding:   binding,
+		bindingOK: true,
+		plan:      plan,
+		routeRecovery: store.RunForkSelectedContractRouteRecovery{
+			Owner:                  store.RunForkSelectedContractRoutePersistenceOwner,
+			RuntimeRecoveryOwner:   store.RunForkSelectedContractRouteRecoveryOwner,
+			ForkRunID:              binding.ForkRunID,
+			SourceRunID:            binding.SourceRunID,
+			ForkEventID:            binding.ForkEventID,
+			ContractSelection:      binding.ContractSelection,
+			RouteTopologyOwner:     store.RunForkSelectedContractRouteTopologyOwner,
+			RecipientPlanningOwner: store.RunForkSelectedContractRecipientPlanningOwner,
+		},
+		routeOK: true,
+	}
 	loader := &fakeSelectedContractSourceLoader{loaded: testLoadedSelectedSource(binding.ContractSelection)}
 
 	result, err := ActivateSelectedContractRunFork(context.Background(), SelectedContractActivationGateRequest{

--- a/internal/runtime/runforkexecution/activity_fork_execution_test.go
+++ b/internal/runtime/runforkexecution/activity_fork_execution_test.go
@@ -107,6 +107,7 @@ func TestExecuteSelectedContractRunForkExecutesOrReusesLoopActivityThroughRuntim
 				SourceEventID: initiatingEventID, SourceRunID: sourceRunID, Attempt: 1,
 				Generation: sourceGeneration, LoopStage: "review",
 			})
+			captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 			if tt.sourceAttemptStatus != "" {
 				seedSelectedContractActivityAttempt(t, db, sourceFact, sourceGeneration, tt.sourceAttemptStatus, tt.resultEventType, tt.failureClass, tt.failureCode, at)
 			}

--- a/internal/runtime/runforkexecution/contract_swap_admission.go
+++ b/internal/runtime/runforkexecution/contract_swap_admission.go
@@ -232,9 +232,9 @@ func contractSwapBootResumeInvalidPaths() []store.RunForkSelectedContractExecuti
 			Reason:      "current routing_rules and flow-instance route rows are not selected-fork route truth",
 		},
 		{
-			Concept:     "same_run_outbox_replay_as_timestamp_fork_resume",
+			Concept:     "same_run_outbox_replay_as_fixed_event_fork_resume",
 			Disposition: store.RunForkSelectedContractDispositionInvalid,
-			Reason:      "same-run replay proof does not define timestamp-fork contract-swap boot/resume semantics",
+			Reason:      "same-run replay proof does not define fixed-event fork contract-swap boot/resume semantics",
 		},
 	}
 }

--- a/internal/runtime/runforkexecution/execution.go
+++ b/internal/runtime/runforkexecution/execution.go
@@ -142,6 +142,9 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		ContractSelection: selection,
 		BundleHash:        materializationBundleHash,
 		BundleSource:      materializationBundleSource,
+		FrontierAdmission: frontier,
+		RouteTopology:     routeTopology,
+		RecipientPlanning: *model.RecipientPlanning,
 	})
 	if err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
@@ -160,21 +163,6 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	if err != nil {
 		return SelectedContractExecutionResult{Owner: store.RunForkSelectedContractExecutionOwner, Materialization: materialization}, err
 	}
-	if _, err := req.Store.RecordRunForkSelectedContractRouteRecovery(ctx, store.RunForkSelectedContractRouteRecoveryRequest{
-		ForkRunID:         materialization.ForkRunID,
-		SourceRunID:       plan.SourceRunID,
-		ForkEventID:       plan.ForkPoint.EventID,
-		ContractSelection: selection,
-		RouteTopology:     routeTopology,
-		RecipientPlanning: *model.RecipientPlanning,
-	}); err != nil {
-		return SelectedContractExecutionResult{
-			Owner:                              store.RunForkSelectedContractExecutionOwner,
-			Materialization:                    materialization,
-			SelectedContractExecutionAdmission: &admission,
-			AgentRuntimeMaterialization:        &agentRuntime.Proof,
-		}, cleanupSelectedContractExecutionFailure(ctx, req.Store, materialization.ForkRunID, err)
-	}
 	container, err := buildSelectedContractForkLocalRuntimeContainer(ctx, publishSelectedContractForkEventsRequest{
 		Store:             req.Store,
 		Admission:         admission,
@@ -184,7 +172,6 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 		SourceRunID:       plan.SourceRunID,
 		ForkRunID:         materialization.ForkRunID,
 		ForkEventID:       plan.ForkPoint.EventID,
-		ForkTime:          plan.ForkPoint.Timestamp,
 		SourceEvents:      sourceEventIDs,
 		ExecutionOwner:    store.RunForkSelectedContractExecutionOwner,
 	})
@@ -223,6 +210,9 @@ func ExecuteSelectedContractRunFork(ctx context.Context, req SelectedContractExe
 	activation, err := req.Store.ActivateRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID:             materialization.ForkRunID,
 		AllowedSourceEventIDs: sourceEventIDs,
+		FrontierAdmission:     frontier,
+		RouteTopology:         routeTopology,
+		RecipientPlanning:     *model.RecipientPlanning,
 	})
 	if err != nil {
 		if closeErr := container.Close(ctx); closeErr != nil {
@@ -295,7 +285,6 @@ type publishSelectedContractForkEventsRequest struct {
 	SourceRunID       string
 	ForkRunID         string
 	ForkEventID       string
-	ForkTime          time.Time
 	SourceEvents      []string
 	ExecutionOwner    string
 }

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -30,6 +30,7 @@ import (
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimemcp "github.com/division-sh/swarm/internal/runtime/mcp"
 	"github.com/division-sh/swarm/internal/runtime/runforkadmission"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/store"
@@ -68,6 +69,7 @@ func TestExecuteSelectedContractRunForkWritesForkLocalExecutionAndLineage(t *tes
 		t.Fatalf("stamp source-only delivery identity: %v", err)
 	}
 	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -279,6 +281,7 @@ func TestExecuteSelectedContractRunForkLoadsDBBackedSourceAndStampsPersistedIden
 	`, sourceRunID, projection.BundleHash, storerunlifecycle.BundleSourcePersisted); err != nil {
 		t.Fatalf("stamp source run bundle identity: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -343,6 +346,7 @@ func TestExecuteSelectedContractRunForkFailsClosedBeforeMaterializationForAgentR
 	sourceEventID := uuid.NewString()
 	at := time.Unix(1700002201, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "task.assigned", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -392,6 +396,7 @@ func TestExecuteSelectedContractRunForkMaterializesAndExecutesForkLocalAgentRunt
 	at := time.Unix(1700002202, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "task.assigned", at)
 	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	agent := &selectedContractForkTestAgent{}
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
@@ -594,6 +599,7 @@ func TestExecuteSelectedContractRunForkProviderCompletionRecordsDurableAuthority
 	at := time.Unix(1700002203, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "task.assigned", at)
 	seedSourceOutcomeThatMustNotSuppressFork(t, db, sourceEventID, entityID, at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
 		At:           sourceEventID,
@@ -739,7 +745,6 @@ func TestSelectedContractServedAndStandaloneContainersCompeteForOnePostgresAutho
 		SourceRunID:       sourceRunID,
 		ForkRunID:         forkRunID,
 		ForkEventID:       forkEventID,
-		ForkTime:          now,
 		SourceEvents:      []string{forkEventID},
 		ExecutionOwner:    store.RunForkSelectedContractExecutionOwner,
 	}
@@ -1021,6 +1026,7 @@ func TestExecuteSelectedContractRunForkTreatsDiagnosticPlatformOutcomeAsLineage(
 	at := time.Unix(1700002215, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
 	seedSelectedExecutionDiagnosticPlatformDeadLetter(t, db, sourceRunID, diagnosticEventID, at.Add(-time.Second))
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1126,15 +1132,9 @@ func TestActivateSelectedContractRunForkExecutesReplayReadyContractSwapThroughSe
 	`, sourceRunID, sourceEventID); err != nil {
 		t.Fatalf("seed replayable source agent delivery: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
-	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
-		SourceRunID:       sourceRunID,
-		At:                sourceEventID,
-		ContractSelection: &selection,
-	})
-	if err != nil {
-		t.Fatalf("MaterializeRunFork: %v", err)
-	}
+	materialized := materializeSelectedExecutionForkForTest(t, ctx, pg, loaded.Source, selection, sourceRunID, sourceEventID)
 
 	result, err := ActivateSelectedContractRunFork(ctx, SelectedContractActivationGateRequest{
 		ForkRunID:    materialized.ForkRunID,
@@ -1254,17 +1254,12 @@ func TestActivateSelectedContractRunForkFailsBeforePublishForPostTReplayScopeMar
 	`, sourceRunID, sourceEventID); err != nil {
 		t.Fatalf("seed replayable source agent delivery: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
-	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{
-		SourceRunID:       sourceRunID,
-		At:                sourceEventID,
-		ContractSelection: &selection,
-	})
-	if err != nil {
-		t.Fatalf("MaterializeRunFork: %v", err)
-	}
+	materialized := materializeSelectedExecutionForkForTest(t, ctx, pg, loaded.Source, selection, sourceRunID, sourceEventID)
 	seedSelectedExecutionPostForkSourceEvent(t, db, sourceRunID, afterEventID, entityID, at.Add(time.Second))
 	seedSelectedExecutionSourceReplayScopeMarker(t, db, sourceRunID, afterEventID, "replay_scope_direct", at.Add(time.Second))
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEventDeliveries)
 
 	result, err := ActivateSelectedContractRunFork(ctx, SelectedContractActivationGateRequest{
 		ForkRunID:    materialized.ForkRunID,
@@ -1341,6 +1336,7 @@ func TestExecuteSelectedContractRunForkTreatsSourceConversationHistoryAsLineage(
 	`, turnID, sourceRunID, sessionID, entityID, sourceEventID, at); err != nil {
 		t.Fatalf("seed source turn: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1472,6 +1468,7 @@ func TestExecuteSelectedContractRunForkAdmitsSameSourceActiveDeliveryForkPointEm
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1567,6 +1564,7 @@ func TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBra
 	`, at); err != nil {
 		t.Fatalf("seed source session agent: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO agent_sessions (
 			session_id, run_id, agent_id, entity_id, flow_instance, scope_key, scope,
@@ -1597,6 +1595,11 @@ func TestExecuteSelectedContractRunForkTreatsPostTSourceConversationHistoryAsBra
 	`, turnID, sourceRunID, sessionID, entityID, sourceEventID, after); err != nil {
 		t.Fatalf("seed post-T source turn: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID,
+		runforkrevision.FamilyAgentSessions,
+		runforkrevision.FamilyAgentConversationAudits,
+		runforkrevision.FamilyAgentTurns,
+	)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1682,6 +1685,7 @@ func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t 
 	at := time.Unix(1700002315, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
 	seedSelectedExecutionSourceReplayScopeMarker(t, db, sourceRunID, sourceEventID, "replay_scope_subscribed", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1735,7 +1739,7 @@ func TestExecuteSelectedContractRunForkTreatsSourceReplayScopeMarkerAsLineage(t 
 	}
 }
 
-func TestExecuteSelectedContractRunForkTreatsSameEventReplayScopeMarkerWriteSkewAsLineage(t *testing.T) {
+func TestExecuteSelectedContractRunForkRejectsSameEventReplayScopeMarkerWriteSkew(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &store.PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1756,6 +1760,7 @@ func TestExecuteSelectedContractRunForkTreatsSameEventReplayScopeMarkerWriteSkew
 	sourceEventID := uuid.NewString()
 	at := time.Unix(1700002320, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 	if _, err := db.ExecContext(ctx, `
 		CREATE OR REPLACE FUNCTION seed_post_t_replay_scope_marker_after_route_recovery()
 		RETURNS trigger AS $$
@@ -1789,16 +1794,13 @@ func TestExecuteSelectedContractRunForkTreatsSameEventReplayScopeMarkerWriteSkew
 			contractsRoot,
 		),
 	})
-	if err != nil {
-		t.Fatalf("ExecuteSelectedContractRunFork: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("ExecuteSelectedContractRunFork error = %v, want committed replay-scope advancement rejection", err)
 	}
-	if !result.Activation.Activated || result.Activation.SourceAdvancedAfterFork || result.Activation.BranchDivergence != nil {
-		t.Fatalf("activation = %#v, want marker write-skew to avoid source advancement", result.Activation)
+	if result.Activation.Activated {
+		t.Fatalf("activation = %#v, want rejection before activation", result.Activation)
 	}
-	if result.ExecutedEventCount == 0 || len(result.ForkEvents) == 0 {
-		t.Fatalf("result = %#v, want selected fork events published", result)
-	}
-	assertNoCopiedSourceReplayScopeMarkers(t, db, result.Materialization.ForkRunID, sourceEventID)
+	assertSelectedContractExecutionCleanup(t, db, sourceRunID, result.Materialization.ForkRunID)
 }
 
 func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterialization(t *testing.T) {
@@ -1822,6 +1824,7 @@ func TestExecuteSelectedContractRunForkRejectsUnresolvedFrontierBeforeMaterializ
 	sourceEventID := uuid.NewString()
 	at := time.Unix(1700002325, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "ghost.event", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1885,6 +1888,7 @@ func TestExecuteSelectedContractRunForkCleansUpBeforeActivationOnPublishFailure(
 	sourceEventID := uuid.NewString()
 	at := time.Unix(1700002335, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -1932,6 +1936,7 @@ func TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint(
 	afterDeliveryID := uuid.NewString()
 	at := time.Unix(1700002350, 0).UTC()
 	seedSelectedExecutionSourceRun(t, db, sourceRunID, entityID, sourceEventID, "item.received", at)
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
@@ -1956,6 +1961,12 @@ func TestExecuteSelectedContractRunForkBranchesWhenSourceAdvancedAfterForkPoint(
 	`, sourceRunID, at.Add(3*time.Second)); err != nil {
 		t.Fatalf("mark source complete after fork point: %v", err)
 	}
+	captureSelectedExecutionSourceRevision(t, db, sourceRunID,
+		runforkrevision.FamilyEvents,
+		runforkrevision.FamilyEventDeliveries,
+		runforkrevision.FamilyEventReceipts,
+		runforkrevision.FamilyDeadLetters,
+	)
 
 	result, err := ExecuteSelectedContractRunFork(ctx, SelectedContractExecutionRequest{
 		SourceRunID:  sourceRunID,
@@ -2429,6 +2440,74 @@ func runForkExecutionRepoRoot(t *testing.T) string {
 		t.Fatalf("repo root: %v", err)
 	}
 	return root
+}
+
+func captureSelectedExecutionSourceRevision(t *testing.T, db *sql.DB, runID string, families ...runforkrevision.Family) int64 {
+	t.Helper()
+	if len(families) == 0 {
+		families = runforkrevision.AllFamilies()
+	}
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin selected execution source revision: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	revision, err := runforkrevision.Capture(context.Background(), tx, runID, families...)
+	if err != nil {
+		t.Fatalf("capture selected execution source revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit selected execution source revision: %v", err)
+	}
+	return revision
+}
+
+func materializeSelectedExecutionForkForTest(
+	t *testing.T,
+	ctx context.Context,
+	pg *store.PostgresStore,
+	source semanticview.Source,
+	selection store.RunForkContractSelection,
+	sourceRunID string,
+	sourceEventID string,
+) store.RunForkMaterialization {
+	t.Helper()
+	plan, err := pg.PlanRunFork(ctx, store.RunForkPlanRequest{SourceRunID: sourceRunID, At: sourceEventID})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	frontier, err := runforkadmission.AdmitContractFrontier(runforkadmission.ContractFrontierRequest{
+		Plan: plan, Source: source, ContractSelection: selection,
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	routeAdmission, err := runforkadmission.AdmitSelectedContractRouteHistory(runforkadmission.SelectedContractRouteHistoryRequest{
+		Plan: plan, Source: source, ContractSelection: selection, FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	topology, err := BuildSelectedContractRouteTopology(SelectedContractRouteTopologyRequest{
+		Admission: frontier, RouteAdmission: routeAdmission,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractRouteTopology: %v", err)
+	}
+	model, err := BuildSelectedContractExecutionModel(SelectedContractExecutionModelRequest{
+		Admission: frontier, RouteAdmission: routeAdmission, RouteTopology: topology,
+	})
+	if err != nil {
+		t.Fatalf("BuildSelectedContractExecutionModel: %v", err)
+	}
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, store.RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID, At: sourceEventID, ContractSelection: selection,
+		FrontierAdmission: frontier, RouteTopology: topology, RecipientPlanning: *model.RecipientPlanning,
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	return materialized
 }
 
 func seedSelectedExecutionSourceRun(t *testing.T, db *sql.DB, sourceRunID, entityID, sourceEventID, eventName string, at time.Time) {

--- a/internal/runtime/runforkexecution/historical_replay_admission.go
+++ b/internal/runtime/runforkexecution/historical_replay_admission.go
@@ -322,7 +322,7 @@ func historicalReplayEventDeliveriesAdmission(replay store.RunForkReplayResumeAd
 			Admission:   store.RunForkHistoricalReplayAdmissionLineageOnlyEvidence,
 			SourceOwner: store.RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner,
 			Tracker:     "#663",
-			Message:     "at/before-T source committed replay-scope marker rows are lineage/no-action evidence only for selected-contract timestamp forks; fork-local recovery proof must be written under the fork run_id",
+			Message:     "source committed replay-scope marker rows present at the selected revision are lineage/no-action evidence only for selected-contract forks; fork-local recovery proof must be written under the fork run_id",
 		}
 	}
 	if disposition, ok := replayDispositionForFact(replay, store.RunForkReplayResumeFactDeliveryInProgressHistory, store.RunForkReplayResumeDispositionLineageOnly); ok &&

--- a/internal/runtime/runforkexecution/model.go
+++ b/internal/runtime/runforkexecution/model.go
@@ -55,6 +55,10 @@ func canonicalSelectedContractRouteTopology(frontier store.RunForkContractFronti
 		})
 	}
 	for _, blocker := range routeAdmission.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == store.RunForkBlockerFlowRouteHistoryUnproven &&
+			routeAdmission.SourceRouteFactsPresent && dynamicSupported {
+			continue
+		}
 		blockers = appendRunForkUnsupportedBlocker(blockers, blocker)
 	}
 
@@ -620,7 +624,7 @@ func selectedContractExecutionInvalidPaths() []store.RunForkSelectedContractExec
 		{
 			Concept:     "same_run_outbox_replay_as_fork_replay",
 			Disposition: store.RunForkSelectedContractDispositionInvalid,
-			Reason:      "same-run recovery does not define timestamp-fork selected-contract replay ownership",
+			Reason:      "same-run recovery does not define fixed-event fork selected-contract replay ownership",
 		},
 		{
 			Concept:     "source_outcome_suppression",

--- a/internal/runtime/runforkexecution/runtime_container.go
+++ b/internal/runtime/runforkexecution/runtime_container.go
@@ -77,9 +77,6 @@ func buildSelectedContractForkLocalRuntimeContainer(ctx context.Context, req pub
 	if err != nil {
 		return selectedContractForkLocalRuntimeContainer{}, err
 	}
-	if req.ForkTime.IsZero() {
-		return selectedContractForkLocalRuntimeContainer{}, fmt.Errorf("%s requires fork point timestamp", store.RunForkSelectedContractForkLocalRuntimeContainerOwner)
-	}
 	if strings.TrimSpace(req.RecipientPlanning.Owner) != store.RunForkSelectedContractRecipientPlanningOwner {
 		return selectedContractForkLocalRuntimeContainer{}, fmt.Errorf("%s requires %s; got %q",
 			store.RunForkSelectedContractForkLocalRuntimeContainerOwner,
@@ -178,7 +175,7 @@ func (c selectedContractForkLocalRuntimeContainer) Proof() SelectedContractForkL
 
 func (c selectedContractForkLocalRuntimeContainer) Publish(ctx context.Context) ([]SelectedContractExecutionForkEvent, error) {
 	req := c.req
-	if err := req.Store.EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, req.SourceRunID, req.ForkEventID, req.ForkTime); err != nil {
+	if err := req.Store.EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, req.SourceRunID, req.ForkEventID); err != nil {
 		return nil, err
 	}
 	sourceEvents, err := req.Store.LoadRunForkSelectedContractSourceEvents(ctx, req.SourceRunID, req.ForkRunID, req.SourceEvents)

--- a/internal/runtime/runforkrevision/revision.go
+++ b/internal/runtime/runforkrevision/revision.go
@@ -114,19 +114,38 @@ func CaptureChanges(ctx context.Context, tx *sql.Tx, changes ...Change) (map[str
 		if len(families) == 0 {
 			return nil, fmt.Errorf("run fork revision capture requires at least one fact family")
 		}
+		changedFamilies := make([]Family, 0, len(families))
+		for _, family := range families {
+			changed, err := canonicalProjectionDiffersFromLatest(ctx, tx, runID, family)
+			if err != nil {
+				return nil, fmt.Errorf("compare run fork %s projection: %w", family, err)
+			}
+			if changed {
+				changedFamilies = append(changedFamilies, family)
+			}
+		}
+		if len(changedFamilies) == 0 {
+			revision, ok, err := currentTransactionRevision(ctx, tx, runID)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				revision, ok, err = latestRevision(ctx, tx, runID)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if ok {
+				revisions[runID] = revision
+			}
+			continue
+		}
 		revision, err := allocate(ctx, tx, runID)
 		if err != nil {
 			return nil, err
 		}
-		for _, family := range families {
-			query := captureQuery(family)
-			if query == "" {
-				return nil, fmt.Errorf("run fork revision capture has no writer for family %q", family)
-			}
-			if _, err := tx.ExecContext(ctx, query, runID, revision); err != nil {
-				return nil, fmt.Errorf("capture run fork %s facts at revision %d: %w", family, revision, err)
-			}
-			if err := captureRemovedFacts(ctx, tx, runID, revision, family); err != nil {
+		for _, family := range changedFamilies {
+			if err := captureCanonicalProjection(ctx, tx, runID, revision, family); err != nil {
 				return nil, err
 			}
 		}
@@ -301,30 +320,49 @@ func schemaContainsRequirements(columns map[string]map[string]struct{}, required
 	return true
 }
 
-func captureRemovedFacts(ctx context.Context, tx *sql.Tx, runID string, revision int64, family Family) error {
+func captureCanonicalProjection(ctx context.Context, tx *sql.Tx, runID string, revision int64, family Family) error {
+	projection := canonicalProjectionQuery(family)
+	if projection == "" {
+		return fmt.Errorf("run fork revision capture has no projection for family %q", family)
+	}
 	if _, err := tx.ExecContext(ctx, `
-		WITH latest AS (
-			SELECT DISTINCT ON (fact_key) fact_key, present
-			FROM run_fork_fact_revisions
-			WHERE run_id = $1::uuid AND family = $3 AND revision < $2
-			ORDER BY fact_key, revision DESC
+		INSERT INTO run_fork_fact_revisions (
+			run_id, revision, family, fact_key, fact, present, source_transaction_id
 		)
-		INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, present, source_transaction_id)
-		SELECT $1::uuid, $2, $3, latest.fact_key, '{}'::jsonb, FALSE, 0
-		FROM latest
-		WHERE latest.present
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM run_fork_fact_revisions current
-			WHERE current.run_id = $1::uuid
-			  AND current.revision = $2
-			  AND current.family = $3
-			  AND current.fact_key = latest.fact_key
-			  AND current.present
-		  )
+		SELECT $1::uuid, $2, $3, current.fact_key, current.fact, TRUE, current.source_transaction_id
+		FROM (`+projection+`) current
+		ON CONFLICT (run_id, family, fact_key, revision)
+		DO UPDATE SET
+			fact = EXCLUDED.fact,
+			present = TRUE,
+			source_transaction_id = EXCLUDED.source_transaction_id
+	`, runID, revision, family); err != nil {
+		return fmt.Errorf("capture run fork %s facts at revision %d: %w", family, revision, err)
+	}
+	return captureRemovedFacts(ctx, tx, runID, revision, family, projection)
+}
+
+func captureRemovedFacts(ctx context.Context, tx *sql.Tx, runID string, revision int64, family Family, projection string) error {
+	if _, err := tx.ExecContext(ctx, `
+			WITH current_facts AS (`+projection+`),
+			latest AS (
+				SELECT DISTINCT ON (fact_key) fact_key, present
+				FROM run_fork_fact_revisions
+				WHERE run_id = $1::uuid AND family = $3 AND revision <= $2
+				ORDER BY fact_key, revision DESC
+			)
+			INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, present, source_transaction_id)
+			SELECT $1::uuid, $2, $3, latest.fact_key, '{}'::jsonb, FALSE, 0
+			FROM latest
+			WHERE latest.present
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM current_facts current
+				WHERE current.fact_key = latest.fact_key
+			  )
 		ON CONFLICT (run_id, family, fact_key, revision)
 		DO UPDATE SET fact = EXCLUDED.fact, present = FALSE, source_transaction_id = 0
-	`, runID, revision, family); err != nil {
+		`, runID, revision, family); err != nil {
 		return fmt.Errorf("capture removed run fork %s facts at revision %d: %w", family, revision, err)
 	}
 	return nil
@@ -349,8 +387,8 @@ func RunIDForEvent(ctx context.Context, tx *sql.Tx, eventID string) (string, err
 }
 
 // ValidateComplete rejects old, bypassed, or partially deleted projections.
-// PostgreSQL xmin is only a same-row writer stamp; it is never exposed as a
-// fork revision or used to order transactions.
+// PostgreSQL xmin is only used to discover candidate writes in the current
+// transaction; canonical projected fact and presence equality own semantics.
 func ValidateComplete(ctx context.Context, tx *sql.Tx, runID string) error {
 	if tx == nil {
 		return fmt.Errorf("run fork revision validation requires an existing postgres transaction")
@@ -360,34 +398,8 @@ func ValidateComplete(ctx context.Context, tx *sql.Tx, runID string) error {
 		return fmt.Errorf("run fork revision validation requires a UUID run_id: %w", err)
 	}
 	for _, family := range allFamilies {
-		current := currentIdentityQuery(family)
-		if current == "" {
-			return fmt.Errorf("run fork revision validation has no projection for family %q", family)
-		}
-		var drifted bool
-		query := `
-			WITH current_facts AS (` + current + `),
-			latest AS (
-				SELECT DISTINCT ON (fact_key) fact_key, present, source_transaction_id
-				FROM run_fork_fact_revisions
-				WHERE run_id = $1::uuid AND family = $2
-				ORDER BY fact_key, revision DESC
-			)
-			SELECT EXISTS (
-				SELECT 1
-				FROM current_facts current
-				LEFT JOIN latest USING (fact_key)
-				WHERE latest.fact_key IS NULL
-				   OR NOT latest.present
-				   OR latest.source_transaction_id <> current.source_transaction_id
-				UNION ALL
-				SELECT 1
-				FROM latest
-				LEFT JOIN current_facts current USING (fact_key)
-				WHERE latest.present AND current.fact_key IS NULL
-			)
-		`
-		if err := tx.QueryRowContext(ctx, query, runID, family).Scan(&drifted); err != nil {
+		drifted, err := canonicalProjectionDiffersFromLatest(ctx, tx, runID, family)
+		if err != nil {
 			return fmt.Errorf("validate run fork %s projection: %w", family, err)
 		}
 		if drifted {
@@ -397,20 +409,47 @@ func ValidateComplete(ctx context.Context, tx *sql.Tx, runID string) error {
 	return nil
 }
 
+func canonicalProjectionDiffersFromLatest(ctx context.Context, tx *sql.Tx, runID string, family Family) (bool, error) {
+	projection := canonicalProjectionQuery(family)
+	if projection == "" {
+		return false, fmt.Errorf("run fork revision owner has no canonical projection for family %q", family)
+	}
+	var differs bool
+	query := `
+		WITH current_facts AS (` + projection + `),
+		latest AS (
+			SELECT DISTINCT ON (fact_key) fact_key, fact, present
+			FROM run_fork_fact_revisions
+			WHERE run_id = $1::uuid AND family = $2
+			ORDER BY fact_key, revision DESC
+		)
+		SELECT EXISTS (
+			SELECT 1
+			FROM current_facts current
+			LEFT JOIN latest USING (fact_key)
+			WHERE latest.fact_key IS NULL
+			   OR NOT latest.present
+			   OR latest.fact IS DISTINCT FROM current.fact
+			UNION ALL
+			SELECT 1
+			FROM latest
+			LEFT JOIN current_facts current USING (fact_key)
+			WHERE latest.present AND current.fact_key IS NULL
+		)
+	`
+	if err := tx.QueryRowContext(ctx, query, runID, family).Scan(&differs); err != nil {
+		return false, err
+	}
+	return differs, nil
+}
+
 func allocate(ctx context.Context, tx *sql.Tx, runID string) (int64, error) {
-	var revision int64
-	err := tx.QueryRowContext(ctx, `
-		SELECT revision
-		FROM run_fork_revisions
-		WHERE run_id = $1::uuid
-		  AND transaction_id = txid_current()
-	`, runID).Scan(&revision)
-	if err == nil {
+	if revision, ok, err := currentTransactionRevision(ctx, tx, runID); err != nil {
+		return 0, err
+	} else if ok {
 		return revision, nil
 	}
-	if err != sql.ErrNoRows {
-		return 0, fmt.Errorf("read current run fork transaction revision: %w", err)
-	}
+	var revision int64
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO run_fork_revision_heads (run_id)
 		VALUES ($1::uuid)
@@ -436,6 +475,39 @@ func allocate(ctx context.Context, tx *sql.Tx, runID string) (int64, error) {
 	return revision, nil
 }
 
+func currentTransactionRevision(ctx context.Context, tx *sql.Tx, runID string) (int64, bool, error) {
+	var revision int64
+	err := tx.QueryRowContext(ctx, `
+			SELECT revision
+			FROM run_fork_revisions
+			WHERE run_id = $1::uuid
+			  AND transaction_id = txid_current()
+		`, runID).Scan(&revision)
+	if err == nil {
+		return revision, true, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, false, fmt.Errorf("read current run fork transaction revision: %w", err)
+	}
+	return 0, false, nil
+}
+
+func latestRevision(ctx context.Context, tx *sql.Tx, runID string) (int64, bool, error) {
+	var revision int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT last_revision
+		FROM run_fork_revision_heads
+		WHERE run_id = $1::uuid
+	`, runID).Scan(&revision)
+	if err == nil {
+		return revision, true, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, false, fmt.Errorf("read latest run fork revision: %w", err)
+	}
+	return 0, false, nil
+}
+
 func normalizeFamilies(families []Family) ([]Family, error) {
 	seen := make(map[Family]struct{}, len(families))
 	out := make([]Family, 0, len(families))
@@ -454,72 +526,37 @@ func normalizeFamilies(families []Family) ([]Family, error) {
 	return out, nil
 }
 
-func captureQuery(family Family) string {
+func canonicalProjectionQuery(family Family) string {
 	switch family {
 	case FamilyEvents:
-		return captureEventsSQL
+		return canonicalEventsProjectionSQL
 	case FamilyEntityMutations:
-		return captureEntityMutationsSQL
+		return canonicalEntityMutationsProjectionSQL
 	case FamilyEntityMetadata:
-		return captureEntityMetadataSQL
+		return canonicalEntityMetadataProjectionSQL
 	case FamilyEventDeliveries:
-		return captureEventDeliveriesSQL
+		return canonicalEventDeliveriesProjectionSQL
 	case FamilyEventReceipts:
-		return captureEventReceiptsSQL
+		return canonicalEventReceiptsProjectionSQL
 	case FamilyDeadLetters:
-		return captureDeadLettersSQL
+		return canonicalDeadLettersProjectionSQL
 	case FamilyTimers:
-		return captureTimersSQL
+		return canonicalTimersProjectionSQL
 	case FamilyAgentSessions:
-		return captureAgentSessionsSQL
+		return canonicalAgentSessionsProjectionSQL
 	case FamilyAgentTurns:
-		return captureAgentTurnsSQL
+		return canonicalAgentTurnsProjectionSQL
 	case FamilyAgentConversationAudits:
-		return captureAgentConversationAuditsSQL
+		return canonicalAgentConversationAuditsProjectionSQL
 	case FamilyReplyContexts:
-		return captureReplyContextsSQL
+		return canonicalReplyContextsProjectionSQL
 	default:
 		return ""
 	}
 }
 
-func currentIdentityQuery(family Family) string {
-	switch family {
-	case FamilyEvents:
-		return `SELECT event_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM events WHERE run_id = $1::uuid`
-	case FamilyEntityMutations:
-		return `SELECT mutation_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM entity_mutations WHERE run_id = $1::uuid`
-	case FamilyEntityMetadata:
-		return `SELECT entity_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM entity_state WHERE run_id = $1::uuid`
-	case FamilyEventDeliveries:
-		return `SELECT delivery_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM event_deliveries WHERE run_id = $1::uuid`
-	case FamilyEventReceipts:
-		return `SELECT r.receipt_id::text AS fact_key, r.xmin::text::bigint AS source_transaction_id FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = $1::uuid`
-	case FamilyDeadLetters:
-		return `SELECT d.dead_letter_id::text AS fact_key, d.xmin::text::bigint AS source_transaction_id FROM dead_letters d JOIN events e ON e.event_id = d.original_event_id WHERE e.run_id = $1::uuid`
-	case FamilyTimers:
-		return `SELECT timer_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM timers WHERE run_id = $1::uuid`
-	case FamilyAgentSessions:
-		return `SELECT session_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_sessions WHERE run_id = $1::uuid`
-	case FamilyAgentTurns:
-		return `SELECT turn_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_turns WHERE run_id = $1::uuid`
-	case FamilyAgentConversationAudits:
-		return `SELECT session_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_conversation_audits WHERE run_id = $1::uuid`
-	case FamilyReplyContexts:
-		return `SELECT reply_context_id AS fact_key, xmin::text::bigint AS source_transaction_id FROM reply_contexts WHERE run_id = $1::uuid`
-	default:
-		return ""
-	}
-}
-
-const captureUpsertSuffix = `
-	ON CONFLICT (run_id, family, fact_key, revision)
-	DO UPDATE SET fact = EXCLUDED.fact, present = TRUE, source_transaction_id = EXCLUDED.source_transaction_id
-`
-
-const captureEventsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT e.run_id, $2, 'events', e.event_id::text,
+const canonicalEventsProjectionSQL = `
+	SELECT e.event_id::text AS fact_key,
 	       jsonb_build_object(
 	           'event_id', e.event_id, 'event_name', e.event_name,
 	           'entity_id', e.entity_id, 'flow_instance', e.flow_instance,
@@ -528,35 +565,32 @@ const captureEventsSQL = `
 	           'chain_depth', e.chain_depth, 'produced_by', e.produced_by,
 	           'produced_by_type', e.produced_by_type, 'handler_node', e.handler_node,
 	           'idempotency_key', e.idempotency_key, 'source_event_id', e.source_event_id,
-	           'created_at', e.created_at), e.xmin::text::bigint
+	           'created_at', e.created_at) AS fact, e.xmin::text::bigint AS source_transaction_id
 	FROM events e
 	WHERE e.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureEntityMutationsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT m.run_id, $2, 'entity_mutations', m.mutation_id::text,
+const canonicalEntityMutationsProjectionSQL = `
+	SELECT m.mutation_id::text AS fact_key,
 	       jsonb_build_object(
 	           'mutation_id', m.mutation_id, 'entity_id', m.entity_id,
 	           'field', m.field, 'new_value', m.new_value,
-	           'caused_by_event', m.caused_by_event, 'created_at', m.created_at), m.xmin::text::bigint
+	           'caused_by_event', m.caused_by_event, 'created_at', m.created_at) AS fact, m.xmin::text::bigint AS source_transaction_id
 	FROM entity_mutations m
 	WHERE m.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureEntityMetadataSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT e.run_id, $2, 'entity_metadata', e.entity_id::text,
+const canonicalEntityMetadataProjectionSQL = `
+	SELECT e.entity_id::text AS fact_key,
 	       jsonb_build_object(
 	           'entity_id', e.entity_id, 'flow_instance', e.flow_instance,
-	           'entity_type', e.entity_type, 'created_at', e.created_at), e.xmin::text::bigint
+	           'entity_type', e.entity_type, 'created_at', e.created_at) AS fact, e.xmin::text::bigint AS source_transaction_id
 	FROM entity_state e
 	WHERE e.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureEventDeliveriesSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT d.run_id, $2, 'event_deliveries', d.delivery_id::text,
+const canonicalEventDeliveriesProjectionSQL = `
+	SELECT d.delivery_id::text AS fact_key,
 	       jsonb_build_object(
 	           'delivery_id', d.delivery_id, 'event_id', d.event_id,
 	           'subscriber_type', d.subscriber_type, 'subscriber_id', d.subscriber_id,
@@ -564,38 +598,35 @@ const captureEventDeliveriesSQL = `
 	           'delivery_context', d.delivery_context, 'status', d.status,
 	           'retry_count', d.retry_count, 'reason_code', d.reason_code,
 	           'active_session_id', d.active_session_id, 'started_at', d.started_at,
-	           'delivered_at', d.delivered_at, 'created_at', d.created_at), d.xmin::text::bigint
+	           'delivered_at', d.delivered_at, 'created_at', d.created_at) AS fact, d.xmin::text::bigint AS source_transaction_id
 	FROM event_deliveries d
 	WHERE d.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureEventReceiptsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT e.run_id, $2, 'event_receipts', r.receipt_id::text,
+const canonicalEventReceiptsProjectionSQL = `
+	SELECT r.receipt_id::text AS fact_key,
 	       jsonb_build_object(
 	           'receipt_id', r.receipt_id, 'event_id', r.event_id,
 	           'subscriber_type', r.subscriber_type, 'subscriber_id', r.subscriber_id,
 	           'outcome', r.outcome, 'reason_code', r.reason_code,
-	           'processed_at', r.processed_at), r.xmin::text::bigint
+	           'processed_at', r.processed_at) AS fact, r.xmin::text::bigint AS source_transaction_id
 	FROM event_receipts r
 	JOIN events e ON e.event_id = r.event_id
 	WHERE e.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureDeadLettersSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT e.run_id, $2, 'dead_letters', d.dead_letter_id::text,
+const canonicalDeadLettersProjectionSQL = `
+	SELECT d.dead_letter_id::text AS fact_key,
 	       jsonb_build_object(
 	           'dead_letter_id', d.dead_letter_id, 'original_event_id', d.original_event_id,
-	           'handler_node', d.handler_node, 'created_at', d.created_at), d.xmin::text::bigint
+	           'handler_node', d.handler_node, 'created_at', d.created_at) AS fact, d.xmin::text::bigint AS source_transaction_id
 	FROM dead_letters d
 	JOIN events e ON e.event_id = d.original_event_id
 	WHERE e.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureTimersSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT t.run_id, $2, 'timers', t.timer_id::text,
+const canonicalTimersProjectionSQL = `
+	SELECT t.timer_id::text AS fact_key,
 	       jsonb_build_object(
 	           'timer_id', t.timer_id, 'timer_name', t.timer_name,
 	           'entity_id', t.entity_id, 'flow_instance', t.flow_instance,
@@ -605,49 +636,45 @@ const captureTimersSQL = `
 	           'recurrence_interval', t.recurrence_interval,
 	           'owner_node', t.owner_node, 'owner_agent', t.owner_agent,
 	           'task_type', t.task_type, 'status', t.status,
-	           'fired_at', t.fired_at, 'created_at', t.created_at), t.xmin::text::bigint
+	           'fired_at', t.fired_at, 'created_at', t.created_at) AS fact, t.xmin::text::bigint AS source_transaction_id
 	FROM timers t
 	WHERE t.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureAgentSessionsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT s.run_id, $2, 'agent_sessions', s.session_id::text,
+const canonicalAgentSessionsProjectionSQL = `
+	SELECT s.session_id::text AS fact_key,
 	       jsonb_build_object(
 	           'session_id', s.session_id, 'status', s.status,
-	           'created_at', s.created_at, 'terminated_at', s.terminated_at), s.xmin::text::bigint
+	           'created_at', s.created_at, 'terminated_at', s.terminated_at) AS fact, s.xmin::text::bigint AS source_transaction_id
 	FROM agent_sessions s
 	WHERE s.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureAgentTurnsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT t.run_id, $2, 'agent_turns', t.turn_id::text,
+const canonicalAgentTurnsProjectionSQL = `
+	SELECT t.turn_id::text AS fact_key,
 	       jsonb_build_object(
 	           'turn_id', t.turn_id, 'session_id', t.session_id,
-	           'created_at', t.created_at), t.xmin::text::bigint
+	           'created_at', t.created_at) AS fact, t.xmin::text::bigint AS source_transaction_id
 	FROM agent_turns t
 	WHERE t.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureAgentConversationAuditsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT a.run_id, $2, 'agent_conversation_audits', a.session_id::text,
+const canonicalAgentConversationAuditsProjectionSQL = `
+	SELECT a.session_id::text AS fact_key,
 	       jsonb_build_object(
 	           'session_id', a.session_id, 'status', a.status,
-	           'created_at', a.created_at, 'updated_at', a.updated_at), a.xmin::text::bigint
+	           'created_at', a.created_at, 'updated_at', a.updated_at) AS fact, a.xmin::text::bigint AS source_transaction_id
 	FROM agent_conversation_audits a
 	WHERE a.run_id = $1::uuid
-` + captureUpsertSuffix
+`
 
-const captureReplyContextsSQL = `
-	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
-	SELECT r.run_id, $2, 'reply_contexts', r.reply_context_id,
+const canonicalReplyContextsProjectionSQL = `
+	SELECT r.reply_context_id AS fact_key,
 	       jsonb_build_object(
 	           'reply_context_id', r.reply_context_id,
 	           'request_event_id', r.request_event_id, 'state', r.state,
 	           'created_at', r.created_at, 'updated_at', r.updated_at,
-	           'terminal_at', r.terminal_at), r.xmin::text::bigint
+	           'terminal_at', r.terminal_at) AS fact, r.xmin::text::bigint AS source_transaction_id
 	FROM reply_contexts r
 	WHERE r.run_id = $1::uuid
-` + captureUpsertSuffix
+`

--- a/internal/runtime/runforkrevision/revision.go
+++ b/internal/runtime/runforkrevision/revision.go
@@ -1,0 +1,653 @@
+package runforkrevision
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Family is the closed registry of facts that may affect supported fork
+// planning at a selected event revision.
+type Family string
+
+// Change declares the complete fork-reader projection families changed for a
+// run by one persistence transaction.
+type Change struct {
+	RunID    string
+	Families []Family
+}
+
+const (
+	FamilyEvents                  Family = "events"
+	FamilyEntityMutations         Family = "entity_mutations"
+	FamilyEntityMetadata          Family = "entity_metadata"
+	FamilyEventDeliveries         Family = "event_deliveries"
+	FamilyEventReceipts           Family = "event_receipts"
+	FamilyDeadLetters             Family = "dead_letters"
+	FamilyTimers                  Family = "timers"
+	FamilyAgentSessions           Family = "agent_sessions"
+	FamilyAgentTurns              Family = "agent_turns"
+	FamilyAgentConversationAudits Family = "agent_conversation_audits"
+	FamilyReplyContexts           Family = "reply_contexts"
+)
+
+var allFamilies = []Family{
+	FamilyEvents,
+	FamilyEntityMutations,
+	FamilyEntityMetadata,
+	FamilyEventDeliveries,
+	FamilyEventReceipts,
+	FamilyDeadLetters,
+	FamilyTimers,
+	FamilyAgentSessions,
+	FamilyAgentTurns,
+	FamilyAgentConversationAudits,
+	FamilyReplyContexts,
+}
+
+func AllFamilies() []Family {
+	return append([]Family(nil), allFamilies...)
+}
+
+func ValidFamily(family Family) bool {
+	for _, candidate := range allFamilies {
+		if family == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// Capture records the current narrow projection for each changed family. It
+// must run after the corresponding writes and inside their existing SQL
+// transaction. Repeated calls in one transaction reuse the same run revision.
+func Capture(ctx context.Context, tx *sql.Tx, runID string, families ...Family) (int64, error) {
+	revisions, err := CaptureChanges(ctx, tx, Change{RunID: runID, Families: families})
+	if err != nil {
+		return 0, err
+	}
+	return revisions[strings.TrimSpace(runID)], nil
+}
+
+// CaptureForEvent derives the authoritative run through the immutable event
+// identity before recording the changed families.
+func CaptureForEvent(ctx context.Context, tx *sql.Tx, eventID string, families ...Family) (int64, error) {
+	runID, err := RunIDForEvent(ctx, tx, eventID)
+	if err != nil {
+		return 0, err
+	}
+	if runID == "" {
+		return 0, nil
+	}
+	return Capture(ctx, tx, runID, families...)
+}
+
+// CaptureChanges allocates revisions in deterministic run-ID order. This is
+// the only supported path for transactions that affect more than one run.
+func CaptureChanges(ctx context.Context, tx *sql.Tx, changes ...Change) (map[string]int64, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("run fork revision capture requires an existing postgres transaction")
+	}
+	byRun := make(map[string][]Family, len(changes))
+	for _, change := range changes {
+		runID := strings.TrimSpace(change.RunID)
+		if _, err := uuid.Parse(runID); err != nil {
+			return nil, fmt.Errorf("run fork revision capture requires a UUID run_id: %w", err)
+		}
+		byRun[runID] = append(byRun[runID], change.Families...)
+	}
+	runIDs := make([]string, 0, len(byRun))
+	for runID := range byRun {
+		runIDs = append(runIDs, runID)
+	}
+	sort.Strings(runIDs)
+	revisions := make(map[string]int64, len(runIDs))
+	for _, runID := range runIDs {
+		families, err := normalizeFamilies(byRun[runID])
+		if err != nil {
+			return nil, err
+		}
+		if len(families) == 0 {
+			return nil, fmt.Errorf("run fork revision capture requires at least one fact family")
+		}
+		revision, err := allocate(ctx, tx, runID)
+		if err != nil {
+			return nil, err
+		}
+		for _, family := range families {
+			query := captureQuery(family)
+			if query == "" {
+				return nil, fmt.Errorf("run fork revision capture has no writer for family %q", family)
+			}
+			if _, err := tx.ExecContext(ctx, query, runID, revision); err != nil {
+				return nil, fmt.Errorf("capture run fork %s facts at revision %d: %w", family, revision, err)
+			}
+			if err := captureRemovedFacts(ctx, tx, runID, revision, family); err != nil {
+				return nil, err
+			}
+		}
+		revisions[runID] = revision
+	}
+	return revisions, nil
+}
+
+// CaptureCurrentTransaction discovers the bounded fact rows changed by the
+// current PostgreSQL transaction and records their families per affected run.
+// It keeps domain writers declarative while preserving one revision for every
+// same-run fact written by the transaction.
+func CaptureCurrentTransaction(ctx context.Context, tx *sql.Tx) (map[string]int64, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("run fork revision capture requires an existing postgres transaction")
+	}
+	changeQueries, err := availableCurrentTransactionChangeQueries(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if len(changeQueries) == 0 {
+		return map[string]int64{}, nil
+	}
+	query := `
+		SELECT DISTINCT run_id, family
+		FROM (` + strings.Join(changeQueries, "\nUNION ALL\n") + `) changed
+		WHERE run_id <> ''
+		ORDER BY run_id, family
+	`
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("discover current run fork revision changes: %w", err)
+	}
+	defer rows.Close()
+	byRun := map[string][]Family{}
+	for rows.Next() {
+		var runID string
+		var family Family
+		if err := rows.Scan(&runID, &family); err != nil {
+			return nil, fmt.Errorf("scan current run fork revision change: %w", err)
+		}
+		byRun[runID] = append(byRun[runID], family)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read current run fork revision changes: %w", err)
+	}
+	changes := make([]Change, 0, len(byRun))
+	for runID, families := range byRun {
+		changes = append(changes, Change{RunID: runID, Families: families})
+	}
+	if len(changes) == 0 {
+		return map[string]int64{}, nil
+	}
+	return CaptureChanges(ctx, tx, changes...)
+}
+
+type currentTransactionFamilySchema struct {
+	required map[string][]string
+	query    string
+}
+
+var currentTransactionFamilySchemas = map[Family]currentTransactionFamilySchema{
+	FamilyEvents: {
+		required: map[string][]string{"events": {"event_id", "run_id", "event_name", "entity_id", "flow_instance", "source_route", "target_route", "target_set", "scope", "payload", "chain_depth", "produced_by", "produced_by_type", "handler_node", "idempotency_key", "source_event_id", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'events'::text AS family FROM events WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyEntityMutations: {
+		required: map[string][]string{"entity_mutations": {"mutation_id", "run_id", "entity_id", "field", "new_value", "caused_by_event", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'entity_mutations'::text AS family FROM entity_mutations WHERE xmin::text::bigint = txid_current()`,
+	},
+	FamilyEntityMetadata: {
+		required: map[string][]string{"entity_state": {"run_id", "entity_id", "flow_instance", "entity_type", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'entity_metadata'::text AS family FROM entity_state WHERE xmin::text::bigint = txid_current()`,
+	},
+	FamilyEventDeliveries: {
+		required: map[string][]string{"event_deliveries": {"delivery_id", "run_id", "event_id", "subscriber_type", "subscriber_id", "delivery_target_route", "delivery_context", "status", "retry_count", "reason_code", "active_session_id", "started_at", "delivered_at", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'event_deliveries'::text AS family FROM event_deliveries WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyEventReceipts: {
+		required: map[string][]string{
+			"event_receipts": {"receipt_id", "event_id", "subscriber_type", "subscriber_id", "outcome", "reason_code", "processed_at"},
+			"events":         {"event_id", "run_id"},
+		},
+		query: `SELECT e.run_id::text AS run_id, 'event_receipts'::text AS family FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id IS NOT NULL AND r.xmin::text::bigint = txid_current()`,
+	},
+	FamilyDeadLetters: {
+		required: map[string][]string{
+			"dead_letters": {"dead_letter_id", "original_event_id", "handler_node", "created_at"},
+			"events":       {"event_id", "run_id"},
+		},
+		query: `SELECT e.run_id::text AS run_id, 'dead_letters'::text AS family FROM dead_letters d JOIN events e ON e.event_id = d.original_event_id WHERE e.run_id IS NOT NULL AND d.xmin::text::bigint = txid_current()`,
+	},
+	FamilyTimers: {
+		required: map[string][]string{"timers": {"timer_id", "run_id", "timer_name", "entity_id", "flow_instance", "fire_event", "fire_payload", "fire_at", "recurring", "recurrence_cron", "recurrence_interval", "owner_node", "owner_agent", "task_type", "status", "fired_at", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'timers'::text AS family FROM timers WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyAgentSessions: {
+		required: map[string][]string{"agent_sessions": {"session_id", "run_id", "status", "created_at", "terminated_at"}},
+		query:    `SELECT run_id::text AS run_id, 'agent_sessions'::text AS family FROM agent_sessions WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyAgentTurns: {
+		required: map[string][]string{"agent_turns": {"turn_id", "run_id", "session_id", "created_at"}},
+		query:    `SELECT run_id::text AS run_id, 'agent_turns'::text AS family FROM agent_turns WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyAgentConversationAudits: {
+		required: map[string][]string{"agent_conversation_audits": {"session_id", "run_id", "status", "created_at", "updated_at"}},
+		query:    `SELECT run_id::text AS run_id, 'agent_conversation_audits'::text AS family FROM agent_conversation_audits WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+	FamilyReplyContexts: {
+		required: map[string][]string{"reply_contexts": {"reply_context_id", "run_id", "request_event_id", "state", "created_at", "updated_at", "terminal_at"}},
+		query:    `SELECT run_id::text AS run_id, 'reply_contexts'::text AS family FROM reply_contexts WHERE run_id IS NOT NULL AND xmin::text::bigint = txid_current()`,
+	},
+}
+
+var revisionOwnerSchema = map[string][]string{
+	"run_fork_revision_heads": {"run_id", "last_revision", "updated_at"},
+	"run_fork_revisions":      {"run_id", "revision", "transaction_id"},
+	"run_fork_fact_revisions": {"run_id", "revision", "family", "fact_key", "fact", "present", "source_transaction_id"},
+}
+
+func availableCurrentTransactionChangeQueries(ctx context.Context, tx *sql.Tx) ([]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT table_name, column_name
+		FROM information_schema.columns
+		WHERE table_schema = current_schema()
+		  AND table_name IN (
+			'events', 'entity_mutations', 'entity_state', 'event_deliveries',
+			'event_receipts', 'dead_letters', 'timers', 'agent_sessions',
+			'agent_turns', 'agent_conversation_audits', 'reply_contexts',
+			'run_fork_revision_heads', 'run_fork_revisions', 'run_fork_fact_revisions'
+		  )
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect run fork revision capture schema: %w", err)
+	}
+	defer rows.Close()
+	columns := map[string]map[string]struct{}{}
+	for rows.Next() {
+		var table, column string
+		if err := rows.Scan(&table, &column); err != nil {
+			return nil, fmt.Errorf("scan run fork revision capture schema: %w", err)
+		}
+		if columns[table] == nil {
+			columns[table] = map[string]struct{}{}
+		}
+		columns[table][column] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read run fork revision capture schema: %w", err)
+	}
+	if !schemaContainsRequirements(columns, revisionOwnerSchema) {
+		return nil, nil
+	}
+	queries := make([]string, 0, len(allFamilies))
+	for _, family := range allFamilies {
+		schema := currentTransactionFamilySchemas[family]
+		if schemaContainsRequirements(columns, schema.required) {
+			queries = append(queries, schema.query)
+		}
+	}
+	return queries, nil
+}
+
+func schemaContainsRequirements(columns map[string]map[string]struct{}, required map[string][]string) bool {
+	for table, names := range required {
+		for _, name := range names {
+			if _, ok := columns[table][name]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func captureRemovedFacts(ctx context.Context, tx *sql.Tx, runID string, revision int64, family Family) error {
+	if _, err := tx.ExecContext(ctx, `
+		WITH latest AS (
+			SELECT DISTINCT ON (fact_key) fact_key, present
+			FROM run_fork_fact_revisions
+			WHERE run_id = $1::uuid AND family = $3 AND revision < $2
+			ORDER BY fact_key, revision DESC
+		)
+		INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, present, source_transaction_id)
+		SELECT $1::uuid, $2, $3, latest.fact_key, '{}'::jsonb, FALSE, 0
+		FROM latest
+		WHERE latest.present
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM run_fork_fact_revisions current
+			WHERE current.run_id = $1::uuid
+			  AND current.revision = $2
+			  AND current.family = $3
+			  AND current.fact_key = latest.fact_key
+			  AND current.present
+		  )
+		ON CONFLICT (run_id, family, fact_key, revision)
+		DO UPDATE SET fact = EXCLUDED.fact, present = FALSE, source_transaction_id = 0
+	`, runID, revision, family); err != nil {
+		return fmt.Errorf("capture removed run fork %s facts at revision %d: %w", family, revision, err)
+	}
+	return nil
+}
+
+func RunIDForEvent(ctx context.Context, tx *sql.Tx, eventID string) (string, error) {
+	if tx == nil {
+		return "", fmt.Errorf("event run lookup requires an existing postgres transaction")
+	}
+	eventID = strings.TrimSpace(eventID)
+	if _, err := uuid.Parse(eventID); err != nil {
+		return "", fmt.Errorf("event run lookup requires a UUID event_id: %w", err)
+	}
+	var runID string
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(run_id::text, '') FROM events WHERE event_id = $1::uuid`, eventID).Scan(&runID); err != nil {
+		return "", fmt.Errorf("resolve run_id for event %s: %w", eventID, err)
+	}
+	if strings.TrimSpace(runID) == "" {
+		return "", nil
+	}
+	return strings.TrimSpace(runID), nil
+}
+
+// ValidateComplete rejects old, bypassed, or partially deleted projections.
+// PostgreSQL xmin is only a same-row writer stamp; it is never exposed as a
+// fork revision or used to order transactions.
+func ValidateComplete(ctx context.Context, tx *sql.Tx, runID string) error {
+	if tx == nil {
+		return fmt.Errorf("run fork revision validation requires an existing postgres transaction")
+	}
+	runID = strings.TrimSpace(runID)
+	if _, err := uuid.Parse(runID); err != nil {
+		return fmt.Errorf("run fork revision validation requires a UUID run_id: %w", err)
+	}
+	for _, family := range allFamilies {
+		current := currentIdentityQuery(family)
+		if current == "" {
+			return fmt.Errorf("run fork revision validation has no projection for family %q", family)
+		}
+		var drifted bool
+		query := `
+			WITH current_facts AS (` + current + `),
+			latest AS (
+				SELECT DISTINCT ON (fact_key) fact_key, present, source_transaction_id
+				FROM run_fork_fact_revisions
+				WHERE run_id = $1::uuid AND family = $2
+				ORDER BY fact_key, revision DESC
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM current_facts current
+				LEFT JOIN latest USING (fact_key)
+				WHERE latest.fact_key IS NULL
+				   OR NOT latest.present
+				   OR latest.source_transaction_id <> current.source_transaction_id
+				UNION ALL
+				SELECT 1
+				FROM latest
+				LEFT JOIN current_facts current USING (fact_key)
+				WHERE latest.present AND current.fact_key IS NULL
+			)
+		`
+		if err := tx.QueryRowContext(ctx, query, runID, family).Scan(&drifted); err != nil {
+			return fmt.Errorf("validate run fork %s projection: %w", family, err)
+		}
+		if drifted {
+			return fmt.Errorf("run %s has unsupported unrevisioned %s facts; recreate the store and retry", runID, family)
+		}
+	}
+	return nil
+}
+
+func allocate(ctx context.Context, tx *sql.Tx, runID string) (int64, error) {
+	var revision int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT revision
+		FROM run_fork_revisions
+		WHERE run_id = $1::uuid
+		  AND transaction_id = txid_current()
+	`, runID).Scan(&revision)
+	if err == nil {
+		return revision, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, fmt.Errorf("read current run fork transaction revision: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_fork_revision_heads (run_id)
+		VALUES ($1::uuid)
+		ON CONFLICT (run_id) DO NOTHING
+	`, runID); err != nil {
+		return 0, fmt.Errorf("ensure run fork revision head: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `
+		UPDATE run_fork_revision_heads
+		SET last_revision = last_revision + 1,
+		    updated_at = now()
+		WHERE run_id = $1::uuid
+		RETURNING last_revision
+	`, runID).Scan(&revision); err != nil {
+		return 0, fmt.Errorf("allocate run fork revision: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO run_fork_revisions (run_id, revision, transaction_id)
+		VALUES ($1::uuid, $2, txid_current())
+	`, runID, revision); err != nil {
+		return 0, fmt.Errorf("record run fork revision: %w", err)
+	}
+	return revision, nil
+}
+
+func normalizeFamilies(families []Family) ([]Family, error) {
+	seen := make(map[Family]struct{}, len(families))
+	out := make([]Family, 0, len(families))
+	for _, family := range families {
+		family = Family(strings.TrimSpace(string(family)))
+		if !ValidFamily(family) {
+			return nil, fmt.Errorf("unsupported run fork revision fact family %q", family)
+		}
+		if _, ok := seen[family]; ok {
+			continue
+		}
+		seen[family] = struct{}{}
+		out = append(out, family)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+func captureQuery(family Family) string {
+	switch family {
+	case FamilyEvents:
+		return captureEventsSQL
+	case FamilyEntityMutations:
+		return captureEntityMutationsSQL
+	case FamilyEntityMetadata:
+		return captureEntityMetadataSQL
+	case FamilyEventDeliveries:
+		return captureEventDeliveriesSQL
+	case FamilyEventReceipts:
+		return captureEventReceiptsSQL
+	case FamilyDeadLetters:
+		return captureDeadLettersSQL
+	case FamilyTimers:
+		return captureTimersSQL
+	case FamilyAgentSessions:
+		return captureAgentSessionsSQL
+	case FamilyAgentTurns:
+		return captureAgentTurnsSQL
+	case FamilyAgentConversationAudits:
+		return captureAgentConversationAuditsSQL
+	case FamilyReplyContexts:
+		return captureReplyContextsSQL
+	default:
+		return ""
+	}
+}
+
+func currentIdentityQuery(family Family) string {
+	switch family {
+	case FamilyEvents:
+		return `SELECT event_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM events WHERE run_id = $1::uuid`
+	case FamilyEntityMutations:
+		return `SELECT mutation_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM entity_mutations WHERE run_id = $1::uuid`
+	case FamilyEntityMetadata:
+		return `SELECT entity_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM entity_state WHERE run_id = $1::uuid`
+	case FamilyEventDeliveries:
+		return `SELECT delivery_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM event_deliveries WHERE run_id = $1::uuid`
+	case FamilyEventReceipts:
+		return `SELECT r.receipt_id::text AS fact_key, r.xmin::text::bigint AS source_transaction_id FROM event_receipts r JOIN events e ON e.event_id = r.event_id WHERE e.run_id = $1::uuid`
+	case FamilyDeadLetters:
+		return `SELECT d.dead_letter_id::text AS fact_key, d.xmin::text::bigint AS source_transaction_id FROM dead_letters d JOIN events e ON e.event_id = d.original_event_id WHERE e.run_id = $1::uuid`
+	case FamilyTimers:
+		return `SELECT timer_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM timers WHERE run_id = $1::uuid`
+	case FamilyAgentSessions:
+		return `SELECT session_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_sessions WHERE run_id = $1::uuid`
+	case FamilyAgentTurns:
+		return `SELECT turn_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_turns WHERE run_id = $1::uuid`
+	case FamilyAgentConversationAudits:
+		return `SELECT session_id::text AS fact_key, xmin::text::bigint AS source_transaction_id FROM agent_conversation_audits WHERE run_id = $1::uuid`
+	case FamilyReplyContexts:
+		return `SELECT reply_context_id AS fact_key, xmin::text::bigint AS source_transaction_id FROM reply_contexts WHERE run_id = $1::uuid`
+	default:
+		return ""
+	}
+}
+
+const captureUpsertSuffix = `
+	ON CONFLICT (run_id, family, fact_key, revision)
+	DO UPDATE SET fact = EXCLUDED.fact, present = TRUE, source_transaction_id = EXCLUDED.source_transaction_id
+`
+
+const captureEventsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT e.run_id, $2, 'events', e.event_id::text,
+	       jsonb_build_object(
+	           'event_id', e.event_id, 'event_name', e.event_name,
+	           'entity_id', e.entity_id, 'flow_instance', e.flow_instance,
+	           'source_route', e.source_route, 'target_route', e.target_route,
+	           'target_set', e.target_set, 'scope', e.scope, 'payload', e.payload,
+	           'chain_depth', e.chain_depth, 'produced_by', e.produced_by,
+	           'produced_by_type', e.produced_by_type, 'handler_node', e.handler_node,
+	           'idempotency_key', e.idempotency_key, 'source_event_id', e.source_event_id,
+	           'created_at', e.created_at), e.xmin::text::bigint
+	FROM events e
+	WHERE e.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureEntityMutationsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT m.run_id, $2, 'entity_mutations', m.mutation_id::text,
+	       jsonb_build_object(
+	           'mutation_id', m.mutation_id, 'entity_id', m.entity_id,
+	           'field', m.field, 'new_value', m.new_value,
+	           'caused_by_event', m.caused_by_event, 'created_at', m.created_at), m.xmin::text::bigint
+	FROM entity_mutations m
+	WHERE m.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureEntityMetadataSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT e.run_id, $2, 'entity_metadata', e.entity_id::text,
+	       jsonb_build_object(
+	           'entity_id', e.entity_id, 'flow_instance', e.flow_instance,
+	           'entity_type', e.entity_type, 'created_at', e.created_at), e.xmin::text::bigint
+	FROM entity_state e
+	WHERE e.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureEventDeliveriesSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT d.run_id, $2, 'event_deliveries', d.delivery_id::text,
+	       jsonb_build_object(
+	           'delivery_id', d.delivery_id, 'event_id', d.event_id,
+	           'subscriber_type', d.subscriber_type, 'subscriber_id', d.subscriber_id,
+	           'delivery_target_route', d.delivery_target_route,
+	           'delivery_context', d.delivery_context, 'status', d.status,
+	           'retry_count', d.retry_count, 'reason_code', d.reason_code,
+	           'active_session_id', d.active_session_id, 'started_at', d.started_at,
+	           'delivered_at', d.delivered_at, 'created_at', d.created_at), d.xmin::text::bigint
+	FROM event_deliveries d
+	WHERE d.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureEventReceiptsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT e.run_id, $2, 'event_receipts', r.receipt_id::text,
+	       jsonb_build_object(
+	           'receipt_id', r.receipt_id, 'event_id', r.event_id,
+	           'subscriber_type', r.subscriber_type, 'subscriber_id', r.subscriber_id,
+	           'outcome', r.outcome, 'reason_code', r.reason_code,
+	           'processed_at', r.processed_at), r.xmin::text::bigint
+	FROM event_receipts r
+	JOIN events e ON e.event_id = r.event_id
+	WHERE e.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureDeadLettersSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT e.run_id, $2, 'dead_letters', d.dead_letter_id::text,
+	       jsonb_build_object(
+	           'dead_letter_id', d.dead_letter_id, 'original_event_id', d.original_event_id,
+	           'handler_node', d.handler_node, 'created_at', d.created_at), d.xmin::text::bigint
+	FROM dead_letters d
+	JOIN events e ON e.event_id = d.original_event_id
+	WHERE e.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureTimersSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT t.run_id, $2, 'timers', t.timer_id::text,
+	       jsonb_build_object(
+	           'timer_id', t.timer_id, 'timer_name', t.timer_name,
+	           'entity_id', t.entity_id, 'flow_instance', t.flow_instance,
+	           'fire_event', t.fire_event, 'fire_payload', t.fire_payload,
+	           'fire_at', t.fire_at, 'recurring', t.recurring,
+	           'recurrence_cron', t.recurrence_cron,
+	           'recurrence_interval', t.recurrence_interval,
+	           'owner_node', t.owner_node, 'owner_agent', t.owner_agent,
+	           'task_type', t.task_type, 'status', t.status,
+	           'fired_at', t.fired_at, 'created_at', t.created_at), t.xmin::text::bigint
+	FROM timers t
+	WHERE t.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureAgentSessionsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT s.run_id, $2, 'agent_sessions', s.session_id::text,
+	       jsonb_build_object(
+	           'session_id', s.session_id, 'status', s.status,
+	           'created_at', s.created_at, 'terminated_at', s.terminated_at), s.xmin::text::bigint
+	FROM agent_sessions s
+	WHERE s.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureAgentTurnsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT t.run_id, $2, 'agent_turns', t.turn_id::text,
+	       jsonb_build_object(
+	           'turn_id', t.turn_id, 'session_id', t.session_id,
+	           'created_at', t.created_at), t.xmin::text::bigint
+	FROM agent_turns t
+	WHERE t.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureAgentConversationAuditsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT a.run_id, $2, 'agent_conversation_audits', a.session_id::text,
+	       jsonb_build_object(
+	           'session_id', a.session_id, 'status', a.status,
+	           'created_at', a.created_at, 'updated_at', a.updated_at), a.xmin::text::bigint
+	FROM agent_conversation_audits a
+	WHERE a.run_id = $1::uuid
+` + captureUpsertSuffix
+
+const captureReplyContextsSQL = `
+	INSERT INTO run_fork_fact_revisions (run_id, revision, family, fact_key, fact, source_transaction_id)
+	SELECT r.run_id, $2, 'reply_contexts', r.reply_context_id,
+	       jsonb_build_object(
+	           'reply_context_id', r.reply_context_id,
+	           'request_event_id', r.request_event_id, 'state', r.state,
+	           'created_at', r.created_at, 'updated_at', r.updated_at,
+	           'terminal_at', r.terminal_at), r.xmin::text::bigint
+	FROM reply_contexts r
+	WHERE r.run_id = $1::uuid
+` + captureUpsertSuffix

--- a/internal/runtime/tools/executor_entity_test.go
+++ b/internal/runtime/tools/executor_entity_test.go
@@ -22,6 +22,7 @@ import (
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/division-sh/swarm/internal/store"
@@ -1310,8 +1311,8 @@ accounts:
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $6)
 	`, sourceRunID, stateEventID, forkEventID, entityID, at, forkAt); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -1337,6 +1338,7 @@ accounts:
 	`, sourceRunID, entityID, at.Add(time.Minute), at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
+	captureEntityToolRunForkRevision(t, db, sourceRunID)
 	result, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: forkEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
@@ -1407,8 +1409,8 @@ accounts:
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'review/inst-1', 'entity', '{}'::jsonb, 'test', 'platform', $6)
+			($1::uuid, $2::uuid, 'fork.state_entry', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $5),
+			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $6)
 	`, sourceRunID, stateEventID, forkEventID, entityID, at, forkAt); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -1434,6 +1436,7 @@ accounts:
 	`, sourceRunID, entityID, at, forkAt); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
+	captureEntityToolRunForkRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunFork(ctx, store.RunForkMaterializeRequest{SourceRunID: sourceRunID, At: forkEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
@@ -1499,6 +1502,21 @@ accounts:
 	}
 	if forkMutationCount != 1 || sourceMutationCount != 0 {
 		t.Fatalf("fork/source save_entity_field mutation count = %d/%d, want 1/0", forkMutationCount, sourceMutationCount)
+	}
+}
+
+func captureEntityToolRunForkRevision(t *testing.T, db *sql.DB, runID string) {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin entity-tool run-fork revision: %v", err)
+	}
+	defer tx.Rollback()
+	if _, err := runforkrevision.Capture(context.Background(), tx, runID, runforkrevision.AllFamilies()...); err != nil {
+		t.Fatalf("capture entity-tool run-fork revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit entity-tool run-fork revision: %v", err)
 	}
 }
 

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -11,6 +11,7 @@ import (
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/google/uuid"
@@ -190,6 +191,18 @@ func (s *PostgresStore) ApplyActiveRunQuiescence(ctx context.Context, req runtim
 			return runtimerunquiescence.Result{}, fmt.Errorf("mark active run quiescence run terminal: %w", err)
 		}
 		if err := upsertActiveRunQuiescenceRunControlTx(ctx, tx, run.RunID, out.ReasonCode, out.ControlledBy, now); err != nil {
+			return runtimerunquiescence.Result{}, err
+		}
+	}
+	changes := make([]runforkrevision.Change, 0, len(runIDs))
+	for _, runID := range runIDs {
+		changes = append(changes, runforkrevision.Change{RunID: runID, Families: []runforkrevision.Family{
+			runforkrevision.FamilyEventDeliveries,
+			runforkrevision.FamilyEventReceipts,
+		}})
+	}
+	if len(deliveries) > 0 {
+		if _, err := runforkrevision.CaptureChanges(ctx, tx, changes...); err != nil {
 			return runtimerunquiescence.Result{}, err
 		}
 	}

--- a/internal/store/agent_lifecycle.go
+++ b/internal/store/agent_lifecycle.go
@@ -126,7 +126,7 @@ func (s *PostgresStore) CommitAgentLifecycleTransition(ctx context.Context, req 
 	if err := insertPostgresLifecycleEvidence(ctx, tx, req, result); err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
 	return result, nil

--- a/internal/store/completion_settlement.go
+++ b/internal/store/completion_settlement.go
@@ -50,7 +50,7 @@ func (s *PostgresStore) SettleCompletion(ctx context.Context, attempt runtimeeff
 	if err := settleExternalAttemptPostgres(ctx, tx, settlement.Settlement); err != nil {
 		return runtimeeffects.CompletionSettlementResult{}, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return runtimeeffects.CompletionSettlementResult{}, fmt.Errorf("settle completion commit: %w", err)
 	}
 	return runtimeeffects.CompletionSettlementResult{

--- a/internal/store/decision_cards.go
+++ b/internal/store/decision_cards.go
@@ -1166,7 +1166,7 @@ func runPostgresDecisionCardMutation(ctx context.Context, db *sql.DB, fn func(co
 	if err := fn(txctx, tx); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return commitPostgresRunForkRevisionTx(txctx, tx)
 }
 
 func (s *SQLiteRuntimeStore) runDecisionCardMutation(ctx context.Context, label string, fn func(context.Context, *sql.Tx) error) error {

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -62,6 +62,9 @@ func (s *PostgresStore) ApplyDestructiveResetCleanup(ctx context.Context, req de
 	if err := lockDestructiveResetCleanupRuns(ctx, tx, runIDs); err != nil {
 		return destructivereset.CleanupResult{}, err
 	}
+	if err := guardDestructiveResetSourceForkDependencies(ctx, tx, runIDs); err != nil {
+		return destructivereset.CleanupResult{}, err
+	}
 	if err := guardDestructiveResetDirectiveAuthority(ctx, tx, runIDs, now); err != nil {
 		return destructivereset.CleanupResult{}, err
 	}
@@ -206,6 +209,28 @@ func lockDestructiveResetCleanupRuns(ctx context.Context, exec destructiveResetC
 	return nil
 }
 
+func guardDestructiveResetSourceForkDependencies(ctx context.Context, exec destructiveResetCleanupExecutor, runIDs []string) error {
+	if len(runIDs) == 0 {
+		return nil
+	}
+	var forkRunID, sourceRunID string
+	err := exec.QueryRowContext(ctx, `
+		SELECT fork.run_id::text, fork.forked_from_run_id::text
+		FROM runs fork
+		WHERE fork.forked_from_run_id = ANY($1::uuid[])
+		  AND NOT (fork.run_id = ANY($1::uuid[]))
+		ORDER BY fork.run_id
+		LIMIT 1
+	`, pq.Array(runIDs)).Scan(&forkRunID, &sourceRunID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect destructive reset fork dependencies: %w", err)
+	}
+	return fmt.Errorf("%w: cannot delete source run %s while dependent fork %s remains outside the cleanup set", destructivereset.ErrInvalidRequest, sourceRunID, forkRunID)
+}
+
 func guardDestructiveResetDirectiveAuthority(ctx context.Context, exec destructiveResetCleanupExecutor, runIDs []string, now time.Time) error {
 	if len(runIDs) == 0 {
 		return nil
@@ -280,24 +305,6 @@ func destructiveResetCleanupSeverPreservedReferences(ctx context.Context, exec d
 					FROM agent_sessions cleanup
 					WHERE cleanup.session_id = preserved.successor_session_id
 					  AND cleanup.run_id = ANY($1::uuid[])
-				  )
-			`,
-		},
-		{
-			name: "runs.fork_lineage",
-			query: `
-				UPDATE runs preserved
-				SET forked_from_run_id = NULL,
-				    forked_from_event_id = NULL
-				WHERE NOT (preserved.run_id = ANY($1::uuid[]))
-				  AND (
-					preserved.forked_from_run_id = ANY($1::uuid[])
-					OR EXISTS (
-						SELECT 1
-						FROM events cleanup_event
-						WHERE cleanup_event.event_id = preserved.forked_from_event_id
-						  AND cleanup_event.run_id = ANY($1::uuid[])
-					)
 				  )
 			`,
 		},
@@ -480,7 +487,7 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBu
 			return `SELECT COUNT(*) FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
 		}
 		return `DELETE FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
-	case "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
+	case "run_fork_fact_revisions", "run_fork_revisions", "run_fork_revision_heads", "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
 		if mode == "count" {
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}

--- a/internal/store/destructive_reset_cleanup_test.go
+++ b/internal/store/destructive_reset_cleanup_test.go
@@ -541,7 +541,7 @@ func TestPostgresStore_DestructiveResetPlanCapturesManagedContainersBeforeCleanu
 	}
 }
 
-func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesIntoCleanupSet(t *testing.T) {
+func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesWhenDependentForkIncluded(t *testing.T) {
 	dsn, _, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	pg, err := NewPostgresStore(dsn)
@@ -654,7 +654,7 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 		Result: destructivereset.Result{
 			OperationName: destructivereset.DefaultOperationName,
 			PlannedAt:     now.Add(-time.Minute),
-			Plan:          cleanupPlanForRunIDs(runID),
+			Plan:          cleanupPlanForRunIDs(runID, lateRunID),
 		},
 		Quiescence: destructivereset.QuiescenceResult{
 			OperationName: destructivereset.DefaultOperationName,
@@ -690,16 +690,8 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 	if predecessorSuccessor.Valid {
 		t.Fatalf("preserved predecessor successor_session_id = %q, want NULL", predecessorSuccessor.String)
 	}
-	var lateForkRun, lateForkEvent sql.NullString
-	if err := pg.DB.QueryRowContext(ctx, `
-		SELECT forked_from_run_id::text, forked_from_event_id::text
-		FROM runs
-		WHERE run_id = $1::uuid
-	`, lateRunID).Scan(&lateForkRun, &lateForkEvent); err != nil {
-		t.Fatalf("read preserved late run lineage: %v", err)
-	}
-	if lateForkRun.Valid || lateForkEvent.Valid {
-		t.Fatalf("preserved late run lineage = fork_run:%q fork_event:%q, want NULL/NULL", lateForkRun.String, lateForkEvent.String)
+	if got := countRowsWhere(t, ctx, pg, "runs", `run_id = $1::uuid`, lateRunID); got != 0 {
+		t.Fatalf("dependent fork rows after cleanup = %d, want deleted with source", got)
 	}
 	var transitionEvent sql.NullString
 	if err := pg.DB.QueryRowContext(ctx, `SELECT transition_event_id::text FROM runtime_ingress_state WHERE id = 1`).Scan(&transitionEvent); err != nil {
@@ -708,16 +700,8 @@ func TestPostgresStore_ApplyDestructiveResetCleanup_SeversPreservedReferencesInt
 	if transitionEvent.Valid {
 		t.Fatalf("runtime ingress transition_event_id = %q, want NULL", transitionEvent.String)
 	}
-	var mutationCause sql.NullString
-	if err := pg.DB.QueryRowContext(ctx, `
-		SELECT caused_by_event::text
-		FROM entity_mutations
-		WHERE mutation_id = $1::uuid
-	`, lateMutationID).Scan(&mutationCause); err != nil {
-		t.Fatalf("read preserved mutation cause: %v", err)
-	}
-	if mutationCause.Valid {
-		t.Fatalf("preserved mutation caused_by_event = %q, want NULL", mutationCause.String)
+	if got := countRowsWhere(t, ctx, pg, "entity_mutations", `mutation_id = $1::uuid`, lateMutationID); got != 0 {
+		t.Fatalf("dependent fork mutation rows after cleanup = %d, want deleted with fork", got)
 	}
 	var sourceTimer sql.NullString
 	if err := pg.DB.QueryRowContext(ctx, `

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/lib/pq"
 )
@@ -189,6 +190,9 @@ func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSc
 			if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
 				return err
 			}
+		}
+		if _, err := runforkrevision.CaptureForEvent(ctx, tx, eventID, runforkrevision.FamilyEventDeliveries, runforkrevision.FamilyEventReceipts); err != nil {
+			return err
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("commit event receipt tx: %w", err)
@@ -415,7 +419,12 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 		  )
 		  AND COALESCE(reason_code, '') <> ALL($4)
 	`
-	res, err := s.DB.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes()))
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin mark event delivery in progress: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes()))
 	if err != nil {
 		return fmt.Errorf("mark event delivery in progress: %w", err)
 	}
@@ -426,6 +435,12 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 			return nil
 		}
 		return fmt.Errorf("mark event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
+	}
+	if _, err := runforkrevision.CaptureForEvent(ctx, tx, eventID, runforkrevision.FamilyEventDeliveries); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit mark event delivery in progress: %w", err)
 	}
 	return nil
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -82,6 +82,11 @@ func (s *PostgresStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) {
 }
 
 func (s *PostgresStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
+	if tx == nil {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.AppendEventTx(txctx, tx, evt)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -94,9 +99,6 @@ func (s *PostgresStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt event
 		}
 		switch caps.Events.Log {
 		case SchemaFlavorCanonical:
-			if tx == nil && persistedBundleRunCreationValidationRequired(ctx, caps) {
-				return s.appendEventSpecWithRunCreationValidationTx(ctx, caps, evt)
-			}
 			return s.appendEventSpec(ctx, caps, tx, evt)
 		default:
 			return unsupportedSchemaCapability("events", caps.Events.Log)
@@ -118,7 +120,7 @@ func (s *PostgresStore) appendEventSpecWithRunCreationValidationTx(ctx context.C
 	if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit event source validation tx: %w", err)
 	}
 	committed = true
@@ -297,6 +299,11 @@ func (s *PostgresStore) InsertEventDeliveriesTx(ctx context.Context, tx *sql.Tx,
 	if len(agentIDs) == 0 {
 		return nil
 	}
+	if tx == nil {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.InsertEventDeliveriesTx(txctx, tx, eventID, agentIDs)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -326,6 +333,11 @@ func (s *PostgresStore) UpsertCommittedReplayScopeTx(
 	eventID string,
 	scope runtimereplayclaim.CommittedReplayScope,
 ) error {
+	if tx == nil {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.UpsertCommittedReplayScopeTx(txctx, tx, eventID, scope)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -375,6 +387,11 @@ func (s *PostgresStore) HasProcessedPipelineReceipt(ctx context.Context, eventID
 }
 
 func (s *PostgresStore) UpsertPipelineReceiptTx(ctx context.Context, tx *sql.Tx, eventID, status string, failure *runtimefailures.Envelope) error {
+	if tx == nil {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.UpsertPipelineReceiptTx(txctx, tx, eventID, status, failure)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -849,7 +866,7 @@ func (s *PostgresStore) persistEventWithDeliveriesSpec(ctx context.Context, caps
 		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID(), agentIDs); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 			return fmt.Errorf("commit event tx: %w", err)
 		}
 		return nil
@@ -878,7 +895,7 @@ func (s *PostgresStore) persistEventWithDeliveriesAndScopeSpec(
 		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 			return fmt.Errorf("commit event tx: %w", err)
 		}
 		return nil
@@ -908,7 +925,7 @@ func (s *PostgresStore) persistEventWithDeliveryRoutesAndScopeSpec(
 		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 			return fmt.Errorf("commit event tx: %w", err)
 		}
 		return nil
@@ -937,7 +954,7 @@ func (s *PostgresStore) persistEventWithDeliveryRouteSetAndScopeSpec(
 		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 			return fmt.Errorf("commit event tx: %w", err)
 		}
 		return nil
@@ -984,19 +1001,15 @@ func (s *PostgresStore) insertEventDeliveriesSpec(ctx context.Context, caps Stor
 }
 
 func (s *PostgresStore) InsertEventDeliveriesWithTargets(ctx context.Context, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
-	caps, err := s.schemaCapabilities(ctx)
-	if err != nil {
-		return err
-	}
-	switch caps.Events.Deliveries {
-	case SchemaFlavorCanonical:
-		return s.insertEventDeliveriesWithTargetsSpec(ctx, caps, nil, eventID, agentIDs, deliveryTargets)
-	default:
-		return unsupportedSchemaCapability("event_deliveries", caps.Events.Deliveries)
-	}
+	return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return s.InsertEventDeliveriesWithTargetsTx(txctx, tx, eventID, agentIDs, deliveryTargets)
+	})
 }
 
 func (s *PostgresStore) InsertEventDeliveriesWithTargetsTx(ctx context.Context, tx *sql.Tx, eventID string, agentIDs []string, deliveryTargets map[string]events.RouteIdentity) error {
+	if tx == nil {
+		return s.InsertEventDeliveriesWithTargets(ctx, eventID, agentIDs, deliveryTargets)
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err
@@ -1014,6 +1027,11 @@ func (s *PostgresStore) InsertEventDeliveryRoutes(ctx context.Context, eventID s
 }
 
 func (s *PostgresStore) InsertEventDeliveryRoutesTx(ctx context.Context, tx *sql.Tx, eventID string, deliveryRoutes []events.DeliveryRoute) error {
+	if tx == nil {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			return s.InsertEventDeliveryRoutesTx(txctx, tx, eventID, deliveryRoutes)
+		})
+	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
 		return err

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -156,6 +156,7 @@ func (s *PostgresStore) purgeInboundEventsSpec(ctx context.Context, before time.
 			FROM events
 			WHERE event_name = 'platform.inbound_recorded'
 			  AND produced_by_type = 'external'
+			  AND run_id IS NULL
 			  AND created_at < $1
 			ORDER BY created_at ASC
 			LIMIT $2

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -436,7 +436,7 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	if _, err := tx.ExecContext(ctx, insertTurn, insertArgs...); err != nil {
 		return fmt.Errorf("insert agent turn: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("append agent turn commit: %w", err)
 	}
 	committed = true
@@ -636,6 +636,11 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	}
 	sessionID := strings.TrimSpace(rec.SessionID)
 	runID := nullUUIDString(rec.RunID)
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("upsert conversation begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
 
 	if resolved.Stateless {
 		if sessionID == "" {
@@ -700,7 +705,7 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 			status,
 		}
 		if caps.Conversations.AuditRunID {
-			if err := s.ensureRunRow(ctx, caps, nil, runID, "", "", true); err != nil {
+			if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
 				return err
 			}
 			q = `
@@ -761,8 +766,11 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 				status,
 			}
 		}
-		if _, err := s.DB.ExecContext(ctx, q, args...); err != nil {
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
 			return fmt.Errorf("insert stateless conversation: %w", err)
+		}
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+			return fmt.Errorf("upsert stateless conversation commit: %w", err)
 		}
 		return nil
 	}
@@ -837,7 +845,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", rec.AgentID, sessionID, mode.String(), resolved.ScopeKey)
 	}
-	return tx.Commit()
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return fmt.Errorf("upsert live conversation commit: %w", err)
+	}
+	return nil
 }
 
 func nullUUIDString(raw string) string {
@@ -1037,5 +1048,8 @@ func (s *PostgresStore) UpdateLiveSessionWatchdog(ctx context.Context, update ru
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", agentID, sessionID, mode.String(), resolved.ScopeKey)
 	}
-	return tx.Commit()
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return fmt.Errorf("update live session watchdog commit: %w", err)
+	}
+	return nil
 }

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -443,11 +443,10 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 	return nil
 }
 
-func (s *PostgresStore) ensureTaskConversationAuditRow(ctx context.Context, rec runtimellm.AgentTurnRecord) error {
-	return s.ensureTaskConversationAuditRowTx(ctx, nil, StoreSchemaCapabilities{}, rec)
-}
-
 func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx *sql.Tx, caps StoreSchemaCapabilities, rec runtimellm.AgentTurnRecord) error {
+	if tx == nil {
+		return fmt.Errorf("task conversation audit persistence requires an existing transaction")
+	}
 	if caps.Conversations.Audits == "" {
 		var err error
 		caps, err = s.schemaCapabilities(ctx)
@@ -463,10 +462,6 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 		if err := s.ensureRunRow(ctx, caps, tx, rec.RunID, "", "", true); err != nil {
 			return err
 		}
-	}
-	execFn := s.DB.ExecContext
-	if tx != nil {
-		execFn = tx.ExecContext
 	}
 	q := `
 		INSERT INTO agent_conversation_audits (
@@ -563,7 +558,7 @@ func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx
 			runtimesessions.RuntimeModeTask.String(),
 		}
 	}
-	if _, err := execFn(ctx, q, args...); err != nil {
+	if _, err := tx.ExecContext(ctx, q, args...); err != nil {
 		return fmt.Errorf("ensure task conversation audit row: %w", err)
 	}
 	return nil
@@ -780,11 +775,6 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if sessionID == "" {
 		return fmt.Errorf("session_id is required for live session conversation persistence")
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin live conversation projection: %w", err)
-	}
-	defer tx.Rollback()
 	if _, err := requirePostgresLiveSessionAuthority(ctx, tx, rec.AgentID, "upsert_conversation", false); err != nil {
 		return err
 	}

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -144,12 +144,18 @@ func platformTableOrder(name string) int {
 		return 5
 	case "events":
 		return 10
-	case "agent_directive_operations":
+	case "run_fork_revision_heads":
 		return 11
-	case "reply_contexts":
+	case "run_fork_revisions":
 		return 12
-	case "activity_attempts":
+	case "run_fork_fact_revisions":
 		return 13
+	case "agent_directive_operations":
+		return 14
+	case "reply_contexts":
+		return 15
+	case "activity_attempts":
+		return 16
 	case "run_fork_selected_contract_bindings":
 		return 15
 	case "run_fork_selected_contract_runtime_executions":

--- a/internal/store/postgres_runtime_sessions.go
+++ b/internal/store/postgres_runtime_sessions.go
@@ -117,7 +117,7 @@ func (s *PostgresStore) acquirePostgresLiveSession(ctx context.Context, agentID 
 		RetriesFromSessionID: strings.TrimSpace(current.retriesFrom.String), LockOwner: lockOwner,
 		ScopeKey: resolved.ScopeKey, ExpiresAt: current.leaseExpires.Time,
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return nil, runtimellm.ConversationRecord{}, fmt.Errorf("commit live session acquire: %w", err)
 	}
 	return lease, record, nil
@@ -127,7 +127,15 @@ func (s *PostgresStore) Release(ctx context.Context, lease *runtimesessions.Leas
 	if lease == nil {
 		return errors.New("nil lease")
 	}
-	res, err := s.DB.ExecContext(ctx, `
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin live session release: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.ExecContext(ctx, `
 		UPDATE agent_sessions SET lease_holder=NULL, lease_expires_at=NULL, updated_at=now()
 		WHERE agent_id=$1 AND runtime_mode=$2 AND session_id=$3::uuid AND scope_key=$4 AND lease_holder=$5 AND status='active'
 	`, lease.AgentID, lease.RuntimeMode.String(), lease.SessionID, strings.TrimSpace(lease.ScopeKey), lease.LockOwner)
@@ -136,6 +144,9 @@ func (s *PostgresStore) Release(ctx context.Context, lease *runtimesessions.Leas
 	}
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		return fmt.Errorf("no active lease to release for agent=%s session=%s", lease.AgentID, lease.SessionID)
+	}
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return fmt.Errorf("commit live session release: %w", err)
 	}
 	return nil
 }
@@ -216,7 +227,7 @@ func (s *PostgresStore) Rotate(ctx context.Context, agentID string, runtimeMode 
 	if _, err := tx.ExecContext(ctx, `UPDATE agent_sessions SET successor_session_id=$2::uuid, updated_at=$3 WHERE session_id=$1::uuid AND status='terminated'`, currentID, newID, now); err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return nil, err
 	}
 	return &runtimesessions.Lease{SessionID: newID, AgentID: agentID, RuntimeMode: resolved.RuntimeMode, SessionScope: resolved.Scope, RetryReason: retryReason, RetriesFromSessionID: currentID, LockOwner: lockOwner, ScopeKey: resolved.ScopeKey, ExpiresAt: expires}, nil
@@ -242,7 +253,10 @@ func (s *PostgresStore) IncrementTurn(ctx context.Context, agentID string, runti
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		return fmt.Errorf("session not found for turn increment: agent=%s runtime=%s scope=%s session=%s", agentID, runtimeMode, scopeKey, sessionID)
 	}
-	return tx.Commit()
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return fmt.Errorf("commit live session turn increment: %w", err)
+	}
+	return nil
 }
 
 func (s *PostgresStore) AdoptSessionID(ctx context.Context, agentID string, runtimeMode runtimesessions.RuntimeMode, sessionScope runtimesessions.SessionScope, lockOwner, newSessionID, scopeKey string) error {
@@ -277,7 +291,10 @@ func (s *PostgresStore) AdoptSessionID(ctx context.Context, agentID string, runt
 	if _, err := tx.ExecContext(ctx, `UPDATE agent_sessions SET runtime_state=COALESCE(runtime_state,'{}'::jsonb)||jsonb_build_object('provider_session_id',$1::text), lease_holder=$2, lease_expires_at=$3, updated_at=$4 WHERE session_id=$5::uuid`, newSessionID, lockOwner, now.Add(s.postgresSessionLockTTL()), now, sessionID); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return fmt.Errorf("commit live session provider adoption: %w", err)
+	}
+	return nil
 }
 
 func (s *PostgresStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, metadata runtimesessions.ResetMetadata) (runtimesessions.ResetSummary, error) {
@@ -286,7 +303,13 @@ func (s *PostgresStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, metada
 	}
 	mode := runtimeMode.String()
 	source := strings.TrimSpace(metadata.Source)
-	rows, err := s.DB.QueryContext(context.Background(), `
+	ctx := context.Background()
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("begin reset postgres live sessions: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `
 		WITH affected AS (
 			SELECT session_id, agent_id, scope_key, runtime_mode, status
 			FROM agent_sessions
@@ -328,6 +351,12 @@ func (s *PostgresStore) ResetAll(runtimeMode runtimesessions.RuntimeMode, metada
 	}
 	if err := rows.Err(); err != nil {
 		return runtimesessions.ResetSummary{}, fmt.Errorf("read postgres live session reset: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("close postgres live session reset: %w", err)
+	}
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		return runtimesessions.ResetSummary{}, fmt.Errorf("commit postgres live session reset: %w", err)
 	}
 	return summary, nil
 }

--- a/internal/store/preservation_cleanup.go
+++ b/internal/store/preservation_cleanup.go
@@ -215,7 +215,7 @@ func (s *PostgresStore) applyPreservationCleanup(ctx context.Context, req preser
 			return preservationcleanup.Result{}, err
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return preservationcleanup.Result{}, fmt.Errorf("commit preservation cleanup tx: %w", err)
 	}
 	committed = true

--- a/internal/store/reply_context_store.go
+++ b/internal/store/reply_context_store.go
@@ -11,6 +11,7 @@ import (
 
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 )
 
 type replyContextSQL interface {
@@ -25,7 +26,21 @@ func (s *PostgresStore) CreateReplyContext(ctx context.Context, record runtimere
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
 		return createPostgresReplyContext(ctx, tx, record)
 	}
-	return createPostgresReplyContext(ctx, s.DB, record)
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin reply context create: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := createPostgresReplyContext(ctx, tx, record); err != nil {
+		return err
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit reply context create: %w", err)
+	}
+	return nil
 }
 
 func createPostgresReplyContext(ctx context.Context, db replyContextSQL, record runtimereplycontext.Record) error {
@@ -170,6 +185,9 @@ func (s *PostgresStore) ClaimReplyContext(ctx context.Context, id, replyEventID 
 	defer func() { _ = tx.Rollback() }()
 	record, outcome, err := claimPostgresReplyContext(ctx, tx, id, replyEventID)
 	if err != nil {
+		return runtimereplycontext.Record{}, "", err
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
 		return runtimereplycontext.Record{}, "", err
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/store/run_control.go
+++ b/internal/store/run_control.go
@@ -9,6 +9,7 @@ import (
 
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 )
 
@@ -101,6 +102,11 @@ func (s *PostgresStore) runControlTransition(ctx context.Context, req runtimerun
 	}
 	if err != nil {
 		return runtimeruncontrol.State{}, err
+	}
+	if action == "stop" && state.AbandonedDeliveries > 0 {
+		if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyEventDeliveries, runforkrevision.FamilyEventReceipts); err != nil {
+			return runtimeruncontrol.State{}, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return runtimeruncontrol.State{}, fmt.Errorf("commit run control transition: %w", err)

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -9,7 +9,6 @@ import (
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 )
 
 const (
@@ -43,16 +42,17 @@ type RunForkActivation struct {
 }
 
 type runForkActivationLineage struct {
-	ForkRunID       string
-	ForkStatus      string
-	SourceRunID     string
-	ForkEventID     string
-	ForkEventName   string
-	ForkEventTime   time.Time
-	SourceRunStatus string
-	EntityIDs       []string
-	FlowInstances   []string
-	SourceFlows     []string
+	ForkRunID         string
+	ForkStatus        string
+	SourceRunID       string
+	ForkEventID       string
+	ForkEventName     string
+	ForkEventTime     time.Time
+	ForkEventRevision int64
+	SourceRunStatus   string
+	EntityIDs         []string
+	FlowInstances     []string
+	SourceFlows       []string
 }
 
 func RequireRunForkActivationCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
@@ -116,12 +116,15 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	if err != nil {
 		return RunForkActivation{}, err
 	}
+	if err := lockRunForkSourceRevisionFrontier(ctx, tx, &lineage); err != nil {
+		return RunForkActivation{}, err
+	}
 	result := RunForkActivation{
 		SourceRunID:             lineage.SourceRunID,
 		ForkRunID:               lineage.ForkRunID,
 		ForkRunStatus:           lineage.ForkStatus,
 		SourceRunStatus:         lineage.SourceRunStatus,
-		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
+		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime, Revision: lineage.ForkEventRevision},
 		ReplayResumeBlocked:     true,
 		MaterializedEntityCount: len(lineage.EntityIDs),
 	}
@@ -153,7 +156,7 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		result.UnsupportedBlockers = plan.UnsupportedBlockers
 		return result, fmt.Errorf("fork activation requires execution-ready materialized fork; blockers: %s", runForkBlockerCodes(plan.UnsupportedBlockers))
 	}
-	if err := ensureRunForkSourceNotAdvanced(ctx, tx, catalog, lineage); err != nil {
+	if err := ensureRunForkSourceNotAdvanced(ctx, tx, lineage); err != nil {
 		result.SourceAdvancedAfterFork = true
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
@@ -219,7 +222,7 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	} else if affected != 1 {
 		return result, fmt.Errorf("fork activation blocked: fork_run_activation_not_applied")
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return result, fmt.Errorf("commit fork activation: %w", err)
 	}
 	committed = true
@@ -358,134 +361,109 @@ func loadRunForkActivationLineage(ctx context.Context, tx *sql.Tx, forkRunID str
 	return lineage, nil
 }
 
-func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
-	checks := []struct {
-		code  string
-		query string
-		args  []any
-	}{
-		{
-			code: "source_events_advanced_after_fork_point",
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM events
-					WHERE run_id = $1::uuid
-					  AND (created_at, event_id) > ($2::timestamptz, $3::uuid)
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
-		},
-		{
-			code: "source_mutations_advanced_after_fork_point",
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM entity_mutations
-					WHERE run_id = $1::uuid
-					  AND created_at > $2::timestamptz
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
-		},
-		{
-			code: "source_current_state_advanced_after_fork_point",
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM entity_state
-					WHERE run_id = $1::uuid
-					  AND updated_at > $2::timestamptz
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
-		},
-		{
-			code: "source_deliveries_advanced_after_fork_point",
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM event_deliveries d
-					WHERE d.run_id = $1::uuid
-					  AND (
-							d.created_at > $2::timestamptz
-							OR d.started_at > $2::timestamptz
-							OR d.delivered_at > $2::timestamptz
-					  )
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
-		},
+func lockRunForkSourceRevisionFrontier(ctx context.Context, tx *sql.Tx, lineage *runForkActivationLineage) error {
+	if lineage == nil {
+		return fmt.Errorf("fork activation requires lineage")
 	}
-	for _, check := range checks {
-		var exists bool
-		if err := tx.QueryRowContext(ctx, check.query, check.args...).Scan(&exists); err != nil {
-			return fmt.Errorf("check %s: %w", check.code, err)
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MIN(revision)
+		FROM run_fork_fact_revisions
+		WHERE run_id = $1::uuid
+		  AND family = 'events'
+		  AND fact_key = $2
+		  AND present
+	`, lineage.SourceRunID, lineage.ForkEventID).Scan(&lineage.ForkEventRevision); err != nil {
+		return fmt.Errorf("resolve fork activation event revision: %w", err)
+	}
+	if lineage.ForkEventRevision <= 0 {
+		return fmt.Errorf("fork activation source event is not revisioned; recreate the store and retry")
+	}
+	var currentRevision int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT last_revision
+		FROM run_fork_revision_heads
+		WHERE run_id = $1::uuid
+		FOR UPDATE
+	`, lineage.SourceRunID).Scan(&currentRevision); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("fork activation source revision frontier is missing; recreate the store and retry")
 		}
-		if exists {
-			return runForkReplayResumeError(check.code, RunForkReplayResumeFactSourceAdvanced, fmt.Sprintf("fork activation blocked: %s", check.code))
-		}
+		return fmt.Errorf("lock fork activation source revision frontier: %w", err)
 	}
-	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, catalog, lineage); err != nil {
-		return err
-	}
-	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, catalog, lineage); err != nil {
-		return err
+	if currentRevision < lineage.ForkEventRevision {
+		return fmt.Errorf("fork activation source revision frontier is corrupt; recreate the store and retry")
 	}
 	return nil
 }
 
-func ensureRunForkNoRelevantPostForkTimers(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
-	if !catalog.hasColumns("timers", "run_id", "entity_id", "flow_instance", "created_at") {
-		return nil
+func collectRunForkSourceAdvancedFacts(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) ([]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT DISTINCT family
+		FROM run_fork_fact_revisions
+		WHERE run_id = $1::uuid
+		  AND revision > $2
+		ORDER BY family
+	`, lineage.SourceRunID, lineage.ForkEventRevision)
+	if err != nil {
+		return nil, fmt.Errorf("read source revisions after fork point: %w", err)
 	}
-	if len(lineage.EntityIDs) == 0 && len(lineage.FlowInstances) == 0 {
-		return nil
+	defer rows.Close()
+	facts := []string{}
+	for rows.Next() {
+		var family string
+		if err := rows.Scan(&family); err != nil {
+			return nil, fmt.Errorf("scan source revision after fork point: %w", err)
+		}
+		code, ok := runForkSourceAdvancedCode(family)
+		if !ok {
+			return nil, fmt.Errorf("unsupported revisioned source family %q; recreate the store and retry", family)
+		}
+		facts = append(facts, code)
 	}
-	var exists bool
-	if err := tx.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM timers
-			WHERE run_id = $1::uuid
-			  AND created_at > $2::timestamptz
-			  AND (
-					(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
-					OR
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
-			  )
-		)
-	`, lineage.SourceRunID, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&exists); err != nil {
-		return fmt.Errorf("check source timer advancement: %w", err)
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate source revisions after fork point: %w", err)
 	}
-	if exists {
-		return runForkReplayResumeError("source_timers_advanced_after_fork_point", RunForkReplayResumeFactSourceAdvanced, "fork activation blocked: source_timers_advanced_after_fork_point")
-	}
-	return nil
+	return uniqueNonEmptyStrings(facts), nil
 }
 
-func ensureRunForkNoRelevantPostForkRoutes(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage) error {
-	if !catalog.hasColumns("routing_rules", "flow_instance", "source_flow", "created_at") {
+func ensureRunForkSourceNotAdvanced(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) error {
+	facts, err := collectRunForkSourceAdvancedFacts(ctx, tx, lineage)
+	if err != nil {
+		return err
+	}
+	if len(facts) == 0 {
 		return nil
 	}
-	if len(lineage.FlowInstances) == 0 && len(lineage.SourceFlows) == 0 {
-		return nil
+	return runForkReplayResumeError(facts[0], RunForkReplayResumeFactSourceAdvanced, fmt.Sprintf("fork activation blocked: %s", facts[0]))
+}
+
+func runForkSourceAdvancedCode(family string) (string, bool) {
+	switch strings.TrimSpace(family) {
+	case "events":
+		return "source_events_advanced_after_fork_point", true
+	case "entity_mutations":
+		return "source_mutations_advanced_after_fork_point", true
+	case "entity_metadata":
+		return "source_current_state_advanced_after_fork_point", true
+	case "event_deliveries":
+		return "source_deliveries_advanced_after_fork_point", true
+	case "event_receipts":
+		return "source_receipts_advanced_after_fork_point", true
+	case "dead_letters":
+		return "source_dead_letters_advanced_after_fork_point", true
+	case "timers":
+		return "source_timers_advanced_after_fork_point", true
+	case "agent_sessions":
+		return "source_sessions_advanced_after_fork_point", true
+	case "agent_turns":
+		return "source_turns_advanced_after_fork_point", true
+	case "agent_conversation_audits":
+		return "source_conversation_audits_advanced_after_fork_point", true
+	case "reply_contexts":
+		return "source_reply_contexts_advanced_after_fork_point", true
+	default:
+		return "", false
 	}
-	var exists bool
-	if err := tx.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM routing_rules
-			WHERE created_at > $1::timestamptz
-			  AND (
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($2::text[]))
-					OR
-					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($3::text[]))
-			  )
-		)
-	`, lineage.ForkEventTime, pq.Array(lineage.FlowInstances), pq.Array(lineage.SourceFlows)).Scan(&exists); err != nil {
-		return fmt.Errorf("check source route advancement: %w", err)
-	}
-	if exists {
-		return runForkReplayResumeError("source_routes_advanced_after_fork_point", RunForkReplayResumeFactSourceAdvanced, "fork activation blocked: source_routes_advanced_after_fork_point")
-	}
-	return nil
 }
 
 func ensureRunForkActivationNoForkReplayState(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID string) error {

--- a/internal/store/run_fork_activity_generation_test.go
+++ b/internal/store/run_fork_activity_generation_test.go
@@ -32,7 +32,7 @@ func TestSelectedContractForkRemintsActivityRequestAndReusesRecordedWriteEvidenc
 	}
 	requestEventID := activityidentity.RequestEventID(fact)
 	at := time.Unix(1700003100, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, requestEventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, requestEventID, at)
 	buckets := map[string]map[string]any{}
 	if err := loopruntime.Store(buckets, activation); err != nil {
 		t.Fatal(err)
@@ -60,7 +60,7 @@ func TestSelectedContractForkRemintsActivityRequestAndReusesRecordedWriteEvidenc
 	`, sourceRunID, entityID, string(handlerLoops), requestEventID, at); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(requestJSON)); err != nil {
+	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', flow_instance = '', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(requestJSON)); err != nil {
 		t.Fatal(err)
 	}
 	resultPayload, _ := json.Marshal(map[string]any{
@@ -82,6 +82,7 @@ func TestSelectedContractForkRemintsActivityRequestAndReusesRecordedWriteEvidenc
 	`, requestEventID, sourceRunID, sourceEventID, entityID, resultEventID, string(resultPayload), forkTestJSON(t, sourceGeneration), at); err != nil {
 		t.Fatal(err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID, At: requestEventID,
 		ContractSelection: RunForkContractSelection{Mode: "selected_contracts", ContractsRoot: "/tmp/contracts", WorkflowName: "flow", WorkflowVersion: "v1"},
@@ -148,7 +149,7 @@ func TestSelectedContractForkRemintsReadOnlyActivityForReexecution(t *testing.T)
 	}
 	requestEventID := activityidentity.RequestEventID(fact)
 	at := time.Unix(1700003200, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, requestEventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, requestEventID, at)
 	buckets := map[string]map[string]any{}
 	if err := loopruntime.Store(buckets, activation); err != nil {
 		t.Fatal(err)
@@ -173,9 +174,10 @@ func TestSelectedContractForkRemintsReadOnlyActivityForReexecution(t *testing.T)
 	`, sourceRunID, entityID, string(handlerLoops), requestEventID, at); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(payload)); err != nil {
+	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', flow_instance = '', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(payload)); err != nil {
 		t.Fatal(err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID, At: requestEventID,
 		ContractSelection: RunForkContractSelection{Mode: "selected_contracts", ContractsRoot: "/tmp/contracts", WorkflowName: "flow", WorkflowVersion: "v1"},
@@ -225,7 +227,7 @@ func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
 	}
 	requestEventID := activityidentity.RequestEventID(fact)
 	at := time.Unix(1700003300, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, requestEventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, requestEventID, at)
 	buckets := map[string]map[string]any{}
 	if err := loopruntime.Store(buckets, activation); err != nil {
 		t.Fatal(err)
@@ -250,7 +252,7 @@ func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
 	`, sourceRunID, entityID, string(handlerLoops), requestEventID, at); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(requestPayload)); err != nil {
+	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', flow_instance = '', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(requestPayload)); err != nil {
 		t.Fatal(err)
 	}
 	failure := `{"class":"dependency_unavailable","code":"provider_unavailable","owner":"activity-runtime","operation":"execute","details":{"provider":"provider.write"}}`
@@ -273,6 +275,7 @@ func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
 	`, requestEventID, sourceRunID, sourceEventID, entityID, resultEventID, string(resultPayload), failure, forkTestJSON(t, generation), at); err != nil {
 		t.Fatal(err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID, At: requestEventID,
 		ContractSelection: RunForkContractSelection{Mode: "selected_contracts", ContractsRoot: "/tmp/contracts", WorkflowName: "flow", WorkflowVersion: "v1"},

--- a/internal/store/run_fork_entity_snapshot_metadata.go
+++ b/internal/store/run_fork_entity_snapshot_metadata.go
@@ -1,8 +1,6 @@
 package store
 
 import (
-	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 )
@@ -32,7 +30,7 @@ type runForkSourceEntityStateMetadata struct {
 	Exists       bool
 }
 
-func (s *PostgresStore) attachRunForkMaterializedEntitySnapshotMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entities []RunForkEntityState) ([]RunForkEntityState, runForkMaterializedEntitySnapshotMetadataAdmission, error) {
+func attachRunForkMaterializedEntitySnapshotMetadata(snapshot *runForkRevisionSnapshot, entities []RunForkEntityState) ([]RunForkEntityState, runForkMaterializedEntitySnapshotMetadataAdmission, error) {
 	out := make([]RunForkEntityState, len(entities))
 	copy(out, entities)
 	admission := runForkMaterializedEntitySnapshotMetadataAdmission{}
@@ -45,10 +43,7 @@ func (s *PostgresStore) attachRunForkMaterializedEntitySnapshotMetadata(ctx cont
 			admission.Dispositions = append(admission.Dispositions, runForkMaterializedEntitySnapshotMetadataBlockerDisposition("", blocker.Message))
 			continue
 		}
-		metadata, message, ok, err := s.loadRunForkMaterializedEntitySnapshotMetadata(ctx, sourceRunID, cursor, out[i])
-		if err != nil {
-			return nil, runForkMaterializedEntitySnapshotMetadataAdmission{}, err
-		}
+		metadata, message, ok := loadRunForkMaterializedEntitySnapshotMetadata(snapshot, out[i])
 		if !ok {
 			blocker := runForkReplayResumeBlocker(RunForkBlockerEntitySnapshotMetadataUnproven)
 			blocker.Message = message
@@ -61,16 +56,10 @@ func (s *PostgresStore) attachRunForkMaterializedEntitySnapshotMetadata(ctx cont
 	return out, admission, nil
 }
 
-func (s *PostgresStore) loadRunForkMaterializedEntitySnapshotMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entity RunForkEntityState) (RunForkMaterializedEntitySnapshotMetadata, string, bool, error) {
+func loadRunForkMaterializedEntitySnapshotMetadata(snapshot *runForkRevisionSnapshot, entity RunForkEntityState) (RunForkMaterializedEntitySnapshotMetadata, string, bool) {
 	entityID := strings.TrimSpace(entity.EntityID)
-	eventFlow, err := s.loadRunForkEntityEventFlowInstance(ctx, sourceRunID, cursor, entityID)
-	if err != nil {
-		return RunForkMaterializedEntitySnapshotMetadata{}, "", false, err
-	}
-	sourceState, err := s.loadRunForkSourceEntityStateMetadata(ctx, sourceRunID, cursor, entityID)
-	if err != nil {
-		return RunForkMaterializedEntitySnapshotMetadata{}, "", false, err
-	}
+	eventFlow := loadRunForkEntityEventFlowInstance(snapshot, entityID)
+	sourceState := loadRunForkSourceEntityStateMetadata(snapshot, entityID)
 
 	flowInstance := strings.TrimSpace(eventFlow)
 	source := RunForkMaterializedEntitySnapshotMetadataSourceEvent
@@ -79,66 +68,55 @@ func (s *PostgresStore) loadRunForkMaterializedEntitySnapshotMetadata(ctx contex
 		source = RunForkMaterializedEntitySnapshotMetadataSourceEntityState
 	}
 	if !sourceState.Exists {
-		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T entity_state metadata for entity %s", entityID), false, nil
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-revision entity metadata for entity %s", entityID), false
 	}
 	entityType := strings.TrimSpace(sourceState.EntityType)
 	if reconstructedEntityType := stringFieldValue(entity.Fields, "entity_type"); reconstructedEntityType != "" && reconstructedEntityType != entityType {
-		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot reconcile reconstructed entity_type %q with source-at-T entity_state entity_type %q for entity %s", reconstructedEntityType, entityType, entityID), false, nil
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot reconcile reconstructed entity_type %q with source-at-revision entity metadata %q for entity %s", reconstructedEntityType, entityType, entityID), false
 	}
 	if flowInstance == "" || entityType == "" {
-		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-T flow_instance/entity_type metadata for entity %s", entityID), false, nil
+		return RunForkMaterializedEntitySnapshotMetadata{}, fmt.Sprintf("fork materialization cannot prove source-at-revision flow_instance/entity_type metadata for entity %s", entityID), false
 	}
 	return RunForkMaterializedEntitySnapshotMetadata{
 		Owner:        RunForkMaterializedEntitySnapshotMetadataOwner,
 		FlowInstance: flowInstance,
 		EntityType:   entityType,
 		Source:       source,
-	}, "", true, nil
+	}, "", true
 }
 
-func (s *PostgresStore) loadRunForkEntityEventFlowInstance(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entityID string) (string, error) {
-	var flowInstance string
-	err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(flow_instance, '')
-		FROM events
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-		  AND COALESCE(flow_instance, '') <> ''
-		  AND (created_at, event_id) <= ($3::timestamptz, $4::uuid)
-		ORDER BY created_at DESC, event_id DESC
-		LIMIT 1
-	`, sourceRunID, entityID, cursor.CreatedAt, cursor.EventID).Scan(&flowInstance)
-	if err == sql.ErrNoRows {
-		return "", nil
+func loadRunForkEntityEventFlowInstance(snapshot *runForkRevisionSnapshot, entityID string) string {
+	if snapshot == nil {
+		return ""
 	}
-	if err != nil {
-		return "", fmt.Errorf("load fork-point event flow_instance metadata for %s: %w", entityID, err)
+	for index := len(snapshot.Events) - 1; index >= 0; index-- {
+		event := snapshot.Events[index]
+		if strings.TrimSpace(event.EntityID) == strings.TrimSpace(entityID) && strings.TrimSpace(event.FlowInstance) != "" {
+			return strings.TrimSpace(event.FlowInstance)
+		}
 	}
-	return strings.TrimSpace(flowInstance), nil
+	return ""
 }
 
-func (s *PostgresStore) loadRunForkSourceEntityStateMetadata(ctx context.Context, sourceRunID string, cursor runForkEventCursor, entityID string) (runForkSourceEntityStateMetadata, error) {
-	var metadata runForkSourceEntityStateMetadata
-	err := s.DB.QueryRowContext(ctx, `
-		SELECT COALESCE(flow_instance, ''), COALESCE(NULLIF(entity_type, ''), 'default')
-		FROM entity_state
-		WHERE run_id = $1::uuid
-		  AND entity_id = $2::uuid
-		  AND created_at <= $3::timestamptz
-	`, sourceRunID, entityID, cursor.CreatedAt).Scan(&metadata.FlowInstance, &metadata.EntityType)
-	if err == sql.ErrNoRows {
-		return runForkSourceEntityStateMetadata{}, nil
+func loadRunForkSourceEntityStateMetadata(snapshot *runForkRevisionSnapshot, entityID string) runForkSourceEntityStateMetadata {
+	if snapshot == nil {
+		return runForkSourceEntityStateMetadata{}
 	}
-	if err != nil {
-		return runForkSourceEntityStateMetadata{}, fmt.Errorf("load source entity_state metadata for %s: %w", entityID, err)
+	for _, fact := range snapshot.EntityMetadata {
+		if strings.TrimSpace(fact.EntityID) != strings.TrimSpace(entityID) {
+			continue
+		}
+		entityType := strings.TrimSpace(fact.EntityType)
+		if entityType == "" {
+			entityType = "default"
+		}
+		return runForkSourceEntityStateMetadata{
+			FlowInstance: strings.TrimSpace(fact.FlowInstance),
+			EntityType:   entityType,
+			Exists:       true,
+		}
 	}
-	metadata.FlowInstance = strings.TrimSpace(metadata.FlowInstance)
-	metadata.EntityType = strings.TrimSpace(metadata.EntityType)
-	if metadata.EntityType == "" {
-		metadata.EntityType = "default"
-	}
-	metadata.Exists = true
-	return metadata, nil
+	return runForkSourceEntityStateMetadata{}
 }
 
 func runForkMaterializedEntitySnapshotMetadataBlockerDisposition(entityID, message string) RunForkReplayResumeDisposition {

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -162,7 +162,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 		}
 		selectedContractBinding = &binding
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit fork materialization: %w", err)
 	}
 	committed = true

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -38,31 +39,23 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES
-			($1::uuid, $2::uuid, 'fork.before', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.field_only', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $6),
-			($1::uuid, $7::uuid, 'fork.after', $4::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $8)
-	`, sourceRunID, firstEventID, secondEventID, entityID, at, fieldOnlyAt, thirdEventID, afterAt); err != nil {
-		t.Fatalf("seed events: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'fork.before', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, firstEventID, entityID, at); err != nil {
+		t.Fatalf("seed first event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
 			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'slug', 'null'::jsonb, '"before-slug"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Before Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $5),
-			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"fork-title"'::jsonb, $4::uuid, 'platform', 'materializer-test', 'field-only', $6),
-			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
-			($1::uuid, $2::uuid, 'title', '"fork-title"'::jsonb, '"after-title"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
-			($1::uuid, $2::uuid, 'slug', '"before-slug"'::jsonb, '"after-slug"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8),
-			($1::uuid, $2::uuid, 'name', '"Before Name"'::jsonb, '"After Name"'::jsonb, $7::uuid, 'platform', 'materializer-test', 'after', $8)
-	`, sourceRunID, entityID, firstEventID, secondEventID, at, fieldOnlyAt, thirdEventID, afterAt); err != nil {
-		t.Fatalf("seed mutations: %v", err)
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'slug', 'null'::jsonb, '"before-slug"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Before Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
+			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4)
+	`, sourceRunID, entityID, firstEventID, at); err != nil {
+		t.Fatalf("seed first mutations: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
@@ -71,13 +64,77 @@ func TestRunForkMaterializer_CreatesPausedForkRunAndSnapshotWithoutResuming(t *t
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'after-slug', 'After Name',
-			'done', '{"ready": true}'::jsonb, '{"title": "after-title", "slug": "after-slug", "name": "After Name"}'::jsonb, '{"score": 9}'::jsonb, 4,
-			$3, $4, $3
+			$1::uuid, $2::uuid, 'flow-a/1', 'default', 'before-slug', 'Before Name',
+			'queued', '{"ready": true}'::jsonb, '{"title": "before-title", "slug": "before-slug", "name": "Before Name"}'::jsonb, '{"score": 7}'::jsonb, 1,
+			$3, $3, $3
 		)
-	`, sourceRunID, entityID, afterAt, at); err != nil {
+	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations, runforkrevision.FamilyEntityMetadata)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.field_only', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, secondEventID, entityID, fieldOnlyAt); err != nil {
+		t.Fatalf("seed selected event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"fork-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'field-only', $4)
+	`, sourceRunID, entityID, secondEventID, fieldOnlyAt); err != nil {
+		t.Fatalf("seed selected mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE entity_state
+		SET fields = jsonb_set(fields, '{title}', '"fork-title"'::jsonb, true),
+		    revision = 2,
+		    updated_at = $3
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID, fieldOnlyAt); err != nil {
+		t.Fatalf("update source state at selected event: %v", err)
+	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations, runforkrevision.FamilyEntityMetadata)
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.after', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, thirdEventID, entityID, afterAt); err != nil {
+		t.Fatalf("seed later event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'after', $4),
+			($1::uuid, $2::uuid, 'title', '"fork-title"'::jsonb, '"after-title"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'after', $4),
+			($1::uuid, $2::uuid, 'slug', '"before-slug"'::jsonb, '"after-slug"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'after', $4),
+			($1::uuid, $2::uuid, 'name', '"Before Name"'::jsonb, '"After Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'after', $4)
+	`, sourceRunID, entityID, thirdEventID, afterAt); err != nil {
+		t.Fatalf("seed later mutations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE entity_state
+		SET current_state = 'done',
+		    slug = 'after-slug',
+		    name = 'After Name',
+		    fields = '{"title": "after-title", "slug": "after-slug", "name": "After Name"}'::jsonb,
+		    accumulator = '{"score": 9}'::jsonb,
+		    revision = 4,
+		    entered_state_at = $3,
+		    updated_at = $3
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID, afterAt); err != nil {
+		t.Fatalf("update later source state: %v", err)
+	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations, runforkrevision.FamilyEntityMetadata)
 
 	result, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: secondEventID})
 	if err != nil {
@@ -248,11 +305,9 @@ func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlow
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES
-			($1::uuid, $2::uuid, 'fork.no_event_flow', $4::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.post_flow', $4::uuid, 'post-flow/ignored', 'entity', '{}'::jsonb, 'test', 'platform', $6)
-	`, sourceRunID, eventID, postEventID, entityID, at, afterAt); err != nil {
-		t.Fatalf("seed events: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'fork.no_event_flow', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, eventID, entityID, at); err != nil {
+		t.Fatalf("seed selected event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
@@ -260,10 +315,9 @@ func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlow
 		)
 		VALUES
 			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"pending"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
-			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Fork Point Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4),
-			($1::uuid, $2::uuid, 'current_state', '"pending"'::jsonb, '"done"'::jsonb, $5::uuid, 'platform', 'materializer-test', 'after', $6)
-	`, sourceRunID, entityID, eventID, at, postEventID, afterAt); err != nil {
-		t.Fatalf("seed mutations: %v", err)
+			($1::uuid, $2::uuid, 'name', 'null'::jsonb, '"Fork Point Name"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'before', $4)
+	`, sourceRunID, entityID, eventID, at); err != nil {
+		t.Fatalf("seed selected mutations: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
@@ -272,13 +326,44 @@ func TestRunForkMaterializer_UsesSourceCurrentStateSnapshotMetadataWhenEventFlow
 			entered_state_at, created_at, updated_at
 		)
 		VALUES (
-			$1::uuid, $2::uuid, 'state-flow/at-T', 'validation_case', 'Current Name',
-			'done', '{}'::jsonb, '{"name": "Current Name"}'::jsonb, '{}'::jsonb, 2,
-			$4, $3, $4
+			$1::uuid, $2::uuid, 'state-flow/at-T', 'validation_case', 'Fork Point Name',
+			'pending', '{}'::jsonb, '{"name": "Fork Point Name"}'::jsonb, '{}'::jsonb, 1,
+			$3, $3, $3
 		)
-	`, sourceRunID, entityID, at, afterAt); err != nil {
+	`, sourceRunID, entityID, at); err != nil {
 		t.Fatalf("seed source entity_state: %v", err)
 	}
+
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations, runforkrevision.FamilyEntityMetadata)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.post_flow', $3::uuid, 'post-flow/ignored', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, postEventID, entityID, afterAt); err != nil {
+		t.Fatalf("seed later event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'current_state', '"pending"'::jsonb, '"done"'::jsonb, $3::uuid, 'platform', 'materializer-test', 'after', $4)
+	`, sourceRunID, entityID, postEventID, afterAt); err != nil {
+		t.Fatalf("seed later mutation: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE entity_state
+		SET name = 'Current Name',
+		    current_state = 'done',
+		    fields = '{"name": "Current Name"}'::jsonb,
+		    revision = 2,
+		    entered_state_at = $3,
+		    updated_at = $3
+		WHERE run_id = $1::uuid AND entity_id = $2::uuid
+	`, sourceRunID, entityID, afterAt); err != nil {
+		t.Fatalf("update later source state: %v", err)
+	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations, runforkrevision.FamilyEntityMetadata)
 
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
@@ -347,6 +432,7 @@ func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *tes
 	`, sourceRunID, entityID, eventID, at); err != nil {
 		t.Fatalf("seed mutation: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEntityMutations)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_state (
 			run_id, entity_id, flow_instance, entity_type,
@@ -362,6 +448,7 @@ func TestRunForkPlanner_FailsClosedWithoutSourceAtTEntitySnapshotMetadata(t *tes
 		t.Fatalf("seed post-T entity_state: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, sourceRunID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -418,6 +505,7 @@ func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeHasNoSourceMetadataAuthori
 		t.Fatalf("seed mutations: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, sourceRunID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -478,6 +566,7 @@ func TestRunForkPlanner_FailsClosedWhenFieldEntityTypeConflictsWithSourceMetadat
 		t.Fatalf("seed entity_state: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, sourceRunID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -500,6 +589,7 @@ func TestRunForkSelectedContractBinding_MaterializesDurableForkRunBinding(t *tes
 	eventID := uuid.NewString()
 	at := time.Unix(1700000510, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	selection := RunForkContractSelection{
 		Mode:            "selected_contracts",
@@ -568,6 +658,7 @@ func TestRunForkSelectedContractBinding_MaterializesDurableBundleHashBinding(t *
 	eventID := uuid.NewString()
 	at := time.Unix(1700000515, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	targetHash := "bundle-v1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	selection := RunForkContractSelection{
@@ -624,6 +715,7 @@ func TestRunForkSelectedContractBinding_FailsClosedOnMissingDuplicateAndInvalidS
 	eventID := uuid.NewString()
 	at := time.Unix(1700000520, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 	invalidSelection := RunForkContractSelection{
 		Mode:            "selected_contracts",
 		WorkflowName:    "selected-workflow",
@@ -674,6 +766,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	sourceRunID := uuid.NewString()
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
+	clearEventID := uuid.NewString()
 	at := time.Unix(1700000600, 0).UTC()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO runs (run_id, status, started_at)
@@ -685,7 +778,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.pending', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+		VALUES ($1::uuid, $2::uuid, 'fork.pending', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, sourceRunID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -717,6 +810,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
 		t.Fatalf("seed in-progress delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	blocked, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
@@ -743,11 +837,23 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 	if _, err := db.ExecContext(ctx, `DELETE FROM event_deliveries WHERE run_id = $1::uuid`, sourceRunID); err != nil {
 		t.Fatalf("clear pending delivery: %v", err)
 	}
-	first, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.delivery_cleared', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, sourceRunID, clearEventID, entityID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed clear-frontier event: %v", err)
+	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents, runforkrevision.FamilyEventDeliveries)
+	if _, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID}); err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
+		t.Fatalf("MaterializeRunFork original frontier after delete error = %v, want immutable non-agent delivery blocker", err)
+	}
+	first, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: clearEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork first: %v", err)
 	}
-	_, err = pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	_, err = pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: clearEventID})
 	if err == nil || !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("MaterializeRunFork repeat error = %v, want already exists", err)
 	}
@@ -756,7 +862,7 @@ func TestRunForkMaterializer_FailsClosedOnRepeatAndUnsupportedBlockers(t *testin
 		FROM runs
 		WHERE forked_from_run_id = $1::uuid
 		  AND forked_from_event_id = $2::uuid
-	`, sourceRunID, eventID).Scan(&forkCount); err != nil {
+	`, sourceRunID, clearEventID).Scan(&forkCount); err != nil {
 		t.Fatalf("count fork rows after repeat: %v", err)
 	}
 	if forkCount != 1 {
@@ -777,6 +883,7 @@ func TestRunForkActivation_ActivatesMaterializedForkAndFreezesSource(t *testing.
 	eventID := uuid.NewString()
 	at := time.Unix(1700000800, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
@@ -858,6 +965,7 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	`, sourceRunID, eventID, at).Scan(&sourceDeliveryID); err != nil {
 		t.Fatalf("seed safe pending delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
@@ -930,7 +1038,7 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	`, materialized.ForkRunID).Scan(&forkEventID, &forkRunID, &eventName, &forkEntityID, &flowInstance, &payload, &sourceEventNull, &chainDepth); err != nil {
 		t.Fatalf("load fork replay event: %v", err)
 	}
-	if forkEventID == eventID || forkRunID != materialized.ForkRunID || eventName != "fork.ready" || forkEntityID != entityID || flowInstance != "flow-a/1" {
+	if forkEventID == eventID || forkRunID != materialized.ForkRunID || eventName != "fork.ready" || forkEntityID != entityID || flowInstance != "" {
 		t.Fatalf("fork event = id:%s run:%s name:%s entity:%s flow:%s", forkEventID, forkRunID, eventName, forkEntityID, flowInstance)
 	}
 	if !sourceEventNull || chainDepth != 0 {
@@ -1178,6 +1286,7 @@ func TestRunForkActivation_RejectsOwnerWorkOutsideCurrentSafePendingEvidence(t *
 				t.Fatalf("seed safe pending delivery: %v", err)
 			}
 			targetDeliveryID := tc.seed(t, ctx, db, sourceRunID, eventID, at)
+			captureRunForkTestRevision(t, db, sourceRunID)
 			materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 			if err != nil {
 				t.Fatalf("MaterializeRunFork: %v", err)
@@ -1267,6 +1376,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	afterEventID := uuid.NewString()
 	at := time.Unix(1700000900, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
@@ -1279,6 +1389,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	`, sourceRunID, afterEventID, entityID, at.Add(time.Second)); err != nil {
 		t.Fatalf("seed post-fork event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEvents)
 	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
 	if err == nil || !strings.Contains(err.Error(), "source_events_advanced_after_fork_point") {
 		t.Fatalf("ActivateRunFork advanced source error = %v, want source advanced blocker", err)
@@ -1301,6 +1412,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	cleanEntityID := uuid.NewString()
 	cleanEventID := uuid.NewString()
 	seedActivationReadySourceRun(t, db, cleanSourceRunID, cleanEntityID, cleanEventID, at.Add(time.Minute))
+	captureRunForkTestRevision(t, db, cleanSourceRunID)
 	cleanMaterialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: cleanSourceRunID, At: cleanEventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork clean: %v", err)
@@ -1314,7 +1426,7 @@ func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	}
 }
 
-func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *testing.T) {
+func TestRunForkActivation_FailsClosedForDeliveryAdvancementAndMissingLineage(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1324,6 +1436,7 @@ func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *
 	eventID := uuid.NewString()
 	at := time.Unix(1700001000, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
@@ -1336,12 +1449,13 @@ func TestRunForkActivation_FailsClosedForInProgressDeliveryAndMissingLineage(t *
 	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
 		t.Fatalf("seed in-progress delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID, runforkrevision.FamilyEventDeliveries)
 	blocked, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
-	if err == nil || !strings.Contains(err.Error(), RunForkBlockerNonAgentDeliveryReplayUnsupported) {
-		t.Fatalf("ActivateRunFork in-progress delivery error = %v, want non-agent delivery blocker", err)
+	if err == nil || !strings.Contains(err.Error(), "source_deliveries_advanced_after_fork_point") {
+		t.Fatalf("ActivateRunFork delivery advancement error = %v, want source delivery advancement blocker", err)
 	}
-	if blocked.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner || !blocked.ReplayResumeAdmission.ReplayResumeFactsPresent {
-		t.Fatalf("blocked activation taxonomy = %#v, want owner and historical replay required", blocked.ReplayResumeAdmission)
+	if !blocked.SourceAdvancedAfterFork || !runForkTestHasActivationBlocker(blocked, "source_deliveries_advanced_after_fork_point") {
+		t.Fatalf("blocked activation = %#v, want source delivery advancement", blocked)
 	}
 
 	orphanRunID := uuid.NewString()
@@ -1365,6 +1479,7 @@ func TestRunForkActivation_FailsClosedForForkReplayStateWithTaxonomy(t *testing.
 	forkEventID := uuid.NewString()
 	at := time.Unix(1700001050, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("MaterializeRunFork: %v", err)
@@ -1450,6 +1565,7 @@ func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testin
 			eventID := uuid.NewString()
 			at := time.Unix(1700001060, 0).UTC()
 			seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+			captureRunForkTestRevision(t, db, sourceRunID)
 			materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
 			if err != nil {
 				t.Fatalf("MaterializeRunFork: %v", err)
@@ -1477,52 +1593,6 @@ func TestRunForkActivation_FailsClosedForForkSessionAndTurnReplayState(t *testin
 				t.Fatalf("fork replay-state taxonomy missing disposition: %#v", blocked.ReplayResumeAdmission)
 			}
 		})
-	}
-}
-
-func TestRunForkActivation_ToleratesOptionalLegacyReplaySchemas(t *testing.T) {
-	_, db, _ := testutil.StartPostgres(t)
-	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
-
-	sourceRunID := uuid.NewString()
-	entityID := uuid.NewString()
-	eventID := uuid.NewString()
-	at := time.Unix(1700001100, 0).UTC()
-	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS timers CASCADE`); err != nil {
-		t.Fatalf("drop timers: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS routing_rules CASCADE`); err != nil {
-		t.Fatalf("drop routing_rules: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_turns CASCADE`); err != nil {
-		t.Fatalf("drop agent_turns: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS agent_sessions CASCADE`); err != nil {
-		t.Fatalf("drop agent_sessions: %v", err)
-	}
-	for name, ddl := range map[string]string{
-		"timers":         `CREATE TABLE timers (timer_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), entity_id UUID, flow_instance TEXT)`,
-		"routing_rules":  `CREATE TABLE routing_rules (rule_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), flow_instance TEXT)`,
-		"agent_sessions": `CREATE TABLE agent_sessions (session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), status TEXT NOT NULL DEFAULT 'active', created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`,
-		"agent_turns":    `CREATE TABLE agent_turns (turn_id UUID PRIMARY KEY DEFAULT gen_random_uuid(), session_id UUID NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`,
-	} {
-		if _, err := db.ExecContext(ctx, ddl); err != nil {
-			t.Fatalf("create legacy %s: %v", name, err)
-		}
-	}
-
-	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
-	if err != nil {
-		t.Fatalf("MaterializeRunFork with optional legacy schemas: %v", err)
-	}
-	activated, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
-	if err != nil {
-		t.Fatalf("ActivateRunFork with optional legacy schemas: %v", err)
-	}
-	if !activated.Activated || activated.ForkRunStatus != RunForkActivatedStatus || activated.SourceRunStatus != RunForkSourceFrozenStatus {
-		t.Fatalf("activation result = %#v", activated)
 	}
 }
 
@@ -1644,7 +1714,7 @@ func (n *sqlNullTime) Scan(value any) error {
 	return nil
 }
 
-func seedActivationReadySourceRun(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+func seedActivationReadySourceRun(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -1657,7 +1727,7 @@ func seedActivationReadySourceRun(t *testing.T, db execContextDB, sourceRunID, e
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+			VALUES ($1::uuid, $2::uuid, 'fork.ready', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, sourceRunID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -1365,6 +1365,41 @@ func TestRunForkDeliveryEventReplayValidationRejectsUnsafeCurrentEvidence(t *tes
 	}
 }
 
+func TestRunForkActivation_IgnoresExcludedSourceSessionColumnChanges(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	at := time.Unix(1700000890, 0).UTC()
+	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
+	seedRunForkSessionProjection(t, db, sourceRunID, "generic-session-agent", sessionID, "terminated", at)
+	selectedRevision := captureRunForkTestRevision(t, db, sourceRunID)
+
+	materialized, err := pg.MaterializeRunFork(ctx, RunForkMaterializeRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("MaterializeRunFork: %v", err)
+	}
+	mutateRunForkSessionExcludedColumns(t, db, sourceRunID, sessionID, at.Add(time.Minute))
+	var afterExcluded int64
+	if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, sourceRunID).Scan(&afterExcluded); err != nil {
+		t.Fatalf("load source revision after excluded session update: %v", err)
+	}
+	if afterExcluded != selectedRevision {
+		t.Fatalf("source revision after excluded session update = %d, want %d", afterExcluded, selectedRevision)
+	}
+
+	activation, err := pg.ActivateRunFork(ctx, RunForkActivateRequest{ForkRunID: materialized.ForkRunID})
+	if err != nil {
+		t.Fatalf("ActivateRunFork after excluded session update: %v", err)
+	}
+	if !activation.Activated || activation.SourceAdvancedAfterFork || runForkTestHasActivationBlocker(activation, "source_sessions_advanced_after_fork_point") {
+		t.Fatalf("activation = %#v, want activation without session advancement", activation)
+	}
+}
+
 func TestRunForkActivation_FailsClosedForSourceAdvancedAndRepeat(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"time"
 
-	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/mutationlog"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 )
 
 const (
@@ -47,6 +46,8 @@ type RunForkPlan struct {
 	Entities                  []RunForkEntityState              `json:"entities,omitempty"`
 	PendingWork               []RunForkPendingWork              `json:"pending_work,omitempty"`
 	UnsupportedBlockers       []RunForkUnsupportedBlocker       `json:"unsupported_blockers,omitempty"`
+	RouteHistory              RunForkRouteHistoryProjection     `json:"route_history"`
+	historicalSnapshot        *runForkRevisionSnapshot
 }
 
 type RunForkPoint struct {
@@ -57,6 +58,16 @@ type RunForkPoint struct {
 	ProducedBy     string    `json:"produced_by,omitempty"`
 	ProducedByType string    `json:"produced_by_type,omitempty"`
 	Timestamp      time.Time `json:"timestamp"`
+	Revision       int64     `json:"revision"`
+}
+
+const (
+	RunForkRouteHistoryNotApplicable      = "not_applicable"
+	RunForkRouteHistoryUnknownUnversioned = "unknown_unversioned"
+)
+
+type RunForkRouteHistoryProjection struct {
+	State string `json:"state"`
 }
 
 type RunForkEntityState struct {
@@ -100,12 +111,14 @@ type runForkEventCursor struct {
 	ProducedBy     string
 	ProducedByType string
 	CreatedAt      time.Time
+	Revision       int64
 }
 
 type runForkAdmissionEvidence struct {
 	Pending                 []RunForkPendingWork
 	RelevantTimer           bool
 	RelevantRoute           bool
+	RouteHistory            RunForkRouteHistoryProjection
 	ActiveSession           bool
 	ActiveConversationAudit bool
 	ActiveTurn              bool
@@ -167,7 +180,7 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	if s == nil || s.DB == nil {
 		return RunForkPlan{}, fmt.Errorf("postgres store is required")
 	}
-	catalog, err := s.requireRunForkPlannerCapabilities(ctx)
+	_, err := s.requireRunForkPlannerCapabilities(ctx)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
@@ -180,14 +193,33 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	}
 	at := strings.TrimSpace(req.At)
 
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	if err != nil {
+		return RunForkPlan{}, fmt.Errorf("begin run fork revision snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	plan := RunForkPlan{SourceRunID: runID}
-	if err := s.loadRunForkSourceSummary(ctx, &plan); err != nil {
+	if err := loadRunForkSourceSummary(ctx, tx, &plan); err != nil {
 		return RunForkPlan{}, err
 	}
-	cursor, err := s.resolveRunForkPoint(ctx, runID, at)
+	if err := runforkrevision.ValidateComplete(ctx, tx, runID); err != nil {
+		return RunForkPlan{}, err
+	}
+	if at != "" {
+		if _, err := uuid.Parse(at); err != nil {
+			return RunForkPlan{}, fmt.Errorf("fork point --at must be an event UUID: %w", err)
+		}
+	}
+	cursor, err := resolveRunForkRevisionPoint(ctx, tx, runID, at)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
+	snapshot, err := loadRunForkRevisionSnapshot(ctx, tx, runID, cursor.Revision)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
+	plan.historicalSnapshot = snapshot
 	plan.ForkPoint = RunForkPoint{
 		Input:          at,
 		EventID:        cursor.EventID,
@@ -196,38 +228,33 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 		ProducedBy:     cursor.ProducedBy,
 		ProducedByType: cursor.ProducedByType,
 		Timestamp:      cursor.CreatedAt,
+		Revision:       cursor.Revision,
 	}
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM events
-		WHERE run_id = $1::uuid
-		  AND (created_at, event_id) <= ($2::timestamptz, $3::uuid)
-	`, runID, cursor.CreatedAt, cursor.EventID).Scan(&plan.EventCountAtFork); err != nil {
-		return RunForkPlan{}, fmt.Errorf("count fork events: %w", err)
-	}
+	plan.EventCountAtFork = len(snapshot.Events)
 
-	entities, err := s.loadRunForkEntityStates(ctx, runID, cursor)
+	entities, err := loadRunForkEntityStates(snapshot)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
-	entities, entitySnapshotMetadataAdmission, err := s.attachRunForkMaterializedEntitySnapshotMetadata(ctx, runID, cursor, entities)
+	entities, entitySnapshotMetadataAdmission, err := attachRunForkMaterializedEntitySnapshotMetadata(snapshot, entities)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
 	plan.Entities = entities
 	plan.ReconstructedEntityCount = len(entities)
 
-	pending, err := s.loadRunForkPendingWork(ctx, runID, cursor)
+	pending, err := loadRunForkPendingWorkFromRevision(snapshot)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
 	plan.PendingWork = pending
 	plan.PendingWorkCount = len(pending)
-	evidence, err := s.loadRunForkAdmissionEvidence(ctx, catalog, runID, cursor, entities, pending)
+	evidence, err := loadRunForkAdmissionEvidenceFromRevision(snapshot, entities, pending)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
 	plan.ReplayResumeAdmission = runForkReplayResumeAdmission(evidence)
+	plan.RouteHistory = evidence.RouteHistory
 	plan.ReplayResumeAdmission = runForkReplayResumeAdmissionWithMaterializedEntitySnapshotMetadata(plan.ReplayResumeAdmission, entitySnapshotMetadataAdmission)
 	plan.UnsupportedBlockers = plan.ReplayResumeAdmission.UnsupportedBlockers
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
@@ -235,9 +262,9 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	return plan, nil
 }
 
-func (s *PostgresStore) loadRunForkSourceSummary(ctx context.Context, plan *RunForkPlan) error {
+func loadRunForkSourceSummary(ctx context.Context, q rowQueryer, plan *RunForkPlan) error {
 	var started, ended sql.NullTime
-	if err := s.DB.QueryRowContext(ctx, `
+	if err := q.QueryRowContext(ctx, `
 		SELECT COALESCE(status, ''), started_at, ended_at
 		FROM runs
 		WHERE run_id = $1::uuid
@@ -258,101 +285,7 @@ func (s *PostgresStore) loadRunForkSourceSummary(ctx context.Context, plan *RunF
 	return nil
 }
 
-func (s *PostgresStore) resolveRunForkPoint(ctx context.Context, runID, at string) (runForkEventCursor, error) {
-	if strings.TrimSpace(at) == "" {
-		var cursor runForkEventCursor
-		if err := s.DB.QueryRowContext(ctx, `
-			SELECT
-				event_id::text,
-				event_name,
-				COALESCE(source_event_id::text, ''),
-				COALESCE(produced_by, ''),
-				COALESCE(produced_by_type, ''),
-				created_at
-			FROM events
-			WHERE run_id = $1::uuid
-			ORDER BY created_at DESC, event_id DESC
-			LIMIT 1
-		`, runID).Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt); err != nil {
-			if err == sql.ErrNoRows {
-				return runForkEventCursor{}, fmt.Errorf("no source-run event exists for fork source run %s", runID)
-			}
-			return runForkEventCursor{}, fmt.Errorf("resolve default fork event: %w", err)
-		}
-		return cursor, nil
-	}
-	if _, err := uuid.Parse(at); err == nil {
-		var cursor runForkEventCursor
-		if err := s.DB.QueryRowContext(ctx, `
-			SELECT
-				event_id::text,
-				event_name,
-				COALESCE(source_event_id::text, ''),
-				COALESCE(produced_by, ''),
-				COALESCE(produced_by_type, ''),
-				created_at
-			FROM events
-			WHERE run_id = $1::uuid
-			  AND event_id = $2::uuid
-		`, runID, at).Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt); err != nil {
-			if err == sql.ErrNoRows {
-				return runForkEventCursor{}, fmt.Errorf("fork point event %s not found in source run %s", at, runID)
-			}
-			return runForkEventCursor{}, fmt.Errorf("resolve fork event: %w", err)
-		}
-		return cursor, nil
-	}
-	atTime, err := time.Parse(time.RFC3339Nano, at)
-	if err != nil {
-		return runForkEventCursor{}, fmt.Errorf("fork point --at must be an event UUID or RFC3339 timestamp: %w", err)
-	}
-	var cursor runForkEventCursor
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT
-			event_id::text,
-			event_name,
-			COALESCE(source_event_id::text, ''),
-			COALESCE(produced_by, ''),
-			COALESCE(produced_by_type, ''),
-			created_at
-		FROM events
-		WHERE run_id = $1::uuid
-		  AND created_at <= $2::timestamptz
-		ORDER BY created_at DESC, event_id DESC
-		LIMIT 1
-	`, runID, atTime).Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt); err != nil {
-		if err == sql.ErrNoRows {
-			return runForkEventCursor{}, fmt.Errorf("no source-run event exists at or before fork timestamp %s", at)
-		}
-		return runForkEventCursor{}, fmt.Errorf("resolve fork timestamp: %w", err)
-	}
-	return cursor, nil
-}
-
-func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID string, cursor runForkEventCursor) ([]RunForkEntityState, error) {
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT
-			m.entity_id::text,
-			m.field,
-			COALESCE(m.new_value, 'null'::jsonb),
-			m.created_at
-		FROM entity_mutations m
-		LEFT JOIN events e
-			ON e.event_id = m.caused_by_event
-		   AND e.run_id = m.run_id
-		WHERE m.run_id = $1::uuid
-		  AND (
-				(e.event_id IS NOT NULL AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid))
-				OR
-				(e.event_id IS NULL AND m.created_at <= $2::timestamptz)
-		  )
-		ORDER BY m.entity_id ASC, m.created_at ASC, m.mutation_id ASC
-	`, runID, cursor.CreatedAt, cursor.EventID)
-	if err != nil {
-		return nil, fmt.Errorf("load fork entity mutations: %w", err)
-	}
-	defer rows.Close()
-
+func loadRunForkEntityStates(snapshot *runForkRevisionSnapshot) ([]RunForkEntityState, error) {
 	type timedProjectionMutation struct {
 		mutationlog.ProjectionMutation
 		CreatedAt time.Time
@@ -360,18 +293,13 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 	grouped := map[string][]timedProjectionMutation{}
 	entityOrder := []string{}
 	seen := map[string]struct{}{}
-	for rows.Next() {
-		var entityID, field string
-		var raw []byte
-		var createdAt time.Time
-		if err := rows.Scan(&entityID, &field, &raw, &createdAt); err != nil {
-			return nil, fmt.Errorf("scan fork entity mutation: %w", err)
-		}
+	for _, fact := range snapshot.EntityMutations {
+		entityID := strings.TrimSpace(fact.EntityID)
+		field := strings.TrimSpace(fact.Field)
 		var value any
-		if err := json.Unmarshal(raw, &value); err != nil {
+		if err := json.Unmarshal(fact.NewValue, &value); err != nil {
 			return nil, fmt.Errorf("decode fork entity mutation %s/%s: %w", entityID, field, err)
 		}
-		entityID = strings.TrimSpace(entityID)
 		if _, ok := seen[entityID]; !ok {
 			seen[entityID] = struct{}{}
 			entityOrder = append(entityOrder, entityID)
@@ -381,11 +309,8 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 				Field:    field,
 				NewValue: value,
 			},
-			CreatedAt: createdAt,
+			CreatedAt: fact.CreatedAt,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read fork entity mutations: %w", err)
 	}
 
 	out := make([]RunForkEntityState, 0, len(entityOrder))
@@ -412,164 +337,6 @@ func (s *PostgresStore) loadRunForkEntityStates(ctx context.Context, runID strin
 			Gates:          projection.Gates,
 			Accumulator:    projection.Accumulator,
 		})
-	}
-	return out, nil
-}
-
-func (s *PostgresStore) loadRunForkPendingWork(ctx context.Context, runID string, cursor runForkEventCursor) ([]RunForkPendingWork, error) {
-	rows, err := s.DB.QueryContext(ctx, `
-		WITH delivery_rows AS (
-			SELECT
-				e.event_id::text AS event_id,
-				e.event_name AS event_name,
-				COALESCE(e.flow_instance, '') AS flow_instance,
-				d.delivery_id::text AS delivery_id,
-				COALESCE(d.subscriber_type, '') AS subscriber_type,
-				COALESCE(d.subscriber_id, '') AS subscriber_id,
-				CASE
-					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.status, '')
-					WHEN d.started_at IS NOT NULL AND d.started_at <= $2::timestamptz THEN 'in_progress'
-					ELSE 'pending'
-				END AS status,
-				CASE
-					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.retry_count, 0)
-					ELSE 0
-				END AS retry_count,
-				CASE
-					WHEN d.delivered_at IS NOT NULL AND d.delivered_at <= $2::timestamptz THEN COALESCE(d.reason_code, '')
-					WHEN COALESCE(d.status, '') = 'pending'
-					 AND d.started_at IS NULL
-					 AND d.delivered_at IS NULL
-					THEN COALESCE(d.reason_code, '')
-					ELSE ''
-				END AS reason_code,
-				CASE
-					WHEN d.started_at IS NOT NULL
-					 AND d.started_at <= $2::timestamptz
-					 AND (d.delivered_at IS NULL OR d.delivered_at > $2::timestamptz)
-					THEN COALESCE(d.active_session_id::text, '')
-					ELSE ''
-				END AS active_session_id,
-				d.created_at AS created_at,
-				CASE WHEN d.started_at <= $2::timestamptz THEN d.started_at ELSE NULL END AS started_at,
-				CASE WHEN d.delivered_at <= $2::timestamptz THEN d.delivered_at ELSE NULL END AS delivered_at,
-				COALESCE(r.outcome, '') AS receipt_outcome,
-				r.processed_at AS receipt_at,
-				EXISTS (
-					SELECT 1
-					FROM dead_letters dl
-					WHERE dl.original_event_id = e.event_id
-					  AND dl.created_at <= $2::timestamptz
-					  AND COALESCE(dl.handler_node, '') <> ''
-					  AND COALESCE(d.subscriber_type, '') = 'node'
-					  AND dl.handler_node = d.subscriber_id
-				) AS dead_letter
-			FROM events e
-			INNER JOIN event_deliveries d ON d.event_id = e.event_id
-			LEFT JOIN event_receipts r
-				ON r.event_id = d.event_id
-			   AND r.subscriber_type = d.subscriber_type
-			   AND r.subscriber_id = d.subscriber_id
-			   AND r.processed_at <= $2::timestamptz
-			WHERE e.run_id = $1::uuid
-			  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
-			  AND d.created_at <= $2::timestamptz
-		),
-		receipt_only_rows AS (
-			SELECT
-				e.event_id::text AS event_id,
-				e.event_name AS event_name,
-				COALESCE(e.flow_instance, '') AS flow_instance,
-				''::text AS delivery_id,
-				COALESCE(r.subscriber_type, '') AS subscriber_type,
-				COALESCE(r.subscriber_id, '') AS subscriber_id,
-				''::text AS status,
-				0 AS retry_count,
-				COALESCE(r.reason_code, '') AS reason_code,
-				''::text AS active_session_id,
-				r.processed_at AS created_at,
-				NULL::timestamptz AS started_at,
-				r.processed_at AS delivered_at,
-				COALESCE(r.outcome, '') AS receipt_outcome,
-				r.processed_at AS receipt_at,
-				FALSE AS dead_letter
-			FROM events e
-			INNER JOIN event_receipts r ON r.event_id = e.event_id
-			WHERE e.run_id = $1::uuid
-			  AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
-			  AND r.processed_at <= $2::timestamptz
-			  AND r.subscriber_type IN ('platform', 'node')
-			  AND NOT EXISTS (
-				SELECT 1
-				FROM event_deliveries d
-				WHERE d.event_id = r.event_id
-				  AND d.subscriber_type = r.subscriber_type
-				  AND d.subscriber_id = r.subscriber_id
-				  AND d.created_at <= $2::timestamptz
-			  )
-		)
-		SELECT
-			event_id,
-			event_name,
-			flow_instance,
-			delivery_id,
-			subscriber_type,
-			subscriber_id,
-			status,
-			retry_count,
-			reason_code,
-			active_session_id,
-			created_at,
-			started_at,
-			delivered_at,
-			receipt_outcome,
-			receipt_at,
-			dead_letter
-		FROM (
-			SELECT * FROM delivery_rows
-			UNION ALL
-			SELECT * FROM receipt_only_rows
-		) work
-		ORDER BY created_at ASC, event_id ASC, delivery_id ASC, subscriber_type ASC, subscriber_id ASC
-	`, runID, cursor.CreatedAt, cursor.EventID)
-	if err != nil {
-		return nil, fmt.Errorf("load fork pending work: %w", err)
-	}
-	defer rows.Close()
-
-	out := []RunForkPendingWork{}
-	for rows.Next() {
-		var item RunForkPendingWork
-		var started, delivered, receipt sql.NullTime
-		var deadLetter bool
-		if err := rows.Scan(
-			&item.EventID,
-			&item.EventName,
-			&item.FlowInstance,
-			&item.DeliveryID,
-			&item.SubscriberType,
-			&item.SubscriberID,
-			&item.Status,
-			&item.RetryCount,
-			&item.ReasonCode,
-			&item.ActiveSessionID,
-			&item.CreatedAt,
-			&started,
-			&delivered,
-			&item.ReceiptOutcome,
-			&receipt,
-			&deadLetter,
-		); err != nil {
-			return nil, fmt.Errorf("scan fork pending work: %w", err)
-		}
-		item.StartedAt = nullableTimePtr(started)
-		item.DeliveredAt = nullableTimePtr(delivered)
-		item.ReceiptAt = nullableTimePtr(receipt)
-		item.Classification = classifyRunForkPendingWork(item, deadLetter)
-		out = append(out, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("read fork pending work: %w", err)
 	}
 	return out, nil
 }
@@ -601,232 +368,6 @@ func classifyRunForkPendingWork(item RunForkPendingWork, deadLetter bool) string
 		}
 		return RunForkPendingClassificationPending
 	}
-}
-
-func (s *PostgresStore) loadRunForkAdmissionEvidence(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor, entities []RunForkEntityState, pending []RunForkPendingWork) (runForkAdmissionEvidence, error) {
-	facts, err := s.loadRunForkSourceFacts(ctx, runID, cursor, entities)
-	if err != nil {
-		return runForkAdmissionEvidence{}, err
-	}
-	relevantTimer, err := s.hasRunForkRelevantTimer(ctx, catalog, runID, facts, cursor)
-	if err != nil {
-		return runForkAdmissionEvidence{}, err
-	}
-	relevantRoute, err := s.hasRunForkRelevantRoute(ctx, catalog, facts, cursor)
-	if err != nil {
-		return runForkAdmissionEvidence{}, err
-	}
-	activeSession := runForkPendingReferencesActiveSession(pending)
-	if !activeSession {
-		activeSession, err = s.hasRunForkActiveSession(ctx, catalog, runID, cursor)
-		if err != nil {
-			return runForkAdmissionEvidence{}, err
-		}
-	}
-	activeConversationAudit, err := s.hasRunForkConversationAuditHistory(ctx, catalog, runID, cursor)
-	if err != nil {
-		return runForkAdmissionEvidence{}, err
-	}
-	activeTurn := runForkPendingReferencesActiveSession(pending)
-	if !activeTurn {
-		activeTurn, err = s.hasRunForkActiveTurn(ctx, catalog, runID, cursor)
-		if err != nil {
-			return runForkAdmissionEvidence{}, err
-		}
-	}
-	openReplyContext, err := s.hasRunForkOpenReplyContext(ctx, runID, cursor)
-	if err != nil {
-		return runForkAdmissionEvidence{}, err
-	}
-	return runForkAdmissionEvidence{
-		Pending:                 pending,
-		RelevantTimer:           relevantTimer,
-		RelevantRoute:           relevantRoute,
-		ActiveSession:           activeSession,
-		ActiveConversationAudit: activeConversationAudit,
-		ActiveTurn:              activeTurn,
-		OpenReplyContext:        openReplyContext,
-	}, nil
-}
-
-func (s *PostgresStore) hasRunForkOpenReplyContext(ctx context.Context, runID string, cursor runForkEventCursor) (bool, error) {
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM reply_contexts rc
-			JOIN events request_event ON request_event.event_id = rc.request_event_id
-			WHERE rc.run_id = $1::uuid
-			  AND rc.state = 'open'
-			  AND (request_event.created_at, request_event.event_id) <= ($2::timestamptz, $3::uuid)
-		)
-	`, runID, cursor.CreatedAt, cursor.EventID).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork open reply contexts: %w", err)
-	}
-	return exists, nil
-}
-
-func (s *PostgresStore) loadRunForkSourceFacts(ctx context.Context, runID string, cursor runForkEventCursor, entities []RunForkEntityState) (runForkSourceFacts, error) {
-	entitySet := map[string]struct{}{}
-	flowSet := map[string]struct{}{}
-	sourceFlowSet := map[string]struct{}{}
-	for _, entity := range entities {
-		if entityID := strings.TrimSpace(entity.EntityID); entityID != "" {
-			entitySet[entityID] = struct{}{}
-		}
-	}
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT COALESCE(entity_id::text, ''), COALESCE(flow_instance, '')
-		FROM events
-		WHERE run_id = $1::uuid
-		  AND (created_at, event_id) <= ($2::timestamptz, $3::uuid)
-	`, runID, cursor.CreatedAt, cursor.EventID)
-	if err != nil {
-		return runForkSourceFacts{}, fmt.Errorf("load fork source facts: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var entityID, flowInstance string
-		if err := rows.Scan(&entityID, &flowInstance); err != nil {
-			return runForkSourceFacts{}, fmt.Errorf("scan fork source facts: %w", err)
-		}
-		if entityID = strings.TrimSpace(entityID); entityID != "" {
-			entitySet[entityID] = struct{}{}
-		}
-		if flowInstance = strings.TrimSpace(flowInstance); flowInstance != "" {
-			flowSet[flowInstance] = struct{}{}
-			if sourceFlow := runtimeflowidentity.SemanticScope(flowInstance); sourceFlow != "" {
-				sourceFlowSet[sourceFlow] = struct{}{}
-			}
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return runForkSourceFacts{}, fmt.Errorf("read fork source facts: %w", err)
-	}
-	return runForkSourceFacts{
-		EntityIDs:     stringSetValues(entitySet),
-		FlowInstances: stringSetValues(flowSet),
-		SourceFlows:   stringSetValues(sourceFlowSet),
-	}, nil
-}
-
-func (s *PostgresStore) hasRunForkRelevantTimer(ctx context.Context, catalog schemaColumnCatalog, runID string, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("timers", "run_id", "entity_id", "flow_instance", "created_at") {
-		return false, nil
-	}
-	if len(facts.EntityIDs) == 0 && len(facts.FlowInstances) == 0 {
-		return false, nil
-	}
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM timers
-			WHERE run_id = $1::uuid
-			  AND created_at <= $2::timestamptz
-			  AND (
-					(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
-					OR
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
-			  )
-		)
-	`, runID, cursor.CreatedAt, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances)).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork timer blockers: %w", err)
-	}
-	return exists, nil
-}
-
-func (s *PostgresStore) hasRunForkRelevantRoute(ctx context.Context, catalog schemaColumnCatalog, facts runForkSourceFacts, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("routing_rules", "flow_instance", "source_flow", "created_at") {
-		return false, nil
-	}
-	if len(facts.FlowInstances) == 0 && len(facts.SourceFlows) == 0 {
-		return false, nil
-	}
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM routing_rules
-			WHERE created_at <= $1::timestamptz
-			  AND (
-					(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($2::text[]))
-					OR
-					(COALESCE(source_flow, '') <> '' AND source_flow = ANY($3::text[]))
-			  )
-		)
-	`, cursor.CreatedAt, pq.Array(facts.FlowInstances), pq.Array(facts.SourceFlows)).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork route blockers: %w", err)
-	}
-	return exists, nil
-}
-
-func (s *PostgresStore) hasRunForkActiveSession(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("agent_sessions", "run_id", "status", "created_at") {
-		return false, nil
-	}
-	activePredicate := "COALESCE(status, '') IN ('active', 'suspended')"
-	if catalog.hasColumns("agent_sessions", "terminated_at") {
-		activePredicate = "(COALESCE(status, '') IN ('active', 'suspended') OR (COALESCE(status, '') = 'terminated' AND terminated_at > $2::timestamptz))"
-	}
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT EXISTS (
-			SELECT 1
-			FROM agent_sessions
-			WHERE run_id = $1::uuid
-			  AND created_at <= $2::timestamptz
-			  AND %s
-		)
-	`, activePredicate), runID, cursor.CreatedAt).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork session blockers: %w", err)
-	}
-	return exists, nil
-}
-
-func (s *PostgresStore) hasRunForkConversationAuditHistory(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("agent_conversation_audits", "run_id", "created_at") {
-		return false, nil
-	}
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1
-			FROM agent_conversation_audits
-			WHERE run_id = $1::uuid
-			  AND created_at <= $2::timestamptz
-		)
-	`, runID, cursor.CreatedAt).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork conversation audit blockers: %w", err)
-	}
-	return exists, nil
-}
-
-func (s *PostgresStore) hasRunForkActiveTurn(ctx context.Context, catalog schemaColumnCatalog, runID string, cursor runForkEventCursor) (bool, error) {
-	if !catalog.hasColumns("agent_turns", "run_id", "session_id", "created_at") ||
-		!catalog.hasColumns("agent_sessions", "session_id", "run_id", "status", "created_at") {
-		return false, nil
-	}
-	activePredicate := "COALESCE(s.status, '') IN ('active', 'suspended')"
-	if catalog.hasColumns("agent_sessions", "terminated_at") {
-		activePredicate = "(COALESCE(s.status, '') IN ('active', 'suspended') OR (COALESCE(s.status, '') = 'terminated' AND s.terminated_at > $2::timestamptz))"
-	}
-	var exists bool
-	if err := s.DB.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT EXISTS (
-			SELECT 1
-			FROM agent_turns t
-			INNER JOIN agent_sessions s ON s.session_id = t.session_id
-			WHERE t.run_id = $1::uuid
-			  AND s.run_id = $1::uuid
-			  AND t.created_at <= $2::timestamptz
-			  AND s.created_at <= $2::timestamptz
-			  AND %s
-		)
-	`, activePredicate), runID, cursor.CreatedAt).Scan(&exists); err != nil {
-		return false, fmt.Errorf("check fork active turn blockers: %w", err)
-	}
-	return exists, nil
 }
 
 func runForkPendingReferencesActiveSession(pending []RunForkPendingWork) bool {

--- a/internal/store/run_fork_planner_test.go
+++ b/internal/store/run_fork_planner_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
+func TestRunForkPlanner_ResolvesCommitOrderedEventRevisionsAndRejectsTimestampSelectors(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -30,12 +31,20 @@ func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
 		INSERT INTO events (
 			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES
-			($1::uuid, $2::uuid, 'fork.first', 'global', '{}'::jsonb, 'test', 'platform', $4),
-			($1::uuid, $3::uuid, 'fork.second', 'global', '{}'::jsonb, 'test', 'platform', $4)
-	`, runID, firstEventID, secondEventID, at); err != nil {
-		t.Fatalf("seed events: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'fork.first', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, firstEventID, at); err != nil {
+		t.Fatalf("seed first event: %v", err)
 	}
+	firstRevision := captureRunForkTestRevision(t, db, runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.second', 'global', '{}'::jsonb, 'test', 'platform', $3)
+	`, runID, secondEventID, at); err != nil {
+		t.Fatalf("seed second event: %v", err)
+	}
+	secondRevision := captureRunForkTestRevision(t, db, runID)
 
 	byEvent, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: firstEventID})
 	if err != nil {
@@ -47,16 +56,23 @@ func TestRunForkPlanner_ResolvesEventAndTimestampForkPoints(t *testing.T) {
 	if byEvent.EventCountAtFork != 1 {
 		t.Fatalf("event count at event fork = %d, want 1", byEvent.EventCountAtFork)
 	}
+	if byEvent.ForkPoint.Revision != firstRevision {
+		t.Fatalf("first event revision = %d, want %d", byEvent.ForkPoint.Revision, firstRevision)
+	}
 
-	byTimestamp, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: at.Format(time.RFC3339Nano)})
+	bySecondEvent, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: secondEventID})
 	if err != nil {
-		t.Fatalf("PlanRunFork(timestamp): %v", err)
+		t.Fatalf("PlanRunFork(second event): %v", err)
 	}
-	if byTimestamp.ForkPoint.EventID != secondEventID {
-		t.Fatalf("timestamp fork point = %s, want same-timestamp max event %s", byTimestamp.ForkPoint.EventID, secondEventID)
+	if bySecondEvent.ForkPoint.EventID != secondEventID || bySecondEvent.ForkPoint.Revision != secondRevision {
+		t.Fatalf("second fork point = %#v, want event %s revision %d", bySecondEvent.ForkPoint, secondEventID, secondRevision)
 	}
-	if byTimestamp.EventCountAtFork != 2 {
-		t.Fatalf("event count at timestamp fork = %d, want 2", byTimestamp.EventCountAtFork)
+	if bySecondEvent.EventCountAtFork != 2 {
+		t.Fatalf("event count at second event = %d, want 2", bySecondEvent.EventCountAtFork)
+	}
+
+	if _, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: at.Format(time.RFC3339Nano)}); err == nil || !strings.Contains(err.Error(), "UUID") {
+		t.Fatalf("timestamp selector error = %v, want UUID-only rejection", err)
 	}
 }
 
@@ -94,7 +110,8 @@ func TestRunForkPlanner_FailsClosedForOpenReplyContextAtForkPoint(t *testing.T) 
 		t.Fatalf("seed reply context: %v", err)
 	}
 
-	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: at.Format(time.RFC3339Nano)})
+	captureRunForkTestRevision(t, db, runID)
+	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: requestEventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
 	}
@@ -126,27 +143,42 @@ func TestRunForkPlanner_ReconstructsEntityStateAtForkPointFromMutations(t *testi
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES
-			($1::uuid, $2::uuid, 'fork.before', $4::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $5),
-			($1::uuid, $3::uuid, 'fork.after', $4::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $6)
-	`, runID, firstEventID, secondEventID, entityID, at, at.Add(time.Minute)); err != nil {
-		t.Fatalf("seed events: %v", err)
+		VALUES ($1::uuid, $2::uuid, 'fork.before', $3::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, firstEventID, entityID, at); err != nil {
+		t.Fatalf("seed first event: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
 			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
-			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
-			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
-			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $5),
-			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $4::uuid, 'platform', 'planner-test', 'after', $6),
-			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $4::uuid, 'platform', 'planner-test', 'after', $6)
-	`, runID, entityID, firstEventID, secondEventID, at, at.Add(time.Minute)); err != nil {
-		t.Fatalf("seed mutations: %v", err)
+			($1::uuid, $2::uuid, 'current_state', 'null'::jsonb, '"queued"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $4),
+			($1::uuid, $2::uuid, 'title', 'null'::jsonb, '"before-title"'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $4),
+			($1::uuid, $2::uuid, 'gates.ready', 'null'::jsonb, 'true'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $4),
+			($1::uuid, $2::uuid, 'accumulator.score', 'null'::jsonb, '7'::jsonb, $3::uuid, 'platform', 'planner-test', 'before', $4)
+	`, runID, entityID, firstEventID, at); err != nil {
+		t.Fatalf("seed first revision mutations: %v", err)
 	}
-
+	captureRunForkTestRevision(t, db, runID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			run_id, event_id, event_name, entity_id, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES ($1::uuid, $2::uuid, 'fork.after', $3::uuid, 'entity', '{}'::jsonb, 'test', 'platform', $4)
+	`, runID, secondEventID, entityID, at); err != nil {
+		t.Fatalf("seed second event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, old_value, new_value, caused_by_event, writer_type, writer_id, handler_step, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, 'current_state', '"queued"'::jsonb, '"done"'::jsonb, $3::uuid, 'platform', 'planner-test', 'after', $4),
+			($1::uuid, $2::uuid, 'title', '"before-title"'::jsonb, '"after-title"'::jsonb, $3::uuid, 'platform', 'planner-test', 'after', $4)
+	`, runID, entityID, secondEventID, at); err != nil {
+		t.Fatalf("seed second revision mutations: %v", err)
+	}
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: firstEventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -219,6 +251,7 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 		t.Fatalf("seed receipt: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -263,6 +296,7 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 	for _, code := range []string{
 		"delivery_history_unproven",
 		RunForkBlockerCommittedReplayScopeReplayUnsupported,
+		RunForkBlockerFlowRouteHistoryUnproven,
 		"session_history_unproven",
 		"active_turn_history_unproven",
 	} {
@@ -270,7 +304,7 @@ func TestRunForkPlanner_ClassifiesPendingWorkAndNamedBlockers(t *testing.T) {
 			t.Fatalf("missing blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
 		}
 	}
-	for _, code := range []string{"timer_history_unproven", "flow_route_history_unproven"} {
+	for _, code := range []string{"timer_history_unproven"} {
 		if blockers[code] {
 			t.Fatalf("unexpected unrelated blocker %q; blockers=%#v", code, plan.UnsupportedBlockers)
 		}
@@ -320,6 +354,7 @@ func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *te
 		t.Fatalf("seed safe pending delivery: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -332,6 +367,9 @@ func TestRunForkPlanner_PendingUnstartedDeliveryIsDeliveryEventReplayReady(t *te
 	}
 	if !plan.ReplayResumeAdmission.DeliveryEventReplayReady || !plan.ReplayResumeAdmission.ReplayResumeFactsPresent || !plan.ReplayResumeAdmission.BoundedReplaySupported {
 		t.Fatalf("replay flags = %#v, want delivery-event replay ready and supported", plan.ReplayResumeAdmission)
+	}
+	if plan.RouteHistory.State != RunForkRouteHistoryNotApplicable {
+		t.Fatalf("route history = %#v, want %s", plan.RouteHistory, RunForkRouteHistoryNotApplicable)
 	}
 	for _, disposition := range plan.ReplayResumeAdmission.Dispositions {
 		if disposition.Fact == RunForkReplayResumeFactDeliveryPendingHistory && disposition.Disposition == RunForkReplayResumeDispositionForkReplay {
@@ -372,6 +410,7 @@ func TestRunForkPlanner_NodePendingDeliveryRemainsBlocked(t *testing.T) {
 		t.Fatalf("seed node pending delivery: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -473,6 +512,7 @@ func TestRunForkPlanner_NonAgentDeliveryStatesRemainNamedBlockers(t *testing.T) 
 				t.Fatalf("seed node delivery: %v", err)
 			}
 
+			captureRunForkTestRevision(t, db, runID)
 			plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 			if err != nil {
 				t.Fatalf("PlanRunFork: %v", err)
@@ -527,6 +567,7 @@ func TestRunForkPlanner_ReplayScopeMarkerRemainsCommittedReplayBlocker(t *testin
 		t.Fatalf("seed replay-scope marker: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -580,7 +621,7 @@ func TestRunForkPlanner_SystemDeliveryRowsAreNotCanonicalEventDeliveries(t *test
 	}
 }
 
-func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRouteTables(t *testing.T) {
+func TestRunForkPlanner_RouteRelevantStateRemainsBlockedDespiteUnrelatedCurrentRouteRows(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -642,25 +683,52 @@ func TestRunForkPlanner_StateOnlyPlanExecutionReadyWithEmptyAndUnrelatedTimerRou
 		t.Fatalf("seed unrelated route: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
 	}
-	if !plan.ExecutionReady {
-		t.Fatalf("ExecutionReady = false, want true for state-only plan; blockers=%#v", plan.UnsupportedBlockers)
+	if plan.ExecutionReady {
+		t.Fatalf("ExecutionReady = true, want route-history blocker; blockers=%#v", plan.UnsupportedBlockers)
 	}
-	if plan.UnsupportedBlockerCount != 0 {
-		t.Fatalf("UnsupportedBlockerCount = %d, want 0; blockers=%#v", plan.UnsupportedBlockerCount, plan.UnsupportedBlockers)
+	if !runForkTestHasBlocker(plan, RunForkBlockerFlowRouteHistoryUnproven) {
+		t.Fatalf("blockers=%#v, want %s", plan.UnsupportedBlockers, RunForkBlockerFlowRouteHistoryUnproven)
+	}
+	if plan.RouteHistory.State != RunForkRouteHistoryUnknownUnversioned {
+		t.Fatalf("route history = %#v, want %s", plan.RouteHistory, RunForkRouteHistoryUnknownUnversioned)
+	}
+	baseline, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal baseline fixed-revision plan: %v", err)
+	}
+	for _, mutation := range []struct {
+		label string
+		query string
+	}{
+		{label: "update", query: `UPDATE routing_rules SET event_pattern='fork.state', flow_instance='flow-a/1', source_flow='flow-a', status='active'`},
+		{label: "delete", query: `DELETE FROM routing_rules`},
+		{label: "insert", query: `INSERT INTO routing_rules (event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow, is_materialized, status, created_at) VALUES ('fork.state', 'node', 'late-node', 'flow-a/9', 'flow-a', true, 'active', now())`},
+	} {
+		if _, err := db.ExecContext(ctx, mutation.query); err != nil {
+			t.Fatalf("%s current routing rules: %v", mutation.label, err)
+		}
+		replanned, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
+		if err != nil {
+			t.Fatalf("PlanRunFork after current route %s: %v", mutation.label, err)
+		}
+		got, err := json.Marshal(replanned)
+		if err != nil {
+			t.Fatalf("marshal fixed-revision plan after route %s: %v", mutation.label, err)
+		}
+		if string(got) != string(baseline) {
+			t.Fatalf("fixed-revision plan changed after current route %s\nbefore: %s\nafter:  %s", mutation.label, baseline, got)
+		}
 	}
 	if plan.ReplayResumeAdmission.Owner != RunForkReplayResumeAdmissionOwner {
 		t.Fatalf("taxonomy owner = %q, want %q", plan.ReplayResumeAdmission.Owner, RunForkReplayResumeAdmissionOwner)
 	}
-	if !plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.ReplayResumeFactsPresent || plan.ReplayResumeAdmission.BoundedReplaySupported {
-		t.Fatalf("taxonomy flags = state_only:%v historical_required:%v bounded_supported:%v, want true/false/false",
-			plan.ReplayResumeAdmission.StateOnlyExecutionReady,
-			plan.ReplayResumeAdmission.ReplayResumeFactsPresent,
-			plan.ReplayResumeAdmission.BoundedReplaySupported,
-		)
+	if plan.ReplayResumeAdmission.StateOnlyExecutionReady || !plan.ReplayResumeAdmission.ReplayResumeFactsPresent || plan.ReplayResumeAdmission.BoundedReplaySupported {
+		t.Fatalf("taxonomy flags = state_only:%v historical_required:%v bounded_supported:%v, want false/true/false", plan.ReplayResumeAdmission.StateOnlyExecutionReady, plan.ReplayResumeAdmission.ReplayResumeFactsPresent, plan.ReplayResumeAdmission.BoundedReplaySupported)
 	}
 	if !runForkTestHasDisposition(plan.ReplayResumeAdmission, RunForkReplayResumeFactEntityStateSnapshot) {
 		t.Fatalf("missing entity-state taxonomy disposition; admission=%#v", plan.ReplayResumeAdmission)
@@ -721,6 +789,7 @@ func TestRunForkPlanner_RelevantTimerAndRouteRemainBlockers(t *testing.T) {
 		t.Fatalf("seed relevant route: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -797,6 +866,7 @@ func TestRunForkPlanner_ScopesDeadLettersToMatchingDelivery(t *testing.T) {
 		t.Fatalf("seed dead letters: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -850,12 +920,21 @@ func TestRunForkPlanner_DoesNotReportPostForkCompletionAsCompletedAtFork(t *test
 			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'agent', 'completed-after-fork', 'delivered', 0, 'ok', $3, $4, $3),
-			($1::uuid, $2::uuid, 'agent', 'started-after-fork', 'delivered', 0, 'ok', $4, $5, $3)
-	`, runID, eventID, at, at.Add(time.Minute), at.Add(2*time.Minute)); err != nil {
-		t.Fatalf("seed deliveries: %v", err)
+			($1::uuid, $2::uuid, 'agent', 'completed-after-fork', 'in_progress', 0, '', $3, NULL, $3),
+			($1::uuid, $2::uuid, 'agent', 'started-after-fork', 'pending', 0, '', NULL, NULL, $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed selected-revision deliveries: %v", err)
 	}
-
+	captureRunForkTestRevision(t, db, runID)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'delivered', reason_code = 'ok',
+		    started_at = COALESCE(started_at, $3), delivered_at = $3
+		WHERE run_id = $1::uuid AND event_id = $2::uuid
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("complete deliveries after selected revision: %v", err)
+	}
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -913,12 +992,21 @@ func TestRunForkPlanner_SuppressesPostForkTerminalMetadata(t *testing.T) {
 			run_id, event_id, subscriber_type, subscriber_id, status, retry_count, reason_code, started_at, delivered_at, created_at
 		)
 		VALUES
-			($1::uuid, $2::uuid, 'agent', 'failed-after-fork', 'failed', 2, 'retry_exhausted', $3, $4, $3),
-			($1::uuid, $2::uuid, 'agent', 'pending-then-failed-after-fork', 'failed', 2, 'retry_exhausted', $4, $5, $3)
-	`, runID, eventID, at, at.Add(time.Minute), at.Add(2*time.Minute)); err != nil {
-		t.Fatalf("seed deliveries: %v", err)
+			($1::uuid, $2::uuid, 'agent', 'failed-after-fork', 'in_progress', 0, '', $3, NULL, $3),
+			($1::uuid, $2::uuid, 'agent', 'pending-then-failed-after-fork', 'pending', 0, '', NULL, NULL, $3)
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("seed selected-revision deliveries: %v", err)
 	}
-
+	captureRunForkTestRevision(t, db, runID)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE event_deliveries
+		SET status = 'failed', retry_count = 2, reason_code = 'retry_exhausted',
+		    started_at = COALESCE(started_at, $3), delivered_at = $3
+		WHERE run_id = $1::uuid AND event_id = $2::uuid
+	`, runID, eventID, at); err != nil {
+		t.Fatalf("fail deliveries after selected revision: %v", err)
+	}
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -992,6 +1080,7 @@ func TestRunForkPlanner_AccountsForReceiptOnlyPlatformAndNodeProcessing(t *testi
 		t.Fatalf("seed delivered receipt: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -1079,6 +1168,7 @@ func TestRunForkPlanner_RunScopedActiveSessionAndTurnRemainBlockers(t *testing.T
 		t.Fatalf("seed active turn: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -1130,6 +1220,7 @@ func TestRunForkPlanner_ActiveConversationAuditRemainsPolicyBlocker(t *testing.T
 		t.Fatalf("seed active task audit: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -1184,6 +1275,7 @@ func TestRunForkPlanner_TerminatedSessionBeforeForkIsLineageOnly(t *testing.T) {
 	`, sessionID, runID, at.Add(-time.Second), at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed terminated session: %v", err)
 	}
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -1230,6 +1322,7 @@ func TestRunForkPlanner_TerminatedAuditStillBlocksWithoutAtForkTerminationProof(
 		t.Fatalf("seed terminated audit: %v", err)
 	}
 
+	captureRunForkTestRevision(t, db, runID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)

--- a/internal/store/run_fork_replay_resume_admission.go
+++ b/internal/store/run_fork_replay_resume_admission.go
@@ -127,7 +127,7 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		})
 		hasHistoricalReplayRequirement = true
 	}
-	if evidence.RelevantRoute {
+	if strings.TrimSpace(evidence.RouteHistory.State) == RunForkRouteHistoryUnknownUnversioned {
 		blocker := runForkReplayResumeBlocker(RunForkBlockerFlowRouteHistoryUnproven)
 		blockers = appendRunForkBlocker(blockers, blocker)
 		dispositions = append(dispositions, RunForkReplayResumeDisposition{
@@ -194,6 +194,31 @@ func runForkReplayResumeAdmission(evidence runForkAdmissionEvidence) RunForkRepl
 		Dispositions:             dispositions,
 		UnsupportedBlockers:      blockers,
 	}
+}
+
+// RunForkReplayResumeAdmissionWithSelectedRouteResolution discharges only the
+// unversioned route-history blocker after the selected route topology and its
+// persisted fork-local recovery have been validated by the caller.
+func RunForkReplayResumeAdmissionWithSelectedRouteResolution(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
+	filtered := make([]RunForkUnsupportedBlocker, 0, len(admission.UnsupportedBlockers))
+	for _, blocker := range admission.UnsupportedBlockers {
+		if strings.TrimSpace(blocker.Code) == RunForkBlockerFlowRouteHistoryUnproven {
+			continue
+		}
+		filtered = append(filtered, blocker)
+	}
+	admission.UnsupportedBlockers = filtered
+	for i := range admission.Dispositions {
+		if strings.TrimSpace(admission.Dispositions[i].Fact) != RunForkReplayResumeFactRouteHistory {
+			continue
+		}
+		admission.Dispositions[i].Disposition = RunForkReplayResumeDispositionReconstruct
+		admission.Dispositions[i].BlockerCode = ""
+		admission.Dispositions[i].Owner = RunForkSelectedContractRoutePersistenceOwner
+		admission.Dispositions[i].Classification = RunForkRouteHistoryUnknownUnversioned
+		admission.Dispositions[i].Message = "selected frontier, binding, and static/dynamic topology proof resolve unversioned source routes into persisted fork-local route recovery"
+	}
+	return runForkReplayResumeAdmissionRecalculateReadiness(admission)
 }
 
 func runForkReplayResumeDispositionForPendingWork(item RunForkPendingWork) RunForkReplayResumeDisposition {
@@ -378,12 +403,12 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 	case RunForkBlockerNonAgentDeliveryReplayUnsupported:
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerNonAgentDeliveryReplayUnsupported,
-			Message: "non-agent delivery replay requires runtime handler, idempotency, receipt, route, and side-effect semantics and is not supported by the timestamp-fork delivery/event replay primitive",
+			Message: "non-agent delivery replay requires runtime handler, idempotency, receipt, route, and side-effect semantics and is not supported by the fixed-revision delivery/event replay primitive",
 		}
 	case RunForkBlockerCommittedReplayScopeReplayUnsupported:
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerCommittedReplayScopeReplayUnsupported,
-			Message: "committed replay-scope marker rows are same-run replay proof and are not node work to replay into a timestamp fork",
+			Message: "committed replay-scope marker rows are same-run replay proof and are not node work to replay into a fixed-revision fork",
 		}
 	case RunForkBlockerTimerHistoryUnproven:
 		return RunForkUnsupportedBlocker{
@@ -413,12 +438,12 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 	case RunForkBlockerEntitySnapshotMetadataUnproven:
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerEntitySnapshotMetadataUnproven,
-			Message: "fork materialization requires owner-authorized source-at-T entity snapshot metadata for every reconstructed entity",
+			Message: "fork materialization requires owner-authorized entity snapshot metadata at the selected revision for every reconstructed entity",
 		}
 	case RunForkBlockerOpenReplyContextUnsupported:
 		return RunForkUnsupportedBlocker{
 			Code:    RunForkBlockerOpenReplyContextUnsupported,
-			Message: "timestamp fork is blocked because the source run has an open reply context at the fork point; complete or cancel the request before forking",
+			Message: "fixed-revision fork is blocked because the source run has an open reply context at the selected revision; complete or cancel the request before forking",
 		}
 	default:
 		code = strings.TrimSpace(code)
@@ -427,7 +452,7 @@ func runForkReplayResumeBlocker(code string) RunForkUnsupportedBlocker {
 		}
 		return RunForkUnsupportedBlocker{
 			Code:    code,
-			Message: fmt.Sprintf("timestamp-fork bounded re-execution is not proven for %s by the canonical admission taxonomy", code),
+			Message: fmt.Sprintf("fixed-revision bounded re-execution is not proven for %s by the canonical admission taxonomy", code),
 		}
 	}
 }

--- a/internal/store/run_fork_revision_conformance_test.go
+++ b/internal/store/run_fork_revision_conformance_test.go
@@ -1,0 +1,273 @@
+package store
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestRunForkRevisionRegistryIsClosed(t *testing.T) {
+	want := []runforkrevision.Family{
+		runforkrevision.FamilyAgentConversationAudits,
+		runforkrevision.FamilyAgentSessions,
+		runforkrevision.FamilyAgentTurns,
+		runforkrevision.FamilyDeadLetters,
+		runforkrevision.FamilyEntityMetadata,
+		runforkrevision.FamilyEntityMutations,
+		runforkrevision.FamilyEventDeliveries,
+		runforkrevision.FamilyEventReceipts,
+		runforkrevision.FamilyEvents,
+		runforkrevision.FamilyReplyContexts,
+		runforkrevision.FamilyTimers,
+	}
+	got := runforkrevision.AllFamilies()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("run-fork revision registry = %q, want exact 11-family registry %q", got, want)
+	}
+}
+
+func TestRunForkRevisionCaptureReusesTransactionRevisionAndRollbackPublishesNothing(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO events (run_id, event_id, event_name, scope, produced_by_type)
+		VALUES ($1::uuid, $2::uuid, 'revision.rollback', 'global', 'platform')
+	`, runID, eventID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO entity_mutations (
+			run_id, entity_id, field, new_value, caused_by_event, writer_type, writer_id
+		) VALUES ($1::uuid, $2::uuid, 'current_state', '"ready"'::jsonb, $3::uuid, 'platform', 'revision-test')
+	`, runID, uuid.NewString(), eventID); err != nil {
+		t.Fatalf("seed mutation: %v", err)
+	}
+	revisions, err := runforkrevision.CaptureCurrentTransaction(ctx, tx)
+	if err != nil {
+		t.Fatalf("capture transaction: %v", err)
+	}
+	if revisions[runID] != 1 {
+		t.Fatalf("captured revision = %d, want 1", revisions[runID])
+	}
+	reused, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyEvents)
+	if err != nil {
+		t.Fatalf("repeat capture: %v", err)
+	}
+	if reused != revisions[runID] {
+		t.Fatalf("repeated capture revision = %d, want transaction revision %d", reused, revisions[runID])
+	}
+	var ledgerRows, factRows int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_revisions WHERE run_id=$1::uuid`, runID).Scan(&ledgerRows); err != nil {
+		t.Fatalf("count transaction ledger: %v", err)
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_fact_revisions WHERE run_id=$1::uuid`, runID).Scan(&factRows); err != nil {
+		t.Fatalf("count transaction facts: %v", err)
+	}
+	if ledgerRows != 1 || factRows != 2 {
+		t.Fatalf("transaction projection = ledger:%d facts:%d, want 1/2", ledgerRows, factRows)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback transaction: %v", err)
+	}
+	for table, query := range map[string]string{
+		"events":                  `SELECT COUNT(*) FROM events WHERE run_id=$1::uuid`,
+		"entity_mutations":        `SELECT COUNT(*) FROM entity_mutations WHERE run_id=$1::uuid`,
+		"run_fork_revisions":      `SELECT COUNT(*) FROM run_fork_revisions WHERE run_id=$1::uuid`,
+		"run_fork_fact_revisions": `SELECT COUNT(*) FROM run_fork_fact_revisions WHERE run_id=$1::uuid`,
+		"run_fork_revision_heads": `SELECT COUNT(*) FROM run_fork_revision_heads WHERE run_id=$1::uuid`,
+	} {
+		var count int
+		if err := db.QueryRowContext(ctx, query, runID).Scan(&count); err != nil {
+			t.Fatalf("count rolled-back %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("rolled-back %s rows = %d, want 0", table, count)
+		}
+	}
+}
+
+func TestRunForkRevisionCaptureSerializesSameRunCommitVisibility(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	firstEventID := uuid.NewString()
+	secondEventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	first, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin first transaction: %v", err)
+	}
+	defer func() { _ = first.Rollback() }()
+	if _, err := first.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type) VALUES ($1::uuid,$2::uuid,'revision.first','global','platform')`, runID, firstEventID); err != nil {
+		t.Fatalf("seed first event: %v", err)
+	}
+	firstRevision, err := runforkrevision.Capture(ctx, first, runID, runforkrevision.FamilyEvents)
+	if err != nil {
+		t.Fatalf("capture first transaction: %v", err)
+	}
+
+	second, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin second transaction: %v", err)
+	}
+	defer func() { _ = second.Rollback() }()
+	if _, err := second.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type) VALUES ($1::uuid,$2::uuid,'revision.second','global','platform')`, runID, secondEventID); err != nil {
+		t.Fatalf("seed second event: %v", err)
+	}
+	type captureResult struct {
+		revision int64
+		err      error
+	}
+	done := make(chan captureResult, 1)
+	go func() {
+		revision, err := runforkrevision.Capture(ctx, second, runID, runforkrevision.FamilyEvents)
+		done <- captureResult{revision: revision, err: err}
+	}()
+	select {
+	case result := <-done:
+		t.Fatalf("second capture completed before first commit: revision=%d err=%v", result.revision, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := first.Commit(); err != nil {
+		t.Fatalf("commit first transaction: %v", err)
+	}
+	result := <-done
+	if result.err != nil {
+		t.Fatalf("capture second transaction: %v", result.err)
+	}
+	if firstRevision != 1 || result.revision != 2 {
+		t.Fatalf("serialized revisions = %d then %d, want 1 then 2", firstRevision, result.revision)
+	}
+	if err := second.Commit(); err != nil {
+		t.Fatalf("commit second transaction: %v", err)
+	}
+	var firstCount, secondCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_fact_revisions WHERE run_id=$1::uuid AND family='events' AND revision=1 AND present`, runID).Scan(&firstCount); err != nil {
+		t.Fatalf("count first revision facts: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_fork_fact_revisions WHERE run_id=$1::uuid AND family='events' AND revision=2 AND present`, runID).Scan(&secondCount); err != nil {
+		t.Fatalf("count second revision facts: %v", err)
+	}
+	if firstCount != 1 || secondCount != 2 {
+		t.Fatalf("visible event facts = revision1:%d revision2:%d, want 1/2", firstCount, secondCount)
+	}
+}
+
+func TestRunForkRevisionCaptureOrdersMultiRunLocksDeterministically(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	runIDs := []string{uuid.NewString(), uuid.NewString()}
+	sort.Strings(runIDs)
+	for _, runID := range runIDs {
+		if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+			t.Fatalf("seed run %s: %v", runID, err)
+		}
+	}
+	type workerResult struct {
+		revisions map[string]int64
+		err       error
+	}
+	start := make(chan struct{})
+	results := make(chan workerResult, 2)
+	worker := func(order []string) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			results <- workerResult{err: err}
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+		for _, runID := range order {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type) VALUES ($1::uuid,$2::uuid,'revision.multi','global','platform')`, runID, uuid.NewString()); err != nil {
+				results <- workerResult{err: err}
+				return
+			}
+		}
+		<-start
+		changes := []runforkrevision.Change{
+			{RunID: order[0], Families: []runforkrevision.Family{runforkrevision.FamilyEvents}},
+			{RunID: order[1], Families: []runforkrevision.Family{runforkrevision.FamilyEvents}},
+		}
+		revisions, err := runforkrevision.CaptureChanges(ctx, tx, changes...)
+		if err == nil {
+			err = tx.Commit()
+		}
+		results <- workerResult{revisions: revisions, err: err}
+	}
+	go worker([]string{runIDs[0], runIDs[1]})
+	go worker([]string{runIDs[1], runIDs[0]})
+	close(start)
+	first := <-results
+	second := <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("opposite-order captures failed: first=%v second=%v", first.err, second.err)
+	}
+	for _, revisions := range []map[string]int64{first.revisions, second.revisions} {
+		if revisions[runIDs[0]] != revisions[runIDs[1]] {
+			t.Fatalf("one transaction received inconsistent multi-run revisions: %#v", revisions)
+		}
+	}
+	if first.revisions[runIDs[0]]+second.revisions[runIDs[0]] != 3 {
+		t.Fatalf("multi-run revision results = %#v and %#v, want one revision 1 and one revision 2", first.revisions, second.revisions)
+	}
+}
+
+func TestRunForkRevisionDeletionPublishesTombstoneAndUnrevisionedDriftFailsClosed(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	timerID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type) VALUES ($1::uuid,$2::uuid,'revision.delete','global','platform')`, runID, eventID); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO timers (timer_id,run_id,timer_name,fire_event,fire_at,owner_agent,task_type,status) VALUES ($1::uuid,$2::uuid,'revision-delete','timer.fire',NOW(),'agent-a','timer','active')`, timerID, runID); err != nil {
+		t.Fatalf("seed timer: %v", err)
+	}
+	firstRevision := captureRunForkTestRevision(t, db, runID)
+	if _, err := db.ExecContext(ctx, `DELETE FROM timers WHERE timer_id=$1::uuid`, timerID); err != nil {
+		t.Fatalf("delete timer: %v", err)
+	}
+	secondRevision := captureRunForkTestRevision(t, db, runID, runforkrevision.FamilyTimers)
+	if secondRevision <= firstRevision {
+		t.Fatalf("deletion revision = %d, want after %d", secondRevision, firstRevision)
+	}
+	var present bool
+	if err := db.QueryRowContext(ctx, `SELECT present FROM run_fork_fact_revisions WHERE run_id=$1::uuid AND family='timers' AND fact_key=$2 AND revision=$3`, runID, timerID, secondRevision).Scan(&present); err != nil {
+		t.Fatalf("load timer tombstone: %v", err)
+	}
+	if present {
+		t.Fatal("deleted timer revision remained present")
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name='revision.drifted' WHERE event_id=$1::uuid`, eventID); err != nil {
+		t.Fatalf("write unrevisioned drift: %v", err)
+	}
+	if _, err := (&PostgresStore{DB: db}).PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: runID, At: eventID}); err == nil || !strings.Contains(err.Error(), "unsupported unrevisioned events facts") {
+		t.Fatalf("PlanRunFork drift error = %v, want fail-closed unrevisioned events", err)
+	}
+}

--- a/internal/store/run_fork_revision_conformance_test.go
+++ b/internal/store/run_fork_revision_conformance_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"reflect"
 	"sort"
@@ -338,6 +339,89 @@ func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) 
 		if status != want {
 			t.Fatalf("lifecycle session revision %d status = %q, want %q", revision, status, want)
 		}
+	}
+}
+
+func TestRunForkRevisionSessionProjectionIgnoresExcludedWriterChurnAndTracksStatusPresence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	store := &PostgresStore{DB: db}
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	agentID := "revision-session-agent"
+	sessionID := uuid.NewString()
+	at := time.Unix(1700000850, 0).UTC()
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed session projection run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type,created_at) VALUES ($1::uuid,$2::uuid,'session.projection','global','platform',$3)`, runID, eventID, at); err != nil {
+		t.Fatalf("seed session projection event: %v", err)
+	}
+	seedRunForkSessionProjection(t, db, runID, agentID, sessionID, "active", at)
+	firstRevision := captureRunForkTestRevision(t, db, runID)
+
+	exerciseRunForkSessionExcludedWriters(t, store, agentID, sessionID)
+	var afterExcluded int64
+	if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, runID).Scan(&afterExcluded); err != nil {
+		t.Fatalf("load revision after excluded writers: %v", err)
+	}
+	if afterExcluded != firstRevision {
+		t.Fatalf("revision after lease/watchdog/turn/provider-session writers = %d, want unchanged %d", afterExcluded, firstRevision)
+	}
+	validationTx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("begin excluded-writer validation: %v", err)
+	}
+	if err := runforkrevision.ValidateComplete(ctx, validationTx, runID); err != nil {
+		_ = validationTx.Rollback()
+		t.Fatalf("validate excluded-writer projection: %v", err)
+	}
+	_ = validationTx.Rollback()
+
+	statusTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin projected status mutation: %v", err)
+	}
+	defer func() { _ = statusTx.Rollback() }()
+	if _, err := statusTx.ExecContext(ctx, `UPDATE agent_sessions SET status='terminated', termination_reason='normal', terminated_at=$2, updated_at=$2 WHERE session_id=$1::uuid`, sessionID, at.Add(time.Minute)); err != nil {
+		t.Fatalf("update projected session status: %v", err)
+	}
+	statusRevisions, err := runforkrevision.CaptureCurrentTransaction(ctx, statusTx)
+	if err != nil {
+		t.Fatalf("capture projected session status: %v", err)
+	}
+	statusRevision := statusRevisions[runID]
+	if statusRevision <= firstRevision {
+		t.Fatalf("projected status revision = %d, want after %d", statusRevision, firstRevision)
+	}
+	if err := statusTx.Commit(); err != nil {
+		t.Fatalf("commit projected session status: %v", err)
+	}
+
+	deleteTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin projected session deletion: %v", err)
+	}
+	defer func() { _ = deleteTx.Rollback() }()
+	if _, err := deleteTx.ExecContext(ctx, `DELETE FROM agent_sessions WHERE session_id=$1::uuid`, sessionID); err != nil {
+		t.Fatalf("delete projected session: %v", err)
+	}
+	deleteRevision, err := runforkrevision.Capture(ctx, deleteTx, runID, runforkrevision.FamilyAgentSessions)
+	if err != nil {
+		t.Fatalf("capture projected session deletion: %v", err)
+	}
+	if deleteRevision <= statusRevision {
+		t.Fatalf("session deletion revision = %d, want after %d", deleteRevision, statusRevision)
+	}
+	if err := deleteTx.Commit(); err != nil {
+		t.Fatalf("commit projected session deletion: %v", err)
+	}
+	var present bool
+	if err := db.QueryRowContext(ctx, `SELECT present FROM run_fork_fact_revisions WHERE run_id=$1::uuid AND family='agent_sessions' AND fact_key=$2 AND revision=$3`, runID, sessionID, deleteRevision).Scan(&present); err != nil {
+		t.Fatalf("load projected session tombstone: %v", err)
+	}
+	if present {
+		t.Fatal("deleted projected session remained present")
 	}
 }
 

--- a/internal/store/run_fork_revision_conformance_test.go
+++ b/internal/store/run_fork_revision_conformance_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -231,6 +234,107 @@ func TestRunForkRevisionCaptureOrdersMultiRunLocksDeterministically(t *testing.T
 	}
 	if first.revisions[runIDs[0]]+second.revisions[runIDs[0]] != 3 {
 		t.Fatalf("multi-run revision results = %#v and %#v, want one revision 1 and one revision 2", first.revisions, second.revisions)
+	}
+}
+
+func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	store := &PostgresStore{DB: db}
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	agentID := "revision-lifecycle-agent"
+	agent := runtimemanager.PersistedAgent{
+		Config: runtimeactors.AgentConfig{
+			ID: agentID, Role: "worker", Type: "sonnet", Model: "regular", Mode: "global",
+			Config: []byte(`{"system_prompt":"revision proof"}`),
+		},
+		Status: "active", HiredBy: "revision-proof", StartedAt: now,
+	}
+	spawned, err := store.CommitAgentLifecycleTransition(ctx, runtimemanager.AgentLifecycleTransition{
+		OperationID: uuid.NewString(), OperationKind: "spawn", RequestHash: "revision-spawn",
+		AgentID: agentID, Trigger: "spawn", TargetEpoch: 1, TargetGeneration: 1,
+		TargetPhase: runtimemanager.AgentLifecycleRegistered, ConfigRevision: "revision-1",
+		RunMode: runtimemanager.AgentRunModeStopped, Agent: &agent, Now: now,
+	})
+	if err != nil {
+		t.Fatalf("spawn lifecycle agent: %v", err)
+	}
+	started, err := store.CommitAgentLifecycleTransition(ctx, runtimemanager.AgentLifecycleTransition{
+		OperationID: uuid.NewString(), OperationKind: "start", RequestHash: "revision-start",
+		AgentID: agentID, Trigger: "start", ExpectedEpoch: spawned.RuntimeEpoch,
+		ExpectedGeneration: spawned.Generation, ExpectedPhase: spawned.Phase,
+		TargetEpoch: spawned.RuntimeEpoch, TargetGeneration: spawned.Generation + 1,
+		TargetPhase: runtimemanager.AgentLifecycleRunning, ConfigRevision: "revision-1",
+		RunMode: runtimemanager.AgentRunModeStandard, Now: now.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("start lifecycle agent: %v", err)
+	}
+
+	runID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin lifecycle source revision: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed lifecycle source run: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO events (run_id,event_id,event_name,scope,produced_by_type,created_at) VALUES ($1::uuid,$2::uuid,'lifecycle.revision','global','platform',$3)`, runID, eventID, now); err != nil {
+		t.Fatalf("seed lifecycle source event: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, conversation, turn_count,
+			runtime_mode, runtime_state, status, created_at, updated_at
+		) VALUES ($1::uuid,$2::uuid,$3,'global','global','[]'::jsonb,0,'session','{}'::jsonb,'active',$4,$4)
+	`, sessionID, runID, agentID, now); err != nil {
+		t.Fatalf("seed lifecycle source session: %v", err)
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		t.Fatalf("capture lifecycle source revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit lifecycle source revision: %v", err)
+	}
+
+	if _, err := store.CommitAgentLifecycleTransition(ctx, runtimemanager.AgentLifecycleTransition{
+		OperationID: uuid.NewString(), OperationKind: "teardown", RequestHash: "revision-terminate",
+		AgentID: agentID, Trigger: "terminate", ExpectedEpoch: started.RuntimeEpoch,
+		ExpectedGeneration: started.Generation, ExpectedPhase: started.Phase,
+		TargetEpoch: started.RuntimeEpoch, TargetGeneration: started.Generation + 1,
+		TargetPhase: runtimemanager.AgentLifecycleTerminated, ConfigRevision: "revision-1",
+		RunMode: runtimemanager.AgentRunModeStopped,
+		Subordinate: runtimesessions.LifecycleMutationPlan{
+			Action:            runtimesessions.LifecycleMutationTerminateCurrentSet,
+			TerminationReason: runtimesessions.TerminationReasonNormal,
+		},
+		Now: now.Add(2 * time.Second),
+	}); err != nil {
+		t.Fatalf("terminate lifecycle source session: %v", err)
+	}
+
+	var head int64
+	if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, runID).Scan(&head); err != nil {
+		t.Fatalf("load lifecycle source revision head: %v", err)
+	}
+	if head != 2 {
+		t.Fatalf("lifecycle source revision head = %d, want 2", head)
+	}
+	for revision, want := range map[int64]string{1: "active", 2: "terminated"} {
+		var status string
+		if err := db.QueryRowContext(ctx, `
+			SELECT fact->>'status'
+			FROM run_fork_fact_revisions
+			WHERE run_id=$1::uuid AND family='agent_sessions' AND fact_key=$2 AND revision=$3 AND present
+		`, runID, sessionID, revision).Scan(&status); err != nil {
+			t.Fatalf("load lifecycle session revision %d: %v", revision, err)
+		}
+		if status != want {
+			t.Fatalf("lifecycle session revision %d status = %q, want %q", revision, status, want)
+		}
 	}
 }
 

--- a/internal/store/run_fork_revision_conformance_test.go
+++ b/internal/store/run_fork_revision_conformance_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -9,7 +10,9 @@ import (
 	"time"
 
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -335,6 +338,82 @@ func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) 
 		if status != want {
 			t.Fatalf("lifecycle session revision %d status = %q, want %q", revision, status, want)
 		}
+	}
+}
+
+func TestScheduleNoOpTerminalMutationsDoNotPublishRunForkRevision(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	runID := uuid.NewString()
+	ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status) VALUES ($1::uuid, 'running')`, runID); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	store := &PostgresStore{DB: db}
+
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *PostgresStore, runtimepipeline.Schedule) error
+	}{
+		{
+			name: "mark fired",
+			mutate: func(ctx context.Context, store *PostgresStore, schedule runtimepipeline.Schedule) error {
+				return store.MarkScheduleFired(ctx, schedule)
+			},
+		},
+		{
+			name: "mark exact fired",
+			mutate: func(ctx context.Context, store *PostgresStore, schedule runtimepipeline.Schedule) error {
+				return store.MarkScheduleFiredExact(ctx, schedule)
+			},
+		},
+		{
+			name: "cancel",
+			mutate: func(ctx context.Context, store *PostgresStore, schedule runtimepipeline.Schedule) error {
+				return store.CancelSchedule(ctx, schedule.AgentID, schedule.EventType)
+			},
+		},
+		{
+			name: "cancel exact",
+			mutate: func(ctx context.Context, store *PostgresStore, schedule runtimepipeline.Schedule) error {
+				return store.CancelScheduleExact(ctx, schedule)
+			},
+		},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schedule := runtimepipeline.Schedule{
+				RunID:        runID,
+				AgentID:      fmt.Sprintf("revision-agent-%d", index),
+				EventType:    fmt.Sprintf("revision.timer.%d", index),
+				Mode:         "once",
+				At:           time.Now().Add(time.Hour),
+				EntityID:     uuid.NewString(),
+				FlowInstance: fmt.Sprintf("revision-flow-%d", index),
+				TaskID:       fmt.Sprintf("revision-task-%d", index),
+				Payload:      []byte(`{}`),
+			}
+			if err := store.UpsertSchedule(ctx, schedule); err != nil {
+				t.Fatalf("upsert schedule: %v", err)
+			}
+			if err := test.mutate(ctx, store, schedule); err != nil {
+				t.Fatalf("first mutation: %v", err)
+			}
+			var revision int64
+			if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, runID).Scan(&revision); err != nil {
+				t.Fatalf("load revision after terminal mutation: %v", err)
+			}
+			if err := test.mutate(ctx, store, schedule); err != nil {
+				t.Fatalf("duplicate mutation: %v", err)
+			}
+			var afterDuplicate int64
+			if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, runID).Scan(&afterDuplicate); err != nil {
+				t.Fatalf("load revision after duplicate mutation: %v", err)
+			}
+			if afterDuplicate != revision {
+				t.Fatalf("revision after duplicate mutation = %d, want unchanged %d", afterDuplicate, revision)
+			}
+		})
 	}
 }
 

--- a/internal/store/run_fork_revision_projection.go
+++ b/internal/store/run_fork_revision_projection.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"sort"
+	"strings"
+
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+)
+
+func loadRunForkPendingWorkFromRevision(snapshot *runForkRevisionSnapshot) ([]RunForkPendingWork, error) {
+	if snapshot == nil {
+		return nil, nil
+	}
+	events := make(map[string]runForkRevisionEvent, len(snapshot.Events))
+	for _, event := range snapshot.Events {
+		events[strings.TrimSpace(event.EventID)] = event
+	}
+	receipts := make(map[string]runForkRevisionReceipt, len(snapshot.Receipts))
+	for _, receipt := range snapshot.Receipts {
+		receipts[runForkRevisionSubscriberKey(receipt.EventID, receipt.SubscriberType, receipt.SubscriberID)] = receipt
+	}
+	deadLetters := make(map[string]map[string]struct{})
+	for _, deadLetter := range snapshot.DeadLetters {
+		eventID := strings.TrimSpace(deadLetter.OriginalEventID)
+		if deadLetters[eventID] == nil {
+			deadLetters[eventID] = map[string]struct{}{}
+		}
+		deadLetters[eventID][strings.TrimSpace(deadLetter.HandlerNode)] = struct{}{}
+	}
+	deliveryKeys := make(map[string]struct{}, len(snapshot.Deliveries))
+	out := make([]RunForkPendingWork, 0, len(snapshot.Deliveries)+len(snapshot.Receipts))
+	for _, delivery := range snapshot.Deliveries {
+		event, ok := events[strings.TrimSpace(delivery.EventID)]
+		if !ok {
+			return nil, runForkRevisionLineageError("event_deliveries", delivery.DeliveryID, delivery.EventID)
+		}
+		key := runForkRevisionSubscriberKey(delivery.EventID, delivery.SubscriberType, delivery.SubscriberID)
+		deliveryKeys[key] = struct{}{}
+		receipt := receipts[key]
+		item := RunForkPendingWork{
+			EventID:         strings.TrimSpace(delivery.EventID),
+			EventName:       strings.TrimSpace(event.EventName),
+			FlowInstance:    strings.TrimSpace(event.FlowInstance),
+			DeliveryID:      strings.TrimSpace(delivery.DeliveryID),
+			SubscriberType:  strings.TrimSpace(delivery.SubscriberType),
+			SubscriberID:    strings.TrimSpace(delivery.SubscriberID),
+			Status:          strings.TrimSpace(delivery.Status),
+			RetryCount:      delivery.RetryCount,
+			ReasonCode:      strings.TrimSpace(delivery.ReasonCode),
+			ActiveSessionID: strings.TrimSpace(delivery.ActiveSessionID),
+			CreatedAt:       delivery.CreatedAt,
+			StartedAt:       delivery.StartedAt,
+			DeliveredAt:     delivery.DeliveredAt,
+			ReceiptOutcome:  strings.TrimSpace(receipt.Outcome),
+		}
+		if !receipt.ProcessedAt.IsZero() {
+			receiptAt := receipt.ProcessedAt
+			item.ReceiptAt = &receiptAt
+		}
+		_, deadLetter := deadLetters[item.EventID][item.SubscriberID]
+		item.Classification = classifyRunForkPendingWork(item, deadLetter)
+		out = append(out, item)
+	}
+	for _, receipt := range snapshot.Receipts {
+		key := runForkRevisionSubscriberKey(receipt.EventID, receipt.SubscriberType, receipt.SubscriberID)
+		if _, ok := deliveryKeys[key]; ok {
+			continue
+		}
+		if receipt.SubscriberType != "platform" && receipt.SubscriberType != "node" {
+			continue
+		}
+		event, ok := events[strings.TrimSpace(receipt.EventID)]
+		if !ok {
+			return nil, runForkRevisionLineageError("event_receipts", receipt.ReceiptID, receipt.EventID)
+		}
+		receiptAt := receipt.ProcessedAt
+		item := RunForkPendingWork{
+			EventID:        strings.TrimSpace(receipt.EventID),
+			EventName:      strings.TrimSpace(event.EventName),
+			FlowInstance:   strings.TrimSpace(event.FlowInstance),
+			SubscriberType: strings.TrimSpace(receipt.SubscriberType),
+			SubscriberID:   strings.TrimSpace(receipt.SubscriberID),
+			ReasonCode:     strings.TrimSpace(receipt.ReasonCode),
+			CreatedAt:      receipt.ProcessedAt,
+			DeliveredAt:    &receiptAt,
+			ReceiptOutcome: strings.TrimSpace(receipt.Outcome),
+			ReceiptAt:      &receiptAt,
+		}
+		item.Classification = classifyRunForkPendingWork(item, false)
+		out = append(out, item)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := runForkRevisionSubscriberKey(out[i].EventID, out[i].SubscriberType, out[i].SubscriberID) + "/" + out[i].DeliveryID
+		right := runForkRevisionSubscriberKey(out[j].EventID, out[j].SubscriberType, out[j].SubscriberID) + "/" + out[j].DeliveryID
+		return left < right
+	})
+	return out, nil
+}
+
+func loadRunForkAdmissionEvidenceFromRevision(snapshot *runForkRevisionSnapshot, entities []RunForkEntityState, pending []RunForkPendingWork) (runForkAdmissionEvidence, error) {
+	facts := loadRunForkSourceFactsFromRevision(snapshot, entities)
+	relevantTimer := false
+	entityIDs := stringSliceSet(facts.EntityIDs)
+	flowInstances := stringSliceSet(facts.FlowInstances)
+	for _, timer := range snapshot.Timers {
+		if _, ok := entityIDs[strings.TrimSpace(timer.EntityID)]; ok && strings.TrimSpace(timer.EntityID) != "" {
+			relevantTimer = true
+			break
+		}
+		if _, ok := flowInstances[strings.TrimSpace(timer.FlowInstance)]; ok && strings.TrimSpace(timer.FlowInstance) != "" {
+			relevantTimer = true
+			break
+		}
+	}
+	routeState := RunForkRouteHistoryNotApplicable
+	if len(facts.FlowInstances) > 0 || len(facts.SourceFlows) > 0 {
+		routeState = RunForkRouteHistoryUnknownUnversioned
+	}
+	activeSessions := map[string]struct{}{}
+	for _, session := range snapshot.Sessions {
+		if session.Status == "active" || session.Status == "suspended" {
+			activeSessions[strings.TrimSpace(session.SessionID)] = struct{}{}
+		}
+	}
+	activeSession := runForkPendingReferencesActiveSession(pending) || len(activeSessions) > 0
+	activeTurn := runForkPendingReferencesActiveSession(pending)
+	if !activeTurn {
+		for _, turn := range snapshot.Turns {
+			if _, ok := activeSessions[strings.TrimSpace(turn.SessionID)]; ok {
+				activeTurn = true
+				break
+			}
+		}
+	}
+	openReplyContext := false
+	for _, replyContext := range snapshot.ReplyContexts {
+		if strings.TrimSpace(replyContext.State) == "open" {
+			openReplyContext = true
+			break
+		}
+	}
+	return runForkAdmissionEvidence{
+		Pending:                 pending,
+		RelevantTimer:           relevantTimer,
+		RouteHistory:            RunForkRouteHistoryProjection{State: routeState},
+		ActiveSession:           activeSession,
+		ActiveConversationAudit: len(snapshot.ConversationAudits) > 0,
+		ActiveTurn:              activeTurn,
+		OpenReplyContext:        openReplyContext,
+	}, nil
+}
+
+func loadRunForkSourceFactsFromRevision(snapshot *runForkRevisionSnapshot, entities []RunForkEntityState) runForkSourceFacts {
+	entitySet := map[string]struct{}{}
+	flowSet := map[string]struct{}{}
+	sourceFlowSet := map[string]struct{}{}
+	for _, entity := range entities {
+		if entityID := strings.TrimSpace(entity.EntityID); entityID != "" {
+			entitySet[entityID] = struct{}{}
+		}
+	}
+	if snapshot != nil {
+		for _, event := range snapshot.Events {
+			if entityID := strings.TrimSpace(event.EntityID); entityID != "" {
+				entitySet[entityID] = struct{}{}
+			}
+			if flowInstance := strings.TrimSpace(event.FlowInstance); flowInstance != "" {
+				flowSet[flowInstance] = struct{}{}
+				if sourceFlow := runtimeflowidentity.SemanticScope(flowInstance); sourceFlow != "" {
+					sourceFlowSet[sourceFlow] = struct{}{}
+				}
+			}
+		}
+	}
+	return runForkSourceFacts{
+		EntityIDs:     stringSetValues(entitySet),
+		FlowInstances: stringSetValues(flowSet),
+		SourceFlows:   stringSetValues(sourceFlowSet),
+	}
+}
+
+func runForkRevisionSubscriberKey(eventID, subscriberType, subscriberID string) string {
+	return strings.TrimSpace(eventID) + "/" + strings.TrimSpace(subscriberType) + "/" + strings.TrimSpace(subscriberID)
+}
+
+func runForkRevisionLineageError(family, factKey, eventID string) error {
+	return runForkReplayResumeError(
+		RunForkBlockerDeliveryHistoryUnproven,
+		RunForkReplayResumeFactDeliveryPendingHistory,
+		"revisioned "+strings.TrimSpace(family)+" fact "+strings.TrimSpace(factKey)+" has no revisioned source event "+strings.TrimSpace(eventID),
+	)
+}
+
+func stringSliceSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/store/run_fork_revision_snapshot.go
+++ b/internal/store/run_fork_revision_snapshot.go
@@ -1,0 +1,365 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	"github.com/google/uuid"
+)
+
+type runForkRevisionedFact struct {
+	FirstRevision int64
+	Revision      int64
+}
+
+type runForkRevisionEvent struct {
+	runForkRevisionedFact
+	EventID        string          `json:"event_id"`
+	EventName      string          `json:"event_name"`
+	EntityID       string          `json:"entity_id"`
+	FlowInstance   string          `json:"flow_instance"`
+	SourceRoute    json.RawMessage `json:"source_route"`
+	TargetRoute    json.RawMessage `json:"target_route"`
+	TargetSet      json.RawMessage `json:"target_set"`
+	Scope          string          `json:"scope"`
+	Payload        json.RawMessage `json:"payload"`
+	ChainDepth     int             `json:"chain_depth"`
+	ProducedBy     string          `json:"produced_by"`
+	ProducedByType string          `json:"produced_by_type"`
+	HandlerNode    string          `json:"handler_node"`
+	IdempotencyKey string          `json:"idempotency_key"`
+	SourceEventID  string          `json:"source_event_id"`
+	CreatedAt      time.Time       `json:"created_at"`
+}
+
+type runForkRevisionEntityMutation struct {
+	runForkRevisionedFact
+	MutationID    string          `json:"mutation_id"`
+	EntityID      string          `json:"entity_id"`
+	Field         string          `json:"field"`
+	NewValue      json.RawMessage `json:"new_value"`
+	CausedByEvent string          `json:"caused_by_event"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+type runForkRevisionEntityMetadata struct {
+	runForkRevisionedFact
+	EntityID     string    `json:"entity_id"`
+	FlowInstance string    `json:"flow_instance"`
+	EntityType   string    `json:"entity_type"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type runForkRevisionDelivery struct {
+	runForkRevisionedFact
+	DeliveryID          string          `json:"delivery_id"`
+	EventID             string          `json:"event_id"`
+	SubscriberType      string          `json:"subscriber_type"`
+	SubscriberID        string          `json:"subscriber_id"`
+	DeliveryTargetRoute json.RawMessage `json:"delivery_target_route"`
+	DeliveryContext     json.RawMessage `json:"delivery_context"`
+	Status              string          `json:"status"`
+	RetryCount          int             `json:"retry_count"`
+	ReasonCode          string          `json:"reason_code"`
+	ActiveSessionID     string          `json:"active_session_id"`
+	StartedAt           *time.Time      `json:"started_at"`
+	DeliveredAt         *time.Time      `json:"delivered_at"`
+	CreatedAt           time.Time       `json:"created_at"`
+}
+
+type runForkRevisionReceipt struct {
+	runForkRevisionedFact
+	ReceiptID      string    `json:"receipt_id"`
+	EventID        string    `json:"event_id"`
+	SubscriberType string    `json:"subscriber_type"`
+	SubscriberID   string    `json:"subscriber_id"`
+	Outcome        string    `json:"outcome"`
+	ReasonCode     string    `json:"reason_code"`
+	ProcessedAt    time.Time `json:"processed_at"`
+}
+
+type runForkRevisionDeadLetter struct {
+	runForkRevisionedFact
+	DeadLetterID    string    `json:"dead_letter_id"`
+	OriginalEventID string    `json:"original_event_id"`
+	HandlerNode     string    `json:"handler_node"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+type runForkRevisionTimer struct {
+	runForkRevisionedFact
+	TimerID            string          `json:"timer_id"`
+	TimerName          string          `json:"timer_name"`
+	EntityID           string          `json:"entity_id"`
+	FlowInstance       string          `json:"flow_instance"`
+	FireEvent          string          `json:"fire_event"`
+	FirePayload        json.RawMessage `json:"fire_payload"`
+	FireAt             time.Time       `json:"fire_at"`
+	Recurring          bool            `json:"recurring"`
+	RecurrenceCron     string          `json:"recurrence_cron"`
+	RecurrenceInterval string          `json:"recurrence_interval"`
+	OwnerNode          string          `json:"owner_node"`
+	OwnerAgent         string          `json:"owner_agent"`
+	TaskType           string          `json:"task_type"`
+	Status             string          `json:"status"`
+	FiredAt            *time.Time      `json:"fired_at"`
+	CreatedAt          time.Time       `json:"created_at"`
+}
+
+type runForkRevisionSession struct {
+	runForkRevisionedFact
+	SessionID    string     `json:"session_id"`
+	Status       string     `json:"status"`
+	CreatedAt    time.Time  `json:"created_at"`
+	TerminatedAt *time.Time `json:"terminated_at"`
+}
+
+type runForkRevisionTurn struct {
+	runForkRevisionedFact
+	TurnID    string    `json:"turn_id"`
+	SessionID string    `json:"session_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type runForkRevisionConversationAudit struct {
+	runForkRevisionedFact
+	SessionID string    `json:"session_id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type runForkRevisionReplyContext struct {
+	runForkRevisionedFact
+	ReplyContextID string     `json:"reply_context_id"`
+	RequestEventID string     `json:"request_event_id"`
+	State          string     `json:"state"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	TerminalAt     *time.Time `json:"terminal_at"`
+}
+
+type runForkRevisionSnapshot struct {
+	RunID              string
+	Revision           int64
+	Events             []runForkRevisionEvent
+	EntityMutations    []runForkRevisionEntityMutation
+	EntityMetadata     []runForkRevisionEntityMetadata
+	Deliveries         []runForkRevisionDelivery
+	Receipts           []runForkRevisionReceipt
+	DeadLetters        []runForkRevisionDeadLetter
+	Timers             []runForkRevisionTimer
+	Sessions           []runForkRevisionSession
+	Turns              []runForkRevisionTurn
+	ConversationAudits []runForkRevisionConversationAudit
+	ReplyContexts      []runForkRevisionReplyContext
+}
+
+func resolveRunForkRevisionPoint(ctx context.Context, tx *sql.Tx, runID, at string) (runForkEventCursor, error) {
+	if tx == nil {
+		return runForkEventCursor{}, fmt.Errorf("run fork revision point requires a database snapshot")
+	}
+	at = strings.TrimSpace(at)
+	where := ""
+	args := []any{runID}
+	if at != "" {
+		if _, err := uuid.Parse(at); err != nil {
+			return runForkEventCursor{}, fmt.Errorf("run fork selector must be an event UUID: %w", err)
+		}
+		where = "AND fact_key = $2"
+		args = append(args, at)
+	}
+	row := tx.QueryRowContext(ctx, `
+		WITH first_events AS (
+			SELECT DISTINCT ON (fact_key) fact_key, revision, fact
+			FROM run_fork_fact_revisions
+			WHERE run_id = $1::uuid AND family = 'events' `+where+`
+			ORDER BY fact_key, revision ASC
+		)
+		SELECT
+			fact_key,
+			COALESCE(fact->>'event_name', ''),
+			COALESCE(fact->>'source_event_id', ''),
+			COALESCE(fact->>'produced_by', ''),
+			COALESCE(fact->>'produced_by_type', ''),
+			COALESCE((fact->>'created_at')::timestamptz, 'epoch'::timestamptz),
+			revision
+		FROM first_events
+		ORDER BY revision DESC, fact_key DESC
+		LIMIT 1
+	`, args...)
+	var cursor runForkEventCursor
+	if err := row.Scan(&cursor.EventID, &cursor.EventName, &cursor.SourceEventID, &cursor.ProducedBy, &cursor.ProducedByType, &cursor.CreatedAt, &cursor.Revision); err != nil {
+		if err == sql.ErrNoRows {
+			if at == "" {
+				return runForkEventCursor{}, fmt.Errorf("no revisioned source-run event exists for fork source run %s", runID)
+			}
+			return runForkEventCursor{}, fmt.Errorf("fork point event %s not found in revisioned source run %s", at, runID)
+		}
+		return runForkEventCursor{}, fmt.Errorf("resolve fork event revision: %w", err)
+	}
+	return cursor, nil
+}
+
+func loadRunForkRevisionSnapshot(ctx context.Context, tx *sql.Tx, runID string, revision int64) (*runForkRevisionSnapshot, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("run fork revision snapshot requires a database transaction")
+	}
+	if revision <= 0 {
+		return nil, fmt.Errorf("run fork revision must be positive")
+	}
+	rows, err := tx.QueryContext(ctx, `
+		WITH bounded AS (
+			SELECT family, fact_key, revision, fact, present,
+			       MIN(revision) OVER (PARTITION BY family, fact_key) AS first_revision,
+			       ROW_NUMBER() OVER (PARTITION BY family, fact_key ORDER BY revision DESC) AS latest_rank
+			FROM run_fork_fact_revisions
+			WHERE run_id = $1::uuid AND revision <= $2
+		)
+		SELECT family, first_revision, revision, fact
+		FROM bounded
+		WHERE latest_rank = 1 AND present
+		ORDER BY family, first_revision, fact_key
+	`, runID, revision)
+	if err != nil {
+		return nil, fmt.Errorf("load run fork revision snapshot: %w", err)
+	}
+	defer rows.Close()
+	snapshot := &runForkRevisionSnapshot{RunID: runID, Revision: revision}
+	for rows.Next() {
+		var family string
+		var firstRevision, factRevision int64
+		var raw []byte
+		if err := rows.Scan(&family, &firstRevision, &factRevision, &raw); err != nil {
+			return nil, fmt.Errorf("scan run fork revision fact: %w", err)
+		}
+		stamp := runForkRevisionedFact{FirstRevision: firstRevision, Revision: factRevision}
+		if err := appendRunForkRevisionFact(snapshot, runforkrevision.Family(family), stamp, raw); err != nil {
+			return nil, err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read run fork revision snapshot: %w", err)
+	}
+	if len(snapshot.Events) == 0 {
+		return nil, fmt.Errorf("run fork revision %d has no revisioned events", revision)
+	}
+	snapshot.sort()
+	return snapshot, nil
+}
+
+func appendRunForkRevisionFact(snapshot *runForkRevisionSnapshot, family runforkrevision.Family, stamp runForkRevisionedFact, raw []byte) error {
+	decode := func(target any) error {
+		if err := json.Unmarshal(raw, target); err != nil {
+			return fmt.Errorf("decode run fork %s revision fact: %w", family, err)
+		}
+		return nil
+	}
+	switch family {
+	case runforkrevision.FamilyEvents:
+		var fact runForkRevisionEvent
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Events = append(snapshot.Events, fact)
+	case runforkrevision.FamilyEntityMutations:
+		var fact runForkRevisionEntityMutation
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.EntityMutations = append(snapshot.EntityMutations, fact)
+	case runforkrevision.FamilyEntityMetadata:
+		var fact runForkRevisionEntityMetadata
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.EntityMetadata = append(snapshot.EntityMetadata, fact)
+	case runforkrevision.FamilyEventDeliveries:
+		var fact runForkRevisionDelivery
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Deliveries = append(snapshot.Deliveries, fact)
+	case runforkrevision.FamilyEventReceipts:
+		var fact runForkRevisionReceipt
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Receipts = append(snapshot.Receipts, fact)
+	case runforkrevision.FamilyDeadLetters:
+		var fact runForkRevisionDeadLetter
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.DeadLetters = append(snapshot.DeadLetters, fact)
+	case runforkrevision.FamilyTimers:
+		var fact runForkRevisionTimer
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Timers = append(snapshot.Timers, fact)
+	case runforkrevision.FamilyAgentSessions:
+		var fact runForkRevisionSession
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Sessions = append(snapshot.Sessions, fact)
+	case runforkrevision.FamilyAgentTurns:
+		var fact runForkRevisionTurn
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.Turns = append(snapshot.Turns, fact)
+	case runforkrevision.FamilyAgentConversationAudits:
+		var fact runForkRevisionConversationAudit
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.ConversationAudits = append(snapshot.ConversationAudits, fact)
+	case runforkrevision.FamilyReplyContexts:
+		var fact runForkRevisionReplyContext
+		if err := decode(&fact); err != nil {
+			return err
+		}
+		fact.runForkRevisionedFact = stamp
+		snapshot.ReplyContexts = append(snapshot.ReplyContexts, fact)
+	default:
+		return fmt.Errorf("run fork revision snapshot contains unsupported family %q", family)
+	}
+	return nil
+}
+
+func (s *runForkRevisionSnapshot) sort() {
+	sort.Slice(s.Events, func(i, j int) bool {
+		return revisionFactLess(s.Events[i].FirstRevision, s.Events[i].EventID, s.Events[j].FirstRevision, s.Events[j].EventID)
+	})
+	sort.Slice(s.EntityMutations, func(i, j int) bool {
+		return revisionFactLess(s.EntityMutations[i].FirstRevision, s.EntityMutations[i].MutationID, s.EntityMutations[j].FirstRevision, s.EntityMutations[j].MutationID)
+	})
+	sort.Slice(s.Deliveries, func(i, j int) bool {
+		return revisionFactLess(s.Deliveries[i].FirstRevision, s.Deliveries[i].DeliveryID, s.Deliveries[j].FirstRevision, s.Deliveries[j].DeliveryID)
+	})
+}
+
+func revisionFactLess(leftRevision int64, leftID string, rightRevision int64, rightID string) bool {
+	if leftRevision != rightRevision {
+		return leftRevision < rightRevision
+	}
+	return strings.TrimSpace(leftID) < strings.TrimSpace(rightID)
+}

--- a/internal/store/run_fork_revision_test_helpers_test.go
+++ b/internal/store/run_fork_revision_test_helpers_test.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+)
+
+func captureRunForkTestRevision(t *testing.T, db *sql.DB, runID string, families ...runforkrevision.Family) int64 {
+	t.Helper()
+	if len(families) == 0 {
+		families = runforkrevision.AllFamilies()
+	}
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin run fork test revision: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	revision, err := runforkrevision.Capture(context.Background(), tx, runID, families...)
+	if err != nil {
+		t.Fatalf("capture run fork test revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit run fork test revision: %v", err)
+	}
+	return revision
+}

--- a/internal/store/run_fork_revision_test_helpers_test.go
+++ b/internal/store/run_fork_revision_test_helpers_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
+	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 )
 
 func captureRunForkTestRevision(t *testing.T, db *sql.DB, runID string, families ...runforkrevision.Family) int64 {
@@ -26,4 +30,89 @@ func captureRunForkTestRevision(t *testing.T, db *sql.DB, runID string, families
 		t.Fatalf("commit run fork test revision: %v", err)
 	}
 	return revision
+}
+
+func seedRunForkSessionProjection(t *testing.T, db *sql.DB, runID, agentID, sessionID, status string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agents (agent_id, role, model, llm_backend, conversation_mode, status, created_at)
+		VALUES ($1, 'worker', 'standard', 'mock', 'session', 'active', $2)
+	`, agentID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run-fork session agent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO agent_sessions (
+			session_id, run_id, agent_id, scope_key, scope, conversation, turn_count,
+			runtime_mode, runtime_state, status, termination_reason, terminated_at, created_at, updated_at
+		) VALUES (
+			$1::uuid, $2::uuid, $3, 'global', 'global', '[]'::jsonb, 0,
+			'session', '{}'::jsonb, $4,
+			CASE WHEN $4::text = 'terminated' THEN 'normal' ELSE NULL END,
+			CASE WHEN $4::text = 'terminated' THEN $5::timestamptz ELSE NULL::timestamptz END, $5, $5
+		)
+	`, sessionID, runID, agentID, status, at.Add(-time.Second)); err != nil {
+		t.Fatalf("seed run-fork session projection: %v", err)
+	}
+}
+
+func mutateRunForkSessionExcludedColumns(t *testing.T, db *sql.DB, runID, sessionID string, at time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin excluded session mutation: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE agent_sessions
+		SET conversation = '[{"role":"assistant","content":"still working"}]'::jsonb,
+		    turn_count = turn_count + 1,
+		    runtime_state = runtime_state || jsonb_build_object(
+		        'provider_session_id', 'provider-excluded',
+		        'watchdog', jsonb_build_object('state', 'healthy_long_running')
+		    ),
+		    lease_holder = 'excluded-owner',
+		    lease_expires_at = $3,
+		    updated_at = $3
+		WHERE run_id = $1::uuid AND session_id = $2::uuid
+	`, runID, sessionID, at); err != nil {
+		t.Fatalf("update excluded session columns: %v", err)
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+		t.Fatalf("capture excluded session mutation: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit excluded session mutation: %v", err)
+	}
+}
+
+func exerciseRunForkSessionExcludedWriters(t *testing.T, store *PostgresStore, agentID, sessionID string) {
+	t.Helper()
+	ctx := runtimeeffects.WithDifferentOwner(context.Background(), runtimeeffects.OwnerBuildTestInfrastructure)
+	lease, _, err := store.AcquireLiveSession(ctx, agentID, runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "revision-writer", "global")
+	if err != nil {
+		t.Fatalf("acquire session lease: %v", err)
+	}
+	if lease.SessionID != sessionID {
+		t.Fatalf("acquired session = %s, want %s", lease.SessionID, sessionID)
+	}
+	if err := store.IncrementTurn(ctx, agentID, runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, sessionID, "global"); err != nil {
+		t.Fatalf("increment session turn: %v", err)
+	}
+	if err := store.AdoptSessionID(ctx, agentID, runtimesessions.RuntimeModeSession, runtimesessions.SessionScopeGlobal, "revision-writer", "provider-revision-writer", "global"); err != nil {
+		t.Fatalf("adopt provider session: %v", err)
+	}
+	if err := store.UpdateLiveSessionWatchdog(ctx, runtimellm.ConversationWatchdogUpdate{
+		SessionID: sessionID, AgentID: agentID, SessionScope: "global", ScopeKey: "global", Mode: "session",
+		Watchdog: &runtimellm.ConversationWatchdog{
+			State: "healthy_long_running", BlockingLayer: "session_execution", Action: "turn_long_running",
+			Outcome: "observed", LastOutputAt: "2026-07-14T12:00:00Z", RecordedAt: "2026-07-14T12:00:30Z",
+		},
+	}); err != nil {
+		t.Fatalf("update session watchdog: %v", err)
+	}
+	if err := store.Release(ctx, lease); err != nil {
+		t.Fatalf("release session lease: %v", err)
+	}
 }

--- a/internal/store/run_fork_revision_writer.go
+++ b/internal/store/run_fork_revision_writer.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+)
+
+func commitPostgresRunForkRevisionTx(ctx context.Context, tx *sql.Tx) error {
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/store/run_fork_selected_contract_conversation_lineage.go
+++ b/internal/store/run_fork_selected_contract_conversation_lineage.go
@@ -45,7 +45,7 @@ func runForkSelectedContractSessionTurnAuditLineageAdmission(plan RunForkPlan, a
 		disposition.Owner = RunForkSelectedContractSessionTurnAuditLineagePolicyOwner
 		disposition.BlockerCode = ""
 		disposition.Classification = ""
-		disposition.Message = fmt.Sprintf("%s classifies at/before-T source %s as selected-contract lineage/no-action evidence only; fresh fork-local conversation rows must be created by normal runtime execution under the fork run_id", RunForkSelectedContractSessionTurnAuditLineagePolicyOwner, fact)
+		disposition.Message = fmt.Sprintf("%s classifies source %s present at the selected run revision as selected-contract lineage/no-action evidence only; fresh fork-local conversation rows must be created by normal runtime execution under the fork run_id", RunForkSelectedContractSessionTurnAuditLineagePolicyOwner, fact)
 		changed = true
 	}
 	if !changed {
@@ -198,7 +198,6 @@ func runForkSelectedContractSameSourceDeliveryForkPointEmission(plan RunForkPlan
 	}
 	if strings.TrimSpace(item.ActiveSessionID) != "" ||
 		item.StartedAt == nil ||
-		item.StartedAt.After(plan.ForkPoint.Timestamp) ||
 		item.DeliveredAt != nil ||
 		item.ReceiptAt != nil ||
 		strings.TrimSpace(item.ReceiptOutcome) != "" {

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
@@ -26,11 +27,17 @@ type RunForkSelectedContractExecutionMaterializeRequest struct {
 	ContractSelection RunForkContractSelection
 	BundleHash        string
 	BundleSource      string
+	FrontierAdmission RunForkContractFrontierAdmission
+	RouteTopology     RunForkSelectedContractRouteTopology
+	RecipientPlanning RunForkSelectedContractRecipientPlanning
 }
 
 type RunForkSelectedContractExecutionActivateRequest struct {
 	ForkRunID             string
 	AllowedSourceEventIDs []string
+	FrontierAdmission     RunForkContractFrontierAdmission
+	RouteTopology         RunForkSelectedContractRouteTopology
+	RecipientPlanning     RunForkSelectedContractRecipientPlanning
 }
 
 type RunForkSelectedContractSourceEvent struct {
@@ -63,6 +70,80 @@ type RunForkSelectedContractBranchDivergence struct {
 	SourceFrozen                   bool      `json:"source_frozen"`
 	SourceAdvancedFacts            []string  `json:"source_advanced_facts,omitempty"`
 	CreatedAt                      time.Time `json:"created_at"`
+}
+
+func prepareRunForkSelectedContractRouteResolution(
+	plan RunForkPlan,
+	forkRunID string,
+	selection RunForkContractSelection,
+	frontier RunForkContractFrontierAdmission,
+	topology RunForkSelectedContractRouteTopology,
+	planning RunForkSelectedContractRecipientPlanning,
+) (RunForkSelectedContractRouteRecovery, bool, error) {
+	switch strings.TrimSpace(plan.RouteHistory.State) {
+	case RunForkRouteHistoryNotApplicable:
+		return RunForkSelectedContractRouteRecovery{}, false, nil
+	case RunForkRouteHistoryUnknownUnversioned:
+	default:
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("selected-contract route resolution received unsupported route history state %q", plan.RouteHistory.State)
+	}
+	if strings.TrimSpace(frontier.Owner) != RunForkContractFrontierAdmissionOwner || !frontier.NonMutating {
+		return RunForkSelectedContractRouteRecovery{}, false, runForkReplayResumeError(
+			RunForkBlockerFlowRouteHistoryUnproven,
+			RunForkReplayResumeFactRouteHistory,
+			"selected-contract route resolution requires canonical frontier admission",
+		)
+	}
+	if !topology.StaticTopologySupported || !topology.DynamicTopologySupported {
+		return RunForkSelectedContractRouteRecovery{}, false, runForkReplayResumeError(
+			RunForkBlockerFlowRouteHistoryUnproven,
+			RunForkReplayResumeFactRouteHistory,
+			"selected-contract route resolution requires complete static and dynamic topology proof",
+		)
+	}
+	if err := validateRunForkSelectedContractRouteRecoverySelection("route resolution frontier", selection, frontier.ContractSelection); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, false, err
+	}
+	count, eventIDs, fingerprint := RunForkContractFrontierEvidenceBinding(frontier)
+	if count != topology.FrontierEventCount || !equalTrimmedStrings(eventIDs, topology.FrontierSourceEventIDs) || fingerprint != strings.TrimSpace(topology.FrontierEvidenceFingerprint) {
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("selected-contract route topology does not match the fixed-event frontier")
+	}
+	if plan.historicalSnapshot == nil || plan.historicalSnapshot.Revision != plan.ForkPoint.Revision {
+		return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("selected-contract route resolution requires the fixed-event revision snapshot")
+	}
+	historicalEvents := map[string]struct{}{}
+	for _, event := range plan.historicalSnapshot.Events {
+		historicalEvents[strings.TrimSpace(event.EventID)] = struct{}{}
+	}
+	for _, eventID := range eventIDs {
+		if _, ok := historicalEvents[strings.TrimSpace(eventID)]; !ok {
+			return RunForkSelectedContractRouteRecovery{}, false, fmt.Errorf("selected-contract route frontier event %s is outside fixed revision %d", eventID, plan.ForkPoint.Revision)
+		}
+	}
+	record, err := normalizeRunForkSelectedContractRouteRecovery(RunForkSelectedContractRouteRecoveryRequest{
+		ForkRunID:         forkRunID,
+		SourceRunID:       plan.SourceRunID,
+		ForkEventID:       plan.ForkPoint.EventID,
+		ContractSelection: selection,
+		RouteTopology:     topology,
+		RecipientPlanning: planning,
+	}, time.Now().UTC())
+	if err != nil {
+		return RunForkSelectedContractRouteRecovery{}, false, err
+	}
+	return record, true, nil
+}
+
+func equalTrimmedStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if strings.TrimSpace(left[i]) != strings.TrimSpace(right[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func RequireRunForkSelectedContractExecutionCapabilities(caps StoreSchemaCapabilities, catalog schemaColumnCatalog) error {
@@ -146,35 +227,13 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		return RunForkMaterialization{}, err
 	}
 	replayAdmission = runForkReplayResumeAdmissionWithTimerReconstruction(replayAdmission, timerReconstruction)
-	conversationAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedConversationHistoryFacts(ctx, s.DB, catalog, plan.SourceRunID, plan.ForkPoint.Timestamp)
+	forkRunID := deterministicRunForkMaterializationID(plan.SourceRunID, plan.ForkPoint.EventID)
+	routeRecovery, routeResolved, err := prepareRunForkSelectedContractRouteResolution(plan, forkRunID, selection, req.FrontierAdmission, req.RouteTopology, req.RecipientPlanning)
 	if err != nil {
-		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
-			return RunForkMaterialization{
-				SourceRunID:           plan.SourceRunID,
-				ForkPoint:             plan.ForkPoint,
-				ExecutionReady:        false,
-				ReplayResumeAdmission: admission,
-				UnsupportedBlockers:   admission.UnsupportedBlockers,
-				DeliveryResumeBlocked: true,
-			}, err
-		}
 		return RunForkMaterialization{}, err
 	}
-	replayAdmission = runForkReplayResumeAdmissionWithSourceAdvancedConversationHistory(replayAdmission, conversationAdvancedFacts)
-	if err := ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, s.DB, catalog, plan.SourceRunID, plan.ForkPoint.EventID, plan.ForkPoint.Timestamp); err != nil {
-		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			admission := runForkReplayResumeAdmissionWithBlocker(replayAdmission, fact, blocker)
-			return RunForkMaterialization{
-				SourceRunID:           plan.SourceRunID,
-				ForkPoint:             plan.ForkPoint,
-				ExecutionReady:        false,
-				ReplayResumeAdmission: admission,
-				UnsupportedBlockers:   admission.UnsupportedBlockers,
-				DeliveryResumeBlocked: true,
-			}, err
-		}
-		return RunForkMaterialization{}, err
+	if routeResolved {
+		replayAdmission = RunForkReplayResumeAdmissionWithSelectedRouteResolution(replayAdmission)
 	}
 	if blockers := runForkSelectedContractExecutionPlanBlockersFromAdmission(plan, replayAdmission, nil); len(blockers) > 0 {
 		return RunForkMaterialization{
@@ -187,7 +246,6 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 		}, fmt.Errorf("selected-contract fork execution materialization blocked: %s", runForkBlockerCodes(blockers))
 	}
 
-	forkRunID := deterministicRunForkMaterializationID(plan.SourceRunID, plan.ForkPoint.EventID)
 	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("begin selected-contract fork materialization: %w", err)
@@ -232,10 +290,15 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err != nil {
 		return RunForkMaterialization{}, err
 	}
+	if routeResolved {
+		if err := insertRunForkSelectedContractRouteRecovery(ctx, tx, routeRecovery); err != nil {
+			return RunForkMaterialization{}, err
+		}
+	}
 	if err := insertRunForkSelectedContractTimerReconstructions(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID, timerReconstruction, now); err != nil {
 		return RunForkMaterialization{}, err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit selected-contract fork materialization: %w", err)
 	}
 	committed = true
@@ -286,12 +349,15 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	if err != nil {
 		return RunForkActivation{}, err
 	}
+	if err := lockRunForkSourceRevisionFrontier(ctx, tx, &lineage); err != nil {
+		return RunForkActivation{}, err
+	}
 	result := RunForkActivation{
 		SourceRunID:             lineage.SourceRunID,
 		ForkRunID:               lineage.ForkRunID,
 		ForkRunStatus:           lineage.ForkStatus,
 		SourceRunStatus:         lineage.SourceRunStatus,
-		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime},
+		ForkPoint:               RunForkPoint{Input: lineage.ForkEventID, EventID: lineage.ForkEventID, EventName: lineage.ForkEventName, Timestamp: lineage.ForkEventTime, Revision: lineage.ForkEventRevision},
 		ReplayResumeBlocked:     true,
 		MaterializedEntityCount: len(lineage.EntityIDs),
 	}
@@ -319,6 +385,23 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		return result, err
 	}
 	result.ReplayResumeAdmission = RunForkSelectedContractReplayResumeAdmission(plan)
+	expectedRouteRecovery, routeResolved, err := prepareRunForkSelectedContractRouteResolution(
+		plan,
+		lineage.ForkRunID,
+		binding.ContractSelection,
+		req.FrontierAdmission,
+		req.RouteTopology,
+		req.RecipientPlanning,
+	)
+	if err != nil {
+		return result, err
+	}
+	if routeResolved {
+		if err := validateRunForkSelectedContractRouteRecoveryAtActivation(ctx, tx, expectedRouteRecovery); err != nil {
+			return result, err
+		}
+		result.ReplayResumeAdmission = RunForkReplayResumeAdmissionWithSelectedRouteResolution(result.ReplayResumeAdmission)
+	}
 	timerResolved, err := runForkSelectedContractTimerReconstructionComplete(ctx, tx, lineage, plan)
 	if err != nil {
 		return result, err
@@ -328,44 +411,30 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		result.UnsupportedBlockers = blockers
 		return result, fmt.Errorf("selected-contract fork activation blocked: %s", runForkBlockerCodes(blockers))
 	}
-	conversationAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedConversationHistoryFacts(ctx, tx, catalog, lineage.SourceRunID, lineage.ForkEventTime)
+	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, lineage)
 	if err != nil {
-		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
-			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
-		}
 		return result, err
 	}
+	conversationAdvancedFacts := runForkSelectedContractConversationAdvancedFacts(sourceAdvancedFacts)
 	result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithSourceAdvancedConversationHistory(result.ReplayResumeAdmission, conversationAdvancedFacts)
-	if err := ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, tx, catalog, lineage.SourceRunID, lineage.ForkEventID, lineage.ForkEventTime); err != nil {
+	if err := ensureRunForkNoPostForkActiveConversationDeliverySessionCoupling(ctx, tx, lineage); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
 			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
 			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
 		}
 		return result, err
 	}
-	sourceAdvancedAdmissionFacts := append([]string{}, conversationAdvancedFacts...)
-	sourceAdvancedAdmissionFacts = append(sourceAdvancedAdmissionFacts, runForkSelectedContractActiveSourceDeliveryConversationCouplingFacts(result.ReplayResumeAdmission)...)
-	sourceAdvancedFacts, err := collectRunForkSelectedContractSourceAdvancedFacts(ctx, tx, catalog, lineage, sourceAdvancedAdmissionFacts)
-	if err != nil {
+	if err := ensureRunForkNoPostForkCommittedReplayScopeMarkersAtRevision(ctx, tx, lineage.SourceRunID, lineage.ForkEventRevision); err != nil {
+		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
+			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
+			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
+		}
 		return result, err
 	}
+	sourceAdvancedFacts = append(sourceAdvancedFacts, runForkSelectedContractActiveSourceDeliveryConversationCouplingFacts(result.ReplayResumeAdmission)...)
+	sourceAdvancedFacts = uniqueNonEmptyStrings(sourceAdvancedFacts)
 	if len(sourceAdvancedFacts) > 0 {
 		result.SourceAdvancedAfterFork = true
-	}
-	if err := ensureRunForkNoRelevantPostForkTimers(ctx, tx, catalog, lineage); err != nil {
-		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
-			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
-		}
-		return result, err
-	}
-	if err := ensureRunForkNoRelevantPostForkRoutes(ctx, tx, catalog, lineage); err != nil {
-		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
-			result.UnsupportedBlockers = appendRunForkBlocker(result.UnsupportedBlockers, blocker)
-			result.ReplayResumeAdmission = runForkReplayResumeAdmissionWithBlocker(result.ReplayResumeAdmission, fact, blocker)
-		}
-		return result, err
 	}
 	if err := ensureRunForkSelectedContractExecutionForkState(ctx, tx, catalog, lineage.ForkRunID, req.AllowedSourceEventIDs); err != nil {
 		if blocker, fact, ok := runForkReplayResumeBlockerFromError(err); ok {
@@ -406,7 +475,7 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		if err := insertRunForkSelectedContractBranchDivergence(ctx, tx, divergence); err != nil {
 			return result, err
 		}
-		if err := tx.Commit(); err != nil {
+		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 			return result, fmt.Errorf("commit selected-contract branch activation: %w", err)
 		}
 		committed = true
@@ -446,7 +515,7 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	} else if affected != 1 {
 		return result, fmt.Errorf("selected-contract fork activation blocked: fork_run_activation_not_applied")
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return result, fmt.Errorf("commit selected-contract fork activation: %w", err)
 	}
 	committed = true
@@ -492,6 +561,9 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 	}
 	if status != RunForkMaterializedStatus {
 		return fmt.Errorf("selected-contract fork discard requires materialized fork status %q; got %q", RunForkMaterializedStatus, status)
+	}
+	if err := guardDestructiveResetSourceForkDependencies(ctx, tx, []string{forkRunID}); err != nil {
+		return fmt.Errorf("discard selected-contract fork with dependent lineage: %w", err)
 	}
 	var preserveCompletionEvidence bool
 	if catalog.hasColumns("run_fork_selected_contract_runtime_executions", "fork_run_id") {
@@ -579,6 +651,15 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 		return fmt.Errorf("delete selected-contract fork entity state: %w", err)
 	}
 	if preserveCompletionEvidence {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM run_fork_fact_revisions WHERE run_id=$1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork fact revisions: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM run_fork_revisions WHERE run_id=$1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork revision ledger: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM run_fork_revision_heads WHERE run_id=$1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork revision head: %w", err)
+		}
 		if _, err := tx.ExecContext(ctx, `UPDATE runs SET status='cancelled', ended_at=NOW() WHERE run_id=$1::uuid AND status=$2`, forkRunID, RunForkMaterializedStatus); err != nil {
 			return fmt.Errorf("retain selected-contract completion run tombstone: %w", err)
 		}
@@ -590,7 +671,7 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 			return fmt.Errorf("delete selected-contract fork run: %w", err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit selected-contract fork discard: %w", err)
 	}
 	committed = true
@@ -667,7 +748,7 @@ func (s *PostgresStore) LoadRunForkSelectedContractSourceEvents(ctx context.Cont
 		}
 		out[idx] = prepared
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return nil, fmt.Errorf("commit selected-contract source event preparation: %w", err)
 	}
 	committed = true
@@ -707,134 +788,14 @@ func runForkSelectedContractBranchSourceStatusSupported(status string) bool {
 	}
 }
 
-func collectRunForkSelectedContractSourceAdvancedFacts(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, lineage runForkActivationLineage, conversationAdvancedFacts []string) ([]string, error) {
-	checks := []struct {
-		code    string
-		enabled bool
-		query   string
-		args    []any
-	}{
-		{
-			code:    "source_events_advanced_after_fork_point",
-			enabled: true,
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM events
-					WHERE run_id = $1::uuid
-					  AND (created_at, event_id) > ($2::timestamptz, $3::uuid)
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
-		},
-		{
-			code:    "source_mutations_advanced_after_fork_point",
-			enabled: true,
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM entity_mutations
-					WHERE run_id = $1::uuid
-					  AND created_at > $2::timestamptz
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
-		},
-		{
-			code:    "source_current_state_advanced_after_fork_point",
-			enabled: true,
-			query: `
-				SELECT EXISTS (
-					SELECT 1 FROM entity_state
-					WHERE run_id = $1::uuid
-					  AND updated_at > $2::timestamptz
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime},
-		},
-		{
-			code:    "source_deliveries_advanced_after_fork_point",
-			enabled: true,
-			query: `
-				SELECT EXISTS (
-					SELECT 1
-					FROM event_deliveries d
-					LEFT JOIN events e ON e.event_id = d.event_id
-					   AND e.run_id = d.run_id
-					WHERE d.run_id = $1::uuid
-					  AND (
-							d.created_at > $2::timestamptz
-							OR d.started_at > $2::timestamptz
-							OR d.delivered_at > $2::timestamptz
-					  )
-					  AND NOT (
-							d.subscriber_type = $4
-							AND d.subscriber_id = $5
-							AND d.reason_code = ANY($6::text[])
-							AND e.event_id IS NOT NULL
-							AND (e.created_at, e.event_id) <= ($2::timestamptz, $3::uuid)
-					  )
-				)
-			`,
-			args: []any{
-				lineage.SourceRunID,
-				lineage.ForkEventTime,
-				lineage.ForkEventID,
-				replayScopeMarkerSubscriberType,
-				replayScopeMarkerSubscriberID,
-				pq.Array(runForkReplayScopeMarkerReasonCodes()),
-			},
-		},
-		{
-			code:    "source_receipts_advanced_after_fork_point",
-			enabled: catalog.hasColumns("event_receipts", "event_id", "processed_at") && catalog.hasColumns("events", "event_id", "run_id", "created_at"),
-			query: `
-				SELECT EXISTS (
-					SELECT 1
-					FROM event_receipts r
-					INNER JOIN events e ON e.event_id = r.event_id
-					WHERE e.run_id = $1::uuid
-					  AND (
-							r.processed_at > $2::timestamptz
-							OR (e.created_at, e.event_id) > ($2::timestamptz, $3::uuid)
-					  )
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
-		},
-		{
-			code:    "source_dead_letters_advanced_after_fork_point",
-			enabled: catalog.hasColumns("dead_letters", "original_event_id", "created_at") && catalog.hasColumns("events", "event_id", "run_id", "created_at"),
-			query: `
-				SELECT EXISTS (
-					SELECT 1
-					FROM dead_letters dl
-					INNER JOIN events e ON e.event_id = dl.original_event_id
-					WHERE e.run_id = $1::uuid
-					  AND (
-							dl.created_at > $2::timestamptz
-							OR (e.created_at, e.event_id) > ($2::timestamptz, $3::uuid)
-					  )
-				)
-			`,
-			args: []any{lineage.SourceRunID, lineage.ForkEventTime, lineage.ForkEventID},
-		},
+func collectRunForkSelectedContractSourceAdvancedFacts(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage) ([]string, error) {
+	facts, err := collectRunForkSourceAdvancedFacts(ctx, tx, lineage)
+	if err != nil {
+		return nil, err
 	}
-	facts := []string{}
 	switch strings.TrimSpace(lineage.SourceRunStatus) {
 	case "completed", "failed", "cancelled":
 		facts = append(facts, "source_run_terminal_at_activation")
-	}
-	facts = append(facts, conversationAdvancedFacts...)
-	for _, check := range checks {
-		if !check.enabled {
-			continue
-		}
-		var exists bool
-		if err := tx.QueryRowContext(ctx, check.query, check.args...).Scan(&exists); err != nil {
-			return nil, fmt.Errorf("check selected-contract branch %s: %w", check.code, err)
-		}
-		if exists {
-			facts = append(facts, check.code)
-		}
 	}
 	return uniqueNonEmptyStrings(facts), nil
 }
@@ -956,42 +917,57 @@ func runForkSelectedContractAdmissionBlockerForPendingWork(admission RunForkRepl
 	return RunForkUnsupportedBlocker{}, false
 }
 
-func (s *PostgresStore) EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, sourceRunID, forkEventID string, forkTime time.Time) error {
+func (s *PostgresStore) EnsureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, sourceRunID, forkEventID string) error {
 	if s == nil || s.DB == nil {
 		return fmt.Errorf("postgres store is required")
 	}
-	catalog, err := loadSchemaColumnCatalog(ctx, s.DB)
+	tx, err := s.DB.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
 	if err != nil {
 		return err
 	}
-	return ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx, s.DB, catalog, sourceRunID, forkEventID, forkTime)
+	defer func() { _ = tx.Rollback() }()
+	if err := runforkrevision.ValidateComplete(ctx, tx, sourceRunID); err != nil {
+		return err
+	}
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MIN(revision)
+		FROM run_fork_fact_revisions
+		WHERE run_id = $1::uuid
+		  AND family = 'events'
+		  AND fact_key = $2
+		  AND present
+	`, sourceRunID, forkEventID).Scan(&revision); err != nil {
+		return fmt.Errorf("resolve committed replay-scope fork revision: %w", err)
+	}
+	if revision <= 0 {
+		return fmt.Errorf("committed replay-scope fork event is not revisioned; recreate the store and retry")
+	}
+	return ensureRunForkNoPostForkCommittedReplayScopeMarkersAtRevision(ctx, tx, sourceRunID, revision)
 }
 
-func ensureRunForkNoPostForkCommittedReplayScopeMarkers(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID, forkEventID string, forkTime time.Time) error {
-	if !catalog.hasColumns("event_deliveries", "run_id", "event_id", "subscriber_type", "subscriber_id", "reason_code") {
-		return nil
-	}
-	if !catalog.hasColumns("events", "event_id", "run_id", "created_at") {
-		return nil
-	}
+func ensureRunForkNoPostForkCommittedReplayScopeMarkersAtRevision(ctx context.Context, q timerReconstructionQueryer, sourceRunID string, forkRevision int64) error {
 	var exists bool
 	query := `
 		SELECT EXISTS (
 			SELECT 1
 			FROM event_deliveries d
-			LEFT JOIN events e ON e.event_id = d.event_id
-			   AND e.run_id = d.run_id
+			JOIN LATERAL (
+				SELECT MAX(revision) AS revision
+				FROM run_fork_fact_revisions
+				WHERE run_id = d.run_id
+				  AND family = 'event_deliveries'
+				  AND fact_key = d.delivery_id::text
+				  AND present
+			) history ON TRUE
 			WHERE d.run_id = $1::uuid
 			  AND d.subscriber_type = $2
 			  AND d.subscriber_id = $3
 			  AND d.reason_code = ANY($4::text[])
-			  AND (
-					e.event_id IS NULL
-					OR (e.created_at, e.event_id) > ($5::timestamptz, $6::uuid)
-			  )
+			  AND history.revision > $5
 		)
 	`
-	if err := q.QueryRowContext(ctx, query, sourceRunID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, pq.Array(runForkReplayScopeMarkerReasonCodes()), forkTime, forkEventID).Scan(&exists); err != nil {
+	if err := q.QueryRowContext(ctx, query, sourceRunID, replayScopeMarkerSubscriberType, replayScopeMarkerSubscriberID, pq.Array(runForkReplayScopeMarkerReasonCodes()), forkRevision).Scan(&exists); err != nil {
 		return fmt.Errorf("check selected-contract source_committed_replay_scope_advanced_after_fork_point: %w", err)
 	}
 	if exists {
@@ -1005,86 +981,41 @@ func runForkReplayScopeMarkerReasonCodes() []string {
 	return []string{replayScopeReasonDirect, replayScopeReasonSubscribed}
 }
 
-func collectRunForkSelectedContractSourceAdvancedConversationHistoryFacts(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) ([]string, error) {
-	if err := ensureRunForkNoPostForkActiveConversationDeliverySessionCoupling(ctx, q, catalog, sourceRunID, forkTime); err != nil {
-		return nil, err
-	}
-	checks := []struct {
-		code       string
-		table      string
-		predicates []string
-	}{
-		{
-			code:       "source_sessions_advanced_after_fork_point",
-			table:      "agent_sessions",
-			predicates: runForkPostForkConversationPredicates(catalog, "agent_sessions", "created_at", "updated_at", "terminated_at"),
-		},
-		{
-			code:       "source_conversation_audits_advanced_after_fork_point",
-			table:      "agent_conversation_audits",
-			predicates: runForkPostForkConversationPredicates(catalog, "agent_conversation_audits", "created_at", "updated_at"),
-		},
-		{
-			code:       "source_turns_advanced_after_fork_point",
-			table:      "agent_turns",
-			predicates: runForkPostForkConversationPredicates(catalog, "agent_turns", "created_at"),
-		},
-	}
-	facts := []string{}
-	for _, check := range checks {
-		if len(check.predicates) == 0 || !catalog.hasColumns(check.table, "run_id") {
-			continue
-		}
-		var exists bool
-		query := fmt.Sprintf(`
-			SELECT EXISTS (
-				SELECT 1
-				FROM %s
-				WHERE run_id = $1::uuid
-				  AND (%s)
-			)
-		`, check.table, strings.Join(check.predicates, " OR "))
-		if err := q.QueryRowContext(ctx, query, sourceRunID, forkTime).Scan(&exists); err != nil {
-			return nil, fmt.Errorf("check selected-contract %s: %w", check.code, err)
-		}
-		if exists {
-			facts = append(facts, check.code)
+func runForkSelectedContractConversationAdvancedFacts(facts []string) []string {
+	out := []string{}
+	for _, fact := range facts {
+		switch strings.TrimSpace(fact) {
+		case "source_sessions_advanced_after_fork_point", "source_conversation_audits_advanced_after_fork_point", "source_turns_advanced_after_fork_point":
+			out = append(out, fact)
 		}
 	}
-	return uniqueNonEmptyStrings(facts), nil
+	return uniqueNonEmptyStrings(out)
 }
 
-func ensureRunForkNoPostForkActiveConversationDeliverySessionCoupling(ctx context.Context, q timerReconstructionQueryer, catalog schemaColumnCatalog, sourceRunID string, forkTime time.Time) error {
-	if !catalog.hasColumns("event_deliveries", "run_id", "status") {
-		return nil
-	}
-	postForkPredicates := []string{}
-	for _, column := range []string{"created_at", "started_at", "delivered_at"} {
-		if catalog.hasColumns("event_deliveries", column) {
-			postForkPredicates = append(postForkPredicates, fmt.Sprintf("d.%s > $2::timestamptz", column))
-		}
-	}
-	if len(postForkPredicates) == 0 {
-		return nil
-	}
-	couplingPredicates := []string{"d.status = 'in_progress'"}
-	if catalog.hasColumns("event_deliveries", "active_session_id") {
-		couplingPredicates = append(couplingPredicates, "d.active_session_id IS NOT NULL")
-	}
-	if catalog.hasColumns("event_deliveries", "started_at", "delivered_at") {
-		couplingPredicates = append(couplingPredicates, "(d.started_at IS NOT NULL AND d.delivered_at IS NULL)")
-	}
+func ensureRunForkNoPostForkActiveConversationDeliverySessionCoupling(ctx context.Context, q timerReconstructionQueryer, lineage runForkActivationLineage) error {
 	var exists bool
-	query := fmt.Sprintf(`
+	query := `
 		SELECT EXISTS (
 			SELECT 1
 			FROM event_deliveries d
+			JOIN LATERAL (
+				SELECT MAX(revision) AS revision
+				FROM run_fork_fact_revisions
+				WHERE run_id = d.run_id
+				  AND family = 'event_deliveries'
+				  AND fact_key = d.delivery_id::text
+				  AND present
+			) history ON TRUE
 			WHERE d.run_id = $1::uuid
-			  AND (%s)
-			  AND (%s)
+			  AND history.revision > $2
+			  AND (
+					d.status = 'in_progress'
+					OR d.active_session_id IS NOT NULL
+					OR (d.started_at IS NOT NULL AND d.delivered_at IS NULL)
+			  )
 		)
-	`, strings.Join(postForkPredicates, " OR "), strings.Join(couplingPredicates, " OR "))
-	if err := q.QueryRowContext(ctx, query, sourceRunID, forkTime).Scan(&exists); err != nil {
+	`
+	if err := q.QueryRowContext(ctx, query, lineage.SourceRunID, lineage.ForkEventRevision).Scan(&exists); err != nil {
 		return fmt.Errorf("check selected-contract source_active_conversation_session_coupling_after_fork_point: %w", err)
 	}
 	if exists {
@@ -1123,16 +1054,6 @@ func runForkReplayResumeAdmissionWithSourceAdvancedConversationHistory(admission
 		})
 	}
 	return admission
-}
-
-func runForkPostForkConversationPredicates(catalog schemaColumnCatalog, table string, columns ...string) []string {
-	predicates := []string{}
-	for _, column := range columns {
-		if catalog.hasColumns(table, column) {
-			predicates = append(predicates, fmt.Sprintf("%s > $2::timestamptz", column))
-		}
-	}
-	return predicates
 }
 
 func ensureRunForkSelectedContractExecutionForkState(ctx context.Context, tx *sql.Tx, catalog schemaColumnCatalog, forkRunID string, allowedSourceEventIDs []string) error {

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -1365,6 +1365,54 @@ func TestPostTGlobalRoutingRuleDoesNotChangeSelectedContractActivation(t *testin
 	}
 }
 
+func TestSelectedContractActivation_IgnoresExcludedSourceSessionColumnChanges(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	sourceRunID := uuid.NewString()
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	sessionID := uuid.NewString()
+	at := time.Unix(1700003615, 0).UTC()
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
+	seedRunForkSessionProjection(t, db, sourceRunID, "selected-session-agent", sessionID, "terminated", at)
+	selectedRevision := captureRunForkTestRevision(t, db, sourceRunID)
+
+	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
+		SourceRunID: sourceRunID,
+		At:          eventID,
+		ContractSelection: RunForkContractSelection{
+			Mode:            "selected_contracts",
+			ContractsRoot:   "/tmp/selected-contracts",
+			WorkflowName:    "selected-workflow",
+			WorkflowVersion: "v1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
+	}
+	seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, eventID, entityID, at)
+	mutateRunForkSessionExcludedColumns(t, db, sourceRunID, sessionID, at.Add(time.Minute))
+	var afterExcluded int64
+	if err := db.QueryRowContext(ctx, `SELECT last_revision FROM run_fork_revision_heads WHERE run_id=$1::uuid`, sourceRunID).Scan(&afterExcluded); err != nil {
+		t.Fatalf("load selected source revision after excluded session update: %v", err)
+	}
+	if afterExcluded != selectedRevision {
+		t.Fatalf("selected source revision after excluded session update = %d, want %d", afterExcluded, selectedRevision)
+	}
+
+	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
+		ForkRunID:             materialized.ForkRunID,
+		AllowedSourceEventIDs: []string{eventID},
+	})
+	if err != nil {
+		t.Fatalf("ActivateRunForkForSelectedContractExecution after excluded session update: %v", err)
+	}
+	if !activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want selected activation without branch divergence", activation)
+	}
+}
+
 func TestPostTSourceConversationHistoryActivatesAsBranchDivergence(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/internal/store/run_fork_selected_contract_execution_mutation_test.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation_test.go
@@ -117,7 +117,7 @@ func TestSelectedContractExecutionMaterializationConsumesPlanSnapshotMetadata(t 
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 	at := time.Unix(1700002405, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
 		UPDATE events
 		SET flow_instance = ''
@@ -134,6 +134,7 @@ func TestSelectedContractExecutionMaterializationConsumesPlanSnapshotMetadata(t 
 	`, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
 		t.Fatalf("update source entity_state metadata: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
@@ -186,8 +187,9 @@ func TestSelectedContractExecutionMaterializationTreatsSourceConversationHistory
 	auditID := uuid.NewString()
 	turnID := uuid.NewString()
 	at := time.Unix(1700002410, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, eventID, sessionID, auditID, turnID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
@@ -256,8 +258,9 @@ func TestSelectedContractExecutionMaterializationTreatsSourceReplayScopeMarkersA
 			entityID := uuid.NewString()
 			eventID := uuid.NewString()
 			at := time.Unix(1700002415, 0).UTC()
-			seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+			seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 			seedSelectedContractSourceReplayScopeMarker(t, db, sourceRunID, eventID, tc.reasonCode, at)
+			captureRunForkTestRevision(t, db, sourceRunID)
 
 			plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 			if err != nil {
@@ -302,7 +305,7 @@ func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCoupl
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 	at := time.Unix(1700002420, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
 			run_id, event_id, subscriber_type, subscriber_id, status, active_session_id, started_at, created_at
@@ -311,6 +314,7 @@ func TestSelectedContractExecutionMaterializationKeepsActiveDeliverySessionCoupl
 	`, sourceRunID, eventID, at, uuid.NewString()); err != nil {
 		t.Fatalf("seed active delivery coupling: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -365,12 +369,13 @@ func TestSelectedContractExecutionMaterializationAdmitsSameSourceDeliveryForkPoi
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			'', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
 			$4::uuid, $5
 		)
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -441,7 +446,7 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'unrelated.started', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
+			'', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
 		)
 	`, sourceRunID, unrelatedEventID, entityID, at.Add(10*time.Second)); err != nil {
 		t.Fatalf("seed unrelated event: %v", err)
@@ -454,6 +459,7 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 	`, sourceRunID, unrelatedEventID, at.Add(11*time.Second)); err != nil {
 		t.Fatalf("seed unrelated in-progress delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
@@ -461,12 +467,13 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			'', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
 			$4::uuid, $5
 		)
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -510,7 +517,7 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'unrelated.started', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
+			'', 'entity', '{}'::jsonb, 'source-runtime', 'platform', $4
 		)
 	`, sourceRunID, unrelatedEventID, entityID, at.Add(10*time.Second)); err != nil {
 		t.Fatalf("seed unrelated event: %v", err)
@@ -530,12 +537,13 @@ func TestSelectedContractExecutionMaterializationKeepsUnrelatedInProgressDeliver
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			'', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
 			$4::uuid, $5
 		)
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -570,7 +578,7 @@ func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsA
 	auditID := uuid.NewString()
 	turnID := uuid.NewString()
 	at := time.Unix(1700002430, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	seedSelectedContractSourceConversationHistory(t, db, sourceRunID, entityID, eventID, sessionID, auditID, turnID, at)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
@@ -591,6 +599,7 @@ func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsA
 	`, eventID, entityID, at); err != nil {
 		t.Fatalf("seed terminal delivery receipt: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -620,7 +629,7 @@ func TestSelectedContractExecutionMaterializationDoesNotTreatTerminalDeliveryAsA
 	assertNoCopiedConversationRows(t, db, materialized.ForkRunID, sessionID, auditID, turnID)
 }
 
-func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWithoutConversationHistoryFailClosed(t *testing.T) {
+func TestSelectedContractExecutionActivationKeepsPostFrontierActiveDeliveryFailClosed(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -639,12 +648,13 @@ func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWith
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			'', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
 			$4::uuid, $5
 		)
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
 		At:          forkPointEventID,
@@ -679,18 +689,19 @@ func TestSelectedContractExecutionActivationKeepsUnrelatedInProgressDeliveryWith
 	`, sourceRunID, unrelatedEventID, at.Add(11*time.Second)); err != nil {
 		t.Fatalf("seed unrelated in-progress delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID: materialized.ForkRunID,
 	})
-	if err == nil || !strings.Contains(err.Error(), RunForkBlockerDeliveryHistoryUnproven) {
-		t.Fatalf("activation error = %v, want unrelated active delivery blocker", err)
+	if err == nil || !strings.Contains(err.Error(), "source_active_conversation_session_coupling_after_fork_point") {
+		t.Fatalf("activation error = %v, want post-frontier active delivery blocker", err)
 	}
 	if activation.Activated || activation.BranchDivergence != nil {
 		t.Fatalf("activation = %#v, want blocked before branch divergence", activation)
 	}
-	if !runForkTestHasActivationBlocker(activation, RunForkBlockerDeliveryHistoryUnproven) {
-		t.Fatalf("activation blockers = %#v, want delivery history blocker", activation.UnsupportedBlockers)
+	if !runForkTestHasActivationBlocker(activation, "source_active_conversation_session_coupling_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, want active delivery/session coupling blocker", activation.UnsupportedBlockers)
 	}
 }
 
@@ -819,13 +830,14 @@ func TestSelectedContractExecutionMaterializationReconstructsActiveTimer(t *test
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 	at := time.Unix(1700002500, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO timers (run_id, timer_name, entity_id, flow_instance, fire_event, fire_payload, fire_at, owner_agent, task_type, status, created_at)
 		VALUES ($1::uuid, 'selected-timer', $2::uuid, 'flow-a/1', 'timer.selected', '{"source":true}'::jsonb, $3, 'agent-a', 'timer', 'active', $4)
 	`, sourceRunID, entityID, at.Add(time.Hour), at); err != nil {
 		t.Fatalf("seed timer: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
 		At:          eventID,
@@ -971,8 +983,9 @@ func TestSelectedContractExecutionMaterializationFailsClosedForUnsupportedTimerH
 			entityID := uuid.NewString()
 			eventID := uuid.NewString()
 			at := time.Unix(1700003525, 0).UTC()
-			seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+			seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 			tc.insertTimer(t, db, sourceRunID, entityID, at)
+			captureRunForkTestRevision(t, db, sourceRunID)
 
 			materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 				SourceRunID: sourceRunID,
@@ -1008,7 +1021,7 @@ func TestSelectedContractTimerReconstructionFailsClosedForInvalidPayload(t *test
 	}
 }
 
-func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappearsAfterPlanning(t *testing.T) {
+func TestSelectedContractTimerReconstructionRemainsFixedWhenSourceTimerIsDeletedLater(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1016,7 +1029,7 @@ func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappea
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 	at := time.Unix(1700003550, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	timerID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO timers (
@@ -1030,6 +1043,7 @@ func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappea
 	`, timerID, sourceRunID, entityID, at.Add(time.Hour), at.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed timer: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	plan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
 	if err != nil {
 		t.Fatalf("PlanRunFork: %v", err)
@@ -1040,17 +1054,32 @@ func TestSelectedContractTimerReconstructionFailsClosedWhenRelevantTimerDisappea
 	if _, err := db.ExecContext(ctx, `DELETE FROM timers WHERE timer_id = $1::uuid`, timerID); err != nil {
 		t.Fatalf("delete timer after planning: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	catalog, err := pg.requireRunForkSelectedContractExecutionCapabilities(ctx)
 	if err != nil {
 		t.Fatalf("require selected contract capabilities: %v", err)
 	}
-	_, err = pg.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
-	if err == nil || !strings.Contains(err.Error(), "no reconstructable active source timers") {
-		t.Fatalf("timer reconstruction error = %v, want no reconstructable timer blocker", err)
+	reconstruction, err := pg.planRunForkSelectedContractTimerReconstruction(ctx, catalog, plan)
+	if err != nil {
+		t.Fatalf("reconstruct timer from original fixed snapshot: %v", err)
+	}
+	if !reconstruction.Required || len(reconstruction.Rows) != 1 || reconstruction.Rows[0].TimerID != timerID {
+		t.Fatalf("original reconstruction = %#v, want deleted source timer from fixed snapshot", reconstruction)
+	}
+	repeatedPlan, err := pg.PlanRunFork(ctx, RunForkPlanRequest{SourceRunID: sourceRunID, At: eventID})
+	if err != nil {
+		t.Fatalf("repeat PlanRunFork: %v", err)
+	}
+	repeated, err := pg.planRunForkSelectedContractTimerReconstruction(ctx, catalog, repeatedPlan)
+	if err != nil {
+		t.Fatalf("reconstruct timer from repeated fixed snapshot: %v", err)
+	}
+	if !repeated.Required || len(repeated.Rows) != 1 || repeated.Rows[0].TimerID != timerID {
+		t.Fatalf("repeated reconstruction = %#v, want identical historical timer", repeated)
 	}
 }
 
-func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) {
+func TestPostTSourceTimerActivatesAsSelectedBranchDivergence(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1076,6 +1105,7 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	if materialized.ForkRunID == "" {
 		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
 	}
+	seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, eventID, entityID, at)
 
 	timerID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
@@ -1090,22 +1120,23 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	`, timerID, sourceRunID, entityID, at.Add(time.Hour), at.Add(time.Minute)); err != nil {
 		t.Fatalf("seed post-T timer: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID:             materialized.ForkRunID,
 		AllowedSourceEventIDs: []string{eventID},
 	})
-	if err == nil || !strings.Contains(err.Error(), "source_timers_advanced_after_fork_point") {
-		t.Fatalf("activation error = %v, want post-T timer blocker", err)
+	if err != nil {
+		t.Fatalf("ActivateRunForkForSelectedContractExecution: %v", err)
 	}
-	if activation.Activated || activation.BranchDivergence != nil {
-		t.Fatalf("activation = %#v, want blocked before selected branch divergence", activation)
+	if !activation.Activated || !activation.SourceAdvancedAfterFork || activation.BranchDivergence == nil {
+		t.Fatalf("activation = %#v, want selected branch divergence", activation)
 	}
-	if !runForkTestHasActivationBlocker(activation, "source_timers_advanced_after_fork_point") {
-		t.Fatalf("activation blockers = %#v, want source_timers_advanced_after_fork_point", activation.UnsupportedBlockers)
+	if runForkTestHasActivationBlocker(activation, "source_timers_advanced_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, selected source advancement should branch", activation.UnsupportedBlockers)
 	}
-	if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_timers_advanced_after_fork_point") {
-		t.Fatalf("activation replay admission = %#v, want source advanced timer blocker", activation.ReplayResumeAdmission)
+	if !containsString(activation.BranchDivergence.SourceAdvancedFacts, "source_timers_advanced_after_fork_point") {
+		t.Fatalf("branch divergence facts = %#v, want source_timers_advanced_after_fork_point", activation.BranchDivergence.SourceAdvancedFacts)
 	}
 
 	var sourceStatus, forkStatus string
@@ -1115,8 +1146,8 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
 		t.Fatalf("load fork status: %v", err)
 	}
-	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
-		t.Fatalf("run statuses source=%q fork=%q, want source running and fork materialized", sourceStatus, forkStatus)
+	if sourceStatus != "running" || forkStatus != RunForkActivatedStatus {
+		t.Fatalf("run statuses source=%q fork=%q, want live source branch and activated fork", sourceStatus, forkStatus)
 	}
 
 	var branchRows, forkTimerRows int
@@ -1130,13 +1161,13 @@ func TestPostTSourceTimerFailsClosedForSelectedContractActivation(t *testing.T) 
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM timers WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkTimerRows); err != nil {
 		t.Fatalf("count fork timers: %v", err)
 	}
-	if branchRows != 0 || forkTimerRows != 0 {
-		t.Fatalf("branch rows=%d fork timer rows=%d, want no branch divergence and no fork timer copies", branchRows, forkTimerRows)
+	if branchRows != 1 || forkTimerRows != 0 {
+		t.Fatalf("branch rows=%d fork timer rows=%d, want one divergence and no post-frontier timer copies", branchRows, forkTimerRows)
 	}
 	assertNoForkTimerCopiesForSource(t, db, sourceRunID)
 }
 
-func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHistory(t *testing.T) {
+func TestPostTSourceSessionDoesNotChangeFixedEventMaterialization(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1163,6 +1194,7 @@ func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHist
 	`, sessionID, sourceRunID, entityID, at.Add(time.Minute)); err != nil {
 		t.Fatalf("seed post-T source session: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
@@ -1183,8 +1215,8 @@ func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHist
 	if runForkTestHasMaterializationBlocker(materialized, "source_sessions_advanced_after_fork_point") {
 		t.Fatalf("selected-contract materialization kept post-T source session blocker: %#v", materialized.UnsupportedBlockers)
 	}
-	if !runForkTestHasLineageDispositionOwnerClassification(materialized.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner, "source_sessions_advanced_after_fork_point") {
-		t.Fatalf("materialization replay admission missing #671 owner: %#v", materialized.ReplayResumeAdmission)
+	if runForkTestHasLineageDispositionOwnerClassification(materialized.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, RunForkSelectedContractSourceAdvancedConversationHistoryPolicyOwner, "source_sessions_advanced_after_fork_point") {
+		t.Fatalf("materialization replay admission consumed a post-frontier source session: %#v", materialized.ReplayResumeAdmission)
 	}
 	var copiedSessions int
 	if err := db.QueryRowContext(ctx, `
@@ -1200,7 +1232,7 @@ func TestPostTSourceSessionMaterializationTreatsAsSourceAdvancedConversationHist
 	}
 }
 
-func TestPostTSourceConversationHistoryMaterializationKeepsActiveCouplingFailClosed(t *testing.T) {
+func TestPostTSourceConversationHistoryDoesNotChangeFixedEventMaterialization(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1222,19 +1254,18 @@ func TestPostTSourceConversationHistoryMaterializationKeepsActiveCouplingFailClo
 			WorkflowVersion: "v1",
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), "source_active_conversation_session_coupling_after_fork_point") {
-		t.Fatalf("materialization error = %v, want active post-T conversation coupling blocker", err)
+	if err != nil {
+		t.Fatalf("MaterializeRunForkForSelectedContractExecution: %v", err)
 	}
-	if materialized.ForkRunID != "" {
-		t.Fatalf("materialized fork despite active post-T conversation coupling: %#v", materialized)
+	if materialized.ForkRunID == "" {
+		t.Fatalf("materialization = %#v, want fixed-event materialization", materialized)
 	}
-	if !runForkTestHasMaterializationBlocker(materialized, "source_active_conversation_session_coupling_after_fork_point") {
-		t.Fatalf("materialization blockers = %#v, want active post-T coupling blocker", materialized.UnsupportedBlockers)
+	if runForkTestHasMaterializationBlocker(materialized, "source_active_conversation_session_coupling_after_fork_point") {
+		t.Fatalf("materialization blockers = %#v, post-frontier coupling belongs to fresh activation validation", materialized.UnsupportedBlockers)
 	}
-	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
-func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) {
+func TestPostTGlobalRoutingRuleDoesNotChangeSelectedContractActivation(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1260,6 +1291,7 @@ func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) 
 	if materialized.ForkRunID == "" {
 		t.Fatalf("materialized fork run_id is empty: %#v", materialized)
 	}
+	seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, eventID, entityID, at)
 
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO routing_rules (
@@ -1275,17 +1307,17 @@ func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) 
 		ForkRunID:             materialized.ForkRunID,
 		AllowedSourceEventIDs: []string{eventID},
 	})
-	if err == nil || !strings.Contains(err.Error(), "source_routes_advanced_after_fork_point") {
-		t.Fatalf("activation error = %v, want post-T route blocker", err)
+	if err != nil {
+		t.Fatalf("ActivateRunForkForSelectedContractExecution: %v", err)
 	}
-	if activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
-		t.Fatalf("activation = %#v, want blocked before selected branch divergence", activation)
+	if !activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want current global route to leave fixed source frontier unchanged", activation)
 	}
-	if !runForkTestHasActivationBlocker(activation, "source_routes_advanced_after_fork_point") {
-		t.Fatalf("activation blockers = %#v, want source_routes_advanced_after_fork_point", activation.UnsupportedBlockers)
+	if runForkTestHasActivationBlocker(activation, "source_routes_advanced_after_fork_point") {
+		t.Fatalf("activation blockers = %#v, current global routes are not historical source facts", activation.UnsupportedBlockers)
 	}
-	if !runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_routes_advanced_after_fork_point") {
-		t.Fatalf("activation replay admission = %#v, want source advanced route blocker", activation.ReplayResumeAdmission)
+	if runForkTestHasDispositionBlocker(activation.ReplayResumeAdmission, RunForkReplayResumeFactSourceAdvanced, "source_routes_advanced_after_fork_point") {
+		t.Fatalf("activation replay admission = %#v, current global routes must not enter the fixed workset", activation.ReplayResumeAdmission)
 	}
 
 	var sourceStatus, forkStatus string
@@ -1295,8 +1327,8 @@ func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) 
 	if err := db.QueryRowContext(ctx, `SELECT status FROM runs WHERE run_id = $1::uuid`, materialized.ForkRunID).Scan(&forkStatus); err != nil {
 		t.Fatalf("load fork status: %v", err)
 	}
-	if sourceStatus != "running" || forkStatus != RunForkMaterializedStatus {
-		t.Fatalf("run statuses source=%q fork=%q, want source running and fork materialized", sourceStatus, forkStatus)
+	if sourceStatus != "forked" || forkStatus != "running" {
+		t.Fatalf("run statuses source=%q fork=%q, want source forked and fork running after activation", sourceStatus, forkStatus)
 	}
 
 	var branchRows, forkDeliveryRows, sourceRouteRows, routeRecoveryRows int
@@ -1328,8 +1360,8 @@ func TestPostTSourceRouteFailsClosedForSelectedContractActivation(t *testing.T) 
 	`, materialized.ForkRunID).Scan(&routeRecoveryRows); err != nil {
 		t.Fatalf("count route recovery rows: %v", err)
 	}
-	if branchRows != 0 || forkDeliveryRows != 0 || sourceRouteRows != 1 || routeRecoveryRows != 0 {
-		t.Fatalf("branch rows=%d fork delivery rows=%d source route rows=%d route recovery rows=%d, want no divergence, no fork deliveries, one source route, no fork route recovery", branchRows, forkDeliveryRows, sourceRouteRows, routeRecoveryRows)
+	if branchRows != 0 || sourceRouteRows != 1 || routeRecoveryRows != 0 {
+		t.Fatalf("branch rows=%d fork delivery rows=%d source route rows=%d route recovery rows=%d, want no divergence, one untouched global route, and no invented recovery", branchRows, forkDeliveryRows, sourceRouteRows, routeRecoveryRows)
 	}
 }
 
@@ -1419,6 +1451,7 @@ func TestPostTSourceConversationHistoryActivatesAsBranchDivergence(t *testing.T)
 			if err := tc.seed(ctx, db, sourceRunID, entityID, eventID, at); err != nil {
 				t.Fatalf("seed post-T %s: %v", tc.name, err)
 			}
+			captureRunForkTestRevision(t, db, sourceRunID)
 
 			activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
 				ForkRunID:             materialized.ForkRunID,
@@ -1474,12 +1507,13 @@ func TestSelectedContractExecutionActivationRecordsSameSourceDeliveryCouplingAsB
 		)
 		VALUES (
 			$1::uuid, $2::uuid, 'validation/vertical.ready_for_review', $3::uuid,
-			'flow-a/1', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
+			'', 'entity', '{}'::jsonb, 'validation-coordinator', 'agent',
 			$4::uuid, $5
 		)
 	`, sourceRunID, forkPointEventID, entityID, sourceEventID, forkAt); err != nil {
 		t.Fatalf("seed fork point event: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
 		At:          forkPointEventID,
@@ -1560,7 +1594,7 @@ func TestPostTSourceConversationHistoryActivationKeepsActiveCouplingFailClosed(t
 	}
 }
 
-func TestSelectedContractActivationTreatsSameEventReplayScopeMarkerWriteSkewAsLineage(t *testing.T) {
+func TestSelectedContractActivationRejectsPostRevisionSameEventReplayScopeMarker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -1588,16 +1622,17 @@ func TestSelectedContractActivationTreatsSameEventReplayScopeMarkerWriteSkewAsLi
 	}
 	seedSelectedContractExecutionForkLineage(t, pg, db, sourceRunID, materialized.ForkRunID, eventID, entityID, at)
 	seedSelectedContractSourceReplayScopeMarker(t, db, sourceRunID, eventID, replayScopeReasonDirect, at.Add(time.Minute))
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID:             materialized.ForkRunID,
 		AllowedSourceEventIDs: []string{eventID},
 	})
-	if err != nil {
-		t.Fatalf("ActivateRunForkForSelectedContractExecution: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "source_committed_replay_scope_advanced_after_fork_point") {
+		t.Fatalf("activation error = %v, want post-revision same-event replay-scope blocker", err)
 	}
-	if !activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
-		t.Fatalf("activation = %#v, want activated without marker-driven source advancement", activation)
+	if activation.Activated || activation.SourceAdvancedAfterFork || activation.BranchDivergence != nil {
+		t.Fatalf("activation = %#v, want blocked before branch divergence", activation)
 	}
 	assertNoCopiedReplayScopeMarkers(t, db, materialized.ForkRunID)
 }
@@ -2039,6 +2074,7 @@ func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t 
 	}
 	seedSelectedContractPostForkSourceEvent(t, db, sourceRunID, afterEventID, entityID, at)
 	seedSelectedContractSourceReplayScopeMarker(t, db, sourceRunID, afterEventID, replayScopeReasonDirect, at.Add(-time.Second))
+	captureRunForkTestRevision(t, db, sourceRunID)
 
 	activation, err := pg.ActivateRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionActivateRequest{
 		ForkRunID:             materialized.ForkRunID,
@@ -2067,7 +2103,7 @@ func TestPostTSourceReplayScopeMarkerFailsClosedForSelectedContractActivation(t 
 	assertNoCopiedReplayScopeMarkers(t, db, materialized.ForkRunID)
 }
 
-func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testing.T) {
+func TestSelectedContractExecutionMaterializationPreservesUnversionedRouteBlocker(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
@@ -2075,16 +2111,15 @@ func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testin
 	entityID := uuid.NewString()
 	eventID := uuid.NewString()
 	at := time.Unix(1700002525, 0).UTC()
-	seedSelectedContractExecutionStoreSource(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO routing_rules (
-			event_pattern, subscriber_type, subscriber_id, flow_instance, source_flow,
-			is_materialized, status, created_at
-		)
-		VALUES ('item.received', 'node', 'selected-route-node', 'flow-a/2', 'flow-a', true, 'active', $1)
-	`, at); err != nil {
-		t.Fatalf("seed routing rule: %v", err)
+		UPDATE events
+		SET flow_instance = 'flow-a/1'
+		WHERE run_id = $1::uuid AND event_id = $2::uuid
+	`, sourceRunID, eventID); err != nil {
+		t.Fatalf("seed selected event route identity: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 	materialized, err := pg.MaterializeRunForkForSelectedContractExecution(ctx, RunForkSelectedContractExecutionMaterializeRequest{
 		SourceRunID: sourceRunID,
 		At:          eventID,
@@ -2095,8 +2130,9 @@ func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testin
 			WorkflowVersion: "v1",
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), RunForkBlockerFlowRouteHistoryUnproven) {
-		t.Fatalf("materialization error = %v, want route blocker", err)
+	blocker, fact, ok := runForkReplayResumeBlockerFromError(err)
+	if err == nil || !ok || blocker.Code != RunForkBlockerFlowRouteHistoryUnproven || fact != RunForkReplayResumeFactRouteHistory {
+		t.Fatalf("materialization error = %v blocker=%#v fact=%q, want typed route blocker", err, blocker, fact)
 	}
 	if materialized.ForkRunID != "" {
 		t.Fatalf("materialized fork despite route blocker: %#v", materialized)
@@ -2104,9 +2140,15 @@ func TestSelectedContractExecutionMaterializationPreservesRouteBlocker(t *testin
 	assertNoSelectedContractForkRows(t, db, sourceRunID)
 }
 
-func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+func seedSelectedContractExecutionStoreSource(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
 	t.Helper()
-	seedSelectedContractExecutionStoreSourceWithoutDelivery(t, db, sourceRunID, entityID, eventID, at)
+	seedSelectedContractExecutionStoreSourceUnpublished(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
+}
+
+func seedSelectedContractExecutionStoreSourceUnpublished(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	seedSelectedContractExecutionStoreSourceRaw(t, db, sourceRunID, entityID, eventID, at)
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO event_deliveries (
@@ -2118,7 +2160,13 @@ func seedSelectedContractExecutionStoreSource(t *testing.T, db execContextDB, so
 	}
 }
 
-func seedSelectedContractExecutionStoreSourceWithoutDelivery(t *testing.T, db execContextDB, sourceRunID, entityID, eventID string, at time.Time) {
+func seedSelectedContractExecutionStoreSourceWithoutDelivery(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
+	t.Helper()
+	seedSelectedContractExecutionStoreSourceRaw(t, db, sourceRunID, entityID, eventID, at)
+	captureRunForkTestRevision(t, db, sourceRunID)
+}
+
+func seedSelectedContractExecutionStoreSourceRaw(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -2131,7 +2179,7 @@ func seedSelectedContractExecutionStoreSourceWithoutDelivery(t *testing.T, db ex
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload, produced_by, produced_by_type, created_at
 		)
-		VALUES ($1::uuid, $2::uuid, 'item.received', $3::uuid, 'flow-a/1', 'entity', '{}'::jsonb, 'test', 'platform', $4)
+		VALUES ($1::uuid, $2::uuid, 'item.received', $3::uuid, '', 'entity', '{}'::jsonb, 'test', 'platform', $4)
 	`, sourceRunID, eventID, entityID, at); err != nil {
 		t.Fatalf("seed source event: %v", err)
 	}
@@ -2235,7 +2283,7 @@ func seedSelectedContractPostForkSourceEvent(t *testing.T, db execContextDB, sou
 	}
 }
 
-func seedPostTActiveConversationCoupling(t *testing.T, db execContextDB, sourceRunID, entityID, eventID, sessionID string, at time.Time) {
+func seedPostTActiveConversationCoupling(t *testing.T, db *sql.DB, sourceRunID, entityID, eventID, sessionID string, at time.Time) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, `
@@ -2265,6 +2313,7 @@ func seedPostTActiveConversationCoupling(t *testing.T, db execContextDB, sourceR
 	`, sourceRunID, eventID, sessionID, at.Add(time.Minute)); err != nil {
 		t.Fatalf("seed post-T active source delivery: %v", err)
 	}
+	captureRunForkTestRevision(t, db, sourceRunID)
 }
 
 func assertNoCopiedConversationRows(t *testing.T, db *sql.DB, forkRunID, sourceSessionID, sourceAuditID, sourceTurnID string) {

--- a/internal/store/run_fork_selected_contract_replay_scope_marker.go
+++ b/internal/store/run_fork_selected_contract_replay_scope_marker.go
@@ -16,9 +16,9 @@ func RunForkSelectedContractReplayResumeAdmission(plan RunForkPlan) RunForkRepla
 	return RunForkSelectedContractCommittedReplayScopeMarkerAdmission(admission)
 }
 
-// RunForkSelectedContractCommittedReplayScopeMarkerAdmission treats at/before-T
-// source committed replay-scope marker rows as lineage/no-action evidence for
-// selected-contract timestamp forks. It does not authorize copying source marker
+// RunForkSelectedContractCommittedReplayScopeMarkerAdmission treats source
+// committed replay-scope marker rows present at the selected revision as
+// lineage/no-action evidence for selected-contract forks. It does not authorize copying source marker
 // rows or using them as fork-local recovery proof.
 func RunForkSelectedContractCommittedReplayScopeMarkerAdmission(admission RunForkReplayResumeAdmission) RunForkReplayResumeAdmission {
 	if strings.TrimSpace(admission.Owner) == "" {
@@ -41,7 +41,7 @@ func RunForkSelectedContractCommittedReplayScopeMarkerAdmission(admission RunFor
 		disposition.Owner = RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner
 		disposition.BlockerCode = ""
 		disposition.Classification = ""
-		disposition.Message = fmt.Sprintf("%s classifies at/before-T source committed replay-scope marker rows as selected-contract lineage/no-action evidence only; fork-local recovery proof must be written under the fork run_id by runtime execution or fork-local replay owners", RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner)
+		disposition.Message = fmt.Sprintf("%s classifies source committed replay-scope marker rows present at the selected revision as selected-contract lineage/no-action evidence only; fork-local recovery proof must be written under the fork run_id by runtime execution or fork-local replay owners", RunForkSelectedContractCommittedReplayScopeMarkerPolicyOwner)
 		changed = true
 	}
 	if !changed {

--- a/internal/store/run_fork_selected_contract_route_recovery.go
+++ b/internal/store/run_fork_selected_contract_route_recovery.go
@@ -109,7 +109,18 @@ func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.C
 	if err != nil {
 		return RunForkSelectedContractRouteRecovery{}, err
 	}
-	if _, err := s.DB.ExecContext(ctx, `
+	if err := insertRunForkSelectedContractRouteRecovery(ctx, s.DB, record); err != nil {
+		return RunForkSelectedContractRouteRecovery{}, err
+	}
+	return record, nil
+}
+
+type runForkSelectedContractRouteRecoveryExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func insertRunForkSelectedContractRouteRecovery(ctx context.Context, execer runForkSelectedContractRouteRecoveryExecer, record RunForkSelectedContractRouteRecovery) error {
+	if _, err := execer.ExecContext(ctx, `
 		INSERT INTO run_fork_selected_contract_route_recoveries (
 			fork_run_id, source_run_id, fork_event_id,
 			owner, runtime_recovery_owner,
@@ -155,9 +166,46 @@ func (s *PostgresStore) RecordRunForkSelectedContractRouteRecovery(ctx context.C
 		record.FrontierEvidenceFingerprint, record.RouteTopologyFingerprint, record.RecipientPlanningFingerprint,
 		record.StaticRouteEventCount, record.DynamicTopologyProofCount, record.RecipientPlanEventCount,
 		string(record.RouteTopology), string(record.RecipientPlanning), record.CreatedAt); err != nil {
-		return RunForkSelectedContractRouteRecovery{}, fmt.Errorf("record selected-contract route recovery: %w", err)
+		return fmt.Errorf("record selected-contract route recovery: %w", err)
 	}
-	return record, nil
+	return nil
+}
+
+func validateRunForkSelectedContractRouteRecoveryAtActivation(ctx context.Context, tx *sql.Tx, expected RunForkSelectedContractRouteRecovery) error {
+	actual, err := loadRunForkSelectedContractRouteRecovery(ctx, tx, `WHERE fork_run_id = $1::uuid`, expected.ForkRunID)
+	if err == sql.ErrNoRows {
+		return runForkReplayResumeError(
+			RunForkBlockerFlowRouteHistoryUnproven,
+			RunForkReplayResumeFactRouteHistory,
+			"selected-contract activation requires persisted route recovery from materialization",
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("load selected-contract route recovery for activation: %w", err)
+	}
+	if actual.Owner != expected.Owner ||
+		actual.RuntimeRecoveryOwner != expected.RuntimeRecoveryOwner ||
+		actual.SourceRunID != expected.SourceRunID ||
+		actual.ForkEventID != expected.ForkEventID ||
+		actual.RouteTopologyOwner != expected.RouteTopologyOwner ||
+		actual.DynamicTopologyOwner != expected.DynamicTopologyOwner ||
+		actual.RecipientPlanningOwner != expected.RecipientPlanningOwner ||
+		actual.FrontierEvidenceFingerprint != expected.FrontierEvidenceFingerprint ||
+		actual.RouteTopologyFingerprint != expected.RouteTopologyFingerprint ||
+		actual.RecipientPlanningFingerprint != expected.RecipientPlanningFingerprint ||
+		actual.StaticRouteEventCount != expected.StaticRouteEventCount ||
+		actual.DynamicTopologyProofCount != expected.DynamicTopologyProofCount ||
+		actual.RecipientPlanEventCount != expected.RecipientPlanEventCount {
+		return runForkReplayResumeError(
+			RunForkBlockerFlowRouteHistoryUnproven,
+			RunForkReplayResumeFactRouteHistory,
+			"selected-contract activation route recovery does not match current canonical topology proof",
+		)
+	}
+	if err := validateRunForkSelectedContractRouteRecoverySelection("route recovery activation", actual.ContractSelection, expected.ContractSelection); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *PostgresStore) LoadRunForkSelectedContractRouteRecovery(ctx context.Context, forkRunID string) (RunForkSelectedContractRouteRecovery, bool, error) {

--- a/internal/store/run_fork_timer_reconstruction.go
+++ b/internal/store/run_fork_timer_reconstruction.go
@@ -5,10 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
-
-	"github.com/lib/pq"
 )
 
 type runForkTimerReconstructionPlan struct {
@@ -89,15 +88,8 @@ func (s *PostgresStore) planRunForkSelectedContractTimerReconstruction(ctx conte
 	if !catalog.hasColumns("timers", "run_id", "source_timer_id", "forked_from_run_id", "forked_from_event_id", "reconstruction_owner") {
 		return runForkTimerReconstructionPlan{}, fmt.Errorf("selected-contract timer reconstruction requires run-scoped timer lineage columns")
 	}
-	facts, err := s.loadRunForkSourceFacts(ctx, plan.SourceRunID, runForkEventCursor{
-		EventID:   plan.ForkPoint.EventID,
-		EventName: plan.ForkPoint.EventName,
-		CreatedAt: plan.ForkPoint.Timestamp,
-	}, plan.Entities)
-	if err != nil {
-		return runForkTimerReconstructionPlan{}, err
-	}
-	rows, err := loadRunForkReconstructableSourceTimers(ctx, s.DB, plan.SourceRunID, plan.ForkPoint.Timestamp, facts)
+	facts := loadRunForkSourceFactsFromRevision(plan.historicalSnapshot, plan.Entities)
+	rows, err := loadRunForkReconstructableSourceTimersFromRevision(plan.historicalSnapshot, facts)
 	if err != nil {
 		return runForkTimerReconstructionPlan{}, err
 	}
@@ -107,65 +99,41 @@ func (s *PostgresStore) planRunForkSelectedContractTimerReconstruction(ctx conte
 	return runForkTimerReconstructionPlan{Required: true, Rows: rows}, nil
 }
 
-func loadRunForkReconstructableSourceTimers(ctx context.Context, q timerReconstructionQueryer, sourceRunID string, at time.Time, facts runForkSourceFacts) ([]runForkTimerReconstructionRow, error) {
+func loadRunForkReconstructableSourceTimersFromRevision(snapshot *runForkRevisionSnapshot, facts runForkSourceFacts) ([]runForkTimerReconstructionRow, error) {
+	if snapshot == nil {
+		return nil, fmt.Errorf("selected-contract timer reconstruction requires a revision snapshot")
+	}
 	if len(facts.EntityIDs) == 0 && len(facts.FlowInstances) == 0 {
 		return nil, nil
 	}
-	rows, err := q.QueryContext(ctx, `
-		SELECT
-			timer_id::text,
-			timer_name,
-			COALESCE(entity_id::text, ''),
-			COALESCE(flow_instance, ''),
-			fire_event,
-			fire_payload,
-			fire_at,
-			recurring,
-			COALESCE(recurrence_cron, ''),
-			COALESCE(recurrence_interval, ''),
-			COALESCE(owner_node, ''),
-			COALESCE(owner_agent, ''),
-			task_type,
-			status,
-			fired_at,
-			created_at
-		FROM timers
-		WHERE run_id = $1::uuid
-		  AND created_at <= $2::timestamptz
-		  AND (
-				(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
-				OR
-				(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
-		  )
-		ORDER BY created_at ASC, timer_id ASC
-	`, sourceRunID, at, pq.Array(facts.EntityIDs), pq.Array(facts.FlowInstances))
-	if err != nil {
-		return nil, fmt.Errorf("load source timers for reconstruction: %w", err)
-	}
-	defer rows.Close()
-
+	entityIDs := stringSliceSet(facts.EntityIDs)
+	flowInstances := stringSliceSet(facts.FlowInstances)
 	out := []runForkTimerReconstructionRow{}
-	for rows.Next() {
-		var row runForkTimerReconstructionRow
-		if err := rows.Scan(
-			&row.TimerID,
-			&row.TimerName,
-			&row.EntityID,
-			&row.FlowInstance,
-			&row.FireEvent,
-			&row.FirePayload,
-			&row.FireAt,
-			&row.Recurring,
-			&row.RecurrenceCron,
-			&row.RecurrenceInterval,
-			&row.OwnerNode,
-			&row.OwnerAgent,
-			&row.TaskType,
-			&row.Status,
-			&row.FiredAt,
-			&row.CreatedAt,
-		); err != nil {
-			return nil, fmt.Errorf("scan source timer for reconstruction: %w", err)
+	for _, timer := range snapshot.Timers {
+		_, entityRelevant := entityIDs[strings.TrimSpace(timer.EntityID)]
+		_, flowRelevant := flowInstances[strings.TrimSpace(timer.FlowInstance)]
+		if (!entityRelevant || strings.TrimSpace(timer.EntityID) == "") && (!flowRelevant || strings.TrimSpace(timer.FlowInstance) == "") {
+			continue
+		}
+		row := runForkTimerReconstructionRow{
+			TimerID:            timer.TimerID,
+			TimerName:          timer.TimerName,
+			EntityID:           timer.EntityID,
+			FlowInstance:       timer.FlowInstance,
+			FireEvent:          timer.FireEvent,
+			FirePayload:        append([]byte(nil), timer.FirePayload...),
+			FireAt:             timer.FireAt,
+			Recurring:          timer.Recurring,
+			RecurrenceCron:     timer.RecurrenceCron,
+			RecurrenceInterval: timer.RecurrenceInterval,
+			OwnerNode:          timer.OwnerNode,
+			OwnerAgent:         timer.OwnerAgent,
+			TaskType:           timer.TaskType,
+			Status:             timer.Status,
+			CreatedAt:          timer.CreatedAt,
+		}
+		if timer.FiredAt != nil {
+			row.FiredAt = sql.NullTime{Time: *timer.FiredAt, Valid: true}
 		}
 		normalized, err := validateRunForkReconstructableSourceTimer(row)
 		if err != nil {
@@ -173,9 +141,7 @@ func loadRunForkReconstructableSourceTimers(ctx context.Context, q timerReconstr
 		}
 		out = append(out, normalized)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate source timers for reconstruction: %w", err)
-	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TimerID < out[j].TimerID })
 	return out, nil
 }
 
@@ -235,35 +201,45 @@ func runForkSelectedContractTimerReconstructionComplete(ctx context.Context, tx 
 	if !runForkPlanHasTimerBlocker(plan) {
 		return false, nil
 	}
-	var sourceCount, forkCount int
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM timers
-		WHERE run_id = $1::uuid
-		  AND created_at <= $2::timestamptz
-		  AND status = 'active'
-		  AND fired_at IS NULL
-		  AND (
-				(entity_id IS NOT NULL AND entity_id::text = ANY($3::text[]))
-				OR
-				(COALESCE(flow_instance, '') <> '' AND flow_instance = ANY($4::text[]))
-		  )
-	`, lineage.SourceRunID, lineage.ForkEventTime, pq.Array(lineage.EntityIDs), pq.Array(lineage.FlowInstances)).Scan(&sourceCount); err != nil {
-		return false, fmt.Errorf("count source timers for reconstruction proof: %w", err)
+	facts := loadRunForkSourceFactsFromRevision(plan.historicalSnapshot, plan.Entities)
+	expected, err := loadRunForkReconstructableSourceTimersFromRevision(plan.historicalSnapshot, facts)
+	if err != nil {
+		return false, err
 	}
-	if sourceCount == 0 {
+	if len(expected) == 0 {
 		return false, nil
 	}
-	if err := tx.QueryRowContext(ctx, `
-		SELECT COUNT(DISTINCT source_timer_id)
+	rows, err := tx.QueryContext(ctx, `
+		SELECT DISTINCT source_timer_id::text
 		FROM timers
 		WHERE run_id = $1::uuid
 		  AND forked_from_run_id = $2::uuid
 		  AND forked_from_event_id = $3::uuid
 		  AND reconstruction_owner = $4
 		  AND status = 'active'
-	`, lineage.ForkRunID, lineage.SourceRunID, lineage.ForkEventID, RunForkHistoricalReplayTimerReconstructionOwner).Scan(&forkCount); err != nil {
-		return false, fmt.Errorf("count fork reconstructed timers: %w", err)
+	`, lineage.ForkRunID, lineage.SourceRunID, lineage.ForkEventID, RunForkHistoricalReplayTimerReconstructionOwner)
+	if err != nil {
+		return false, fmt.Errorf("load fork reconstructed timers: %w", err)
 	}
-	return forkCount == sourceCount, nil
+	defer rows.Close()
+	actual := map[string]struct{}{}
+	for rows.Next() {
+		var timerID string
+		if err := rows.Scan(&timerID); err != nil {
+			return false, fmt.Errorf("scan fork reconstructed timer: %w", err)
+		}
+		actual[timerID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate fork reconstructed timers: %w", err)
+	}
+	if len(actual) != len(expected) {
+		return false, nil
+	}
+	for _, timer := range expected {
+		if _, ok := actual[timer.TimerID]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -75,6 +75,11 @@ func (s *PostgresStore) RunEventTransaction(ctx context.Context, fn func(context
 		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return err
 	}
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(txctx, tx); err != nil {
+		_ = tx.Rollback()
+		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return err

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -1004,6 +1004,13 @@ func runtimeWriterRules() []runtimeWriterRule {
 			reason:         "diagnostic/dead-letter raw SQL helper is adjacent and split from selected SQLite mutation boundary",
 		},
 		{
+			name:           "postgres run-fork revision owner",
+			path:           rx(`^internal/runtime/runforkrevision/.*\.go$`),
+			kinds:          allPrimitiveKinds(),
+			classification: classDifferentConcept,
+			reason:         "Postgres fixed-revision capture is the run-fork history owner; SQLite run-fork mutation remains typed unsupported",
+		},
+		{
 			name:           "workspace and digest stores",
 			path:           rx(`^internal/(runtime/workspace|digest)/.*\.go$`),
 			kinds:          allPrimitiveKinds(),

--- a/internal/store/scenario_setup.go
+++ b/internal/store/scenario_setup.go
@@ -107,7 +107,7 @@ func (s *PostgresStore) SetupScenarioEntities(ctx context.Context, req ScenarioS
 			return ScenarioSetupResult{}, fmt.Errorf("record postgres scenario setup entity mutation %s: %w", entity.Alias, err)
 		}
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return ScenarioSetupResult{}, fmt.Errorf("commit postgres scenario setup: %w", err)
 	}
 	committed = true

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -235,24 +235,24 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 }
 
 func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, runID, agentID, eventType string) error {
-	return s.runScheduleMutation(ctx, runID, "cancel timer", func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-		UPDATE timers
-		SET status = 'cancelled'
+	return s.runScheduleMutation(ctx, runID, "cancel timer", func(tx *sql.Tx) (bool, error) {
+		result, err := tx.ExecContext(ctx, `
+			UPDATE timers
+			SET status = 'cancelled'
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
 		  AND owner_agent = $2
 		  AND fire_event = $3
 		  AND status = 'active'
-	`, runID, agentID, eventType)
-		return err
+		`, runID, agentID, eventType)
+		return scheduleMutationChanged(result, err)
 	})
 }
 
 func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
-	return s.runScheduleMutation(ctx, sc.RunID, "cancel exact timer", func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE timers
-		SET status = 'cancelled'
+	return s.runScheduleMutation(ctx, sc.RunID, "cancel exact timer", func(tx *sql.Tx) (bool, error) {
+		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE timers
+			SET status = 'cancelled'
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
 		  AND owner_agent = $2
 		  AND fire_event = $3
@@ -260,8 +260,8 @@ func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimep
 		  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
 		  AND %s = $6
 		  AND status = 'active'
-	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
-		return err
+		`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
+		return scheduleMutationChanged(result, err)
 	})
 }
 
@@ -328,17 +328,17 @@ func (s *PostgresStore) markScheduleFiredSpec(ctx context.Context, sc runtimepip
 	if !strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
 		status = "active"
 	}
-	return s.runScheduleMutation(ctx, sc.RunID, "mark timer fired", func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-		UPDATE timers
+	return s.runScheduleMutation(ctx, sc.RunID, "mark timer fired", func(tx *sql.Tx) (bool, error) {
+		result, err := tx.ExecContext(ctx, `
+			UPDATE timers
 		SET status = $4,
 		    fired_at = now()
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
 		  AND owner_agent = $2
 		  AND fire_event = $3
 		  AND status = 'active'
-	`, sc.RunID, sc.AgentID, sc.EventType, status)
-		return err
+		`, sc.RunID, sc.AgentID, sc.EventType, status)
+		return scheduleMutationChanged(result, err)
 	})
 }
 
@@ -347,9 +347,9 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	if !strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
 		status = "active"
 	}
-	return s.runScheduleMutation(ctx, sc.RunID, "mark exact timer fired", func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE timers
+	return s.runScheduleMutation(ctx, sc.RunID, "mark exact timer fired", func(tx *sql.Tx) (bool, error) {
+		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE timers
 		SET status = $7,
 		    fired_at = now()
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
@@ -359,21 +359,22 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 		  AND flow_instance IS NOT DISTINCT FROM NULLIF($5,'')
 		  AND %s = $6
 		  AND status = 'active'
-	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
-		return err
+		`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
+		return scheduleMutationChanged(result, err)
 	})
 }
 
-func (s *PostgresStore) runScheduleMutation(ctx context.Context, runID, label string, mutate func(*sql.Tx) error) error {
+func (s *PostgresStore) runScheduleMutation(ctx context.Context, runID, label string, mutate func(*sql.Tx) (bool, error)) error {
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin %s: %w", label, err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err := mutate(tx); err != nil {
+	changed, err := mutate(tx)
+	if err != nil {
 		return fmt.Errorf("%s: %w", label, err)
 	}
-	if strings.TrimSpace(runID) != "" {
+	if changed && strings.TrimSpace(runID) != "" {
 		if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyTimers); err != nil {
 			return err
 		}
@@ -382,6 +383,17 @@ func (s *PostgresStore) runScheduleMutation(ctx context.Context, runID, label st
 		return fmt.Errorf("commit %s: %w", label, err)
 	}
 	return nil
+}
+
+func scheduleMutationChanged(result sql.Result, err error) (bool, error) {
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
 }
 
 func extractPersistedScheduleTaskID(payload []byte) (string, []byte) {

--- a/internal/store/schedule_store.go
+++ b/internal/store/schedule_store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 )
 
 func (s *PostgresStore) UpsertSchedule(ctx context.Context, sc runtimepipeline.Schedule) error {
@@ -221,6 +223,11 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 	if err != nil {
 		return fmt.Errorf("insert timer: %w", err)
 	}
+	if strings.TrimSpace(sc.RunID) != "" {
+		if _, err := runforkrevision.Capture(ctx, tx, sc.RunID, runforkrevision.FamilyTimers); err != nil {
+			return err
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit timer tx: %w", err)
 	}
@@ -228,7 +235,8 @@ func (s *PostgresStore) upsertScheduleSpec(ctx context.Context, sc runtimepipeli
 }
 
 func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, runID, agentID, eventType string) error {
-	_, err := s.DB.ExecContext(ctx, `
+	return s.runScheduleMutation(ctx, runID, "cancel timer", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
 		UPDATE timers
 		SET status = 'cancelled'
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
@@ -236,14 +244,13 @@ func (s *PostgresStore) cancelScheduleSpec(ctx context.Context, runID, agentID, 
 		  AND fire_event = $3
 		  AND status = 'active'
 	`, runID, agentID, eventType)
-	if err != nil {
-		return fmt.Errorf("cancel timer: %w", err)
-	}
-	return nil
+		return err
+	})
 }
 
 func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
-	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
+	return s.runScheduleMutation(ctx, sc.RunID, "cancel exact timer", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = 'cancelled'
 		WHERE run_id IS NOT DISTINCT FROM NULLIF($1,'')::uuid
@@ -254,10 +261,8 @@ func (s *PostgresStore) cancelScheduleExactSpec(ctx context.Context, sc runtimep
 		  AND %s = $6
 		  AND status = 'active'
 	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID))
-	if err != nil {
-		return fmt.Errorf("cancel exact timer: %w", err)
-	}
-	return nil
+		return err
+	})
 }
 
 func (s *PostgresStore) loadActiveSchedulesSpec(ctx context.Context) ([]runtimepipeline.Schedule, error) {
@@ -323,7 +328,8 @@ func (s *PostgresStore) markScheduleFiredSpec(ctx context.Context, sc runtimepip
 	if !strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
 		status = "active"
 	}
-	_, err := s.DB.ExecContext(ctx, `
+	return s.runScheduleMutation(ctx, sc.RunID, "mark timer fired", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
 		UPDATE timers
 		SET status = $4,
 		    fired_at = now()
@@ -332,10 +338,8 @@ func (s *PostgresStore) markScheduleFiredSpec(ctx context.Context, sc runtimepip
 		  AND fire_event = $3
 		  AND status = 'active'
 	`, sc.RunID, sc.AgentID, sc.EventType, status)
-	if err != nil {
-		return fmt.Errorf("mark timer fired: %w", err)
-	}
-	return nil
+		return err
+	})
 }
 
 func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runtimepipeline.Schedule) error {
@@ -343,7 +347,8 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 	if !strings.EqualFold(strings.TrimSpace(sc.Mode), "once") {
 		status = "active"
 	}
-	_, err := s.DB.ExecContext(ctx, fmt.Sprintf(`
+	return s.runScheduleMutation(ctx, sc.RunID, "mark exact timer fired", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE timers
 		SET status = $7,
 		    fired_at = now()
@@ -355,8 +360,26 @@ func (s *PostgresStore) markScheduleFiredExactSpec(ctx context.Context, sc runti
 		  AND %s = $6
 		  AND status = 'active'
 	`, exactScheduleTaskIDSQL()), sc.RunID, sc.AgentID, sc.EventType, sc.EntityID, sc.FlowInstance, strings.TrimSpace(sc.TaskID), status)
+		return err
+	})
+}
+
+func (s *PostgresStore) runScheduleMutation(ctx context.Context, runID, label string, mutate func(*sql.Tx) error) error {
+	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("mark exact timer fired: %w", err)
+		return fmt.Errorf("begin %s: %w", label, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := mutate(tx); err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	if strings.TrimSpace(runID) != "" {
+		if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyTimers); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit %s: %w", label, err)
 	}
 	return nil
 }

--- a/internal/store/schema_dialect.go
+++ b/internal/store/schema_dialect.go
@@ -10,7 +10,7 @@ import (
 var (
 	sqliteCreateTablePattern         = regexp.MustCompile(`(?is)^create\s+table\s+if\s+not\s+exists\s+("?[a-z_][a-z0-9_]*"?)\s*\((.*)\)\s*$`)
 	sqliteCreateIndexPattern         = regexp.MustCompile(`(?is)^create\s+(unique\s+)?index\s+if\s+not\s+exists\s+("?[a-z_][a-z0-9_]*"?)\s+on\s+("?[a-z_][a-z0-9_]*"?)\s*\(`)
-	sqliteForeignKeyPattern          = regexp.MustCompile(`(?is)^foreign\s+key\s*\(([^)]+)\)\s+references\s+("?[a-z_][a-z0-9_]*"?)\s*\(([^)]+)\)\s*$`)
+	sqliteForeignKeyPattern          = regexp.MustCompile(`(?is)^foreign\s+key\s*\(([^)]+)\)\s+references\s+("?[a-z_][a-z0-9_]*"?)\s*\(([^)]+)\)(?:\s+on\s+delete\s+(cascade|restrict|set\s+null|no\s+action))?\s*$`)
 	sqliteUnsupportedConstructChecks = []struct {
 		pattern *regexp.Regexp
 		label   string
@@ -122,7 +122,7 @@ func sqliteRenderTableLine(line string) (string, error) {
 
 func sqliteRenderForeignKeyConstraint(line string) (string, error) {
 	matches := sqliteForeignKeyPattern.FindStringSubmatch(strings.TrimSpace(line))
-	if len(matches) != 4 {
+	if len(matches) != 5 {
 		return "", fmt.Errorf("unsupported SQLite foreign key constraint %q", line)
 	}
 	columns, err := sqliteRenderIdentifierList(matches[1])
@@ -140,7 +140,11 @@ func sqliteRenderForeignKeyConstraint(line string) (string, error) {
 	if len(columns) != len(references) {
 		return "", fmt.Errorf("SQLite foreign key column count does not match referenced column count")
 	}
-	return fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s(%s)", strings.Join(columns, ", "), tableName, strings.Join(references, ", ")), nil
+	rendered := fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s(%s)", strings.Join(columns, ", "), tableName, strings.Join(references, ", "))
+	if action := strings.ToUpper(strings.Join(strings.Fields(matches[4]), " ")); action != "" {
+		rendered += " ON DELETE " + action
+	}
+	return rendered, nil
 }
 
 func sqliteRenderIdentifierList(raw string) ([]string, error) {

--- a/internal/store/selected_contract_runtime_execution_test.go
+++ b/internal/store/selected_contract_runtime_execution_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -386,6 +387,7 @@ func TestSelectedForkCompletionAuthorityCleanupPreservesEvidencePostgres(t *test
 	if _, err := db.ExecContext(ctx, `UPDATE runs SET status=$2 WHERE run_id=$1::uuid`, fixture.forkRun, RunForkMaterializedStatus); err != nil {
 		t.Fatalf("mark selected fork materialized for cleanup: %v", err)
 	}
+	assertSelectedCompletionEvidencePresent(t, db, "pre-cleanup fork revision", `SELECT COUNT(*) FROM run_fork_revisions WHERE run_id=$1::uuid`, fixture.forkRun)
 	if err := store.DiscardMaterializedSelectedContractExecutionFork(ctx, fixture.forkRun); err != nil {
 		t.Fatalf("discard mutable selected fork: %v", err)
 	}
@@ -401,6 +403,60 @@ func TestSelectedForkCompletionAuthorityCleanupPreservesEvidencePostgres(t *test
 	assertSelectedCompletionEvidenceCount(t, db, "operation and attempt", `SELECT COUNT(*) FROM runtime_external_effect_operations o JOIN runtime_external_effect_attempts a ON a.operation_id=o.operation_id WHERE o.selected_execution_id=$1::uuid AND a.attempt_id=$2::uuid`, authority.ID, handle.Attempt().AttemptID)
 	assertSelectedCompletionEvidenceCount(t, db, "turn and attempt", `SELECT COUNT(*) FROM agent_turns t JOIN runtime_external_effect_attempts a ON a.attempt_id=t.completion_attempt_id WHERE t.turn_id=$1::uuid AND t.run_id=$2::uuid`, authority.Target.ID, fixture.forkRun)
 	assertSelectedCompletionEvidenceCount(t, db, "spend and attempt", `SELECT COUNT(*) FROM spend_ledger s JOIN runtime_external_effect_attempts a ON a.attempt_id=s.external_effect_attempt_id WHERE s.external_effect_attempt_id=$1::uuid`, handle.Attempt().AttemptID)
+	assertSelectedCompletionEvidenceAbsent(t, db, "fork fact revisions", `SELECT COUNT(*) FROM run_fork_fact_revisions WHERE run_id=$1::uuid`, fixture.forkRun)
+	assertSelectedCompletionEvidenceAbsent(t, db, "fork revision ledger", `SELECT COUNT(*) FROM run_fork_revisions WHERE run_id=$1::uuid`, fixture.forkRun)
+	assertSelectedCompletionEvidenceAbsent(t, db, "fork revision head", `SELECT COUNT(*) FROM run_fork_revision_heads WHERE run_id=$1::uuid`, fixture.forkRun)
+}
+
+func TestSelectedForkDiscardRejectsLiveDependentForkPostgres(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	store := &PostgresStore{DB: db}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	sourceRunID := uuid.NewString()
+	forkRunID := uuid.NewString()
+	dependentRunID := uuid.NewString()
+	forkEventID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id,status,started_at) VALUES
+			($1::uuid,'running',$3),
+			($2::uuid,'paused',$3)
+	`, sourceRunID, forkRunID, now); err != nil {
+		t.Fatalf("seed selected fork lineage: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (event_id,run_id,event_name,scope,produced_by_type,created_at)
+		VALUES ($1::uuid,$2::uuid,'fork.dependency','global','platform',$3)
+	`, forkEventID, forkRunID, now); err != nil {
+		t.Fatalf("seed selected fork event: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id,status,started_at,forked_from_run_id,forked_from_event_id)
+		VALUES ($1::uuid,'paused',$4,$2::uuid,$3::uuid)
+	`, dependentRunID, forkRunID, forkEventID, now); err != nil {
+		t.Fatalf("seed dependent fork: %v", err)
+	}
+
+	err := store.DiscardMaterializedSelectedContractExecutionFork(ctx, forkRunID)
+	if err == nil || !strings.Contains(err.Error(), dependentRunID) {
+		t.Fatalf("discard error = %v, want dependent fork %s", err, dependentRunID)
+	}
+	for label, query := range map[string]string{
+		"source fork":    `SELECT COUNT(*) FROM runs WHERE run_id=$1::uuid`,
+		"source event":   `SELECT COUNT(*) FROM events WHERE event_id=$1::uuid`,
+		"dependent fork": `SELECT COUNT(*) FROM runs WHERE run_id=$1::uuid`,
+	} {
+		id := forkRunID
+		if label == "source event" {
+			id = forkEventID
+		} else if label == "dependent fork" {
+			id = dependentRunID
+		}
+		var count int
+		if err := db.QueryRowContext(ctx, query, id).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("%s rows=%d err=%v, want 1 after rejected discard", label, count, err)
+		}
+	}
 }
 
 func assertSelectedCompletionEvidenceCount(t *testing.T, db *sql.DB, name, query string, args ...any) {
@@ -408,6 +464,22 @@ func assertSelectedCompletionEvidenceCount(t *testing.T, db *sql.DB, name, query
 	var count int
 	if err := db.QueryRow(query, args...).Scan(&count); err != nil || count != 1 {
 		t.Fatalf("retained %s rows=%d err=%v, want 1", name, count, err)
+	}
+}
+
+func assertSelectedCompletionEvidencePresent(t *testing.T, db *sql.DB, name, query string, args ...any) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(query, args...).Scan(&count); err != nil || count == 0 {
+		t.Fatalf("retained %s rows=%d err=%v, want at least 1", name, count, err)
+	}
+}
+
+func assertSelectedCompletionEvidenceAbsent(t *testing.T, db *sql.DB, name, query string, args ...any) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(query, args...).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("retained %s rows=%d err=%v, want 0", name, count, err)
 	}
 }
 

--- a/internal/store/sqlite_inbound.go
+++ b/internal/store/sqlite_inbound.go
@@ -139,6 +139,7 @@ func (s *SQLiteRuntimeStore) PurgeInboundEventsBefore(ctx context.Context, befor
 				FROM events
 				WHERE event_name = 'platform.inbound_recorded'
 				  AND produced_by_type = 'external'
+				  AND run_id IS NULL
 				  AND created_at < ?
 				ORDER BY created_at ASC
 				LIMIT ?

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -21,8 +21,8 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	if len(platformPlans) != 47 {
-		t.Fatalf("platform table plan count = %d, want 47", len(platformPlans))
+	if len(platformPlans) != 50 {
+		t.Fatalf("platform table plan count = %d, want 50", len(platformPlans))
 	}
 	entityPlans, err := GenerateEntityTableDDLs(runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{
@@ -507,6 +507,24 @@ func TestSQLiteStatementsForPlanAcceptsMultilineTableConstraint(t *testing.T) {
 	}
 	if len(statements) != 1 || !strings.Contains(statements[0], "OR (status = 'completed'") {
 		t.Fatalf("rendered statements = %#v, want intact multiline check", statements)
+	}
+}
+
+func TestSQLiteStatementsForPlanAcceptsCompositeForeignKeyDeleteCascade(t *testing.T) {
+	statements, err := SQLiteStatementsForPlan(SchemaTableDDL{
+		TableName:  "child",
+		SchemaKind: "test",
+		Statements: []string{`CREATE TABLE IF NOT EXISTS child (
+    run_id UUID NOT NULL,
+    revision BIGINT NOT NULL,
+    FOREIGN KEY (run_id, revision) REFERENCES parent(run_id, revision) ON DELETE CASCADE
+)`},
+	})
+	if err != nil {
+		t.Fatalf("SQLiteStatementsForPlan: %v", err)
+	}
+	if len(statements) != 1 || !strings.Contains(statements[0], `FOREIGN KEY ("run_id", "revision") REFERENCES "parent"("run_id", "revision") ON DELETE CASCADE`) {
+		t.Fatalf("rendered statements = %#v, want composite cascading foreign key", statements)
 	}
 }
 

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -157,7 +157,7 @@ func (s *PostgresStore) SaveEntityField(ctx context.Context, update runtimetools
 	}, mutationWriter(update.Writer)); err != nil {
 		return 0, fmt.Errorf("record postgres entity mutation: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return 0, fmt.Errorf("commit postgres entity field update: %w", err)
 	}
 	committed = true
@@ -266,7 +266,7 @@ func (s *PostgresStore) CreateEntity(ctx context.Context, rec runtimetools.Entit
 	}, mutationWriter(rec.Writer)); err != nil {
 		return fmt.Errorf("record postgres entity create mutation: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
+	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return fmt.Errorf("commit postgres entity create: %w", err)
 	}
 	committed = true

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10567,6 +10567,9 @@ platform_tables:
         - run_fork_selected_contract_route_recoveries
         - run_fork_selected_contract_bindings
       delete_by_run_id:
+        - run_fork_fact_revisions
+        - run_fork_revisions
+        - run_fork_revision_heads
         - activity_attempts
         - decision_card_lifecycle_outbox
         - decision_card_route_obligations
@@ -10642,6 +10645,48 @@ platform_tables:
         \ idx_events_flow (flow_instance, event_name) WHERE flow_instance IS NOT NULL,\n    INDEX idx_events_source_route ((source_route->>'flow_instance'), (source_route->>'entity_id')) WHERE source_route <> '{}'::jsonb,\n    INDEX idx_events_target_route ((target_route->>'flow_instance'), (target_route->>'entity_id')) WHERE target_route <> '{}'::jsonb,\n    INDEX idx_events_global (event_name,\
         \ created_at) WHERE scope = 'global',\n    INDEX idx_events_idempotency (idempotency_key) WHERE idempotency_key\
         \ IS NOT NULL,\n    INDEX idx_events_source (source_event_id) WHERE source_event_id IS NOT NULL\n);"
+    run_fork_revision_heads:
+      description: >-
+        Canonical per-run counter for the bounded supported-fork historical projection. The existing
+        store transaction owner increments this row while holding its row lock; all approved fork-reader
+        facts written by the same PostgreSQL transaction share the resulting revision.
+      ddl: |
+        CREATE TABLE run_fork_revision_heads (
+            run_id        UUID PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE,
+            last_revision BIGINT NOT NULL DEFAULT 0 CHECK (last_revision >= 0),
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+    run_fork_revisions:
+      description: >-
+        Commit-serialized revision ledger for the bounded supported-fork projection. transaction_id is
+        used only to reuse one revision inside one SQL transaction; it is not a public historical cursor.
+      ddl: |
+        CREATE TABLE run_fork_revisions (
+            run_id        UUID NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+            revision      BIGINT NOT NULL CHECK (revision > 0),
+            transaction_id BIGINT NOT NULL,
+            recorded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (run_id, revision),
+            UNIQUE (run_id, transaction_id)
+        );
+    run_fork_fact_revisions:
+      description: >-
+        Append-only, closed-registry projection of the eleven source fact families consumed by supported
+        PostgreSQL fork planning. This table is not a general temporal database and has no trigger,
+        migration, compatibility, or arbitrary-history API.
+      ddl: |
+        CREATE TABLE run_fork_fact_revisions (
+            run_id    UUID NOT NULL,
+            revision  BIGINT NOT NULL,
+            family    TEXT NOT NULL CHECK (family IN ('events', 'entity_mutations', 'entity_metadata', 'event_deliveries', 'event_receipts', 'dead_letters', 'timers', 'agent_sessions', 'agent_turns', 'agent_conversation_audits', 'reply_contexts')),
+            fact_key  TEXT NOT NULL CHECK (fact_key <> ''),
+            fact      JSONB NOT NULL,
+            present   BOOLEAN NOT NULL DEFAULT TRUE,
+            source_transaction_id BIGINT NOT NULL CHECK (source_transaction_id >= 0),
+            PRIMARY KEY (run_id, family, fact_key, revision),
+            FOREIGN KEY (run_id, revision) REFERENCES run_fork_revisions(run_id, revision) ON DELETE CASCADE,
+            INDEX idx_run_fork_fact_revision_snapshot (run_id, revision, family, fact_key)
+        );
     agent_directive_operations:
       description: >-
         Durable operation/outcome owner for agent.send_directive. One row reserves one
@@ -10853,7 +10898,7 @@ platform_tables:
         split/fail-closed.'
       ddl: "CREATE TABLE activity_attempts (\n    request_event_id UUID PRIMARY KEY,\n    run_id            UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id   UUID,\n    parent_event_id   UUID,\n    entity_id         UUID,\n    flow_instance     TEXT,\n    node_id           TEXT NOT NULL,\n    handler_event_key TEXT NOT NULL,\n    activity_id       TEXT NOT NULL,\n    tool              TEXT NOT NULL,\n    effect_class      TEXT NOT NULL CHECK (effect_class = 'non_idempotent_write'),\n    attempt           INTEGER NOT NULL DEFAULT 1 CHECK (attempt = 1),\n    status            TEXT NOT NULL CHECK (status IN ('started', 'succeeded', 'failed', 'uncertain')),\n    success_event     TEXT NOT NULL,\n    failure_event     TEXT NOT NULL,\n    result_event_id   UUID,\n    result_event_type TEXT,\n    result_payload    JSONB,\n    failure           JSONB,\n    input_hash        TEXT NOT NULL,\n    loop_generation   JSONB NOT NULL DEFAULT '{}'::jsonb,\n    loop_stage        TEXT,\n    reply_context_id  TEXT REFERENCES reply_contexts(reply_context_id),\n    started_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    completed_at      TIMESTAMPTZ,\n    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    CHECK ((status = 'started' AND result_event_id IS NULL AND result_event_type IS NULL AND result_payload IS NULL AND failure IS NULL AND completed_at IS NULL) OR (status = 'succeeded' AND result_event_id IS NOT NULL AND result_event_type IS NOT NULL AND result_payload IS NOT NULL AND failure IS NULL AND completed_at IS NOT NULL) OR (status IN ('failed', 'uncertain') AND result_event_id IS NOT NULL AND result_event_type IS NOT NULL AND result_payload IS NOT NULL AND failure IS NOT NULL AND completed_at IS NOT NULL)),\n    INDEX idx_activity_attempts_run (run_id, started_at),\n    INDEX idx_activity_attempts_activity (run_id, activity_id, tool),\n    INDEX idx_activity_attempts_result_event (result_event_id) WHERE result_event_id IS NOT NULL\n);"
     run_fork_selected_contract_bindings:
-      description: Durable selected-contract source binding for timestamp forks. One row binds a fork run to the selected
+      description: Durable selected-contract source binding for fixed-event forks. One row binds a fork run to the selected
         contract source identity that was admitted before materialization. This is prerequisite fork-run state for future
         selected-contract execution; CLI/API arguments, dry-run JSON, and local model output are not semantic owners. It
         does not authorize handler execution, event/delivery replay, timer, route, session, turn, source-advanced, or
@@ -10896,13 +10941,13 @@ platform_tables:
             ON run_fork_selected_contract_runtime_executions (fork_run_id)
             WHERE state <> 'closed';
     run_fork_selected_contract_executions:
-      description: Source-to-fork lineage table for mutating selected-contract timestamp-fork execution. The runtime
+      description: Source-to-fork lineage table for mutating selected-contract fixed-event fork execution. The runtime
         selected-contract execution owner publishes fresh fork-local events under the fork run_id and records which source
         frontier event each fork event executed from. Source events, deliveries, receipts, dead letters, retry state, and
         post-fork outcomes are lineage evidence only and must not be copied or used as fork suppressors.
       ddl: "CREATE TABLE run_fork_selected_contract_executions (\n    execution_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),\n    fork_run_id     UUID NOT NULL REFERENCES runs(run_id),\n    source_run_id   UUID NOT NULL REFERENCES runs(run_id),\n    source_event_id UUID NOT NULL REFERENCES events(event_id),\n    fork_event_id   UUID NOT NULL REFERENCES events(event_id),\n    event_name      TEXT NOT NULL,\n    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    UNIQUE (fork_run_id, source_event_id),\n    UNIQUE (fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_fork (fork_run_id, fork_event_id),\n    INDEX idx_run_fork_selected_contract_executions_source (source_run_id, source_event_id)\n);"
     run_fork_selected_contract_branch_divergences:
-      description: Durable source/fork branch divergence evidence for selected-contract timestamp-fork execution. This
+      description: Durable source/fork branch divergence evidence for selected-contract fixed-event fork execution. This
         table is written only by the selected-contract execution owner when the source has advanced after the fork point
         and selected execution proceeds as a branch rather than freezing or rewinding the source. Source post-fork facts
         remain source-run evidence only; fork-local work is regenerated under the fork run_id.
@@ -10941,7 +10986,7 @@ platform_tables:
         \ (event_id),\n    INDEX idx_deliveries_active_session (active_session_id) WHERE active_session_id IS NOT NULL\n\
         );"
     run_fork_delivery_event_replays:
-      description: Source-to-fork lineage table for the supported timestamp-fork delivery/event replay primitive. The fork
+      description: Source-to-fork lineage table for the supported fixed-event fork delivery/event replay primitive. The fork
         run gets fresh fork-local event_id and delivery_id values; this table records which source event/delivery facts
         produced those fork-local rows. It is not a generic historical replay log and does not authorize session, turn,
         timer, route, source-advanced, or contract-swap reconstruction.
@@ -11761,7 +11806,7 @@ platform_tables:
       (search_entities, query_entities, get_entity) return entity_state rows from the current run context only. Cross-run
       duplicate detection or historical analysis must use an explicit cross-run read model rather than the live current-state
       registry.
-    rationale: Mutating timestamp forks require source and fork runs to preserve entity_id while diverging safely. Global
+    rationale: Mutating fixed-event forks require source and fork runs to preserve entity_id while diverging safely. Global
       live current state would let forked execution overwrite or read source-run state by accident. Products that need
       historical or portfolio-wide duplicate detection must consume explicit cross-run history/read surfaces.
     dedup_responsibility: Duplicate detection across runs is a product concern, not a live current-state registry concern.
@@ -11933,7 +11978,7 @@ run_model:
       - dashboard alert UI
       - CLI alert rendering
   fork:
-    description: 'Fork creates an isolated run by reconstructing provable current state at a point in time,
+    description: 'Fork creates an isolated run by reconstructing provable current state at a selected event revision,
       optionally loading selected contracts, and then executing only owner-admitted fork-local work. The supported
       model is bounded re-execution from inputs: delivery_event_replay_ready pending unstarted agent deliveries,
       selected-contract frontier execution, and approved timer reconstruction. The system does not infer arbitrary
@@ -11944,8 +11989,8 @@ run_model:
     dry_run_command: 'retired in v1 CLI; historical `swarm fork --dry-run` is not a supported operator command'
     materialize_only_command: 'retired in v1 CLI; historical `swarm fork --materialize-only` is not a supported operator command'
     activation_command: 'retired in v1 CLI; historical `swarm fork --activate` is not a supported operator command'
-    planning_admission: 'The dry-run form is a read-only planning/admission surface. It resolves the fork
-      point, reconstructs provable state, classifies replay candidates, optionally loads selected contracts
+    planning_admission: 'The canonical planner is a read-only planning/admission surface. It resolves the selected
+      event revision, reconstructs provable state, classifies replay candidates, optionally loads selected contracts
       for non-mutating contract/frontier/route admission, and returns execution_ready=false
       with named unsupported blockers whenever persisted recorder facts cannot prove safe execution. Dry-run
       MUST NOT create a forked run, mark the source run forked, copy entity state, redeliver events, or change
@@ -11957,23 +12002,24 @@ run_model:
       fork run_id after loading and validating that selected source, but that binding is prerequisite metadata only.
       It does not mark the source run forked, freeze the source run, redeliver pending work, resume event
       processing, change contracts, or mutate delivery/session/timer/route state. Materialized fork current-state
-      rows start a new fork-local revision sequence at revision=1; source-at-T entity_state.revision is not
+      rows start a new fork-local revision sequence at revision=1; source entity_state.revision at the selected event revision is not
       copied because revision is a current-row commit counter, not append-only historical state in entity_mutations.
       Materialization MUST consume runtime.run_fork.materialized_entity_snapshot_metadata for every reconstructed
-      entity before writing fork-local entity_state. That owner may use at/before-T event flow evidence, or source
-      entity_state creation metadata when the source row was created at or before T, for flow_instance. Entity_type
-      MUST come from source entity_state creation metadata when the source row was created at or before T; reconstructed
+      entity before writing fork-local entity_state. That owner may use event flow evidence present in the fixed revision,
+      or source entity_state creation metadata present in that revision, for flow_instance. Entity_type
+      MUST come from source entity_state creation metadata present in that revision; reconstructed
       fields.entity_type is projection state and MUST NOT authorize materialization, though a conflicting reconstructed
       value may fail closed. The owner MUST NOT read source current_state, gates, fields, accumulator, revision, or updated_at
       as fork-point projection truth. If flow_instance/entity_type cannot be proven for a reconstructed entity,
       materialization fails closed with entity_snapshot_metadata_unproven and writes no fork rows.
-      Materialized fork rows preserve entered_state_at from the source-at-T current_state mutation evidence; they
-      MUST NOT stamp entered_state_at with the fork point unless that is when the current_state was entered.
+      Materialized fork rows preserve entered_state_at from current_state mutation evidence present in the selected
+      revision; they MUST NOT stamp entered_state_at with the selected event occurrence time unless that is when the
+      current_state was entered.
       Full fork execution remains a separately gated operation.'
     activation_admission: 'The activate form consumes an already materialized state-only fork and is the
       supported activation slice for forks whose state was produced by materialize-only admission. Activation
       requires a fork run with status=paused, fork lineage, fork-local entity_state rows, and a revalidated
-      execution_ready=true planner result at the original fork point. Activation atomically transitions the
+      execution_ready=true planner result at the original selected event revision. Activation atomically transitions the
       fork run to status=running and the source run to status=forked. It may create fork-local event and delivery
       rows only after runtime.run_fork.historical_replay_execution consumes a concrete
       runtime.run_fork.historical_replay_execution_admission that marks event_deliveries as executable fork work for
@@ -11982,16 +12028,64 @@ run_model:
       runtime.run_fork.historical_replay_execution and MUST NOT reselect replayable source deliveries directly from
       RunForkPlan or store.run_fork.replay_resume_admission. The store delivery-event replay primitive uses fresh fork
       event IDs, a direct committed replay-scope marker, and run_fork_delivery_event_replays lineage rows. It fails closed with no partial mutation if the source run advanced
-      after the fork point, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
+      after the materialized source revision, if the fork already has events, deliveries, sessions, or turns, or if node, in-progress,
       failed, dead-letter, timer, route, session, active-turn, replay, or contract-swap facts
       would require unsupported historical replay. Source committed replay-scope marker facts remain fail-closed unless
-      an approved selected-contract marker policy classifies at/before-T markers as lineage/no-action evidence only.
+      an approved selected-contract marker policy classifies markers present in the selected revision as lineage/no-action evidence only.
       Activation does not copy source event IDs, replay delivered/completed
       or receipt-only facts, reconstruct timer, route, session, turn, or contract rows, or recompute recipients from
       current subscriptions.'
     planning_owner: 'Fork planning/admission is owned by the canonical store-backed fork planner. CLI,
       Builder, dashboard, and other operator surfaces MUST consume that owner and MUST NOT reimplement
       fork planning with direct SQL joins.'
+    fixed_event_revision_and_workset:
+      owner: store.run_fork.fixed_event_revision_and_workset
+      selector: >-
+        A supported fork selector is an event UUID in the source run. The event's first persisted run revision is
+        the inclusive historical boundary. Event and lifecycle timestamps are display and diagnostic values only;
+        they never decide historical membership, ordering, readiness, or blockers. There is no timestamp selector
+        or timestamp fallback.
+      historical_registry:
+      - events
+      - entity_mutations
+      - entity_metadata
+      - event_deliveries
+      - event_receipts
+      - dead_letters
+      - timers
+      - agent_sessions
+      - agent_turns
+      - agent_conversation_audits
+      - reply_contexts
+      write_contract: >-
+        Existing PostgreSQL store transactions allocate one commit-serialized revision per affected run after
+        provider, tool, agent, and network work. Every changed family in one transaction shares that revision;
+        repeated capture in the transaction reuses it; rollback publishes neither facts nor revision. Transactions
+        affecting multiple runs lock revision heads in deterministic run-ID order. No revision lock may span external
+        work. Deletion emits present=false for the removed fact in the same transaction.
+      read_contract: >-
+        PlanRunFork resolves the event UUID to its first revision and reads all eleven families through one read-only
+        repeatable-read PostgreSQL snapshot. Every generic and selected planning, readiness, materialization, and
+        historical activation replan consumes that projection. Missing, ambiguous, lineage-invalid, partially deleted,
+        or unrevisioned facts fail closed; old stores are unsupported and must be recreated. SQLite returns typed
+        unsupported for fork mutation and does not emulate this owner.
+      route_projection: >-
+        Global routing_rules are current unversioned state and are never queried as historical authority. The fixed
+        projection emits not_applicable when no route-relevant source fact exists and unknown_unversioned otherwise.
+        Generic materialization and activation preserve flow_route_history_unproven. Selected execution may discharge
+        unknown_unversioned only with matching selected binding, frontier, static/dynamic topology, and recipient proof;
+        activation revalidates the persisted selected route recovery and never queries current routing_rules.
+      distinct_current_evidence: >-
+        activity_attempts are post-frontier selected-execution evidence, not a twelfth historical family. Source
+        preparation reads the immutable selected request event and current terminal attempt in one serializable
+        transaction and copies accepted evidence under fork-local identity. Missing or nonterminal evidence fails
+        closed without changing PlanRunFork membership or readiness. Fresh source-advancement validation is likewise
+        an activation safety owner and is not answered from the historical snapshot.
+      retention: >-
+        The eleven authoritative source families remain available while a live dependent fork requires them. Partial
+        fact deletion is unsupported. Existing whole-run cleanup may remove the complete source only when no live
+        dependent fork remains; no tombstone subsystem, migration, backfill, export, purge, or compatibility reader is
+        provided for old selected stores.
     replay_resume_admission_taxonomy: 'Fork planning, materialization, and activation surfaces expose the
       canonical store-backed replay_resume_admission taxonomy. This taxonomy classifies
       historical source-run facts as reconstruct, lineage-only, fail-closed blockers, split siblings, or
@@ -12002,7 +12096,7 @@ run_model:
       receipt-only redelivery, session/turn/timer/route reconstruction, contract swap execution, or runtime-wide replay
       mutation. There is no separately promised arbitrary source-run resume lane: unsupported fact families remain
       fail-closed unless a consumer-named successor promotes a new owner.'
-    selected_contract_readiness_classifier: 'Selected-contract timestamp-fork readiness explanation is owned by
+    selected_contract_readiness_classifier: 'Selected-contract fixed-event revision readiness explanation is owned by
       runtime.run_fork.selected_contract_readiness_classifier. This owner is non-mutating and consumes the canonical
       store planner, store.run_fork.replay_resume_admission, runtime.run_fork.contract_frontier_admission, selected
       route admission/topology/dynamic topology, runtime.run_fork.selected_contract_recipient_planning, selected
@@ -12025,7 +12119,7 @@ run_model:
       handler execution, fork-local event/delivery writes, receipts, dead letters, idempotency, emitted follow-up events,
       timers, routes, sessions, turns, source advancement, and contract-swap boot/resume. The model MUST NOT create
       fork-local executable work, run handlers, accept source outcomes as fork suppressors, or treat same-run outbox
-      replay as timestamp-fork selected-contract execution.'
+      replay as fixed-event selected-contract execution.'
     selected_contract_execution_admission: 'Selected-contract fork execution admission is a non-mutating runtime-side
       prerequisite for future selected-contract execution. The canonical owner consumes the durable
       store.run_fork.selected_contract_binding by fork run_id, loads and validates the selected semantic source from that
@@ -12045,8 +12139,8 @@ run_model:
       creation, or fork delivery row creation. This gate does not run handlers, create selected fork-local executable
       event/delivery rows, write receipts, dead letters, idempotency state, emitted follow-up events, timers, routes,
       sessions, turns, source-advanced policy, contract-swap state, or UI/API execution state.'
-    selected_contract_source_advanced_branch: 'Mutating selected-contract timestamp-fork execution treats a source run
-      that advanced after the fork point as branch divergence evidence, not as executable fork work and not as a fork
+    selected_contract_source_advanced_branch: 'Mutating selected-contract fixed-event execution treats a source run
+      that advanced after the materialized source revision as branch divergence evidence, not as executable fork work and not as a fork
       suppressor. This policy is owned by runtime.run_fork.selected_contract_execution and its store-owned durable branch
       divergence evidence. It is selected-contract execution only: generic/state-only activation still requires no source
       advancement and may freeze the source run. A selected-contract branch must not freeze or rewind an already-advanced
@@ -12058,9 +12152,9 @@ run_model:
         branch-divergence evidence. Same-source in-progress delivery coupling admitted by
         runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy is also
         branch-divergence lineage evidence and not executable delivery/session truth.'
-    selected_contract_source_advanced_conversation_history_policy: 'Mutating selected-contract timestamp-fork execution
+    selected_contract_source_advanced_conversation_history_policy: 'Mutating selected-contract fixed-event execution
       may consume runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy to classify
-      post-fork-T source agent_sessions, agent_turns, and agent_conversation_audits as source-advanced branch-divergence
+      source agent_sessions, agent_turns, and agent_conversation_audits committed after the selected revision as source-advanced branch-divergence
       lineage/no-action evidence only. This policy is selected-contract execution only and is not conversation-history
       reconstruction. Source session, provider-session, transcript, audit, turn, receipt, outcome, or task-audit rows
       MUST NOT be copied into the fork, reused as fork-local runtime truth, or used as selected-fork suppressors. Fresh
@@ -12068,58 +12162,59 @@ run_model:
       Pending or in-progress source delivery/session coupling, fork-local pre-existing conversation rows, generic/state-only
       activation, broad source-run resumption, timers, routes, non-agent replay, restart recovery, and operator surfaces
       remain fail-closed or split siblings unless separately approved.'
-    selected_contract_active_source_delivery_conversation_coupling_policy: 'Mutating selected-contract timestamp-fork
+    selected_contract_active_source_delivery_conversation_coupling_policy: 'Mutating selected-contract fixed-event
       execution may consume runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy
-      to classify exactly one narrow at-T active delivery/session coupling case as lineage/no-action and branch-divergence
-      evidence: the in-progress source agent delivery is for the source event referenced by the fork-point event
-      source_event_id, the fork-point event was produced by the same agent subscriber, the delivery started at/before T,
-      and the delivery row has no active_session_id, receipt, receipt outcome, or delivered_at at T. The policy does not
+      to classify exactly one narrow selected-revision active delivery/session coupling case as lineage/no-action and branch-divergence
+      evidence: the delivery fact present in the selected revision is in progress for the source event referenced by the selected event
+      source_event_id, the selected event was produced by the same agent subscriber, and that revision has no
+      active_session_id, receipt, receipt outcome, or delivered_at. The policy does not
       authorize copying source delivery rows, sessions, turns, audits, provider session IDs, transcripts, receipts,
-      outcomes, or conversation audits into the fork and does not let a source terminal outcome after T suppress or decide
+      outcomes, or conversation audits into the fork and does not let a later source terminal outcome suppress or decide
       selected fork execution. Unrelated in-flight deliveries, active_session_id coupling, partial receipt/outcome state,
-      fork-local pre-existing conversation rows, post-T source conversation facts outside the source-advanced
+      fork-local pre-existing conversation rows, post-revision source conversation facts outside the source-advanced
       conversation-history owner, non-agent replay, timers, routes, retry/idempotency, follow-up policy, restart recovery,
       and operator surfaces remain fail-closed or split siblings unless separately approved.'
-    selected_contract_timer_route_policy: 'Mutating selected-contract timestamp-fork execution treats source route facts
-      as evidence-only fail-closed blockers until a separately approved route reconstruction owner exists. Active source
+    selected_contract_timer_route_policy: 'Mutating selected-contract fixed-event execution consumes a typed route-history
+      projection rather than current routing_rules. not_applicable adds no route blocker; unknown_unversioned remains
+      flow_route_history_unproven for generic execution and may be discharged for selected execution only by matching
+      selected binding, frontier, static/dynamic topology, recipient, and persisted route-recovery proof. Active source
       timers may be reconstructed only by runtime.run_fork.historical_replay_execution.timer_reconstruction, which
       consumes store.run_fork.replay_resume_admission timer_history as lineage, writes fresh fork-local timer rows under
       the fork run_id with source_timer_id/forked_from_run_id/forked_from_event_id/reconstruction_owner lineage, and
       requires scheduler claim/fire/recovery identity to include run_id. Source timer rows are never copied as executable
-      truth, fired as source work, or used as selected-fork suppressors. Unsupported source timer histories and post-T
-      source timer facts remain fail-closed. The runtime.run_fork.selected_contract_execution owner must continue to
-      consume flow_route_history blockers and MUST NOT copy routing_rules, persist fork-local route rows, derive
+      truth, fired as source work, or used as selected-fork suppressors. Unsupported source timer histories and timer
+      facts committed after the selected revision remain fail-closed. The runtime.run_fork.selected_contract_execution owner must continue to
+      consume unresolved flow_route_history blockers and MUST NOT copy or query current routing_rules as historical truth, persist fork-local route rows, derive
       selected-source recipients for execution outside recipient planning, or use source route outcomes as selected-fork
       suppressors.'
-    selected_contract_session_turn_audit_lineage_policy: 'Mutating selected-contract timestamp-fork execution may consume
+    selected_contract_session_turn_audit_lineage_policy: 'Mutating selected-contract fixed-event execution may consume
       runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy to classify
-      at/before-fork-T source agent_sessions, agent_turns, and agent_conversation_audits as lineage/no-action evidence
+      source agent_sessions, agent_turns, and agent_conversation_audits present in the selected revision as lineage/no-action evidence
       only. This policy is selected-contract execution only and is not session, turn, or audit reconstruction. It applies
       only when selected-contract execution regenerates fresh fork-local work through canonical owners and no pending or
-      in-progress source delivery at T requires live session continuity through active_session_id, started_at, partial
+      in-progress source delivery in the selected revision requires live session continuity through active_session_id, partial
       receipt/outcome state, or equivalent active execution evidence, except for the separately owned same-source
-      fork-point emission case admitted by runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy.
+      selected-event emission case admitted by runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy.
       Source session, turn, audit, provider-session,
       transcript, receipt, outcome, or task-audit rows MUST NOT be copied into the fork, reused as fork-local runtime
       truth, or used as selected-fork suppressors. Fork-local conversation rows before the selected execution owner
-      creates them remain fail-closed. Post-T source session, turn, and conversation-audit facts are outside this
-      at/before-T lineage owner and may be classified only by the selected-contract source-advanced conversation-history
+      creates them remain fail-closed. Post-revision source session, turn, and conversation-audit facts are outside this
+      selected-revision lineage owner and may be classified only by the selected-contract source-advanced conversation-history
       policy. Committed replay-scope marker policy is a split sibling.'
-    selected_contract_committed_replay_scope_marker_policy: 'Mutating selected-contract timestamp-fork execution may
+    selected_contract_committed_replay_scope_marker_policy: 'Mutating selected-contract fixed-event execution may
       consume runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy to
-      classify at/before-fork-T source committed replay-scope marker rows as lineage/no-action evidence only. This policy
+      classify source committed replay-scope marker delivery facts present in the selected revision as lineage/no-action evidence only. This policy
       is selected-contract execution only and is not same-run replay recovery, fork-local delivery-event replay recovery,
-      or generic historical replay. At/before-T classification is determined by the underlying source event position
-      relative to the fork point, not by the committed marker delivery row write timestamp; delayed marker delivery
-      write-skew for an at/before-T source event remains lineage/no-action and MUST NOT be reclassified as generic
-      selected-contract source-delivery advancement. Source marker rows MUST NOT be copied into the fork, reused as
+      or generic historical replay. The delivery fact and its source event lineage must be committed in the selected
+      revision projection. A marker delivery committed after that revision is source advancement and MUST NOT be admitted
+      by the underlying event''s occurrence timestamp or position. Source marker rows MUST NOT be copied into the fork, reused as
       fork-local recovery proof, treated as executable fork work, or used as selected-fork suppressors. Fork-local
       committed replay-scope truth must be freshly written under the fork run_id by selected-contract execution or
-      approved fork-local delivery-event replay owners. Source marker facts whose underlying source event is after T
+      approved fork-local delivery-event replay owners. Source marker facts absent from the selected revision
       remain fail-closed unless a separate approved source-advanced/reconstruction owner changes that policy.'
-    selected_contract_diagnostic_platform_outcome_policy: 'Mutating selected-contract timestamp-fork execution may consume
+    selected_contract_diagnostic_platform_outcome_policy: 'Mutating selected-contract fixed-event execution may consume
       runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy to classify
-      at/before-fork-T source outcome facts for spec-declared diagnostic/non-routed platform events as lineage/no-action
+      source outcome facts present in the selected revision for spec-declared diagnostic/non-routed platform events as lineage/no-action
       evidence only. The diagnostic event set is defined by platform_events.routing_rules.diagnostic_events, currently
       platform.runtime_log and platform.inbound_recorded. This policy is selected-contract frontier admission only. It
       MUST NOT route diagnostic platform events through selected contracts, synthesize selected recipients, copy source
@@ -12129,9 +12224,11 @@ run_model:
       unless a separate approved owner changes that policy.'
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
-      runtime.run_fork.contract_frontier_admission for selected frontier work, consumes selected-source static route
-      derivation through internal/runtime/bus.DeriveRouteTable for historical route evidence, and treats source
-      routing_rules and flow_instance_routes as evidence-only fail-closed facts. It MUST NOT copy source route rows,
+      runtime.run_fork.contract_frontier_admission for selected frontier work, consumes the fixed planner route state,
+      and consumes selected-source static route derivation through internal/runtime/bus.DeriveRouteTable. A planner
+      unknown_unversioned state is carried as an unresolved requirement with SourceRouteFactsPresent=true; admission
+      does not claim source route history and does not clear flow_route_history_unproven. It MUST NOT read or copy
+      current/source routing_rules or flow_instance_routes as historical evidence,
       persist fork-local route rows, derive executable recipients, create event_deliveries, run handlers, or absorb
       timer reconstruction, session/turn reconstruction, source-advanced policy, contract-swap ownership, or UI/API
       route ownership.'
@@ -12140,7 +12237,9 @@ run_model:
       runtime.run_fork.selected_contract_route_admission as prerequisite evidence, classifies selected-source static
       route topology as fork-local truth only through internal/runtime/bus.DeriveRouteTable and the durable selected
       contract/frontier binding, and classifies dynamic flow-instance topology as fork-local-proven or fail-closed with
-      a named blocker. It MUST NOT copy source routing_rules or materialized flow-instance route rows, persist
+      a named blocker. It is the only selected owner allowed to discharge unknown_unversioned, and only when selected
+      owner identity, binding, frontier IDs/fingerprint, and complete static/dynamic topology all match. It MUST NOT
+      read or copy source/current routing_rules or materialized flow-instance route rows, persist
       fork-local route rows, derive executable recipients, invoke the delivery planner for fork work, create
       event_deliveries, run handlers, or absorb timer/session/turn/source-advanced/contract-swap/UI ownership.'
     selected_contract_dynamic_route_topology: 'Selected-contract dynamic route topology proof is a non-mutating
@@ -12158,7 +12257,8 @@ run_model:
       topology proof or fail-closed state, recipient-plan evidence, selected binding identity, and evidence
       fingerprints under the fork run_id. Topology and recipient-planning fingerprints MUST be computed and verified
       over canonical JSON semantics rather than raw JSONB storage bytes. Runtime recovery MUST read this owner after restart for selected-contract
-      fork route truth and MUST NOT read source/current routing_rules, source flow_instance_routes, current
+      fork route truth, revalidate the selected frontier/binding/topology fingerprint before clearing the planner''s
+      unknown_unversioned requirement, and MUST NOT read source/current routing_rules, source flow_instance_routes, current
       ListFlowInstanceRoutes output, or source event_deliveries as executable fork route or recipient truth. Recipient
       planning and EventBus.Publish recipient-plan guards remain authoritative before publish. This owner MUST NOT write
       event_deliveries, run handlers, replay timers, reconstruct sessions/turns/audits, replay non-agent work,
@@ -12261,7 +12361,7 @@ run_model:
       source rows, suppress fork-local execution with source outcomes, own current-state/entity
       materialization, reconstruct sessions/turns/audits, replay timers/routes/non-agent work, or claim restart
       recovery.'
-    selected_contract_supported_execution: 'The historical selected-contract timestamp-fork execution harness was
+    selected_contract_supported_execution: 'The historical selected-contract fork execution harness was
       swarm fork --contracts; that legacy harness flag remains rejected unless a later source-authority PR promotes it.
       The intended public command is now `swarm run fork <source-run-id> ...` (CLI v2.2 spelling) defined by
       multi_bundle_persistence.cli_surface.run_fork and blocked on #989 API/runtime/CLI implementation. The runtime
@@ -12285,23 +12385,27 @@ run_model:
       the connector exactly once under that fork-local generation and does not copy a source attempt;
       non_idempotent_write with reuse_recorded_result copies only terminal succeeded, failed, or uncertain evidence under
       fork-local request/result identities and publishes that recorded result without calling the connector. Failed and
-      uncertain evidence MUST preserve its typed failure, including platform.outcome_uncertain. Source events are
+      uncertain evidence MUST preserve its typed failure, including platform.outcome_uncertain. activity_attempts is
+      deliberately post-frontier selected-execution evidence rather than historical workset membership: source
+      preparation reads the selected immutable request event and current terminal attempt in one serializable transaction,
+      copies accepted evidence under fork-local identity, and fails closed on missing/nonterminal evidence without
+      changing PlanRunFork membership or readiness. Source events are
       payload/lineage inputs only;
       source event_deliveries, recipients, receipts, dead letters, retry/idempotency state, and post-fork outcomes MUST
-      NOT become executable fork work or fork suppressors. At/before-T source committed replay-scope marker rows may be
+      NOT become executable fork work or fork suppressors. Source committed replay-scope marker rows present in the selected revision may be
       consumed only as lineage/no-action evidence by the selected-contract marker policy; fork-local recovery must use
-      fresh fork-run marker rows. At/before-T source outcome facts for spec-declared diagnostic/non-routed platform
+      fresh fork-run marker rows. Source outcome facts present in the selected revision for spec-declared diagnostic/non-routed platform
       events may be consumed only as lineage/no-action evidence by the selected-contract diagnostic platform outcome
       policy. Route persistence, timer reconstruction, session/turn/audit
       reconstruction, non-agent delivery replay, runtime restart recovery, contract-swap boot/resume beyond selected
       frontier execution, and UI/API ownership remain separately gated siblings.'
-    contract_swap_boot_resume_admission: 'Contract-swap boot/resume readiness for timestamp forks is owned by
+    contract_swap_boot_resume_admission: 'Contract-swap boot/resume readiness for fixed-event forks is owned by
       runtime.run_fork.contract_swap_boot_resume_admission. This owner is non-mutating and consumes the durable
       store.run_fork.selected_contract_binding, runtime.run_fork.selected_contract_execution_admission,
       store.run_fork.replay_resume_admission, selected route topology, selected recipient planning, and fork-local
       selected route recovery evidence before answering whether full boot/resume under selected or swapped contracts is
       allowed. It MUST fail closed with named blockers for source deliveries, receipts, dead letters, retry/idempotency
-      state, post-fork source outcomes, timers, current/source routes, sessions, turns, audits, source committed
+      state, post-revision source outcomes, timers, current/source routes, sessions, turns, audits, source committed
       replay-scope rows not admitted by the selected-contract marker policy, non-agent replay, missing selected route
       recovery, or any missing/stale selected binding/source evidence. It
       MUST NOT run handlers, create fork-local events or event_deliveries, copy source rows, write receipts, dead
@@ -12318,7 +12422,7 @@ run_model:
       activation delivery/event replay, it may consume the canonical replay_resume_admission taxonomy directly and must
       still classify every historical fact family before mutation. It classifies source events, event deliveries, receipts,
       dead letters, retry/idempotency state, emitted follow-ups, timers, routes/current route rows, sessions, turns,
-      audits, non-agent/node/system work, source-advanced/post-T source outcomes, runtime restart recovery, and
+      audits, non-agent/node/system work, source-advanced/post-revision source outcomes, runtime restart recovery, and
       CLI/API/dashboard/operator consumers exactly once as executable fork work, reconstructed fork-local state,
       lineage-only evidence, fail-closed blockers, or split siblings. Source events and outcomes are lineage/proof only;
       the only admitted executable delivery family is the separately proven delivery_event_replay_ready primitive from
@@ -12335,7 +12439,7 @@ run_model:
       emits the executable work set that downstream store/runtime writers may mutate. The current supported closure
       level is canonical owner promotion with delivery_event_replay_ready plus the selected-contract active-timer
       reconstruction child runtime.run_fork.historical_replay_execution.timer_reconstruction. The timer reconstruction
-      child may reconstruct only active source timers at T into fresh fork-local timer rows under fork run_id with
+      child may reconstruct only active source timers present in the selected revision into fresh fork-local timer rows under fork run_id with
       lineage fields; it does not copy source rows, fire source timers, clear route/session/turn/audit/non-agent
       blockers, or authorize full scheduler/recovery replay beyond run-scoped timer claim/fire/reload identity. The
       selected-contract contract-swap child runtime.run_fork.historical_replay_execution.contract_swap_boot_resume may
@@ -12360,7 +12464,7 @@ run_model:
       through EventBus with selected recipient-plan guards, run selected handlers through the normal runtime pipeline,
       and record fork-local lineage without copying source event IDs or source delivery rows. Source delivery
       subscriber identity, source receipts, source dead letters, source retry/idempotency, emitted source follow-ups,
-      timers, source/current routes, sessions, turns, audits, non-agent/node/system work, source-advanced/post-T facts,
+      timers, source/current routes, sessions, turns, audits, non-agent/node/system work, source-advanced/post-revision facts,
       runtime restart state, and CLI/API/dashboard/Builder state are lineage-only, fail-closed blockers, split siblings,
       or consumers; they MUST NOT become selected-fork recipient truth, executable fork work, or fork suppressors. This
       child MUST NOT use store.run_fork.delivery_event_replay as-is when that writer preserves source subscriber
@@ -12380,7 +12484,7 @@ run_model:
       runtime delivery pipeline process the fork-local pending delivery. It MUST NOT copy source event IDs, source
       delivery IDs, receipts, dead letters,
       retry/idempotency state, emitted follow-ups, timers, route rows, sessions, turns, audits, non-agent/node/system
-      work, runtime restart state, API/UI/dashboard state, or use source/post-T outcomes as fork suppressors. Timers,
+      work, runtime restart state, API/UI/dashboard state, or use source/post-revision outcomes as fork suppressors. Timers,
       routes, sessions, turns, audits, non-agent replay, contract-swap/full resume, restart recovery, and operator
       surfaces remain separately gated siblings under #564/#549/#618.'
     historical_replay_delivery_event_replay_recovery: 'Restart and sweeper recovery for the admitted
@@ -12397,30 +12501,28 @@ run_model:
       This owner MUST NOT reconstruct timers, routes, sessions, turns, audits, non-agent/node/system work,
       contract-swap boot/resume, runtime-wide restart recovery, API/UI/dashboard state, or close successor concepts
       such as #1721 memoized re-execution or #1722 fleet fork reporting.'
-    event_id_shorthand: 'When --at receives an event ID, the system resolves it to that event''s created_at
-      timestamp. Under the hood, fork is always timestamp-based. The event ID is a convenience for pinpointing
-      a moment without looking up timestamps manually.'
+    event_id_shorthand: 'The --at-event value is the historical authority, not shorthand. The system resolves the
+      source event UUID to that event''s first persisted commit-ordered run revision. Occurrence and lifecycle
+      timestamps remain diagnostics and are never a fallback selector or historical membership predicate.'
     semantics:
-      1_reconstruct_state: 'Reconstruct all entity states at timestamp T. For every entity touched by the source
-        run (SELECT DISTINCT entity_id FROM entity_mutations WHERE run_id = :source_run_id), reverse-apply
-        all mutations with created_at > T (newest first, set each field to old_value). Alternative: forward-apply
-        from empty entity for reliability. Only committed mutations are included — in-progress deliveries at T
-        are excluded, their partial mutations are not applied. A reconstructed entity is materializable only after
-        runtime.run_fork.materialized_entity_snapshot_metadata authorizes its source-at-T flow_instance/entity_type
-        metadata or produces a named fail-closed blocker.'
-      2_detect_pending: 'Identify events that were pending at timestamp T — events with created_at <= T whose
-        delivery chain was incomplete. This includes deliveries with status pending or in_progress at T and
-        entities in non-terminal states expecting further events. Open-stream accumulator buckets are persisted
-        entity state, not pending finite-completion work. These are the events the system will re-deliver.'
+      1_reconstruct_state: 'Resolve the source event UUID to revision R, load the eleven-family projection at
+        revision <= R in one repeatable-read snapshot, and forward-apply revisioned entity_mutations in deterministic
+        revision/fact order. A reconstructed entity is materializable only after
+        runtime.run_fork.materialized_entity_snapshot_metadata authorizes flow_instance/entity_type metadata present
+        in the same fixed projection or produces a named fail-closed blocker. No created_at predicate participates.'
+      2_detect_pending: 'Classify event_deliveries and event_receipts present in the same fixed revision R together
+        with their revisioned source-event lineage, dead letters, sessions, turns, audits, timers, and reply contexts.
+        Only owner-admitted delivery_event_replay_ready work may be redelivered; incomplete, ambiguous, unrevisioned,
+        or unsupported facts fail closed. Later lifecycle transitions do not change repeated planning at R.'
       3_create_run: 'Insert new run row with forked_from_run_id = source run, forked_from_event_id = target event
         (if event ID was provided). Copy reconstructed entity states into the fork context.'
       3a_materialize_only_run: 'For a materialize-only fork, insert the fork run row with status=paused,
         forked_from_run_id = source run, forked_from_event_id = target event, and event_count = 0.
         Source run status is unchanged. Copy reconstructed entity states into the fork context with fork-local
-        revision=1 and source-at-T entered_state_at for the reconstructed current_state, then stop; do not boot,
+        revision=1 and entered_state_at from the selected revision''s current_state mutation evidence, then stop; do not boot,
         resume, redeliver, or mutate runtime delivery/session/timer/route state.'
       3b_activate_materialized_fork: 'For an activation fork, consume a previously materialized fork run.
-        Revalidate the original fork point against current source-run facts, require no source advancement and
+        Revalidate the original selected revision against current source-run facts, require no source advancement and
         no unsupported replay/timer/route/session/turn/contract-swap facts, optionally create fork-local event/delivery
         rows and direct committed replay-scope markers for the delivery_event_replay_ready subset only through
         runtime.run_fork.historical_replay_execution consuming historical replay execution admission and owner-authorized
@@ -12428,7 +12530,7 @@ run_model:
         does not authorize replay directly from replay_resume_admission or RunForkPlan pending rows. Future runtime work uses the fork
         run_id, fork-local entity_state rows, and fork-local pending delivery rows; broader source-run replay remains
         unsupported outside the gated delivery/event primitive.'
-      3b1_selected_contract_readiness_classifier: 'For selected-contract timestamp-fork dry-run/explain, the
+      3b1_selected_contract_readiness_classifier: 'For selected-contract fixed-event readiness explanation, the
         runtime.run_fork.selected_contract_readiness_classifier owner consumes existing planner, replay taxonomy,
         contract-frontier, route/topology, recipient-planning, selected-execution, current-state/materialization,
         contract-swap, historical-replay, and fork-local runtime lineage owners to emit one read-only readiness matrix
@@ -12439,14 +12541,14 @@ run_model:
         their own canonical owners and fail closed. CLI/API/dashboard/Builder surfaces may consume the matrix but MUST
         NOT compute readiness semantics independently.'
       3c_selected_contract_source_advanced_branch: 'For selected-contract mutating fork execution, source advancement
-        after the fork point is explicit branch divergence evidence when the selected execution owner can regenerate
+        after the materialized source revision is explicit branch divergence evidence when the selected execution owner can regenerate
         fork-local work under the fork run_id. The source run remains in its current status and is not frozen or rewound.
         Post-fork source events, deliveries, receipts, dead letters, retry state, outcomes, current state, and mutations
         remain source-run evidence only; they are not copied into the fork and do not suppress fork-local selected
         execution. Generic/state-only activation continues to use 3b no-source-advancement/freeze semantics.'
-      3c1_selected_contract_source_advanced_conversation_history_policy: 'For selected-contract timestamp-fork
+      3c1_selected_contract_source_advanced_conversation_history_policy: 'For selected-contract fixed-event
         execution, runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy consumes
-        post-fork-T source agent_sessions, agent_turns, and agent_conversation_audits as source-advanced
+        post-revision source agent_sessions, agent_turns, and agent_conversation_audits as source-advanced
         branch-divergence lineage/no-action evidence only. The owner covers all three conversation-history source fact
         families together and records the admitted fact codes in replay_resume_admission and selected-contract branch
         divergence evidence. It is not session, turn, audit, provider-session, transcript, receipt, outcome, or task-audit
@@ -12456,23 +12558,25 @@ run_model:
         pre-existing conversation rows, generic/state-only activation, broad source-run resumption, timers, routes,
         non-agent replay, restart recovery, and operator surfaces remain fail-closed or split siblings unless
         independently approved.'
-      3d_selected_contract_timer_route_policy: 'For selected-contract mutating fork execution, source timer and route
-        facts remain evidence-only blockers. The selected execution owner consumes timer_history_unproven and
-        flow_route_history_unproven from the canonical replay/resume taxonomy and fails before materializing,
-        activating, firing timers, copying routing rules, deriving selected-source recipients, or creating fork-local
-        executable work. Timer reconstruction and route reconstruction are separately gated fork replay/resume
-        children.'
+      3d_selected_contract_timer_route_policy: 'For selected-contract mutating fork execution, source timer facts
+        remain revisioned evidence and unsupported histories remain blockers. Route history is projected as
+        not_applicable or unknown_unversioned without querying current routing_rules. Generic execution preserves
+        flow_route_history_unproven. Selected execution may clear unknown_unversioned only through matching selected
+        frontier/binding/static-dynamic topology/recipient proof and persisted route recovery, before materialization,
+        publish, or activation. Timer reconstruction remains a separately gated fork replay/resume child.'
       3e_selected_contract_route_admission: 'For selected-contract mutating fork execution, selected route/subscription
         admission is evidence-only and non-mutating. It distinguishes frontier recipient admission from historical
-        route reconstruction, uses the selected contract route table only as route evidence, and fails closed before
-        route persistence, executable recipient derivation, delivery writes, or handler execution. Source routing rows,
-        source flow-instance routes, and source recipients are never copied into the fork.'
+        route reconstruction, carries unknown_unversioned as an unresolved requirement, and uses the selected contract
+        route table only as selected-source evidence. Only the matching selected topology owner may discharge that
+        requirement. Source/current routing_rules, source flow-instance routes, and source recipients are neither read
+        as historical authority nor copied into the fork.'
       3f_selected_contract_route_topology: 'For selected-contract mutating fork execution, fork-local route/topology
         truth is a separate owner beyond route admission. The selected execution model and admission consume
         runtime.run_fork.selected_contract_route_topology rather than treating route admission as final truth. Static
         selected-source topology is classified from selected-source route derivation and selected binding/frontier
         evidence only. Dynamic flow-instance topology requires explicit fork-local topology proof and otherwise
-        remains fail-closed. This owner is still non-mutating: it does not persist route rows, derive executable
+        remains fail-closed. A matching complete topology is the only authority that may discharge the planner''s
+        unknown_unversioned route requirement for selected execution. This owner is still non-mutating: it does not persist route rows, derive executable
         recipients, write deliveries, or run handlers.'
       3f1_selected_contract_dynamic_route_topology: 'For selected-contract mutating fork execution, dynamic
         flow-instance route topology is proven by runtime.run_fork.selected_contract_dynamic_route_topology as a
@@ -12551,42 +12655,42 @@ run_model:
         lineage, and regenerates follow-up events under the fork run_id. This bounded owner does not include route
         persistence/recovery, timer reconstruction, session/turn/audit reconstruction, non-agent replay, contract-swap
         boot/resume beyond selected frontier execution, runtime restart recovery, and UI/API ownership remain separate
-        parents or siblings. At/before-T source session/turn/audit facts may be admitted only as lineage/no-action
-        evidence by the separate selected-contract session/turn/audit lineage policy. Post-T source session/turn/audit
+        parents or siblings. Source session/turn/audit facts present in the selected revision may be admitted only as lineage/no-action
+        evidence by the separate selected-contract session/turn/audit lineage policy. Post-revision source session/turn/audit
         facts may be admitted only as source-advanced branch-divergence lineage/no-action evidence by the separate
-        selected-contract source-advanced conversation-history policy. At/before-T source committed replay-scope marker
+        selected-contract source-advanced conversation-history policy. Source committed replay-scope marker facts present in the selected revision
         rows may be admitted only as lineage/no-action evidence by the separate selected-contract committed replay-scope
-        marker policy. Same-source in-progress source delivery coupling at the fork-point emission boundary may be
+        marker policy. Same-source in-progress source delivery coupling at the selected-event emission boundary may be
         admitted only by the separate selected-contract active source delivery conversation-coupling policy.'
-      3h1_selected_contract_session_turn_audit_lineage_policy: 'For selected-contract timestamp-fork execution,
+      3h1_selected_contract_session_turn_audit_lineage_policy: 'For selected-contract fixed-event execution,
         runtime.run_fork.historical_replay_execution.selected_contract_session_turn_audit_lineage_policy consumes the
         canonical replay_resume_admission session_history, active_turn_history, and conversation_audit_history facts and
-        may demote those at/before-T source facts from fail-closed blockers to lineage/no-action evidence only. The owner
+        may demote those source facts present in the selected revision from fail-closed blockers to lineage/no-action evidence only. The owner
         must keep pending/in-progress delivery session coupling and fork-local pre-existing conversation rows
         fail-closed except when the separate selected-contract active source delivery conversation-coupling policy has
-        admitted the same-source fork-point emission case. It must not copy or reuse source session IDs, provider session IDs, transcripts, task audits, turns,
+        admitted the same-source selected-event emission case. It must not copy or reuse source session IDs, provider session IDs, transcripts, task audits, turns,
         receipts, outcomes, or source audit rows as fork-local runtime truth or suppressors. Fresh fork-local sessions,
-        turns, and audits may appear only through normal selected fork runtime execution under the fork run_id. Post-T
-        source conversation facts are outside this at/before-T owner and may be admitted only by
+        turns, and audits may appear only through normal selected fork runtime execution under the fork run_id. Post-revision
+        source conversation facts are outside this selected-revision owner and may be admitted only by
         runtime.run_fork.selected_contract_execution.source_advanced_conversation_history_policy. This owner does not
         close full session reconstruction, committed replay-scope marker policy, timers, routes, non-agent replay,
         restart recovery, contract-swap boot/resume, or operator surfaces.'
-      3h2_selected_contract_committed_replay_scope_marker_policy: 'For selected-contract timestamp-fork execution,
+      3h2_selected_contract_committed_replay_scope_marker_policy: 'For selected-contract fixed-event execution,
         runtime.run_fork.historical_replay_execution.selected_contract_committed_replay_scope_marker_policy consumes the
-        canonical replay_resume_admission committed_replay_scope fact and may demote at/before-T source committed
+        canonical replay_resume_admission committed_replay_scope fact and may demote source committed
         replay-scope marker rows from fail-closed blockers to lineage/no-action evidence only. Source marker rows are
         same-run proof only: they are not executable fork work, not fork-local recovery truth, not copied into the fork,
-        and not selected-fork suppressors. The cutoff for marker facts is the underlying source event position, so
-        marker delivery write-skew after T for an at/before-T source event is lineage/no-action and must be excluded from
-        generic selected-contract `source_deliveries_advanced_after_fork_point` evidence. Fork-local replay/recovery
+        and not selected-fork suppressors. The marker delivery fact must itself be present in the selected revision;
+        a later marker write is source advancement and cannot inherit the underlying event''s earlier revision or
+        occurrence time. Fork-local replay/recovery
         proof must be newly written under the fork run_id by selected-contract execution or approved fork-local
-        delivery-event replay owners. Source committed replay-scope marker facts whose underlying source event is after T
+        delivery-event replay owners. Source committed replay-scope marker facts absent from the selected revision
         remain fail-closed unless a separate approved owner changes that policy. This owner does not close same-run
         recovery, fork-local delivery-event replay recovery, sessions, turns, audits, timers, routes, non-agent replay,
         restart recovery, contract-swap boot/resume, or operator surfaces.'
-      3h3_selected_contract_diagnostic_platform_outcome_policy: 'For selected-contract timestamp-fork execution,
+      3h3_selected_contract_diagnostic_platform_outcome_policy: 'For selected-contract fixed-event execution,
         runtime.run_fork.contract_frontier_admission.selected_contract_diagnostic_platform_outcome_policy consumes
-        at/before-T source outcome facts for platform_events.routing_rules.diagnostic_events and may demote those
+        source outcome facts present in the selected revision for platform_events.routing_rules.diagnostic_events and may demote those
         diagnostic/non-routed platform facts from selected frontier work to lineage/no-action evidence only. The owner is
         part of selected-contract frontier admission before route topology, recipient planning, and selected execution.
         Diagnostic platform source facts are not executable fork work, route truth, selected recipients, copied source
@@ -12594,22 +12698,22 @@ run_model:
         generic non-agent replay, delivery-event replay, committed replay-scope marker policy, sessions, turns, audits,
         timers, routes, retry/idempotency, follow-up policy, restart recovery, contract-swap boot/resume, and operator
         surfaces remain separate fail-closed or split siblings unless independently approved.'
-      3h4_selected_contract_active_source_delivery_conversation_coupling_policy: 'For selected-contract timestamp-fork
+      3h4_selected_contract_active_source_delivery_conversation_coupling_policy: 'For selected-contract fixed-event
         execution, runtime.run_fork.selected_contract_execution.active_source_delivery_conversation_coupling_policy
-        consumes replay_resume_admission delivery_in_progress_history evidence and fork-point source-event causality to
-        admit only the same-source delivery fork-point emission case: the source delivery is in progress at T, belongs to
-        the fork-point event source_event_id, and its agent subscriber produced the fork-point event, with no
-        active_session_id, receipt, receipt outcome, or delivered_at at T. This owner may demote that delivery fact from a
+        consumes replay_resume_admission delivery_in_progress_history evidence and selected-event source-event causality to
+        admit only the same-source delivery selected-event emission case: the source delivery is in progress in the selected revision, belongs to
+        the selected event source_event_id, and its agent subscriber produced the selected event, with no
+        active_session_id, receipt, receipt outcome, or delivered_at in that revision. This owner may demote that delivery fact from a
         generic delivery_history_unproven blocker to lineage/no-action evidence and may allow the session/turn/audit
-        lineage policy to classify at/before-T source conversation rows. It records the admitted case as selected-contract
+        lineage policy to classify source conversation rows present in the selected revision. It records the admitted case as selected-contract
         branch-divergence evidence. It must not copy source delivery/session/turn/audit rows, use source terminal outcomes
-        after T as fork suppressors, or admit unrelated active deliveries, active_session_id coupling, post-T source
+        committed after the selected revision as fork suppressors, or admit unrelated active deliveries, active_session_id coupling, post-revision source
         conversation facts, fork-local pre-existing rows, non-agent replay, timers, routes, retry/idempotency, follow-up
         policy, restart recovery, or operator surfaces.'
-      3i_contract_swap_boot_resume_admission: 'For timestamp forks with selected or swapped contracts, full boot/resume
+      3i_contract_swap_boot_resume_admission: 'For fixed-event forks with selected or swapped contracts, full boot/resume
         readiness is answered by runtime.run_fork.contract_swap_boot_resume_admission before any mutating historical
         replay/resume work. The owner consumes selected binding/source admission, replay/resume taxonomy, selected route
-        topology, selected recipient planning, and selected route recovery evidence. Source rows and post-T outcomes
+        topology, selected recipient planning, and selected route recovery evidence. Source rows and post-revision outcomes
         remain lineage/evidence or fail-closed blockers; they are not executable fork work and do not suppress future
         fork-local work. This owner is non-mutating and does not authorize handler execution, delivery writes, receipts,
         dead letters, idempotency, emitted follow-ups, timers, sessions, turns, non-agent replay, route row mutation, or
@@ -12658,19 +12762,20 @@ run_model:
         idempotency, or arbitrary in-flight work.'
       5_resume: 'Execute only owner-admitted fork-local work under the new run_id. Today that means the
         delivery_event_replay_ready primitive, selected-contract frontier execution when independently admitted, and
-        timer reconstruction where the timer owner has proven active-at-T lineage. Unsupported historical fact families
+        timer reconstruction where the timer owner has proven active lineage in the selected revision. Unsupported historical fact families
         fail closed with typed blockers; the platform never infers unfinished source work from current rows.'
-    parallel_safety: 'Timestamp-based fork handles parallel agent execution naturally. At timestamp T, all
-      concurrent branches either committed their mutations or did not. No DAG traversal, no branch
-      classification, no sibling carry-over logic. The reconstructed state is simply "what was the world at T."'
+    parallel_safety: 'Each source transaction publishes all changed fork-reader families under one commit-serialized
+      per-run revision. Concurrent same-run transactions serialize through the revision head; multi-run transactions
+      lock heads in deterministic run-ID order. A selected event revision therefore includes complete committed
+      transactions and excludes later ones without comparing application or database clocks.'
     contract_swap: 'When --contracts specifies a new contract path, any admitted fork-local delivery/event work must use
       the selected handler logic uniformly with no mixed-version state. This intent is not itself an execution owner.
       Runtime/store readiness for selected-contract boot/resume is governed by
       runtime.run_fork.contract_swap_boot_resume_admission, and mutation remains limited to separately approved bounded
       owners for admitted fork work.'
-    timestamp_precision: 'Events committed in the same millisecond are disambiguated by (created_at, event_id)
-      composite ordering. The fork point is inclusive: mutations from the target moment are included in
-      reconstructed state. Only mutations strictly after T are undone.'
+    timestamp_precision: 'Timestamp precision has no fork semantics. Event UUID resolves to the event''s first
+      commit-ordered run revision, and the boundary is inclusive of every fact present at that revision. Facts in later
+      revisions are excluded regardless of equal, earlier, or later occurrence timestamps.'
     isolation: 'Forked runs are fully isolated. They get their own event stream, their own entity state copies,
       and their own agent sessions. Fork state materialization writes entity_state rows under the fork run_id while
       preserving entity_id from the source run. Results can be compared side-by-side with the original run.'

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12059,7 +12059,10 @@ run_model:
       - reply_contexts
       write_contract: >-
         Existing PostgreSQL store transactions allocate one commit-serialized revision per affected run after
-        provider, tool, agent, and network work. Every changed family in one transaction shares that revision;
+        provider, tool, agent, and network work. A family is changed only when its canonical projected fact JSON or
+        fact presence differs from the latest published revision; writes to excluded physical columns do not advance
+        the family. Publication and completeness validation MUST compare that same canonical projection and presence,
+        never row transaction identity. Every changed family in one transaction shares that revision;
         repeated capture in the transaction reuses it; rollback publishes neither facts nor revision. Transactions
         affecting multiple runs lock revision heads in deterministic run-ID order. No revision lock may span external
         work. Deletion emits present=false for the removed fact in the same transaction.


### PR DESCRIPTION
## Summary

- add the commit-serialized, run-scoped revision owner for the approved eleven historical fork fact families
- make `PlanRunFork` resolve event UUIDs to one fixed revision and classify one repeatable-read snapshot without timestamp or current-route inference
- preserve fresh generic/selected activation validation, selected source-advanced branching, post-frontier activity evidence, and typed SQLite rejection
- pass canonical selected frontier/topology/recipient proof through route recovery and remove the tier-12 future-time fixture workaround

Closes #2049

## Governing References

This migration implements the binding Gate B record in issue #2049 and updates the authoritative runtime contract in the same PR:

- `platform-spec.yaml#run_model.fork.fixed_event_revision_and_workset`
- `platform-spec.yaml#run_model.fork.timestamp_precision`
- `platform-spec.yaml#run_model.fork.selected_contract_timer_route_policy`
- `platform-spec.yaml#run_model.fork.selected_contract_supported_execution`
- `platform-spec.yaml#run_model.fork.selected_contract_source_advanced_branch`
- `platform-spec.yaml#bounded_loops.replay_restart_fork`

Gate B approval and correction: https://github.com/division-sh/swarm/issues/2049#issuecomment-4965067496 and https://github.com/division-sh/swarm/issues/2049#issuecomment-4965085625.

## Semantic Migration

- **New canonical owner:** `store.run_fork.fixed_event_revision_and_workset`, backed by `internal/runtime/runforkrevision` and consumed by `PostgresStore.PlanRunFork`.
- **Invalid old producer/reader paths:** mixed `created_at`/lifecycle timestamp membership, timestamp selectors/fallbacks, current `routing_rules` historical inference, mutable-current-row historical classification, and transaction commits that persisted approved fact families without revision capture.
- **Production paths checked:** event/delivery/receipt/dead-letter, entity mutation/metadata, timer, session/turn/audit, reply-context, generic and selected materialization/activation, selected execution and activation gate, lifecycle-owned session transitions, public RPC/CLI, catalog E2E, and SQLite unsupported handling.
- **Migration status:** complete for the chosen eleven-family class. Old stores and unrevisioned rows fail closed and must be recreated; no compatibility reader, backfill, timestamp fallback, or dual owner remains. `activity_attempts` deliberately remains distinct post-frontier selected-execution evidence.

## Verification

- `go run ./cmd/swarm-test-postgres -- go test ./... -count=1 -timeout=600s` (green, 143.44s wall time)
- affected store/runtime package suite (green)
- public CLI/API and SQLite typed-unsupported proofs (green)
- `TestRunServeRuntimeJoinForkReplayPreservesActivationAndTimer -count=20` (20/20 green)
- tier-12 selected-contract catalog execution with ordinary event time, canonical route recovery, and source-advanced branch proof (green)
