### PR TITLE
[agent-c][issue #1987] Add content-bound activity approval

### DIFF
--- a/cmd/swarm/cli_human_projection_test.go
+++ b/cmd/swarm/cli_human_projection_test.go
@@ -477,7 +477,7 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Reason: "local context registry status is a separate local-targeting taxonomy",
 	},
 	"control_mailbox.go\x00writeMailboxDetailResult": {
-		Names:  []string{"status", "status"},
+		Names:  []string{"status", "status", "status"},
 		Reason: "typed mailbox notice/card status is a separate control taxonomy",
 	},
 	"control_mailbox.go\x00writeMailboxListResult": {

--- a/cmd/swarm/control_mailbox.go
+++ b/cmd/swarm/control_mailbox.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
 	"github.com/spf13/cobra"
 )
 
@@ -15,12 +16,14 @@ type mailboxProjection struct {
 	Kind         string                      `json:"kind"`
 	Notice       *mailboxItem                `json:"notice,omitempty"`
 	DecisionCard *mailboxDecisionCardSummary `json:"decision_card,omitempty"`
+	Effect       *mailboxEffectState         `json:"effect,omitempty"`
 }
 
 type mailboxDetailProjection struct {
 	Kind         string               `json:"kind"`
 	Notice       *mailboxNoticeDetail `json:"notice,omitempty"`
 	DecisionCard *mailboxDecisionCard `json:"decision_card,omitempty"`
+	Effect       *mailboxEffectState  `json:"effect,omitempty"`
 }
 
 type mailboxItem struct {
@@ -70,7 +73,17 @@ type mailboxDecisionCardAnchor struct {
 	RequesterAgentID  string                   `json:"requester_agent_id,omitempty"`
 	OperationID       string                   `json:"operation_id,omitempty"`
 	Category          string                   `json:"category,omitempty"`
+	RequestEventID    string                   `json:"request_event_id,omitempty"`
+	ActivityID        string                   `json:"activity_id,omitempty"`
+	Decision          string                   `json:"decision,omitempty"`
 	Scope             mailboxDecisionCardScope `json:"scope,omitempty"`
+}
+
+type mailboxEffectState struct {
+	ContinuationState string `json:"continuation_state"`
+	DispatchState     string `json:"dispatch_state"`
+	RequestEventID    string `json:"request_event_id"`
+	ActivityID        string `json:"activity_id"`
 }
 
 type mailboxDecisionCard struct {
@@ -312,6 +325,13 @@ func validateMailboxProjection(item mailboxProjection) error {
 		if err := validateMailboxDecisionCardAnchor(*item.DecisionCard); err != nil {
 			return err
 		}
+		if item.DecisionCard.AnchorKind == string(decisioncard.AnchorKindProposedEffect) {
+			if item.Effect == nil || item.Effect.RequestEventID == "" || item.Effect.ActivityID == "" || item.Effect.DispatchState == "" {
+				return fmt.Errorf("proposed_effect dispatch state is required")
+			}
+		} else if item.Effect != nil {
+			return fmt.Errorf("effect state is valid only for proposed_effect cards")
+		}
 	default:
 		return fmt.Errorf("kind must be notice or decision_card")
 	}
@@ -320,22 +340,29 @@ func validateMailboxProjection(item mailboxProjection) error {
 
 func validateMailboxDecisionCardAnchor(card mailboxDecisionCardSummary) error {
 	switch strings.TrimSpace(card.AnchorKind) {
-	case "stage_gate":
+	case string(decisioncard.AnchorKindStageGate):
 		if card.Anchor.FlowInstance == "" || card.Anchor.EntityID == "" || card.Anchor.Stage == "" || card.Anchor.StageActivationID == "" || card.Decision == "" {
 			return fmt.Errorf("stage_gate anchor detail is incomplete")
 		}
 		if card.Category != "" || card.Anchor.RequesterAgentID != "" || card.Anchor.OperationID != "" {
 			return fmt.Errorf("stage_gate card carries human_task selector fields")
 		}
-	case "human_task":
+	case string(decisioncard.AnchorKindHumanTask):
 		if card.Anchor.RequesterAgentID == "" || card.Anchor.OperationID == "" || card.Anchor.Category == "" || card.Category == "" {
 			return fmt.Errorf("human_task anchor detail is incomplete")
 		}
 		if card.Category != card.Anchor.Category || card.Decision != "" || card.Anchor.Stage != "" || card.Anchor.StageActivationID != "" {
 			return fmt.Errorf("human_task card carries conflicting anchor detail")
 		}
+	case string(decisioncard.AnchorKindProposedEffect):
+		if card.Anchor.RequestEventID == "" || card.Anchor.ActivityID == "" || card.Anchor.Decision == "" || card.Decision == "" {
+			return fmt.Errorf("proposed_effect anchor detail is incomplete")
+		}
+		if card.Decision != card.Anchor.Decision || card.Anchor.Stage != "" || card.Anchor.RequesterAgentID != "" {
+			return fmt.Errorf("proposed_effect card carries conflicting anchor detail")
+		}
 	default:
-		return fmt.Errorf("anchor_kind must be stage_gate or human_task")
+		return fmt.Errorf("anchor_kind must be one of: %s", decisioncard.RegisteredAnchorKindDescription())
 	}
 	if card.Scope.Kind == "" {
 		return fmt.Errorf("decision-card scope is required")
@@ -352,6 +379,16 @@ func validateMailboxDetailResult(result mailboxDetailProjection) error {
 	case "decision_card":
 		if result.DecisionCard == nil || strings.TrimSpace(result.DecisionCard.CardID) == "" || strings.TrimSpace(result.DecisionCard.CardContentHash) == "" || result.DecisionCard.Snapshot == nil {
 			return fmt.Errorf("malformed mailbox.get decision card")
+		}
+		if err := validateMailboxDecisionCardAnchor(result.DecisionCard.mailboxDecisionCardSummary); err != nil {
+			return err
+		}
+		if result.DecisionCard.AnchorKind == string(decisioncard.AnchorKindProposedEffect) {
+			if result.Effect == nil || result.Effect.RequestEventID == "" || result.Effect.ActivityID == "" || result.Effect.DispatchState == "" {
+				return fmt.Errorf("malformed mailbox.get proposed_effect dispatch state")
+			}
+		} else if result.Effect != nil {
+			return fmt.Errorf("mailbox.get effect state is valid only for proposed_effect cards")
 		}
 	default:
 		return fmt.Errorf("malformed mailbox.get result: kind must be notice or decision_card")
@@ -397,8 +434,12 @@ func writeMailboxDetailResult(out io.Writer, result mailboxDetailProjection) {
 	writeCLIFieldLine(out, cliDetailField{Key: "status", Value: card.Status}, cliDetailField{Key: "anchor_kind", Value: card.AnchorKind}, cliDetailField{Key: "scope", Value: mailboxDecisionCardScopeLabel(card.Scope)})
 	if card.AnchorKind == "stage_gate" {
 		writeCLIFieldLine(out, cliDetailField{Key: "decision", Value: card.Decision}, cliDetailField{Key: "stage", Value: card.Anchor.Stage})
-	} else {
+	} else if card.AnchorKind == "human_task" {
 		writeCLIFieldLine(out, cliDetailField{Key: "category", Value: card.Category}, cliDetailField{Key: "requested_by", Value: card.Anchor.RequesterAgentID})
+	} else {
+		writeCLIFieldLine(out, cliDetailField{Key: "decision", Value: card.Decision}, cliDetailField{Key: "activity", Value: card.Anchor.ActivityID})
+		writeCLIFieldLine(out, cliDetailField{Key: "authorization", Value: card.Status}, cliDetailField{Key: "dispatch", Value: result.Effect.DispatchState})
+		fmt.Fprintf(out, "activity_request_id=%s\n", result.Effect.RequestEventID)
 	}
 	fmt.Fprintf(out, "card_content_hash=%s\n", card.CardContentHash)
 	writeMailboxObject(out, "snapshot", card.Snapshot)
@@ -408,7 +449,10 @@ func mailboxDecisionCardListLabels(card mailboxDecisionCardSummary) (string, str
 	if card.AnchorKind == "stage_gate" {
 		return "stage_gate:" + card.Decision, mailboxDecisionCardScopeLabel(card.Scope)
 	}
-	return "human_task:" + card.Category, mailboxDecisionCardScopeLabel(card.Scope)
+	if card.AnchorKind == "human_task" {
+		return "human_task:" + card.Category, mailboxDecisionCardScopeLabel(card.Scope)
+	}
+	return "proposed_effect:" + card.Decision, mailboxDecisionCardScopeLabel(card.Scope)
 }
 
 func mailboxDecisionCardScopeLabel(scope mailboxDecisionCardScope) string {

--- a/cmd/swarm/control_mailbox_test.go
+++ b/cmd/swarm/control_mailbox_test.go
@@ -25,6 +25,7 @@ func TestMailboxListUsesTaggedNoticeAndDecisionCardProjection(t *testing.T) {
 				map[string]any{"kind": "notice", "notice": mailboxNoticeResult("notice-1")},
 				map[string]any{"kind": "decision_card", "decision_card": mailboxCardSummaryResult("card-1")},
 				map[string]any{"kind": "decision_card", "decision_card": mailboxHumanTaskCardSummaryResult("human-card-1")},
+				map[string]any{"kind": "decision_card", "decision_card": mailboxProposedEffectCardSummaryResult("effect-card-1"), "effect": mailboxProposedEffectStateResult()},
 			},
 			"next_cursor": "cursor-2",
 		})
@@ -45,7 +46,7 @@ func TestMailboxListUsesTaggedNoticeAndDecisionCardProjection(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"MAILBOX_ID", "notice-1", "notice", "card-1", "decision_card", "launch_review", "human-card-1", "human_task:strategic_decision", "next_cursor=cursor-2"} {
+	for _, want := range []string{"MAILBOX_ID", "notice-1", "notice", "card-1", "decision_card", "launch_review", "human-card-1", "human_task:strategic_decision", "effect-card-1", "proposed_effect:support_reply", "next_cursor=cursor-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -84,6 +85,7 @@ func TestMailboxViewRendersTaggedResources(t *testing.T) {
 		{name: "notice", id: "notice-1", result: map[string]any{"kind": "notice", "notice": map[string]any{"item": mailboxNoticeResult("notice-1"), "payload": map[string]any{"summary": "review"}}}, wants: []string{"Mailbox notice notice-1", "status=pending", `payload={"summary":"review"}`}},
 		{name: "card", id: "card-1", result: map[string]any{"kind": "decision_card", "decision_card": mailboxCardDetailResult("card-1")}, wants: []string{"Decision card card-1", "decision=launch_review", "card_content_hash=content-hash", `"decision":"launch_review"`}},
 		{name: "human task", id: "human-card-1", result: map[string]any{"kind": "decision_card", "decision_card": mailboxHumanTaskCardDetailResult("human-card-1")}, wants: []string{"Decision card human-card-1", "anchor_kind=human_task", "scope=root", "category=strategic_decision", "requested_by=ceo", "card_content_hash=human-content-hash"}},
+		{name: "proposed effect", id: "effect-card-1", result: map[string]any{"kind": "decision_card", "decision_card": mailboxProposedEffectCardDetailResult("effect-card-1"), "effect": mailboxProposedEffectStateResult()}, wants: []string{"Decision card effect-card-1", "anchor_kind=proposed_effect", "decision=support_reply", "activity=send_support_reply", "authorization=pending", "dispatch=held", "activity_request_id=00000000-0000-0000-0000-000000000303"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			setCLIAPITestToken(t, "test-token")
@@ -294,6 +296,36 @@ func mailboxHumanTaskCardDetailResult(id string) map[string]any {
 		"outcomes":    map[string]any{"approve": map[string]any{}, "reject": map[string]any{}},
 	}
 	return out
+}
+
+func mailboxProposedEffectCardSummaryResult(id string) map[string]any {
+	return map[string]any{
+		"kind": "decision_card", "card_id": id, "run_id": "run-1", "anchor_kind": "proposed_effect",
+		"anchor": map[string]any{
+			"request_event_id": "00000000-0000-0000-0000-000000000303", "activity_id": "send_support_reply", "decision": "support_reply",
+			"scope": map[string]any{"kind": "entity", "flow_instance": "root", "entity_id": "entity-1"},
+		},
+		"scope":    map[string]any{"kind": "entity", "flow_instance": "root", "entity_id": "entity-1"},
+		"decision": "support_reply", "title": "Send support reply", "status": "pending",
+		"created_at": "2026-05-13T12:00:01Z", "updated_at": "2026-05-13T12:00:01Z",
+	}
+}
+
+func mailboxProposedEffectCardDetailResult(id string) map[string]any {
+	out := mailboxProposedEffectCardSummaryResult(id)
+	out["card_content_hash"] = "effect-card-content-hash"
+	out["snapshot"] = map[string]any{
+		"decision": "support_reply", "context": map[string]any{"input": map[string]any{"text": "Exact reply"}},
+		"outcomes": map[string]any{"approve": map[string]any{}, "revise": map[string]any{}, "reject": map[string]any{}},
+	}
+	return out
+}
+
+func mailboxProposedEffectStateResult() map[string]any {
+	return map[string]any{
+		"continuation_state": "pending", "dispatch_state": "held",
+		"request_event_id": "00000000-0000-0000-0000-000000000303", "activity_id": "send_support_reply",
+	}
 }
 
 func testRootCommandOptions(server *httptest.Server) rootCommandOptions {

--- a/cmd/swarm/main_test.go
+++ b/cmd/swarm/main_test.go
@@ -6186,7 +6186,14 @@ func seedServedDecisionCardFixture(t *testing.T, rt servedControlProofRuntime) s
 	if bundleHash == "" {
 		bundleHash = "bundle-v1:sha256:" + strings.Repeat("a", 64)
 	}
-	activation, err := gateruntime.New(runID, "root", entityID, "", "awaiting_review", "launch_review", bundleHash, sourceEventID, now)
+	routes, err := gateruntime.FreezeRoutes(map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve", AdvancesTo: "done"},
+		"reject":  {Verdict: "reject", AdvancesTo: "rework"},
+	})
+	if err != nil {
+		t.Fatalf("FreezeRoutes: %v", err)
+	}
+	activation, err := gateruntime.New(runID, "root", entityID, "", "awaiting_review", "launch_review", bundleHash, routes, sourceEventID, now)
 	if err != nil {
 		t.Fatalf("new gate activation: %v", err)
 	}
@@ -15104,7 +15111,7 @@ func waitForServeReadyLine(t *testing.T, out *lockedBuffer, done <-chan int) {
 
 const (
 	serveRuntimeReadyTimeout = 30 * time.Second
-	serveRuntimeStopTimeout  = 5 * time.Second
+	serveRuntimeStopTimeout  = runtimepkg.DefaultShutdownGrace + 15*time.Second
 )
 
 type serveRuntimeTestProcess struct {

--- a/cmd/swarm/test_command.go
+++ b/cmd/swarm/test_command.go
@@ -16,6 +16,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/google/cel-go/cel"
@@ -1765,24 +1766,28 @@ func (r scenarioRunner) findDecisionCard(ctx context.Context, evaluator *scenari
 			params["entity_id"] = text
 		case "anchor_kind":
 			params["anchor_kind"] = text
-		case "card_id", "decision", "stage", "flow_instance", "requester_agent_id", "category", "scope":
+		case "card_id", "decision", "stage", "flow_instance", "requester_agent_id", "category", "scope", "request_event_id", "activity_id":
 		default:
 			return "", "", scenarioTestValidationError{err: fmt.Errorf("unsupported decision-card match field %q", key)}
 		}
 	}
 	anchorKind := evaluatedMatch["anchor_kind"]
-	if anchorKind != "stage_gate" && anchorKind != "human_task" {
-		return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.anchor_kind is required and must be stage_gate or human_task")}
+	if !decisioncard.IsRegisteredAnchorKind(anchorKind) {
+		return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.anchor_kind is required and must be one of: %s", decisioncard.RegisteredAnchorKindDescription())}
 	}
 	for key := range evaluatedMatch {
 		switch anchorKind {
-		case "stage_gate":
-			if key == "requester_agent_id" || key == "category" || key == "scope" {
-				return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.%s is valid only for anchor_kind human_task", key)}
+		case string(decisioncard.AnchorKindStageGate):
+			if key == "requester_agent_id" || key == "category" || key == "scope" || key == "request_event_id" || key == "activity_id" {
+				return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.%s is not valid for anchor_kind stage_gate", key)}
 			}
-		case "human_task":
-			if key == "decision" || key == "stage" {
-				return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.%s is valid only for anchor_kind stage_gate", key)}
+		case string(decisioncard.AnchorKindHumanTask):
+			if key == "decision" || key == "stage" || key == "request_event_id" || key == "activity_id" {
+				return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.%s is not valid for anchor_kind human_task", key)}
+			}
+		case string(decisioncard.AnchorKindProposedEffect):
+			if key == "stage" || key == "requester_agent_id" || key == "category" {
+				return "", "", scenarioTestValidationError{err: fmt.Errorf("decision-card match.%s is not valid for anchor_kind proposed_effect", key)}
 			}
 		}
 	}
@@ -1821,6 +1826,12 @@ func (r scenarioRunner) findDecisionCard(ctx context.Context, evaluator *scenari
 			continue
 		}
 		if expected := evaluatedMatch["category"]; expected != "" && card.Category != expected {
+			continue
+		}
+		if expected := evaluatedMatch["request_event_id"]; expected != "" && card.Anchor.RequestEventID != expected {
+			continue
+		}
+		if expected := evaluatedMatch["activity_id"]; expected != "" && card.Anchor.ActivityID != expected {
 			continue
 		}
 		if expected := evaluatedMatch["scope"]; expected != "" && card.Scope.Kind != expected {

--- a/cmd/swarm/test_command_test.go
+++ b/cmd/swarm/test_command_test.go
@@ -1402,9 +1402,9 @@ func TestSwarmTestRejectsCrossAnchorDecisionCardSelectorsBeforeLookup(t *testing
 		want  string
 	}{
 		{name: "missing kind", match: "decision: launch_review", want: "match.anchor_kind is required"},
-		{name: "human selector on stage gate", match: "anchor_kind: stage_gate\n        category: strategic_decision", want: "match.category is valid only for anchor_kind human_task"},
-		{name: "stage selector on human task", match: "anchor_kind: human_task\n        stage: review", want: "match.stage is valid only for anchor_kind stage_gate"},
-		{name: "unknown kind", match: "anchor_kind: proposed_effect", want: "must be stage_gate or human_task"},
+		{name: "human selector on stage gate", match: "anchor_kind: stage_gate\n        category: strategic_decision", want: "match.category is not valid for anchor_kind stage_gate"},
+		{name: "stage selector on human task", match: "anchor_kind: human_task\n        stage: review", want: "match.stage is not valid for anchor_kind human_task"},
+		{name: "unknown kind", match: "anchor_kind: external_effect", want: "must be one of: stage_gate, human_task, proposed_effect"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			isolateCLIAPIConfigEnv(t)

--- a/internal/apispec/spec_test.go
+++ b/internal/apispec/spec_test.go
@@ -21,8 +21,8 @@ func TestPlatformAPISpecValidationCoverage(t *testing.T) {
 	if report.MethodCount != 61 {
 		t.Fatalf("method count = %d, want 61", report.MethodCount)
 	}
-	if report.SchemaCount != 131 {
-		t.Fatalf("schema count = %d, want 131", report.SchemaCount)
+	if report.SchemaCount != 133 {
+		t.Fatalf("schema count = %d, want 133", report.SchemaCount)
 	}
 	if report.ErrorCodeCount != 46 {
 		t.Fatalf("error code count = %d, want 46", report.ErrorCodeCount)
@@ -97,8 +97,8 @@ func TestGeneratedOpenRPCArtifactMatchesPlatformSpec(t *testing.T) {
 	if len(doc.Methods) != 61 {
 		t.Fatalf("generated OpenRPC methods = %d, want 61", len(doc.Methods))
 	}
-	if len(doc.Components.Schemas) != 131 {
-		t.Fatalf("generated OpenRPC schemas = %d, want 131", len(doc.Components.Schemas))
+	if len(doc.Components.Schemas) != 133 {
+		t.Fatalf("generated OpenRPC schemas = %d, want 133", len(doc.Components.Schemas))
 	}
 	if len(doc.Components.Errors) != 46 {
 		t.Fatalf("generated OpenRPC errors = %d, want 46", len(doc.Components.Errors))

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -20,6 +20,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	"github.com/division-sh/swarm/internal/runtime/destructivereset"
@@ -1563,7 +1564,15 @@ func (s *mutatingProbeDecisionCardStore) ListDecisionCards(_ context.Context, op
 	if err != nil {
 		return nil, "", err
 	}
-	return []decisioncard.ListItem{{Kind: decisioncard.KindDecisionCard, CardID: s.card.CardID, RunID: s.card.RunID, Anchor: s.card.Anchor, Scope: scope, Title: s.card.Snapshot.Title, Status: s.card.Status, DeferredUntil: s.card.DeferredUntil, CreatedAt: s.card.CreatedAt, UpdatedAt: s.card.UpdatedAt}}, "", nil
+	item := decisioncard.ListItem{Kind: decisioncard.KindDecisionCard, CardID: s.card.CardID, RunID: s.card.RunID, Anchor: s.card.Anchor, Scope: scope, Title: s.card.Snapshot.Title, Status: s.card.Status, DeferredUntil: s.card.DeferredUntil, CreatedAt: s.card.CreatedAt, UpdatedAt: s.card.UpdatedAt}
+	switch s.card.Anchor.Kind() {
+	case decisioncard.AnchorKindStageGate, decisioncard.AnchorKindProposedEffect:
+		item.Decision = s.card.Snapshot.Decision
+	case decisioncard.AnchorKindHumanTask:
+		anchor, _ := s.card.Anchor.HumanTask()
+		item.Category = anchor.Category
+	}
+	return []decisioncard.ListItem{item}, "", nil
 }
 
 func (s *mutatingProbeDecisionCardStore) GetDecisionCard(_ context.Context, id string) (decisioncard.Card, error) {
@@ -1651,6 +1660,35 @@ func (s *mutatingProbeDecisionCardStore) SupersedeDecisionCardsForStage(context.
 
 func (s *mutatingProbeDecisionCardStore) SupersedeDecisionCardsForRun(context.Context, string, string, time.Time) error {
 	return s.err
+}
+
+func (s *mutatingProbeDecisionCardStore) CreateProposedEffectCard(context.Context, decisioncard.Card, decisioncard.ProposedEffectContinuation) error {
+	return s.err
+}
+
+func (s *mutatingProbeDecisionCardStore) LoadProposedEffectContinuation(context.Context, string) (decisioncard.ProposedEffectContinuation, error) {
+	return decisioncard.ProposedEffectContinuation{}, s.err
+}
+
+func (s *mutatingProbeDecisionCardStore) CompleteProposedEffectRoute(context.Context, string, string, time.Time) (decisioncard.ProposedEffectContinuation, error) {
+	return decisioncard.ProposedEffectContinuation{}, s.err
+}
+
+func (s *mutatingProbeDecisionCardStore) SupersedeProposedEffectsForLoopGenerations(context.Context, string, string, []attemptgeneration.Generation, string, time.Time) error {
+	return s.err
+}
+
+func (s *mutatingProbeDecisionCardStore) ProposedEffectReadback(context.Context, string) (decisioncard.ProposedEffectReadback, error) {
+	anchor, err := s.card.Anchor.ProposedEffect()
+	if err != nil {
+		return decisioncard.ProposedEffectReadback{}, err
+	}
+	return decisioncard.ProposedEffectReadback{
+		ContinuationState: decisioncard.ProposedEffectPending,
+		DispatchState:     "held",
+		RequestEventID:    anchor.RequestEventID,
+		ActivityID:        anchor.ActivityID,
+	}, s.err
 }
 
 func callMutatingProbeRPC(t *testing.T, handler *Handler, methodName string, params map[string]any, authHeader string) (int, rpcResponse, string) {

--- a/internal/apiv1/openrpc_ws_runtime_test.go
+++ b/internal/apiv1/openrpc_ws_runtime_test.go
@@ -271,6 +271,37 @@ func TestMailboxWebSocketSubscriptionPreservesHumanTaskAnchorKind(t *testing.T) 
 	}
 }
 
+func TestMailboxWebSocketSubscriptionProjectsProposedEffectDispatchState(t *testing.T) {
+	base := time.Unix(1700001500, 0).UTC()
+	state := &mutatingRuntimeProbeState{now: base}
+	cards := newMutatingProbeDecisionCardStore(state)
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: "00000000-0000-0000-0000-000000000303", ActivityID: "send_support_reply", Decision: "support_reply",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root", EntityID: "entity-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cards.card.Anchor = anchor
+	handler, _ := newWebSocketRuntimeProbeHandler(t, webSocketRuntimeProbeObservability(base), time.Hour, cards)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	conn := dialTestWS(t, server.URL)
+	defer conn.Close()
+	writeWSRequest(t, conn, map[string]any{
+		"jsonrpc": "2.0", "id": "proposed-effect-mailbox-subscribe", "method": "mailbox.subscribe", "params": map[string]any{},
+	})
+	response := readWSResponse(t, conn)
+	subscriptionID := assertWebSocketRuntimeSubscribeSuccess(t, "mailbox.subscribe", response)
+	notification := readWSNotification(t, conn)
+	assertWebSocketRuntimeNotification(t, "mailbox.subscribe", subscriptionID, notification)
+	result := asMap(t, notification.Params.Result)
+	effect := asMap(t, result["effect"])
+	if effect["dispatch_state"] != "held" || effect["request_event_id"] != "00000000-0000-0000-0000-000000000303" {
+		t.Fatalf("proposed-effect subscription dispatch state = %#v", effect)
+	}
+}
+
 func transportAdmissionRuntimeMethods(t *testing.T, api *apispec.APISpecification, openRPC apispec.OpenRPCDocument, matrix openRPCComplianceMatrix) ([]string, []string) {
 	t.Helper()
 	openRPCMethods := map[string]struct{}{}

--- a/internal/apiv1/operator_decision_cards.go
+++ b/internal/apiv1/operator_decision_cards.go
@@ -74,7 +74,7 @@ func decisionCardHandlers(opts OperatorReadOptions) map[string]MethodHandler {
 			id := strings.TrimSpace(firstStringParam(req.Params, "mailbox_id", "card_id"))
 			card, err := opts.DecisionCards.GetDecisionCard(ctx, id)
 			if err == nil {
-				return map[string]any{"kind": decisioncard.KindDecisionCard, "decision_card": card}, nil
+				return decisionCardProjection(ctx, opts.DecisionCards, card, card.Anchor.Kind())
 			}
 			if !errors.Is(err, decisioncard.ErrNotFound) {
 				return nil, err
@@ -313,7 +313,11 @@ func listMailboxProjection(ctx context.Context, req Request, opts OperatorReadOp
 		entries = append(entries, mailboxProjectionEntry{Value: map[string]any{"kind": decisioncard.KindNotice, "notice": notice}, Kind: decisioncard.KindNotice, ID: notice.MailboxID, CreatedAt: createdAt})
 	}
 	for _, card := range cards {
-		entries = append(entries, mailboxProjectionEntry{Value: map[string]any{"kind": decisioncard.KindDecisionCard, "decision_card": card}, Kind: decisioncard.KindDecisionCard, ID: card.CardID, CreatedAt: card.CreatedAt})
+		projection, err := decisionCardProjection(ctx, opts.DecisionCards, card, card.Anchor.Kind())
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, mailboxProjectionEntry{Value: projection, Kind: decisioncard.KindDecisionCard, ID: card.CardID, CreatedAt: card.CreatedAt})
 	}
 	sort.SliceStable(entries, func(i, j int) bool {
 		if !entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
@@ -344,6 +348,32 @@ func listMailboxProjection(ctx context.Context, req Request, opts OperatorReadOp
 		next = encodeMailboxProjectionCursor(nextState)
 	}
 	return mailboxProjectionListResult{Items: items, NextCursor: next}, nil
+}
+
+func decisionCardProjection(ctx context.Context, cards decisioncard.Store, card any, kind decisioncard.AnchorKind) (map[string]any, error) {
+	out := map[string]any{"kind": decisioncard.KindDecisionCard, "decision_card": card}
+	if kind != decisioncard.AnchorKindProposedEffect {
+		return out, nil
+	}
+	store, ok := cards.(decisioncard.ProposedEffectStore)
+	if !ok || store == nil {
+		return nil, fmt.Errorf("proposed-effect readback store is not configured")
+	}
+	var cardID string
+	switch typed := card.(type) {
+	case decisioncard.Card:
+		cardID = typed.CardID
+	case decisioncard.ListItem:
+		cardID = typed.CardID
+	default:
+		return nil, fmt.Errorf("unsupported decision-card projection %T", card)
+	}
+	readback, err := store.ProposedEffectReadback(ctx, cardID)
+	if err != nil {
+		return nil, err
+	}
+	out["effect"] = readback
+	return out, nil
 }
 
 func decodeMailboxProjectionCursor(raw string) (mailboxProjectionCursor, error) {

--- a/internal/apiv1/operator_mailbox.go
+++ b/internal/apiv1/operator_mailbox.go
@@ -102,8 +102,8 @@ func mailboxListOptionsFromParams(params map[string]any) (store.MailboxV1ListOpt
 		return out, err
 	}
 	out.AnchorKind = strings.TrimSpace(out.AnchorKind)
-	if out.AnchorKind != "" && out.AnchorKind != string(decisioncard.AnchorKindStageGate) && out.AnchorKind != string(decisioncard.AnchorKindHumanTask) {
-		return out, NewInvalidParamsError(map[string]any{"field": "anchor_kind", "reason": "must be stage_gate or human_task"})
+	if out.AnchorKind != "" && !decisioncard.IsRegisteredAnchorKind(out.AnchorKind) {
+		return out, NewInvalidParamsError(map[string]any{"field": "anchor_kind", "reason": "must be a registered decision-card anchor kind"})
 	}
 	out.Priority = strings.TrimSpace(strings.ToLower(out.Priority))
 	if out.Priority != "" && out.Priority != "normal" && out.Priority != "high" && out.Priority != "critical" {

--- a/internal/apiv1/operator_mailbox_proposed_effect_supported_surface_test.go
+++ b/internal/apiv1/operator_mailbox_proposed_effect_supported_surface_test.go
@@ -1,0 +1,313 @@
+package apiv1
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/store/storetest"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestMailboxDecideHTTPReleasesProposedEffectThroughProviderOnBothStores(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(*testing.T) (any, *sql.DB)
+	}{
+		{
+			name: "sqlite",
+			open: func(t *testing.T) (any, *sql.DB) {
+				selected := storetest.StartSQLiteRuntimeStoreWithContext(t, context.Background())
+				return selected, selected.DB
+			},
+		},
+		{
+			name: "postgres",
+			open: func(t *testing.T) (any, *sql.DB) {
+				_, db, cleanup := testutil.StartPostgres(t)
+				t.Cleanup(cleanup)
+				return &store.PostgresStore{DB: db}, db
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			bodySeen := make(chan string, 1)
+			provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				rawBody, _ := io.ReadAll(r.Body)
+				raw, _ := canonicaljson.Decode(rawBody)
+				textValue, _ := raw.Lookup("text")
+				text, _ := textValue.String()
+				bodySeen <- text
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"message_id":"provider-1"}`))
+			}))
+			defer provider.Close()
+
+			persistence, db := tc.open(t)
+			bundle := mailboxWriteSupportedSurfaceBundle(t)
+			bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+				"provider_write": {
+					HandlerType: "http", EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+					InputSchema: runtimecontracts.ToolInputSchema{
+						Type: "object", Required: []string{"text"},
+						Properties: map[string]runtimecontracts.ToolInputSchema{"text": {Type: "string"}},
+					},
+					OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+					HTTP: &runtimecontracts.HTTPToolSpec{
+						Method: http.MethodPost, URL: provider.URL,
+						Body: map[string]any{"text": "{{input.text}}"},
+					},
+				},
+			}
+			activityNode := runtimecontracts.SystemNodeContract{
+				ID: "activity-runtime", ExecutionType: runtimecontracts.SystemNodeExecutionType,
+				SubscribesTo: []string{"mailbox.card_decided", "platform.activity_requested"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"mailbox.card_decided":        {},
+					"platform.activity_requested": {},
+				},
+			}
+			bundle.Nodes[activityNode.ID] = activityNode
+			if bundle.Semantics.NodeHandlers == nil {
+				bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+			}
+			bundle.Semantics.NodeHandlers[activityNode.ID] = activityNode.EventHandlers
+			if bundle.Semantics.EventOwners == nil {
+				bundle.Semantics.EventOwners = map[string][]string{}
+			}
+			bundle.Semantics.EventOwners["platform.activity_requested"] = []string{activityNode.ID}
+			bundle.Semantics.EventOwners["mailbox.card_decided"] = []string{activityNode.ID}
+
+			source := semanticview.Wrap(bundle)
+			fact := bundleSourceFactForTestBundle(t, bundle)
+			handler, bus := newProposedEffectMailboxHandler(t, persistence, db, source, fact)
+
+			runID, entityID := uuid.NewString(), uuid.NewString()
+			insertProposedEffectAPIRun(t, db, tc.name, runID)
+			cards := persistence.(decisioncard.Store)
+			card, continuation := proposedEffectAPICard(t, runID, entityID, fact, source.WorkflowVersion())
+			if err := cards.(decisioncard.ProposedEffectStore).CreateProposedEffectCard(context.Background(), card, continuation); err != nil {
+				t.Fatal(err)
+			}
+
+			response := rpcCall(t, handler, fmt.Sprintf(`{"jsonrpc":"2.0","id":"decide","method":"mailbox.decide","params":{"card_id":%q,"verdict":"approve","fields":{},"observed_content_hash":%q,"idempotency_key":%q}}`, card.CardID, card.CardContentHash, "approve-proposed-effect-"+tc.name))
+			if response.Error != nil {
+				t.Fatalf("mailbox.decide error = %#v", response.Error)
+			}
+			if result := asMap(t, response.Result); result["status"] != decisioncard.StatusDecided || result["verdict"] != "approve" {
+				t.Fatalf("mailbox.decide result = %#v", result)
+			}
+			decisionEventID := stringValue(t, asMap(t, response.Result)["decision_event_id"], "decision_event_id")
+			waitCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := bus.WaitForQuiescence(waitCtx); err != nil {
+				t.Fatalf("wait for proposed-effect route: %v", err)
+			}
+			select {
+			case got := <-bodySeen:
+				if got != "Exact operator-approved content" {
+					t.Fatalf("provider text = %q", got)
+				}
+			case <-waitCtx.Done():
+				readback, readbackErr := cards.(decisioncard.ProposedEffectStore).ProposedEffectReadback(context.Background(), card.CardID)
+				t.Fatalf("provider did not receive approved effect; readback=%#v error=%v", readback, readbackErr)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("provider calls = %d, want 1", got)
+			}
+			decisionEvent := loadMailboxWritePersistedEvent(t, db, tc.name, decisionEventID)
+			if decisionEvent.ID() != decisionEventID {
+				t.Fatalf("persisted decision event id = %q, want %q", decisionEvent.ID(), decisionEventID)
+			}
+			requestEvent := loadMailboxWritePersistedEvent(t, db, tc.name, continuation.RequestEventID)
+			if requestEvent.Type() != events.EventType("platform.activity_requested") {
+				t.Fatalf("persisted request event type = %q", requestEvent.Type())
+			}
+			readback, err := cards.(decisioncard.ProposedEffectStore).ProposedEffectReadback(context.Background(), card.CardID)
+			if err != nil || readback.ContinuationState != decisioncard.ProposedEffectRequestReleased || readback.DispatchState != "succeeded" {
+				t.Fatalf("proposed-effect readback = %#v, %v", readback, err)
+			}
+			assertProposedEffectAPIExecutionRows(t, db, tc.name, runID)
+		})
+	}
+}
+
+func newProposedEffectMailboxHandler(
+	t *testing.T,
+	persistence any,
+	db *sql.DB,
+	source semanticview.Source,
+	fact runtimecorrelation.BundleSourceFact,
+) (*Handler, *runtimebus.EventBus) {
+	t.Helper()
+	var coordinator *runtimepipeline.PipelineCoordinator
+	bus, err := runtimebus.NewEventBusWithOptions(persistence.(runtimebus.EventStore), runtimebus.EventBusOptions{
+		ContractBundle:    source,
+		BundleFingerprint: fact.BundleHash,
+		BundleSourceFact:  fact,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if coordinator == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{coordinator}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
+	if sqliteStore, ok := persistence.(*store.SQLiteRuntimeStore); ok {
+		workflowStore = runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(db, sqliteStore)
+	}
+	cards, ok := persistence.(decisioncard.Store)
+	if !ok {
+		t.Fatal("persistence store does not implement decisioncard.Store")
+	}
+	coordinator = runtimepipeline.NewPipelineCoordinatorWithOptions(bus, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module: newRunCompletionSystemNodeModule(t, source), WorkflowStore: workflowStore,
+		DecisionCards: cards, EventReceiptsCapability: eventReceiptsCapability(persistence),
+		BundleFingerprint: fact.BundleHash,
+	})
+	bus.RegisterRuntimeActiveAgentDescriptor(runtimebus.ActiveAgentDescriptor{AgentID: "workflow-runtime"})
+	bus.Subscribe("workflow-runtime", events.EventType("mailbox.card_decided"), events.EventType("platform.activity_requested"))
+	mailbox, ok := persistence.(MailboxAPIStore)
+	if !ok {
+		t.Fatal("persistence store does not implement MailboxAPIStore")
+	}
+	runs, ok := persistence.(RunReadStore)
+	if !ok {
+		t.Fatal("persistence store does not implement RunReadStore")
+	}
+	observability, ok := persistence.(ObservabilityReadStore)
+	if !ok {
+		t.Fatal("persistence store does not implement ObservabilityReadStore")
+	}
+	idempotency, ok := persistence.(APIIdempotencyStore)
+	if !ok {
+		t.Fatal("persistence store does not implement APIIdempotencyStore")
+	}
+	runBundleContext, _ := persistence.(RunBundleContextStore)
+	handler := testHandler(t, Options{
+		AuthTokens: []string{testToken},
+		Handlers: OperatorReadHandlers(OperatorReadOptions{
+			Now: func() time.Time { return time.Now().UTC() }, Ready: func() bool { return true }, Database: fakePinger{},
+			Runs: runs, Observability: observability, Idempotency: idempotency, Events: bus, Source: source,
+			RunBundleContext: runBundleContext, Mailbox: mailbox, DecisionCards: cards, DecisionAuthority: workflowStore,
+			Bundle: runtimecontracts.BundleIdentity{
+				WorkflowName: source.WorkflowName(), WorkflowVersion: source.WorkflowVersion(),
+				Fingerprint: fact.BundleFingerprint, BundleHash: fact.BundleHash,
+			},
+		}),
+	})
+	return handler, bus
+}
+
+func proposedEffectAPICard(t *testing.T, runID, entityID string, fact runtimecorrelation.BundleSourceFact, workflowVersion string) (decisioncard.Card, decisioncard.ProposedEffectContinuation) {
+	t.Helper()
+	now := time.Date(2026, 7, 14, 23, 0, 0, 0, time.UTC)
+	sourceEventID := uuid.NewString()
+	requestEventID := activityidentity.RequestEventID(activityidentity.Fact{
+		RunID: runID, SourceEventID: sourceEventID, EntityID: entityID,
+		NodeID: "activity-runtime", HandlerEventKey: "support.reply_drafted",
+		ActivityID: "send_support_reply", Tool: "provider_write", Attempt: 1,
+	})
+	input, err := canonicaljson.FromGo(map[string]any{"text": "Exact operator-approved content"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation := decisioncard.ProposedEffectContinuation{
+		CardID: decisioncard.ProposedEffectCardID(requestEventID, "support_reply"), RunID: runID,
+		RequestEventID: requestEventID, ActivityID: "send_support_reply", Tool: "provider_write",
+		BundleHash: fact.BundleHash, WorkflowVersion: workflowVersion, Input: input,
+		EffectClass:  runtimecontracts.ActivityEffectClassNonIdempotentWrite,
+		SuccessEvent: "send_support_reply.succeeded", FailureEvent: "send_support_reply.failed",
+		RevisionEvent: "send_support_reply.revision_requested", RejectedEvent: "send_support_reply.rejected",
+		RetryMaxAttempts: 1, ForkPolicy: runtimecontracts.ActivityForkRequireConfirmation,
+		EntityID: entityID, NodeID: "activity-runtime", FlowInstance: "root", HandlerEventKey: "support.reply_drafted",
+		SourceEventID: sourceEventID, SourceRunID: runID, SourceTaskID: "task-1",
+		State: decisioncard.ProposedEffectPending, CreatedAt: now, UpdatedAt: now,
+	}.Canonical()
+	effect, err := continuation.EffectValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation.EffectContentHash, err = canonicaljson.HashValue(effect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: requestEventID, ActivityID: continuation.ActivityID, Decision: "support_reply",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root", EntityID: entityID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := decisioncard.FreezeSnapshot("support_reply", "", map[string]any{"input": input.Interface()}, map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve"},
+		"revise":  {Verdict: "revise", Input: map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Required: true}}},
+		"reject":  {Verdict: "reject", Input: map[string]runtimecontracts.WorkflowGateInputField{"reason": {Type: "text"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	card, err := decisioncard.New(decisioncard.Card{
+		CardID: continuation.CardID, RunID: runID, Anchor: anchor, Snapshot: snapshot,
+		EffectContentHash: continuation.EffectContentHash, BundleHash: fact.BundleHash,
+		WorkflowVersion: workflowVersion, CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return card, continuation
+}
+
+func insertProposedEffectAPIRun(t *testing.T, db *sql.DB, backend, runID string) {
+	t.Helper()
+	query := `INSERT INTO runs (run_id, status, started_at) VALUES (?, 'running', ?)`
+	if backend == "postgres" {
+		query = `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`
+	}
+	if _, err := db.ExecContext(context.Background(), query, runID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertProposedEffectAPIExecutionRows(t *testing.T, db *sql.DB, backend, runID string) {
+	t.Helper()
+	query := `SELECT
+		(SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested'),
+		(SELECT COUNT(*) FROM activity_attempts WHERE run_id = ? AND status = 'succeeded')`
+	args := []any{runID, runID}
+	if backend == "postgres" {
+		query = `SELECT
+			(SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested'),
+			(SELECT COUNT(*) FROM activity_attempts WHERE run_id = $1::uuid AND status = 'succeeded')`
+		args = []any{runID}
+	}
+	var requests, attempts int
+	if err := db.QueryRowContext(context.Background(), query, args...).Scan(&requests, &attempts); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 || attempts != 1 {
+		t.Fatalf("approved effect execution rows = requests:%d attempts:%d, want 1/1", requests, attempts)
+	}
+}

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,6 +111,53 @@ func TestOperatorMailboxHandlersSupportedRPCPath(t *testing.T) {
 		resp := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"retired","method":"`+retired+`","params":{}}`)
 		if resp.Error == nil || resp.Error.Code != codeMethodNotFound {
 			t.Fatalf("%s error = %#v, want method not found", retired, resp.Error)
+		}
+	}
+}
+
+func TestOperatorMailboxProjectsProposedEffectAuthorizationAndDispatchSeparately(t *testing.T) {
+	state := newMutatingRuntimeProbeState(t, "mailbox.get")
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: "00000000-0000-0000-0000-000000000303", ActivityID: "send_support_reply", Decision: "support_reply",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root", EntityID: "entity-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.decisionCards.card.Anchor = anchor
+	state.decisionCards.card.Snapshot = mustTestDecisionSnapshot("support_reply", "Send support reply", map[string]any{"input": map[string]any{"text": "Exact reply"}}, map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve"}, "revise": {Verdict: "revise"}, "reject": {Verdict: "reject"},
+	})
+	state.decisionCards.card.EffectContentHash = "sha256:" + strings.Repeat("e", 64)
+	handler := testHandler(t, Options{AuthTokens: []string{testToken}, Handlers: OperatorReadHandlers(state.options(t))})
+
+	for _, method := range []string{"mailbox.list", "mailbox.get"} {
+		params := `{}`
+		if method == "mailbox.get" {
+			params = `{"mailbox_id":"card-1"}`
+		}
+		response := rpcCall(t, handler, `{"jsonrpc":"2.0","id":"proof","method":"`+method+`","params":`+params+`}`)
+		if response.Error != nil {
+			t.Fatalf("%s error = %#v", method, response.Error)
+		}
+		projection := asMap(t, response.Result)
+		if method == "mailbox.list" {
+			items := asSlice(t, projection["items"])
+			for _, item := range items {
+				candidate := asMap(t, item)
+				if candidate["kind"] == decisioncard.KindDecisionCard {
+					projection = candidate
+					break
+				}
+			}
+		}
+		card := asMap(t, projection["decision_card"])
+		effect := asMap(t, projection["effect"])
+		if card["status"] != decisioncard.StatusPending || card["anchor_kind"] != string(decisioncard.AnchorKindProposedEffect) {
+			t.Fatalf("%s authorization projection = %#v", method, card)
+		}
+		if effect["dispatch_state"] != "held" || effect["request_event_id"] != "00000000-0000-0000-0000-000000000303" || effect["activity_id"] != "send_support_reply" {
+			t.Fatalf("%s dispatch projection = %#v", method, effect)
 		}
 	}
 }

--- a/internal/apiv1/subscriptions.go
+++ b/internal/apiv1/subscriptions.go
@@ -355,7 +355,12 @@ func (r *SubscriptionRuntime) runDecisionCardSubscription(ctx context.Context, s
 			return false
 		}
 		for _, change := range changes {
-			if !session.notify(subscriptionID, change) {
+			notification, err := r.decisionCardChangeProjection(ctx, change)
+			if err != nil {
+				session.close()
+				return false
+			}
+			if !session.notify(subscriptionID, notification) {
 				return false
 			}
 			cursor = change.Sequence
@@ -377,6 +382,29 @@ func (r *SubscriptionRuntime) runDecisionCardSubscription(ctx context.Context, s
 			}
 		}
 	}
+}
+
+func (r *SubscriptionRuntime) decisionCardChangeProjection(ctx context.Context, change decisioncard.Change) (any, error) {
+	card, err := r.decisionCards.GetDecisionCard(ctx, change.CardID)
+	if err != nil {
+		return nil, err
+	}
+	if card.Anchor.Kind() != decisioncard.AnchorKindProposedEffect {
+		return change, nil
+	}
+	store, ok := r.decisionCards.(decisioncard.ProposedEffectStore)
+	if !ok || store == nil {
+		return nil, fmt.Errorf("proposed-effect subscription readback store is not configured")
+	}
+	effect, err := store.ProposedEffectReadback(ctx, change.CardID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"sequence": change.Sequence, "card_id": change.CardID, "run_id": change.RunID,
+		"change_type": change.ChangeType, "payload": change.Payload.Interface(), "created_at": change.CreatedAt,
+		"effect": effect,
+	}, nil
 }
 
 func (r *SubscriptionRuntime) emitEventNotifications(ctx context.Context, session *webSocketSession, subscriptionID string, reads ObservabilityReadStore, filter store.OperatorEventListFilter, since *time.Time, seen map[string]string) bool {

--- a/internal/runtime/activity_validation.go
+++ b/internal/runtime/activity_validation.go
@@ -55,7 +55,7 @@ func validateHandlerActivitySurface(source semanticview.Source, flowID, nodeID, 
 		if !handler.Emit.Empty() || !handler.OnSuccess.Empty() {
 			errs = append(errs, fmt.Errorf("%s activity: activity and authored emit/on_success emit are mutually exclusive in Stage 1; use generated activity result events", context))
 		}
-		errs = append(errs, validateActivitySpec(source, flowID, nodeID, handlerEventKey, context+".activity", handler.Activity)...)
+		errs = append(errs, validateActivitySpec(source, flowID, nodeID, handlerEventKey, "", -1, context+".activity", handler.Activity)...)
 	}
 	if hasRuleActivity {
 		if !handler.Activity.Empty() {
@@ -78,7 +78,7 @@ func validateHandlerActivitySurface(source semanticview.Source, flowID, nodeID, 
 			if !rule.Emit.Empty() || (rule.FanOut != nil && !rule.FanOut.Emit.Empty()) {
 				errs = append(errs, fmt.Errorf("%s activity: activity and authored emit/fan_out emit are mutually exclusive in Stage 1; use generated activity result events", ruleContext))
 			}
-			errs = append(errs, validateActivitySpec(source, flowID, nodeID, handlerEventKey, ruleContext+".activity", rule.Activity)...)
+			errs = append(errs, validateActivitySpec(source, flowID, nodeID, handlerEventKey, rule.ID, idx, ruleContext+".activity", rule.Activity)...)
 		}
 	}
 	errs = append(errs, rejectUnsupportedNestedActivityContexts(context, handler)...)
@@ -95,7 +95,7 @@ func rejectUnsupportedNestedActivityContexts(context string, handler runtimecont
 	return errs
 }
 
-func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEventKey, context string, activity runtimecontracts.ActivitySpec) []error {
+func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEventKey, ruleID string, ruleIndex int, context string, activity runtimecontracts.ActivitySpec) []error {
 	var errs []error
 	toolID := strings.TrimSpace(activity.Tool)
 	if toolID == "" {
@@ -152,6 +152,24 @@ func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEve
 	if len(tool.Credentials) > 0 && effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
 		errs = append(errs, fmt.Errorf("%s: tool %q uses static credentials; static credential activity HTTP execution is supported only for non_idempotent_write authored HTTP activities", context, toolID))
 	}
+	if activity.Approval != nil {
+		decision := strings.TrimSpace(activity.Approval.Decision)
+		if decision == "" || decision != activity.Approval.Decision {
+			errs = append(errs, fmt.Errorf("%s.approval.decision: a canonical stable decision id is required", context))
+		}
+		if effectClass == runtimecontracts.ActivityEffectClassReadOnly {
+			errs = append(errs, fmt.Errorf("%s.approval: read-only activities don't need approval - approvals guard outward effects", context))
+		} else if effectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+			errs = append(errs, fmt.Errorf("%s.approval: activity approval requires effect_class non_idempotent_write", context))
+		}
+		approvalSite := runtimecontracts.ActivitySite{
+			FlowID: flowID, NodeID: nodeID, HandlerEventKey: handlerEventKey, RuleID: ruleID, RuleIndex: ruleIndex, Spec: activity,
+		}
+		if !activityRevisionConsumerExists(source, approvalSite) {
+			events := runtimecontracts.ActivityResultEventsForSite(approvalSite)
+			errs = append(errs, fmt.Errorf("%s.approval: generated revision event %q has no consumer; add a handler so operator feedback cannot disappear", context, events.RevisionRequested))
+		}
+	}
 	errs = append(errs, validateActivityInputAgainstToolSchema(context, activity, tool.InputSchema)...)
 	site := runtimecontracts.ActivitySite{
 		FlowID:          flowID,
@@ -164,6 +182,25 @@ func validateActivitySpec(source semanticview.Source, flowID, nodeID, handlerEve
 		errs = append(errs, fmt.Errorf("%s: generated result event names could not be derived", context))
 	}
 	return errs
+}
+
+func activityRevisionConsumerExists(source semanticview.Source, site runtimecontracts.ActivitySite) bool {
+	if source == nil || site.Spec.Approval == nil {
+		return false
+	}
+	want := eventidentity.Normalize(runtimecontracts.ActivityResultEventsForSite(site).RevisionRequested)
+	for nodeID := range source.NodeEntries() {
+		consumerFlow := ""
+		if info, ok := source.NodeContractSource(nodeID); ok {
+			consumerFlow = strings.TrimSpace(info.FlowID)
+		}
+		for subscribed := range source.NodeEventHandlers(nodeID) {
+			if eventidentity.Normalize(source.ResolveFlowEventReference(consumerFlow, subscribed)) == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func validateActivityResultEventNameCollisions(source semanticview.Source) []error {
@@ -205,7 +242,11 @@ func validateActivityResultEventNameCollisions(source semanticview.Source) []err
 		for _, site := range runtimecontracts.ActivitySitesForNode(flowID, nodeID, source.NodeEventHandlers(nodeID)) {
 			context := activitySiteContext(site)
 			resultEvents := runtimecontracts.ActivityResultEventsForSite(site)
-			for _, eventType := range []string{resultEvents.SuccessEvent, resultEvents.FailureEvent} {
+			eventTypes := []string{resultEvents.SuccessEvent, resultEvents.FailureEvent}
+			if site.Spec.Approval != nil {
+				eventTypes = append(eventTypes, resultEvents.RevisionRequested, resultEvents.Rejected)
+			}
+			for _, eventType := range eventTypes {
 				normalized := eventidentity.Normalize(eventType)
 				if normalized == "" {
 					continue

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -20,6 +20,7 @@ type View struct {
 	SourceAuthority string              `json:"source_authority"`
 	Root            RootView            `json:"root"`
 	Flows           []FlowView          `json:"flows"`
+	ApprovalPoints  []ApprovalPointView `json:"approval_points,omitempty"`
 	StageGraphs     []StageGraphView    `json:"stage_graphs,omitempty"`
 	RoutingTopology RoutingTopologyView `json:"routing_topology"`
 	Diagnostics     []DiagnosticView    `json:"diagnostics,omitempty"`
@@ -181,6 +182,17 @@ type StageGraphFanOutView struct {
 	EventType string   `json:"event_type,omitempty"`
 }
 
+type ApprovalPointView struct {
+	FlowID       string `json:"flow_id,omitempty"`
+	NodeID       string `json:"node_id"`
+	HandlerEvent string `json:"handler_event"`
+	Source       string `json:"source"`
+	ActivityID   string `json:"activity_id"`
+	Tool         string `json:"tool"`
+	Decision     string `json:"decision"`
+	EffectClass  string `json:"effect_class"`
+}
+
 type RequiredAgentsView struct {
 	Source     string              `json:"source"`
 	SourceFile string              `json:"source_file,omitempty"`
@@ -303,6 +315,7 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		SourceAuthority: "projection_only_existing_contract_owners",
 		Root:            buildRoot(bundle),
 		Flows:           buildFlows(source, bundle),
+		ApprovalPoints:  buildApprovalPoints(bundle),
 		RoutingTopology: BuildRoutingTopologyWithReport(source, bundle, opts.BootReport),
 		Diagnostics:     buildDiagnostics(bundle, opts.BootReport),
 		Equivalence: EquivalenceView{
@@ -323,6 +336,31 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		view.StageGraphs = buildStageGraphs(source, bundle)
 	}
 	return view, nil
+}
+
+func buildApprovalPoints(bundle *runtimecontracts.WorkflowContractBundle) []ApprovalPointView {
+	if bundle == nil {
+		return nil
+	}
+	var out []ApprovalPointView
+	for _, site := range bundle.ActivitySites() {
+		if site.Spec.Approval == nil {
+			continue
+		}
+		result := runtimecontracts.ActivityResultEventsForSite(site)
+		tool := bundle.ToolEntries()[strings.TrimSpace(site.Spec.Tool)]
+		out = append(out, ApprovalPointView{
+			FlowID:       strings.TrimSpace(site.FlowID),
+			NodeID:       strings.TrimSpace(site.NodeID),
+			HandlerEvent: strings.TrimSpace(site.HandlerEventKey),
+			Source:       strings.TrimSpace(site.Source),
+			ActivityID:   result.ActivityID,
+			Tool:         strings.TrimSpace(site.Spec.Tool),
+			Decision:     strings.TrimSpace(site.Spec.Approval.Decision),
+			EffectClass:  strings.TrimSpace(tool.EffectClass),
+		})
+	}
+	return out
 }
 
 func BuildRoutingTopology(source semanticview.Source) RoutingTopologyView {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -63,6 +63,46 @@ func TestBuildIncludesHarnessInputSource(t *testing.T) {
 	}
 }
 
+func TestBuildShowsApprovedOutwardEffectAsCanonicalApprovalPoint(t *testing.T) {
+	handler := runtimecontracts.SystemNodeEventHandler{Activity: runtimecontracts.ActivitySpec{
+		ID: "send_support_reply", Tool: "telegram_send",
+		Approval: &runtimecontracts.ActivityApprovalSpec{Decision: "support_reply"},
+	}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"support": {
+				ID:            "support",
+				ExecutionType: runtimecontracts.SystemNodeExecutionType,
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"support.reply_drafted": handler},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"support": {"support.reply_drafted": handler},
+			},
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				"support": {ID: "support", ExecutionType: runtimecontracts.SystemNodeExecutionType},
+			},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"telegram_send": {HandlerType: "http", EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite)},
+		},
+	}
+	view, err := Build(context.Background(), semanticview.Wrap(bundle), BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(view.ApprovalPoints) != 1 {
+		t.Fatalf("approval points = %#v, want one", view.ApprovalPoints)
+	}
+	got := view.ApprovalPoints[0]
+	if got.NodeID != "support" || got.HandlerEvent != "support.reply_drafted" || got.Source != "handler.activity" ||
+		got.ActivityID != "send_support_reply" || got.Tool != "telegram_send" || got.Decision != "support_reply" ||
+		got.EffectClass != string(runtimecontracts.ActivityEffectClassNonIdempotentWrite) {
+		t.Fatalf("approval point = %#v", got)
+	}
+}
+
 func TestBuildStageGraphShowsFanInBarrierEffectiveJoinProvenance(t *testing.T) {
 	repoRoot := canonicalrouting.RepoRoot(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -194,7 +194,11 @@ func generatedActivityResultEventNamesLocal(source semanticview.Source) map[stri
 		}
 		for _, site := range runtimecontracts.ActivitySitesForNode(flowID, nodeID, source.NodeEventHandlers(nodeID)) {
 			results := runtimecontracts.ActivityResultEventsForSite(site)
-			for _, eventType := range []string{results.SuccessEvent, results.FailureEvent} {
+			eventTypes := []string{results.SuccessEvent, results.FailureEvent}
+			if site.Spec.Approval != nil {
+				eventTypes = append(eventTypes, results.RevisionRequested, results.Rejected)
+			}
+			for _, eventType := range eventTypes {
 				if normalized := eventidentity.Normalize(eventType); normalized != "" {
 					out[normalized] = struct{}{}
 				}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -526,6 +526,7 @@ seam_families:
       - internal/runtime/pipeline/coordinator.go
       - internal/runtime/pipeline/runtime_support.go
       - internal/runtime/pipeline/workflow_conformance_test.go
+      - internal/runtime/pipeline/workflow_gate_recovery_external_test.go
       - internal/runtime/pipeline/workflow_handler_preview.go
       - internal/store/run_fork_selected_contract_route_recovery_test.go
       - internal/store/sqlite_runtime_test.go

--- a/internal/runtime/contracts/loader_diagnostics.go
+++ b/internal/runtime/contracts/loader_diagnostics.go
@@ -365,6 +365,8 @@ func loaderFieldOptionsForContext(context string) map[string]struct{} {
 		return onSuccessFieldOptions
 	case "activity":
 		return activityFieldOptions
+	case "activity.approval":
+		return activityApprovalFieldOptions
 	case "emit.target":
 		return emitTargetFieldOptions
 	case "mailbox":

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -143,12 +143,15 @@ func TestPlatformEventCatalogSchemasValidateCurrentProducerPayloadShapes(t *test
 			eventType: "platform.activity_requested",
 			payload: map[string]any{
 				"activity_id": "telegram_send_message", "tool": "telegram.send_message",
+				"bundle_hash": "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "workflow_version": "1",
 				"input":        map[string]any{"chat_id": float64(42), "text": "hello"},
 				"effect_class": "non_idempotent_write", "success_event": "telegram-chat.telegram_send_message.succeeded",
-				"failure_event": "telegram-chat.telegram_send_message.failed", "retry_max_attempts": 1,
+				"failure_event":  "telegram-chat.telegram_send_message.failed",
+				"revision_event": "telegram-chat.telegram_send_message.revision_requested",
+				"rejected_event": "telegram-chat.telegram_send_message.rejected", "retry_max_attempts": 1,
 				"retry_backoff": "none", "fork_policy": "reuse_recorded_result",
 				"entity_id": "00000000-0000-0000-0000-000000000127", "node_id": "telegram-responder",
-				"flow_id": "telegram-chat", "handler_event_key": "inbound.telegram",
+				"flow_id": "telegram-chat", "flow_instance": "telegram-chat/instance-1", "handler_event_key": "inbound.telegram",
 				"source_event_id": "00000000-0000-0000-0000-000000000128",
 				"source_run_id":   "00000000-0000-0000-0000-000000000129", "source_task_id": "",
 				"parent_event_id": "00000000-0000-0000-0000-000000000128", "chain_depth": 1,
@@ -221,6 +224,17 @@ func TestPlatformEventCatalogSchemasValidateCurrentProducerPayloadShapes(t *test
 			}
 			if err := eventschema.ValidatePayloadAgainstSchema(schema.Schema, tc.payload); err != nil {
 				t.Fatalf("generated %s schema rejected producer payload %#v: %v", tc.eventType, tc.payload, err)
+			}
+			if tc.eventType == "platform.activity_requested" {
+				immediate := make(map[string]any, len(tc.payload)-2)
+				for name, value := range tc.payload {
+					if name != "bundle_hash" && name != "workflow_version" {
+						immediate[name] = value
+					}
+				}
+				if err := eventschema.ValidatePayloadAgainstSchema(schema.Schema, immediate); err != nil {
+					t.Fatalf("generated %s schema rejected immediate unpinned producer payload %#v: %v", tc.eventType, immediate, err)
+				}
 			}
 		})
 	}

--- a/internal/runtime/contracts/workflow_contract_activity.go
+++ b/internal/runtime/contracts/workflow_contract_activity.go
@@ -27,9 +27,11 @@ type ActivitySite struct {
 }
 
 type ActivityResultEvents struct {
-	ActivityID   string
-	SuccessEvent string
-	FailureEvent string
+	ActivityID        string
+	SuccessEvent      string
+	FailureEvent      string
+	RevisionRequested string
+	Rejected          string
 }
 
 type ActivityRetryDefaults struct {
@@ -132,9 +134,47 @@ func ActivityResultEventsForSite(site ActivitySite) ActivityResultEvents {
 	}
 	base = eventidentity.Normalize(base)
 	return ActivityResultEvents{
-		ActivityID:   activityID,
-		SuccessEvent: eventidentity.Normalize(base + "." + ActivityResultStatusSucceeded),
-		FailureEvent: eventidentity.Normalize(base + "." + ActivityResultStatusFailed),
+		ActivityID:        activityID,
+		SuccessEvent:      eventidentity.Normalize(base + "." + ActivityResultStatusSucceeded),
+		FailureEvent:      eventidentity.Normalize(base + "." + ActivityResultStatusFailed),
+		RevisionRequested: eventidentity.Normalize(base + ".revision_requested"),
+		Rejected:          eventidentity.Normalize(base + ".rejected"),
+	}
+}
+
+func ActivityApprovalEventCatalogEntry(site ActivitySite, revision bool) EventCatalogEntry {
+	note := "Generated durable activity approval rejection event"
+	required := []string{"card_id", "activity_id", "tool", "effect_class", "effect_content_hash", "decided_by", "decided_at"}
+	properties := map[string]EventFieldSpec{
+		"card_id":             {Type: "string", Description: "Decision-card identity that settled the proposed effect."},
+		"activity_id":         {Type: "string", Description: "Generated durable activity id."},
+		"tool":                {Type: "string", Description: "Authored tools.yaml tool id held by the proposal."},
+		"effect_class":        {Type: "string", Description: "Authored durable activity effect class."},
+		"effect_content_hash": {Type: "string", Description: "Canonical immutable proposed-effect digest."},
+		"decided_by":          {Type: "string", Description: "Authenticated actor that settled the card."},
+		"decided_at":          {Type: "string", Description: "Canonical decision timestamp."},
+		"reason":              {Type: "text", Description: "Optional operator rejection reason."},
+	}
+	if revision {
+		note = "Generated durable activity revision-request event"
+		required = append(required, "feedback")
+		properties = map[string]EventFieldSpec{
+			"card_id":             {Type: "string", Description: "Decision-card identity that settled the proposed effect."},
+			"activity_id":         {Type: "string", Description: "Generated durable activity id."},
+			"tool":                {Type: "string", Description: "Authored tools.yaml tool id held by the proposal."},
+			"effect_class":        {Type: "string", Description: "Authored durable activity effect class."},
+			"effect_content_hash": {Type: "string", Description: "Canonical immutable proposed-effect digest."},
+			"decided_by":          {Type: "string", Description: "Authenticated actor that settled the card."},
+			"decided_at":          {Type: "string", Description: "Canonical decision timestamp."},
+			"feedback":            {Type: "text", Description: "Required operator revision feedback."},
+		}
+	}
+	return EventCatalogEntry{
+		Swarm: EventSwarmMetadata{Note: note, Source: "contract_derived_activity_approval", Producer: []string{strings.TrimSpace(site.NodeID)}, Status: "generated"},
+		Note:  note, Emitter: EventEmitterRef{NodeID: strings.TrimSpace(site.NodeID)}, EmitterType: "system_node",
+		Producer: []string{strings.TrimSpace(site.NodeID)}, Source: "contract_derived_activity_approval", Status: "generated",
+		OwningNode: strings.TrimSpace(site.NodeID), Payload: EventPayloadSpec{Type: "object", Properties: properties, Required: required}, Required: required,
+		Consumer: []string{},
 	}
 }
 
@@ -286,6 +326,10 @@ func (b *WorkflowContractBundle) GeneratedActivityEventEntries() map[string]Even
 		events := ActivityResultEventsForSite(site)
 		out[events.SuccessEvent] = ActivityResultEventCatalogEntry(site, tool, ActivityResultStatusSucceeded)
 		out[events.FailureEvent] = ActivityResultEventCatalogEntry(site, tool, ActivityResultStatusFailed)
+		if site.Spec.Approval != nil {
+			out[events.RevisionRequested] = ActivityApprovalEventCatalogEntry(site, true)
+			out[events.Rejected] = ActivityApprovalEventCatalogEntry(site, false)
+		}
 	}
 	return out
 }
@@ -303,8 +347,45 @@ func (b *WorkflowContractBundle) GeneratedActivityEventSchemas() map[string]Even
 		for eventType, schema := range ActivityResultEventSchemasForSite(site, tool) {
 			out[eventType] = schema
 		}
+		if site.Spec.Approval != nil {
+			events := ActivityResultEventsForSite(site)
+			out[events.RevisionRequested] = activityApprovalEventSchema(true)
+			out[events.Rejected] = activityApprovalEventSchema(false)
+		}
 	}
 	return out
+}
+
+func activityApprovalEventSchema(revision bool) EventSchema {
+	description := "Generated durable activity approval rejection event"
+	required := []string{"card_id", "activity_id", "tool", "effect_class", "effect_content_hash", "decided_by", "decided_at"}
+	properties := map[string]any{
+		"card_id":             map[string]any{"type": "string"},
+		"activity_id":         map[string]any{"type": "string"},
+		"tool":                map[string]any{"type": "string"},
+		"effect_class":        map[string]any{"type": "string"},
+		"effect_content_hash": map[string]any{"type": "string"},
+		"decided_by":          map[string]any{"type": "string"},
+		"decided_at":          map[string]any{"type": "string"},
+		"reason":              map[string]any{"type": "string"},
+	}
+	if revision {
+		description = "Generated durable activity revision-request event"
+		required = append(required, "feedback")
+		properties = map[string]any{
+			"card_id":             map[string]any{"type": "string"},
+			"activity_id":         map[string]any{"type": "string"},
+			"tool":                map[string]any{"type": "string"},
+			"effect_class":        map[string]any{"type": "string"},
+			"effect_content_hash": map[string]any{"type": "string"},
+			"decided_by":          map[string]any{"type": "string"},
+			"decided_at":          map[string]any{"type": "string"},
+			"feedback":            map[string]any{"type": "string"},
+		}
+	}
+	return EventSchema{Description: description, Schema: map[string]any{
+		"type": "object", "additionalProperties": false, "required": required, "properties": properties,
+	}}
 }
 
 func (b *WorkflowContractBundle) ActivitySites() []ActivitySite {
@@ -357,6 +438,9 @@ func (b *WorkflowContractBundle) generatedActivityEventsForNode(nodeID string) [
 		}
 		events := ActivityResultEventsForSite(site)
 		out = append(out, events.SuccessEvent, events.FailureEvent)
+		if site.Spec.Approval != nil {
+			out = append(out, events.RevisionRequested, events.Rejected)
+		}
 	}
 	return uniqueOrderedStrings(out)
 }

--- a/internal/runtime/contracts/workflow_contract_activity_test.go
+++ b/internal/runtime/contracts/workflow_contract_activity_test.go
@@ -1,6 +1,39 @@
 package contracts
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestActivityApprovalYAMLIsStrictAndCanonical(t *testing.T) {
+	var valid ActivitySpec
+	if err := yaml.Unmarshal([]byte("tool: provider.write\napproval: {decision: support_reply}\n"), &valid); err != nil {
+		t.Fatal(err)
+	}
+	if valid.Approval == nil || valid.Approval.Decision != "support_reply" {
+		t.Fatalf("approval = %#v", valid.Approval)
+	}
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "scalar", yaml: "tool: provider.write\napproval: support_reply\n", want: "must be a mapping"},
+		{name: "missing decision", yaml: "tool: provider.write\napproval: {}\n", want: "approval.decision is required"},
+		{name: "unknown field", yaml: "tool: provider.write\napproval: {decision: support_reply, mode: once}\n", want: "mode"},
+		{name: "noncanonical decision", yaml: "tool: provider.write\napproval: {decision: ' support_reply '}\n", want: "is not canonical"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ActivitySpec
+			err := yaml.Unmarshal([]byte(tc.yaml), &got)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Unmarshal error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
 
 func TestActivityResultEventsMaterializeIntoCatalogSchemaAndProduces(t *testing.T) {
 	bundle := &WorkflowContractBundle{

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -468,13 +468,18 @@ const (
 )
 
 type ActivitySpec struct {
-	ID    string                     `yaml:"id,omitempty"`
-	Tool  string                     `yaml:"tool"`
-	Input map[string]ExpressionValue `yaml:"input"`
+	ID       string                     `yaml:"id,omitempty"`
+	Tool     string                     `yaml:"tool"`
+	Input    map[string]ExpressionValue `yaml:"input"`
+	Approval *ActivityApprovalSpec      `yaml:"approval,omitempty"`
 }
 
 func (a ActivitySpec) Empty() bool {
-	return strings.TrimSpace(a.ID) == "" && strings.TrimSpace(a.Tool) == "" && len(a.Input) == 0
+	return strings.TrimSpace(a.ID) == "" && strings.TrimSpace(a.Tool) == "" && len(a.Input) == 0 && a.Approval == nil
+}
+
+type ActivityApprovalSpec struct {
+	Decision string `yaml:"decision"`
 }
 
 func NormalizeActivityEffectClass(raw string) ActivityEffectClass {

--- a/internal/runtime/contracts/workflow_contract_yaml_handlers.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_handlers.go
@@ -229,9 +229,14 @@ var onSuccessFieldOptions = map[string]struct{}{
 }
 
 var activityFieldOptions = map[string]struct{}{
-	"id":    {},
-	"tool":  {},
-	"input": {},
+	"id":       {},
+	"tool":     {},
+	"input":    {},
+	"approval": {},
+}
+
+var activityApprovalFieldOptions = map[string]struct{}{
+	"decision": {},
 }
 
 var emitTargetFieldOptions = map[string]struct{}{
@@ -376,12 +381,50 @@ func (a *ActivitySpec) UnmarshalYAML(node *yaml.Node) error {
 				return err
 			}
 			out.Input = input
+		case "approval":
+			approval, err := decodeActivityApprovalNode(value)
+			if err != nil {
+				return err
+			}
+			out.Approval = approval
 		}
 	}
 	out.ID = strings.TrimSpace(out.ID)
 	out.Tool = strings.TrimSpace(out.Tool)
 	*a = out
 	return nil
+}
+
+func decodeActivityApprovalNode(node *yaml.Node) (*ActivityApprovalSpec, error) {
+	if node == nil || node.Kind == 0 || strings.EqualFold(strings.TrimSpace(node.Tag), "!!null") {
+		return nil, fmt.Errorf("INVALID-ACTIVITY-APPROVAL: activity.approval must be a mapping with decision")
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("INVALID-ACTIVITY-APPROVAL: activity.approval must be a mapping with decision")
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		if _, ok := activityApprovalFieldOptions[key]; !ok {
+			return nil, NewUndefinedFieldDiagnostic("activity.approval", key, activityApprovalFieldOptions)
+		}
+	}
+	var out ActivityApprovalSpec
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if strings.TrimSpace(node.Content[i].Value) == "decision" {
+			if err := node.Content[i+1].Decode(&out.Decision); err != nil {
+				return nil, err
+			}
+		}
+	}
+	rawDecision := out.Decision
+	out.Decision = strings.TrimSpace(rawDecision)
+	if out.Decision == "" {
+		return nil, fmt.Errorf("INVALID-ACTIVITY-APPROVAL: activity.approval.decision is required; use the activity id when it is the intended stable approval class")
+	}
+	if rawDecision != out.Decision {
+		return nil, fmt.Errorf("INVALID-ACTIVITY-APPROVAL: activity.approval.decision %q is not canonical; use %q", rawDecision, out.Decision)
+	}
+	return &out, nil
 }
 
 func decodeActivityInputNode(node *yaml.Node) (map[string]ExpressionValue, error) {

--- a/internal/runtime/decisioncard/anchor.go
+++ b/internal/runtime/decisioncard/anchor.go
@@ -11,8 +11,9 @@ import (
 type AnchorKind string
 
 const (
-	AnchorKindStageGate AnchorKind = "stage_gate"
-	AnchorKindHumanTask AnchorKind = "human_task"
+	AnchorKindStageGate      AnchorKind = "stage_gate"
+	AnchorKindHumanTask      AnchorKind = "human_task"
+	AnchorKindProposedEffect AnchorKind = "proposed_effect"
 )
 
 type ScopeKind string
@@ -64,6 +65,40 @@ type HumanTaskAnchor struct {
 	OperationID      string
 	Category         string
 	Scope            Scope
+}
+
+type ProposedEffectAnchor struct {
+	RequestEventID string
+	ActivityID     string
+	Decision       string
+	Scope          Scope
+}
+
+func RegisteredAnchorKinds() []AnchorKind {
+	return []AnchorKind{AnchorKindStageGate, AnchorKindHumanTask, AnchorKindProposedEffect}
+}
+
+func RegisteredAnchorKindNames() []string {
+	kinds := RegisteredAnchorKinds()
+	out := make([]string, len(kinds))
+	for i, kind := range kinds {
+		out[i] = string(kind)
+	}
+	return out
+}
+
+func RegisteredAnchorKindDescription() string {
+	return strings.Join(RegisteredAnchorKindNames(), ", ")
+}
+
+func IsRegisteredAnchorKind(value string) bool {
+	candidate := AnchorKind(strings.TrimSpace(value))
+	for _, kind := range RegisteredAnchorKinds() {
+		if candidate == kind {
+			return true
+		}
+	}
+	return false
 }
 
 // Anchor is the closed decision-card identity union. Its semantic payload is
@@ -131,6 +166,28 @@ func NewHumanTaskAnchor(in HumanTaskAnchor) (Anchor, error) {
 	return Anchor{kind: AnchorKindHumanTask, data: data}, nil
 }
 
+func NewProposedEffectAnchor(in ProposedEffectAnchor) (Anchor, error) {
+	in.RequestEventID = strings.TrimSpace(in.RequestEventID)
+	in.ActivityID = strings.TrimSpace(in.ActivityID)
+	in.Decision = strings.TrimSpace(in.Decision)
+	if in.RequestEventID == "" || in.ActivityID == "" || in.Decision == "" {
+		return Anchor{}, fmt.Errorf("proposed_effect anchor request_event_id, activity_id, and decision are required")
+	}
+	if err := in.Scope.Validate(); err != nil {
+		return Anchor{}, err
+	}
+	data, err := canonicaljson.FromGo(map[string]any{
+		"request_event_id": in.RequestEventID,
+		"activity_id":      in.ActivityID,
+		"decision":         in.Decision,
+		"scope":            in.Scope,
+	})
+	if err != nil {
+		return Anchor{}, fmt.Errorf("admit proposed_effect anchor: %w", err)
+	}
+	return Anchor{kind: AnchorKindProposedEffect, data: data}, nil
+}
+
 func DecodeAnchor(kind string, raw []byte) (Anchor, error) {
 	value, err := canonicaljson.Decode(raw)
 	if err != nil {
@@ -155,6 +212,9 @@ func (a Anchor) Validate() error {
 	case AnchorKindHumanTask:
 		_, err := a.HumanTask()
 		return err
+	case AnchorKindProposedEffect:
+		_, err := a.ProposedEffect()
+		return err
 	default:
 		return fmt.Errorf("decision-card anchor kind %q is not registered", a.kind)
 	}
@@ -174,9 +234,54 @@ func (a Anchor) Scope() (Scope, error) {
 			return Scope{}, err
 		}
 		return task.Scope, nil
+	case AnchorKindProposedEffect:
+		effect, err := a.ProposedEffect()
+		if err != nil {
+			return Scope{}, err
+		}
+		return effect.Scope, nil
 	default:
 		return Scope{}, fmt.Errorf("decision-card anchor kind %q is not registered", a.kind)
 	}
+}
+
+func (a Anchor) ProposedEffect() (ProposedEffectAnchor, error) {
+	if a.kind != AnchorKindProposedEffect {
+		return ProposedEffectAnchor{}, fmt.Errorf("decision-card anchor %q is not proposed_effect", a.kind)
+	}
+	values, ok := a.data.ObjectMap()
+	if !ok {
+		return ProposedEffectAnchor{}, fmt.Errorf("proposed_effect anchor must be an object")
+	}
+	if err := exactAnchorFields(values, "proposed_effect", []string{"request_event_id", "activity_id", "decision", "scope"}, nil); err != nil {
+		return ProposedEffectAnchor{}, err
+	}
+	scopeValue, ok := values["scope"]
+	if !ok {
+		return ProposedEffectAnchor{}, fmt.Errorf("proposed_effect anchor scope is required")
+	}
+	scopeMap, ok := scopeValue.ObjectMap()
+	if !ok {
+		return ProposedEffectAnchor{}, fmt.Errorf("proposed_effect anchor scope must be an object")
+	}
+	if err := exactAnchorFields(scopeMap, "proposed_effect scope", []string{"kind"}, []string{"flow_instance", "entity_id"}); err != nil {
+		return ProposedEffectAnchor{}, err
+	}
+	out := ProposedEffectAnchor{
+		RequestEventID: requiredAnchorString(values, "request_event_id"),
+		ActivityID:     requiredAnchorString(values, "activity_id"),
+		Decision:       requiredAnchorString(values, "decision"),
+		Scope: Scope{
+			Kind: ScopeKind(requiredAnchorString(scopeMap, "kind")), FlowInstance: optionalAnchorString(scopeMap, "flow_instance"), EntityID: optionalAnchorString(scopeMap, "entity_id"),
+		},
+	}
+	if out.RequestEventID == "" || out.ActivityID == "" || out.Decision == "" {
+		return ProposedEffectAnchor{}, fmt.Errorf("proposed_effect anchor contains an empty required identity")
+	}
+	if err := out.Scope.Validate(); err != nil {
+		return ProposedEffectAnchor{}, err
+	}
+	return out, nil
 }
 
 func (a Anchor) StageGate() (StageGateAnchor, error) {

--- a/internal/runtime/decisioncard/frozen.go
+++ b/internal/runtime/decisioncard/frozen.go
@@ -2,42 +2,16 @@ package decisioncard
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 )
 
-// FrozenExpression is the decision-card-owned form of an authored expression.
-// Literal values are admitted once when the card is materialized.
-type FrozenExpression struct {
-	Kind    runtimecontracts.ExpressionKind
-	Literal semanticvalue.Value
-	Ref     string
-	CEL     string
-}
-
-func (e FrozenExpression) HasLiteralValue() bool {
-	return e.Kind == runtimecontracts.ExpressionKindLiteral
-}
-
-type FrozenEmit struct {
-	Event  string
-	Fields map[string]FrozenExpression
-}
-
-func (e FrozenEmit) Empty() bool {
-	return strings.TrimSpace(e.Event) == "" && len(e.Fields) == 0
-}
-
 type FrozenOutcome struct {
-	Verdict    string
-	Label      string
-	Input      map[string]runtimecontracts.WorkflowGateInputField
-	AdvancesTo string
-	Emit       FrozenEmit
-	EmitSchema semanticvalue.Value
+	Verdict string
+	Label   string
+	Input   map[string]runtimecontracts.WorkflowGateInputField
 }
 
 func FreezeSnapshot(decision, title string, context map[string]any, outcomes map[string]runtimecontracts.WorkflowGateOutcomePlan) (Snapshot, error) {
@@ -53,32 +27,7 @@ func FreezeSnapshot(decision, title string, context map[string]any, outcomes map
 	}
 	frozen := make(map[string]FrozenOutcome, len(outcomes))
 	for verdict, outcome := range outcomes {
-		item := FrozenOutcome{
-			Verdict: outcome.Verdict, Label: outcome.Label, Input: cloneGateInputs(outcome.Input),
-			AdvancesTo: outcome.AdvancesTo,
-			Emit:       FrozenEmit{Event: outcome.Emit.Event, Fields: make(map[string]FrozenExpression, len(outcome.Emit.Fields))},
-			EmitSchema: semanticvalue.EmptyObject(),
-		}
-		for field, expression := range outcome.Emit.Fields {
-			frozenExpression := FrozenExpression{Kind: expression.Kind, Ref: expression.Ref, CEL: expression.CEL}
-			if expression.HasLiteralValue() {
-				frozenExpression.Literal, err = canonicaljson.FromGo(expression.Literal)
-				if err != nil {
-					return Snapshot{}, fmt.Errorf("admit decision card outcome %s literal %s: %w", verdict, field, err)
-				}
-			}
-			item.Emit.Fields[field] = frozenExpression
-		}
-		if len(outcome.EmitSchema) > 0 {
-			item.EmitSchema, err = canonicaljson.FromGo(outcome.EmitSchema)
-			if err != nil {
-				return Snapshot{}, fmt.Errorf("admit decision card outcome %s schema: %w", verdict, err)
-			}
-			if item.EmitSchema.Kind() != semanticvalue.KindObject {
-				return Snapshot{}, fmt.Errorf("decision card outcome %s schema must be an object", verdict)
-			}
-		}
-		frozen[verdict] = item
+		frozen[verdict] = FrozenOutcome{Verdict: outcome.Verdict, Label: outcome.Label, Input: cloneGateInputs(outcome.Input)}
 	}
 	return Snapshot{Decision: decision, Title: title, Context: contextValue, Outcomes: frozen}, nil
 }
@@ -126,37 +75,9 @@ func (o FrozenOutcome) semanticValue() (semanticvalue.Value, error) {
 	if err != nil {
 		return semanticvalue.Value{}, err
 	}
-	expressions := make(map[string]semanticvalue.Value, len(o.Emit.Fields))
-	for name, expression := range o.Emit.Fields {
-		fields := map[string]semanticvalue.Value{}
-		if expression.HasLiteralValue() {
-			fields["Literal"] = expression.Literal
-		} else {
-			fields["Literal"] = semanticvalue.Null()
-		}
-		encoded, err := semanticObjectWithText(
-			map[string]string{"Kind": string(expression.Kind), "Ref": expression.Ref, "CEL": expression.CEL},
-			fields,
-		)
-		if err != nil {
-			return semanticvalue.Value{}, fmt.Errorf("encode emit field %s: %w", name, err)
-		}
-		expressions[name] = encoded
-	}
-	expressionValue, err := semanticvalue.ObjectFromMap(expressions)
-	if err != nil {
-		return semanticvalue.Value{}, err
-	}
-	emit, err := semanticObjectWithText(
-		map[string]string{"Event": o.Emit.Event},
-		map[string]semanticvalue.Value{"Fields": expressionValue},
-	)
-	if err != nil {
-		return semanticvalue.Value{}, err
-	}
 	return semanticObjectWithText(
-		map[string]string{"Verdict": o.Verdict, "Label": o.Label, "AdvancesTo": o.AdvancesTo},
-		map[string]semanticvalue.Value{"Input": inputValue, "Emit": emit, "EmitSchema": o.EmitSchema},
+		map[string]string{"Verdict": o.Verdict, "Label": o.Label},
+		map[string]semanticvalue.Value{"Input": inputValue},
 	)
 }
 
@@ -227,7 +148,7 @@ func frozenOutcomeFromSemanticValue(value semanticvalue.Value) (FrozenOutcome, e
 	if !ok {
 		return FrozenOutcome{}, fmt.Errorf("outcome must be an object")
 	}
-	if err := requireExactSemanticFields(root, "outcome", "Verdict", "Label", "Input", "AdvancesTo", "Emit", "EmitSchema"); err != nil {
+	if err := requireExactSemanticFields(root, "outcome", "Verdict", "Label", "Input"); err != nil {
 		return FrozenOutcome{}, err
 	}
 	verdict, err := requiredSemanticString(root, "Verdict")
@@ -235,10 +156,6 @@ func frozenOutcomeFromSemanticValue(value semanticvalue.Value) (FrozenOutcome, e
 		return FrozenOutcome{}, err
 	}
 	label, err := requiredSemanticString(root, "Label")
-	if err != nil {
-		return FrozenOutcome{}, err
-	}
-	advancesTo, err := requiredSemanticString(root, "AdvancesTo")
 	if err != nil {
 		return FrozenOutcome{}, err
 	}
@@ -273,68 +190,7 @@ func frozenOutcomeFromSemanticValue(value semanticvalue.Value) (FrozenOutcome, e
 		}
 		inputs[name] = runtimecontracts.WorkflowGateInputField{Type: kind, Required: required, Label: label}
 	}
-	emitValue, ok := root["Emit"]
-	if !ok {
-		return FrozenOutcome{}, fmt.Errorf("outcome emit is required")
-	}
-	emitFields, ok := emitValue.ObjectMap()
-	if !ok {
-		return FrozenOutcome{}, fmt.Errorf("outcome emit must be an object")
-	}
-	if err := requireExactSemanticFields(emitFields, "outcome emit", "Event", "Fields"); err != nil {
-		return FrozenOutcome{}, err
-	}
-	event, err := requiredSemanticString(emitFields, "Event")
-	if err != nil {
-		return FrozenOutcome{}, err
-	}
-	expressionContainer, ok := emitFields["Fields"]
-	if !ok {
-		return FrozenOutcome{}, fmt.Errorf("outcome emit fields are required")
-	}
-	expressionMembers, ok := expressionContainer.ObjectMap()
-	if !ok {
-		return FrozenOutcome{}, fmt.Errorf("outcome emit fields must be an object")
-	}
-	expressions := make(map[string]FrozenExpression, len(expressionMembers))
-	for name, encoded := range expressionMembers {
-		fields, ok := encoded.ObjectMap()
-		if !ok {
-			return FrozenOutcome{}, fmt.Errorf("emit field %s must be an object", name)
-		}
-		if err := requireExactSemanticFields(fields, "emit field "+name, "Kind", "Ref", "CEL", "Literal"); err != nil {
-			return FrozenOutcome{}, err
-		}
-		kind, err := requiredSemanticString(fields, "Kind")
-		if err != nil {
-			return FrozenOutcome{}, fmt.Errorf("emit field %s: %w", name, err)
-		}
-		ref, err := requiredSemanticString(fields, "Ref")
-		if err != nil {
-			return FrozenOutcome{}, fmt.Errorf("emit field %s: %w", name, err)
-		}
-		cel, err := requiredSemanticString(fields, "CEL")
-		if err != nil {
-			return FrozenOutcome{}, fmt.Errorf("emit field %s: %w", name, err)
-		}
-		expression := FrozenExpression{Kind: runtimecontracts.ExpressionKind(kind), Ref: ref, CEL: cel}
-		if expression.HasLiteralValue() {
-			literal, ok := fields["Literal"]
-			if !ok {
-				return FrozenOutcome{}, fmt.Errorf("emit field %s literal is required", name)
-			}
-			expression.Literal = literal
-		}
-		expressions[name] = expression
-	}
-	schema := root["EmitSchema"]
-	if schema.Kind() != semanticvalue.KindObject {
-		return FrozenOutcome{}, fmt.Errorf("outcome emit schema must be an object")
-	}
-	return FrozenOutcome{
-		Verdict: verdict, Label: label, Input: inputs, AdvancesTo: advancesTo,
-		Emit: FrozenEmit{Event: event, Fields: expressions}, EmitSchema: schema,
-	}, nil
+	return FrozenOutcome{Verdict: verdict, Label: label, Input: inputs}, nil
 }
 
 func requireExactSemanticFields(values map[string]semanticvalue.Value, label string, expected ...string) error {

--- a/internal/runtime/decisioncard/model.go
+++ b/internal/runtime/decisioncard/model.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
-	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
 	"github.com/google/uuid"
 )
 
@@ -74,7 +72,7 @@ var reservedNoticeFields = map[string]struct{}{
 func ValidateNoticeShape(itemType string, payload map[string]any) error {
 	itemType = strings.ToLower(strings.TrimSpace(itemType))
 	itemType = strings.NewReplacer("-", "_", ".", "_").Replace(itemType)
-	if itemType == KindDecisionCard || itemType == string(AnchorKindHumanTask) {
+	if itemType == KindDecisionCard || IsRegisteredAnchorKind(itemType) {
 		return fmt.Errorf("mailbox item_type %s is reserved for the typed decision-card owner", itemType)
 	}
 	return validateNoticePayloadFields(payload, "")
@@ -177,17 +175,11 @@ type decisionSchemaProjection struct {
 
 type decisionOutcomeSchemaProjection struct {
 	Input map[string]decisionInputSchemaProjection `json:"input"`
-	Emit  *decisionEmitSchemaProjection            `json:"emit,omitempty"`
 }
 
 type decisionInputSchemaProjection struct {
 	Type     string `json:"type"`
 	Required bool   `json:"required"`
-}
-
-type decisionEmitSchemaProjection struct {
-	Fields map[string]map[string]any `json:"fields"`
-	Schema map[string]any            `json:"schema"`
 }
 
 type Card struct {
@@ -197,6 +189,7 @@ type Card struct {
 	Status             string              `json:"status"`
 	Snapshot           Snapshot            `json:"snapshot"`
 	CardContentHash    string              `json:"card_content_hash"`
+	EffectContentHash  string              `json:"effect_content_hash,omitempty"`
 	DecisionSchemaHash string              `json:"decision_schema_hash"`
 	BundleHash         string              `json:"bundle_hash"`
 	WorkflowVersion    string              `json:"workflow_version"`
@@ -233,12 +226,20 @@ func (c Card) MarshalJSON() ([]byte, error) {
 		"effective_cadence": c.EffectiveCadence, "provenance": c.Provenance.Interface(),
 		"created_at": c.CreatedAt.UTC(), "updated_at": c.UpdatedAt.UTC(),
 	}
+	if c.EffectContentHash != "" {
+		out["effect_content_hash"] = c.EffectContentHash
+	}
 	switch c.Anchor.Kind() {
 	case AnchorKindStageGate:
 		out["decision"] = c.Snapshot.Decision
 	case AnchorKindHumanTask:
 		if anchor, anchorErr := c.Anchor.HumanTask(); anchorErr == nil {
 			out["category"] = anchor.Category
+		}
+	case AnchorKindProposedEffect:
+		if anchor, anchorErr := c.Anchor.ProposedEffect(); anchorErr == nil {
+			out["decision"] = anchor.Decision
+			out["activity_id"] = anchor.ActivityID
 		}
 	}
 	for name, value := range map[string]string{
@@ -422,6 +423,12 @@ func (c Card) Validate() error {
 	if err := c.Anchor.Validate(); err != nil {
 		return err
 	}
+	if c.Anchor.Kind() == AnchorKindProposedEffect && strings.TrimSpace(c.EffectContentHash) == "" {
+		return fmt.Errorf("proposed-effect decision card effect_content_hash is required")
+	}
+	if c.Anchor.Kind() != AnchorKindProposedEffect && strings.TrimSpace(c.EffectContentHash) != "" {
+		return fmt.Errorf("decision card anchor %s cannot carry effect_content_hash", c.Anchor.Kind())
+	}
 	if c.Provenance.Kind() != semanticvalue.KindObject {
 		return fmt.Errorf("decision card provenance must be an object")
 	}
@@ -490,16 +497,10 @@ func validateSnapshotContract(snapshot Snapshot) error {
 		if err := validateCanonicalDecisionMapIdentity("outcome "+verdict+" input field", outcome.Input); err != nil {
 			return err
 		}
-		if err := validateCanonicalDecisionMapIdentity("outcome "+verdict+" emit field", outcome.Emit.Fields); err != nil {
-			return err
-		}
 		for name, declaration := range outcome.Input {
 			if _, err := runtimecontracts.ValidateCanonicalWorkflowGateInputType(declaration.Type); err != nil {
 				return fmt.Errorf("decision card outcome %s input %s: %w", strings.TrimSpace(verdict), strings.TrimSpace(name), err)
 			}
-		}
-		if err := validateFrozenOutcomeContract(verdict, outcome); err != nil {
-			return err
 		}
 	}
 	return nil
@@ -521,79 +522,6 @@ func validateCanonicalDecisionMapIdentity[T any](label string, values map[string
 		}
 	}
 	return nil
-}
-
-func validateFrozenOutcomeContract(verdict string, outcome FrozenOutcome) error {
-	if outcome.Emit.Empty() {
-		if outcome.EmitSchema.Kind() != semanticvalue.KindObject || outcome.EmitSchema.Len() != 0 {
-			return fmt.Errorf("decision card outcome %s carries an event schema without an emit", verdict)
-		}
-		return nil
-	}
-	if outcome.EmitSchema.Kind() != semanticvalue.KindObject || outcome.EmitSchema.Len() == 0 {
-		return fmt.Errorf("decision card outcome %s emit is missing its frozen resolved event schema", verdict)
-	}
-	schema, err := semanticObjectProjection(outcome.EmitSchema, "decision card outcome schema")
-	if err != nil {
-		return err
-	}
-	properties := runtimesharedjson.SchemaProperties(schema["properties"])
-	literalPayload := make(map[string]any, len(outcome.Emit.Fields))
-	allLiteral := true
-	for field, expression := range outcome.Emit.Fields {
-		fieldSchema, ok := properties[field]
-		if !ok {
-			return fmt.Errorf("decision card outcome %s emit field %s is absent from its frozen event schema", verdict, field)
-		}
-		if expression.HasLiteralValue() {
-			literalPayload[field] = expression.Literal.Interface()
-			if err := runtimeeventschema.ValidateValueAgainstSchema(fieldSchema, expression.Literal.Interface()); err != nil {
-				return fmt.Errorf("decision card outcome %s literal emit field %s: %w", verdict, field, err)
-			}
-			continue
-		}
-		allLiteral = false
-		inputName, err := outcomeDecisionField(expression)
-		if err != nil {
-			return fmt.Errorf("decision card outcome %s emit field %s: %w", verdict, field, err)
-		}
-		input, ok := outcome.Input[inputName]
-		if !ok {
-			return fmt.Errorf("decision card outcome %s emit field %s reads undeclared decision.%s", verdict, field, inputName)
-		}
-		if !input.Required {
-			return fmt.Errorf("decision card outcome %s emit field %s reads optional decision.%s", verdict, field, inputName)
-		}
-		if !runtimecontracts.WorkflowGateInputTypeCompatibleWithResolvedSchema(input.Type, fieldSchema) {
-			return fmt.Errorf("decision card outcome %s decision.%s type %s is incompatible with emit field %s frozen schema", verdict, inputName, input.Type, field)
-		}
-	}
-	for _, required := range runtimesharedjson.RequiredList(schema["required"]) {
-		if _, ok := outcome.Emit.Fields[required]; !ok {
-			return fmt.Errorf("decision card outcome %s emit is missing required field %s from its frozen event schema", verdict, required)
-		}
-	}
-	if allLiteral {
-		if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema, literalPayload); err != nil {
-			return fmt.Errorf("decision card outcome %s assembled literal payload: %w", verdict, err)
-		}
-	}
-	return nil
-}
-
-func outcomeDecisionField(expression FrozenExpression) (string, error) {
-	raw := strings.TrimSpace(expression.Ref)
-	if raw == "" {
-		raw = strings.TrimSpace(expression.CEL)
-	}
-	if !strings.HasPrefix(raw, "decision.") || strings.Count(raw, ".") != 1 {
-		return "", fmt.Errorf("only exact decision.<field> references are supported")
-	}
-	field := strings.TrimPrefix(raw, "decision.")
-	if field == "" || field != strings.TrimSpace(field) {
-		return "", fmt.Errorf("decision field reference %q is not canonical", raw)
-	}
-	return field, nil
 }
 
 func New(card Card) (Card, error) {
@@ -680,28 +608,6 @@ func projectDecisionSchema(snapshot Snapshot) (semanticvalue.Value, error) {
 		for name, input := range outcome.Input {
 			projected.Input[name] = decisionInputSchemaProjection{Type: input.Type, Required: input.Required}
 		}
-		if !outcome.Emit.Empty() {
-			schema, err := semanticObjectProjection(outcome.EmitSchema, "decision card outcome schema")
-			if err != nil {
-				return semanticvalue.Value{}, err
-			}
-			emit := &decisionEmitSchemaProjection{
-				Fields: make(map[string]map[string]any, len(outcome.Emit.Fields)),
-				Schema: runtimeeventschema.CanonicalAcceptanceSchema(schema),
-			}
-			for field, expression := range outcome.Emit.Fields {
-				if expression.HasLiteralValue() {
-					emit.Fields[field] = map[string]any{"kind": "literal", "value": expression.Literal.Interface()}
-					continue
-				}
-				inputName, err := outcomeDecisionField(expression)
-				if err != nil {
-					return semanticvalue.Value{}, fmt.Errorf("project decision schema outcome %s field %s: %w", verdict, field, err)
-				}
-				emit.Fields[field] = map[string]any{"kind": "decision", "field": inputName}
-			}
-			projected.Emit = emit
-		}
 		projection.Outcomes[verdict] = projected
 	}
 	value, err := canonicaljson.FromGo(projection)
@@ -754,50 +660,7 @@ func ValidateDecision(card Card, verdict string, fields semanticvalue.Value) err
 			return fmt.Errorf("%w: field %s must be %s", ErrInvalidFields, name, declaration.Type)
 		}
 	}
-	if !outcome.Emit.Empty() {
-		payload, err := BuildOutcomePayload(outcome, fields)
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidFields, err)
-		}
-		schema, schemaErr := semanticObjectProjection(outcome.EmitSchema, "decision card outcome schema")
-		if schemaErr != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidFields, schemaErr)
-		}
-		payloadMap, payloadErr := semanticObjectProjection(payload, "decision card outcome payload")
-		if payloadErr != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidFields, payloadErr)
-		}
-		if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema, payloadMap); err != nil {
-			return fmt.Errorf("%w: emitted payload does not satisfy the frozen event schema: %v", ErrInvalidFields, err)
-		}
-	}
 	return nil
-}
-
-// BuildOutcomePayload resolves the frozen gate outcome using only authored
-// literals and exact decision fields. Settlement and routing share this owner.
-func BuildOutcomePayload(outcome FrozenOutcome, fields semanticvalue.Value) (semanticvalue.Value, error) {
-	fieldValues, ok := fields.ObjectMap()
-	if !ok {
-		return semanticvalue.Value{}, fmt.Errorf("decision fields must be an object")
-	}
-	payload := make(map[string]semanticvalue.Value, len(outcome.Emit.Fields))
-	for field, expression := range outcome.Emit.Fields {
-		if expression.HasLiteralValue() {
-			payload[field] = expression.Literal
-			continue
-		}
-		inputName, err := outcomeDecisionField(expression)
-		if err != nil {
-			return semanticvalue.Value{}, fmt.Errorf("gate outcome field %s: %w", field, err)
-		}
-		value, ok := fieldValues[inputName]
-		if !ok || value.Kind() == semanticvalue.KindNull {
-			return semanticvalue.Value{}, fmt.Errorf("gate outcome field %s: decision field %s is absent", field, inputName)
-		}
-		payload[field] = value
-	}
-	return semanticvalue.ObjectFromMap(payload)
 }
 
 func SnapshotJSON(card Card) ([]byte, error) {

--- a/internal/runtime/decisioncard/model_test.go
+++ b/internal/runtime/decisioncard/model_test.go
@@ -206,7 +206,7 @@ func TestNewAndValidateRejectNonCanonicalTopLevelDecisionID(t *testing.T) {
 	}
 }
 
-func TestDecisionSchemaHashTracksEffectiveAcceptanceAndIgnoresPresentation(t *testing.T) {
+func TestDecisionSchemaHashTracksVerdictInputsAndIgnoresExecutionRoutes(t *testing.T) {
 	newCard := func(title, outcomeLabel, inputLabel, pattern string) Card {
 		t.Helper()
 		schema := textEventSchema(map[string]map[string]any{
@@ -235,8 +235,8 @@ func TestDecisionSchemaHashTracksEffectiveAcceptanceAndIgnoresPresentation(t *te
 
 	lowercase := newCard("Launch review", "Approve", "Code", "^[a-z]+$")
 	uppercase := newCard("Launch review", "Approve", "Code", "^[A-Z]+$")
-	if lowercase.DecisionSchemaHash == uppercase.DecisionSchemaHash {
-		t.Fatalf("acceptance-changing patterns share schema hash %q", lowercase.DecisionSchemaHash)
+	if lowercase.DecisionSchemaHash != uppercase.DecisionSchemaHash {
+		t.Fatalf("stage-route schema changed generic verdict schema hash: %q != %q", lowercase.DecisionSchemaHash, uppercase.DecisionSchemaHash)
 	}
 
 	polished := newCard("Production launch review", "Ship it", "Approval code", "^[a-z]+$")
@@ -248,7 +248,7 @@ func TestDecisionSchemaHashTracksEffectiveAcceptanceAndIgnoresPresentation(t *te
 	}
 }
 
-func TestDecisionSchemaHashSplitsSafeNumericBounds(t *testing.T) {
+func TestDecisionSchemaHashIgnoresStageRouteNumericBounds(t *testing.T) {
 	newCard := func(minimum int64) Card {
 		t.Helper()
 		card, err := New(baseTestDecisionCard(map[string]runtimecontracts.WorkflowGateOutcomePlan{
@@ -269,8 +269,8 @@ func TestDecisionSchemaHashSplitsSafeNumericBounds(t *testing.T) {
 	}
 	lower := newCard(9007199254740990)
 	upper := newCard(9007199254740991)
-	if lower.DecisionSchemaHash == upper.DecisionSchemaHash {
-		t.Fatalf("distinct safe numeric bounds share schema hash %q", lower.DecisionSchemaHash)
+	if lower.DecisionSchemaHash != upper.DecisionSchemaHash {
+		t.Fatalf("stage-route numeric bounds changed generic verdict schema hash: %q != %q", lower.DecisionSchemaHash, upper.DecisionSchemaHash)
 	}
 }
 
@@ -417,21 +417,6 @@ func assertSafeSnapshotNumbers(t *testing.T, snapshot Snapshot, want float64) {
 		t.Fatal("context.large_integer is absent")
 	}
 	assertNumber("context.large_integer", contextValue.Interface())
-	outcome := snapshot.Outcomes["approve"]
-	assertNumber("outcome literal", outcome.Emit.Fields["large_integer"].Literal.Interface())
-	schema, ok := outcome.EmitSchema.Interface().(map[string]any)
-	if !ok {
-		t.Fatalf("emit schema = %#v", outcome.EmitSchema.Interface())
-	}
-	properties, ok := schema["properties"].(map[string]any)
-	if !ok {
-		t.Fatalf("emit schema properties = %#v", schema["properties"])
-	}
-	property, ok := properties["large_integer"].(map[string]any)
-	if !ok {
-		t.Fatalf("large_integer schema = %#v", properties["large_integer"])
-	}
-	assertNumber("schema minimum", property["minimum"])
 }
 
 func TestNewRejectsUnsupportedSnapshotNumbersBeforeHashing(t *testing.T) {
@@ -442,16 +427,6 @@ func TestNewRejectsUnsupportedSnapshotNumbersBeforeHashing(t *testing.T) {
 		outcomes map[string]runtimecontracts.WorkflowGateOutcomePlan
 	}{
 		{name: "context", context: map[string]any{"unsafe": unsafeInteger}, outcomes: map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": {Verdict: "approve", AdvancesTo: "operating"}}},
-		{name: "outcome literal", outcomes: map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Emit:       runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{"value": runtimecontracts.LiteralExpression(unsafeInteger)}},
-			EmitSchema: textEventSchema(map[string]map[string]any{"value": {"type": "integer"}}, []string{"value"}),
-		}}},
-		{name: "schema bound", outcomes: map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Emit:       runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{"value": runtimecontracts.LiteralExpression(1)}},
-			EmitSchema: textEventSchema(map[string]map[string]any{"value": {"type": "integer", "minimum": unsafeInteger}}, []string{"value"}),
-		}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := FreezeSnapshot("launch_review", "", tc.context, tc.outcomes); err == nil {
@@ -470,13 +445,6 @@ func TestNewRejectsNonCanonicalGateMapIdentityBeforeHashing(t *testing.T) {
 		{name: "input", outcomes: map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": {
 			AdvancesTo: "operating", Input: map[string]runtimecontracts.WorkflowGateInputField{" note ": {Type: "text"}},
 		}}},
-		{name: "emit", outcomes: map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": {
-			AdvancesTo: "operating",
-			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-				" note ": runtimecontracts.LiteralExpression("ready"),
-			}},
-			EmitSchema: textEventSchema(map[string]map[string]any{"note": {"type": "string"}}, []string{"note"}),
-		}}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -488,91 +456,6 @@ func TestNewRejectsNonCanonicalGateMapIdentityBeforeHashing(t *testing.T) {
 				t.Fatalf("noncanonical card was hashed before rejection: %#v", card)
 			}
 		})
-	}
-}
-
-func TestValidateDecisionConsumesFrozenEmitSchemaBeforeSettlement(t *testing.T) {
-	patternSchema := textEventSchema(map[string]map[string]any{
-		"code": {"type": "string", "pattern": "^[a-z]+$"},
-	}, []string{"code"})
-	card, err := New(baseTestDecisionCard(map[string]runtimecontracts.WorkflowGateOutcomePlan{
-		"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Input: map[string]runtimecontracts.WorkflowGateInputField{"code": {Type: "text", Required: true}},
-			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-				"code": runtimecontracts.CELExpression("decision.code"),
-			}},
-			EmitSchema: patternSchema,
-		},
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ValidateDecision(card, "approve", semanticObject(map[string]any{"code": "NOT-LOWER"})); err == nil || !strings.Contains(err.Error(), "pattern") {
-		t.Fatalf("ValidateDecision error = %v, want frozen pattern rejection", err)
-	}
-	if err := ValidateDecision(card, "approve", semanticObject(map[string]any{"code": "ready"})); err != nil {
-		t.Fatalf("valid refined decision rejected: %v", err)
-	}
-}
-
-func TestNewRejectsOptionalEmittedDecisionInputBeforeHashing(t *testing.T) {
-	card, err := New(baseTestDecisionCard(map[string]runtimecontracts.WorkflowGateOutcomePlan{
-		"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Input: map[string]runtimecontracts.WorkflowGateInputField{"note": {Type: "text", Required: false}},
-			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-				"note": runtimecontracts.CELExpression("decision.note"),
-			}},
-			EmitSchema: textEventSchema(map[string]map[string]any{"note": {"type": "string"}}, []string{"note"}),
-		},
-	}))
-	if err == nil || !strings.Contains(err.Error(), "reads optional decision.note") {
-		t.Fatalf("New error = %v, want optional emitted input rejection", err)
-	}
-	if card.CardContentHash != "" || card.DecisionSchemaHash != "" {
-		t.Fatalf("invalid optional-input card was hashed: %#v", card)
-	}
-}
-
-func TestNewAndValidateDecisionConsumeRelationalEmitSchema(t *testing.T) {
-	relational := textEventSchema(map[string]map[string]any{
-		"component": {"type": "string"},
-		"owner":     {"type": "string", "x-swarm-equalTo": "component"},
-	}, []string{"component", "owner"})
-	staticCard, staticErr := New(baseTestDecisionCard(map[string]runtimecontracts.WorkflowGateOutcomePlan{
-		"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-				"component": runtimecontracts.LiteralExpression("api"),
-				"owner":     runtimecontracts.LiteralExpression("worker"),
-			}},
-			EmitSchema: relational,
-		},
-	}))
-	if staticErr == nil || !strings.Contains(staticErr.Error(), "must equal") || staticCard.CardContentHash != "" {
-		t.Fatalf("static relational card = %#v, error = %v, want pre-hash rejection", staticCard, staticErr)
-	}
-
-	dynamic, err := New(baseTestDecisionCard(map[string]runtimecontracts.WorkflowGateOutcomePlan{
-		"approve": {
-			Verdict: "approve", AdvancesTo: "operating",
-			Input: map[string]runtimecontracts.WorkflowGateInputField{
-				"component": {Type: "text", Required: true},
-				"owner":     {Type: "text", Required: true},
-			},
-			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-				"component": runtimecontracts.CELExpression("decision.component"),
-				"owner":     runtimecontracts.CELExpression("decision.owner"),
-			}},
-			EmitSchema: relational,
-		},
-	}))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ValidateDecision(dynamic, "approve", semanticObject(map[string]any{"component": "api", "owner": "worker"})); err == nil || !strings.Contains(err.Error(), "must equal") {
-		t.Fatalf("dynamic relational decision error = %v, want pre-settlement rejection", err)
 	}
 }
 
@@ -616,6 +499,59 @@ func semanticObject(values map[string]any) semanticvalue.Value {
 	return value
 }
 
+func TestRegisteredAnchorKindsAreClosedAndProjectScope(t *testing.T) {
+	stage, err := NewStageGateAnchor(StageGateAnchor{
+		FlowInstance: "root", EntityID: "entity-1", Stage: "review", StageActivationID: "activation-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	human, err := NewHumanTaskAnchor(HumanTaskAnchor{
+		RequesterAgentID: "agent-a", OperationID: "operation-1", Category: "review",
+		Scope: Scope{Kind: ScopeFlow, FlowInstance: "root"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proposed, err := NewProposedEffectAnchor(ProposedEffectAnchor{
+		RequestEventID: "request-1", ActivityID: "send", Decision: "send_review",
+		Scope: Scope{Kind: ScopeGlobal},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	anchors := map[AnchorKind]Anchor{
+		AnchorKindStageGate: stage, AnchorKindHumanTask: human, AnchorKindProposedEffect: proposed,
+	}
+	if len(anchors) != len(RegisteredAnchorKinds()) {
+		t.Fatalf("constructed anchor kinds = %d, registered = %d", len(anchors), len(RegisteredAnchorKinds()))
+	}
+	for _, kind := range RegisteredAnchorKinds() {
+		anchor, ok := anchors[kind]
+		if !ok {
+			t.Fatalf("registered anchor kind %q has no constructor proof", kind)
+		}
+		if err := anchor.Validate(); err != nil {
+			t.Fatalf("validate %s: %v", kind, err)
+		}
+		if _, err := anchor.Scope(); err != nil {
+			t.Fatalf("scope %s: %v", kind, err)
+		}
+		raw, err := canonicaljson.Encode(anchor.SemanticValue())
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := DecodeAnchor(string(kind), raw)
+		if err != nil || decoded.Kind() != kind {
+			t.Fatalf("decode %s = %s, %v", kind, decoded.Kind(), err)
+		}
+	}
+	if _, err := DecodeAnchor("unknown", []byte(`{}`)); err == nil {
+		t.Fatal("unknown anchor kind was accepted")
+	}
+}
+
 func textEventSchema(properties map[string]map[string]any, required []string) map[string]any {
 	rawProperties := make(map[string]any, len(properties))
 	for name, schema := range properties {
@@ -646,27 +582,6 @@ func decisionSnapshotStructuralDriftCases() []decisionSnapshotStructuralDriftCas
 		}},
 		{name: "input_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
 			delete(decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Input", "feedback"), "label")
-		}},
-		{name: "emit_shadow", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit")["shadow_semantics"] = true
-		}},
-		{name: "emit_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit"), "Event")
-		}},
-		{name: "expression_shadow", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback")["shadow_semantics"] = true
-		}},
-		{name: "expression_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback"), "Ref")
-		}},
-		{name: "missing_emit_schema", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(decisionSnapshotNestedObject(t, root, "outcomes", "revise"), "EmitSchema")
-		}},
-		{name: "missing_literal", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback"), "Literal")
-		}},
-		{name: "ignored_nonliteral_value", want: "does not preserve its exact semantic value", mutate: func(t *testing.T, root map[string]any) {
-			decisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback")["Literal"] = "shadow"
 		}},
 	}
 }

--- a/internal/runtime/decisioncard/proposed_effect.go
+++ b/internal/runtime/decisioncard/proposed_effect.go
@@ -1,0 +1,233 @@
+package decisioncard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	"github.com/google/uuid"
+)
+
+const (
+	ProposedEffectPending           = "pending"
+	ProposedEffectDecisionCommitted = "decision_committed"
+	ProposedEffectRequestReleased   = "request_released"
+	ProposedEffectOutcomeDispatched = "outcome_dispatched"
+	ProposedEffectSuperseded        = "superseded"
+)
+
+type ProposedEffectContinuation struct {
+	CardID            string
+	RunID             string
+	RequestEventID    string
+	ActivityID        string
+	Tool              string
+	BundleHash        string
+	WorkflowVersion   string
+	Input             semanticvalue.Value
+	EffectContentHash string
+	EffectClass       runtimecontracts.ActivityEffectClass
+	SuccessEvent      string
+	FailureEvent      string
+	RevisionEvent     string
+	RejectedEvent     string
+	RetryMaxAttempts  int
+	RetryBackoff      string
+	ForkPolicy        runtimecontracts.ActivityForkPolicy
+	EntityID          string
+	NodeID            string
+	FlowID            string
+	FlowInstance      string
+	HandlerEventKey   string
+	SourceEventID     string
+	SourceRunID       string
+	SourceTaskID      string
+	ParentEventID     string
+	ChainDepth        int
+	Attempt           int
+	Generation        attemptgeneration.Generation
+	LoopStage         string
+	ReplyContextID    string
+	State             string
+	Verdict           string
+	DecisionEventID   string
+	RouteEventID      string
+	SupersededReason  string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+func ProposedEffectCardID(requestEventID, decision string) string {
+	identity := strings.TrimSpace(requestEventID) + "\x00" + strings.TrimSpace(decision)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm.proposed-effect.card.v1\x00"+identity)).String()
+}
+
+func (c ProposedEffectContinuation) Canonical() ProposedEffectContinuation {
+	c.CardID = strings.TrimSpace(c.CardID)
+	c.RunID = strings.TrimSpace(c.RunID)
+	c.RequestEventID = strings.TrimSpace(c.RequestEventID)
+	c.ActivityID = strings.TrimSpace(c.ActivityID)
+	c.Tool = strings.TrimSpace(c.Tool)
+	c.BundleHash = strings.TrimSpace(c.BundleHash)
+	c.WorkflowVersion = strings.TrimSpace(c.WorkflowVersion)
+	c.EffectContentHash = strings.TrimSpace(c.EffectContentHash)
+	c.SuccessEvent = strings.TrimSpace(c.SuccessEvent)
+	c.FailureEvent = strings.TrimSpace(c.FailureEvent)
+	c.RevisionEvent = strings.TrimSpace(c.RevisionEvent)
+	c.RejectedEvent = strings.TrimSpace(c.RejectedEvent)
+	c.RetryBackoff = strings.TrimSpace(c.RetryBackoff)
+	c.EntityID = strings.TrimSpace(c.EntityID)
+	c.NodeID = strings.TrimSpace(c.NodeID)
+	c.FlowID = strings.TrimSpace(c.FlowID)
+	c.FlowInstance = strings.Trim(strings.TrimSpace(c.FlowInstance), "/")
+	c.HandlerEventKey = strings.TrimSpace(c.HandlerEventKey)
+	c.SourceEventID = strings.TrimSpace(c.SourceEventID)
+	c.SourceRunID = strings.TrimSpace(c.SourceRunID)
+	c.SourceTaskID = strings.TrimSpace(c.SourceTaskID)
+	c.ParentEventID = strings.TrimSpace(c.ParentEventID)
+	c.Generation = c.Generation.Normalize()
+	c.LoopStage = strings.TrimSpace(c.LoopStage)
+	c.ReplyContextID = strings.TrimSpace(c.ReplyContextID)
+	c.State = strings.TrimSpace(c.State)
+	c.Verdict = strings.TrimSpace(c.Verdict)
+	c.DecisionEventID = strings.TrimSpace(c.DecisionEventID)
+	c.RouteEventID = strings.TrimSpace(c.RouteEventID)
+	c.SupersededReason = strings.TrimSpace(c.SupersededReason)
+	c.CreatedAt = CanonicalTimestamp(c.CreatedAt)
+	c.UpdatedAt = CanonicalTimestamp(c.UpdatedAt)
+	if c.Attempt <= 0 {
+		c.Attempt = 1
+	}
+	if c.Input.Kind() == semanticvalue.KindNull {
+		c.Input = semanticvalue.EmptyObject()
+	}
+	return c
+}
+
+func (c ProposedEffectContinuation) EffectValue() (semanticvalue.Value, error) {
+	c = c.Canonical()
+	value, err := canonicaljson.FromGo(map[string]any{
+		"request_event_id":   c.RequestEventID,
+		"activity_id":        c.ActivityID,
+		"tool":               c.Tool,
+		"bundle_hash":        c.BundleHash,
+		"workflow_version":   c.WorkflowVersion,
+		"effect_class":       string(c.EffectClass),
+		"success_event":      c.SuccessEvent,
+		"failure_event":      c.FailureEvent,
+		"revision_event":     c.RevisionEvent,
+		"rejected_event":     c.RejectedEvent,
+		"retry_max_attempts": c.RetryMaxAttempts,
+		"retry_backoff":      c.RetryBackoff,
+		"fork_policy":        string(c.ForkPolicy),
+		"entity_id":          c.EntityID,
+		"node_id":            c.NodeID,
+		"flow_id":            c.FlowID,
+		"flow_instance":      c.FlowInstance,
+		"handler_event_key":  c.HandlerEventKey,
+		"source_event_id":    c.SourceEventID,
+		"source_run_id":      c.SourceRunID,
+		"source_task_id":     c.SourceTaskID,
+		"parent_event_id":    c.ParentEventID,
+		"chain_depth":        c.ChainDepth,
+		"attempt":            c.Attempt,
+		"loop_generation":    c.Generation,
+		"loop_stage":         c.LoopStage,
+		"reply_context_id":   c.ReplyContextID,
+	})
+	if err != nil {
+		return semanticvalue.Value{}, err
+	}
+	return value.With("input", c.Input)
+}
+
+func (c ProposedEffectContinuation) Validate(card Card) error {
+	c = c.Canonical()
+	if card.Anchor.Kind() != AnchorKindProposedEffect {
+		return fmt.Errorf("proposed-effect continuation requires a proposed_effect card")
+	}
+	anchor, err := card.Anchor.ProposedEffect()
+	if err != nil {
+		return err
+	}
+	if c.CardID == "" || c.CardID != card.CardID || c.RunID == "" || c.RunID != card.RunID {
+		return fmt.Errorf("proposed-effect continuation card/run identity does not match its card")
+	}
+	if c.RequestEventID != anchor.RequestEventID || c.ActivityID != anchor.ActivityID {
+		return fmt.Errorf("proposed-effect continuation identity does not match its anchor")
+	}
+	if c.EffectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+		return fmt.Errorf("proposed-effect continuation requires effect_class non_idempotent_write")
+	}
+	if c.Input.Kind() != semanticvalue.KindObject {
+		return fmt.Errorf("proposed-effect input must be a semantic object")
+	}
+	for name, value := range map[string]string{
+		"request_event_id": c.RequestEventID, "activity_id": c.ActivityID, "tool": c.Tool,
+		"bundle_hash": c.BundleHash, "workflow_version": c.WorkflowVersion,
+		"success_event": c.SuccessEvent, "failure_event": c.FailureEvent, "revision_event": c.RevisionEvent,
+		"rejected_event": c.RejectedEvent, "source_event_id": c.SourceEventID, "source_run_id": c.SourceRunID,
+	} {
+		if value == "" {
+			return fmt.Errorf("proposed-effect continuation %s is required", name)
+		}
+	}
+	if c.BundleHash != card.BundleHash || c.WorkflowVersion != card.WorkflowVersion {
+		return fmt.Errorf("proposed-effect continuation contract identity does not match its card")
+	}
+	effectValue, err := c.EffectValue()
+	if err != nil {
+		return fmt.Errorf("encode proposed effect: %w", err)
+	}
+	effectHash, err := canonicaljson.HashValue(effectValue)
+	if err != nil {
+		return fmt.Errorf("hash proposed effect: %w", err)
+	}
+	if c.EffectContentHash != effectHash || card.EffectContentHash != effectHash {
+		return fmt.Errorf("proposed-effect content hash does not match its immutable effect")
+	}
+	switch c.State {
+	case ProposedEffectPending:
+		if c.Verdict != "" || c.DecisionEventID != "" || c.RouteEventID != "" || c.SupersededReason != "" {
+			return fmt.Errorf("pending proposed effect carries terminal evidence")
+		}
+	case ProposedEffectDecisionCommitted:
+		if c.Verdict == "" || c.DecisionEventID == "" || c.RouteEventID != "" {
+			return fmt.Errorf("decision-committed proposed effect has invalid evidence")
+		}
+	case ProposedEffectRequestReleased, ProposedEffectOutcomeDispatched:
+		if c.Verdict == "" || c.DecisionEventID == "" || c.RouteEventID == "" {
+			return fmt.Errorf("routed proposed effect has invalid evidence")
+		}
+	case ProposedEffectSuperseded:
+		if c.SupersededReason == "" {
+			return fmt.Errorf("superseded proposed effect requires a reason")
+		}
+	default:
+		return fmt.Errorf("proposed-effect continuation state %q is invalid", c.State)
+	}
+	if c.CreatedAt.IsZero() || c.UpdatedAt.IsZero() {
+		return fmt.Errorf("proposed-effect continuation timestamps are required")
+	}
+	return nil
+}
+
+type ProposedEffectStore interface {
+	CreateProposedEffectCard(context.Context, Card, ProposedEffectContinuation) error
+	LoadProposedEffectContinuation(context.Context, string) (ProposedEffectContinuation, error)
+	CompleteProposedEffectRoute(context.Context, string, string, time.Time) (ProposedEffectContinuation, error)
+	SupersedeProposedEffectsForLoopGenerations(context.Context, string, string, []attemptgeneration.Generation, string, time.Time) error
+	ProposedEffectReadback(context.Context, string) (ProposedEffectReadback, error)
+}
+
+type ProposedEffectReadback struct {
+	ContinuationState string `json:"continuation_state"`
+	DispatchState     string `json:"dispatch_state"`
+	RequestEventID    string `json:"request_event_id"`
+	ActivityID        string `json:"activity_id"`
+}

--- a/internal/runtime/decisioncard/semantic_zone_test.go
+++ b/internal/runtime/decisioncard/semantic_zone_test.go
@@ -64,6 +64,18 @@ func TestDecisionCardSemanticZonesCannotBypassValueAdmission(t *testing.T) {
 				".UseNumber()", ".WriteJSON(",
 			},
 		},
+		{
+			path: "internal/store/proposed_effect_cards.go",
+			forbidden: []string{
+				"Input map[string]any", "json.Unmarshal(", "json.NewDecoder(", ".UseNumber()", ".WriteJSON(",
+			},
+		},
+		{
+			path: "internal/runtime/pipeline/activity_engine.go",
+			forbidden: []string{
+				"Input map[string]any", "json.Unmarshal(evt.Payload()", ".UseNumber()", ".WriteJSON(",
+			},
+		},
 	} {
 		raw, err := os.ReadFile(filepath.Join(root, zone.path))
 		if err != nil {
@@ -73,6 +85,40 @@ func TestDecisionCardSemanticZonesCannotBypassValueAdmission(t *testing.T) {
 			if strings.Contains(string(raw), forbidden) {
 				t.Errorf("%s bypasses semanticvalue admission with %q", zone.path, forbidden)
 			}
+		}
+	}
+}
+
+func TestRegisteredAnchorKindsStaySynchronizedWithDeclaredConsumers(t *testing.T) {
+	root := decisionCardRepoRoot(t)
+	wantEnum := "enum: [" + strings.Join(RegisteredAnchorKindNames(), ", ") + "]"
+	spec, err := os.ReadFile(filepath.Join(root, "platform-spec.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(spec), wantEnum) != 1 {
+		t.Fatalf("platform spec anchor enum must occur exactly once as %q", wantEnum)
+	}
+
+	for _, consumer := range []struct {
+		path     string
+		required string
+		forbid   string
+	}{
+		{path: "internal/apiv1/operator_mailbox.go", required: "decisioncard.IsRegisteredAnchorKind", forbid: `kind != "stage_gate"`},
+		{path: "cmd/swarm/test_command.go", required: "decisioncard.IsRegisteredAnchorKind", forbid: `anchorKind != "stage_gate"`},
+		{path: "cmd/swarm/control_mailbox.go", required: "decisioncard.RegisteredAnchorKindDescription", forbid: "anchor_kind must be stage_gate"},
+	} {
+		raw, err := os.ReadFile(filepath.Join(root, consumer.path))
+		if err != nil {
+			t.Fatalf("read %s: %v", consumer.path, err)
+		}
+		text := string(raw)
+		if !strings.Contains(text, consumer.required) {
+			t.Errorf("%s does not consume the closed anchor owner %q", consumer.path, consumer.required)
+		}
+		if strings.Contains(text, consumer.forbid) {
+			t.Errorf("%s duplicates anchor acceptance vocabulary with %q", consumer.path, consumer.forbid)
 		}
 	}
 }

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -38,6 +38,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "decision_card_route_obligations", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "decision_card_route_obligations.run_id", DeleteOrderGroup: 1},
 		{Table: "decision_card_changes", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "decision_card_changes.run_id", DeleteOrderGroup: 1},
 		{Table: "decision_card_input_drafts", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "decision_card_input_drafts.run_id", DeleteOrderGroup: 1},
+		{Table: "proposed_effect_continuations", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "proposed_effect_continuations.run_id", DeleteOrderGroup: 1},
 		{Table: "human_task_continuations", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "human_task_continuations.run_id", DeleteOrderGroup: 1},
 		{Table: "decision_cards", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "decision_cards.run_id", DeleteOrderGroup: 2},
 		{Table: "agent_directive_operations", TableKind: CleanupTableKindPlatform, Classification: CleanupRetainDirectiveAuthority, PredicateOwner: "agent_directive_operations.resolved_run_id plus operation state/expires_at", PreservationProof: "runtime.nuke fails closed while nonterminal, indeterminate, or unexpired terminal directive authority exists"},

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/accprojection"
 	runtimeaccumulator "github.com/division-sh/swarm/internal/runtime/accumulator"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
@@ -29,6 +30,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/workflowexpr"
 )
@@ -2272,6 +2274,13 @@ func (e *Executor) stepActivity(frame *executionFrame) error {
 		}
 		input[field] = value
 	}
+	semanticInput, err := canonicaljson.FromGo(input)
+	if err != nil {
+		return fmt.Errorf("admit activity input: %w", err)
+	}
+	if semanticInput.Kind() != semanticvalue.KindObject {
+		return fmt.Errorf("activity input must be a semantic object")
+	}
 	ruleID := ""
 	ruleIndex := -1
 	if frame.rule != nil {
@@ -2288,19 +2297,23 @@ func (e *Executor) stepActivity(frame *executionFrame) error {
 	}
 	resultEvents := runtimecontracts.ActivityResultEventsForSite(site)
 	defaults := runtimecontracts.ActivityRetryDefaultsForEffectClass(effectClass)
+	sourceRoute := emitSourceRoute(frame)
 	intent := ActivityIntent{
 		ActivityID:       resultEvents.ActivityID,
 		Tool:             toolID,
-		Input:            input,
+		Input:            semanticInput,
 		EffectClass:      effectClass,
 		SuccessEvent:     resultEvents.SuccessEvent,
 		FailureEvent:     resultEvents.FailureEvent,
+		RevisionEvent:    resultEvents.RevisionRequested,
+		RejectedEvent:    resultEvents.Rejected,
 		RetryMaxAttempts: defaults.MaxAttempts,
 		RetryBackoff:     defaults.Backoff,
 		ForkPolicy:       runtimecontracts.ActivityForkPolicyForEffectClass(effectClass),
 		EntityID:         frame.req.EntityID,
 		NodeID:           frame.req.NodeID,
 		FlowID:           frame.req.FlowID,
+		FlowInstance:     sourceRoute.FlowInstance,
 		HandlerEventKey:  frame.req.HandlerEventKey,
 		SourceEventID:    frame.req.Event.ID(),
 		SourceRunID:      frame.req.Event.RunID(),
@@ -2309,6 +2322,9 @@ func (e *Executor) stepActivity(frame *executionFrame) error {
 		ChainDepth:       frame.req.ChainDepth,
 		Attempt:          1,
 	}.Normalized()
+	if activitySpec.Approval != nil {
+		intent.ApprovalDecision = strings.TrimSpace(activitySpec.Approval.Decision)
+	}
 	if frame.loopActivation != nil {
 		intent.Generation = frame.loopActivation.Generation()
 		intent.LoopStage = frame.loopActivation.CurrentStage

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -2760,8 +2760,8 @@ func TestExecutor_ActivityIntentPersistsBeforePostCommitDispatch(t *testing.T) {
 		t.Fatalf("activity intents writer=%d dispatcher=%d, want 1/1", len(writer.intents), len(dispatcher.intents))
 	}
 	intent := writer.intents[0]
-	if got := intent.Input["url"]; got != "https://example.com" {
-		t.Fatalf("activity input url = %#v", got)
+	if got, ok := intent.Input.Lookup("url"); !ok || got.Interface() != "https://example.com" {
+		t.Fatalf("activity input url = %#v, present=%v", got.Interface(), ok)
 	}
 	if intent.SuccessEvent != "research.scanner_source_requested_source_scrape.succeeded" {
 		t.Fatalf("success event = %q", intent.SuccessEvent)

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 	"github.com/division-sh/swarm/internal/runtime/platformcontext"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 )
 
 const DefaultMaxChainDepth = 50
@@ -332,16 +333,22 @@ type ActivityIntent struct {
 	Context          events.DeliveryContext
 	ActivityID       string
 	Tool             string
-	Input            map[string]any
+	BundleHash       string
+	WorkflowVersion  string
+	Input            semanticvalue.Value
+	ApprovalDecision string
 	EffectClass      runtimecontracts.ActivityEffectClass
 	SuccessEvent     string
 	FailureEvent     string
+	RevisionEvent    string
+	RejectedEvent    string
 	RetryMaxAttempts int
 	RetryBackoff     string
 	ForkPolicy       runtimecontracts.ActivityForkPolicy
 	EntityID         identity.EntityID
 	NodeID           identity.NodeID
 	FlowID           identity.FlowID
+	FlowInstance     string
 	HandlerEventKey  string
 	SourceEventID    string
 	SourceRunID      string
@@ -357,19 +364,25 @@ func (i ActivityIntent) Normalized() ActivityIntent {
 	i.Context = i.Context.Normalized()
 	i.ActivityID = strings.TrimSpace(i.ActivityID)
 	i.Tool = strings.TrimSpace(i.Tool)
+	i.BundleHash = strings.TrimSpace(i.BundleHash)
+	i.WorkflowVersion = strings.TrimSpace(i.WorkflowVersion)
 	i.SuccessEvent = strings.TrimSpace(i.SuccessEvent)
 	i.FailureEvent = strings.TrimSpace(i.FailureEvent)
+	i.RevisionEvent = strings.TrimSpace(i.RevisionEvent)
+	i.RejectedEvent = strings.TrimSpace(i.RejectedEvent)
 	i.RetryBackoff = strings.TrimSpace(i.RetryBackoff)
 	i.HandlerEventKey = strings.TrimSpace(i.HandlerEventKey)
+	i.ApprovalDecision = strings.TrimSpace(i.ApprovalDecision)
 	i.SourceEventID = strings.TrimSpace(i.SourceEventID)
 	i.ParentEventID = strings.TrimSpace(i.ParentEventID)
+	i.FlowInstance = strings.Trim(strings.TrimSpace(i.FlowInstance), "/")
 	i.Generation = i.Generation.Normalize()
 	i.LoopStage = strings.TrimSpace(i.LoopStage)
 	if i.Attempt <= 0 {
 		i.Attempt = 1
 	}
-	if i.Input == nil {
-		i.Input = map[string]any{}
+	if i.Input.Kind() == semanticvalue.KindNull {
+		i.Input = semanticvalue.EmptyObject()
 	}
 	return i
 }

--- a/internal/runtime/gateruntime/gate.go
+++ b/internal/runtime/gateruntime/gate.go
@@ -28,6 +28,7 @@ type Activation struct {
 	ActivationID     string    `json:"activation_id"`
 	CardID           string    `json:"card_id"`
 	BundleHash       string    `json:"bundle_hash"`
+	RoutesJSON       string    `json:"routes_json"`
 	Status           Status    `json:"status"`
 	StartedByEvent   string    `json:"started_by_event,omitempty"`
 	DecisionEventID  string    `json:"decision_event_id,omitempty"`
@@ -36,7 +37,7 @@ type Activation struct {
 	UpdatedAt        time.Time `json:"updated_at"`
 }
 
-func New(runID, flowInstance, entityID, flowID, stage, decisionID, bundleHash, sourceEvent string, enteredAt time.Time) (Activation, error) {
+func New(runID, flowInstance, entityID, flowID, stage, decisionID, bundleHash, routesJSON, sourceEvent string, enteredAt time.Time) (Activation, error) {
 	if enteredAt.IsZero() {
 		enteredAt = time.Now().UTC()
 	}
@@ -52,7 +53,7 @@ func New(runID, flowInstance, entityID, flowID, stage, decisionID, bundleHash, s
 	activation := Activation{
 		FlowID: strings.TrimSpace(flowID), Stage: strings.TrimSpace(stage), DecisionID: strings.TrimSpace(decisionID),
 		ActivationID: activationID, CardID: uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm.decision.card.v1\x00"+cardIdentity)).String(),
-		BundleHash: strings.TrimSpace(bundleHash), Status: StatusOpen, StartedByEvent: strings.TrimSpace(sourceEvent),
+		BundleHash: strings.TrimSpace(bundleHash), RoutesJSON: strings.TrimSpace(routesJSON), Status: StatusOpen, StartedByEvent: strings.TrimSpace(sourceEvent),
 		OpenedAt: enteredAt.UTC(), UpdatedAt: enteredAt.UTC(),
 	}
 	if err := activation.Validate(); err != nil {
@@ -64,6 +65,9 @@ func New(runID, flowInstance, entityID, flowID, stage, decisionID, bundleHash, s
 func (a Activation) Validate() error {
 	if strings.TrimSpace(a.Stage) == "" || strings.TrimSpace(a.DecisionID) == "" || strings.TrimSpace(a.ActivationID) == "" || strings.TrimSpace(a.CardID) == "" || strings.TrimSpace(a.BundleHash) == "" {
 		return fmt.Errorf("gate activation identity is incomplete")
+	}
+	if err := ValidateRoutes(a.RoutesJSON); err != nil {
+		return err
 	}
 	if _, err := uuid.Parse(a.ActivationID); err != nil {
 		return fmt.Errorf("gate activation id is invalid: %w", err)

--- a/internal/runtime/gateruntime/gate_test.go
+++ b/internal/runtime/gateruntime/gate_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 )
 
+const testRoutesJSON = `{"approve":{"advances_to":"operating","emit":{"event":"","fields":{}},"emit_schema":{}}}`
+
 func TestActivationLifecycleIsFencedAndDurable(t *testing.T) {
 	now := time.Date(2026, time.July, 12, 10, 0, 0, 0, time.UTC)
-	activation, err := New("run-1", "root", "entity-1", "", "awaiting_review", "launch_review", "bundle-hash", "stage.entered", now)
+	activation, err := New("run-1", "root", "entity-1", "", "awaiting_review", "launch_review", "bundle-hash", testRoutesJSON, "stage.entered", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +34,7 @@ func TestActivationLifecycleIsFencedAndDurable(t *testing.T) {
 
 func TestActivationRouteRequiresCommittedEventIdentity(t *testing.T) {
 	now := time.Date(2026, time.July, 12, 10, 0, 0, 0, time.UTC)
-	activation, err := New("run-1", "root", "entity-1", "", "awaiting_review", "launch_review", "bundle-hash", "stage.entered", now)
+	activation, err := New("run-1", "root", "entity-1", "", "awaiting_review", "launch_review", "bundle-hash", testRoutesJSON, "stage.entered", now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/gateruntime/routes.go
+++ b/internal/runtime/gateruntime/routes.go
@@ -1,0 +1,341 @@
+package gateruntime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
+)
+
+type FrozenExpression struct {
+	Kind    runtimecontracts.ExpressionKind
+	Literal semanticvalue.Value
+	Ref     string
+	CEL     string
+}
+
+func (e FrozenExpression) HasLiteralValue() bool {
+	return e.Kind == runtimecontracts.ExpressionKindLiteral
+}
+
+type FrozenEmit struct {
+	Event  string
+	Fields map[string]FrozenExpression
+}
+
+func (e FrozenEmit) Empty() bool {
+	return strings.TrimSpace(e.Event) == "" && len(e.Fields) == 0
+}
+
+type Route struct {
+	AdvancesTo string
+	Emit       FrozenEmit
+	EmitSchema semanticvalue.Value
+}
+
+func FreezeRoutes(outcomes map[string]runtimecontracts.WorkflowGateOutcomePlan) (string, error) {
+	routes := make(map[string]semanticvalue.Value, len(outcomes))
+	for verdict, outcome := range outcomes {
+		if verdict == "" || verdict != strings.TrimSpace(verdict) {
+			return "", fmt.Errorf("gate continuation verdict %q is not canonical", verdict)
+		}
+		route := Route{
+			AdvancesTo: strings.TrimSpace(outcome.AdvancesTo),
+			Emit:       FrozenEmit{Event: strings.TrimSpace(outcome.Emit.Event), Fields: make(map[string]FrozenExpression, len(outcome.Emit.Fields))},
+			EmitSchema: semanticvalue.EmptyObject(),
+		}
+		for field, expression := range outcome.Emit.Fields {
+			frozen := FrozenExpression{Kind: expression.Kind, Ref: strings.TrimSpace(expression.Ref), CEL: strings.TrimSpace(expression.CEL)}
+			if expression.HasLiteralValue() {
+				literal, err := canonicaljson.FromGo(expression.Literal)
+				if err != nil {
+					return "", fmt.Errorf("admit gate route %s literal %s: %w", verdict, field, err)
+				}
+				frozen.Literal = literal
+			}
+			route.Emit.Fields[field] = frozen
+		}
+		if len(outcome.EmitSchema) > 0 {
+			schema, err := canonicaljson.FromGo(outcome.EmitSchema)
+			if err != nil {
+				return "", fmt.Errorf("admit gate route %s schema: %w", verdict, err)
+			}
+			if schema.Kind() != semanticvalue.KindObject {
+				return "", fmt.Errorf("gate route %s schema must be an object", verdict)
+			}
+			route.EmitSchema = schema
+		}
+		if err := validateRoute(verdict, route, outcome.Input); err != nil {
+			return "", err
+		}
+		encoded, err := routeSemanticValue(route)
+		if err != nil {
+			return "", err
+		}
+		routes[verdict] = encoded
+	}
+	value, err := semanticvalue.ObjectFromMap(routes)
+	if err != nil {
+		return "", err
+	}
+	raw, err := canonicaljson.Encode(value)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func RouteFor(routesJSON, verdict string) (Route, error) {
+	value, err := canonicaljson.Decode([]byte(strings.TrimSpace(routesJSON)))
+	if err != nil {
+		return Route{}, fmt.Errorf("decode gate continuation routes: %w", err)
+	}
+	routes, ok := value.ObjectMap()
+	if !ok {
+		return Route{}, fmt.Errorf("gate continuation routes must be an object")
+	}
+	encoded, ok := routes[strings.TrimSpace(verdict)]
+	if !ok {
+		return Route{}, fmt.Errorf("gate verdict %s has no durable route", verdict)
+	}
+	route, err := routeFromSemanticValue(encoded)
+	if err != nil {
+		return Route{}, fmt.Errorf("decode gate route %s: %w", verdict, err)
+	}
+	return route, nil
+}
+
+func ValidateRoutes(routesJSON string) error {
+	value, err := canonicaljson.Decode([]byte(strings.TrimSpace(routesJSON)))
+	if err != nil {
+		return fmt.Errorf("decode gate continuation routes: %w", err)
+	}
+	routes, ok := value.ObjectMap()
+	if !ok || len(routes) == 0 {
+		return fmt.Errorf("gate continuation routes must be a non-empty object")
+	}
+	for verdict, encoded := range routes {
+		if verdict == "" || verdict != strings.TrimSpace(verdict) {
+			return fmt.Errorf("gate continuation verdict %q is not canonical", verdict)
+		}
+		if _, err := routeFromSemanticValue(encoded); err != nil {
+			return fmt.Errorf("decode gate route %s: %w", verdict, err)
+		}
+	}
+	return nil
+}
+
+func BuildRoutePayload(route Route, fields semanticvalue.Value) (semanticvalue.Value, error) {
+	fieldValues, ok := fields.ObjectMap()
+	if !ok {
+		return semanticvalue.Value{}, fmt.Errorf("decision fields must be an object")
+	}
+	payload := make(map[string]semanticvalue.Value, len(route.Emit.Fields))
+	for field, expression := range route.Emit.Fields {
+		if expression.HasLiteralValue() {
+			payload[field] = expression.Literal
+			continue
+		}
+		inputName, err := decisionField(expression)
+		if err != nil {
+			return semanticvalue.Value{}, fmt.Errorf("gate route field %s: %w", field, err)
+		}
+		value, ok := fieldValues[inputName]
+		if !ok || value.Kind() == semanticvalue.KindNull {
+			return semanticvalue.Value{}, fmt.Errorf("gate route field %s: decision field %s is absent", field, inputName)
+		}
+		payload[field] = value
+	}
+	value, err := semanticvalue.ObjectFromMap(payload)
+	if err != nil {
+		return semanticvalue.Value{}, err
+	}
+	if !route.Emit.Empty() {
+		schema, _ := route.EmitSchema.ObjectMap()
+		payloadMap, _ := value.ObjectMap()
+		projectedSchema := make(map[string]any, len(schema))
+		for key, item := range schema {
+			projectedSchema[key] = item.Interface()
+		}
+		projectedPayload := make(map[string]any, len(payloadMap))
+		for key, item := range payloadMap {
+			projectedPayload[key] = item.Interface()
+		}
+		if err := runtimeeventschema.ValidatePayloadAgainstSchema(projectedSchema, projectedPayload); err != nil {
+			return semanticvalue.Value{}, fmt.Errorf("emitted payload does not satisfy the frozen event schema: %w", err)
+		}
+	}
+	return value, nil
+}
+
+func validateRoute(verdict string, route Route, inputs map[string]runtimecontracts.WorkflowGateInputField) error {
+	if route.AdvancesTo == "" {
+		return fmt.Errorf("gate route %s advances_to is required", verdict)
+	}
+	if route.Emit.Empty() {
+		if route.EmitSchema.Kind() != semanticvalue.KindObject || route.EmitSchema.Len() != 0 {
+			return fmt.Errorf("gate route %s carries an event schema without an emit", verdict)
+		}
+		return nil
+	}
+	if route.EmitSchema.Kind() != semanticvalue.KindObject || route.EmitSchema.Len() == 0 {
+		return fmt.Errorf("gate route %s emit is missing its frozen resolved event schema", verdict)
+	}
+	for field := range route.Emit.Fields {
+		if field == "" || field != strings.TrimSpace(field) {
+			return fmt.Errorf("gate route %s emit field %q is not canonical", verdict, field)
+		}
+	}
+	schemaMembers, _ := route.EmitSchema.ObjectMap()
+	schema := make(map[string]any, len(schemaMembers))
+	for key, value := range schemaMembers {
+		schema[key] = value.Interface()
+	}
+	properties := runtimesharedjson.SchemaProperties(schema["properties"])
+	literalPayload := make(map[string]any, len(route.Emit.Fields))
+	allLiteral := true
+	for field, expression := range route.Emit.Fields {
+		fieldSchema, ok := properties[field]
+		if !ok {
+			return fmt.Errorf("gate route %s emit field %s is absent from its frozen event schema", verdict, field)
+		}
+		if expression.HasLiteralValue() {
+			literalPayload[field] = expression.Literal.Interface()
+			if err := runtimeeventschema.ValidateValueAgainstSchema(fieldSchema, expression.Literal.Interface()); err != nil {
+				return fmt.Errorf("gate route %s literal emit field %s: %w", verdict, field, err)
+			}
+			continue
+		}
+		allLiteral = false
+		inputName, err := decisionField(expression)
+		if err != nil {
+			return fmt.Errorf("gate route %s emit field %s: %w", verdict, field, err)
+		}
+		input, ok := inputs[inputName]
+		if !ok || !input.Required {
+			return fmt.Errorf("gate route %s emit field %s must read a required declared decision.%s", verdict, field, inputName)
+		}
+		if !runtimecontracts.WorkflowGateInputTypeCompatibleWithResolvedSchema(input.Type, fieldSchema) {
+			return fmt.Errorf("gate route %s decision.%s type %s is incompatible with emit field %s frozen schema", verdict, inputName, input.Type, field)
+		}
+	}
+	for _, required := range runtimesharedjson.RequiredList(schema["required"]) {
+		if _, ok := route.Emit.Fields[required]; !ok {
+			return fmt.Errorf("gate route %s emit is missing required field %s from its frozen event schema", verdict, required)
+		}
+	}
+	if allLiteral {
+		if err := runtimeeventschema.ValidatePayloadAgainstSchema(schema, literalPayload); err != nil {
+			return fmt.Errorf("gate route %s assembled literal payload: %w", verdict, err)
+		}
+	}
+	return nil
+}
+
+func decisionField(expression FrozenExpression) (string, error) {
+	raw := strings.TrimSpace(expression.Ref)
+	if raw == "" {
+		raw = strings.TrimSpace(expression.CEL)
+	}
+	if !strings.HasPrefix(raw, "decision.") || strings.Count(raw, ".") != 1 {
+		return "", fmt.Errorf("only exact decision.<field> references are supported")
+	}
+	field := strings.TrimPrefix(raw, "decision.")
+	if field == "" || field != strings.TrimSpace(field) {
+		return "", fmt.Errorf("decision field reference %q is not canonical", raw)
+	}
+	return field, nil
+}
+
+func routeSemanticValue(route Route) (semanticvalue.Value, error) {
+	fields := make(map[string]any, len(route.Emit.Fields))
+	for name, expression := range route.Emit.Fields {
+		var literal any
+		if expression.HasLiteralValue() {
+			literal = expression.Literal.Interface()
+		}
+		fields[name] = map[string]any{"kind": string(expression.Kind), "ref": expression.Ref, "cel": expression.CEL, "literal": literal}
+	}
+	return canonicaljson.FromGo(map[string]any{
+		"advances_to": route.AdvancesTo,
+		"emit":        map[string]any{"event": route.Emit.Event, "fields": fields},
+		"emit_schema": route.EmitSchema.Interface(),
+	})
+}
+
+func routeFromSemanticValue(value semanticvalue.Value) (Route, error) {
+	root, ok := value.ObjectMap()
+	if !ok {
+		return Route{}, fmt.Errorf("route must be an object")
+	}
+	if err := exactFields(root, "route", "advances_to", "emit", "emit_schema"); err != nil {
+		return Route{}, err
+	}
+	advancesTo, ok := root["advances_to"].String()
+	if !ok || strings.TrimSpace(advancesTo) == "" {
+		return Route{}, fmt.Errorf("route advances_to must be a non-empty string")
+	}
+	emitRoot, ok := root["emit"].ObjectMap()
+	if !ok {
+		return Route{}, fmt.Errorf("route emit must be an object")
+	}
+	if err := exactFields(emitRoot, "route emit", "event", "fields"); err != nil {
+		return Route{}, err
+	}
+	event, ok := emitRoot["event"].String()
+	if !ok {
+		return Route{}, fmt.Errorf("route emit event must be a string")
+	}
+	fieldMembers, ok := emitRoot["fields"].ObjectMap()
+	if !ok {
+		return Route{}, fmt.Errorf("route emit fields must be an object")
+	}
+	fields := make(map[string]FrozenExpression, len(fieldMembers))
+	for name, encoded := range fieldMembers {
+		members, ok := encoded.ObjectMap()
+		if !ok {
+			return Route{}, fmt.Errorf("route emit field %s must be an object", name)
+		}
+		if err := exactFields(members, "route emit field "+name, "kind", "ref", "cel", "literal"); err != nil {
+			return Route{}, err
+		}
+		kind, kindOK := members["kind"].String()
+		ref, refOK := members["ref"].String()
+		cel, celOK := members["cel"].String()
+		if !kindOK || !refOK || !celOK {
+			return Route{}, fmt.Errorf("route emit field %s identity fields must be strings", name)
+		}
+		expression := FrozenExpression{Kind: runtimecontracts.ExpressionKind(kind), Ref: ref, CEL: cel}
+		if expression.HasLiteralValue() {
+			expression.Literal = members["literal"]
+		} else if members["literal"].Kind() != semanticvalue.KindNull {
+			return Route{}, fmt.Errorf("route emit field %s non-literal expression carries a literal", name)
+		}
+		fields[name] = expression
+	}
+	schema := root["emit_schema"]
+	if schema.Kind() != semanticvalue.KindObject {
+		return Route{}, fmt.Errorf("route emit_schema must be an object")
+	}
+	return Route{AdvancesTo: advancesTo, Emit: FrozenEmit{Event: event, Fields: fields}, EmitSchema: schema}, nil
+}
+
+func exactFields(values map[string]semanticvalue.Value, label string, expected ...string) error {
+	want := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		want[name] = struct{}{}
+		if _, ok := values[name]; !ok {
+			return fmt.Errorf("%s is missing field %s", label, name)
+		}
+	}
+	for name := range values {
+		if _, ok := want[name]; !ok {
+			return fmt.Errorf("%s has unexpected field %s", label, name)
+		}
+	}
+	return nil
+}

--- a/internal/runtime/gateruntime/routes_test.go
+++ b/internal/runtime/gateruntime/routes_test.go
@@ -1,0 +1,86 @@
+package gateruntime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+func TestFreezeRoutesOwnsExecutionSchemaAndPayloadValidation(t *testing.T) {
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           map[string]any{"code": map[string]any{"type": "string", "pattern": "^[a-z]+$"}},
+		"required":             []any{"code"},
+		"additionalProperties": false,
+	}
+	raw, err := FreezeRoutes(map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {
+			Verdict: "approve", AdvancesTo: "operating",
+			Input: map[string]runtimecontracts.WorkflowGateInputField{"code": {Type: "text", Required: true}},
+			Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
+				"code": runtimecontracts.CELExpression("decision.code"),
+			}},
+			EmitSchema: schema,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	route, err := RouteFor(raw, "approve")
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid, _ := canonicaljson.FromGo(map[string]any{"code": "NOT-LOWER"})
+	if _, err := BuildRoutePayload(route, invalid); err == nil || !strings.Contains(err.Error(), "pattern") {
+		t.Fatalf("BuildRoutePayload invalid error = %v", err)
+	}
+	valid, _ := canonicaljson.FromGo(map[string]any{"code": "ready"})
+	payload, err := BuildRoutePayload(route, valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := payload.Lookup("code"); !ok || value.Interface() != "ready" {
+		t.Fatalf("payload = %#v", payload.Interface())
+	}
+}
+
+func TestFreezeRoutesRejectsInvalidExecutionBeforePersistence(t *testing.T) {
+	unsafe := int64(9007199254740992)
+	for _, tc := range []struct {
+		name    string
+		outcome runtimecontracts.WorkflowGateOutcomePlan
+		want    string
+	}{
+		{name: "unsafe literal", want: "safe range", outcome: runtimecontracts.WorkflowGateOutcomePlan{
+			Verdict: "approve", AdvancesTo: "operating",
+			Emit:       runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{"value": runtimecontracts.LiteralExpression(unsafe)}},
+			EmitSchema: map[string]any{"type": "object", "properties": map[string]any{"value": map[string]any{"type": "integer"}}, "required": []any{"value"}},
+		}},
+		{name: "optional decision field", want: "required declared", outcome: runtimecontracts.WorkflowGateOutcomePlan{
+			Verdict: "approve", AdvancesTo: "operating",
+			Input:      map[string]runtimecontracts.WorkflowGateInputField{"note": {Type: "text"}},
+			Emit:       runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{"note": runtimecontracts.CELExpression("decision.note")}},
+			EmitSchema: map[string]any{"type": "object", "properties": map[string]any{"note": map[string]any{"type": "string"}}, "required": []any{"note"}},
+		}},
+		{name: "noncanonical field", want: "not canonical", outcome: runtimecontracts.WorkflowGateOutcomePlan{
+			Verdict: "approve", AdvancesTo: "operating",
+			Emit:       runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{" note ": runtimecontracts.LiteralExpression("ready")}},
+			EmitSchema: map[string]any{"type": "object", "properties": map[string]any{"note": map[string]any{"type": "string"}}},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := FreezeRoutes(map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": tc.outcome}); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("FreezeRoutes error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateRoutesRejectsStructuralShadowFields(t *testing.T) {
+	raw := `{"approve":{"advances_to":"operating","emit":{"event":"","fields":{},"shadow":true},"emit_schema":{}}}`
+	if err := ValidateRoutes(raw); err == nil || !strings.Contains(err.Error(), "unexpected field shadow") {
+		t.Fatalf("ValidateRoutes error = %v", err)
+	}
+}

--- a/internal/runtime/pipeline/activity_boring_proof_test.go
+++ b/internal/runtime/pipeline/activity_boring_proof_test.go
@@ -672,7 +672,7 @@ func activityBoringExpectedIntentForSourceEvent(evt events.Event, inputURL strin
 	return runtimeengine.ActivityIntent{
 		ActivityID:       resultEvents.ActivityID,
 		Tool:             "source_scrape",
-		Input:            map[string]any{"url": inputURL},
+		Input:            mustActivityInput(map[string]any{"url": inputURL}),
 		EffectClass:      runtimecontracts.ActivityEffectClassReadOnly,
 		SuccessEvent:     resultEvents.SuccessEvent,
 		FailureEvent:     resultEvents.FailureEvent,
@@ -699,7 +699,7 @@ func newActivityBoringIntent(inputURL, runID string) runtimeengine.ActivityInten
 	return runtimeengine.ActivityIntent{
 		ActivityID:       "scanner_source_scrape",
 		Tool:             "source_scrape",
-		Input:            map[string]any{"url": inputURL},
+		Input:            mustActivityInput(map[string]any{"url": inputURL}),
 		EffectClass:      runtimecontracts.ActivityEffectClassReadOnly,
 		SuccessEvent:     "research.scanner_source_scrape.succeeded",
 		FailureEvent:     "research.scanner_source_scrape.failed",

--- a/internal/runtime/pipeline/activity_engine.go
+++ b/internal/runtime/pipeline/activity_engine.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -16,17 +15,20 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/httpresponsesuccess"
 	runtimemanagedcredentials "github.com/division-sh/swarm/internal/runtime/managedcredentials"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -44,7 +46,29 @@ func (w pipelineActivityIntentWriter) WriteActivityIntents(ctx context.Context, 
 	if outbox == nil {
 		return fmt.Errorf("activity intent writer requires pipeline outbox")
 	}
-	requests, err := activityRequestEmitIntents(intents)
+	immediate := make([]runtimeengine.ActivityIntent, 0, len(intents))
+	for _, intent := range intents {
+		intent = intent.Normalized()
+		if intent.ApprovalDecision == "" {
+			immediate = append(immediate, intent)
+			continue
+		}
+		if _, ok := PipelineSQLTxFromContext(ctx); !ok {
+			return fmt.Errorf("approved activity %s must be materialized in the workflow mutation", intent.ActivityID)
+		}
+		store, ok := w.coordinator.decisionCards.(decisioncard.ProposedEffectStore)
+		if !ok || store == nil {
+			return fmt.Errorf("proposed-effect continuation store is required for approved activity %s", intent.ActivityID)
+		}
+		card, continuation, err := w.coordinator.buildProposedEffectCard(ctx, intent)
+		if err != nil {
+			return err
+		}
+		if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+			return err
+		}
+	}
+	requests, err := activityRequestEmitIntents(immediate)
 	if err != nil {
 		return err
 	}
@@ -63,10 +87,15 @@ func (w pipelineActivityIntentWriter) WriteActivityIntents(ctx context.Context, 
 			detail["loop_generation"] = intent.Generation.PayloadValue()
 			detail["loop_stage"] = intent.LoopStage
 		}
+		action := "intent_persisted"
+		if intent.ApprovalDecision != "" {
+			action = "proposal_persisted"
+			detail["approval_decision"] = intent.ApprovalDecision
+		}
 		entry := RuntimeLogEntry{
 			Level:     "info",
 			Component: "activity",
-			Action:    "intent_persisted",
+			Action:    action,
 			EventID:   activityRequestEventID(intent),
 			EventType: intent.SuccessEvent,
 			EntityID:  intent.EntityID.String(),
@@ -105,16 +134,116 @@ func (d pipelineActivityDispatcher) DispatchActivities(ctx context.Context, inte
 	if dispatcher == nil {
 		return fmt.Errorf("activity dispatcher requires pipeline outbox dispatcher")
 	}
-	requests, err := activityRequestEmitIntents(intents)
+	immediate := make([]runtimeengine.ActivityIntent, 0, len(intents))
+	for _, intent := range intents {
+		intent = intent.Normalized()
+		if intent.ApprovalDecision == "" {
+			immediate = append(immediate, intent)
+		}
+	}
+	requests, err := activityRequestEmitIntents(immediate)
 	if err != nil {
 		return err
 	}
 	return dispatcher.DispatchPostCommit(ctx, requests)
 }
 
+func (pc *PipelineCoordinator) buildProposedEffectCard(ctx context.Context, intent runtimeengine.ActivityIntent) (decisioncard.Card, decisioncard.ProposedEffectContinuation, error) {
+	intent = intent.Normalized()
+	if intent.ApprovalDecision == "" {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("approved activity decision is required")
+	}
+	if intent.EffectClass != runtimecontracts.ActivityEffectClassNonIdempotentWrite {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("approved activity %s must be non_idempotent_write", intent.ActivityID)
+	}
+	runID := strings.TrimSpace(intent.SourceRunID)
+	requestEventID := activityRequestEventID(intent)
+	flowInstance := firstNonEmptyString(intent.FlowInstance, intent.FlowID.String(), "root")
+	createdAt := time.Now().UTC()
+	bundleHash := workflowGateBundleHash(ctx, pc)
+	if bundleHash == "" {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("bundle identity is required before proposing approved activity %s", intent.ActivityID)
+	}
+	workflowVersion := ""
+	if source := pc.SemanticSource(); source != nil {
+		workflowVersion = strings.TrimSpace(source.WorkflowVersion())
+	}
+	if workflowVersion == "" {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("workflow version is required before proposing approved activity %s", intent.ActivityID)
+	}
+	continuation := decisioncard.ProposedEffectContinuation{
+		CardID: decisioncard.ProposedEffectCardID(requestEventID, intent.ApprovalDecision), RunID: runID,
+		RequestEventID: requestEventID, ActivityID: intent.ActivityID, Tool: intent.Tool,
+		BundleHash: bundleHash, WorkflowVersion: workflowVersion, Input: intent.Input,
+		EffectClass: intent.EffectClass, SuccessEvent: intent.SuccessEvent, FailureEvent: intent.FailureEvent,
+		RevisionEvent: intent.RevisionEvent, RejectedEvent: intent.RejectedEvent,
+		RetryMaxAttempts: intent.RetryMaxAttempts, RetryBackoff: intent.RetryBackoff, ForkPolicy: intent.ForkPolicy,
+		EntityID: intent.EntityID.String(), NodeID: intent.NodeID.String(), FlowID: intent.FlowID.String(), FlowInstance: flowInstance,
+		HandlerEventKey: intent.HandlerEventKey, SourceEventID: intent.SourceEventID, SourceRunID: intent.SourceRunID,
+		SourceTaskID: intent.SourceTaskID, ParentEventID: intent.ParentEventID, ChainDepth: intent.ChainDepth,
+		Attempt: intent.Attempt, Generation: intent.Generation, LoopStage: intent.LoopStage,
+		ReplyContextID: intent.Context.ReplyContextID(), State: decisioncard.ProposedEffectPending,
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}.Canonical()
+	effect, err := continuation.EffectValue()
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("encode proposed activity effect: %w", err)
+	}
+	effectHash, err := canonicaljson.HashValue(effect)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("hash proposed activity effect: %w", err)
+	}
+	continuation.EffectContentHash = effectHash
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: requestEventID, ActivityID: intent.ActivityID, Decision: intent.ApprovalDecision,
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: flowInstance, EntityID: intent.EntityID.String()},
+	})
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	outcomes := map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve", Label: "Approve"},
+		"revise": {
+			Verdict: "revise", Label: "Request revision",
+			Input: map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Label: "Feedback", Required: true}},
+		},
+		"reject": {
+			Verdict: "reject", Label: "Reject",
+			Input: map[string]runtimecontracts.WorkflowGateInputField{"reason": {Type: "text", Label: "Reason"}},
+		},
+	}
+	snapshot, err := decisioncard.FreezeSnapshot(intent.ApprovalDecision, "", map[string]any{
+		"activity_id": intent.ActivityID, "tool": intent.Tool, "effect_class": string(intent.EffectClass), "input": intent.Input.Interface(),
+	}, outcomes)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	provenance, err := canonicaljson.FromGo(map[string]any{
+		"source_event": intent.SourceEventID, "flow_id": intent.FlowID.String(), "flow_instance": flowInstance, "node_id": intent.NodeID.String(),
+	})
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("admit proposed-effect provenance: %w", err)
+	}
+	card, err := decisioncard.New(decisioncard.Card{
+		CardID: continuation.CardID, RunID: runID, Anchor: anchor, Snapshot: snapshot,
+		EffectContentHash: effectHash, BundleHash: bundleHash, WorkflowVersion: workflowVersion,
+		EffectiveCadence: pc.decisionCardCadence.Stamp(createdAt), Provenance: provenance, CreatedAt: createdAt,
+	})
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	if err := continuation.Validate(card); err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	return card, continuation, nil
+}
+
 func (d pipelineActivityDispatcher) executeActivityIntent(ctx context.Context, intent runtimeengine.ActivityIntent) error {
 	intent = intent.Normalized()
 	source := d.coordinator.SemanticSource()
+	if err := d.admitActivityContractPin(ctx, intent, source); err != nil {
+		return err
+	}
 	if source == nil {
 		return runtimefailures.New(runtimefailures.ClassInternalFailure, "activity_semantic_source_missing", "activity-runtime", "execute_activity", nil)
 	}
@@ -195,6 +324,38 @@ func (d pipelineActivityDispatcher) executeActivityIntent(ctx context.Context, i
 	failureIntent := intent
 	failureIntent.Attempt = maxAttempts
 	return d.publishActivityFailure(ctx, failureIntent, lastErr)
+}
+
+func (d pipelineActivityDispatcher) admitActivityContractPin(ctx context.Context, intent runtimeengine.ActivityIntent, source semanticview.Source) error {
+	if intent.BundleHash == "" && intent.WorkflowVersion == "" {
+		return nil
+	}
+	if intent.BundleHash == "" || intent.WorkflowVersion == "" {
+		return runtimefailures.New(runtimefailures.ClassSchemaInvalid, "activity_contract_pin_incomplete", "activity-runtime", "admit_activity_contract", map[string]any{
+			"activity_id": intent.ActivityID, "bundle_hash": intent.BundleHash, "workflow_version": intent.WorkflowVersion,
+		})
+	}
+	currentBundleHash := workflowGateBundleHash(ctx, d.coordinator)
+	currentWorkflowVersion := ""
+	if source != nil {
+		currentWorkflowVersion = strings.TrimSpace(source.WorkflowVersion())
+	}
+	if currentBundleHash == intent.BundleHash && currentWorkflowVersion == intent.WorkflowVersion {
+		return nil
+	}
+	return DeferPipelineReceipt(runtimefailures.New(
+		runtimefailures.ClassDependencyUnavailable,
+		"activity_contract_pin_unavailable",
+		"activity-runtime",
+		"admit_activity_contract",
+		map[string]any{
+			"activity_id":               intent.ActivityID,
+			"required_bundle_hash":      intent.BundleHash,
+			"current_bundle_hash":       currentBundleHash,
+			"required_workflow_version": intent.WorkflowVersion,
+			"current_workflow_version":  currentWorkflowVersion,
+		},
+	))
 }
 
 func (d pipelineActivityDispatcher) admitReadOnlyActivityGeneration(ctx context.Context, intent runtimeengine.ActivityIntent) error {
@@ -412,16 +573,20 @@ func (pc *PipelineCoordinator) handleActivityRequestEvent(ctx context.Context, e
 type activityRequestPayload struct {
 	ActivityID       string                       `json:"activity_id"`
 	Tool             string                       `json:"tool"`
-	Input            map[string]any               `json:"input"`
+	BundleHash       string                       `json:"bundle_hash,omitempty"`
+	WorkflowVersion  string                       `json:"workflow_version,omitempty"`
 	EffectClass      string                       `json:"effect_class"`
 	SuccessEvent     string                       `json:"success_event"`
 	FailureEvent     string                       `json:"failure_event"`
+	RevisionEvent    string                       `json:"revision_event,omitempty"`
+	RejectedEvent    string                       `json:"rejected_event,omitempty"`
 	RetryMaxAttempts int                          `json:"retry_max_attempts"`
 	RetryBackoff     string                       `json:"retry_backoff"`
 	ForkPolicy       string                       `json:"fork_policy"`
 	EntityID         string                       `json:"entity_id"`
 	NodeID           string                       `json:"node_id"`
 	FlowID           string                       `json:"flow_id"`
+	FlowInstance     string                       `json:"flow_instance,omitempty"`
 	HandlerEventKey  string                       `json:"handler_event_key"`
 	SourceEventID    string                       `json:"source_event_id"`
 	SourceRunID      string                       `json:"source_run_id"`
@@ -451,7 +616,15 @@ func activityRequestEmitIntents(intents []runtimeengine.ActivityIntent) ([]runti
 func activityRequestEmitIntent(intent runtimeengine.ActivityIntent) (runtimeengine.EmitIntent, error) {
 	intent = intent.Normalized()
 	payload := activityRequestPayloadFromIntent(intent)
-	raw, err := json.Marshal(payload)
+	value, err := canonicaljson.FromGo(payload)
+	if err != nil {
+		return runtimeengine.EmitIntent{}, err
+	}
+	value, err = value.With("input", intent.Input)
+	if err != nil {
+		return runtimeengine.EmitIntent{}, fmt.Errorf("attach admitted activity input: %w", err)
+	}
+	raw, err := canonicaljson.Encode(value)
 	if err != nil {
 		return runtimeengine.EmitIntent{}, err
 	}
@@ -550,16 +723,20 @@ func activityRequestPayloadFromIntent(intent runtimeengine.ActivityIntent) activ
 	return activityRequestPayload{
 		ActivityID:       intent.ActivityID,
 		Tool:             intent.Tool,
-		Input:            cloneStringAnyMap(intent.Input),
+		BundleHash:       intent.BundleHash,
+		WorkflowVersion:  intent.WorkflowVersion,
 		EffectClass:      string(intent.EffectClass),
 		SuccessEvent:     intent.SuccessEvent,
 		FailureEvent:     intent.FailureEvent,
+		RevisionEvent:    intent.RevisionEvent,
+		RejectedEvent:    intent.RejectedEvent,
 		RetryMaxAttempts: intent.RetryMaxAttempts,
 		RetryBackoff:     intent.RetryBackoff,
 		ForkPolicy:       string(intent.ForkPolicy),
 		EntityID:         intent.EntityID.String(),
 		NodeID:           intent.NodeID.String(),
 		FlowID:           intent.FlowID.String(),
+		FlowInstance:     intent.FlowInstance,
 		HandlerEventKey:  intent.HandlerEventKey,
 		SourceEventID:    intent.SourceEventID,
 		SourceRunID:      intent.SourceRunID,
@@ -573,24 +750,37 @@ func activityRequestPayloadFromIntent(intent runtimeengine.ActivityIntent) activ
 }
 
 func activityIntentFromRequestEvent(evt events.Event) (runtimeengine.ActivityIntent, error) {
-	var payload activityRequestPayload
-	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+	semanticPayload, err := canonicaljson.Decode(evt.Payload())
+	if err != nil {
 		return runtimeengine.ActivityIntent{}, fmt.Errorf("decode activity request %s: %w", evt.ID(), err)
+	}
+	var payload activityRequestPayload
+	if err := canonicaljson.ValueInto(semanticPayload, &payload); err != nil {
+		return runtimeengine.ActivityIntent{}, fmt.Errorf("decode activity request %s: %w", evt.ID(), err)
+	}
+	input, ok := semanticPayload.Lookup("input")
+	if !ok || input.Kind() != semanticvalue.KindObject {
+		return runtimeengine.ActivityIntent{}, fmt.Errorf("activity request %s input must be a semantic object", evt.ID())
 	}
 	intent := runtimeengine.ActivityIntent{
 		Context:          evt.DeliveryContext(),
 		ActivityID:       payload.ActivityID,
 		Tool:             payload.Tool,
-		Input:            cloneStringAnyMap(payload.Input),
+		BundleHash:       payload.BundleHash,
+		WorkflowVersion:  payload.WorkflowVersion,
+		Input:            input,
 		EffectClass:      runtimecontracts.NormalizeActivityEffectClass(payload.EffectClass),
 		SuccessEvent:     payload.SuccessEvent,
 		FailureEvent:     payload.FailureEvent,
+		RevisionEvent:    payload.RevisionEvent,
+		RejectedEvent:    payload.RejectedEvent,
 		RetryMaxAttempts: payload.RetryMaxAttempts,
 		RetryBackoff:     payload.RetryBackoff,
 		ForkPolicy:       runtimecontracts.ActivityForkPolicy(strings.TrimSpace(payload.ForkPolicy)),
 		EntityID:         identity.NormalizeEntityID(payload.EntityID),
 		NodeID:           identity.NormalizeNodeID(payload.NodeID),
 		FlowID:           identity.NormalizeFlowID(payload.FlowID),
+		FlowInstance:     payload.FlowInstance,
 		HandlerEventKey:  payload.HandlerEventKey,
 		SourceEventID:    payload.SourceEventID,
 		SourceRunID:      payload.SourceRunID,
@@ -603,6 +793,9 @@ func activityIntentFromRequestEvent(evt events.Event) (runtimeengine.ActivityInt
 	}.Normalized()
 	if intent.ActivityID == "" || intent.Tool == "" || intent.SuccessEvent == "" || intent.FailureEvent == "" {
 		return runtimeengine.ActivityIntent{}, fmt.Errorf("activity request %s is missing required activity identity", evt.ID())
+	}
+	if (intent.BundleHash == "") != (intent.WorkflowVersion == "") {
+		return runtimeengine.ActivityIntent{}, fmt.Errorf("activity request %s carries an incomplete contract pin", evt.ID())
 	}
 	return intent, nil
 }
@@ -660,8 +853,15 @@ func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context,
 			return preparedActivityHTTPTool{}, activityContractFailure(intent.Tool, "managed_credential_effect_class_unsupported")
 		}
 	}
-	input := cloneStringAnyMap(intent.Input)
-	env := map[string]any{"input": input, "credentials": credentials}
+	input, ok := intent.Input.ObjectMap()
+	if !ok {
+		return preparedActivityHTTPTool{}, activityContractFailure(intent.Tool, "input_not_object")
+	}
+	inputDTO := make(map[string]any, len(input))
+	for name, value := range input {
+		inputDTO[name] = value.Interface()
+	}
+	env := map[string]any{"input": inputDTO, "credentials": credentials}
 	url, err := resolveActivityHTTPURLTemplate(tool.HTTP.URL, env)
 	if err != nil {
 		return preparedActivityHTTPTool{}, activityTemplateFailure(err, intent.Tool, "url", secrets)
@@ -725,7 +925,7 @@ func (d pipelineActivityDispatcher) prepareActivityHTTPTool(ctx context.Context,
 		secrets:     secrets,
 		managedAuth: managedAuth,
 		success:     cloneActivityResponseSuccess(tool.ResponseSuccess),
-		inputHash:   activityInputHash(input),
+		inputHash:   activityInputHash(intent.Input),
 	}, nil
 }
 
@@ -944,33 +1144,22 @@ func (d pipelineActivityDispatcher) resolveActivityManagedCredential(ctx context
 	}, nil
 }
 
-func activityManagedCredentialInputValue(input map[string]any, key string) string {
+func activityManagedCredentialInputValue(input semanticvalue.Value, key string) string {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return ""
 	}
-	value, ok := input[key]
-	if !ok || value == nil {
+	value, ok := input.Lookup(key)
+	if !ok || value.Kind() == semanticvalue.KindNull {
 		return ""
 	}
-	switch typed := value.(type) {
-	case string:
-		return strings.TrimSpace(typed)
-	case json.Number:
-		return strings.TrimSpace(typed.String())
-	case float64:
-		return strings.TrimSpace(strconv.FormatFloat(typed, 'f', -1, 64))
-	case float32:
-		return strings.TrimSpace(strconv.FormatFloat(float64(typed), 'f', -1, 32))
-	case int:
-		return strconv.Itoa(typed)
-	case int64:
-		return strconv.FormatInt(typed, 10)
-	case uint64:
-		return strconv.FormatUint(typed, 10)
-	default:
-		return strings.TrimSpace(fmt.Sprint(typed))
+	if text, ok := value.String(); ok {
+		return strings.TrimSpace(text)
 	}
+	if number, ok := value.Number(); ok {
+		return strings.TrimSpace(strconv.FormatFloat(number, 'g', -1, 64))
+	}
+	return strings.TrimSpace(fmt.Sprint(value.Interface()))
 }
 
 type activityHTTPUncertainError struct {
@@ -1349,7 +1538,7 @@ func activityAttemptStartRecord(intent runtimeengine.ActivityIntent, inputHash s
 		SourceEventID:   intent.SourceEventID,
 		ParentEventID:   intent.ParentEventID,
 		EntityID:        intent.EntityID.String(),
-		FlowInstance:    intent.FlowID.String(),
+		FlowInstance:    firstNonEmptyString(intent.FlowInstance, intent.FlowID.String()),
 		NodeID:          intent.NodeID.String(),
 		HandlerEventKey: intent.HandlerEventKey,
 		ActivityID:      intent.ActivityID,
@@ -1376,11 +1565,10 @@ func (rec ActivityAttemptRecord) withTerminal(status, eventID, eventType string,
 	return rec
 }
 
-func activityInputHash(input map[string]any) string {
-	raw, err := json.Marshal(input)
+func activityInputHash(input semanticvalue.Value) string {
+	hash, err := canonicaljson.HashValue(input)
 	if err != nil {
-		raw = []byte(fmt.Sprintf("%#v", input))
+		panic(fmt.Sprintf("hash admitted activity input: %v", err))
 	}
-	sum := sha256.Sum256(raw)
-	return fmt.Sprintf("sha256:%x", sum[:])
+	return hash
 }

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/division-sh/swarm/internal/providerconnectors"
 	"github.com/division-sh/swarm/internal/providertriggers"
 	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -28,6 +29,7 @@ import (
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -65,8 +67,17 @@ func TestPipelineActivityIntentWriterPersistsDurableActivityRequestEvent(t *test
 	if payload.Tool != "source_scrape" || payload.SuccessEvent != "research.scanner_source_scrape.succeeded" {
 		t.Fatalf("request payload = %#v", payload)
 	}
-	if got := payload.Input["url"]; got != "https://example.com/source" {
-		t.Fatalf("request input url = %#v", got)
+	semanticPayload, err := canonicaljson.Decode(request.Event.Payload())
+	if err != nil {
+		t.Fatalf("admit request payload: %v", err)
+	}
+	input, ok := semanticPayload.Lookup("input")
+	if !ok {
+		t.Fatal("request input is missing")
+	}
+	url, ok := input.Lookup("url")
+	if got, isText := url.String(); !ok || !isText || got != "https://example.com/source" {
+		t.Fatalf("request input url = %q (string=%v)", got, isText)
 	}
 }
 
@@ -601,7 +612,7 @@ func TestGeneratedSyntheticConnectorUsesCanonicalActivityJournalOnReplay(t *test
 	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
 	intent.Tool = "acme.create_widget"
 	intent.ActivityID = "acme_create_widget"
-	intent.Input = map[string]any{"account_id": "account-7", "name": "proof widget"}
+	intent.Input = mustActivityInput(map[string]any{"account_id": "account-7", "name": "proof widget"})
 	request, err := activityRequestEmitIntent(intent)
 	if err != nil {
 		t.Fatalf("activityRequestEmitIntent: %v", err)
@@ -709,7 +720,7 @@ func runTelegramConnectorRoundTripThroughInboundDelivery(t *testing.T, ctx conte
 	intent := testNonIdempotentActivityIntent(runID, inboundEvent.ID(), entityID)
 	intent.Tool = "telegram.send_message"
 	intent.ActivityID = "telegram_send_message"
-	intent.Input = map[string]any{"chat_id": chatID, "text": "reply: " + incomingText}
+	intent.Input = mustActivityInput(map[string]any{"chat_id": chatID, "text": "reply: " + incomingText})
 	intent.SuccessEvent = "telegram.send_message.succeeded"
 	intent.FailureEvent = "telegram.send_message.failed"
 	intent.SourceTaskID = inboundEvent.TaskID()
@@ -1205,7 +1216,7 @@ func TestPipelineActivityRequestTelegramConnectorMissingTokenFailsAfterClaimBefo
 	intent := testNonIdempotentActivityIntent(runID, sourceEventID, entityID)
 	intent.Tool = "telegram.send_message"
 	intent.ActivityID = "telegram_send_message"
-	intent.Input = map[string]any{"chat_id": "42", "text": "reply"}
+	intent.Input = mustActivityInput(map[string]any{"chat_id": "42", "text": "reply"})
 	intent.SuccessEvent = "telegram.send_message.succeeded"
 	intent.FailureEvent = "telegram.send_message.failed"
 	intent = intent.Normalized()
@@ -1255,7 +1266,7 @@ func testActivityIntent(inputURL string) runtimeengine.ActivityIntent {
 	return runtimeengine.ActivityIntent{
 		ActivityID:    "scanner_source_scrape",
 		Tool:          "source_scrape",
-		Input:         map[string]any{"url": inputURL},
+		Input:         mustActivityInput(map[string]any{"url": inputURL}),
 		EffectClass:   runtimecontracts.ActivityEffectClassReadOnly,
 		SuccessEvent:  "research.scanner_source_scrape.succeeded",
 		FailureEvent:  "research.scanner_source_scrape.failed",
@@ -1268,6 +1279,14 @@ func testActivityIntent(inputURL string) runtimeengine.ActivityIntent {
 		ChainDepth:    4,
 		Attempt:       1,
 	}.Normalized()
+}
+
+func mustActivityInput(input map[string]any) semanticvalue.Value {
+	value, err := canonicaljson.FromGo(input)
+	if err != nil {
+		panic(err)
+	}
+	return value
 }
 
 func testNonIdempotentActivityIntent(runID, sourceEventID, entityID string) runtimeengine.ActivityIntent {

--- a/internal/runtime/pipeline/workflow_gate_decision.go
+++ b/internal/runtime/pipeline/workflow_gate_decision.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
@@ -53,9 +54,153 @@ func (pc *PipelineCoordinator) handleWorkflowGateDecisionEvent(ctx context.Conte
 		return pc.handleStageGateDecisionCard(ctx, evt, card)
 	case decisioncard.AnchorKindHumanTask:
 		return pc.handleHumanTaskDecisionCard(ctx, evt, card)
+	case decisioncard.AnchorKindProposedEffect:
+		return pc.handleProposedEffectDecisionCard(ctx, evt, card)
 	default:
 		return nil, fmt.Errorf("decision-card anchor kind %q is not registered", card.Anchor.Kind())
 	}
+}
+
+func (pc *PipelineCoordinator) handleProposedEffectDecisionCard(ctx context.Context, evt events.Event, card decisioncard.Card) ([]events.Event, error) {
+	store, ok := pc.decisionCards.(decisioncard.ProposedEffectStore)
+	if !ok || store == nil {
+		return nil, fmt.Errorf("proposed-effect continuation store is not configured")
+	}
+	continuation, err := store.LoadProposedEffectContinuation(ctx, card.CardID)
+	if err != nil {
+		return nil, err
+	}
+	if continuation.DecisionEventID != evt.ID() || continuation.Verdict != card.Verdict {
+		return nil, fmt.Errorf("mailbox.card_decided does not match the authoritative proposed-effect continuation")
+	}
+	var released []runtimeengine.EmitIntent
+	err = pc.workflowStore.RunPipelineMutation(ctx, func(txctx context.Context) error {
+		continuation, err := store.LoadProposedEffectContinuation(txctx, card.CardID)
+		if err != nil {
+			return err
+		}
+		if continuation.RouteEventID == evt.ID() && (continuation.State == decisioncard.ProposedEffectRequestReleased || continuation.State == decisioncard.ProposedEffectOutcomeDispatched) {
+			return nil
+		}
+		if continuation.State != decisioncard.ProposedEffectDecisionCommitted {
+			return fmt.Errorf("proposed-effect continuation is not ready to route")
+		}
+		if current := workflowGateBundleHash(txctx, pc); current == "" || current != card.BundleHash {
+			return DeferPipelineReceipt(runtimefailures.New(
+				runtimefailures.ClassDependencyUnavailable,
+				"decision_card_bundle_unavailable",
+				runtimeWorkflowID,
+				"route_proposed_effect_decision",
+				map[string]any{"card_id": card.CardID, "required_bundle_hash": card.BundleHash, "current_bundle_hash": current},
+			))
+		}
+		switch card.Verdict {
+		case "approve":
+			request, err := activityRequestEmitIntent(activityIntentFromProposedEffect(continuation))
+			if err != nil {
+				return err
+			}
+			outbox := pc.bus.EngineOutbox()
+			if outbox == nil {
+				return fmt.Errorf("approved activity release requires pipeline outbox")
+			}
+			if err := outbox.WriteOutbox(txctx, []runtimeengine.EmitIntent{request}); err != nil {
+				return err
+			}
+			released = []runtimeengine.EmitIntent{request}
+		case "revise", "reject":
+			product, err := proposedEffectOutcomeEvent(card, evt, continuation)
+			if err != nil {
+				return err
+			}
+			publisher, ok := pc.bus.(workflowGateMutationPublisher)
+			if !ok || publisher == nil {
+				return fmt.Errorf("transactional event publisher is required for proposed-effect outcome")
+			}
+			if continuation.ReplyContextID != "" {
+				delivery := events.DeliveryContext{Reply: &events.ReplyContextRef{ID: continuation.ReplyContextID}}
+				product = product.WithDeliveryContext(delivery)
+				txctx = events.WithDeliveryContext(txctx, delivery)
+			}
+			if err := publisher.PublishInMutation(txctx, product); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("proposed-effect verdict %q is unsupported", card.Verdict)
+		}
+		_, err = store.CompleteProposedEffectRoute(txctx, card.CardID, evt.ID(), card.DecidedAt)
+		return err
+	})
+	if err != nil || len(released) == 0 {
+		return nil, err
+	}
+	dispatcher := pc.bus.EngineDispatcher()
+	if dispatcher == nil {
+		return nil, fmt.Errorf("approved activity release requires post-commit dispatcher")
+	}
+	if err := dispatcher.DispatchPostCommit(context.WithoutCancel(ctx), released); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func activityIntentFromProposedEffect(continuation decisioncard.ProposedEffectContinuation) runtimeengine.ActivityIntent {
+	continuation = continuation.Canonical()
+	intent := runtimeengine.ActivityIntent{
+		Context: events.DeliveryContext{}, ActivityID: continuation.ActivityID, Tool: continuation.Tool,
+		BundleHash: continuation.BundleHash, WorkflowVersion: continuation.WorkflowVersion,
+		Input: continuation.Input, EffectClass: continuation.EffectClass,
+		SuccessEvent: continuation.SuccessEvent, FailureEvent: continuation.FailureEvent,
+		RevisionEvent: continuation.RevisionEvent, RejectedEvent: continuation.RejectedEvent,
+		RetryMaxAttempts: continuation.RetryMaxAttempts, RetryBackoff: continuation.RetryBackoff, ForkPolicy: continuation.ForkPolicy,
+		EntityID: identity.NormalizeEntityID(continuation.EntityID), NodeID: identity.NormalizeNodeID(continuation.NodeID),
+		FlowID: identity.NormalizeFlowID(continuation.FlowID), FlowInstance: continuation.FlowInstance,
+		HandlerEventKey: continuation.HandlerEventKey, SourceEventID: continuation.SourceEventID,
+		SourceRunID: continuation.SourceRunID, SourceTaskID: continuation.SourceTaskID,
+		ParentEventID: continuation.ParentEventID, ChainDepth: continuation.ChainDepth,
+		Attempt: continuation.Attempt, Generation: continuation.Generation, LoopStage: continuation.LoopStage,
+	}
+	if continuation.ReplyContextID != "" {
+		intent.Context = events.DeliveryContext{Reply: &events.ReplyContextRef{ID: continuation.ReplyContextID}}
+	}
+	return intent.Normalized()
+}
+
+func proposedEffectOutcomeEvent(card decisioncard.Card, parent events.Event, continuation decisioncard.ProposedEffectContinuation) (events.Event, error) {
+	var noEvent events.Event
+	eventType := continuation.RevisionEvent
+	payloadValues := map[string]any{
+		"card_id": card.CardID, "activity_id": continuation.ActivityID,
+		"tool": continuation.Tool, "effect_class": string(continuation.EffectClass),
+		"effect_content_hash": continuation.EffectContentHash,
+		"decided_by":          card.DecidedBy, "decided_at": card.DecidedAt.UTC().Format(time.RFC3339Nano),
+	}
+	switch card.Verdict {
+	case "revise":
+		feedback, ok := card.Fields.Lookup("feedback")
+		if !ok {
+			return noEvent, fmt.Errorf("revision feedback is required")
+		}
+		payloadValues["feedback"] = feedback.Interface()
+	case "reject":
+		eventType = continuation.RejectedEvent
+		if reason, ok := card.Fields.Lookup("reason"); ok {
+			payloadValues["reason"] = reason.Interface()
+		}
+	default:
+		return noEvent, fmt.Errorf("proposed-effect outcome verdict %q is unsupported", card.Verdict)
+	}
+	raw, err := canonicaljson.Bytes(payloadValues)
+	if err != nil {
+		return noEvent, err
+	}
+	if strings.TrimSpace(eventType) == "" {
+		return noEvent, fmt.Errorf("proposed-effect %s event is missing", card.Verdict)
+	}
+	envelope := events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, continuation.EntityID), continuation.FlowInstance)
+	eventID := uuid.NewSHA1(uuid.NameSpaceOID, []byte("swarm.proposed-effect.outcome.v1\x00"+card.CardID+"\x00"+parent.ID()+"\x00"+card.Verdict)).String()
+	return events.NewChildEvent(eventID, events.EventType(eventType), runtimeWorkflowID, continuation.SourceTaskID, raw,
+		parent.ChainDepth()+1, parent, envelope, card.DecidedAt.UTC()), nil
 }
 
 func (pc *PipelineCoordinator) handleDecisionCardDeferredEvent(ctx context.Context, evt events.Event) ([]events.Event, error) {
@@ -196,10 +341,6 @@ func humanTaskRequesterOutcomeEnvelope(continuation decisioncard.HumanTaskContin
 }
 
 func (pc *PipelineCoordinator) handleStageGateDecisionCard(ctx context.Context, evt events.Event, card decisioncard.Card) ([]events.Event, error) {
-	outcome, ok := card.Snapshot.Outcomes[card.Verdict]
-	if !ok {
-		return nil, fmt.Errorf("card verdict %s is absent from the frozen outcome plan", card.Verdict)
-	}
 	if current := workflowGateBundleHash(ctx, pc); current == "" || current != card.BundleHash {
 		return nil, DeferPipelineReceipt(runtimefailures.New(
 			runtimefailures.ClassDependencyUnavailable,
@@ -209,14 +350,44 @@ func (pc *PipelineCoordinator) handleStageGateDecisionCard(ctx context.Context, 
 			map[string]any{"card_id": card.CardID, "required_bundle_hash": card.BundleHash, "current_bundle_hash": current},
 		))
 	}
-	emitted, err := workflowGateOutcomeEvent(card, evt, outcome)
+	route, err := pc.loadStageGateRoute(ctx, card)
 	if err != nil {
 		return nil, err
 	}
-	if err := pc.routeWorkflowGateDecision(ctx, card, evt, outcome, emitted); err != nil {
+	emitted, err := workflowGateOutcomeEvent(card, evt, route)
+	if err != nil {
+		return nil, err
+	}
+	if err := pc.routeWorkflowGateDecision(ctx, card, evt, route, emitted); err != nil {
 		return nil, err
 	}
 	return nil, nil
+}
+
+func (pc *PipelineCoordinator) loadStageGateRoute(ctx context.Context, card decisioncard.Card) (gateruntime.Route, error) {
+	anchor, err := card.Anchor.StageGate()
+	if err != nil {
+		return gateruntime.Route{}, err
+	}
+	instance, found, err := pc.workflowStore.Load(ctx, anchor.EntityID)
+	if err != nil {
+		return gateruntime.Route{}, err
+	}
+	if !found {
+		return gateruntime.Route{}, fmt.Errorf("decision card workflow instance is missing")
+	}
+	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+	if err != nil {
+		return gateruntime.Route{}, err
+	}
+	activation, found, err := gateruntime.Load(carrier.StateBuckets, anchor.FlowID, card.Snapshot.Decision)
+	if err != nil {
+		return gateruntime.Route{}, err
+	}
+	if !found || activation.ActivationID != anchor.StageActivationID || activation.CardID != card.CardID {
+		return gateruntime.Route{}, fmt.Errorf("decision card activation is no longer authoritative")
+	}
+	return gateruntime.RouteFor(activation.RoutesJSON, card.Verdict)
 }
 
 func (pc *PipelineCoordinator) handleHumanTaskDecisionCard(ctx context.Context, evt events.Event, card decisioncard.Card) ([]events.Event, error) {
@@ -267,7 +438,7 @@ func (pc *PipelineCoordinator) handleHumanTaskDecisionCard(ctx context.Context, 
 	})
 }
 
-func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, card decisioncard.Card, evt events.Event, outcome decisioncard.FrozenOutcome, emitted *events.Event) error {
+func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, card decisioncard.Card, evt events.Event, route gateruntime.Route, emitted *events.Event) error {
 	anchor, err := card.Anchor.StageGate()
 	if err != nil {
 		return err
@@ -289,7 +460,7 @@ func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, ca
 				return err
 			}
 			if found && activation.ActivationID == anchor.StageActivationID && activation.CardID == card.CardID && activation.Status == gateruntime.StatusRouted && activation.DecisionEventID == evt.ID() {
-				if currentStage != strings.TrimSpace(outcome.AdvancesTo) {
+				if currentStage != strings.TrimSpace(route.AdvancesTo) {
 					return fmt.Errorf("routed decision card state does not match its frozen outcome")
 				}
 				alreadyRouted = true
@@ -307,7 +478,7 @@ func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, ca
 			if err := gateruntime.Store(carrier.StateBuckets, activation); err != nil {
 				return err
 			}
-			next := strings.TrimSpace(outcome.AdvancesTo)
+			next := strings.TrimSpace(route.AdvancesTo)
 			instance.CurrentState = next
 			instance.EnteredStageAt = time.Now().UTC()
 			instance.TransitionHistory = append(instance.TransitionHistory, workflowTransitionRecord(pc.WorkflowDefinition(), currentStage, next, evt.ID()))
@@ -319,14 +490,14 @@ func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, ca
 		if alreadyRouted {
 			return nil
 		}
-		pc.notifyTestEntityStateUpdated(anchor.EntityID, outcome.AdvancesTo)
-		if err := pc.reconcileWorkflowStageTimers(txctx, anchor.EntityID, currentStage, outcome.AdvancesTo, evt.ID()); err != nil {
+		pc.notifyTestEntityStateUpdated(anchor.EntityID, route.AdvancesTo)
+		if err := pc.reconcileWorkflowStageTimers(txctx, anchor.EntityID, currentStage, route.AdvancesTo, evt.ID()); err != nil {
 			return err
 		}
-		if err := pc.applyWorkflowJoinIntents(txctx, anchor.EntityID, currentStage, outcome.AdvancesTo); err != nil {
+		if err := pc.applyWorkflowJoinIntents(txctx, anchor.EntityID, currentStage, route.AdvancesTo); err != nil {
 			return err
 		}
-		if err := pc.applyWorkflowGateIntents(txctx, anchor.EntityID, currentStage, outcome.AdvancesTo, evt.ID()); err != nil {
+		if err := pc.applyWorkflowGateIntents(txctx, anchor.EntityID, currentStage, route.AdvancesTo, evt.ID()); err != nil {
 			return err
 		}
 		if emitted != nil {
@@ -342,11 +513,11 @@ func (pc *PipelineCoordinator) routeWorkflowGateDecision(ctx context.Context, ca
 	})
 }
 
-func workflowGateOutcomeEvent(card decisioncard.Card, parent events.Event, outcome decisioncard.FrozenOutcome) (*events.Event, error) {
-	if outcome.Emit.Empty() || strings.TrimSpace(outcome.Emit.Event) == "" {
+func workflowGateOutcomeEvent(card decisioncard.Card, parent events.Event, route gateruntime.Route) (*events.Event, error) {
+	if route.Emit.Empty() || strings.TrimSpace(route.Emit.Event) == "" {
 		return nil, nil
 	}
-	payload, err := decisioncard.BuildOutcomePayload(outcome, card.Fields)
+	payload, err := gateruntime.BuildRoutePayload(route, card.Fields)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +525,7 @@ func workflowGateOutcomeEvent(card decisioncard.Card, parent events.Event, outco
 	if err != nil {
 		return nil, err
 	}
-	eventType := strings.TrimSpace(outcome.Emit.Event)
+	eventType := strings.TrimSpace(route.Emit.Event)
 	anchor, err := card.Anchor.StageGate()
 	if err != nil {
 		return nil, err

--- a/internal/runtime/pipeline/workflow_gate_fence.go
+++ b/internal/runtime/pipeline/workflow_gate_fence.go
@@ -20,7 +20,7 @@ func (s *WorkflowInstanceStore) CommitDecision(ctx context.Context, card decisio
 	switch card.Anchor.Kind() {
 	case decisioncard.AnchorKindStageGate:
 		return s.commitGateDecision(ctx, card, eventID, now)
-	case decisioncard.AnchorKindHumanTask:
+	case decisioncard.AnchorKindHumanTask, decisioncard.AnchorKindProposedEffect:
 		return nil
 	default:
 		return fmt.Errorf("decision-card anchor kind %q is not registered", card.Anchor.Kind())

--- a/internal/runtime/pipeline/workflow_gate_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_gate_lifecycle.go
@@ -105,14 +105,22 @@ func (pc *PipelineCoordinator) applyWorkflowGateIntents(ctx context.Context, ent
 			enteredAt = now
 		}
 		identity := StoredFlowInstance(pc.SemanticSource(), *instance)
-		activation, err := gateruntime.New(runID, identity.InstancePath, entityID, flowID, nextStage, plan.Decision, bundleHash, sourceEvent, enteredAt)
+		frozenOutcomes, err := pc.resolvedWorkflowGateOutcomes(plan)
+		if err != nil {
+			return err
+		}
+		routesJSON, err := gateruntime.FreezeRoutes(frozenOutcomes)
+		if err != nil {
+			return fmt.Errorf("freeze gate %s continuation routes: %w", plan.Decision, err)
+		}
+		activation, err := gateruntime.New(runID, identity.InstancePath, entityID, flowID, nextStage, plan.Decision, bundleHash, routesJSON, sourceEvent, enteredAt)
 		if err != nil {
 			return err
 		}
 		if err := gateruntime.Store(carrier.StateBuckets, activation); err != nil {
 			return err
 		}
-		card, err := pc.buildWorkflowDecisionCard(ctx, entityID, *instance, identity.InstancePath, activation, plan)
+		card, err := pc.buildWorkflowDecisionCard(ctx, entityID, *instance, identity.InstancePath, activation, plan, frozenOutcomes)
 		if err != nil {
 			return err
 		}
@@ -197,7 +205,7 @@ func workflowGateBundleHash(ctx context.Context, pc *PipelineCoordinator) string
 	return ""
 }
 
-func (pc *PipelineCoordinator) buildWorkflowDecisionCard(ctx context.Context, entityID string, instance WorkflowInstance, flowInstance string, activation gateruntime.Activation, plan runtimecontracts.WorkflowGatePlan) (decisioncard.Card, error) {
+func (pc *PipelineCoordinator) buildWorkflowDecisionCard(ctx context.Context, entityID string, instance WorkflowInstance, flowInstance string, activation gateruntime.Activation, plan runtimecontracts.WorkflowGatePlan, frozenOutcomes map[string]runtimecontracts.WorkflowGateOutcomePlan) (decisioncard.Card, error) {
 	contextSnapshot := make(map[string]any, len(plan.Context))
 	for name, expression := range plan.Context {
 		value, err := evalWorkflowGateContext(expression, instance, pc.SemanticSource(), plan.FlowID)
@@ -209,25 +217,6 @@ func (pc *PipelineCoordinator) buildWorkflowDecisionCard(ctx context.Context, en
 	runID := runtimecorrelation.RunIDFromContext(ctx)
 	if runID == "" {
 		runID = asString(instance.Metadata["run_id"])
-	}
-	frozenOutcomes := make(map[string]runtimecontracts.WorkflowGateOutcomePlan, len(plan.Outcomes))
-	for verdict, outcome := range plan.Outcomes {
-		if eventName := strings.TrimSpace(outcome.Emit.Event); eventName != "" {
-			source := pc.SemanticSource()
-			if source == nil {
-				return decisioncard.Card{}, fmt.Errorf("freeze gate %s outcome %s event schema: semantic source is unavailable", plan.Decision, verdict)
-			}
-			resolution := semanticview.ResolveEventSchema(source, plan.FlowID, eventName)
-			if !resolution.HasSchema {
-				return decisioncard.Card{}, fmt.Errorf("freeze gate %s outcome %s event schema: event %s has no resolvable payload schema", plan.Decision, verdict, eventName)
-			}
-			if err := resolution.UnresolvedTypeError(); err != nil {
-				return decisioncard.Card{}, fmt.Errorf("freeze gate %s outcome %s event schema: %w", plan.Decision, verdict, err)
-			}
-			outcome.Emit.Event = source.ResolveFlowEventReference(plan.FlowID, eventName)
-			outcome.EmitSchema = cloneWorkflowGateSchema(resolution.Schema.Schema)
-		}
-		frozenOutcomes[verdict] = outcome
 	}
 	snapshot, err := decisioncard.FreezeSnapshot(plan.Decision, plan.Title, contextSnapshot, frozenOutcomes)
 	if err != nil {
@@ -254,6 +243,29 @@ func (pc *PipelineCoordinator) buildWorkflowDecisionCard(ctx context.Context, en
 		CreatedAt:        activation.OpenedAt,
 	}
 	return decisioncard.New(card)
+}
+
+func (pc *PipelineCoordinator) resolvedWorkflowGateOutcomes(plan runtimecontracts.WorkflowGatePlan) (map[string]runtimecontracts.WorkflowGateOutcomePlan, error) {
+	frozenOutcomes := make(map[string]runtimecontracts.WorkflowGateOutcomePlan, len(plan.Outcomes))
+	for verdict, outcome := range plan.Outcomes {
+		if eventName := strings.TrimSpace(outcome.Emit.Event); eventName != "" {
+			source := pc.SemanticSource()
+			if source == nil {
+				return nil, fmt.Errorf("freeze gate %s outcome %s event schema: semantic source is unavailable", plan.Decision, verdict)
+			}
+			resolution := semanticview.ResolveEventSchema(source, plan.FlowID, eventName)
+			if !resolution.HasSchema {
+				return nil, fmt.Errorf("freeze gate %s outcome %s event schema: event %s has no resolvable payload schema", plan.Decision, verdict, eventName)
+			}
+			if err := resolution.UnresolvedTypeError(); err != nil {
+				return nil, fmt.Errorf("freeze gate %s outcome %s event schema: %w", plan.Decision, verdict, err)
+			}
+			outcome.Emit.Event = source.ResolveFlowEventReference(plan.FlowID, eventName)
+			outcome.EmitSchema = cloneWorkflowGateSchema(resolution.Schema.Schema)
+		}
+		frozenOutcomes[verdict] = outcome
+	}
+	return frozenOutcomes, nil
 }
 
 func cloneWorkflowGateSchema(in map[string]any) map[string]any {

--- a/internal/runtime/pipeline/workflow_gate_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_gate_lifecycle_test.go
@@ -352,9 +352,6 @@ func TestWorkflowGateEntryCreatesMatchingActivationAndCardOnBothStores(t *testin
 			if len(cards.created) != 1 || len(cards.createTx) != 1 || !cards.createTx[0] {
 				t.Fatalf("created cards/transaction = %#v/%#v", cards.created, cards.createTx)
 			}
-			if schema := cards.created[0].Snapshot.Outcomes["approve"].EmitSchema; schema.Len() == 0 {
-				t.Fatalf("created card did not freeze the resolved outcome event schema: %#v", cards.created[0].Snapshot)
-			}
 			loaded, ok, err := workflowStore.Load(ctx, entityID)
 			if err != nil || !ok {
 				t.Fatalf("Load = %#v, %v, %v", loaded, ok, err)
@@ -366,6 +363,10 @@ func TestWorkflowGateEntryCreatesMatchingActivationAndCardOnBothStores(t *testin
 			activation, found, err := gateruntime.Load(carrier.StateBuckets, "", "launch_review")
 			if err != nil || !found {
 				t.Fatalf("gate activation = %#v, %v, %v", activation, found, err)
+			}
+			route, err := gateruntime.RouteFor(activation.RoutesJSON, "approve")
+			if err != nil || route.EmitSchema.Len() == 0 {
+				t.Fatalf("gate continuation did not freeze the resolved outcome event schema: %#v, %v", route, err)
 			}
 			cardAnchor := mustStageGateAnchor(t, cards.created[0])
 			if activation.CardID != cards.created[0].CardID || activation.ActivationID != cardAnchor.StageActivationID || activation.Status != gateruntime.StatusOpen {
@@ -431,14 +432,17 @@ func TestWorkflowGateDecisionRoutePublishesAtomicallyAndRecoversIdempotentlyOnBo
 			card.Verdict = "approve"
 			card.DecisionEventID = decisionEventID
 			card.DecidedAt = now.Add(time.Minute)
-			outcome := card.Snapshot.Outcomes[card.Verdict]
+			route, err := pc.loadStageGateRoute(ctx, card)
+			if err != nil {
+				t.Fatal(err)
+			}
 			parent := eventtest.RuntimeControl(decisionEventID, workflowGateDecisionEventType, "platform", "", json.RawMessage(`{"card_id":"`+card.CardID+`"}`), 0, runID, "", events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), card.DecidedAt)
-			emitted, err := workflowGateOutcomeEvent(card, parent, outcome)
+			emitted, err := workflowGateOutcomeEvent(card, parent, route)
 			if err != nil || emitted == nil {
 				t.Fatalf("workflowGateOutcomeEvent = %#v, %v", emitted, err)
 			}
 			bus.publishErr = errors.New("planted outcome persistence failure")
-			if err := pc.routeWorkflowGateDecision(ctx, card, parent, outcome, emitted); !errors.Is(err, bus.publishErr) {
+			if err := pc.routeWorkflowGateDecision(ctx, card, parent, route, emitted); !errors.Is(err, bus.publishErr) {
 				t.Fatalf("route failure = %v", err)
 			}
 			assertGateLifecycleState(t, workflowStore, ctx, entityID, "awaiting_review", gateruntime.StatusDecisionCommitted)
@@ -447,7 +451,7 @@ func TestWorkflowGateDecisionRoutePublishesAtomicallyAndRecoversIdempotentlyOnBo
 				t.Fatalf("rolled-back outcome rows = %d, %v", persisted, err)
 			}
 			bus.publishErr = nil
-			if err := pc.routeWorkflowGateDecision(ctx, card, parent, outcome, emitted); err != nil {
+			if err := pc.routeWorkflowGateDecision(ctx, card, parent, route, emitted); err != nil {
 				t.Fatal(err)
 			}
 			assertGateLifecycleState(t, workflowStore, ctx, entityID, "operating", gateruntime.StatusRouted)
@@ -457,7 +461,7 @@ func TestWorkflowGateDecisionRoutePublishesAtomicallyAndRecoversIdempotentlyOnBo
 			if err := workflowStore.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gate_outcome_atomic_probe`).Scan(&persisted); err != nil || persisted != 1 {
 				t.Fatalf("committed outcome rows = %d, %v", persisted, err)
 			}
-			if err := pc.routeWorkflowGateDecision(ctx, card, parent, outcome, emitted); err != nil {
+			if err := pc.routeWorkflowGateDecision(ctx, card, parent, route, emitted); err != nil {
 				t.Fatalf("idempotent route recovery: %v", err)
 			}
 			if len(bus.publishes) != 1 {

--- a/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
+++ b/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +15,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
@@ -20,6 +24,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/gateruntime"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/store/storetest"
@@ -42,6 +47,22 @@ func (gateRecoveryModule) WorkflowNodes() []runtimepipeline.WorkflowNode        
 func (gateRecoveryModule) GuardRegistry() runtimepipeline.GuardRegistry            { return nil }
 func (gateRecoveryModule) ActionRegistry() runtimepipeline.ActionRegistry          { return nil }
 
+type proposedEffectProofModule struct {
+	source   semanticview.Source
+	workflow *runtimepipeline.WorkflowDefinition
+	nodes    []runtimepipeline.WorkflowNode
+}
+
+func (m proposedEffectProofModule) SemanticSource() semanticview.Source { return m.source }
+func (m proposedEffectProofModule) WorkflowDefinition() *runtimepipeline.WorkflowDefinition {
+	return m.workflow
+}
+func (m proposedEffectProofModule) WorkflowNodes() []runtimepipeline.WorkflowNode {
+	return append([]runtimepipeline.WorkflowNode(nil), m.nodes...)
+}
+func (proposedEffectProofModule) GuardRegistry() runtimepipeline.GuardRegistry   { return nil }
+func (proposedEffectProofModule) ActionRegistry() runtimepipeline.ActionRegistry { return nil }
+
 type gateRecoveryStoreCase struct {
 	name          string
 	postgres      bool
@@ -49,6 +70,75 @@ type gateRecoveryStoreCase struct {
 	events        runtimebus.EventStore
 	cards         decisioncard.Store
 	workflowStore *runtimepipeline.WorkflowInstanceStore
+}
+
+type proposedEffectProofCredentialStore struct {
+	value string
+	gets  atomic.Int32
+}
+
+type proposedEffectRouteProofBus struct {
+	published       []events.Event
+	publishContexts []events.DeliveryContext
+	outbox          []runtimeengine.EmitIntent
+	dispatched      []runtimeengine.EmitIntent
+}
+
+type proposedEffectRouteProofOutbox struct{ bus *proposedEffectRouteProofBus }
+type proposedEffectRouteProofDispatcher struct{ bus *proposedEffectRouteProofBus }
+
+func (*proposedEffectRouteProofBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+	return make(chan events.Event)
+}
+func (*proposedEffectRouteProofBus) Publish(context.Context, events.Event) error { return nil }
+func (*proposedEffectRouteProofBus) PublishDirect(context.Context, events.Event, []string) error {
+	return nil
+}
+func (*proposedEffectRouteProofBus) ResolveSubscribedRecipients(string) []string { return nil }
+func (*proposedEffectRouteProofBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
+	return nil
+}
+func (b *proposedEffectRouteProofBus) EngineOutbox() runtimeengine.OutboxWriter {
+	return proposedEffectRouteProofOutbox{bus: b}
+}
+func (b *proposedEffectRouteProofBus) EngineDispatcher() runtimeengine.PostCommitDispatcher {
+	return proposedEffectRouteProofDispatcher{bus: b}
+}
+func (b *proposedEffectRouteProofBus) PublishInMutation(ctx context.Context, evt events.Event) error {
+	if _, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); !ok {
+		return errors.New("proposed-effect proof publication requires pipeline transaction")
+	}
+	b.published = append(b.published, evt)
+	b.publishContexts = append(b.publishContexts, events.DeliveryContextFromContext(ctx))
+	return nil
+}
+func (o proposedEffectRouteProofOutbox) WriteOutbox(_ context.Context, intents []runtimeengine.EmitIntent) error {
+	o.bus.outbox = append(o.bus.outbox, intents...)
+	return nil
+}
+func (d proposedEffectRouteProofDispatcher) DispatchPostCommit(_ context.Context, intents []runtimeengine.EmitIntent) error {
+	d.bus.dispatched = append(d.bus.dispatched, intents...)
+	return nil
+}
+
+func (s *proposedEffectProofCredentialStore) Get(_ context.Context, key string) (string, bool, error) {
+	s.gets.Add(1)
+	if key != "provider_token" {
+		return "", false, nil
+	}
+	return s.value, true, nil
+}
+
+func (*proposedEffectProofCredentialStore) Set(context.Context, string, string) error {
+	return errors.New("proof credential store is read-only")
+}
+
+func (*proposedEffectProofCredentialStore) List(context.Context) ([]string, error) {
+	return []string{"provider_token"}, nil
+}
+
+func (*proposedEffectProofCredentialStore) Delete(context.Context, string) error {
+	return errors.New("proof credential store is read-only")
 }
 
 func recoveryStageAnchor(t *testing.T, card decisioncard.Card) decisioncard.StageGateAnchor {
@@ -157,6 +247,513 @@ func TestWorkflowGateUnavailablePinRecoversThroughPersistedEventBusOnBothStores(
 		t.Run(tc.name, func(t *testing.T) {
 			testWorkflowGateUnavailablePinRecovery(t, tc.open(t))
 		})
+	}
+}
+
+func TestApprovedActivityHoldsThenDispatchesExactFrozenInputOnBothStores(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(*testing.T) gateRecoveryStoreCase
+	}{{"sqlite", openSQLiteGateRecoveryStore}, {"postgres", openPostgresGateRecoveryStore}} {
+		t.Run(tc.name, func(t *testing.T) {
+			selected := tc.open(t)
+			const providerSecret = "provider-secret-not-in-effect"
+			credentials := &proposedEffectProofCredentialStore{value: providerSecret}
+			var calls atomic.Int32
+			body := make(chan map[string]any, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if got := r.Header.Get("Authorization"); got != "Bearer "+providerSecret {
+					t.Errorf("provider authorization = %q", got)
+				}
+				var got map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+					t.Errorf("decode provider body: %v", err)
+				} else {
+					body <- got
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"message_id": "provider-1"})
+			}))
+			defer server.Close()
+
+			bundle := proposedEffectProofBundle(server.URL)
+			source := semanticview.Wrap(bundle)
+			bus, err := runtimebus.NewEventBusWithOptions(selected.events, runtimebus.EventBusOptions{ContractBundle: source})
+			if err != nil {
+				t.Fatal(err)
+			}
+			module := proposedEffectProofModule{
+				source:   source,
+				workflow: runtimepipeline.NewWorkflowDefinition("support", []runtimepipeline.WorkflowStage{{Name: "drafting"}}, nil),
+				nodes: []runtimepipeline.WorkflowNode{{
+					ID: "support", Subscriptions: []events.EventType{"support.reply_drafted", "send_support_reply.revision_requested", "send_support_reply.rejected", "platform.activity_requested"},
+					Produces:      []events.EventType{"send_support_reply.succeeded", "send_support_reply.failed", "send_support_reply.revision_requested", "send_support_reply.rejected"},
+					ExecutionType: runtimecontracts.SystemNodeExecutionType,
+					Policies: map[string]runtimepipeline.WorkflowEventPolicy{
+						"support.reply_drafted":       {Consume: true, RequireEntity: true},
+						"platform.activity_requested": {Consume: true, RequireEntity: true},
+					},
+				}},
+			}
+			newCoordinator := func(bundleHash string) *runtimepipeline.PipelineCoordinator {
+				return runtimepipeline.NewPipelineCoordinatorWithOptions(bus, selected.db, runtimepipeline.PipelineCoordinatorOptions{
+					Module: module, WorkflowStore: selected.workflowStore, DecisionCards: selected.cards, BundleFingerprint: bundleHash,
+					Credentials:             credentials,
+					EventReceiptsCapability: func(context.Context) (bool, error) { return true, nil },
+				})
+			}
+			coordinator := newCoordinator(gateRecoveryBundle)
+			bus.SetInterceptors(coordinator)
+
+			runID, entityID := uuid.NewString(), uuid.NewString()
+			insertGateRecoveryRun(t, selected, runID)
+			ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+			if err := selected.workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
+				InstanceID: entityID, StorageRef: entityID, WorkflowName: "support", WorkflowVersion: "1", CurrentState: "drafting",
+				Metadata: map[string]any{"entity_id": entityID, "run_id": runID, "flow_path": "root", "instance_id": entityID},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			const replyContextID = "reply-context-proposed-effect"
+			sourceEvent := eventtest.RootIngress(uuid.NewString(), events.EventType("support.reply_drafted"), "support-agent", "task-1",
+				[]byte(`{"chat_id":"support-room","text":"Exact frozen reply"}`), 0, runID, "",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()).WithDeliveryContext(
+				events.DeliveryContext{Reply: &events.ReplyContextRef{ID: replyContextID}},
+			)
+			seedProposedEffectProofDelivery(t, selected, sourceEvent, "support")
+			sourceCtx := events.WithDeliveryContext(ctx, sourceEvent.DeliveryContext())
+			forward, _, err := coordinator.Intercept(sourceCtx, sourceEvent)
+			if err != nil {
+				t.Fatalf("execute proposal source: %v", err)
+			}
+			if forward {
+				t.Fatalf("proposal source was not consumed by its workflow node: type=%s entity=%q nodes=%#v target=%#v", sourceEvent.Type(), sourceEvent.EntityID(), coordinator.WorkflowNodes(), sourceEvent.TargetRoute())
+			}
+			waitForGateRecoveryQuiescence(t, bus, ctx)
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("provider calls while proposal pending = %d, want 0", got)
+			}
+			if got := credentials.gets.Load(); got != 0 {
+				t.Fatalf("credential resolutions while proposal pending = %d, want 0", got)
+			}
+			items, _, err := selected.cards.ListDecisionCards(ctx, decisioncard.ListOptions{RunID: runID, AnchorKind: string(decisioncard.AnchorKindProposedEffect), Limit: 10})
+			if err != nil || len(items) != 1 {
+				t.Fatalf("pending proposed-effect cards = %#v, %v", items, err)
+			}
+			card, err := selected.cards.GetDecisionCard(ctx, items[0].CardID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertProposedEffectProofCounts(t, selected, runID, 0, 0)
+			input, ok := card.Snapshot.Context.Lookup("input")
+			if !ok || input.Kind() == 0 {
+				t.Fatalf("frozen effect input missing from card: %#v", card.Snapshot.Context)
+			}
+			continuation, err := selected.cards.(decisioncard.ProposedEffectStore).LoadProposedEffectContinuation(ctx, card.CardID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if continuation.ReplyContextID != replyContextID {
+				t.Fatalf("proposed-effect reply context = %q, want %q", continuation.ReplyContextID, replyContextID)
+			}
+			effect, err := continuation.EffectValue()
+			if err != nil {
+				t.Fatal(err)
+			}
+			rawEffect, err := canonicaljson.Encode(effect)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rawSnapshot, err := decisioncard.SnapshotJSON(card)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(rawEffect), providerSecret) || strings.Contains(string(rawSnapshot), providerSecret) {
+				t.Fatal("provider credential leaked into the immutable effect or decision snapshot")
+			}
+			decisionEventID := uuid.NewString()
+			if _, err := selected.cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+				CardID: card.CardID, Verdict: "approve", ActorTokenID: "operator",
+				ObservedContentHash: card.CardContentHash, DecisionEventID: decisionEventID, Now: time.Now().UTC(),
+			}); err != nil {
+				t.Fatalf("approve proposed effect: %v", err)
+			}
+			decisionPayload, _ := json.Marshal(map[string]any{"card_id": card.CardID})
+			decisionEvent := eventtest.RuntimeControl(decisionEventID, events.EventType("mailbox.card_decided"), "platform", "", decisionPayload, 0, runID, "",
+				events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "root"), time.Now().UTC())
+			forward, emitted, err := newCoordinator(otherGateBundle).Intercept(ctx, decisionEvent)
+			if err == nil || !runtimepipeline.IsPipelineReceiptDeferred(err) {
+				t.Fatalf("route approval under changed bundle = forward:%v emitted:%d error:%v, want recoverable deferral", forward, len(emitted), err)
+			}
+			assertProposedEffectProofCounts(t, selected, runID, 0, 0)
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("provider calls under changed bundle = %d, want 0", got)
+			}
+			if got := credentials.gets.Load(); got != 0 {
+				t.Fatalf("credential resolutions under changed bundle = %d, want 0", got)
+			}
+			deferred, err := selected.cards.(decisioncard.ProposedEffectStore).LoadProposedEffectContinuation(ctx, card.CardID)
+			if err != nil || deferred.State != decisioncard.ProposedEffectDecisionCommitted || deferred.RouteEventID != "" {
+				t.Fatalf("bundle-deferred proposed effect = %#v, %v", deferred, err)
+			}
+			bus.SetInterceptors()
+			forward, emitted, err = coordinator.Intercept(ctx, decisionEvent)
+			if err != nil {
+				t.Fatalf("route approval decision: %v", err)
+			}
+			if forward {
+				t.Fatal("approval decision was not consumed by the proposed-effect authority")
+			}
+			releasedRequest := loadProposedEffectProofRequest(t, selected, runID)
+			changedCoordinator := newCoordinator(otherGateBundle)
+			if changedForward, changedEmitted, changedErr := changedCoordinator.Intercept(ctx, releasedRequest); changedErr == nil || !runtimepipeline.IsPipelineReceiptDeferred(changedErr) {
+				t.Fatalf("consume released request under changed bundle = forward:%v emitted:%d error:%v, want recoverable deferral", changedForward, len(changedEmitted), changedErr)
+			}
+			if got := calls.Load(); got != 0 {
+				t.Fatalf("provider calls while released request pin unavailable = %d, want 0", got)
+			}
+			bus.SetInterceptors(coordinator)
+			if consumed, _, consumeErr := coordinator.Intercept(ctx, releasedRequest); consumeErr != nil || consumed {
+				t.Fatalf("consume released activity request under pinned bundle = forward:%v error:%v", consumed, consumeErr)
+			}
+			waitForGateRecoveryQuiescence(t, bus, ctx)
+			assertProposedEffectProofCounts(t, selected, runID, 1, 1)
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("provider calls after approval = %d, want 1", got)
+			}
+			if got := credentials.gets.Load(); got != 1 {
+				t.Fatalf("credential resolutions after approval = %d, want 1", got)
+			}
+			select {
+			case got := <-body:
+				if got["chat_id"] != "support-room" || got["text"] != "Exact frozen reply" {
+					t.Fatalf("provider input = %#v", got)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("provider body was not observed")
+			}
+			readback, err := selected.cards.(decisioncard.ProposedEffectStore).ProposedEffectReadback(ctx, card.CardID)
+			if err != nil || readback.DispatchState != "succeeded" {
+				t.Fatalf("proposed-effect readback = %#v, %v", readback, err)
+			}
+			coordinator = newCoordinator(gateRecoveryBundle)
+			bus.SetInterceptors(coordinator)
+			released := loadProposedEffectProofRequest(t, selected, runID)
+			forward, _, err = coordinator.Intercept(ctx, released)
+			if err != nil {
+				t.Fatalf("replay persisted approved request: %v", err)
+			}
+			if forward {
+				t.Fatal("persisted approved request replay was not consumed")
+			}
+			waitForGateRecoveryQuiescence(t, bus, ctx)
+			assertProposedEffectProofCounts(t, selected, runID, 1, 1)
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("provider calls after persisted replay = %d, want 1", got)
+			}
+			if _, _, err := changedCoordinator.Intercept(ctx, decisionEvent); err != nil {
+				t.Fatalf("approval route replay after commit acknowledgment loss under changed bundle: %v", err)
+			}
+			waitForGateRecoveryQuiescence(t, bus, ctx)
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("provider calls after duplicate approval = %d, want 1", got)
+			}
+
+			routeWithoutDispatch := func(verdict, wantEvent string, fields map[string]any) {
+				t.Helper()
+				proposal := eventtest.RootIngress(uuid.NewString(), events.EventType("support.reply_drafted"), "support-agent", "task-1",
+					[]byte(`{"chat_id":"support-room","text":"Needs another operator outcome"}`), 0, runID, "",
+					events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC()).WithDeliveryContext(
+					events.DeliveryContext{Reply: &events.ReplyContextRef{ID: replyContextID}},
+				)
+				seedProposedEffectProofDelivery(t, selected, proposal, "support")
+				proposalCtx := events.WithDeliveryContext(ctx, proposal.DeliveryContext())
+				consumed, _, routeErr := coordinator.Intercept(proposalCtx, proposal)
+				if routeErr != nil || consumed {
+					t.Fatalf("create %s proposal = forward:%v error:%v", verdict, consumed, routeErr)
+				}
+				waitForGateRecoveryQuiescence(t, bus, ctx)
+				pending, _, routeErr := selected.cards.ListDecisionCards(ctx, decisioncard.ListOptions{
+					RunID: runID, Status: decisioncard.StatusPending, AnchorKind: string(decisioncard.AnchorKindProposedEffect), Limit: 10,
+				})
+				if routeErr != nil || len(pending) != 1 {
+					t.Fatalf("pending %s proposal = %#v, %v", verdict, pending, routeErr)
+				}
+				pendingCard, routeErr := selected.cards.GetDecisionCard(ctx, pending[0].CardID)
+				if routeErr != nil {
+					t.Fatal(routeErr)
+				}
+				pendingContinuation, routeErr := selected.cards.(decisioncard.ProposedEffectStore).LoadProposedEffectContinuation(ctx, pendingCard.CardID)
+				if routeErr != nil || pendingContinuation.ReplyContextID != replyContextID {
+					t.Fatalf("%s proposed-effect reply context = %q, %v; want %q", verdict, pendingContinuation.ReplyContextID, routeErr, replyContextID)
+				}
+				admittedFields, routeErr := canonicaljson.FromGo(fields)
+				if routeErr != nil {
+					t.Fatal(routeErr)
+				}
+				decisionID := uuid.NewString()
+				if _, routeErr = selected.cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+					CardID: pendingCard.CardID, Verdict: verdict, Fields: admittedFields, ActorTokenID: "operator",
+					ObservedContentHash: pendingCard.CardContentHash, DecisionEventID: decisionID, Now: time.Now().UTC(),
+				}); routeErr != nil {
+					t.Fatalf("decide %s: %v", verdict, routeErr)
+				}
+				payload, _ := json.Marshal(map[string]any{"card_id": pendingCard.CardID})
+				decision := eventtest.RuntimeControl(decisionID, events.EventType("mailbox.card_decided"), "platform", "", payload, 0, runID, "",
+					events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "root"), time.Now().UTC())
+				consumed, _, routeErr = coordinator.Intercept(ctx, decision)
+				if routeErr != nil || consumed {
+					t.Fatalf("route %s = forward:%v error:%v", verdict, consumed, routeErr)
+				}
+				waitForGateRecoveryQuiescence(t, bus, ctx)
+				assertProposedEffectProofCounts(t, selected, runID, 1, 1)
+				assertProposedEffectOutcomeCount(t, selected, runID, wantEvent, 1)
+				if _, _, routeErr = newCoordinator(otherGateBundle).Intercept(ctx, decision); routeErr != nil {
+					t.Fatalf("%s route replay after commit acknowledgment loss under changed bundle: %v", verdict, routeErr)
+				}
+				if got := calls.Load(); got != 1 {
+					t.Fatalf("provider calls after %s = %d, want 1", verdict, got)
+				}
+				readback, routeErr := selected.cards.(decisioncard.ProposedEffectStore).ProposedEffectReadback(ctx, pendingCard.CardID)
+				if routeErr != nil || readback.DispatchState != "not_dispatched" {
+					t.Fatalf("%s readback = %#v, %v", verdict, readback, routeErr)
+				}
+			}
+			routeWithoutDispatch("revise", "send_support_reply.revision_requested", map[string]any{"feedback": "Please rewrite it."})
+			routeWithoutDispatch("reject", "send_support_reply.rejected", map[string]any{"reason": "Do not send."})
+		})
+	}
+}
+
+func TestProposedEffectCompletedRouteReplaysBeforeBundleFenceAndPreservesReplyContextOnBothStores(t *testing.T) {
+	for _, storeCase := range []struct {
+		name string
+		open func(*testing.T) gateRecoveryStoreCase
+	}{{"sqlite", openSQLiteGateRecoveryStore}, {"postgres", openPostgresGateRecoveryStore}} {
+		for _, verdict := range []string{"approve", "revise", "reject"} {
+			t.Run(storeCase.name+"/"+verdict, func(t *testing.T) {
+				selected := storeCase.open(t)
+				ctx := context.Background()
+				runID, entityID := uuid.NewString(), uuid.NewString()
+				insertGateRecoveryRun(t, selected, runID)
+				now := time.Date(2026, 7, 14, 22, 0, 0, 0, time.UTC)
+				input, err := canonicaljson.FromGo(map[string]any{"chat_id": "support-room", "text": "Exact approved text"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				requestEventID := uuid.NewString()
+				continuation := decisioncard.ProposedEffectContinuation{
+					CardID: decisioncard.ProposedEffectCardID(requestEventID, "support_reply"), RunID: runID,
+					RequestEventID: requestEventID, ActivityID: "send_support_reply", Tool: "provider_write",
+					BundleHash: gateRecoveryBundle, WorkflowVersion: "1", Input: input,
+					EffectClass:  runtimecontracts.ActivityEffectClassNonIdempotentWrite,
+					SuccessEvent: "send_support_reply.succeeded", FailureEvent: "send_support_reply.failed",
+					RevisionEvent: "send_support_reply.revision_requested", RejectedEvent: "send_support_reply.rejected",
+					RetryMaxAttempts: 1, ForkPolicy: runtimecontracts.ActivityForkRequireConfirmation,
+					EntityID: entityID, NodeID: "support", FlowInstance: "root", HandlerEventKey: "support.reply_drafted",
+					SourceEventID: uuid.NewString(), SourceRunID: runID, SourceTaskID: "task-1",
+					ReplyContextID: "reply-context-route-proof", State: decisioncard.ProposedEffectPending,
+					CreatedAt: now, UpdatedAt: now,
+				}.Canonical()
+				effect, err := continuation.EffectValue()
+				if err != nil {
+					t.Fatal(err)
+				}
+				continuation.EffectContentHash, err = canonicaljson.HashValue(effect)
+				if err != nil {
+					t.Fatal(err)
+				}
+				anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+					RequestEventID: requestEventID, ActivityID: continuation.ActivityID, Decision: "support_reply",
+					Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root", EntityID: entityID},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				snapshot, err := decisioncard.FreezeSnapshot("support_reply", "", map[string]any{"input": input.Interface()}, map[string]runtimecontracts.WorkflowGateOutcomePlan{
+					"approve": {Verdict: "approve"},
+					"revise":  {Verdict: "revise", Input: map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Required: true}}},
+					"reject":  {Verdict: "reject", Input: map[string]runtimecontracts.WorkflowGateInputField{"reason": {Type: "text"}}},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				card, err := decisioncard.New(decisioncard.Card{
+					CardID: continuation.CardID, RunID: runID, Anchor: anchor, Snapshot: snapshot,
+					EffectContentHash: continuation.EffectContentHash, BundleHash: gateRecoveryBundle,
+					WorkflowVersion: "1", CreatedAt: now,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				proposedStore := selected.cards.(decisioncard.ProposedEffectStore)
+				if err := proposedStore.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatal(err)
+				}
+				fields := semanticvalue.EmptyObject()
+				if verdict == "revise" {
+					fields, _ = canonicaljson.FromGo(map[string]any{"feedback": "Please revise."})
+				} else if verdict == "reject" {
+					fields, _ = canonicaljson.FromGo(map[string]any{"reason": "Do not send."})
+				}
+				decisionEventID := uuid.NewString()
+				if _, err := selected.cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+					CardID: card.CardID, Verdict: verdict, Fields: fields, ActorTokenID: "operator",
+					ObservedContentHash: card.CardContentHash, DecisionEventID: decisionEventID, Now: now.Add(time.Minute),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				payload, _ := canonicaljson.Bytes(map[string]any{"card_id": card.CardID})
+				decisionEvent := eventtest.RuntimeControl(decisionEventID, events.EventType("mailbox.card_decided"), "platform", "", payload, 0, runID, "",
+					events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), "root"), now.Add(time.Minute))
+				source := semanticview.Wrap(proposedEffectProofBundle("http://127.0.0.1:1"))
+				bus := &proposedEffectRouteProofBus{}
+				coordinator := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, selected.db, runtimepipeline.PipelineCoordinatorOptions{
+					Module: gateRecoveryModule{source: source}, WorkflowStore: selected.workflowStore,
+					DecisionCards: selected.cards, BundleFingerprint: gateRecoveryBundle,
+				})
+				forward, emitted, err := coordinator.Intercept(ctx, decisionEvent)
+				if err != nil || forward || len(emitted) != 0 {
+					t.Fatalf("route %s = forward:%v emitted:%d error:%v", verdict, forward, len(emitted), err)
+				}
+				stored, err := proposedStore.LoadProposedEffectContinuation(ctx, card.CardID)
+				if err != nil || stored.RouteEventID != decisionEventID {
+					t.Fatalf("routed continuation = %#v, %v", stored, err)
+				}
+				if verdict == "approve" {
+					if len(bus.outbox) != 1 || len(bus.dispatched) != 1 {
+						t.Fatalf("approve route intents = outbox:%d dispatched:%d, want 1/1", len(bus.outbox), len(bus.dispatched))
+					}
+					request, err := canonicaljson.Decode(bus.outbox[0].Event.Payload())
+					bundleValue, bundlePresent := request.Lookup("bundle_hash")
+					bundleHash, bundleText := bundleValue.String()
+					versionValue, versionPresent := request.Lookup("workflow_version")
+					workflowVersion, versionText := versionValue.String()
+					if err != nil || !bundlePresent || !bundleText || bundleHash != gateRecoveryBundle || !versionPresent || !versionText || workflowVersion != "1" {
+						t.Fatalf("released request contract pin = bundle:%q/%v/%v version:%q/%v/%v error:%v", bundleHash, bundlePresent, bundleText, workflowVersion, versionPresent, versionText, err)
+					}
+				} else {
+					if len(bus.published) != 1 || len(bus.publishContexts) != 1 {
+						t.Fatalf("%s route publications = events:%d contexts:%d, want 1/1", verdict, len(bus.published), len(bus.publishContexts))
+					}
+					if gotEvent, gotContext := bus.published[0].DeliveryContext().ReplyContextID(), bus.publishContexts[0].ReplyContextID(); gotEvent != continuation.ReplyContextID || gotContext != continuation.ReplyContextID {
+						t.Fatalf("%s reply authority = event:%q context:%q, want %q", verdict, gotEvent, gotContext, continuation.ReplyContextID)
+					}
+				}
+				beforeOutbox, beforePublished := len(bus.outbox), len(bus.published)
+				changed := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, selected.db, runtimepipeline.PipelineCoordinatorOptions{
+					Module: gateRecoveryModule{source: source}, WorkflowStore: selected.workflowStore,
+					DecisionCards: selected.cards, BundleFingerprint: otherGateBundle,
+				})
+				if _, _, err := changed.Intercept(ctx, decisionEvent); err != nil {
+					t.Fatalf("%s terminal route replay under changed bundle: %v", verdict, err)
+				}
+				if len(bus.outbox) != beforeOutbox || len(bus.published) != beforePublished {
+					t.Fatalf("%s terminal route replay duplicated work", verdict)
+				}
+			})
+		}
+	}
+}
+
+func TestApprovedActivityProposalCreationRollsBackWorkflowCardAndContinuationOnBothStores(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(*testing.T) gateRecoveryStoreCase
+	}{{"sqlite", openSQLiteGateRecoveryStore}, {"postgres", openPostgresGateRecoveryStore}} {
+		t.Run(tc.name, func(t *testing.T) {
+			selected := tc.open(t)
+			bundle := proposedEffectProofBundle("http://127.0.0.1:1")
+			handler := bundle.Nodes["support"].EventHandlers["support.reply_drafted"]
+			handler.AdvancesTo = "queued"
+			node := bundle.Nodes["support"]
+			node.EventHandlers["support.reply_drafted"] = handler
+			bundle.Nodes["support"] = node
+			bundle.Semantics.NodeHandlers["support"]["support.reply_drafted"] = handler
+
+			source := semanticview.Wrap(bundle)
+			bus, err := runtimebus.NewEventBusWithOptions(selected.events, runtimebus.EventBusOptions{ContractBundle: source})
+			if err != nil {
+				t.Fatal(err)
+			}
+			module := proposedEffectProofModule{
+				source:   source,
+				workflow: runtimepipeline.NewWorkflowDefinition("support", []runtimepipeline.WorkflowStage{{Name: "drafting"}, {Name: "queued"}}, nil),
+				nodes: []runtimepipeline.WorkflowNode{{
+					ID: "support", Subscriptions: []events.EventType{"support.reply_drafted"},
+					Produces:      []events.EventType{"send_support_reply.succeeded", "send_support_reply.failed", "send_support_reply.revision_requested", "send_support_reply.rejected"},
+					ExecutionType: runtimecontracts.SystemNodeExecutionType,
+					Policies:      map[string]runtimepipeline.WorkflowEventPolicy{"support.reply_drafted": {Consume: true, RequireEntity: true}},
+				}},
+			}
+			coordinator := runtimepipeline.NewPipelineCoordinatorWithOptions(bus, selected.db, runtimepipeline.PipelineCoordinatorOptions{
+				Module: module, WorkflowStore: selected.workflowStore, DecisionCards: selected.cards, BundleFingerprint: gateRecoveryBundle,
+				EventReceiptsCapability: func(context.Context) (bool, error) { return true, nil },
+			})
+			bus.SetInterceptors(coordinator)
+
+			runID, entityID := uuid.NewString(), uuid.NewString()
+			insertGateRecoveryRun(t, selected, runID)
+			ctx := runtimecorrelation.WithRunID(context.Background(), runID)
+			if err := selected.workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
+				InstanceID: entityID, StorageRef: entityID, WorkflowName: "support", WorkflowVersion: "1", CurrentState: "drafting",
+				Metadata: map[string]any{"entity_id": entityID, "run_id": runID, "flow_path": "root", "instance_id": entityID},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			installProposedEffectCreateFailure(t, selected)
+
+			event := eventtest.RootIngress(uuid.NewString(), events.EventType("support.reply_drafted"), "support-agent", "task-rollback",
+				[]byte(`{"chat_id":"support-room","text":"must roll back"}`), 0, runID, "",
+				events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), time.Now().UTC())
+			seedProposedEffectProofDelivery(t, selected, event, "support")
+			forward, _, err := coordinator.Intercept(ctx, event)
+			if err != nil || forward {
+				t.Fatalf("proposal failure interception = forward:%v error:%v", forward, err)
+			}
+
+			instance, ok, err := selected.workflowStore.Load(ctx, entityID)
+			if err != nil || !ok || instance.CurrentState != "drafting" {
+				t.Fatalf("workflow after rollback = %#v, %v, %v", instance, ok, err)
+			}
+			items, _, err := selected.cards.ListDecisionCards(ctx, decisioncard.ListOptions{RunID: runID, Limit: 10})
+			if err != nil || len(items) != 0 {
+				t.Fatalf("decision cards after rollback = %#v, %v", items, err)
+			}
+			assertProposedEffectProofCounts(t, selected, runID, 0, 0)
+			var continuations int
+			query := `SELECT COUNT(*) FROM proposed_effect_continuations WHERE run_id = ?`
+			if selected.postgres {
+				query = `SELECT COUNT(*) FROM proposed_effect_continuations WHERE run_id = $1::uuid`
+			}
+			if err := selected.db.QueryRowContext(ctx, query, runID).Scan(&continuations); err != nil || continuations != 0 {
+				t.Fatalf("proposed-effect continuations after rollback = %d, %v", continuations, err)
+			}
+			deliveryQuery := `SELECT status FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'support'`
+			if selected.postgres {
+				deliveryQuery = `SELECT status FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'support'`
+			}
+			var deliveryStatus string
+			if err := selected.db.QueryRowContext(ctx, deliveryQuery, event.ID()).Scan(&deliveryStatus); err != nil || deliveryStatus != "dead_letter" {
+				t.Fatalf("planted persistence failure delivery status = %q, %v", deliveryStatus, err)
+			}
+		})
+	}
+}
+
+func installProposedEffectCreateFailure(t *testing.T, selected gateRecoveryStoreCase) {
+	t.Helper()
+	statement := `CREATE TRIGGER fail_proposed_effect_create BEFORE INSERT ON proposed_effect_continuations BEGIN SELECT RAISE(ABORT, 'injected proposed-effect persistence failure'); END`
+	if selected.postgres {
+		statement = `
+			CREATE FUNCTION fail_proposed_effect_create_fn() RETURNS trigger AS $$
+			BEGIN RAISE EXCEPTION 'injected proposed-effect persistence failure'; END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER fail_proposed_effect_create BEFORE INSERT ON proposed_effect_continuations
+			FOR EACH ROW EXECUTE FUNCTION fail_proposed_effect_create_fn()`
+	}
+	if _, err := selected.db.Exec(statement); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -929,6 +1526,146 @@ func openPostgresGateRecoveryStore(t *testing.T) gateRecoveryStoreCase {
 		name: "postgres", postgres: true, db: db, events: selected, cards: selected,
 		workflowStore: runtimepipeline.NewWorkflowInstanceStore(db),
 	}
+}
+
+func proposedEffectProofBundle(serverURL string) *runtimecontracts.WorkflowContractBundle {
+	handler := runtimecontracts.SystemNodeEventHandler{Activity: runtimecontracts.ActivitySpec{
+		ID: "send_support_reply", Tool: "provider_write",
+		Input: map[string]runtimecontracts.ExpressionValue{
+			"chat_id": runtimecontracts.CELExpression("payload.chat_id"),
+			"text":    runtimecontracts.CELExpression("payload.text"),
+		},
+		Approval: &runtimecontracts.ActivityApprovalSpec{Decision: "support_reply"},
+	}}
+	return &runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"support": {
+				ID: "support", ExecutionType: runtimecontracts.SystemNodeExecutionType,
+				SubscribesTo: []string{"support.reply_drafted", "send_support_reply.revision_requested", "send_support_reply.rejected"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"support.reply_drafted":                 handler,
+					"send_support_reply.revision_requested": {},
+					"send_support_reply.rejected":           {},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "support", Version: "1", InitialStage: "drafting",
+			EventOwners: map[string][]string{
+				"support.reply_drafted":                 {"support"},
+				"send_support_reply.revision_requested": {"support"},
+				"send_support_reply.rejected":           {"support"},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"support": {
+					"support.reply_drafted":                 handler,
+					"send_support_reply.revision_requested": {},
+					"send_support_reply.rejected":           {},
+				},
+			},
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				"support": {
+					ID: "support", ExecutionType: runtimecontracts.SystemNodeExecutionType,
+					RuntimeSubscriptions: []string{"support.reply_drafted", "send_support_reply.revision_requested", "send_support_reply.rejected"},
+					Produces:             []string{"send_support_reply.succeeded", "send_support_reply.failed", "send_support_reply.revision_requested", "send_support_reply.rejected"},
+				},
+			},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"provider_write": {
+				HandlerType: "http", EffectClass: string(runtimecontracts.ActivityEffectClassNonIdempotentWrite),
+				Credentials: []string{"provider_token"},
+				InputSchema: runtimecontracts.ToolInputSchema{
+					Type: "object", Required: []string{"chat_id", "text"},
+					Properties: map[string]runtimecontracts.ToolInputSchema{"chat_id": {Type: "string"}, "text": {Type: "string"}},
+				},
+				OutputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+				HTTP: &runtimecontracts.HTTPToolSpec{
+					Method: "POST", URL: strings.TrimRight(serverURL, "/"),
+					Headers: map[string]string{"Authorization": "Bearer {{credentials.provider_token}}"},
+					Body:    map[string]any{"chat_id": "{{input.chat_id}}", "text": "{{input.text}}"},
+				},
+			},
+		},
+	}
+}
+
+func waitForGateRecoveryQuiescence(t *testing.T, bus *runtimebus.EventBus, ctx context.Context) {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := bus.WaitForQuiescence(waitCtx); err != nil {
+		t.Fatalf("wait for event bus quiescence: %v", err)
+	}
+}
+
+func assertProposedEffectProofCounts(t *testing.T, selected gateRecoveryStoreCase, runID string, requests, attempts int) {
+	t.Helper()
+	requestQuery := `SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested'`
+	attemptQuery := `SELECT COUNT(*) FROM activity_attempts WHERE run_id = ?`
+	if selected.postgres {
+		requestQuery = `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested'`
+		attemptQuery = `SELECT COUNT(*) FROM activity_attempts WHERE run_id = $1::uuid`
+	}
+	var gotRequests, gotAttempts int
+	if err := selected.db.QueryRowContext(context.Background(), requestQuery, runID).Scan(&gotRequests); err != nil {
+		t.Fatal(err)
+	}
+	if err := selected.db.QueryRowContext(context.Background(), attemptQuery, runID).Scan(&gotAttempts); err != nil {
+		t.Fatal(err)
+	}
+	if gotRequests != requests || gotAttempts != attempts {
+		t.Fatalf("durable activity counts = requests:%d attempts:%d, want %d/%d", gotRequests, gotAttempts, requests, attempts)
+	}
+}
+
+func assertProposedEffectOutcomeCount(t *testing.T, selected gateRecoveryStoreCase, runID, eventType string, want int) {
+	t.Helper()
+	query := `SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = ?`
+	if selected.postgres {
+		query = `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = $2`
+	}
+	var got int
+	if err := selected.db.QueryRowContext(context.Background(), query, runID, eventType).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("%s event count = %d, want %d", eventType, got, want)
+	}
+}
+
+func seedProposedEffectProofDelivery(t *testing.T, selected gateRecoveryStoreCase, evt events.Event, nodeID string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := selected.events.AppendEvent(ctx, evt); err != nil {
+		t.Fatal(err)
+	}
+	query := `INSERT INTO event_deliveries (delivery_id, run_id, event_id, subscriber_type, subscriber_id, status, retry_count, created_at) VALUES (?, ?, ?, 'node', ?, 'pending', 0, ?)`
+	args := []any{uuid.NewString(), evt.RunID(), evt.ID(), nodeID, time.Now().UTC()}
+	if selected.postgres {
+		query = `INSERT INTO event_deliveries (run_id, event_id, subscriber_type, subscriber_id, status, retry_count, created_at) VALUES ($1::uuid, $2::uuid, 'node', $3, 'pending', 0, $4)`
+		args = []any{evt.RunID(), evt.ID(), nodeID, time.Now().UTC()}
+	}
+	if _, err := selected.db.ExecContext(ctx, query, args...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadProposedEffectProofRequest(t *testing.T, selected gateRecoveryStoreCase, runID string) events.Event {
+	t.Helper()
+	query := `SELECT event_id, event_name, payload, chain_depth, COALESCE(source_event_id, ''), COALESCE(entity_id, ''), COALESCE(flow_instance, '') FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested'`
+	if selected.postgres {
+		query = `SELECT event_id::text, event_name, payload, chain_depth, COALESCE(source_event_id::text, ''), COALESCE(entity_id::text, ''), COALESCE(flow_instance, '') FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested'`
+	}
+	var eventID, eventType, parentID, entityID, flowInstance string
+	var payload []byte
+	var depth int
+	if err := selected.db.QueryRowContext(context.Background(), query, runID).Scan(&eventID, &eventType, &payload, &depth, &parentID, &entityID, &flowInstance); err != nil {
+		t.Fatal(err)
+	}
+	envelope := events.EnvelopeForEntityID(events.EventEnvelope{}, entityID)
+	envelope = events.EnvelopeForFlowInstance(envelope, flowInstance)
+	return eventtest.PersistedProjection(eventID, events.EventType(eventType), "workflow-runtime", "", payload, depth, runID, parentID, envelope, time.Now().UTC())
 }
 
 func gateRecoveryContractBundle() *runtimecontracts.WorkflowContractBundle {

--- a/internal/runtime/pipeline/workflow_loop_supersession.go
+++ b/internal/runtime/pipeline/workflow_loop_supersession.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/joinruntime"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
@@ -61,6 +65,30 @@ func (pc *PipelineCoordinator) reconcileSupersededLoopSchedules(ctx context.Cont
 	instance, ok, err := pc.workflowStore.Load(ctx, strings.TrimSpace(entityID))
 	if err != nil || !ok {
 		return err
+	}
+	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+	if err != nil {
+		return fmt.Errorf("decode current loop state: %w", err)
+	}
+	loops, err := loopruntime.List(carrier.StateBuckets)
+	if err != nil {
+		return fmt.Errorf("list current loop state: %w", err)
+	}
+	current := make([]attemptgeneration.Generation, 0, len(loops))
+	for _, activation := range loops {
+		if generation := activation.Generation(); generation.Valid() && activation.Status == loopruntime.StatusOpen {
+			current = append(current, generation)
+		}
+	}
+	if pc.decisionCards != nil {
+		store, ok := pc.decisionCards.(decisioncard.ProposedEffectStore)
+		if !ok || store == nil {
+			return fmt.Errorf("proposed-effect continuation store is required for loop supersession")
+		}
+		runID := firstNonEmptyString(runtimecorrelation.RunIDFromContext(ctx), asString(instance.Metadata["run_id"]))
+		if err := store.SupersedeProposedEffectsForLoopGenerations(ctx, runID, entityID, current, "loop_generation_superseded", time.Now().UTC()); err != nil {
+			return err
+		}
 	}
 	source := pc.SemanticSource()
 	for _, state := range instance.TimerState {

--- a/internal/runtime/pipeline/workflow_proposed_effect_test.go
+++ b/internal/runtime/pipeline/workflow_proposed_effect_test.go
@@ -1,0 +1,102 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	"github.com/google/uuid"
+)
+
+func TestProposedEffectOutcomeEventRoutesExactTypedVerdicts(t *testing.T) {
+	now := time.Date(2026, 7, 14, 20, 0, 0, 0, time.UTC)
+	parent := eventtest.RuntimeControl(uuid.NewString(), workflowGateDecisionEventType, "platform", "", []byte(`{"card_id":"card-1"}`), 0,
+		uuid.NewString(), "", events.EnvelopeForEntityID(events.EventEnvelope{}, uuid.NewString()), now)
+	continuation := decisioncard.ProposedEffectContinuation{
+		ActivityID: "send_support_reply", Tool: "telegram.send_message", EffectClass: runtimecontracts.ActivityEffectClassNonIdempotentWrite,
+		EffectContentHash: "sha256:effect", SourceTaskID: "task-1",
+		EntityID: parent.EntityID(), FlowInstance: "root",
+		RevisionEvent: "send_support_reply.revision_requested", RejectedEvent: "send_support_reply.rejected",
+	}
+	for _, tc := range []struct {
+		name      string
+		verdict   string
+		fields    semanticvalue.Value
+		wantEvent events.EventType
+		wantField string
+		wantValue string
+	}{
+		{
+			name: "revise", verdict: "revise", fields: mustProposedEffectFields(t, map[string]any{"feedback": "Remove the customer secret."}),
+			wantEvent: "send_support_reply.revision_requested", wantField: "feedback", wantValue: "Remove the customer secret.",
+		},
+		{
+			name: "reject", verdict: "reject", fields: mustProposedEffectFields(t, map[string]any{"reason": "Not authorized."}),
+			wantEvent: "send_support_reply.rejected", wantField: "reason", wantValue: "Not authorized.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			card := decisioncard.Card{
+				CardID: uuid.NewString(), Verdict: tc.verdict, Fields: tc.fields,
+				DecidedBy: "operator", DecidedAt: now,
+			}
+			got, err := proposedEffectOutcomeEvent(card, parent, continuation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Type() != tc.wantEvent || got.ParentEventID() != parent.ID() || got.EntityID() != parent.EntityID() || got.FlowInstance() != "root" {
+				t.Fatalf("outcome identity = type:%s parent:%s entity:%s flow:%s", got.Type(), got.ParentEventID(), got.EntityID(), got.FlowInstance())
+			}
+			payload, err := canonicaljson.Decode(got.Payload())
+			if err != nil {
+				t.Fatal(err)
+			}
+			field, ok := payload.Lookup(tc.wantField)
+			value, text := field.String()
+			if !ok || !text || value != tc.wantValue {
+				t.Fatalf("outcome %s = %q (present=%v text=%v)", tc.wantField, value, ok, text)
+			}
+			for fieldName, want := range map[string]string{
+				"card_id": card.CardID, "activity_id": continuation.ActivityID, "tool": continuation.Tool,
+				"effect_class": string(continuation.EffectClass), "effect_content_hash": continuation.EffectContentHash,
+				"decided_by": card.DecidedBy, "decided_at": now.Format(time.RFC3339Nano),
+			} {
+				field, present := payload.Lookup(fieldName)
+				value, stringValue := field.String()
+				if !present || !stringValue || value != want {
+					t.Fatalf("outcome %s = %q (present=%v text=%v), want %q", fieldName, value, present, stringValue, want)
+				}
+			}
+			repeated, err := proposedEffectOutcomeEvent(card, parent, continuation)
+			if err != nil || repeated.ID() != got.ID() {
+				t.Fatalf("repeated outcome identity = %s, %v; want %s", repeated.ID(), err, got.ID())
+			}
+		})
+	}
+}
+
+func TestProposedEffectRevisionRequiresFeedback(t *testing.T) {
+	now := time.Date(2026, 7, 14, 20, 30, 0, 0, time.UTC)
+	parent := eventtest.RuntimeControl(uuid.NewString(), workflowGateDecisionEventType, "platform", "", []byte(`{"card_id":"card-1"}`), 0,
+		uuid.NewString(), "", events.EventEnvelope{}, now)
+	_, err := proposedEffectOutcomeEvent(decisioncard.Card{
+		CardID: uuid.NewString(), Verdict: "revise", Fields: semanticvalue.EmptyObject(), DecidedAt: now,
+	}, parent, decisioncard.ProposedEffectContinuation{RevisionEvent: "activity.revision_requested"})
+	if err == nil {
+		t.Fatal("revision without feedback succeeded")
+	}
+}
+
+func mustProposedEffectFields(t *testing.T, fields map[string]any) semanticvalue.Value {
+	t.Helper()
+	value, err := canonicaljson.FromGo(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -296,6 +296,58 @@ func TestValidateWorkflowContractSurface_DurableActivityNonIdempotentWriteAdmitt
 	}
 }
 
+func TestValidateWorkflowContractSurface_ActivityApprovalBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		effectClass     runtimecontracts.ActivityEffectClass
+		decision        string
+		includeConsumer bool
+		wantError       string
+	}{
+		{name: "valid", effectClass: runtimecontracts.ActivityEffectClassNonIdempotentWrite, decision: "support_reply", includeConsumer: true},
+		{name: "read only teaching error", effectClass: runtimecontracts.ActivityEffectClassReadOnly, decision: "support_reply", includeConsumer: true, wantError: "read-only activities don't need approval"},
+		{name: "missing revision consumer", effectClass: runtimecontracts.ActivityEffectClassNonIdempotentWrite, decision: "support_reply", wantError: "has no consumer"},
+		{name: "noncanonical programmatic decision", effectClass: runtimecontracts.ActivityEffectClassNonIdempotentWrite, decision: " support_reply ", includeConsumer: true, wantError: "canonical stable decision id is required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := testRuntimeWorkflowValidationBundle()
+			bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+				"provider_write": {
+					HandlerType: "http", EffectClass: string(tc.effectClass),
+					InputSchema: runtimecontracts.ToolInputSchema{Type: "object"},
+					HTTP:        &runtimecontracts.HTTPToolSpec{Method: "POST", URL: "https://example.test"},
+				},
+			}
+			handlers := map[string]runtimecontracts.SystemNodeEventHandler{
+				"support.reply_drafted": {
+					Activity: runtimecontracts.ActivitySpec{
+						ID: "send_support_reply", Tool: "provider_write",
+						Approval: &runtimecontracts.ActivityApprovalSpec{Decision: tc.decision},
+					},
+				},
+			}
+			if tc.includeConsumer {
+				handlers["send_support_reply.revision_requested"] = runtimecontracts.SystemNodeEventHandler{}
+			}
+			bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+				"support": {ID: "support", EventHandlers: handlers},
+			}
+			_, err := ValidateWorkflowContractSurface(context.Background(), semanticview.Wrap(bundle), WorkflowContractValidationOptions{
+				CheckMCPReachable: false, StrictEmitSchemas: false, FatalToolImplementationWarning: false, FatalBootWarnings: false,
+			})
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("validation error = %v, want %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
 func TestValidateWorkflowContractSurface_TelegramProviderConnectorToolAdmitted(t *testing.T) {
 	bundle := testRuntimeWorkflowValidationBundle()
 	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{

--- a/internal/store/author_activity_registry_test.go
+++ b/internal/store/author_activity_registry_test.go
@@ -14,12 +14,52 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
 	"github.com/division-sh/swarm/internal/yamlsource"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 	_ "modernc.org/sqlite"
 )
+
+func TestAuthorActivityDecisionCardAdapterCoversRegisteredAnchors(t *testing.T) {
+	stage, err := decisioncard.NewStageGateAnchor(decisioncard.StageGateAnchor{
+		FlowInstance: "root/review", FlowID: "review", EntityID: uuid.NewString(), Stage: "pending", StageActivationID: uuid.NewString(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	human, err := decisioncard.NewHumanTaskAnchor(decisioncard.HumanTaskAnchor{
+		RequesterAgentID: "reviewer", OperationID: "human-op", Category: "review",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeFlow, FlowInstance: "root/review"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proposed, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: uuid.NewString(), ActivityID: "send_reply", Decision: "support_reply",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root/review", EntityID: uuid.NewString()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registered := map[decisioncard.AnchorKind]decisioncard.Anchor{
+		decisioncard.AnchorKindStageGate: stage, decisioncard.AnchorKindHumanTask: human, decisioncard.AnchorKindProposedEffect: proposed,
+	}
+	if len(registered) != len(decisioncard.RegisteredAnchorKinds()) {
+		t.Fatalf("author activity decision-card adapters = %d, registered anchors = %d", len(registered), len(decisioncard.RegisteredAnchorKinds()))
+	}
+	for _, kind := range decisioncard.RegisteredAnchorKinds() {
+		anchor, ok := registered[kind]
+		if !ok {
+			t.Fatalf("registered decision-card anchor %q has no author activity fixture", kind)
+		}
+		anchorID, _, _, err := decisionCardAuthorActivityIdentity(anchor)
+		if err != nil || anchorID == "" {
+			t.Fatalf("decision-card anchor %q author activity identity = %q, %v", kind, anchorID, err)
+		}
+	}
+}
 
 func TestAuthorActivityPlatformEventDispositionCoversSpecCatalog(t *testing.T) {
 	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(authorActivityRegistryRepoRoot(t)))

--- a/internal/store/decision_cards.go
+++ b/internal/store/decision_cards.go
@@ -15,6 +15,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/gateruntime"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
@@ -76,9 +77,9 @@ func insertDecisionCard(ctx context.Context, db decisionCardSQL, card decisionca
 	query := `
 			INSERT INTO decision_cards (
 				card_id, run_id, anchor_kind, anchor, status, snapshot,
-				card_content_hash, decision_schema_hash, bundle_hash, workflow_version,
+				card_content_hash, effect_content_hash, decision_schema_hash, bundle_hash, workflow_version,
 				effective_cadence, provenance, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (card_id) DO NOTHING`
 	if postgres {
 		query = strings.ReplaceAll(query, "?", "$%d")
@@ -86,7 +87,7 @@ func insertDecisionCard(ctx context.Context, db decisionCardSQL, card decisionca
 	}
 	res, err := db.ExecContext(ctx, query,
 		card.CardID, card.RunID, card.Anchor.Kind(), string(anchor), card.Status, string(snapshot),
-		card.CardContentHash, card.DecisionSchemaHash, card.BundleHash, nullString(card.WorkflowVersion),
+		card.CardContentHash, card.EffectContentHash, card.DecisionSchemaHash, card.BundleHash, nullString(card.WorkflowVersion),
 		string(cadence), string(provenance), card.CreatedAt.UTC(), card.UpdatedAt.UTC(),
 	)
 	if err != nil {
@@ -104,7 +105,9 @@ func insertDecisionCard(ctx context.Context, db decisionCardSQL, card decisionca
 		if loadErr != nil {
 			return loadErr
 		}
-		return fmt.Errorf("decision card identity collision: %s", card.CardID)
+		return runtimefailures.New(runtimefailures.ClassConflictingDuplicate, "decision_card_identity_conflict", "decision-card-store", "create", map[string]any{
+			"card_id": card.CardID, "anchor_kind": card.Anchor.Kind(),
+		})
 	}
 	_, err = appendDecisionCardChangeDTO(ctx, db, card.RunID, card.CardID, decisioncard.ChangeCreated, map[string]any{
 		"status": card.Status, "anchor_kind": card.Anchor.Kind(),
@@ -130,7 +133,7 @@ func (s *SQLiteRuntimeStore) GetDecisionCard(ctx context.Context, id string) (de
 
 const decisionCardSelect = `SELECT
 	card_id, run_id, anchor_kind, anchor, status, snapshot, card_content_hash,
-	decision_schema_hash, bundle_hash, COALESCE(workflow_version, ''),
+	COALESCE(effect_content_hash, ''), decision_schema_hash, bundle_hash, COALESCE(workflow_version, ''),
 	effective_cadence, provenance, COALESCE(verdict, ''), COALESCE(fields, '{}'),
 	COALESCE(decided_by, ''), decided_at, deferred_until,
 	COALESCE(CAST(decision_event_id AS TEXT), ''), COALESCE(delivery_receipt_id, ''),
@@ -159,7 +162,7 @@ func scanDecisionCard(row *sql.Row) (decisioncard.Card, error) {
 	var decidedAt, deferredUntil, createdAt, updatedAt any
 	err := row.Scan(
 		&card.CardID, &card.RunID, &anchorKind, &anchor, &card.Status, &snapshot, &card.CardContentHash,
-		&card.DecisionSchemaHash, &card.BundleHash, &card.WorkflowVersion,
+		&card.EffectContentHash, &card.DecisionSchemaHash, &card.BundleHash, &card.WorkflowVersion,
 		&cadence, &provenance, &card.Verdict, &fields, &card.DecidedBy, &decidedAt, &deferredUntil,
 		&card.DecisionEventID, &card.DeliveryReceiptID, &card.DeliveryRenderHash, &card.SupersededReason,
 		&createdAt, &updatedAt,
@@ -261,9 +264,9 @@ func listDecisionCards(ctx context.Context, db decisionCardSQL, opts decisioncar
 		placeholder := "?"
 		if postgres {
 			placeholder = "$" + strconv.Itoa(len(args))
-			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND anchor->>'entity_id' = "+placeholder+") OR (anchor_kind = 'human_task' AND anchor->'scope'->>'entity_id' = "+placeholder+"))")
+			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND anchor->>'entity_id' = "+placeholder+") OR (anchor_kind IN ('human_task', 'proposed_effect') AND anchor->'scope'->>'entity_id' = "+placeholder+"))")
 		} else {
-			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND json_extract(anchor, '$.entity_id') = "+placeholder+") OR (anchor_kind = 'human_task' AND json_extract(anchor, '$.scope.entity_id') = "+placeholder+"))")
+			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND json_extract(anchor, '$.entity_id') = "+placeholder+") OR (anchor_kind IN ('human_task', 'proposed_effect') AND json_extract(anchor, '$.scope.entity_id') = "+placeholder+"))")
 		}
 	}
 	if value := strings.TrimSpace(opts.AnchorKind); value != "" {
@@ -323,6 +326,13 @@ func listDecisionCards(ctx context.Context, db decisionCardSQL, opts decisioncar
 			}
 			row.Category = human.Category
 			row.Decision = ""
+		} else if row.Anchor.Kind() == decisioncard.AnchorKindProposedEffect {
+			effect, err := row.Anchor.ProposedEffect()
+			if err != nil {
+				return nil, "", err
+			}
+			row.Category = "proposed_effect"
+			row.Decision = effect.Decision
 		}
 		if at, ok, err := sqliteTimeValue(deferred); err != nil {
 			return nil, "", err
@@ -426,6 +436,13 @@ func decideDecisionCard(ctx context.Context, tx *sql.Tx, req decisioncard.Decide
 				return decisioncard.DecisionOutcome{}, err
 			}
 			return decisioncard.DecisionOutcome{Card: card, ChangeID: changeID, ForcedDeferred: true}, nil
+		}
+	}
+	if card.Anchor.Kind() == decisioncard.AnchorKindProposedEffect {
+		proposed := card
+		proposed.Verdict = strings.TrimSpace(req.Verdict)
+		if err := commitProposedEffectDecision(ctx, tx, proposed, req.DecisionEventID, now, postgres); err != nil {
+			return decisioncard.DecisionOutcome{}, err
 		}
 	}
 	if strings.TrimSpace(req.InputDraftID) != "" {
@@ -928,6 +945,11 @@ func supersedeDecisionCardsForRun(ctx context.Context, tx *sql.Tx, runID, reason
 				return err
 			}
 		}
+		if card.Anchor.Kind() == decisioncard.AnchorKindProposedEffect {
+			if err := supersedeProposedEffectContinuation(ctx, tx, card.CardID, reason, now, postgres); err != nil {
+				return err
+			}
+		}
 		update := `UPDATE decision_cards SET status = ?, superseded_reason = ?, updated_at = ? WHERE card_id = ? AND status = 'pending'`
 		if postgres {
 			update = `UPDATE decision_cards SET status = $1, superseded_reason = $2, updated_at = $3 WHERE card_id = $4 AND status = 'pending'`
@@ -1186,24 +1208,9 @@ func recordDecisionCardChangeAuthorActivity(ctx context.Context, db decisionCard
 	if err != nil {
 		return err
 	}
-	anchorID := ""
-	entityID := ""
-	flowID := ""
-	switch card.Anchor.Kind() {
-	case decisioncard.AnchorKindStageGate:
-		anchor, err := card.Anchor.StageGate()
-		if err != nil {
-			return err
-		}
-		anchorID, entityID, flowID = anchor.StageActivationID, anchor.EntityID, anchor.FlowInstance
-	case decisioncard.AnchorKindHumanTask:
-		anchor, err := card.Anchor.HumanTask()
-		if err != nil {
-			return err
-		}
-		anchorID, entityID, flowID = anchor.OperationID, anchor.Scope.EntityID, anchor.Scope.FlowInstance
-	default:
-		return fmt.Errorf("decision card anchor kind %q has no author activity adapter", card.Anchor.Kind())
+	anchorID, entityID, flowID, err := decisionCardAuthorActivityIdentity(card.Anchor)
+	if err != nil {
+		return err
 	}
 	identity := strconv.FormatInt(changeID, 10)
 	projection := runtimeauthoractivity.Projection{
@@ -1221,6 +1228,31 @@ func recordDecisionCardChangeAuthorActivity(ctx context.Context, db decisionCard
 		OccurredAt: now.UTC(), RunID: strings.TrimSpace(runID), EntityID: entityID, FlowID: flowID,
 		Projection: projection,
 	})
+}
+
+func decisionCardAuthorActivityIdentity(anchor decisioncard.Anchor) (anchorID, entityID, flowID string, err error) {
+	switch anchor.Kind() {
+	case decisioncard.AnchorKindStageGate:
+		stage, err := anchor.StageGate()
+		if err != nil {
+			return "", "", "", err
+		}
+		return stage.StageActivationID, stage.EntityID, stage.FlowInstance, nil
+	case decisioncard.AnchorKindHumanTask:
+		task, err := anchor.HumanTask()
+		if err != nil {
+			return "", "", "", err
+		}
+		return task.OperationID, task.Scope.EntityID, task.Scope.FlowInstance, nil
+	case decisioncard.AnchorKindProposedEffect:
+		effect, err := anchor.ProposedEffect()
+		if err != nil {
+			return "", "", "", err
+		}
+		return effect.RequestEventID, effect.Scope.EntityID, effect.Scope.FlowInstance, nil
+	default:
+		return "", "", "", fmt.Errorf("decision card anchor kind %q has no author activity adapter", anchor.Kind())
+	}
 }
 
 func runPostgresDecisionCardMutation(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) error) error {

--- a/internal/store/decision_cards_test.go
+++ b/internal/store/decision_cards_test.go
@@ -25,6 +25,18 @@ import (
 	"github.com/google/uuid"
 )
 
+func testGateRoutes(t *testing.T) string {
+	t.Helper()
+	routes, err := gateruntime.FreezeRoutes(map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve", AdvancesTo: "operating"},
+		"reject":  {Verdict: "reject", AdvancesTo: "building"},
+	})
+	if err != nil {
+		t.Fatalf("FreezeRoutes: %v", err)
+	}
+	return routes
+}
+
 func TestDecisionCardStoreLifecycleParity(t *testing.T) {
 	for _, backend := range []string{"sqlite", "postgres"} {
 		backend := backend
@@ -186,15 +198,8 @@ func TestDecisionCardStoreRejectsStructuralSnapshotDriftAtEveryTypedLevelOnBothS
 				CardID: uuid.NewString(), RunID: runID, Anchor: newDecisionCardTestStageAnchor("launch/review", "launch", uuid.NewString(), "awaiting_review", uuid.NewString()),
 				Snapshot: freezeDecisionCardTestSnapshot(t, "launch_review", map[string]any{"summary": "ready"}, map[string]runtimecontracts.WorkflowGateOutcomePlan{
 					"revise": {
-						Verdict: "revise", AdvancesTo: "building",
-						Input: map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Required: true}},
-						Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-							"feedback": runtimecontracts.CELExpression("decision.feedback"),
-						}},
-						EmitSchema: map[string]any{
-							"type": "object", "properties": map[string]any{"feedback": map[string]any{"type": "string"}},
-							"required": []string{"feedback"}, "additionalProperties": false,
-						},
+						Verdict: "revise",
+						Input:   map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Required: true}},
 					},
 				}),
 				BundleHash: "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", WorkflowVersion: "1",
@@ -286,18 +291,6 @@ func TestDecisionCardStoreEnforcesSafeNumericSnapshotCarriersOnBothStores(t *tes
 			assertStoreSnapshotNumber(t, "provenance.safe_integer", provenanceNumber.Interface(), float64(safeInteger))
 			provenanceSubnormal, _ := loaded.Provenance.Lookup("subnormal")
 			assertStoreSnapshotNumber(t, "provenance.subnormal", provenanceSubnormal.Interface(), math.SmallestNonzeroFloat64)
-			outcome := loaded.Snapshot.Outcomes["approve"]
-			assertStoreSnapshotNumber(t, "outcome literal", outcome.Emit.Fields["large_integer"].Literal.Interface(), float64(safeInteger))
-			schema := outcome.EmitSchema.Interface().(map[string]any)
-			properties, ok := schema["properties"].(map[string]any)
-			if !ok {
-				t.Fatalf("emit schema properties = %#v", schema["properties"])
-			}
-			property, ok := properties["large_integer"].(map[string]any)
-			if !ok {
-				t.Fatalf("large_integer schema = %#v", properties["large_integer"])
-			}
-			assertStoreSnapshotNumber(t, "schema minimum", property["minimum"], float64(safeInteger))
 
 			decisionEventID := uuid.NewString()
 			if _, err := cardStore.DecideDecisionCard(ctx, decisioncard.DecideRequest{
@@ -422,23 +415,14 @@ func TestDecisionCardInvalidFrozenOutcomeNeverCommitsOnBothStores(t *testing.T) 
 			ctx := context.Background()
 			cardStore, runID := decisionCardTestStore(t, backend)
 			now := time.Date(2026, 7, 13, 5, 30, 0, 0, time.UTC)
-			properties := map[string]any{
-				"code":      map[string]any{"type": "string", "pattern": "^[a-z]+$"},
-				"component": map[string]any{"type": "string"},
-				"owner":     map[string]any{"type": "string", "x-swarm-equalTo": "component"},
-			}
 			card, err := decisioncard.New(decisioncard.Card{
 				CardID: uuid.NewString(), RunID: runID, Anchor: newDecisionCardTestStageAnchor("root", "launch", uuid.NewString(), "awaiting_review", uuid.NewString()),
 				Snapshot: freezeDecisionCardTestSnapshot(t, "launch_review", nil, map[string]runtimecontracts.WorkflowGateOutcomePlan{
 					"approve": {
-						Verdict: "approve", AdvancesTo: "operating",
+						Verdict: "approve",
 						Input: map[string]runtimecontracts.WorkflowGateInputField{
 							"code": {Type: "text", Required: true}, "component": {Type: "text", Required: true}, "owner": {Type: "text", Required: true},
 						},
-						Emit: runtimecontracts.EmitSpec{Event: "review.completed", Fields: map[string]runtimecontracts.ExpressionValue{
-							"code": runtimecontracts.CELExpression("decision.code"), "component": runtimecontracts.CELExpression("decision.component"), "owner": runtimecontracts.CELExpression("decision.owner"),
-						}},
-						EmitSchema: map[string]any{"type": "object", "properties": properties, "required": []string{"code", "component", "owner"}, "additionalProperties": false},
 					},
 				}),
 				BundleHash: "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", WorkflowVersion: "1",
@@ -451,7 +435,7 @@ func TestDecisionCardInvalidFrozenOutcomeNeverCommitsOnBothStores(t *testing.T) 
 				t.Fatal(err)
 			}
 			_, err = cardStore.DecideDecisionCard(ctx, decisioncard.DecideRequest{
-				CardID: card.CardID, Verdict: "approve", Fields: admitDecisionCardTestObject(t, map[string]any{"code": "NOT-LOWER", "component": "api", "owner": "worker"}),
+				CardID: card.CardID, Verdict: "approve", Fields: admitDecisionCardTestObject(t, map[string]any{"code": 7, "component": "api", "owner": "worker"}),
 				ActorTokenID: "operator", ObservedContentHash: card.CardContentHash, DecisionEventID: uuid.NewString(), Now: now.Add(time.Minute),
 			})
 			if !errors.Is(err, decisioncard.ErrInvalidFields) {
@@ -614,7 +598,7 @@ func TestRunTerminalizationAtomicallyFencesGateActivationsAndCardsOnBothStores(t
 			db, postgres := decisionCardStoreDB(t, cardStore)
 			now := time.Date(2026, 7, 12, 16, 0, 0, 0, time.UTC)
 			entityID := uuid.NewString()
-			activation, err := gateruntime.New(runID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "state:awaiting_review", now)
+			activation, err := gateruntime.New(runID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", testGateRoutes(t), "state:awaiting_review", now)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -689,7 +673,7 @@ func TestRunTerminalizationAtomicallyFencesGateActivationsAndCardsOnBothStores(t
 			db, postgres := decisionCardStoreDB(t, cardStore)
 			now := time.Date(2026, 7, 12, 17, 0, 0, 0, time.UTC)
 			entityID := uuid.NewString()
-			activation, err := gateruntime.New(runID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "state:awaiting_review", now)
+			activation, err := gateruntime.New(runID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", testGateRoutes(t), "state:awaiting_review", now)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -898,27 +882,6 @@ func storeDecisionSnapshotStructuralDriftCases() []storeDecisionSnapshotStructur
 		}},
 		{name: "input_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
 			delete(storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Input", "feedback"), "label")
-		}},
-		{name: "emit_shadow", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit")["shadow_semantics"] = true
-		}},
-		{name: "emit_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit"), "Event")
-		}},
-		{name: "expression_shadow", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback")["shadow_semantics"] = true
-		}},
-		{name: "expression_missing", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback"), "Ref")
-		}},
-		{name: "missing_emit_schema", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise"), "EmitSchema")
-		}},
-		{name: "missing_literal", want: unexpected, mutate: func(t *testing.T, root map[string]any) {
-			delete(storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback"), "Literal")
-		}},
-		{name: "ignored_nonliteral_value", want: "does not preserve its exact semantic value", mutate: func(t *testing.T, root map[string]any) {
-			storeDecisionSnapshotNestedObject(t, root, "outcomes", "revise", "Emit", "Fields", "feedback")["Literal"] = "shadow"
 		}},
 	}
 }

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -487,7 +487,7 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBu
 			return `SELECT COUNT(*) FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
 		}
 		return `DELETE FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
-	case "author_activity_occurrences", "run_fork_fact_revisions", "run_fork_revisions", "run_fork_revision_heads", "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
+	case "author_activity_occurrences", "run_fork_fact_revisions", "run_fork_revisions", "run_fork_revision_heads", "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "proposed_effect_continuations", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
 		if mode == "count" {
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -208,16 +208,18 @@ func platformTableOrder(name string) int {
 		return 100
 	case "decision_cards":
 		return 101
-	case "decision_card_input_drafts":
+	case "proposed_effect_continuations", "human_task_continuations":
 		return 102
-	case "decision_card_changes":
+	case "decision_card_input_drafts":
 		return 103
-	case "decision_card_route_obligations":
+	case "decision_card_changes":
 		return 104
-	case "decision_card_lifecycle_outbox":
+	case "decision_card_route_obligations":
 		return 105
-	case "api_idempotency":
+	case "decision_card_lifecycle_outbox":
 		return 106
+	case "api_idempotency":
+		return 107
 	case "runtime_ingress_state":
 		return 108
 	case "run_control_state":

--- a/internal/store/proposed_effect_cards.go
+++ b/internal/store/proposed_effect_cards.go
@@ -1,0 +1,470 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	"github.com/google/uuid"
+)
+
+var _ decisioncard.ProposedEffectStore = (*PostgresStore)(nil)
+var _ decisioncard.ProposedEffectStore = (*SQLiteRuntimeStore)(nil)
+
+func (s *PostgresStore) CreateProposedEffectCard(ctx context.Context, card decisioncard.Card, continuation decisioncard.ProposedEffectContinuation) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return insertProposedEffectCard(ctx, tx, card, continuation, true)
+	}
+	return runPostgresDecisionCardMutation(ctx, s.DB, func(txctx context.Context, tx *sql.Tx) error {
+		return insertProposedEffectCard(txctx, tx, card, continuation, true)
+	})
+}
+
+func (s *SQLiteRuntimeStore) CreateProposedEffectCard(ctx context.Context, card decisioncard.Card, continuation decisioncard.ProposedEffectContinuation) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return insertProposedEffectCard(ctx, tx, card, continuation, false)
+	}
+	return s.runDecisionCardMutation(ctx, "sqlite create proposed-effect card", func(txctx context.Context, tx *sql.Tx) error {
+		return insertProposedEffectCard(txctx, tx, card, continuation, false)
+	})
+}
+
+func insertProposedEffectCard(ctx context.Context, tx *sql.Tx, card decisioncard.Card, continuation decisioncard.ProposedEffectContinuation, postgres bool) error {
+	continuation = continuation.Canonical()
+	if err := continuation.Validate(card); err != nil {
+		return err
+	}
+	if err := insertDecisionCard(ctx, tx, card, postgres); err != nil {
+		return err
+	}
+	effect, err := continuation.EffectValue()
+	if err != nil {
+		return err
+	}
+	rawEffect, err := canonicaljson.Encode(effect)
+	if err != nil {
+		return err
+	}
+	query := `INSERT INTO proposed_effect_continuations (
+		card_id, run_id, request_event_id, effect, effect_content_hash, state,
+		created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (card_id) DO NOTHING`
+	if postgres {
+		query = `INSERT INTO proposed_effect_continuations (
+			card_id, run_id, request_event_id, effect, effect_content_hash, state,
+			created_at, updated_at
+		) VALUES ($1, $2::uuid, $3::uuid, $4::jsonb, $5, $6, $7, $8) ON CONFLICT (card_id) DO NOTHING`
+	}
+	result, err := tx.ExecContext(ctx, query, continuation.CardID, continuation.RunID, continuation.RequestEventID,
+		string(rawEffect), continuation.EffectContentHash, continuation.State, continuation.CreatedAt, continuation.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("create proposed-effect continuation: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		existing, loadErr := loadProposedEffectContinuation(ctx, tx, card.CardID, postgres, false)
+		if loadErr != nil {
+			return loadErr
+		}
+		if existing.RequestEventID != continuation.RequestEventID || existing.BundleHash != continuation.BundleHash ||
+			existing.WorkflowVersion != continuation.WorkflowVersion || existing.EffectContentHash != continuation.EffectContentHash || !existing.Input.Equal(continuation.Input) {
+			return runtimefailures.New(runtimefailures.ClassConflictingDuplicate, "proposed_effect_identity_conflict", "proposed-effect-store", "create", map[string]any{
+				"card_id": card.CardID, "request_event_id": continuation.RequestEventID,
+			})
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStore) LoadProposedEffectContinuation(ctx context.Context, cardID string) (decisioncard.ProposedEffectContinuation, error) {
+	db := decisionCardSQL(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		db = tx
+	}
+	return loadProposedEffectContinuation(ctx, db, cardID, true, false)
+}
+
+func (s *SQLiteRuntimeStore) LoadProposedEffectContinuation(ctx context.Context, cardID string) (decisioncard.ProposedEffectContinuation, error) {
+	db := decisionCardSQL(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		db = tx
+	}
+	return loadProposedEffectContinuation(ctx, db, cardID, false, false)
+}
+
+func (s *PostgresStore) ProposedEffectReadback(ctx context.Context, cardID string) (decisioncard.ProposedEffectReadback, error) {
+	db := decisionCardSQL(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		db = tx
+	}
+	return proposedEffectReadback(ctx, db, cardID, true)
+}
+
+func (s *SQLiteRuntimeStore) ProposedEffectReadback(ctx context.Context, cardID string) (decisioncard.ProposedEffectReadback, error) {
+	db := decisionCardSQL(s.DB)
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		db = tx
+	}
+	return proposedEffectReadback(ctx, db, cardID, false)
+}
+
+func proposedEffectReadback(ctx context.Context, db decisionCardSQL, cardID string, postgres bool) (decisioncard.ProposedEffectReadback, error) {
+	continuation, err := loadProposedEffectContinuation(ctx, db, cardID, postgres, false)
+	if err != nil {
+		return decisioncard.ProposedEffectReadback{}, err
+	}
+	dispatchState := "held"
+	switch continuation.State {
+	case decisioncard.ProposedEffectDecisionCommitted:
+		dispatchState = "release_pending"
+	case decisioncard.ProposedEffectRequestReleased:
+		dispatchState = "released"
+	case decisioncard.ProposedEffectOutcomeDispatched:
+		dispatchState = "not_dispatched"
+	case decisioncard.ProposedEffectSuperseded:
+		dispatchState = "superseded"
+	}
+	query := `SELECT status FROM activity_attempts WHERE request_event_id = ?`
+	if postgres {
+		query = `SELECT status FROM activity_attempts WHERE request_event_id = $1::uuid`
+	}
+	var attemptState string
+	if err := db.QueryRowContext(ctx, query, continuation.RequestEventID).Scan(&attemptState); err == nil {
+		dispatchState = strings.TrimSpace(attemptState)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return decisioncard.ProposedEffectReadback{}, err
+	}
+	return decisioncard.ProposedEffectReadback{
+		ContinuationState: continuation.State, DispatchState: dispatchState,
+		RequestEventID: continuation.RequestEventID, ActivityID: continuation.ActivityID,
+	}, nil
+}
+
+func loadProposedEffectContinuation(ctx context.Context, db decisionCardSQL, cardID string, postgres, forUpdate bool) (decisioncard.ProposedEffectContinuation, error) {
+	query := `SELECT card_id, run_id, request_event_id, effect, effect_content_hash, state,
+		COALESCE(verdict, ''), COALESCE(CAST(decision_event_id AS TEXT), ''), COALESCE(CAST(route_event_id AS TEXT), ''),
+		COALESCE(superseded_reason, ''), created_at, updated_at
+		FROM proposed_effect_continuations WHERE card_id = ?`
+	if postgres {
+		query = strings.Replace(query, "?", "$1", 1)
+		if forUpdate {
+			query += ` FOR UPDATE`
+		}
+	}
+	var out decisioncard.ProposedEffectContinuation
+	var effect []byte
+	var created, updated any
+	err := db.QueryRowContext(ctx, query, strings.TrimSpace(cardID)).Scan(
+		&out.CardID, &out.RunID, &out.RequestEventID, &effect, &out.EffectContentHash, &out.State,
+		&out.Verdict, &out.DecisionEventID, &out.RouteEventID, &out.SupersededReason, &created, &updated,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return decisioncard.ProposedEffectContinuation{}, decisioncard.ErrNotFound
+	}
+	if err != nil {
+		return decisioncard.ProposedEffectContinuation{}, err
+	}
+	if at, ok, parseErr := sqliteTimeValue(created); parseErr != nil || !ok {
+		return decisioncard.ProposedEffectContinuation{}, fmt.Errorf("decode proposed-effect created_at: %w", parseErr)
+	} else {
+		out.CreatedAt = at
+	}
+	if at, ok, parseErr := sqliteTimeValue(updated); parseErr != nil || !ok {
+		return decisioncard.ProposedEffectContinuation{}, fmt.Errorf("decode proposed-effect updated_at: %w", parseErr)
+	} else {
+		out.UpdatedAt = at
+	}
+	value, err := canonicaljson.Decode(effect)
+	if err != nil {
+		return decisioncard.ProposedEffectContinuation{}, fmt.Errorf("decode proposed effect: %w", err)
+	}
+	if err := projectProposedEffect(value, &out); err != nil {
+		return decisioncard.ProposedEffectContinuation{}, err
+	}
+	return out.Canonical(), nil
+}
+
+type proposedEffectProjection struct {
+	RequestEventID   string                       `json:"request_event_id"`
+	ActivityID       string                       `json:"activity_id"`
+	Tool             string                       `json:"tool"`
+	BundleHash       string                       `json:"bundle_hash"`
+	WorkflowVersion  string                       `json:"workflow_version"`
+	EffectClass      string                       `json:"effect_class"`
+	SuccessEvent     string                       `json:"success_event"`
+	FailureEvent     string                       `json:"failure_event"`
+	RevisionEvent    string                       `json:"revision_event"`
+	RejectedEvent    string                       `json:"rejected_event"`
+	RetryMaxAttempts int                          `json:"retry_max_attempts"`
+	RetryBackoff     string                       `json:"retry_backoff"`
+	ForkPolicy       string                       `json:"fork_policy"`
+	EntityID         string                       `json:"entity_id"`
+	NodeID           string                       `json:"node_id"`
+	FlowID           string                       `json:"flow_id"`
+	FlowInstance     string                       `json:"flow_instance"`
+	HandlerEventKey  string                       `json:"handler_event_key"`
+	SourceEventID    string                       `json:"source_event_id"`
+	SourceRunID      string                       `json:"source_run_id"`
+	SourceTaskID     string                       `json:"source_task_id"`
+	ParentEventID    string                       `json:"parent_event_id"`
+	ChainDepth       int                          `json:"chain_depth"`
+	Attempt          int                          `json:"attempt"`
+	Generation       attemptgeneration.Generation `json:"loop_generation"`
+	LoopStage        string                       `json:"loop_stage"`
+	ReplyContextID   string                       `json:"reply_context_id"`
+}
+
+func projectProposedEffect(value semanticvalue.Value, out *decisioncard.ProposedEffectContinuation) error {
+	if out == nil {
+		return fmt.Errorf("proposed-effect projection destination is nil")
+	}
+	input, ok := value.Lookup("input")
+	if !ok || input.Kind() != semanticvalue.KindObject {
+		return fmt.Errorf("proposed-effect input must be a semantic object")
+	}
+	var dto proposedEffectProjection
+	if err := canonicaljson.ValueInto(value, &dto); err != nil {
+		return fmt.Errorf("project proposed effect: %w", err)
+	}
+	out.RequestEventID = dto.RequestEventID
+	out.ActivityID = dto.ActivityID
+	out.Tool = dto.Tool
+	out.BundleHash = dto.BundleHash
+	out.WorkflowVersion = dto.WorkflowVersion
+	out.Input = input
+	out.EffectClass = runtimecontracts.NormalizeActivityEffectClass(dto.EffectClass)
+	out.SuccessEvent = dto.SuccessEvent
+	out.FailureEvent = dto.FailureEvent
+	out.RevisionEvent = dto.RevisionEvent
+	out.RejectedEvent = dto.RejectedEvent
+	out.RetryMaxAttempts = dto.RetryMaxAttempts
+	out.RetryBackoff = dto.RetryBackoff
+	out.ForkPolicy = runtimecontracts.ActivityForkPolicy(dto.ForkPolicy)
+	out.EntityID = dto.EntityID
+	out.NodeID = dto.NodeID
+	out.FlowID = dto.FlowID
+	out.FlowInstance = dto.FlowInstance
+	out.HandlerEventKey = dto.HandlerEventKey
+	out.SourceEventID = dto.SourceEventID
+	out.SourceRunID = dto.SourceRunID
+	out.SourceTaskID = dto.SourceTaskID
+	out.ParentEventID = dto.ParentEventID
+	out.ChainDepth = dto.ChainDepth
+	out.Attempt = dto.Attempt
+	out.Generation = dto.Generation
+	out.LoopStage = dto.LoopStage
+	out.ReplyContextID = dto.ReplyContextID
+	return nil
+}
+
+func commitProposedEffectDecision(ctx context.Context, tx *sql.Tx, card decisioncard.Card, eventID string, now time.Time, postgres bool) error {
+	continuation, err := loadProposedEffectContinuation(ctx, tx, card.CardID, postgres, true)
+	if err != nil {
+		return err
+	}
+	if continuation.State != decisioncard.ProposedEffectPending {
+		return decisioncard.ErrAlreadyTerminal
+	}
+	query := `UPDATE proposed_effect_continuations SET state = 'decision_committed', verdict = ?, decision_event_id = ?, updated_at = ? WHERE card_id = ? AND state = 'pending'`
+	if postgres {
+		query = `UPDATE proposed_effect_continuations SET state = 'decision_committed', verdict = $1, decision_event_id = $2::uuid, updated_at = $3 WHERE card_id = $4 AND state = 'pending'`
+	}
+	result, err := tx.ExecContext(ctx, query, strings.TrimSpace(card.Verdict), strings.TrimSpace(eventID), now, card.CardID)
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows != 1 {
+		return decisioncard.ErrAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *PostgresStore) CompleteProposedEffectRoute(ctx context.Context, cardID, routeEventID string, at time.Time) (decisioncard.ProposedEffectContinuation, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return completeProposedEffectRoute(ctx, tx, cardID, routeEventID, at, true)
+	}
+	var out decisioncard.ProposedEffectContinuation
+	err := runPostgresDecisionCardMutation(ctx, s.DB, func(txctx context.Context, tx *sql.Tx) error {
+		var inner error
+		out, inner = completeProposedEffectRoute(txctx, tx, cardID, routeEventID, at, true)
+		return inner
+	})
+	return out, err
+}
+
+func (s *SQLiteRuntimeStore) CompleteProposedEffectRoute(ctx context.Context, cardID, routeEventID string, at time.Time) (decisioncard.ProposedEffectContinuation, error) {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return completeProposedEffectRoute(ctx, tx, cardID, routeEventID, at, false)
+	}
+	var out decisioncard.ProposedEffectContinuation
+	err := s.runDecisionCardMutation(ctx, "sqlite complete proposed-effect route", func(txctx context.Context, tx *sql.Tx) error {
+		var inner error
+		out, inner = completeProposedEffectRoute(txctx, tx, cardID, routeEventID, at, false)
+		return inner
+	})
+	return out, err
+}
+
+func completeProposedEffectRoute(ctx context.Context, tx *sql.Tx, cardID, routeEventID string, at time.Time, postgres bool) (decisioncard.ProposedEffectContinuation, error) {
+	at = decisioncard.CanonicalTimestamp(at)
+	current, err := loadProposedEffectContinuation(ctx, tx, cardID, postgres, true)
+	if err != nil {
+		return decisioncard.ProposedEffectContinuation{}, err
+	}
+	wantState := decisioncard.ProposedEffectOutcomeDispatched
+	if current.Verdict == "approve" {
+		wantState = decisioncard.ProposedEffectRequestReleased
+	}
+	if current.State == wantState && current.RouteEventID == strings.TrimSpace(routeEventID) {
+		return current, nil
+	}
+	if current.State != decisioncard.ProposedEffectDecisionCommitted || current.DecisionEventID == "" {
+		return decisioncard.ProposedEffectContinuation{}, fmt.Errorf("proposed-effect continuation does not authorize route %s", routeEventID)
+	}
+	query := `UPDATE proposed_effect_continuations SET state = ?, route_event_id = ?, updated_at = ? WHERE card_id = ? AND state = 'decision_committed' AND decision_event_id = ?`
+	if postgres {
+		query = `UPDATE proposed_effect_continuations SET state = $1, route_event_id = $2::uuid, updated_at = $3 WHERE card_id = $4 AND state = 'decision_committed' AND decision_event_id = $5::uuid`
+	}
+	result, err := tx.ExecContext(ctx, query, wantState, strings.TrimSpace(routeEventID), at, current.CardID, current.DecisionEventID)
+	if err != nil {
+		return decisioncard.ProposedEffectContinuation{}, err
+	}
+	if rows, _ := result.RowsAffected(); rows != 1 {
+		return decisioncard.ProposedEffectContinuation{}, fmt.Errorf("proposed-effect route lost authority")
+	}
+	current.State = wantState
+	current.RouteEventID = strings.TrimSpace(routeEventID)
+	current.UpdatedAt = at
+	return current, nil
+}
+
+func (s *PostgresStore) SupersedeProposedEffectsForLoopGenerations(ctx context.Context, runID, entityID string, current []attemptgeneration.Generation, reason string, at time.Time) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return supersedeProposedEffectsForLoopGenerations(ctx, tx, runID, entityID, current, reason, at, true)
+	}
+	return runPostgresDecisionCardMutation(ctx, s.DB, func(txctx context.Context, tx *sql.Tx) error {
+		return supersedeProposedEffectsForLoopGenerations(txctx, tx, runID, entityID, current, reason, at, true)
+	})
+}
+
+func (s *SQLiteRuntimeStore) SupersedeProposedEffectsForLoopGenerations(ctx context.Context, runID, entityID string, current []attemptgeneration.Generation, reason string, at time.Time) error {
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		return supersedeProposedEffectsForLoopGenerations(ctx, tx, runID, entityID, current, reason, at, false)
+	}
+	return s.runDecisionCardMutation(ctx, "sqlite supersede proposed effects for loop generation", func(txctx context.Context, tx *sql.Tx) error {
+		return supersedeProposedEffectsForLoopGenerations(txctx, tx, runID, entityID, current, reason, at, false)
+	})
+}
+
+func supersedeProposedEffectsForLoopGenerations(ctx context.Context, tx *sql.Tx, runID, entityID string, current []attemptgeneration.Generation, reason string, at time.Time, postgres bool) error {
+	runID = strings.TrimSpace(runID)
+	entityID = strings.TrimSpace(entityID)
+	reason = strings.TrimSpace(reason)
+	at = decisioncard.CanonicalTimestamp(at)
+	if runID == "" || entityID == "" || reason == "" || at.IsZero() {
+		return fmt.Errorf("loop-generation proposed-effect supersession identity is incomplete")
+	}
+	query := `SELECT p.card_id FROM proposed_effect_continuations p JOIN decision_cards c ON c.card_id = p.card_id
+		WHERE c.run_id = ? AND c.status = 'pending' AND p.state = 'pending' ORDER BY p.card_id`
+	if postgres {
+		query = `SELECT p.card_id FROM proposed_effect_continuations p JOIN decision_cards c ON c.card_id = p.card_id
+			WHERE c.run_id = $1::uuid AND c.status = 'pending' AND p.state = 'pending' ORDER BY p.card_id FOR UPDATE OF p, c`
+	}
+	rows, err := tx.QueryContext(ctx, query, runID)
+	if err != nil {
+		return err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		ids = append(ids, strings.TrimSpace(id))
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, cardID := range ids {
+		continuation, err := loadProposedEffectContinuation(ctx, tx, cardID, postgres, false)
+		if err != nil {
+			return err
+		}
+		if continuation.EntityID != entityID || !continuation.Generation.Valid() || generationStillCurrent(continuation.Generation, current) {
+			continue
+		}
+		card, err := loadDecisionCard(ctx, tx, cardID, postgres, true)
+		if err != nil {
+			return err
+		}
+		if err := supersedeProposedEffectContinuation(ctx, tx, cardID, reason, at, postgres); err != nil {
+			return err
+		}
+		update := `UPDATE decision_cards SET status = ?, superseded_reason = ?, updated_at = ? WHERE card_id = ? AND status = 'pending'`
+		if postgres {
+			update = `UPDATE decision_cards SET status = $1, superseded_reason = $2, updated_at = $3 WHERE card_id = $4 AND status = 'pending'`
+		}
+		result, err := tx.ExecContext(ctx, update, decisioncard.StatusSuperseded, reason, at, cardID)
+		if err != nil {
+			return err
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return decisioncard.ErrAlreadyTerminal
+		}
+		if _, err := appendDecisionCardChangeDTO(ctx, tx, runID, cardID, decisioncard.ChangeSuperseded, map[string]any{"reason": reason}, at, postgres); err != nil {
+			return err
+		}
+		payload, err := canonicaljson.Bytes(map[string]any{"card_id": card.CardID, "anchor_kind": card.Anchor.Kind(), "reason": reason})
+		if err != nil {
+			return err
+		}
+		scope, err := card.Anchor.Scope()
+		if err != nil {
+			return err
+		}
+		evt := events.NewRuntimeControlEvent(uuid.NewString(), events.EventType("mailbox.card_superseded"), "platform", "", payload, 0, card.RunID, "",
+			events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, scope.EntityID), scope.FlowInstance), at)
+		if err := insertDecisionCardLifecycleOutbox(ctx, tx, card, evt, postgres); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generationStillCurrent(candidate attemptgeneration.Generation, current []attemptgeneration.Generation) bool {
+	for _, generation := range current {
+		if candidate.Equal(generation) {
+			return true
+		}
+	}
+	return false
+}
+
+func supersedeProposedEffectContinuation(ctx context.Context, tx *sql.Tx, cardID, reason string, at time.Time, postgres bool) error {
+	query := `UPDATE proposed_effect_continuations SET state = 'superseded', superseded_reason = ?, updated_at = ? WHERE card_id = ? AND state = 'pending'`
+	if postgres {
+		query = `UPDATE proposed_effect_continuations SET state = 'superseded', superseded_reason = $1, updated_at = $2 WHERE card_id = $3 AND state = 'pending'`
+	}
+	result, err := tx.ExecContext(ctx, query, strings.TrimSpace(reason), decisioncard.CanonicalTimestamp(at), strings.TrimSpace(cardID))
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows != 1 {
+		return decisioncard.ErrAlreadyTerminal
+	}
+	return nil
+}

--- a/internal/store/proposed_effect_cards_test.go
+++ b/internal/store/proposed_effect_cards_test.go
@@ -1,0 +1,438 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	"github.com/google/uuid"
+)
+
+func TestProposedEffectCardLifecycleParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		for _, verdict := range []string{"approve", "revise", "reject"} {
+			t.Run(backend+"/"+verdict, func(t *testing.T) {
+				ctx := context.Background()
+				cards, runID := decisionCardTestStore(t, backend)
+				store := cards.(decisioncard.ProposedEffectStore)
+				now := time.Date(2026, 7, 14, 15, 0, 0, 0, time.UTC)
+				card, continuation := newProposedEffectTestCard(t, runID, now, attemptgeneration.Generation{})
+				if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatalf("CreateProposedEffectCard: %v", err)
+				}
+				if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatalf("idempotent CreateProposedEffectCard: %v", err)
+				}
+				readback, err := store.ProposedEffectReadback(ctx, card.CardID)
+				if err != nil || readback.DispatchState != "held" {
+					t.Fatalf("pending readback = %#v, %v", readback, err)
+				}
+				changed := continuation
+				changed.Input, _ = canonicaljson.FromGo(map[string]any{"chat_id": "support", "text": "changed"})
+				changedEffect, err := changed.EffectValue()
+				if err != nil {
+					t.Fatal(err)
+				}
+				changed.EffectContentHash, err = canonicaljson.HashValue(changedEffect)
+				if err != nil {
+					t.Fatal(err)
+				}
+				changedCard := card
+				changedCard.EffectContentHash = changed.EffectContentHash
+				changedCard.CardContentHash = ""
+				changedCard, err = decisioncard.New(changedCard)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := store.CreateProposedEffectCard(ctx, changedCard, changed); !isProposedEffectFailureClass(err, runtimefailures.ClassConflictingDuplicate) {
+					t.Fatalf("changed-content create error = %v, want conflicting duplicate", err)
+				}
+				fields := semanticvalue.EmptyObject()
+				if verdict == "revise" {
+					fields, _ = canonicaljson.FromGo(map[string]any{"feedback": "Please remove the secret."})
+				} else if verdict == "reject" {
+					fields, _ = canonicaljson.FromGo(map[string]any{"reason": "Not authorized."})
+				}
+				decisionEventID := uuid.NewString()
+				if _, err := cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+					CardID: card.CardID, Verdict: verdict, Fields: fields, ActorTokenID: "operator",
+					ObservedContentHash: card.CardContentHash, DecisionEventID: decisionEventID, Now: now.Add(time.Minute),
+				}); err != nil {
+					t.Fatalf("DecideDecisionCard: %v", err)
+				}
+				committed, err := store.LoadProposedEffectContinuation(ctx, card.CardID)
+				if err != nil || committed.State != decisioncard.ProposedEffectDecisionCommitted || committed.Verdict != verdict {
+					t.Fatalf("committed continuation = %#v, %v", committed, err)
+				}
+				assertProposedEffectAuthorActivity(t, cards, runID, card.CardID, continuation.RequestEventID, []string{"created", "decided"}, verdict, "")
+				if _, err := store.CompleteProposedEffectRoute(ctx, card.CardID, decisionEventID, now.Add(2*time.Minute)); err != nil {
+					t.Fatalf("CompleteProposedEffectRoute: %v", err)
+				}
+				readback, err = store.ProposedEffectReadback(ctx, card.CardID)
+				wantDispatch := "released"
+				wantContinuation := decisioncard.ProposedEffectRequestReleased
+				if verdict != "approve" {
+					wantDispatch = "not_dispatched"
+					wantContinuation = decisioncard.ProposedEffectOutcomeDispatched
+				}
+				if err != nil || readback.DispatchState != wantDispatch || readback.ContinuationState != wantContinuation {
+					t.Fatalf("routed readback = %#v, %v; want %s/%s", readback, err, wantContinuation, wantDispatch)
+				}
+			})
+		}
+	}
+}
+
+func assertProposedEffectAuthorActivity(t *testing.T, cards decisioncard.Store, runID, cardID, requestEventID string, wantTransitions []string, verdict, supersedeReason string) {
+	t.Helper()
+	reader, ok := cards.(interface {
+		ListAuthorActivity(context.Context, runtimeauthoractivity.ListOptions) (runtimeauthoractivity.ListResult, error)
+	})
+	if !ok {
+		t.Fatalf("decision card store %T lacks author activity readback", cards)
+	}
+	result, err := reader.ListAuthorActivity(context.Background(), runtimeauthoractivity.ListOptions{RunID: runID, Limit: 100})
+	if err != nil {
+		t.Fatalf("list proposed-effect author activity: %v", err)
+	}
+	var found []runtimeauthoractivity.Occurrence
+	for _, occurrence := range result.Occurrences {
+		if occurrence.Kind == runtimeauthoractivity.KindCardLifecycle && occurrence.Projection.CardID == cardID {
+			found = append(found, occurrence)
+		}
+	}
+	if len(found) != len(wantTransitions) {
+		t.Fatalf("proposed-effect author activity occurrences = %#v, want exactly %v", found, wantTransitions)
+	}
+	for index, transition := range wantTransitions {
+		occurrence := found[index]
+		if occurrence.Transition != transition {
+			t.Fatalf("proposed-effect author activity transition[%d] = %q, want %q: %#v", index, occurrence.Transition, transition, found)
+		}
+		if occurrence.Projection.AnchorKind != string(decisioncard.AnchorKindProposedEffect) || occurrence.Projection.AnchorID != requestEventID {
+			t.Fatalf("proposed-effect %s anchor projection = %#v", transition, occurrence.Projection)
+		}
+		if transition == "decided" && occurrence.Projection.Verdict != verdict {
+			t.Fatalf("proposed-effect decided verdict = %q, want %q", occurrence.Projection.Verdict, verdict)
+		}
+		if transition == "superseded" && occurrence.Projection.SupersedeReason != supersedeReason {
+			t.Fatalf("proposed-effect superseded reason = %q, want %q", occurrence.Projection.SupersedeReason, supersedeReason)
+		}
+	}
+}
+
+func TestProposedEffectContractPinParticipatesInDuplicateIdentityOnBothStores(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		for _, mutate := range []struct {
+			name  string
+			apply func(*decisioncard.Card, *decisioncard.ProposedEffectContinuation)
+		}{
+			{
+				name: "bundle_hash",
+				apply: func(card *decisioncard.Card, continuation *decisioncard.ProposedEffectContinuation) {
+					continuation.BundleHash = "bundle-v1:sha256:" + strings.Repeat("b", 64)
+					card.BundleHash = continuation.BundleHash
+				},
+			},
+			{
+				name: "workflow_version",
+				apply: func(card *decisioncard.Card, continuation *decisioncard.ProposedEffectContinuation) {
+					continuation.WorkflowVersion = "2"
+					card.WorkflowVersion = continuation.WorkflowVersion
+				},
+			},
+		} {
+			t.Run(backend+"/"+mutate.name, func(t *testing.T) {
+				ctx := context.Background()
+				cards, runID := decisionCardTestStore(t, backend)
+				proposed := cards.(decisioncard.ProposedEffectStore)
+				card, continuation := newProposedEffectTestCard(t, runID, time.Date(2026, 7, 14, 16, 0, 0, 0, time.UTC), attemptgeneration.Generation{})
+				if err := proposed.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatal(err)
+				}
+				mutate.apply(&card, &continuation)
+				effect, err := continuation.EffectValue()
+				if err != nil {
+					t.Fatal(err)
+				}
+				continuation.EffectContentHash, err = canonicaljson.HashValue(effect)
+				if err != nil {
+					t.Fatal(err)
+				}
+				card.EffectContentHash = continuation.EffectContentHash
+				card.CardContentHash = ""
+				card, err = decisioncard.New(card)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := proposed.CreateProposedEffectCard(ctx, card, continuation); !isProposedEffectFailureClass(err, runtimefailures.ClassConflictingDuplicate) {
+					t.Fatalf("changed %s create error = %v, want conflicting duplicate", mutate.name, err)
+				}
+			})
+		}
+	}
+}
+
+func TestProposedEffectReadbackKeepsAuthorizationAndDispatchAxesSeparateOnBothStores(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		for _, status := range []string{
+			runtimepipeline.ActivityAttemptStatusStarted,
+			runtimepipeline.ActivityAttemptStatusSucceeded,
+			runtimepipeline.ActivityAttemptStatusFailed,
+			runtimepipeline.ActivityAttemptStatusUncertain,
+		} {
+			t.Run(backend+"/"+status, func(t *testing.T) {
+				ctx := context.Background()
+				cards, runID := decisionCardTestStore(t, backend)
+				store := cards.(decisioncard.ProposedEffectStore)
+				now := time.Date(2026, 7, 14, 17, 0, 0, 0, time.UTC)
+				card, continuation := newProposedEffectTestCard(t, runID, now, attemptgeneration.Generation{})
+				if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatal(err)
+				}
+				decisionEventID := uuid.NewString()
+				if _, err := cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+					CardID: card.CardID, Verdict: "approve", Fields: semanticvalue.EmptyObject(), ActorTokenID: "operator",
+					ObservedContentHash: card.CardContentHash, DecisionEventID: decisionEventID, Now: now.Add(time.Minute),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := store.CompleteProposedEffectRoute(ctx, card.CardID, decisionEventID, now.Add(2*time.Minute)); err != nil {
+					t.Fatal(err)
+				}
+
+				journal := proposedEffectTestJournal(cards)
+				started, inserted, err := journal.StartActivityAttempt(ctx, runtimepipeline.ActivityAttemptRecord{
+					RequestEventID: continuation.RequestEventID, RunID: runID, SourceEventID: continuation.SourceEventID,
+					EntityID: continuation.EntityID, FlowInstance: continuation.FlowInstance, NodeID: continuation.NodeID,
+					HandlerEventKey: continuation.HandlerEventKey, ActivityID: continuation.ActivityID, Tool: continuation.Tool,
+					EffectClass: string(continuation.EffectClass), Attempt: 1, Status: runtimepipeline.ActivityAttemptStatusStarted,
+					SuccessEvent: continuation.SuccessEvent, FailureEvent: continuation.FailureEvent, InputHash: continuation.EffectContentHash,
+				})
+				if err != nil || !inserted {
+					t.Fatalf("start attempt = %#v, %v, inserted=%v", started, err, inserted)
+				}
+				if status != runtimepipeline.ActivityAttemptStatusStarted {
+					terminal := started
+					terminal.Status = status
+					terminal.ResultEventID = uuid.NewString()
+					terminal.ResultEventType = continuation.SuccessEvent
+					terminal.ResultPayload = map[string]any{"activity_id": continuation.ActivityID}
+					if status != runtimepipeline.ActivityAttemptStatusSucceeded {
+						failure := runtimefailures.Normalize(runtimefailures.New(
+							map[string]runtimefailures.Class{
+								runtimepipeline.ActivityAttemptStatusFailed:    runtimefailures.ClassConnectorFailure,
+								runtimepipeline.ActivityAttemptStatusUncertain: runtimefailures.ClassOutcomeUncertain,
+							}[status],
+							"proposed_effect_readback_fixture", "test", "dispatch", nil,
+						), "test", "dispatch")
+						terminal.Failure = &failure
+						terminal.ResultEventType = continuation.FailureEvent
+					}
+					if _, err := journal.CompleteActivityAttempt(ctx, terminal); err != nil {
+						t.Fatal(err)
+					}
+				}
+				readback, err := store.ProposedEffectReadback(ctx, card.CardID)
+				if err != nil || readback.DispatchState != status || readback.ContinuationState != decisioncard.ProposedEffectRequestReleased {
+					t.Fatalf("readback = %#v, %v; want authorization=decided continuation=released dispatch=%s", readback, err, status)
+				}
+			})
+		}
+	}
+}
+
+func proposedEffectTestJournal(cards decisioncard.Store) *runtimepipeline.WorkflowInstanceStore {
+	switch selected := cards.(type) {
+	case *SQLiteRuntimeStore:
+		return runtimepipeline.NewSQLiteWorkflowInstanceStoreWithRuntimeMutationRunner(selected.DB, selected)
+	case *PostgresStore:
+		return runtimepipeline.NewWorkflowInstanceStore(selected.DB)
+	default:
+		panic("unsupported proposed-effect test store")
+	}
+}
+
+func isProposedEffectFailureClass(err error, class runtimefailures.Class) bool {
+	var failure *runtimefailures.Error
+	return errors.As(err, &failure) && failure.Failure.Class == class
+}
+
+func TestProposedEffectDecisionAndSupersessionWinnerParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		for _, winner := range []string{"decision", "run_supersession", "loop_supersession"} {
+			t.Run(backend+"/"+winner, func(t *testing.T) {
+				ctx := context.Background()
+				cards, runID := decisionCardTestStore(t, backend)
+				store := cards.(decisioncard.ProposedEffectStore)
+				now := time.Date(2026, 7, 14, 15, 30, 0, 0, time.UTC)
+				generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: uuid.NewString(), RevisionField: "revision_id", RevisionID: uuid.NewString(), Attempt: 1}
+				card, continuation := newProposedEffectTestCard(t, runID, now, generation)
+				if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+					t.Fatal(err)
+				}
+				decide := func() error {
+					_, err := cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+						CardID: card.CardID, Verdict: "approve", Fields: semanticvalue.EmptyObject(), ActorTokenID: "operator",
+						ObservedContentHash: card.CardContentHash, DecisionEventID: uuid.NewString(), Now: now.Add(time.Minute),
+					})
+					return err
+				}
+				supersede := func() error {
+					switch winner {
+					case "loop_supersession":
+						next := generation
+						next.RevisionID = uuid.NewString()
+						next.Attempt++
+						return store.SupersedeProposedEffectsForLoopGenerations(ctx, runID, continuation.EntityID, []attemptgeneration.Generation{next}, "loop_generation_superseded", now.Add(2*time.Minute))
+					default:
+						return cards.SupersedeDecisionCardsForRun(ctx, runID, "run_terminated", now.Add(2*time.Minute))
+					}
+				}
+				if winner == "decision" {
+					if err := decide(); err != nil {
+						t.Fatal(err)
+					}
+					if err := supersede(); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := supersede(); err != nil {
+						t.Fatal(err)
+					}
+					if err := decide(); !errors.Is(err, decisioncard.ErrAlreadyTerminal) {
+						t.Fatalf("decision after supersession = %v, want already terminal", err)
+					}
+				}
+				storedCard, err := cards.GetDecisionCard(ctx, card.CardID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				storedContinuation, err := store.LoadProposedEffectContinuation(ctx, card.CardID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if winner == "decision" {
+					if storedCard.Status != decisioncard.StatusDecided || storedContinuation.State != decisioncard.ProposedEffectDecisionCommitted {
+						t.Fatalf("decision winner = card:%s continuation:%s", storedCard.Status, storedContinuation.State)
+					}
+					assertProposedEffectAuthorActivity(t, cards, runID, card.CardID, continuation.RequestEventID, []string{"created", "decided"}, "approve", "")
+				} else if storedCard.Status != decisioncard.StatusSuperseded || storedContinuation.State != decisioncard.ProposedEffectSuperseded {
+					t.Fatalf("supersession winner = card:%s continuation:%s", storedCard.Status, storedContinuation.State)
+				} else {
+					reason := "run_terminated"
+					if winner == "loop_supersession" {
+						reason = "loop_generation_superseded"
+					}
+					assertProposedEffectAuthorActivity(t, cards, runID, card.CardID, continuation.RequestEventID, []string{"created", "superseded"}, "", reason)
+				}
+			})
+		}
+	}
+}
+
+func TestProposedEffectSupersessionScopesParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx := context.Background()
+			cards, runID := decisionCardTestStore(t, backend)
+			store := cards.(decisioncard.ProposedEffectStore)
+			now := time.Date(2026, 7, 14, 16, 0, 0, 0, time.UTC)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: uuid.NewString(), RevisionField: "revision_id", RevisionID: uuid.NewString(), Attempt: 1}
+			card, continuation := newProposedEffectTestCard(t, runID, now, generation)
+			if err := store.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+				t.Fatal(err)
+			}
+			if err := cards.SupersedeDecisionCardsForStage(ctx, runID, continuation.EntityID, uuid.NewString(), "stage_exited", now.Add(time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			stillPending, _ := cards.GetDecisionCard(ctx, card.CardID)
+			if stillPending.Status != decisioncard.StatusPending {
+				t.Fatalf("ordinary stage exit status = %s", stillPending.Status)
+			}
+			if err := store.SupersedeProposedEffectsForLoopGenerations(ctx, runID, continuation.EntityID, []attemptgeneration.Generation{generation}, "loop_generation_superseded", now.Add(2*time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			stillPending, _ = cards.GetDecisionCard(ctx, card.CardID)
+			if stillPending.Status != decisioncard.StatusPending {
+				t.Fatalf("current generation status = %s", stillPending.Status)
+			}
+			next := generation
+			next.RevisionID = uuid.NewString()
+			next.Attempt = 2
+			if err := store.SupersedeProposedEffectsForLoopGenerations(ctx, runID, continuation.EntityID, []attemptgeneration.Generation{next}, "loop_generation_superseded", now.Add(3*time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			superseded, _ := cards.GetDecisionCard(ctx, card.CardID)
+			stored, _ := store.LoadProposedEffectContinuation(ctx, card.CardID)
+			if superseded.Status != decisioncard.StatusSuperseded || stored.State != decisioncard.ProposedEffectSuperseded {
+				t.Fatalf("supersession = card:%#v continuation:%#v", superseded, stored)
+			}
+		})
+	}
+}
+
+func newProposedEffectTestCard(t *testing.T, runID string, now time.Time, generation attemptgeneration.Generation) (decisioncard.Card, decisioncard.ProposedEffectContinuation) {
+	t.Helper()
+	requestID := uuid.NewString()
+	entityID := uuid.NewString()
+	input, err := canonicaljson.FromGo(map[string]any{"chat_id": "support", "text": "Approved reply"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation := decisioncard.ProposedEffectContinuation{
+		CardID: decisioncard.ProposedEffectCardID(requestID, "support_reply"), RunID: runID,
+		RequestEventID: requestID, ActivityID: "send_support_reply", Tool: "telegram.send_message", Input: input,
+		BundleHash: "bundle-v1:sha256:" + strings.Repeat("a", 64), WorkflowVersion: "1",
+		EffectClass:  runtimecontracts.ActivityEffectClassNonIdempotentWrite,
+		SuccessEvent: "support_reply.succeeded", FailureEvent: "support_reply.failed",
+		RevisionEvent: "support_reply.revision_requested", RejectedEvent: "support_reply.rejected",
+		RetryMaxAttempts: 1, ForkPolicy: runtimecontracts.ActivityForkRequireConfirmation,
+		EntityID: entityID, NodeID: "support", FlowID: "", FlowInstance: "root",
+		HandlerEventKey: "support.drafted", SourceEventID: uuid.NewString(), SourceRunID: runID,
+		Generation: generation, ReplyContextID: "reply-context-source", State: decisioncard.ProposedEffectPending, CreatedAt: now, UpdatedAt: now,
+	}.Canonical()
+	effect, err := continuation.EffectValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	continuation.EffectContentHash, err = canonicaljson.HashValue(effect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: requestID, ActivityID: continuation.ActivityID, Decision: "support_reply",
+		Scope: decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: "root", EntityID: entityID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := decisioncard.FreezeSnapshot("support_reply", "", map[string]any{"input": input.Interface()}, map[string]runtimecontracts.WorkflowGateOutcomePlan{
+		"approve": {Verdict: "approve"},
+		"revise":  {Verdict: "revise", Input: map[string]runtimecontracts.WorkflowGateInputField{"feedback": {Type: "text", Required: true}}},
+		"reject":  {Verdict: "reject", Input: map[string]runtimecontracts.WorkflowGateInputField{"reason": {Type: "text"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	card, err := decisioncard.New(decisioncard.Card{
+		CardID: continuation.CardID, RunID: runID, Anchor: anchor, Snapshot: snapshot,
+		EffectContentHash: continuation.EffectContentHash,
+		BundleHash:        "bundle-v1:sha256:" + strings.Repeat("a", 64), WorkflowVersion: "1",
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return card, continuation
+}

--- a/internal/store/run_fork_activity_generation.go
+++ b/internal/store/run_fork_activity_generation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
@@ -75,6 +77,26 @@ func prepareRunForkSelectedContractSourceEvent(ctx context.Context, tx *sql.Tx, 
 		return event, fmt.Errorf("decode selected-contract activity request %s: %w", event.SourceEventID, err)
 	}
 	policy := runtimecontracts.ActivityForkPolicy(strings.TrimSpace(request.ForkPolicy))
+	proposed, err := loadRunForkProposedEffectAuthority(ctx, tx, event.SourceEventID)
+	if err != nil {
+		return event, err
+	}
+	if proposed {
+		if policy != runtimecontracts.ActivityForkRequireConfirmation {
+			return event, fmt.Errorf("approved activity request %s must retain require_manual_confirmation fork policy", event.SourceEventID)
+		}
+		evidence, err := loadRunForkActivityAttemptEvidence(ctx, tx, event.SourceEventID)
+		if err != nil {
+			return event, fmt.Errorf("approved proposed effect %s cannot authorize a fork-local call: %w", event.SourceEventID, err)
+		}
+		if evidence.Status == "uncertain" {
+			return event, fmt.Errorf("approved proposed effect %s has ambiguous dispatch evidence and cannot authorize a fork-local call", event.SourceEventID)
+		}
+		if err := copyRunForkActivityAttemptEvidence(ctx, tx, forkRunID, event.FlowInstance, request, generations, evidence); err != nil {
+			return event, err
+		}
+		return event, nil
+	}
 	switch policy {
 	case runtimecontracts.ActivityForkReexecuteRead:
 		if runtimecontracts.NormalizeActivityEffectClass(request.EffectClass) != runtimecontracts.ActivityEffectClassReadOnly {
@@ -96,6 +118,26 @@ func prepareRunForkSelectedContractSourceEvent(ctx context.Context, tx *sql.Tx, 
 		return event, err
 	}
 	return event, nil
+}
+
+func loadRunForkProposedEffectAuthority(ctx context.Context, tx *sql.Tx, requestEventID string) (bool, error) {
+	var status, verdict, state string
+	err := tx.QueryRowContext(ctx, `
+		SELECT c.status, COALESCE(c.verdict, ''), p.state
+		FROM proposed_effect_continuations p
+		JOIN decision_cards c ON c.card_id = p.card_id
+		WHERE p.request_event_id = $1::uuid
+	`, strings.TrimSpace(requestEventID)).Scan(&status, &verdict, &state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("load proposed-effect fork authority for request %s: %w", requestEventID, err)
+	}
+	if status != decisioncard.StatusDecided || verdict != "approve" || state != decisioncard.ProposedEffectRequestReleased {
+		return false, fmt.Errorf("approved proposed effect %s is not terminal fork evidence: card=%s verdict=%s continuation=%s", requestEventID, status, verdict, state)
+	}
+	return true, nil
 }
 
 func bindRunForkActivitySourceEvent(raw json.RawMessage, forkRunID, sourceRequestEventID string) (json.RawMessage, error) {
@@ -218,9 +260,6 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 			break
 		}
 	}
-	if !generation.Valid() {
-		return fmt.Errorf("fork activity %s has no fork-local loop generation", request.ActivityID)
-	}
 	if request.Attempt <= 0 {
 		request.Attempt = 1
 	}
@@ -232,7 +271,7 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 	}
 	requestEventID := activityidentity.RequestEventID(fact)
 	resultEventID := activityidentity.ResultEventID(fact, evidence.ResultEventType)
-	resultPayload, err := remintRunForkPayload(evidence.ResultPayload, forkRunID, []attemptgeneration.Generation{generation})
+	resultPayload, err := remintRunForkPayload(evidence.ResultPayload, forkRunID, generationsForRunForkActivity(generation))
 	if err != nil {
 		return fmt.Errorf("remint activity %s recorded result: %w", request.ActivityID, err)
 	}
@@ -280,7 +319,8 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 	if err := json.Unmarshal(gotGeneration, &got); err != nil {
 		return err
 	}
-	if gotRunID != forkRunID || gotStatus != evidence.Status || gotResultID != resultEventID || !got.Equal(generation) {
+	generationMatches := (!got.Valid() && !generation.Valid()) || got.Equal(generation)
+	if gotRunID != forkRunID || gotStatus != evidence.Status || gotResultID != resultEventID || !generationMatches {
 		return fmt.Errorf("fork-local activity evidence %s conflicts with canonical fork identity", request.ActivityID)
 	}
 	if !inserted {
@@ -306,4 +346,11 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 		},
 		Failure: canonicalFailure,
 	})
+}
+
+func generationsForRunForkActivity(generation attemptgeneration.Generation) []attemptgeneration.Generation {
+	if !generation.Valid() {
+		return nil
+	}
+	return []attemptgeneration.Generation{generation}
 }

--- a/internal/store/run_fork_gate_activation.go
+++ b/internal/store/run_fork_gate_activation.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	"github.com/division-sh/swarm/internal/runtime/gateruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
@@ -94,4 +97,166 @@ func materializeRunForkDecisionCards(ctx context.Context, tx *sql.Tx, forkRunID,
 		}
 	}
 	return nil
+}
+
+func materializeRunForkProposedEffectCards(ctx context.Context, tx *sql.Tx, sourceRunID, forkRunID, entityID string, forkPoint RunForkPoint, now time.Time) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT p.card_id
+		FROM proposed_effect_continuations p
+		JOIN decision_cards c ON c.card_id = p.card_id
+		WHERE p.run_id = $1::uuid
+		  AND p.effect->>'entity_id' = $2
+		  AND c.created_at <= $3
+		ORDER BY c.created_at, p.card_id
+		FOR UPDATE OF p, c
+	`, strings.TrimSpace(sourceRunID), strings.TrimSpace(entityID), forkPoint.Timestamp.UTC())
+	if err != nil {
+		return fmt.Errorf("load source proposed effects for fork: %w", err)
+	}
+	var cardIDs []string
+	for rows.Next() {
+		var cardID string
+		if err := rows.Scan(&cardID); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		cardIDs = append(cardIDs, cardID)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(cardIDs) == 0 {
+		return nil
+	}
+	forkGenerations, err := loadRunForkEntityGenerations(ctx, tx, forkRunID, entityID)
+	if err != nil {
+		return err
+	}
+	for _, cardID := range cardIDs {
+		sourceCard, err := loadDecisionCard(ctx, tx, cardID, true, false)
+		if err != nil {
+			return fmt.Errorf("load source proposed-effect card %s: %w", cardID, err)
+		}
+		pendingAtFork := sourceCard.Status == decisioncard.StatusPending
+		if !sourceCard.DecidedAt.IsZero() {
+			pendingAtFork = sourceCard.DecidedAt.After(forkPoint.Timestamp)
+		} else if sourceCard.Status == decisioncard.StatusSuperseded {
+			pendingAtFork = sourceCard.UpdatedAt.After(forkPoint.Timestamp)
+		}
+		if !pendingAtFork {
+			continue
+		}
+		sourceContinuation, err := loadProposedEffectContinuation(ctx, tx, cardID, true, false)
+		if err != nil {
+			return fmt.Errorf("load source proposed-effect continuation %s: %w", cardID, err)
+		}
+		forkCard, forkContinuation, err := forkPendingProposedEffect(sourceCard, sourceContinuation, forkRunID, forkGenerations, now)
+		if err != nil {
+			return err
+		}
+		if err := insertProposedEffectCard(ctx, tx, forkCard, forkContinuation, true); err != nil {
+			return fmt.Errorf("insert fork-local proposed effect: %w", err)
+		}
+	}
+	return nil
+}
+
+func forkPendingProposedEffect(sourceCard decisioncard.Card, source decisioncard.ProposedEffectContinuation, forkRunID string, forkGenerations []attemptgeneration.Generation, now time.Time) (decisioncard.Card, decisioncard.ProposedEffectContinuation, error) {
+	source = source.Canonical()
+	fork := source
+	fork.RunID = strings.TrimSpace(forkRunID)
+	fork.SourceRunID = fork.RunID
+	fork.ReplyContextID = ""
+	fork.SourceEventID = activityidentity.ForkLineageEventID(fork.RunID, source.SourceEventID)
+	if source.ParentEventID != "" {
+		fork.ParentEventID = activityidentity.ForkLineageEventID(fork.RunID, source.ParentEventID)
+	}
+	if source.Generation.Valid() {
+		matched := false
+		for _, generation := range forkGenerations {
+			if strings.TrimSpace(generation.LoopID) == strings.TrimSpace(source.Generation.LoopID) {
+				fork.Generation = generation.Normalize()
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, fmt.Errorf("fork proposed effect %s has no fork-local loop generation", source.ActivityID)
+		}
+	}
+	fact := activityidentity.Fact{
+		RunID: fork.RunID, SourceEventID: fork.SourceEventID, ParentEventID: fork.ParentEventID,
+		EntityID: fork.EntityID, FlowID: fork.FlowID, NodeID: fork.NodeID,
+		HandlerEventKey: fork.HandlerEventKey, ActivityID: fork.ActivityID, Tool: fork.Tool,
+		Attempt: fork.Attempt, RevisionID: fork.Generation.RevisionID,
+	}
+	fork.RequestEventID = activityidentity.RequestEventID(fact)
+	sourceAnchor, err := sourceCard.Anchor.ProposedEffect()
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	fork.CardID = decisioncard.ProposedEffectCardID(fork.RequestEventID, sourceAnchor.Decision)
+	fork.State = decisioncard.ProposedEffectPending
+	fork.Verdict = ""
+	fork.DecisionEventID = ""
+	fork.RouteEventID = ""
+	fork.SupersededReason = ""
+	fork.CreatedAt = now.UTC()
+	fork.UpdatedAt = now.UTC()
+	effect, err := fork.EffectValue()
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	fork.EffectContentHash, err = canonicaljson.HashValue(effect)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	scope := sourceAnchor.Scope
+	scope.FlowInstance = strings.Trim(strings.TrimSpace(scope.FlowInstance), "/")
+	scope.EntityID = strings.TrimSpace(scope.EntityID)
+	scope.EntityID = fork.EntityID
+	anchor, err := decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{
+		RequestEventID: fork.RequestEventID, ActivityID: fork.ActivityID, Decision: sourceAnchor.Decision, Scope: scope,
+	})
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	forkCard := sourceCard
+	forkCard.CardID = fork.CardID
+	forkCard.RunID = fork.RunID
+	forkCard.Anchor = anchor
+	forkCard.EffectContentHash = fork.EffectContentHash
+	forkCard.Status = decisioncard.StatusPending
+	forkCard.Verdict = ""
+	forkCard.Fields = semanticvalue.EmptyObject()
+	forkCard.DecidedBy = ""
+	forkCard.DecidedAt = time.Time{}
+	forkCard.DeferredUntil = time.Time{}
+	forkCard.DecisionEventID = ""
+	forkCard.DeliveryReceiptID = ""
+	forkCard.DeliveryRenderHash = ""
+	forkCard.SupersededReason = ""
+	forkCard.CreatedAt = now.UTC()
+	forkCard.UpdatedAt = now.UTC()
+	forkedFromCardID, _ := semanticvalue.String(sourceCard.CardID)
+	forkCard.Provenance, err = sourceCard.Provenance.With("forked_from_card_id", forkedFromCardID)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	forkedFromRequestID, _ := semanticvalue.String(source.RequestEventID)
+	forkCard.Provenance, err = forkCard.Provenance.With("forked_from_request_event_id", forkedFromRequestID)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	forkCard, err = decisioncard.New(forkCard)
+	if err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	if err := fork.Validate(forkCard); err != nil {
+		return decisioncard.Card{}, decisioncard.ProposedEffectContinuation{}, err
+	}
+	return forkCard, fork, nil
 }

--- a/internal/store/run_fork_gate_activation_test.go
+++ b/internal/store/run_fork_gate_activation_test.go
@@ -3,10 +3,14 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	"github.com/division-sh/swarm/internal/runtime/gateruntime"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -21,7 +25,7 @@ func TestMaterializeRunForkDecisionCardsCreatesForkLocalPendingAuthority(t *test
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $3), ($2::uuid, 'running', $3)`, sourceRunID, forkRunID, now); err != nil {
 		t.Fatalf("seed runs: %v", err)
 	}
-	sourceActivation, err := gateruntime.New(sourceRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "event-1", now)
+	sourceActivation, err := gateruntime.New(sourceRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", testGateRoutes(t), "event-1", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +46,7 @@ func TestMaterializeRunForkDecisionCardsCreatesForkLocalPendingAuthority(t *test
 	if err := cardStore.CreateHumanTaskCard(ctx, humanCard, humanContinuation); err != nil {
 		t.Fatalf("create source human-task card: %v", err)
 	}
-	forkActivation, err := gateruntime.New(forkRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", sourceActivation.BundleHash, sourceActivation.StartedByEvent, sourceActivation.OpenedAt)
+	forkActivation, err := gateruntime.New(forkRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", sourceActivation.BundleHash, sourceActivation.RoutesJSON, sourceActivation.StartedByEvent, sourceActivation.OpenedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +90,7 @@ func TestMaterializeRunForkDecisionCardsPreservesCommittedSemanticFields(t *test
 	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $3), ($2::uuid, 'running', $3)`, sourceRunID, forkRunID, now); err != nil {
 		t.Fatalf("seed runs: %v", err)
 	}
-	sourceActivation, err := gateruntime.New(sourceRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "event-1", now)
+	sourceActivation, err := gateruntime.New(sourceRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", testGateRoutes(t), "event-1", now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +120,7 @@ func TestMaterializeRunForkDecisionCardsPreservesCommittedSemanticFields(t *test
 	if err := sourceActivation.CommitDecision(decisionEventID, now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	forkActivation, err := gateruntime.New(forkRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", sourceActivation.BundleHash, sourceActivation.StartedByEvent, sourceActivation.OpenedAt)
+	forkActivation, err := gateruntime.New(forkRunID, "launch/review", entityID, "launch", "awaiting_review", "launch_review", sourceActivation.BundleHash, sourceActivation.RoutesJSON, sourceActivation.StartedByEvent, sourceActivation.OpenedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,5 +144,185 @@ func TestMaterializeRunForkDecisionCardsPreservesCommittedSemanticFields(t *test
 	provenanceValue, _ := provenanceNumber.Number()
 	if forkCard.Status != decisioncard.StatusDecided || forkCard.DecisionEventID != decisionEventID || !ok || fieldNumber != float64(safeInteger) || contextValue != float64(safeInteger) || provenanceValue != float64(safeInteger) {
 		t.Fatalf("committed fork card lost semantic authority: %#v", forkCard)
+	}
+}
+
+func TestMaterializeRunForkProposedEffectCreatesFreshPendingAuthority(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	sourceRunID, forkRunID := uuid.NewString(), uuid.NewString()
+	now := time.Date(2026, 7, 14, 18, 0, 0, 0, time.UTC)
+	if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $3), ($2::uuid, 'running', $3)`, sourceRunID, forkRunID, now); err != nil {
+		t.Fatal(err)
+	}
+	cards := &PostgresStore{DB: db}
+	sourceCard, sourceContinuation := newProposedEffectTestCard(t, sourceRunID, now, attemptgeneration.Generation{})
+	if err := cards.CreateProposedEffectCard(ctx, sourceCard, sourceContinuation); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (
+			run_id, entity_id, flow_instance, entity_type, current_state,
+			gates, fields, accumulator, entered_state_at, created_at, updated_at
+		) VALUES ($1::uuid, $2::uuid, 'root', 'default', 'operating', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, $3, $3, $3)
+	`, forkRunID, sourceContinuation.EntityID, now); err != nil {
+		t.Fatal(err)
+	}
+	point := RunForkPoint{EventID: uuid.NewString(), Timestamp: now.Add(time.Minute)}
+	if err := cards.runAuthorActivityMutation(ctx, "test materialize fork proposed-effect card", func(txctx context.Context, tx *sql.Tx) error {
+		return materializeRunForkProposedEffectCards(txctx, tx, sourceRunID, forkRunID, sourceContinuation.EntityID, point, now.Add(2*time.Minute))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	items, _, err := cards.ListDecisionCards(ctx, decisioncard.ListOptions{RunID: forkRunID, Limit: 10})
+	if err != nil || len(items) != 1 {
+		t.Fatalf("fork proposed cards = %#v, %v", items, err)
+	}
+	forkCard, err := cards.GetDecisionCard(ctx, items[0].CardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forkContinuation, err := cards.LoadProposedEffectContinuation(ctx, forkCard.CardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceContinuation.ReplyContextID == "" || forkContinuation.ReplyContextID != "" {
+		t.Fatalf("fork reply authority = source:%q fork:%q, want source-only", sourceContinuation.ReplyContextID, forkContinuation.ReplyContextID)
+	}
+	if forkCard.Status != decisioncard.StatusPending || forkCard.CardID == sourceCard.CardID || forkContinuation.RequestEventID == sourceContinuation.RequestEventID || forkContinuation.SourceRunID != forkRunID {
+		t.Fatalf("fork authority retained source identity: source=%#v/%#v fork=%#v/%#v", sourceCard, sourceContinuation, forkCard, forkContinuation)
+	}
+	if forkContinuation.Input.Equal(sourceContinuation.Input) == false || forkContinuation.EffectContentHash == sourceContinuation.EffectContentHash {
+		t.Fatalf("fork effect content = source:%#v fork:%#v", sourceContinuation, forkContinuation)
+	}
+	forkedFrom, ok := forkCard.Provenance.Lookup("forked_from_card_id")
+	if value, stringOK := forkedFrom.String(); !ok || !stringOK || value != sourceCard.CardID {
+		t.Fatalf("fork provenance = %#v", forkCard.Provenance)
+	}
+}
+
+func TestPrepareRunForkApprovedProposedEffectRequiresUnambiguousTerminalEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     string
+		wantErr    string
+		wantCopied bool
+	}{
+		{name: "succeeded", status: "succeeded", wantCopied: true},
+		{name: "uncertain", status: "uncertain", wantErr: "ambiguous dispatch evidence"},
+		{name: "started", status: "started", wantErr: "recorded evidence is not terminal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, _ := testutil.StartPostgres(t)
+			ctx := context.Background()
+			sourceRunID, forkRunID := uuid.NewString(), uuid.NewString()
+			now := time.Date(2026, 7, 14, 19, 0, 0, 0, time.UTC)
+			if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $3), ($2::uuid, 'running', $3)`, sourceRunID, forkRunID, now); err != nil {
+				t.Fatal(err)
+			}
+			cards := &PostgresStore{DB: db}
+			card, continuation := newProposedEffectTestCard(t, sourceRunID, now, attemptgeneration.Generation{})
+			if err := cards.CreateProposedEffectCard(ctx, card, continuation); err != nil {
+				t.Fatal(err)
+			}
+			decisionEventID := uuid.NewString()
+			if _, err := cards.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+				CardID: card.CardID, Verdict: "approve", ActorTokenID: "operator",
+				ObservedContentHash: card.CardContentHash, DecisionEventID: decisionEventID, Now: now.Add(time.Minute),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := cards.CompleteProposedEffectRoute(ctx, card.CardID, uuid.NewString(), now.Add(2*time.Minute)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO entity_state (
+					run_id, entity_id, flow_instance, entity_type, current_state,
+					gates, fields, accumulator, entered_state_at, created_at, updated_at
+				) VALUES ($1::uuid, $2::uuid, 'root', 'default', 'operating', '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, $3, $3, $3)
+			`, forkRunID, continuation.EntityID, now); err != nil {
+				t.Fatal(err)
+			}
+			resultEventID := activityidentity.ResultEventID(activityidentity.Fact{
+				RunID: sourceRunID, SourceEventID: continuation.SourceEventID, EntityID: continuation.EntityID,
+				FlowID: continuation.FlowID, NodeID: continuation.NodeID, HandlerEventKey: continuation.HandlerEventKey,
+				ActivityID: continuation.ActivityID, Tool: continuation.Tool, Attempt: 1,
+			}, continuation.SuccessEvent)
+			var storedResultEventID any = resultEventID
+			var resultEventType any = continuation.SuccessEvent
+			var resultPayload any = `{"activity_id":"send_support_reply","result":{"ok":true}}`
+			var failure any
+			var completedAt any = now.Add(3 * time.Minute)
+			switch tc.status {
+			case "uncertain":
+				resultEventType = continuation.FailureEvent
+				resultPayload = `{"activity_id":"send_support_reply","failure":{"code":"provider_outcome_uncertain"}}`
+				failure = `{"schema_version":"platform.failure/v1","class":"platform.outcome_uncertain","detail":{"code":"provider_outcome_uncertain"},"retryable":false,"deterministic":false,"message":"Provider outcome is uncertain.","remediation":"Inspect provider state.","component":"activity-runtime","operation":"execute"}`
+			case "started":
+				storedResultEventID, resultEventType, resultPayload, failure, completedAt = nil, nil, nil, nil, nil
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO activity_attempts (
+					request_event_id, run_id, source_event_id, entity_id, flow_instance, node_id, handler_event_key,
+					activity_id, tool, effect_class, attempt, status, success_event, failure_event,
+					result_event_id, result_event_type, result_payload, failure, input_hash, loop_generation, loop_stage,
+					started_at, completed_at, updated_at
+				) VALUES (
+					$1::uuid, $2::uuid, $3::uuid, $4::uuid, 'root', $5, $6,
+					$7, $8, 'non_idempotent_write', 1, $9, $10, $11,
+					$12::uuid, $13, $14::jsonb, $15::jsonb, 'input-hash', '{}'::jsonb, '', $16, $17, $16
+				)
+			`, continuation.RequestEventID, sourceRunID, continuation.SourceEventID, continuation.EntityID,
+				continuation.NodeID, continuation.HandlerEventKey, continuation.ActivityID, continuation.Tool, tc.status,
+				continuation.SuccessEvent, continuation.FailureEvent, storedResultEventID, resultEventType,
+				resultPayload, failure, now.Add(3*time.Minute), completedAt); err != nil {
+				t.Fatal(err)
+			}
+			payload, err := json.Marshal(map[string]any{
+				"activity_id": continuation.ActivityID, "tool": continuation.Tool, "input": continuation.Input.Interface(),
+				"effect_class": string(continuation.EffectClass), "success_event": continuation.SuccessEvent,
+				"failure_event": continuation.FailureEvent, "fork_policy": string(continuation.ForkPolicy),
+				"entity_id": continuation.EntityID, "node_id": continuation.NodeID, "flow_id": continuation.FlowID,
+				"handler_event_key": continuation.HandlerEventKey, "source_event_id": continuation.SourceEventID,
+				"source_run_id": sourceRunID, "attempt": 1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var prepared RunForkSelectedContractSourceEvent
+			err = cards.runAuthorActivityMutation(ctx, "test prepare fork proposed-effect source event", func(txctx context.Context, tx *sql.Tx) error {
+				var inner error
+				prepared, inner = prepareRunForkSelectedContractSourceEvent(txctx, tx, forkRunID, RunForkSelectedContractSourceEvent{
+					SourceEventID: continuation.RequestEventID, EventName: runForkActivityRequestEvent,
+					EntityID: continuation.EntityID, FlowInstance: "root", Payload: payload,
+				})
+				return inner
+			})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("prepare error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var forkPayload runForkActivityRequestPayload
+			if err := json.Unmarshal(prepared.Payload, &forkPayload); err != nil {
+				t.Fatal(err)
+			}
+			forkRequestID := activityidentity.RequestEventID(activityidentity.Fact{
+				RunID: forkRunID, SourceEventID: forkPayload.SourceEventID, ParentEventID: forkPayload.ParentEventID,
+				EntityID: forkPayload.EntityID, FlowID: forkPayload.FlowID, NodeID: forkPayload.NodeID,
+				HandlerEventKey: forkPayload.HandlerEventKey, ActivityID: forkPayload.ActivityID, Tool: forkPayload.Tool, Attempt: 1,
+			})
+			var copiedStatus string
+			if err := db.QueryRowContext(ctx, `SELECT status FROM activity_attempts WHERE request_event_id = $1::uuid`, forkRequestID).Scan(&copiedStatus); err != nil {
+				t.Fatal(err)
+			}
+			if !tc.wantCopied || copiedStatus != tc.status {
+				t.Fatalf("copied status = %q", copiedStatus)
+			}
+		})
 	}
 }

--- a/internal/store/run_fork_loop_generation.go
+++ b/internal/store/run_fork_loop_generation.go
@@ -104,7 +104,7 @@ func forkGateActivationState(raw map[string]any, forkRunID, flowInstance, entity
 	}
 	bindings := make([]runForkGateActivationBinding, 0, len(activations))
 	for _, source := range activations {
-		forked, err := gateruntime.New(forkRunID, flowInstance, entityID, source.FlowID, source.Stage, source.DecisionID, source.BundleHash, source.StartedByEvent, source.OpenedAt)
+		forked, err := gateruntime.New(forkRunID, flowInstance, entityID, source.FlowID, source.Stage, source.DecisionID, source.BundleHash, source.RoutesJSON, source.StartedByEvent, source.OpenedAt)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/store/run_fork_loop_generation_test.go
+++ b/internal/store/run_fork_loop_generation_test.go
@@ -85,7 +85,7 @@ func TestForkAttemptGenerationRemintsActivationAndTimerIdentity(t *testing.T) {
 
 func TestForkGateActivationStateRemintsAuthorityIdentity(t *testing.T) {
 	now := time.Date(2026, time.July, 12, 12, 0, 0, 0, time.UTC)
-	source, err := gateruntime.New("source-run", "launch/review", "entity-1", "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:"+strings.Repeat("a", 64), "event-1", now)
+	source, err := gateruntime.New("source-run", "launch/review", "entity-1", "launch", "awaiting_review", "launch_review", "bundle-v1:sha256:"+strings.Repeat("a", 64), testGateRoutes(t), "event-1", now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -357,6 +357,9 @@ func materializeRunForkEntityState(ctx context.Context, tx *sql.Tx, forkRunID st
 	if err := materializeRunForkDecisionCards(ctx, tx, forkRunID, entityID, gateBindings, now); err != nil {
 		return err
 	}
+	if err := materializeRunForkProposedEffectCards(ctx, tx, plan.SourceRunID, forkRunID, entityID, plan.ForkPoint, now); err != nil {
+		return err
+	}
 	return mutationlog.InsertEntityStateDiff(ctx, tx, entityID, mutationlog.EntityStateProjection{}, mutationlog.EntityStateProjection{
 		CurrentState: currentState,
 		Fields:       entity.Fields,

--- a/internal/store/schema_compatibility_bootstrap_test.go
+++ b/internal/store/schema_compatibility_bootstrap_test.go
@@ -150,7 +150,7 @@ func TestSchemaBootstrapRejectsStageOnlyDecisionCardStoreBeforeMutation(t *testi
 		}
 
 		assertStageOnlyDecisionCardColumns(t, sqliteColumnSet(t, context.Background(), store.DB, "decision_cards"))
-		assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), current), SchemaDialectSQLite, path, current.Origin, &legacy.Origin, "decision_cards", "anchor_kind", "human_task_continuations")
+		assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), current), SchemaDialectSQLite, path, current.Origin, &legacy.Origin, "decision_cards", "anchor_kind", "human_task_continuations", "proposed_effect_continuations")
 		assertStageOnlyDecisionCardColumns(t, sqliteColumnSet(t, context.Background(), store.DB, "decision_cards"))
 		var continuations int
 		if err := store.DB.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='human_task_continuations'`).Scan(&continuations); err != nil {
@@ -158,6 +158,12 @@ func TestSchemaBootstrapRejectsStageOnlyDecisionCardStoreBeforeMutation(t *testi
 		}
 		if continuations != 0 {
 			t.Fatal("incompatible bootstrap created human_task_continuations")
+		}
+		if err := store.DB.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='proposed_effect_continuations'`).Scan(&continuations); err != nil {
+			t.Fatal(err)
+		}
+		if continuations != 0 {
+			t.Fatal("incompatible bootstrap created proposed_effect_continuations")
 		}
 	})
 
@@ -175,7 +181,7 @@ func TestSchemaBootstrapRejectsStageOnlyDecisionCardStoreBeforeMutation(t *testi
 		if !postgresColumnExists(t, context.Background(), db, "decision_cards", "flow_instance") || postgresColumnExists(t, context.Background(), db, "decision_cards", "anchor_kind") {
 			t.Fatal("stage-only PostgreSQL fixture has unexpected decision-card columns")
 		}
-		assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), current), SchemaDialectPostgres, target, current.Origin, &legacy.Origin, "decision_cards", "anchor_kind", "human_task_continuations")
+		assertSchemaCompatibilityDiagnostic(t, store.BootstrapSchema(context.Background(), current), SchemaDialectPostgres, target, current.Origin, &legacy.Origin, "decision_cards", "anchor_kind", "human_task_continuations", "proposed_effect_continuations")
 		if !postgresColumnExists(t, context.Background(), db, "decision_cards", "flow_instance") || postgresColumnExists(t, context.Background(), db, "decision_cards", "anchor_kind") {
 			t.Fatal("incompatible bootstrap mutated stage-only decision-card columns")
 		}
@@ -185,6 +191,12 @@ func TestSchemaBootstrapRejectsStageOnlyDecisionCardStoreBeforeMutation(t *testi
 		}
 		if continuations {
 			t.Fatal("incompatible bootstrap created human_task_continuations")
+		}
+		if err := db.QueryRow(`SELECT to_regclass('public.proposed_effect_continuations') IS NOT NULL`).Scan(&continuations); err != nil {
+			t.Fatal(err)
+		}
+		if continuations {
+			t.Fatal("incompatible bootstrap created proposed_effect_continuations")
 		}
 	})
 }
@@ -200,10 +212,10 @@ func stageOnlyDecisionCardSchemaRequest(t testing.TB) SchemaBootstrapRequest {
 	t.Helper()
 	request := canonicalSchemaBootstrapTestRequest(t)
 	request.Origin.SwarmVersion = "stage-only-card-schema"
-	plans := make([]SchemaTableDDL, 0, len(request.PlatformPlans)-1)
+	plans := make([]SchemaTableDDL, 0, len(request.PlatformPlans)-2)
 	for _, plan := range request.PlatformPlans {
 		switch plan.TableName {
-		case "human_task_continuations":
+		case "human_task_continuations", "proposed_effect_continuations":
 			continue
 		case "decision_cards":
 			plan = stageOnlyDecisionCardTablePlan()

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -21,8 +21,8 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	if len(platformPlans) != 52 {
-		t.Fatalf("platform table plan count = %d, want 52", len(platformPlans))
+	if len(platformPlans) != 53 {
+		t.Fatalf("platform table plan count = %d, want 53", len(platformPlans))
 	}
 	entityPlans, err := GenerateEntityTableDDLs(runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{

--- a/openrpc.json
+++ b/openrpc.json
@@ -10588,6 +10588,9 @@
           "decision_schema_hash": {
             "type": "string"
           },
+          "effect_content_hash": {
+            "type": "string"
+          },
           "run_id": {
             "$ref": "#/components/schemas/OpaqueId"
           },
@@ -10628,13 +10631,17 @@
           },
           {
             "$ref": "#/components/schemas/HumanTaskDecisionCardAnchor"
+          },
+          {
+            "$ref": "#/components/schemas/ProposedEffectDecisionCardAnchor"
           }
         ]
       },
       "DecisionCardAnchorKind": {
         "enum": [
           "stage_gate",
-          "human_task"
+          "human_task",
+          "proposed_effect"
         ],
         "type": "string"
       },
@@ -10660,6 +10667,9 @@
           },
           "created_at": {
             "$ref": "#/components/schemas/Timestamp"
+          },
+          "effect": {
+            "$ref": "#/components/schemas/ProposedEffectState"
           },
           "payload": {
             "additionalProperties": true,
@@ -10688,6 +10698,9 @@
         "properties": {
           "decision_card": {
             "$ref": "#/components/schemas/DecisionCard"
+          },
+          "effect": {
+            "$ref": "#/components/schemas/ProposedEffectState"
           },
           "kind": {
             "const": "decision_card",
@@ -10784,6 +10797,9 @@
         "properties": {
           "decision_card": {
             "$ref": "#/components/schemas/DecisionCardSummary"
+          },
+          "effect": {
+            "$ref": "#/components/schemas/ProposedEffectState"
           },
           "kind": {
             "const": "decision_card",
@@ -11976,6 +11992,72 @@
           "forked"
         ],
         "type": "string"
+      },
+      "ProposedEffectDecisionCardAnchor": {
+        "additionalProperties": false,
+        "properties": {
+          "activity_id": {
+            "type": "string"
+          },
+          "decision": {
+            "type": "string"
+          },
+          "request_event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/DecisionCardScope"
+          }
+        },
+        "required": [
+          "request_event_id",
+          "activity_id",
+          "decision",
+          "scope"
+        ],
+        "type": "object"
+      },
+      "ProposedEffectState": {
+        "additionalProperties": false,
+        "properties": {
+          "activity_id": {
+            "type": "string"
+          },
+          "continuation_state": {
+            "enum": [
+              "pending",
+              "decision_committed",
+              "request_released",
+              "outcome_dispatched",
+              "superseded"
+            ],
+            "type": "string"
+          },
+          "dispatch_state": {
+            "enum": [
+              "held",
+              "release_pending",
+              "released",
+              "not_dispatched",
+              "superseded",
+              "started",
+              "succeeded",
+              "failed",
+              "uncertain"
+            ],
+            "type": "string"
+          },
+          "request_event_id": {
+            "$ref": "#/components/schemas/OpaqueId"
+          }
+        },
+        "required": [
+          "continuation_state",
+          "dispatch_state",
+          "request_event_id",
+          "activity_id"
+        ],
+        "type": "object"
       },
       "RpcSubscriptionNotification": {
         "additionalProperties": false,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -382,20 +382,23 @@ contract_formats:
           the terminal pipeline receipt. Raw events-row append is forbidden.
         snapshot: >
           Card creation evaluates context once and freezes the structured
-          snapshot, authored outcome/input schema, effective cadence,
+          presentation snapshot, authored verdict/input schema, effective cadence,
           provenance, bundle/workflow identity, card_content_hash, and
           decision_schema_hash. The raw top-level decision_id MUST already equal
           its trimmed canonical spelling and MUST equal snapshot.decision before
           either hash or any persistence is acquired; deriving a canonical
           snapshot identity from a different public/persisted spelling is
           forbidden. decision_schema_hash is the versioned canonical semantic
-          verdict/input contract: verdict and input identities, canonical input
-          types and requiredness, semantic outcome field mappings/literals, and
-          the enforcement-only projection of every frozen target-schema
-          constraint consumed by mailbox.decide. Acceptance-changing edits MUST
-          change it. Title, verdict/input labels, descriptions, display hints,
-          and other presentation metadata MUST NOT change it; those remain
-          covered by card_content_hash. Card creation and every persisted-card
+          verdict/input contract: verdict and input identities plus canonical
+          input types and requiredness. Acceptance-changing edits MUST change it.
+          Title, verdict/input labels, descriptions, display hints, and other
+          presentation metadata MUST NOT change it; those remain covered by
+          card_content_hash. The generic card never owns executable route data.
+          The stage-gate activation continuation separately freezes each verdict's
+          advances_to target, emit expressions, and resolved emit schema before
+          persistence; settlement consumes only that durable route and the pinned
+          bundle, never the current authored gate. Proposed-effect and human-task
+          continuations likewise own their kind-specific execution. Card creation and every persisted-card
           create/read validation MUST use the same hash owner: validation
           recomputes both hashes from the decoded snapshot and requires exact
           equality before the card can be persisted, returned, or mutated.
@@ -549,11 +552,16 @@ contract_formats:
         and remint generation-bearing event payloads, timer/join/accumulator
         identities, pending activity requests, journal evidence, and result IDs.
         read_only activity requests use reexecute_read under fork-local identity.
-        non_idempotent_write requests use reuse_recorded_result: terminal source
-        evidence is copied into a fork-local terminal activity_attempt and the
-        existing dispatcher republishes that fork-local result without invoking
-        the connector. Missing, non-terminal, or policy-inconsistent activity
-        evidence fails the fork closed.
+        Unapproved non_idempotent_write requests use reuse_recorded_result: accepted
+        terminal source evidence is copied into a fork-local terminal activity_attempt
+        and the existing dispatcher republishes that fork-local result without invoking
+        the connector. An activity.approval proposal pending at the fork point mints a
+        fork-local card, request identity, effect hash, and continuation, clears source-run
+        reply context authority, and requires a fresh decision. A revised or rejected proposal remains terminal evidence. An
+        approved proposal may copy only an unambiguous succeeded or failed terminal
+        attempt; started, uncertain, missing, or otherwise non-terminal dispatch evidence
+        fails the fork closed. Source-run approval never authorizes a fork-local provider
+        call. Policy-inconsistent evidence also fails the fork closed.
       expression_context: >
         `loop.id`, `loop.activation_id`, `loop.revision_id`, `loop.attempt`, and
         `loop.max_attempts` are available after loop admission. The CEL
@@ -3337,9 +3345,10 @@ handler_specification:
               shell, product-local git, or HTTP-tool activity. Those paths must fail closed or remain different semantic
               concepts; they do not prove artifact commit support.
             migration_blocker: >
-              Generic durable activities currently execute only read_only authored HTTP tools. idempotent_write
-              and non_idempotent_write activities remain non-executable until a stable activity attempt/result journal and
-              idempotency execution owner are specified and implemented.
+              Generic durable activities execute read_only authored HTTP tools and non_idempotent_write authored HTTP tools
+              through the stable activity attempt/result journal and idempotency execution owner. idempotent_write remains
+              non-executable. artifact_repo_commit remains action-owned because the generic activity surface does not admit
+              that platform_builtin source or preserve its repository-specific request-history and state-repair contract.
             future_migration_condition: >
               A separately gated migration may rebind artifact repository commits to a built-in
               activity only if it preserves the current provider/root/path allowlist, schema/size/ref validation, provider
@@ -3353,13 +3362,17 @@ handler_specification:
       field: activity
       type: object
       purpose: >
-        Declares a durable, node-owned external tool call. The handler transaction persists the activity intent as a
-        platform.activity_requested event before commit; the tool call executes only after the transaction commits and after
-        the entity lock is released. Activity outcome is reported by generated typed result events, not hidden runtime-only
-        state.
+        Declares a durable, node-owned external tool call. An activity without approval persists
+        platform.activity_requested in the handler transaction. An approved non_idempotent_write instead atomically persists
+        the handler mutation, a pending proposed_effect decision card, and its immutable continuation; no request, attempt,
+        credential lookup, or provider call exists while that card is pending. Approval later releases the deterministic
+        request through the same durable activity path. Every tool call executes only after its owning transaction commits
+        and after the entity lock is released. Activity outcome is reported by generated typed result events, not hidden
+        runtime-only state.
       minimal_form:
         tool: string — authored tools.yaml tool id
         input: object — maps tool input field names to the same expression value grammar used by emit.fields
+        approval: 'optional object for non_idempotent_write only; canonical minimal form is `{decision: <stable-decision-id>}`'
       generated_result_events:
         naming: <flow>.<activity_id>.succeeded and <flow>.<activity_id>.failed. If activity.id is omitted, the platform derives
           a stable id from node id, handler event key, selected rule identity when present, and tool id.
@@ -3369,12 +3382,50 @@ handler_specification:
           event-name normalization.
         success_payload: activity_id, tool, effect_class, attempt, result. The result field is shaped by the tool output_schema.
         failure_payload: activity_id, tool, effect_class, attempt, failure (required platform.failure/v1 envelope).
+      generated_approval_events:
+        naming: <flow>.<activity_id>.revision_requested and <flow>.<activity_id>.rejected.
+        materialization: >
+          An activity with approval derives both events into the canonical event catalog, schemas, effective produces,
+          collision checks, and topology. revision_requested carries required feedback and MUST have an authored consumer;
+          rejected carries an optional reason. Neither verdict creates platform.activity_requested or calls the provider.
+      approval:
+        grammar: 'activity.approval has exactly one required field: decision. Aliases, defaults, emit placement, and unknown fields fail closed.'
+        supported_class: >
+          V1 permits approval only for executable non_idempotent_write authored HTTP activities. read_only approval fails
+          with the teaching error that reads do not need approval because approvals guard outward effects. Other effect
+          classes and tool sources remain rejected by their existing admission owners.
+        immutable_effect: >
+          Input expressions evaluate once into the closed semantic value model before hashing or persistence. The proposed
+          effect contains the reserved deterministic request identity, tool, exact bundle_hash and workflow_version contract
+          pin, effect class,
+          admitted input, generated outcome events, source lineage, delivery context, and loop generation. Credentials and
+          transport authentication are excluded and resolve only after approval and attempt admission. effect_content_hash
+          covers this full value; card_content_hash separately covers presentation and verdict-input material.
+        continuation: >
+          decision_cards owns presentation and mutable verdict state. proposed_effect_continuations is the sole execution
+          owner. approve atomically writes one deterministic platform.activity_requested and marks request_released; revise
+          and reject atomically publish their generated typed outcome and mark outcome_dispatched. Duplicate decisions,
+          route replay, and restart converge by card/request identity. A replay recognizes an already-completed
+          request_released or outcome_dispatched route before checking the current bundle because no contract interpretation
+          remains. Revise and reject restore the continuation's opaque delivery context on the typed outcome. A started or
+          uncertain attempt never redispatches.
+        supersession: >
+          Run termination and replacement of the owning loop generation may supersede a pending proposal through one CAS
+          race with decision. Ordinary stage exit does not supersede it.
+        readback: >
+          Mailbox list/get/subscribe and CLI projection expose authorization and dispatch as independent axes. approved never
+          implies sent. The authoring view exposes approval_points with exact flow, node, handler, activity, tool, decision,
+          and effect class for graph/prove consumers.
       durable_request_event:
         event_name: platform.activity_requested
         owner: platform_events.catalog["platform.activity_requested"]
-        behavior: The request event is generated by the handler transaction, persisted through the canonical outbox before
-          commit, and consumed by the workflow runtime after commit. It is the replay/recovery owner for starting the external
-          activity call; diagnostic runtime_log rows are non-authoritative. Generated result event ids are stable for the
+        behavior: The request event is generated by the handler transaction for unapproved activities or by the atomic
+          proposed-effect approval route for approved activities. It is persisted through the canonical outbox before the
+          owning transaction commits and consumed by the workflow runtime after commit. It is the replay/recovery owner for starting the external
+          activity call; diagnostic runtime_log rows are non-authoritative. An approved request carries the exact bundle_hash
+          and workflow_version from its immutable effect. Before current tool lookup, credential resolution, attempt creation,
+          or provider preparation, the consumer MUST match both values to the executable semantic source. Missing, partial,
+          unavailable, or mismatched approved-request identity defers fail-closed and performs no call. Generated result event ids are stable for the
           request identity and generated result event type. Before any external tool call, the workflow runtime MUST check the
           canonical event store for either stable generated result event id for that request identity. If a success or failure
           result event is already recorded, duplicate delivery, replay, and crash recovery MUST reuse the recorded result and
@@ -3421,7 +3472,7 @@ handler_specification:
             duplicate/redelivered request events before deciding whether dispatch is allowed. Any existing started,
             uncertain, succeeded, or failed row blocks automatic provider re-dispatch and managed credential refresh.
           retry_default: max_attempts 1, no retry
-          fork_default: require_manual_confirmation
+          fork_default: explicit proposed-effect/evidence disposition under runtime.run_fork.selected_contract_execution; never infer fork authorization from source approval
         long_running: Split to a later resume/cancel/journal slice; fail closed in Stage 1.
       interactions:
         with_action: PROHIBITED. action and activity are mutually exclusive for the selected handler path.
@@ -3432,7 +3483,8 @@ handler_specification:
           sites are not supported in Stage 1. Retired `handler.branch` syntax is unsupported for all handler semantics,
           including activity placement.
       execution_position: After emit.event/action selection point and before clear. The intent is persisted inside the handler
-        transaction; tool execution and generated result publication occur after commit and outside the entity lock.
+        transaction as either an immediate durable request or a held proposed-effect card plus continuation. Tool execution
+        and generated result publication occur only after request release, commit, and entity-lock exit.
     retired_fields:
       description: Legacy handler fields retired by the structured handler grammar.
       rule: These fields are retired compatibility syntax, not alternate current-contract forms.
@@ -9018,6 +9070,11 @@ flow_model:
           carriers. It must show flow namespace, nodes, initial/terminal markers,
           edges, and edge source. It is projection-only and MUST NOT introduce a
           second transition-authoring owner.
+        approval_point_rule: >
+          The expanded authoring view projects every activity.approval from the canonical lowered activity-site owner as one
+          approval_points row containing flow, node, handler event, source location, activity, tool, decision, and effect
+          class. describe --graph and future describe --prove rendering consume this projection and MUST NOT rediscover
+          approval points from YAML or event names.
         source_location_rule: >
           Diagnostics in the expanded view must carry check_id, message,
           remediation/evidence when available from the verifier finding owner,
@@ -10574,6 +10631,7 @@ platform_tables:
         - decision_card_route_obligations
         - decision_card_changes
         - decision_card_input_drafts
+        - proposed_effect_continuations
         - human_task_continuations
         - decision_cards
         - reply_contexts
@@ -10664,6 +10722,7 @@ platform_tables:
       subject_rules:
         event_emitted: The subject is the exact canonical producer identity and type paired with the exact event type. The event UUID is source evidence and MUST NOT render as the subject.
         effect_lifecycle: The subject is derived from exact adapter, transport, and authority metadata. The effect-attempt UUID is source evidence and MUST NOT render as the subject.
+        card_lifecycle: Every registered decision-card anchor kind MUST have one exact metadata-only adapter. stage_gate uses stage_activation_id, human_task uses operation_id, and proposed_effect uses request_event_id as anchor identity; all lifecycle changes join the decision-card mutation transaction and story.
       failure_rule: Every admitted failure transition renders a stable subject and failed term with an exact diagnostic route even when optional detail is absent.
     rendering:
       shared_owner: internal/runtime/authoractivity typed renderer with CLI-owned palette callbacks
@@ -11294,23 +11353,25 @@ platform_tables:
         \ IS NOT NULL,\n    INDEX idx_mailbox_type (item_type, status),\n    INDEX idx_mailbox_global (scope, status) WHERE\
         \ scope = 'global'\n);"
     decision_cards:
-      description: 'Sole mutable verdict owner for typed stage-gate and human-task decisions. anchor_kind plus anchor is a
+      description: 'Sole mutable verdict owner for typed stage-gate, human-task, and proposed-effect decisions. anchor_kind plus anchor is a
         closed tagged identity union: stage_gate carries its stage-activation fence; human_task carries requester, logical
-        operation, and entity/flow/global scope. A row freezes the structured card snapshot, authored verdict/input schema,
+        operation, and entity/flow/global scope; proposed_effect carries the reserved activity-request identity, activity,
+        decision class, and scope. A row freezes the structured card snapshot, authored verdict/input schema,
         effective cadence, contract and provenance identity, and presentation hashes. Generic mailbox rows never mirror
         writable card state. Creation and every lifecycle mutation admit authoritative timestamps to UTC microsecond
         precision before validation, card/continuation mutation, change emission, event construction, or readback; this
         includes decisions, defers, expiry, outcome completion, and supersession. Unknown anchor kinds fail closed;
-        proposed_effect remains unimplemented under #1987.'
+        proposed_effect execution is owned separately by proposed_effect_continuations.'
       ddl: |
         CREATE TABLE decision_cards (
             card_id                UUID PRIMARY KEY,
             run_id                 UUID NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
-            anchor_kind            TEXT NOT NULL CHECK (anchor_kind IN ('stage_gate', 'human_task')),
+            anchor_kind            TEXT NOT NULL CHECK (anchor_kind IN ('stage_gate', 'human_task', 'proposed_effect')),
             anchor                 JSONB NOT NULL,
             status                 TEXT NOT NULL CHECK (status IN ('pending', 'decided', 'superseded', 'expired')),
             snapshot               JSONB NOT NULL,
             card_content_hash      TEXT NOT NULL,
+            effect_content_hash    TEXT,
             decision_schema_hash   TEXT NOT NULL,
             bundle_hash            TEXT NOT NULL,
             workflow_version       TEXT,
@@ -11331,6 +11392,31 @@ platform_tables:
             INDEX idx_decision_cards_mailbox (status, deferred_until, created_at),
             INDEX idx_decision_cards_run (run_id, created_at),
             INDEX idx_decision_cards_anchor (run_id, anchor_kind, created_at)
+        );
+    proposed_effect_continuations:
+      description: 'Sole executable continuation owner for proposed_effect decision cards. The immutable effect JSON is the
+        closed semantic activity value admitted before persistence, including exact bundle_hash and workflow_version; its
+        digest equals decision_cards.effect_content_hash.
+        pending decisions cannot publish platform.activity_requested. approve atomically releases the reserved request
+        identity once; revise/reject atomically publish their generated typed event instead. A started or uncertain provider
+        attempt never authorizes redispatch. Ordinary stage exit does not supersede a proposal; run termination and owning
+        loop-generation replacement do.'
+      ddl: |
+        CREATE TABLE proposed_effect_continuations (
+            card_id                UUID PRIMARY KEY REFERENCES decision_cards(card_id) ON DELETE CASCADE,
+            run_id                 UUID NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+            request_event_id       UUID NOT NULL UNIQUE,
+            effect                 JSONB NOT NULL,
+            effect_content_hash    TEXT NOT NULL,
+            state                  TEXT NOT NULL CHECK (state IN ('pending', 'decision_committed', 'request_released', 'outcome_dispatched', 'superseded')),
+            verdict                TEXT,
+            decision_event_id      UUID,
+            route_event_id         UUID,
+            superseded_reason      TEXT,
+            created_at             TIMESTAMPTZ NOT NULL,
+            updated_at             TIMESTAMPTZ NOT NULL,
+            CHECK ((state = 'pending' AND verdict IS NULL AND decision_event_id IS NULL AND route_event_id IS NULL AND superseded_reason IS NULL) OR (state = 'decision_committed' AND verdict IS NOT NULL AND decision_event_id IS NOT NULL AND route_event_id IS NULL AND superseded_reason IS NULL) OR (state IN ('request_released', 'outcome_dispatched') AND verdict IS NOT NULL AND decision_event_id IS NOT NULL AND route_event_id IS NOT NULL AND superseded_reason IS NULL) OR (state = 'superseded' AND superseded_reason IS NOT NULL)),
+            INDEX idx_proposed_effect_run (run_id, state, created_at)
         );
     human_task_continuations:
       description: 'Operational continuation for the human_task anchor, keyed by the decision card. It owns the opaque
@@ -12450,9 +12536,12 @@ run_model:
       platform.activity_requested event, source preparation MUST bind the request payload source_event_id to the actual
       fork-local frontier event before deriving fork-local request/result identities. read_only with reexecute_read executes
       the connector exactly once under that fork-local generation and does not copy a source attempt;
-      non_idempotent_write with reuse_recorded_result copies only terminal succeeded, failed, or uncertain evidence under
-      fork-local request/result identities and publishes that recorded result without calling the connector. Failed and
-      uncertain evidence MUST preserve its typed failure, including platform.outcome_uncertain. activity_attempts is
+      an unapproved non_idempotent_write with reuse_recorded_result copies accepted terminal evidence under fork-local
+      request/result identities and publishes that recorded result without calling the connector. For activity.approval,
+      a source proposal pending at the fork point creates a fresh fork-local pending card and continuation; revised/rejected
+      evidence remains terminal; approved succeeded/failed terminal attempt evidence may copy without a connector call; and
+      approved started, uncertain, missing, or otherwise non-terminal evidence fails the fork closed. Source approval never
+      authorizes a fork-local connector call. Accepted failed evidence preserves its typed failure. activity_attempts is
       deliberately post-frontier selected-execution evidence rather than historical workset membership: source
       preparation reads the selected immutable request event and current terminal attempt in one serializable transaction,
       copies accepted evidence under fork-local identity, and fails closed on missing/nonterminal evidence without
@@ -13739,7 +13828,7 @@ platform_events:
       routing_class: diagnostic_direct_persisted
       note: Full payload schema defined in platform_tables. Not duplicated here.
     platform.activity_requested:
-      description: Internal durable request to execute a handler activity after the handler transaction commits.
+      description: Internal durable request to execute a handler activity after its immediate handler or proposed-effect approval transaction commits.
       schema_authority: 'platform-spec.yaml#platform_events.catalog["platform.activity_requested"].payload'
       producer_evidence:
         produced_by_type: platform
@@ -13751,16 +13840,21 @@ platform_events:
       payload:
         activity_id: string
         tool: string
+        bundle_hash: string (optional; required for a request released by proposed_effect approval; omitted for an immediate unapproved request)
+        workflow_version: string (optional; required for a request released by proposed_effect approval; omitted for an immediate unapproved request)
         input: object
         effect_class: string
         success_event: string
         failure_event: string
+        revision_event: string (optional; generated typed feedback event for an approved activity)
+        rejected_event: string (optional; generated typed rejection event for an approved activity)
         retry_max_attempts: integer
         retry_backoff: string
         fork_policy: string
         entity_id: string
         node_id: string
         flow_id: string
+        flow_instance: string (optional; exact producing flow instance)
         handler_event_key: string
         source_event_id: string
         source_run_id: string
@@ -23823,6 +23917,7 @@ api_specification:
         properties:
           kind: {type: string, const: decision_card}
           decision_card: {$ref: '#/components/schemas/DecisionCardSummary'}
+          effect: {$ref: '#/components/schemas/ProposedEffectState'}
       DecisionCardDetailProjection:
         type: object
         additionalProperties: false
@@ -23830,6 +23925,7 @@ api_specification:
         properties:
           kind: {type: string, const: decision_card}
           decision_card: {$ref: '#/components/schemas/DecisionCard'}
+          effect: {$ref: '#/components/schemas/ProposedEffectState'}
       DecisionCardSummary:
         type: object
         additionalProperties: false
@@ -23850,7 +23946,7 @@ api_specification:
           updated_at: {$ref: '#/components/schemas/Timestamp'}
       DecisionCardAnchorKind:
         type: string
-        enum: [stage_gate, human_task]
+        enum: [stage_gate, human_task, proposed_effect]
       DecisionCardScope:
         type: object
         additionalProperties: false
@@ -23863,6 +23959,7 @@ api_specification:
         oneOf:
         - $ref: '#/components/schemas/StageGateDecisionCardAnchor'
         - $ref: '#/components/schemas/HumanTaskDecisionCardAnchor'
+        - $ref: '#/components/schemas/ProposedEffectDecisionCardAnchor'
       StageGateDecisionCardAnchor:
         type: object
         additionalProperties: false
@@ -23882,6 +23979,24 @@ api_specification:
           operation_id: {$ref: '#/components/schemas/OpaqueId'}
           category: {type: string}
           scope: {$ref: '#/components/schemas/DecisionCardScope'}
+      ProposedEffectDecisionCardAnchor:
+        type: object
+        additionalProperties: false
+        required: [request_event_id, activity_id, decision, scope]
+        properties:
+          request_event_id: {$ref: '#/components/schemas/OpaqueId'}
+          activity_id: {type: string}
+          decision: {type: string}
+          scope: {$ref: '#/components/schemas/DecisionCardScope'}
+      ProposedEffectState:
+        type: object
+        additionalProperties: false
+        required: [continuation_state, dispatch_state, request_event_id, activity_id]
+        properties:
+          continuation_state: {type: string, enum: [pending, decision_committed, request_released, outcome_dispatched, superseded]}
+          dispatch_state: {type: string, enum: [held, release_pending, released, not_dispatched, superseded, started, succeeded, failed, uncertain]}
+          request_event_id: {$ref: '#/components/schemas/OpaqueId'}
+          activity_id: {type: string}
       DecisionCard:
         type: object
         additionalProperties: true
@@ -23897,6 +24012,7 @@ api_specification:
           status: {$ref: '#/components/schemas/MailboxStatus'}
           snapshot: {type: object, additionalProperties: true}
           card_content_hash: {type: string}
+          effect_content_hash: {type: string}
           decision_schema_hash: {type: string}
           bundle_hash: {type: string}
           created_at: {$ref: '#/components/schemas/Timestamp'}
@@ -23936,6 +24052,7 @@ api_specification:
           change_type: {type: string, enum: [created, decided, deferred, expired, superseded, input_draft_started, input_draft_cancelled, input_draft_expired, input_draft_consumed]}
           payload: {type: object, additionalProperties: true}
           created_at: {$ref: '#/components/schemas/Timestamp'}
+          effect: {$ref: '#/components/schemas/ProposedEffectState'}
       MailboxPriority:
         type: string
         enum:


### PR DESCRIPTION
## Summary

- add strict `activity.approval.decision` authoring for executable `non_idempotent_write` activities
- freeze one immutable semantic proposed effect and hold all request, credential, attempt, and provider execution until an exact card verdict
- add the closed `proposed_effect` decision-card anchor and its sole durable continuation owner
- move stage-gate execution routes out of generic card snapshots into the existing gate-activation continuation
- preserve separate authorization and dispatch/result axes across store, HTTP, WebSocket, CLI, replay, lifecycle, and fork surfaces

## Governing contract

Authoritative sections updated and implemented in this PR:

- `platform-spec.yaml#handler_specification.handler_fields.activity.approval`
- `platform-spec.yaml#handler_specification.handler_fields.activity.durable_request_event`
- `platform-spec.yaml#platform_tables.tables.decision_cards`
- `platform-spec.yaml#platform_tables.tables.proposed_effect_continuations`
- `platform-spec.yaml#run_model.selected_contract_execution`
- `platform-spec.yaml#api_specification.components.schemas.DecisionCardAnchorKind`
- `platform-spec.yaml#api_specification.components.schemas.ProposedEffectState`

The binding issue record is the design lock, approved Pre-Implementation Coverage Audit, broad-refactor escalation, and independent Gate C approval on #1987.

## Semantic migration

- **New canonical owner:** `decisioncard.ProposedEffectContinuation` plus selected-store `proposed_effect_continuations` owns immutable effect execution and approve/revise/reject routing.
- **Old path now invalid:** an approved activity may no longer write `platform.activity_requested` directly from handler lowering; generic `FrozenOutcome` no longer owns stage execution.
- **Production paths checked:** handler and rule activity lowering, selected-store mutations, activity outbox/dispatcher, credential resolution, event schemas/catalog, run/loop supersession, stage exit, replay/recovery, selected-contract fork, mailbox list/get/decide/subscribe, HTTP, WebSocket, CLI/scenario projection, destructive reset, fresh-schema checks, and OpenRPC.
- **Migration completeness:** complete for the executable proposed-effect class. No aliases, dual writes, old-store readers, migrations, exports, purges, or compatibility shims were added. Unapproved activities remain a distinct authored concept.
- **Remaining parent work:** channel delivery-receipt authenticity stays in #1988; the broader repository semantic-value migration stays in #2046.

## Verification

- `go run ./cmd/swarm-test-postgres -- go test -p 1 ./...`
- repeated the formerly contention-sensitive catalog groups three times under host Postgres
- generated OpenRPC parity, YAML parsing, and `git diff --check`
- issue-specific SQLite and Postgres provider-counter, rollback, lifecycle, readback, replay, and fork proofs

Closes #1987