### PR TITLE
[agent-e][issue #2010] Add canonical author activity story owner

### DIFF
--- a/cmd/swarm/raw_sql_boundary_test.go
+++ b/cmd/swarm/raw_sql_boundary_test.go
@@ -156,6 +156,18 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Issue:          1783,
 			Reason:         "mutation log persistence is an explicit runtime SQL owner used from mutation transaction boundaries",
 		},
+		"internal/runtime/authoractivity/mutation.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          2010,
+			SpecRef:        "platform-spec.yaml#platform_tables.author_activity_story",
+			Reason:         "author activity mutation is the canonical ordered story transaction owner for registered runtime producers",
+		},
+		"internal/runtime/authoractivity/read.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          2010,
+			SpecRef:        "platform-spec.yaml#platform_tables.author_activity_story",
+			Reason:         "author activity read is the canonical backend-neutral story occurrence reader",
+		},
 		"internal/runtime/manager/flow_activation.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1962,
@@ -171,6 +183,12 @@ func selectedRawSQLBoundaryLedger() map[string]rawSQLBoundaryEntry {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,
 			Issue:          1783,
 			Reason:         "pipeline activity journal writes through the existing pipeline transaction owner",
+		},
+		"internal/runtime/pipeline/author_activity.go": {
+			Classification: rawSQLRuntimeUnitOfWorkBoundary,
+			Issue:          2010,
+			SpecRef:        "platform-spec.yaml#platform_tables.author_activity_story",
+			Reason:         "pipeline author activity bridges registered pipeline producers into the canonical ordered story owner",
 		},
 		"internal/runtime/pipeline/coordinator.go": {
 			Classification: rawSQLRuntimeUnitOfWorkBoundary,

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimeingress "github.com/division-sh/swarm/internal/runtime/ingress"
 	"github.com/division-sh/swarm/internal/runtime/lifecycleprobe/lifecycletest"
-	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -1722,24 +1721,11 @@ func (s *failCommittedReplayScopeStore) RunEventMutation(ctx context.Context, fn
 	if fn == nil {
 		return nil
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	postCommit := make([]func(), 0, 4)
-	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
-	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
-	mutation := &failCommittedReplayScopeMutation{tx: tx, store: s}
-	mutation.ctx = runtimebus.WithEventMutationContext(txctx, mutation)
-	if err := fn(mutation); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	runtimepipeline.FlushPipelinePostCommitActions(postCommit)
-	return nil
+	return s.PostgresStore.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		mutation := &failCommittedReplayScopeMutation{tx: tx, store: s}
+		mutation.ctx = runtimebus.WithEventMutationContext(txctx, mutation)
+		return fn(mutation)
+	})
 }
 
 func (m *failCommittedReplayScopeMutation) Context() context.Context {

--- a/internal/runtime/authoractivity/authoractivity_test.go
+++ b/internal/runtime/authoractivity/authoractivity_test.go
@@ -1,0 +1,372 @@
+package authoractivity
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+)
+
+func TestRegistryAcceptsOnlyDeclaredKindsTransitionsAndProjectionFields(t *testing.T) {
+	if len(Kinds()) != len(kindContracts) {
+		t.Fatalf("Kinds() count = %d, registry count = %d", len(Kinds()), len(kindContracts))
+	}
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	for kind, contract := range kindContracts {
+		for transition := range contract.Transitions {
+			draft := testDraft(kind, transition, now)
+			if failureRequired(kind, transition) {
+				draft.Failure = testFailure(t)
+			}
+			if err := ValidateDraft(draft); err != nil {
+				t.Fatalf("ValidateDraft(%s/%s): %v", kind, transition, err)
+			}
+		}
+	}
+	unknown := testDraft(KindEventEmitted, "guessed", now)
+	if err := ValidateDraft(unknown); err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("unknown transition error = %v", err)
+	}
+	unsafe := testDraft(KindInboundReceived, "received", now)
+	unsafe.Projection.ToolName = "must-not-cross-kind-boundary"
+	if err := ValidateDraft(unsafe); err == nil || !strings.Contains(err.Error(), "projection field") {
+		t.Fatalf("cross-kind projection error = %v", err)
+	}
+	missingFailure := testDraft(KindDeliveryLifecycle, "failed", now)
+	if err := ValidateDraft(missingFailure); err == nil || !strings.Contains(err.Error(), "requires canonical failure") {
+		t.Fatalf("missing failure error = %v", err)
+	}
+	invalidOptionalFailure := testDraft(KindAgentLifecycle, "failed", now)
+	invalidOptionalFailure.Failure = &runtimefailures.Envelope{}
+	if err := ValidateDraft(invalidOptionalFailure); err == nil || !strings.Contains(err.Error(), "failure") {
+		t.Fatalf("invalid optional failure error = %v", err)
+	}
+}
+
+func TestKindContractsRejectUnsafeEventAndEffectSubjectFields(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		draft  Draft
+		remove func(*Projection)
+	}{
+		{
+			name: "event internal identity", draft: testDraft(KindEventEmitted, "emitted", now),
+			remove: func(projection *Projection) { projection.ProducerID = "" },
+		},
+		{
+			name: "effect internal identity", draft: testDraft(KindEffectLifecycle, "launched", now),
+			remove: func(projection *Projection) { projection.Adapter = "" },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsafe := tt.draft
+			unsafe.Projection.SubjectType = "internal"
+			unsafe.Projection.SubjectID = "raw-identity"
+			if err := ValidateDraft(unsafe); err == nil || !strings.Contains(err.Error(), "projection field") {
+				t.Fatalf("unsafe subject error = %v", err)
+			}
+			missing := tt.draft
+			tt.remove(&missing.Projection)
+			if err := ValidateDraft(missing); err == nil || !strings.Contains(err.Error(), "is required") {
+				t.Fatalf("missing author-safe subject error = %v", err)
+			}
+		})
+	}
+}
+
+func TestKindContractsRejectWrongSourceOwnerAndSubjectType(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	wrongOwner := testDraft(KindEffectLifecycle, "launched", now)
+	wrongOwner.SourceOwner = "events"
+	if err := ValidateDraft(wrongOwner); err == nil || !strings.Contains(err.Error(), `expected "runtime_external_effect_attempts"`) {
+		t.Fatalf("wrong source owner error = %v", err)
+	}
+
+	wrongSubject := testDraft(KindDeliveryLifecycle, "delivered", now)
+	wrongSubject.Projection.SubjectType = "delivery"
+	if err := ValidateDraft(wrongSubject); err == nil || !strings.Contains(err.Error(), "subject_type") {
+		t.Fatalf("wrong subject type error = %v", err)
+	}
+}
+
+func TestSQLiteMutationOwnsRollbackReplayNestedBatchingAndPagination(t *testing.T) {
+	db := openAuthorActivitySQLite(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 123000000, time.UTC)
+
+	if err := Require(ctx); err == nil {
+		t.Fatal("raw producer context was accepted")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	story, err := Begin(ctx, tx, DialectSQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nested, err := Begin(story, tx, DialectSQLite); err != nil || nested != story {
+		t.Fatalf("nested Begin = (%v, %v), want exact joined context", nested, err)
+	}
+	rolledBack := testDraft(KindInboundReceived, "received", now)
+	rolledBack.DedupKey = "rollback"
+	if err := Record(story, rolledBack); err != nil {
+		t.Fatal(err)
+	}
+	if err := Finalize(story); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	first := testDraft(KindInboundReceived, "received", now.Add(time.Second))
+	first.DedupKey = "first"
+	first.Projection = Projection{SubjectType: "entity", SubjectID: "entity-a", Provider: "telegram"}
+	second := testDraft(KindEventEmitted, "emitted", now.Add(2*time.Second))
+	second.DedupKey = "second"
+	second.Projection = Projection{EventType: "message.normalized", ProducerType: "agent", ProducerID: "normalizer"}
+	commitDrafts(t, db, DialectSQLite, first, first, second)
+	replayTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayStory, err := Begin(ctx, replayTx, DialectSQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if occurredAt, found, err := PersistedOccurredAt(replayStory, first.DedupKey); err != nil || !found || !occurredAt.Equal(first.OccurredAt) {
+		t.Fatalf("PersistedOccurredAt = (%v, %v, %v), want %v", occurredAt, found, err, first.OccurredAt)
+	}
+	if _, found, err := PersistedOccurredAt(replayStory, "missing"); err != nil || found {
+		t.Fatalf("missing PersistedOccurredAt = (%v, %v), want not found", found, err)
+	}
+	if err := replayTx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := List(ctx, db, DialectSQLite, ListOptions{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Occurrences) != 1 || listed.Occurrences[0].Sequence != 1 || listed.NextCursor != 1 {
+		t.Fatalf("first page = %#v", listed)
+	}
+	listed, err = List(ctx, db, DialectSQLite, ListOptions{AfterSequence: listed.NextCursor, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Occurrences) != 1 || listed.Occurrences[0].Sequence != 2 {
+		t.Fatalf("second page = %#v", listed)
+	}
+
+	// An identical persisted replay is a no-op and does not consume sequence 3.
+	commitDrafts(t, db, DialectSQLite, first)
+	third := testDraft(KindCardLifecycle, "created", now.Add(3*time.Second))
+	third.DedupKey = "third"
+	commitDrafts(t, db, DialectSQLite, third)
+	listed, err = List(ctx, db, DialectSQLite, ListOptions{AfterSequence: 2, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Occurrences) != 1 || listed.Occurrences[0].Sequence != 3 {
+		t.Fatalf("post-replay page = %#v", listed)
+	}
+}
+
+func TestSQLiteMutationRejectsConflictingReplayAtomically(t *testing.T) {
+	db := openAuthorActivitySQLite(t)
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	created := testDraft(KindEntityLifecycle, "created", now)
+	created.DedupKey = "entity-transition"
+	created.Projection = Projection{SubjectType: "entity", SubjectID: "entity-a", NewState: "new"}
+	commitDrafts(t, db, DialectSQLite, created)
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	story, err := Begin(context.Background(), tx, DialectSQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflict := created
+	conflict.Transition = "stage_changed"
+	conflict.Projection = Projection{SubjectType: "entity", SubjectID: "entity-a", OldState: "new", NewState: "active"}
+	if _, err := tx.ExecContext(story, `CREATE TABLE source_effect (value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(story, `INSERT INTO source_effect (value) VALUES ('must-rollback')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := Record(story, conflict); err != nil {
+		t.Fatal(err)
+	}
+	if err := Finalize(story); err == nil || !strings.Contains(err.Error(), "conflicting persisted replay") {
+		t.Fatalf("Finalize conflict error = %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	var exists int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='source_effect'`).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists != 0 {
+		t.Fatal("source mutation survived conflicting story rollback")
+	}
+}
+
+func TestRenderModesKeepHumanProseSeparateFromTypedNDJSON(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 34, 56, 0, time.UTC)
+	failure := testFailure(t)
+	occurrences := []Occurrence{{
+		OccurrenceID: uuid.NewString(), Sequence: 1, Kind: KindDeliveryLifecycle, Version: Version,
+		Transition: "failed", SourceOwner: "event_deliveries", SourceIdentity: "delivery-a", DedupKey: "delivery-a:failed",
+		OccurredAt: now, RunID: "11111111-1111-1111-1111-111111111111",
+		Projection: Projection{SubjectType: "agent", SubjectID: "normalizer", EventType: "message.normalized"}, Failure: failure,
+	}}
+	var plain bytes.Buffer
+	if err := Render(&plain, occurrences, RenderOptions{Mode: RenderPlain, Width: 120}); err != nil {
+		t.Fatal(err)
+	}
+	plainText := plain.String()
+	for _, forbidden := range []string{"\x1b[", failure.Message, failure.Remediation, "provider-secret"} {
+		if strings.Contains(plainText, forbidden) {
+			t.Fatalf("plain output leaked %q: %s", forbidden, plainText)
+		}
+	}
+	if !strings.Contains(plainText, "agent[normalizer]  failed, retrying") || !strings.Contains(plainText, "swarm logs --run 11111111-1111-1111-1111-111111111111 --level error") {
+		t.Fatalf("plain output = %q", plainText)
+	}
+
+	var ndjson bytes.Buffer
+	if err := Render(&ndjson, occurrences, RenderOptions{Mode: RenderNDJSON}); err != nil {
+		t.Fatal(err)
+	}
+	var decoded Occurrence
+	if err := json.Unmarshal(bytes.TrimSpace(ndjson.Bytes()), &decoded); err != nil {
+		t.Fatalf("NDJSON is not typed occurrence JSON: %v\n%s", err, ndjson.String())
+	}
+	if !reflect.DeepEqual(decoded, occurrences[0]) {
+		t.Fatalf("NDJSON occurrence = %#v, want %#v", decoded, occurrences[0])
+	}
+}
+
+func TestAgentLifecycleFailureWithoutEnvelopeStillRendersDiagnosticRoute(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 34, 56, 0, time.UTC)
+	occurrence := Occurrence{
+		OccurrenceID: uuid.NewString(), Sequence: 1, Kind: KindAgentLifecycle, Version: Version,
+		Transition: "failed", SourceOwner: "agent_lifecycle_transition_facts", SourceIdentity: "transition-a",
+		DedupKey: "agent-transition:transition-a", OccurredAt: now, RunID: "11111111-1111-1111-1111-111111111111",
+		AgentID: "normalizer", Projection: Projection{SubjectType: "agent", SubjectID: "normalizer", NextPhase: "failed"},
+	}
+	var plain bytes.Buffer
+	if err := Render(&plain, []Occurrence{occurrence}, RenderOptions{Mode: RenderPlain, Width: 120}); err != nil {
+		t.Fatal(err)
+	}
+	text := plain.String()
+	if !strings.Contains(text, "agent[normalizer]  failed") || !strings.Contains(text, "swarm logs --run 11111111-1111-1111-1111-111111111111 --level error") {
+		t.Fatalf("agent failure output = %q", text)
+	}
+}
+
+func openAuthorActivitySQLite(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+uuid.NewString()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	for _, ddl := range []string{
+		`CREATE TABLE author_activity_order (singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1), last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0))`,
+		`CREATE TABLE author_activity_occurrences (
+			occurrence_id TEXT PRIMARY KEY, sequence BIGINT NOT NULL UNIQUE CHECK (sequence > 0), kind TEXT NOT NULL,
+			version INTEGER NOT NULL CHECK (version = 1), transition TEXT NOT NULL, source_owner TEXT NOT NULL,
+			source_identity TEXT NOT NULL, dedup_key TEXT NOT NULL UNIQUE, run_id TEXT, entity_id TEXT, agent_id TEXT,
+			flow_id TEXT, projection TEXT NOT NULL DEFAULT '{}', failure TEXT, occurred_at TIMESTAMP NOT NULL
+		)`,
+	} {
+		if _, err := db.Exec(ddl); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return db
+}
+
+func commitDrafts(t *testing.T, db *sql.DB, dialect Dialect, drafts ...Draft) {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	story, err := Begin(context.Background(), tx, dialect)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	for _, draft := range drafts {
+		if err := Record(story, draft); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+	}
+	if err := Finalize(story); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testDraft(kind Kind, transition string, at time.Time) Draft {
+	identity := string(kind) + ":" + transition
+	contract, ok := kindContracts[kind]
+	if !ok {
+		return Draft{Kind: kind, Transition: transition, OccurredAt: at}
+	}
+	projection := Projection{}
+	switch contract.SubjectStrategy {
+	case subjectTypedIdentity:
+		subjectTypes := sortedSet(contract.SubjectTypes)
+		projection.SubjectType = subjectTypes[0]
+		projection.SubjectID = "subject-a"
+	case subjectProducer:
+		projection.EventType = "message.normalized"
+		projection.ProducerType = "agent"
+		projection.ProducerID = "normalizer"
+	case subjectAdapter:
+		projection.Adapter = "anthropic_api"
+		projection.Transport = "https"
+		projection.AuthorityKind = "normal_agent"
+		projection.AuthorityID = "normalizer"
+	}
+	return Draft{
+		OccurrenceID: uuid.NewString(), Kind: kind, Version: Version, Transition: transition,
+		SourceOwner: contract.SourceOwner, SourceIdentity: identity, DedupKey: identity, OccurredAt: at,
+		Projection: projection,
+	}
+}
+
+func testFailure(t *testing.T) *runtimefailures.Envelope {
+	t.Helper()
+	err := runtimefailures.New(runtimefailures.ClassConnectorFailure, "provider_unavailable", "test", "author_activity", nil)
+	failure, ok := runtimefailures.EnvelopeFromError(err)
+	if !ok {
+		t.Fatalf("canonical failure construction returned %T", err)
+	}
+	return &failure
+}

--- a/internal/runtime/authoractivity/model.go
+++ b/internal/runtime/authoractivity/model.go
@@ -1,0 +1,390 @@
+package authoractivity
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+)
+
+const Version = 1
+
+type Kind string
+
+const (
+	KindInboundReceived    Kind = "inbound.received"
+	KindEventEmitted       Kind = "event.emitted"
+	KindEntityLifecycle    Kind = "entity.lifecycle"
+	KindDeliveryLifecycle  Kind = "delivery.lifecycle"
+	KindDeadLetterRecorded Kind = "dead_letter.recorded"
+	KindActivityLifecycle  Kind = "activity.lifecycle"
+	KindEffectLifecycle    Kind = "effect.lifecycle"
+	KindTurnLifecycle      Kind = "turn.lifecycle"
+	KindTurnToolCompleted  Kind = "turn.tool_completed"
+	KindCardLifecycle      Kind = "card.lifecycle"
+	KindAgentLifecycle     Kind = "agent.lifecycle"
+	KindDirectiveLifecycle Kind = "directive.lifecycle"
+	KindRunLifecycle       Kind = "run.lifecycle"
+	KindPlatformSignal     Kind = "platform.signal"
+)
+
+// Projection is the closed, metadata-only persistence shape for author activity.
+// It deliberately has no generic payload, evidence, prompt, response, or result field.
+type Projection struct {
+	SubjectType        string     `json:"subject_type,omitempty"`
+	SubjectID          string     `json:"subject_id,omitempty"`
+	Provider           string     `json:"provider,omitempty"`
+	EventType          string     `json:"event_type,omitempty"`
+	ProducerType       string     `json:"producer_type,omitempty"`
+	ProducerID         string     `json:"producer_id,omitempty"`
+	OldState           string     `json:"old_state,omitempty"`
+	NewState           string     `json:"new_state,omitempty"`
+	WriterType         string     `json:"writer_type,omitempty"`
+	WriterID           string     `json:"writer_id,omitempty"`
+	SubscriberType     string     `json:"subscriber_type,omitempty"`
+	SubscriberID       string     `json:"subscriber_id,omitempty"`
+	RetryCount         *int       `json:"retry_count,omitempty"`
+	ReasonCode         string     `json:"reason_code,omitempty"`
+	NodeID             string     `json:"node_id,omitempty"`
+	Activity           string     `json:"activity,omitempty"`
+	Tool               string     `json:"tool,omitempty"`
+	EffectClass        string     `json:"effect_class,omitempty"`
+	Attempt            *int       `json:"attempt,omitempty"`
+	Adapter            string     `json:"adapter,omitempty"`
+	Transport          string     `json:"transport,omitempty"`
+	AuthorityKind      string     `json:"authority_kind,omitempty"`
+	AuthorityID        string     `json:"authority_id,omitempty"`
+	TurnID             string     `json:"turn_id,omitempty"`
+	DurationMS         *int       `json:"duration_ms,omitempty"`
+	ParseOK            *bool      `json:"parse_ok,omitempty"`
+	UsageExactness     string     `json:"usage_exactness,omitempty"`
+	InputTokens        *int64     `json:"input_tokens,omitempty"`
+	OutputTokens       *int64     `json:"output_tokens,omitempty"`
+	ToolName           string     `json:"tool_name,omitempty"`
+	ToolUseID          string     `json:"tool_use_id,omitempty"`
+	CardID             string     `json:"card_id,omitempty"`
+	AnchorKind         string     `json:"anchor_kind,omitempty"`
+	AnchorID           string     `json:"anchor_id,omitempty"`
+	DecisionID         string     `json:"decision_id,omitempty"`
+	Verdict            string     `json:"verdict,omitempty"`
+	DeferUntil         *time.Time `json:"defer_until,omitempty"`
+	SupersedeReason    string     `json:"supersede_reason,omitempty"`
+	PreviousPhase      string     `json:"previous_phase,omitempty"`
+	NextPhase          string     `json:"next_phase,omitempty"`
+	PreviousGeneration *uint64    `json:"previous_generation,omitempty"`
+	NextGeneration     *uint64    `json:"next_generation,omitempty"`
+	RunMode            string     `json:"run_mode,omitempty"`
+	Method             string     `json:"method,omitempty"`
+	Source             string     `json:"source,omitempty"`
+	ParentRunID        string     `json:"parent_run_id,omitempty"`
+	ForkRunID          string     `json:"fork_run_id,omitempty"`
+	TriggerEventType   string     `json:"trigger_event_type,omitempty"`
+	ControlReason      string     `json:"control_reason,omitempty"`
+	Level              string     `json:"level,omitempty"`
+	Spend              string     `json:"spend,omitempty"`
+	Cap                string     `json:"cap,omitempty"`
+	Percentage         string     `json:"percentage,omitempty"`
+	Period             string     `json:"period,omitempty"`
+	OperationalState   string     `json:"operational_state,omitempty"`
+	BlockingLayer      string     `json:"blocking_layer,omitempty"`
+}
+
+type Draft struct {
+	OccurrenceID   string
+	Kind           Kind
+	Version        int
+	Transition     string
+	SourceOwner    string
+	SourceIdentity string
+	DedupKey       string
+	OccurredAt     time.Time
+	RunID          string
+	EntityID       string
+	AgentID        string
+	FlowID         string
+	Projection     Projection
+	Failure        *runtimefailures.Envelope
+}
+
+type Occurrence struct {
+	OccurrenceID   string                    `json:"occurrence_id"`
+	Sequence       int64                     `json:"sequence"`
+	Kind           Kind                      `json:"kind"`
+	Version        int                       `json:"version"`
+	Transition     string                    `json:"transition"`
+	SourceOwner    string                    `json:"source_owner"`
+	SourceIdentity string                    `json:"source_identity"`
+	DedupKey       string                    `json:"dedup_key"`
+	OccurredAt     time.Time                 `json:"occurred_at"`
+	RunID          string                    `json:"run_id,omitempty"`
+	EntityID       string                    `json:"entity_id,omitempty"`
+	AgentID        string                    `json:"agent_id,omitempty"`
+	FlowID         string                    `json:"flow_id,omitempty"`
+	Projection     Projection                `json:"projection"`
+	Failure        *runtimefailures.Envelope `json:"failure,omitempty"`
+}
+
+type ListOptions struct {
+	AfterSequence int64
+	Limit         int
+	RunID         string
+	EntityID      string
+	AgentID       string
+	FlowID        string
+}
+
+type ListResult struct {
+	Occurrences []Occurrence `json:"occurrences"`
+	NextCursor  int64        `json:"next_cursor,omitempty"`
+}
+
+type subjectStrategy uint8
+
+const (
+	subjectTypedIdentity subjectStrategy = iota + 1
+	subjectProducer
+	subjectAdapter
+)
+
+type kindContract struct {
+	Transitions              map[string]struct{}
+	SourceOwner              string
+	SourceIdentityRequired   bool
+	AllowedProjectionFields  map[string]struct{}
+	RequiredProjectionFields map[string]struct{}
+	FailureTransitions       map[string]struct{}
+	SubjectStrategy          subjectStrategy
+	SubjectTypes             map[string]struct{}
+}
+
+var kindContracts = map[Kind]kindContract{
+	KindInboundReceived: {
+		Transitions: set("received"), SourceOwner: "events", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "provider"),
+		RequiredProjectionFields: set("subject_type", "subject_id"),
+		SubjectStrategy:          subjectTypedIdentity, SubjectTypes: set("entity"),
+	},
+	KindEventEmitted: {
+		Transitions: set("emitted"), SourceOwner: "events", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("event_type", "producer_type", "producer_id"),
+		RequiredProjectionFields: set("event_type", "producer_type", "producer_id"),
+		SubjectStrategy:          subjectProducer,
+	},
+	KindEntityLifecycle: {
+		Transitions: set("created", "stage_changed"), SourceOwner: "entity_mutations", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "old_state", "new_state", "writer_type", "writer_id"),
+		RequiredProjectionFields: set("subject_type", "subject_id"),
+		SubjectStrategy:          subjectTypedIdentity, SubjectTypes: set("entity"),
+	},
+	KindDeliveryLifecycle: {
+		Transitions: set("in_progress", "delivered", "failed", "dead_letter"), SourceOwner: "event_deliveries", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "event_type", "subscriber_type", "subscriber_id", "retry_count", "reason_code"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("failed", "dead_letter"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("agent", "node"),
+	},
+	KindDeadLetterRecorded: {
+		Transitions: set("recorded"), SourceOwner: "dead_letters", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "event_type", "retry_count", "reason_code", "node_id"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("recorded"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("event"),
+	},
+	KindActivityLifecycle: {
+		Transitions: set("started", "succeeded", "failed", "uncertain"), SourceOwner: "activity_attempts", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "node_id", "activity", "tool", "effect_class", "attempt", "event_type"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("failed", "uncertain"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("activity"),
+	},
+	KindEffectLifecycle: {
+		Transitions: set("launched", "terminal_failure", "outcome_uncertain"), SourceOwner: "runtime_external_effect_attempts", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("adapter", "transport", "authority_kind", "authority_id", "effect_class", "attempt"),
+		RequiredProjectionFields: set("adapter", "transport", "authority_kind", "authority_id"), FailureTransitions: set("terminal_failure", "outcome_uncertain"),
+		SubjectStrategy: subjectAdapter,
+	},
+	KindTurnLifecycle: {
+		Transitions: set("completed", "failed"), SourceOwner: "agent_turns", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "turn_id", "duration_ms", "parse_ok", "usage_exactness", "input_tokens", "output_tokens", "retry_count", "event_type"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("failed"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("agent"),
+	},
+	KindTurnToolCompleted: {
+		Transitions: set("completed"), SourceOwner: "agent_turns", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "turn_id", "tool_name", "tool_use_id"),
+		RequiredProjectionFields: set("subject_type", "subject_id"),
+		SubjectStrategy:          subjectTypedIdentity, SubjectTypes: set("agent"),
+	},
+	KindCardLifecycle: {
+		Transitions: set("created", "decided", "deferred", "expired", "superseded"), SourceOwner: "decision_card_changes", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "card_id", "anchor_kind", "anchor_id", "decision_id", "verdict", "defer_until", "supersede_reason"),
+		RequiredProjectionFields: set("subject_type", "subject_id"),
+		SubjectStrategy:          subjectTypedIdentity, SubjectTypes: set("card"),
+	},
+	KindAgentLifecycle: {
+		Transitions: set("registered", "running", "terminated", "failed"), SourceOwner: "agent_lifecycle_transition_facts", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "previous_phase", "next_phase", "previous_generation", "next_generation", "run_mode"),
+		RequiredProjectionFields: set("subject_type", "subject_id"),
+		SubjectStrategy:          subjectTypedIdentity, SubjectTypes: set("agent"),
+	},
+	KindDirectiveLifecycle: {
+		Transitions: set("received", "in_flight", "completed", "failed", "outcome_uncertain"), SourceOwner: "agent_directive_operations", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "method", "source"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("failed", "outcome_uncertain"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("agent"),
+	},
+	KindRunLifecycle: {
+		Transitions: set("started", "fork_prepared", "paused", "resumed", "fork_started", "completed", "failed", "cancelled", "forked"), SourceOwner: "runs", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "parent_run_id", "fork_run_id", "trigger_event_type", "control_reason", "source"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("failed"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("run"),
+	},
+	KindPlatformSignal: {
+		Transitions: set("agent_failed_retrying", "agent_failed", "event_quarantined", "dead_letters_escalated", "run_stalled", "runtime_reset", "authorization_required", "budget_warning", "budget_throttle", "budget_emergency", "budget_ok", "runtime_paused", "runtime_resumed", "recovery_failed"),
+		SourceOwner: "events", SourceIdentityRequired: true,
+		AllowedProjectionFields:  set("subject_type", "subject_id", "event_type", "retry_count", "reason_code", "tool", "level", "spend", "cap", "percentage", "period", "source", "operational_state", "blocking_layer"),
+		RequiredProjectionFields: set("subject_type", "subject_id"), FailureTransitions: set("agent_failed_retrying", "agent_failed", "authorization_required", "recovery_failed"),
+		SubjectStrategy: subjectTypedIdentity, SubjectTypes: set("agent", "entity", "run", "event", "platform"),
+	},
+}
+
+func set(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func Kinds() []Kind {
+	out := make([]Kind, 0, len(kindContracts))
+	for kind := range kindContracts {
+		out = append(out, kind)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func ValidateDraft(d Draft) error {
+	d.Kind = Kind(strings.TrimSpace(string(d.Kind)))
+	contract, ok := kindContracts[d.Kind]
+	if !ok {
+		return fmt.Errorf("author activity kind %q is not registered", d.Kind)
+	}
+	if d.Version == 0 {
+		d.Version = Version
+	}
+	if d.Version != Version {
+		return fmt.Errorf("author activity %s version %d is not registered", d.Kind, d.Version)
+	}
+	transition := strings.TrimSpace(d.Transition)
+	if _, ok := contract.Transitions[transition]; !ok {
+		return fmt.Errorf("author activity %s transition %q is not registered", d.Kind, transition)
+	}
+	sourceOwner := strings.TrimSpace(d.SourceOwner)
+	if sourceOwner != contract.SourceOwner {
+		return fmt.Errorf("author activity %s source_owner %q is not registered; expected %q", d.Kind, sourceOwner, contract.SourceOwner)
+	}
+	if contract.SourceIdentityRequired && strings.TrimSpace(d.SourceIdentity) == "" {
+		return fmt.Errorf("author activity %s source_identity is required", d.Kind)
+	}
+	if strings.TrimSpace(d.DedupKey) == "" {
+		return fmt.Errorf("author activity %s dedup_key is required", d.Kind)
+	}
+	if d.OccurredAt.IsZero() {
+		return fmt.Errorf("author activity %s occurred_at is required", d.Kind)
+	}
+	if err := validateProjection(d.Kind, contract, d.Projection); err != nil {
+		return err
+	}
+	if failureRequired(d.Kind, transition) && d.Failure == nil {
+		return fmt.Errorf("author activity %s/%s requires canonical failure", d.Kind, transition)
+	}
+	if d.Failure != nil {
+		if err := runtimefailures.ValidateEnvelope(*d.Failure); err != nil {
+			return fmt.Errorf("author activity %s/%s failure: %w", d.Kind, transition, err)
+		}
+	}
+	return nil
+}
+
+func failureRequired(kind Kind, transition string) bool {
+	contract, ok := kindContracts[kind]
+	if !ok {
+		return false
+	}
+	_, required := contract.FailureTransitions[strings.TrimSpace(transition)]
+	return required
+}
+
+func validateProjection(kind Kind, contract kindContract, projection Projection) error {
+	raw, err := json.Marshal(projection)
+	if err != nil {
+		return fmt.Errorf("marshal author activity %s projection: %w", kind, err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return fmt.Errorf("decode author activity %s projection: %w", kind, err)
+	}
+	for field := range fields {
+		if _, ok := contract.AllowedProjectionFields[field]; !ok {
+			return fmt.Errorf("author activity %s projection field %q is not registered", kind, field)
+		}
+	}
+	for _, field := range sortedSet(contract.RequiredProjectionFields) {
+		if !projectionFieldPopulated(fields[field]) {
+			return fmt.Errorf("author activity %s projection field %q is required", kind, field)
+		}
+	}
+	if contract.SubjectStrategy == subjectTypedIdentity {
+		subjectType := strings.TrimSpace(projection.SubjectType)
+		if _, ok := contract.SubjectTypes[subjectType]; !ok {
+			return fmt.Errorf("author activity %s subject_type %q is not registered", kind, subjectType)
+		}
+	}
+	return nil
+}
+
+func projectionFieldPopulated(raw json.RawMessage) bool {
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	if text, ok := value.(string); ok {
+		return strings.TrimSpace(text) != ""
+	}
+	return true
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cloneDraft(d Draft) Draft {
+	d.SourceOwner = strings.TrimSpace(d.SourceOwner)
+	d.SourceIdentity = strings.TrimSpace(d.SourceIdentity)
+	d.DedupKey = strings.TrimSpace(d.DedupKey)
+	d.Transition = strings.TrimSpace(d.Transition)
+	d.RunID = strings.TrimSpace(d.RunID)
+	d.EntityID = strings.TrimSpace(d.EntityID)
+	d.AgentID = strings.TrimSpace(d.AgentID)
+	d.FlowID = strings.TrimSpace(d.FlowID)
+	d.OccurredAt = d.OccurredAt.UTC()
+	d.Failure = runtimefailures.CloneEnvelope(d.Failure)
+	return d
+}
+
+func draftsEqual(left, right Draft) bool {
+	left.OccurrenceID = ""
+	right.OccurrenceID = ""
+	return reflect.DeepEqual(cloneDraft(left), cloneDraft(right))
+}

--- a/internal/runtime/authoractivity/mutation.go
+++ b/internal/runtime/authoractivity/mutation.go
@@ -1,0 +1,347 @@
+package authoractivity
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/google/uuid"
+)
+
+type Dialect string
+
+const (
+	DialectPostgres Dialect = "postgres"
+	DialectSQLite   Dialect = "sqlite"
+)
+
+type mutationContextKey struct{}
+
+type mutationState struct {
+	tx         *sql.Tx
+	dialect    Dialect
+	last       int64
+	drafts     []Draft
+	finalizing bool
+}
+
+func Begin(ctx context.Context, tx *sql.Tx, dialect Dialect) (context.Context, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("author activity transaction is required")
+	}
+	if existing, ok := stateFromContext(ctx); ok {
+		if existing.tx == tx && existing.dialect == dialect {
+			return ctx, nil
+		}
+		// Post-commit work may retain the completed transaction's context. A
+		// finalized owner cannot be joined, so a different transaction starts a
+		// fresh story while an active owner still fails closed.
+		if !existing.finalizing {
+			return nil, fmt.Errorf("author activity nested mutation belongs to a different transaction")
+		}
+	}
+	if dialect != DialectPostgres && dialect != DialectSQLite {
+		return nil, fmt.Errorf("author activity dialect %q is not supported", dialect)
+	}
+	state := &mutationState{tx: tx, dialect: dialect, drafts: make([]Draft, 0, 4)}
+	if err := state.lock(ctx); err != nil {
+		return nil, err
+	}
+	return context.WithValue(ctx, mutationContextKey{}, state), nil
+}
+
+func InMutation(ctx context.Context, tx *sql.Tx) bool {
+	state, ok := stateFromContext(ctx)
+	return ok && state.tx == tx && !state.finalizing
+}
+
+// FinalizedMutation reports whether ctx retains a completed story transaction.
+// Post-commit work may inherit that context, but must start a fresh story rather
+// than join the retired transaction. A raw transaction never satisfies this
+// predicate and therefore continues to fail closed at story-aware boundaries.
+func FinalizedMutation(ctx context.Context, tx *sql.Tx) bool {
+	state, ok := stateFromContext(ctx)
+	return ok && state.tx == tx && state.finalizing
+}
+
+func Require(ctx context.Context) error {
+	state, ok := stateFromContext(ctx)
+	if !ok || state == nil || state.tx == nil || state.finalizing {
+		return fmt.Errorf("registered author activity producer requires story-aware mutation context")
+	}
+	return nil
+}
+
+func Record(ctx context.Context, draft Draft) error {
+	state, ok := stateFromContext(ctx)
+	if !ok || state == nil || state.tx == nil {
+		return fmt.Errorf("registered author activity producer requires story-aware mutation context")
+	}
+	if state.finalizing {
+		return fmt.Errorf("author activity producer attempted domain mutation after story finalization")
+	}
+	draft = cloneDraft(draft)
+	if draft.Version == 0 {
+		draft.Version = Version
+	}
+	if draft.OccurrenceID == "" {
+		draft.OccurrenceID = uuid.NewString()
+	}
+	if err := ValidateDraft(draft); err != nil {
+		return err
+	}
+	state.drafts = append(state.drafts, draft)
+	return nil
+}
+
+// PersistedOccurredAt returns the immutable timestamp already assigned to a
+// deduplicated occurrence. Replay producers use it to reconstruct the exact
+// original draft; all other occurrence fields remain subject to strict replay
+// equality during Finalize.
+func PersistedOccurredAt(ctx context.Context, dedupKey string) (time.Time, bool, error) {
+	state, ok := stateFromContext(ctx)
+	if !ok || state == nil || state.tx == nil || state.finalizing {
+		return time.Time{}, false, fmt.Errorf("author activity mutation context is required")
+	}
+	dedupKey = strings.TrimSpace(dedupKey)
+	if dedupKey == "" {
+		return time.Time{}, false, fmt.Errorf("author activity dedup key is required")
+	}
+	occurrence, found, err := state.loadByDedup(ctx, dedupKey)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !found {
+		return time.Time{}, false, nil
+	}
+	return occurrence.OccurredAt.UTC(), true, nil
+}
+
+func Finalize(ctx context.Context) error {
+	state, ok := stateFromContext(ctx)
+	if !ok || state == nil || state.tx == nil {
+		return fmt.Errorf("author activity mutation context is required")
+	}
+	if state.finalizing {
+		return fmt.Errorf("author activity mutation already finalized")
+	}
+	state.finalizing = true
+	unique := make([]Draft, 0, len(state.drafts))
+	byDedup := make(map[string]Draft, len(state.drafts))
+	for _, draft := range state.drafts {
+		if previous, exists := byDedup[draft.DedupKey]; exists {
+			if !draftsEqual(previous, draft) {
+				return fmt.Errorf("author activity conflicting in-transaction replay for dedup key %q", draft.DedupKey)
+			}
+			continue
+		}
+		byDedup[draft.DedupKey] = draft
+		existing, found, err := state.loadByDedup(ctx, draft.DedupKey)
+		if err != nil {
+			return err
+		}
+		if found {
+			if !occurrenceMatchesDraft(existing, draft) {
+				return fmt.Errorf("author activity conflicting persisted replay for dedup key %q", draft.DedupKey)
+			}
+			continue
+		}
+		unique = append(unique, draft)
+	}
+	if len(unique) == 0 {
+		return nil
+	}
+	first := state.last + 1
+	last := state.last + int64(len(unique))
+	if err := state.updateLast(ctx, last); err != nil {
+		return err
+	}
+	for i, draft := range unique {
+		if err := state.insert(ctx, first+int64(i), draft); err != nil {
+			return err
+		}
+	}
+	state.last = last
+	return nil
+}
+
+func stateFromContext(ctx context.Context) (*mutationState, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	state, ok := ctx.Value(mutationContextKey{}).(*mutationState)
+	return state, ok && state != nil
+}
+
+func (s *mutationState) lock(ctx context.Context) error {
+	switch s.dialect {
+	case DialectPostgres:
+		if _, err := s.tx.ExecContext(ctx, `INSERT INTO author_activity_order (singleton_id, last_sequence) VALUES (1, 0) ON CONFLICT (singleton_id) DO NOTHING`); err != nil {
+			return fmt.Errorf("initialize author activity order: %w", err)
+		}
+		if err := s.tx.QueryRowContext(ctx, `SELECT last_sequence FROM author_activity_order WHERE singleton_id = 1 FOR UPDATE`).Scan(&s.last); err != nil {
+			return fmt.Errorf("lock author activity order: %w", err)
+		}
+	case DialectSQLite:
+		if _, err := s.tx.ExecContext(ctx, `INSERT OR IGNORE INTO author_activity_order (singleton_id, last_sequence) VALUES (1, 0)`); err != nil {
+			return fmt.Errorf("initialize author activity order: %w", err)
+		}
+		if _, err := s.tx.ExecContext(ctx, `UPDATE author_activity_order SET last_sequence = last_sequence WHERE singleton_id = 1`); err != nil {
+			return fmt.Errorf("lock author activity order: %w", err)
+		}
+		if err := s.tx.QueryRowContext(ctx, `SELECT last_sequence FROM author_activity_order WHERE singleton_id = 1`).Scan(&s.last); err != nil {
+			return fmt.Errorf("read author activity order: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *mutationState) updateLast(ctx context.Context, last int64) error {
+	query := `UPDATE author_activity_order SET last_sequence = $1 WHERE singleton_id = 1 AND last_sequence = $2`
+	args := []any{last, s.last}
+	if s.dialect == DialectSQLite {
+		query = `UPDATE author_activity_order SET last_sequence = ? WHERE singleton_id = 1 AND last_sequence = ?`
+	}
+	result, err := s.tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("advance author activity order: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read author activity order advancement: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("author activity order changed outside the locked mutation")
+	}
+	return nil
+}
+
+func (s *mutationState) loadByDedup(ctx context.Context, key string) (Occurrence, bool, error) {
+	query := occurrenceSelect + ` WHERE dedup_key = $1`
+	if s.dialect == DialectSQLite {
+		query = occurrenceSelect + ` WHERE dedup_key = ?`
+	}
+	occurrence, err := scanOccurrence(s.tx.QueryRowContext(ctx, query, key))
+	if err == sql.ErrNoRows {
+		return Occurrence{}, false, nil
+	}
+	if err != nil {
+		return Occurrence{}, false, fmt.Errorf("read author activity dedup key %q: %w", key, err)
+	}
+	return occurrence, true, nil
+}
+
+func (s *mutationState) insert(ctx context.Context, sequence int64, draft Draft) error {
+	projection, err := json.Marshal(draft.Projection)
+	if err != nil {
+		return fmt.Errorf("marshal author activity projection: %w", err)
+	}
+	var failure any
+	if draft.Failure != nil {
+		failureRaw, err := json.Marshal(draft.Failure)
+		if err != nil {
+			return fmt.Errorf("marshal author activity failure: %w", err)
+		}
+		failure = string(failureRaw)
+	}
+	args := []any{draft.OccurrenceID, sequence, string(draft.Kind), draft.Version, draft.Transition, draft.SourceOwner, draft.SourceIdentity, draft.DedupKey, nullable(draft.RunID), nullable(draft.EntityID), nullable(draft.AgentID), nullable(draft.FlowID), string(projection), failure, draft.OccurredAt.UTC()}
+	query := `INSERT INTO author_activity_occurrences (occurrence_id, sequence, kind, version, transition, source_owner, source_identity, dedup_key, run_id, entity_id, agent_id, flow_id, projection, failure, occurred_at) VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, NULLIF($9, '')::uuid, NULLIF($10, '')::uuid, NULLIF($11, ''), NULLIF($12, ''), $13::jsonb, NULLIF($14, '')::jsonb, $15)`
+	if s.dialect == DialectSQLite {
+		query = `INSERT INTO author_activity_occurrences (occurrence_id, sequence, kind, version, transition, source_owner, source_identity, dedup_key, run_id, entity_id, agent_id, flow_id, projection, failure, occurred_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		args[8] = nullableSQLite(draft.RunID)
+		args[9] = nullableSQLite(draft.EntityID)
+		args[10] = nullableSQLite(draft.AgentID)
+		args[11] = nullableSQLite(draft.FlowID)
+	}
+	if _, err := s.tx.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("insert author activity %s/%s: %w", draft.Kind, draft.Transition, err)
+	}
+	return nil
+}
+
+func occurrenceMatchesDraft(occurrence Occurrence, draft Draft) bool {
+	existing := Draft{
+		Kind: occurrence.Kind, Version: occurrence.Version, Transition: occurrence.Transition,
+		SourceOwner: occurrence.SourceOwner, SourceIdentity: occurrence.SourceIdentity, DedupKey: occurrence.DedupKey,
+		OccurredAt: occurrence.OccurredAt, RunID: occurrence.RunID, EntityID: occurrence.EntityID,
+		AgentID: occurrence.AgentID, FlowID: occurrence.FlowID, Projection: occurrence.Projection,
+		Failure: occurrence.Failure,
+	}
+	return draftsEqual(existing, draft)
+}
+
+func nullable(value string) string { return strings.TrimSpace(value) }
+
+func nullableSQLite(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+const occurrenceSelect = `SELECT CAST(occurrence_id AS TEXT), sequence, kind, version, transition, source_owner, source_identity, dedup_key, COALESCE(CAST(run_id AS TEXT), ''), COALESCE(CAST(entity_id AS TEXT), ''), COALESCE(agent_id, ''), COALESCE(flow_id, ''), projection, failure, occurred_at FROM author_activity_occurrences`
+
+type rowScanner interface{ Scan(...any) error }
+
+func scanOccurrence(row rowScanner) (Occurrence, error) {
+	var occurrence Occurrence
+	var projectionRaw []byte
+	var failureRaw []byte
+	var occurredAtRaw any
+	err := row.Scan(&occurrence.OccurrenceID, &occurrence.Sequence, &occurrence.Kind, &occurrence.Version, &occurrence.Transition, &occurrence.SourceOwner, &occurrence.SourceIdentity, &occurrence.DedupKey, &occurrence.RunID, &occurrence.EntityID, &occurrence.AgentID, &occurrence.FlowID, &projectionRaw, &failureRaw, &occurredAtRaw)
+	if err != nil {
+		return Occurrence{}, err
+	}
+	if err := json.Unmarshal(projectionRaw, &occurrence.Projection); err != nil {
+		return Occurrence{}, fmt.Errorf("decode author activity projection: %w", err)
+	}
+	if len(failureRaw) > 0 && string(failureRaw) != "null" {
+		var failure runtimefailures.Envelope
+		if err := json.Unmarshal(failureRaw, &failure); err != nil {
+			return Occurrence{}, fmt.Errorf("decode author activity failure: %w", err)
+		}
+		if err := runtimefailures.ValidateEnvelope(failure); err != nil {
+			return Occurrence{}, fmt.Errorf("validate author activity failure: %w", err)
+		}
+		occurrence.Failure = &failure
+	}
+	occurredAt, err := decodeTime(occurredAtRaw)
+	if err != nil {
+		return Occurrence{}, fmt.Errorf("decode author activity occurred_at: %w", err)
+	}
+	occurrence.OccurredAt = occurredAt
+	if err := ValidateDraft(Draft{Kind: occurrence.Kind, Version: occurrence.Version, Transition: occurrence.Transition, SourceOwner: occurrence.SourceOwner, SourceIdentity: occurrence.SourceIdentity, DedupKey: occurrence.DedupKey, OccurredAt: occurrence.OccurredAt, Projection: occurrence.Projection, Failure: occurrence.Failure}); err != nil {
+		return Occurrence{}, fmt.Errorf("invalid persisted author activity %s: %w", occurrence.OccurrenceID, err)
+	}
+	return occurrence, nil
+}
+
+func decodeTime(raw any) (time.Time, error) {
+	switch value := raw.(type) {
+	case time.Time:
+		return value.UTC(), nil
+	case string:
+		return parseStoredTime(value)
+	case []byte:
+		return parseStoredTime(string(value))
+	default:
+		return time.Time{}, fmt.Errorf("unsupported time value %T", raw)
+	}
+}
+
+func parseStoredTime(value string) (time.Time, error) {
+	var lastErr error
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05.999999999 -0700 MST", "2006-01-02 15:04:05 -0700 MST"} {
+		parsed, err := time.Parse(layout, strings.TrimSpace(value))
+		if err == nil {
+			return parsed.UTC(), nil
+		}
+		lastErr = err
+	}
+	return time.Time{}, lastErr
+}

--- a/internal/runtime/authoractivity/postgres_test.go
+++ b/internal/runtime/authoractivity/postgres_test.go
@@ -1,0 +1,146 @@
+package authoractivity
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+func TestPostgresSingletonOrdersByCommitAndRollbackReusesSequence(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+
+	txA, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storyA, err := Begin(ctx, txA, DialectPostgres)
+	if err != nil {
+		t.Fatal(err)
+	}
+	draftA := testDraft(KindInboundReceived, "received", now)
+	draftA.DedupKey = "postgres-a"
+	if err := Record(storyA, draftA); err != nil {
+		t.Fatal(err)
+	}
+
+	type blockedResult struct {
+		tx    *sql.Tx
+		story context.Context
+		err   error
+	}
+	blocked := make(chan blockedResult, 1)
+	go func() {
+		txB, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			blocked <- blockedResult{err: err}
+			return
+		}
+		storyB, err := Begin(ctx, txB, DialectPostgres)
+		blocked <- blockedResult{tx: txB, story: storyB, err: err}
+	}()
+
+	select {
+	case result := <-blocked:
+		if result.tx != nil {
+			_ = result.tx.Rollback()
+		}
+		t.Fatalf("second story acquired singleton before first committed: %v", result.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	before, err := List(ctx, db, DialectPostgres, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.Occurrences) != 0 {
+		t.Fatalf("reader observed uncommitted occurrence: %#v", before.Occurrences)
+	}
+	if err := Finalize(storyA); err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	resultB := <-blocked
+	if resultB.err != nil {
+		t.Fatal(resultB.err)
+	}
+	draftB := testDraft(KindEventEmitted, "emitted", now.Add(time.Second))
+	draftB.DedupKey = "postgres-b"
+	if err := Record(resultB.story, draftB); err != nil {
+		t.Fatal(err)
+	}
+	if err := Finalize(resultB.story); err != nil {
+		t.Fatal(err)
+	}
+	if err := resultB.tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	txRollback, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rollbackStory, err := Begin(ctx, txRollback, DialectPostgres)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rolledBack := testDraft(KindCardLifecycle, "created", now.Add(2*time.Second))
+	rolledBack.DedupKey = "postgres-rollback"
+	if err := Record(rollbackStory, rolledBack); err != nil {
+		t.Fatal(err)
+	}
+	if err := Finalize(rollbackStory); err != nil {
+		t.Fatal(err)
+	}
+	if err := txRollback.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	third := testDraft(KindRunLifecycle, "started", now.Add(3*time.Second))
+	third.DedupKey = "postgres-third"
+	commitDrafts(t, db, DialectPostgres, third)
+
+	listed, err := List(ctx, db, DialectPostgres, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Occurrences) != 3 || listed.Occurrences[0].Sequence != 1 || listed.Occurrences[1].Sequence != 2 || listed.Occurrences[2].Sequence != 3 {
+		t.Fatalf("ordered occurrences = %#v", listed.Occurrences)
+	}
+}
+
+func TestSQLitePostgresRegistryPersistenceParity(t *testing.T) {
+	_, postgres, _ := testutil.StartPostgres(t)
+	sqlite := openAuthorActivitySQLite(t)
+	now := time.Date(2026, 7, 14, 13, 0, 0, 0, time.UTC)
+	drafts := make([]Draft, 0, 32)
+	for _, kind := range Kinds() {
+		for transition := range kindContracts[kind].Transitions {
+			draft := testDraft(kind, transition, now.Add(time.Duration(len(drafts))*time.Millisecond))
+			if failureRequired(kind, transition) {
+				draft.Failure = testFailure(t)
+			}
+			drafts = append(drafts, draft)
+		}
+	}
+	commitDrafts(t, sqlite, DialectSQLite, drafts...)
+	commitDrafts(t, postgres, DialectPostgres, drafts...)
+	sqliteRows, err := List(context.Background(), sqlite, DialectSQLite, ListOptions{Limit: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postgresRows, err := List(context.Background(), postgres, DialectPostgres, ListOptions{Limit: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(sqliteRows, postgresRows) {
+		t.Fatalf("backend rows differ\nsqlite: %#v\npostgres: %#v", sqliteRows, postgresRows)
+	}
+}

--- a/internal/runtime/authoractivity/read.go
+++ b/internal/runtime/authoractivity/read.go
@@ -1,0 +1,75 @@
+package authoractivity
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+type Queryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func List(ctx context.Context, db Queryer, dialect Dialect, opts ListOptions) (ListResult, error) {
+	if db == nil {
+		return ListResult{}, fmt.Errorf("author activity reader is required")
+	}
+	if opts.AfterSequence < 0 {
+		return ListResult{}, fmt.Errorf("author activity cursor must be non-negative")
+	}
+	if opts.Limit == 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit < 1 || opts.Limit > 500 {
+		return ListResult{}, fmt.Errorf("author activity limit must be between 1 and 500")
+	}
+	if dialect != DialectPostgres && dialect != DialectSQLite {
+		return ListResult{}, fmt.Errorf("author activity dialect %q is not supported", dialect)
+	}
+	where := []string{"sequence > " + bind(dialect, 1)}
+	args := []any{opts.AfterSequence}
+	filters := []struct {
+		column string
+		value  string
+	}{{"run_id", opts.RunID}, {"entity_id", opts.EntityID}, {"agent_id", opts.AgentID}, {"flow_id", opts.FlowID}}
+	for _, filter := range filters {
+		value := strings.TrimSpace(filter.value)
+		if value == "" {
+			continue
+		}
+		args = append(args, value)
+		placeholder := bind(dialect, len(args))
+		if dialect == DialectPostgres && (filter.column == "run_id" || filter.column == "entity_id") {
+			placeholder += "::uuid"
+		}
+		where = append(where, filter.column+" = "+placeholder)
+	}
+	args = append(args, opts.Limit)
+	query := occurrenceSelect + " WHERE " + strings.Join(where, " AND ") + " ORDER BY sequence ASC LIMIT " + bind(dialect, len(args))
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return ListResult{}, fmt.Errorf("list author activity: %w", err)
+	}
+	defer rows.Close()
+	result := ListResult{Occurrences: make([]Occurrence, 0, opts.Limit)}
+	for rows.Next() {
+		occurrence, err := scanOccurrence(rows)
+		if err != nil {
+			return ListResult{}, err
+		}
+		result.Occurrences = append(result.Occurrences, occurrence)
+		result.NextCursor = occurrence.Sequence
+	}
+	if err := rows.Err(); err != nil {
+		return ListResult{}, fmt.Errorf("list author activity: %w", err)
+	}
+	return result, nil
+}
+
+func bind(dialect Dialect, index int) string {
+	if dialect == DialectPostgres {
+		return fmt.Sprintf("$%d", index)
+	}
+	return "?"
+}

--- a/internal/runtime/authoractivity/render.go
+++ b/internal/runtime/authoractivity/render.go
@@ -1,0 +1,232 @@
+package authoractivity
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+type RenderMode string
+
+const (
+	RenderTTY    RenderMode = "tty"
+	RenderPlain  RenderMode = "plain"
+	RenderNDJSON RenderMode = "ndjson"
+)
+
+type Palette struct {
+	Time    func(string) string
+	Subject func(string) string
+	Success func(string) string
+	Warning func(string) string
+	Failure func(string) string
+}
+
+type RenderOptions struct {
+	Mode    RenderMode
+	Width   int
+	Palette Palette
+}
+
+func Render(w io.Writer, occurrences []Occurrence, opts RenderOptions) error {
+	if w == nil {
+		return fmt.Errorf("author activity writer is required")
+	}
+	if opts.Mode == "" {
+		opts.Mode = RenderPlain
+	}
+	if opts.Mode == RenderNDJSON {
+		encoder := json.NewEncoder(w)
+		encoder.SetEscapeHTML(false)
+		for _, occurrence := range occurrences {
+			if err := validateOccurrenceForRender(occurrence); err != nil {
+				return err
+			}
+			if err := encoder.Encode(occurrence); err != nil {
+				return fmt.Errorf("render author activity NDJSON: %w", err)
+			}
+		}
+		return nil
+	}
+	if opts.Mode != RenderPlain && opts.Mode != RenderTTY {
+		return fmt.Errorf("author activity render mode %q is not supported", opts.Mode)
+	}
+	width := opts.Width
+	if width <= 0 || width > 120 {
+		width = 120
+	}
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	for _, occurrence := range occurrences {
+		line, continuation, err := humanLine(occurrence, opts)
+		if err != nil {
+			return err
+		}
+		line = truncateLine(line, width)
+		if _, err := fmt.Fprintln(writer, line); err != nil {
+			return err
+		}
+		if continuation != "" {
+			continuation = truncateLine("          "+continuation, width)
+			if _, err := fmt.Fprintln(writer, continuation); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func humanLine(occurrence Occurrence, opts RenderOptions) (string, string, error) {
+	if err := validateOccurrenceForRender(occurrence); err != nil {
+		return "", "", err
+	}
+	timestamp := occurrence.OccurredAt.Format("15:04:05")
+	subject, err := activitySubject(occurrence)
+	if err != nil {
+		return "", "", err
+	}
+	action := activityAction(occurrence)
+	if opts.Mode == RenderTTY {
+		timestamp = apply(opts.Palette.Time, timestamp)
+		subject = apply(opts.Palette.Subject, subject)
+		switch {
+		case occurrence.Failure != nil || strings.Contains(action, "failed"):
+			action = apply(opts.Palette.Failure, action)
+		case strings.Contains(action, "uncertain") || strings.Contains(action, "warning") || strings.Contains(action, "stalled"):
+			action = apply(opts.Palette.Warning, action)
+		default:
+			action = apply(opts.Palette.Success, action)
+		}
+	}
+	line := strings.Join([]string{timestamp, subject, action}, "  ")
+	if !diagnosticRouteRequired(occurrence) {
+		return line, "", nil
+	}
+	route := "swarm logs --level error"
+	if occurrence.RunID != "" {
+		route = "swarm logs --run " + occurrence.RunID + " --level error"
+	}
+	return line, route, nil
+}
+
+func diagnosticRouteRequired(occurrence Occurrence) bool {
+	if occurrence.Failure != nil {
+		return true
+	}
+	return occurrence.Kind == KindAgentLifecycle && occurrence.Transition == "failed"
+}
+
+func activitySubject(occurrence Occurrence) (string, error) {
+	contract, ok := kindContracts[occurrence.Kind]
+	if !ok {
+		return "", fmt.Errorf("author activity kind %q is not registered", occurrence.Kind)
+	}
+	projection := occurrence.Projection
+	switch contract.SubjectStrategy {
+	case subjectTypedIdentity:
+		return strings.TrimSpace(projection.SubjectType) + "[" + strings.TrimSpace(projection.SubjectID) + "]", nil
+	case subjectProducer:
+		return strings.TrimSpace(projection.ProducerID), nil
+	case subjectAdapter:
+		return strings.TrimSpace(projection.Adapter), nil
+	default:
+		return "", fmt.Errorf("author activity %s subject strategy is not registered", occurrence.Kind)
+	}
+}
+
+func validateOccurrenceForRender(occurrence Occurrence) error {
+	if err := ValidateDraft(Draft{
+		OccurrenceID: occurrence.OccurrenceID, Kind: occurrence.Kind, Version: occurrence.Version,
+		Transition: occurrence.Transition, SourceOwner: occurrence.SourceOwner, SourceIdentity: occurrence.SourceIdentity,
+		DedupKey: occurrence.DedupKey, OccurredAt: occurrence.OccurredAt, RunID: occurrence.RunID,
+		EntityID: occurrence.EntityID, AgentID: occurrence.AgentID, FlowID: occurrence.FlowID,
+		Projection: occurrence.Projection, Failure: occurrence.Failure,
+	}); err != nil {
+		return fmt.Errorf("render author activity occurrence: %w", err)
+	}
+	return nil
+}
+
+func activityAction(occurrence Occurrence) string {
+	p := occurrence.Projection
+	switch occurrence.Kind {
+	case KindInboundReceived:
+		return "message received"
+	case KindEventEmitted:
+		return suffix("emitted", p.EventType)
+	case KindEntityLifecycle:
+		if occurrence.Transition == "stage_changed" {
+			return strings.TrimSpace("moved " + p.OldState + " -> " + p.NewState)
+		}
+		return suffix("created", "stage "+p.NewState)
+	case KindDeliveryLifecycle:
+		switch occurrence.Transition {
+		case "in_progress":
+			return "in flight"
+		case "delivered":
+			return "sent"
+		case "failed":
+			return "failed, retrying"
+		default:
+			return "failed"
+		}
+	case KindDeadLetterRecorded:
+		return "event failed"
+	case KindActivityLifecycle:
+		return mapAction(occurrence.Transition, map[string]string{"started": "in flight", "succeeded": "completed", "failed": "failed", "uncertain": "outcome uncertain"})
+	case KindEffectLifecycle:
+		return mapAction(occurrence.Transition, map[string]string{"launched": "in flight", "terminal_failure": "failed", "outcome_uncertain": "outcome uncertain"})
+	case KindTurnLifecycle:
+		return "turn " + occurrence.Transition
+	case KindTurnToolCompleted:
+		return suffix("tool completed", p.ToolName)
+	case KindCardLifecycle:
+		return occurrence.Transition
+	case KindAgentLifecycle:
+		return occurrence.Transition
+	case KindDirectiveLifecycle:
+		return "directive " + strings.ReplaceAll(occurrence.Transition, "_", " ")
+	case KindRunLifecycle:
+		return strings.ReplaceAll(occurrence.Transition, "_", " ")
+	case KindPlatformSignal:
+		return strings.ReplaceAll(occurrence.Transition, "_", " ")
+	default:
+		return occurrence.Transition
+	}
+}
+
+func truncateLine(line string, width int) string {
+	if utf8.RuneCountInString(line) <= width {
+		return line
+	}
+	if width <= 1 {
+		return "…"
+	}
+	runes := []rune(line)
+	return string(runes[:width-1]) + "…"
+}
+
+func suffix(prefix, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return prefix
+	}
+	return prefix + " " + value
+}
+
+func mapAction(value string, mapping map[string]string) string {
+	if mapped := mapping[value]; mapped != "" {
+		return mapped
+	}
+	return strings.ReplaceAll(value, "_", " ")
+}
+
+func apply(fn func(string) string, value string) string {
+	if fn == nil {
+		return value
+	}
+	return fn(value)
+}

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -3,6 +3,7 @@ package bus_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"slices"
@@ -1659,10 +1660,21 @@ func TestEventBusPostgresPublicationClaimsDoNotExhaustPersistencePool(t *testing
 				}()
 			}
 			close(start)
-			for i := 0; i < poolSize; i++ {
-				requireSignalBefore(t, claimed, 5*time.Second, "aligned PostgreSQL publication claim")
+			if form == "mutation_bound" {
+				// Mutation-bound publications own the global author-story order
+				// lock before acquiring event-specific publication claims. Release
+				// the first story so the remaining stories can enter in order.
+				requireSignalBefore(t, claimed, 5*time.Second, "first serialized PostgreSQL publication claim")
+				close(release)
+				for i := 1; i < poolSize; i++ {
+					requireSignalBefore(t, claimed, 5*time.Second, "subsequent serialized PostgreSQL publication claim")
+				}
+			} else {
+				for i := 0; i < poolSize; i++ {
+					requireSignalBefore(t, claimed, 5*time.Second, "aligned PostgreSQL publication claim")
+				}
+				close(release)
 			}
-			close(release)
 			for i := 0; i < poolSize; i++ {
 				if err := requireErrorBefore(t, errs, 10*time.Second, "pool-saturated publication"); err != nil {
 					t.Fatal(err)
@@ -2496,7 +2508,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeWithoutPersis
 			eventID:   "10000000-0000-0000-0000-000000000002",
 			eventType: events.EventType("platform.recovery_failed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", platformSignalFixturePayload(t, eventType), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 	}
@@ -2557,7 +2569,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000001",
 			eventType: events.EventType("platform.agent_failed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", platformSignalFixturePayload(t, eventType), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -2573,7 +2585,7 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			eventID:   "20000000-0000-0000-0000-000000000003",
 			eventType: events.EventType("platform.budget_threshold_crossed"),
 			event: func(id string, eventType events.EventType) events.Event {
-				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+				return eventtest.RuntimeDiagnostic(id, eventType, "runtime", "", platformSignalFixturePayload(t, eventType), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 			},
 		},
 		{
@@ -2620,6 +2632,29 @@ func TestEventBusPublish_RuntimeOwnedStandalonePlatformRunsConvergeAfterFinalRec
 			}
 		})
 	}
+}
+
+func platformSignalFixturePayload(t *testing.T, eventType events.EventType) []byte {
+	t.Helper()
+	payload := map[string]any{}
+	switch eventType {
+	case events.EventType("platform.agent_failed"), events.EventType("platform.recovery_failed"):
+		failure := runtimefailures.Normalize(runtimefailures.New(
+			runtimefailures.ClassInternalFailure,
+			"unclassified_runtime_error",
+			"eventbus-test",
+			"publish_platform_signal",
+			nil,
+		), "eventbus-test", "publish_platform_signal")
+		payload["failure"] = &failure
+	case events.EventType("platform.budget_threshold_crossed"):
+		payload["level"] = "warning"
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal platform signal fixture %s: %v", eventType, err)
+	}
+	return raw
 }
 
 func TestEventBusRuntimeIngressPauseQueuesAndResumeReleases(t *testing.T) {

--- a/internal/runtime/bus/run_control_dispatch_test.go
+++ b/internal/runtime/bus/run_control_dispatch_test.go
@@ -2,6 +2,7 @@ package bus_test
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
-	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/testutil"
@@ -285,17 +285,10 @@ func TestEventBusRunControlPauseQueuesPostCommitEmitBeforeInterceptors(t *testin
 			time.Now().UTC(),
 		),
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin tx: %v", err)
-	}
-	txctx := runtimepipeline.WithPipelineSQLTxContext(ctx, tx)
-	if err := eb.EngineOutbox().WriteOutbox(txctx, []runtimeengine.EmitIntent{intent}); err != nil {
-		_ = tx.Rollback()
+	if err := pg.RunEventTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		return eb.EngineOutbox().WriteOutbox(txctx, []runtimeengine.EmitIntent{intent})
+	}); err != nil {
 		t.Fatalf("WriteOutbox: %v", err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit outbox tx: %v", err)
 	}
 
 	if _, err := controller.Pause(ctx, runtimeruncontrol.TransitionRequest{RunID: runID, Reason: "test", ControlledBy: "test"}); err != nil {

--- a/internal/runtime/deadletters/record.go
+++ b/internal/runtime/deadletters/record.go
@@ -26,8 +26,14 @@ type Record struct {
 	Timestamp       string
 }
 
-type execer interface {
+type InsertResult struct {
+	DeadLetterID string
+	Inserted     bool
+}
+
+type queryExecer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 func Insert(ctx context.Context, db *sql.DB, rec Record) error {
@@ -39,11 +45,11 @@ func Insert(ctx context.Context, db *sql.DB, rec Record) error {
 		return fmt.Errorf("begin dead letter transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	changed, err := insert(ctx, tx, rec)
+	result, err := insert(ctx, tx, rec)
 	if err != nil {
 		return err
 	}
-	if changed {
+	if result.Inserted {
 		if _, err := runforkrevision.CaptureForEvent(ctx, tx, rec.OriginalEventID, runforkrevision.FamilyDeadLetters); err != nil {
 			return err
 		}
@@ -55,14 +61,18 @@ func Insert(ctx context.Context, db *sql.DB, rec Record) error {
 }
 
 func InsertTx(ctx context.Context, tx *sql.Tx, rec Record) error {
-	if tx == nil {
-		return fmt.Errorf("dead letter tx is required")
-	}
-	_, err := insert(ctx, tx, rec)
+	_, err := InsertTxWithResult(ctx, tx, rec)
 	return err
 }
 
-func insert(ctx context.Context, db execer, rec Record) (bool, error) {
+func InsertTxWithResult(ctx context.Context, tx *sql.Tx, rec Record) (InsertResult, error) {
+	if tx == nil {
+		return InsertResult{}, fmt.Errorf("dead letter tx is required")
+	}
+	return insert(ctx, tx, rec)
+}
+
+func insert(ctx context.Context, db queryExecer, rec Record) (InsertResult, error) {
 	rec.OriginalEventID = strings.TrimSpace(rec.OriginalEventID)
 	rec.OriginalEvent = strings.TrimSpace(rec.OriginalEvent)
 	rec.EntityID = strings.TrimSpace(rec.EntityID)
@@ -70,7 +80,7 @@ func insert(ctx context.Context, db execer, rec Record) (bool, error) {
 	rec.HandlerNode = strings.TrimSpace(rec.HandlerNode)
 	rec.Timestamp = strings.TrimSpace(rec.Timestamp)
 	if rec.OriginalEventID == "" {
-		return false, fmt.Errorf("dead letter original event id is required")
+		return InsertResult{}, fmt.Errorf("dead letter original event id is required")
 	}
 	if rec.EntityID != "" {
 		if _, err := uuid.Parse(rec.EntityID); err != nil {
@@ -79,7 +89,7 @@ func insert(ctx context.Context, db execer, rec Record) (bool, error) {
 	}
 	failureJSON, err := runtimefailures.MarshalEnvelope(rec.Failure)
 	if err != nil {
-		return false, fmt.Errorf("dead letter failure is invalid: %w", err)
+		return InsertResult{}, fmt.Errorf("dead letter failure is invalid: %w", err)
 	}
 	if len(rec.OriginalPayload) == 0 {
 		rec.OriginalPayload = json.RawMessage(`{}`)
@@ -93,34 +103,37 @@ func insert(ctx context.Context, db execer, rec Record) (bool, error) {
 	if rec.Timestamp == "" {
 		rec.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
 	}
+	deadLetterID := uuid.NewString()
 
 	const q = `
 		INSERT INTO dead_letters (
-			original_event_id, original_event, original_payload, entity_id, flow_instance,
+			dead_letter_id, original_event_id, original_event, original_payload, entity_id, flow_instance,
 			failure, retry_count, chain_depth, handler_node, created_at
 		)
 		SELECT
 			$1::uuid,
-			COALESCE(NULLIF($2, ''), COALESCE((SELECT e.event_name FROM events e WHERE e.event_id = $1::uuid), '')),
-			COALESCE(NULLIF($3::jsonb, 'null'::jsonb), COALESCE((SELECT e.payload FROM events e WHERE e.event_id = $1::uuid), '{}'::jsonb)),
-			NULLIF($4, '')::uuid,
-			COALESCE(NULLIF($5, ''), COALESCE((SELECT NULLIF(e.flow_instance, '') FROM events e WHERE e.event_id = $1::uuid), 'runtime')),
-			$6::jsonb,
-			$7,
+			$2::uuid,
+			COALESCE(NULLIF($3, ''), COALESCE((SELECT e.event_name FROM events e WHERE e.event_id = $2::uuid), '')),
+			COALESCE(NULLIF($4::jsonb, 'null'::jsonb), COALESCE((SELECT e.payload FROM events e WHERE e.event_id = $2::uuid), '{}'::jsonb)),
+			NULLIF($5, '')::uuid,
+			COALESCE(NULLIF($6, ''), COALESCE((SELECT NULLIF(e.flow_instance, '') FROM events e WHERE e.event_id = $2::uuid), 'runtime')),
+			$7::jsonb,
 			$8,
-			NULLIF($9, ''),
-			COALESCE(NULLIF($10, '')::timestamptz, now())
+			$9,
+			NULLIF($10, ''),
+			COALESCE(NULLIF($11, '')::timestamptz, now())
 		WHERE NOT EXISTS (
 			SELECT 1
 			FROM dead_letters dl
-			WHERE dl.original_event_id = $1::uuid
-			  AND dl.failure = $6::jsonb
-			  AND COALESCE(dl.handler_node, '') = COALESCE(NULLIF($9, ''), '')
+			WHERE dl.original_event_id = $2::uuid
+			  AND dl.failure = $7::jsonb
+			  AND COALESCE(dl.handler_node, '') = COALESCE(NULLIF($10, ''), '')
 		)
 	`
 	result, err := db.ExecContext(
 		ctx,
 		q,
+		deadLetterID,
 		rec.OriginalEventID,
 		rec.OriginalEvent,
 		[]byte(rec.OriginalPayload),
@@ -133,11 +146,23 @@ func insert(ctx context.Context, db execer, rec Record) (bool, error) {
 		rec.Timestamp,
 	)
 	if err != nil {
-		return false, fmt.Errorf("insert dead letter: %w", err)
+		return InsertResult{}, fmt.Errorf("insert dead letter: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("read inserted dead letter rows: %w", err)
+		return InsertResult{}, fmt.Errorf("read inserted dead letter rows: %w", err)
 	}
-	return rows > 0, nil
+	if rows > 0 {
+		return InsertResult{DeadLetterID: deadLetterID, Inserted: true}, nil
+	}
+	if err := db.QueryRowContext(ctx, `
+		SELECT dead_letter_id::text
+		FROM dead_letters
+		WHERE original_event_id = $1::uuid
+		  AND failure = $2::jsonb
+		  AND COALESCE(handler_node, '') = COALESCE(NULLIF($3, ''), '')
+	`, rec.OriginalEventID, failureJSON, rec.HandlerNode).Scan(&deadLetterID); err != nil {
+		return InsertResult{}, fmt.Errorf("load existing dead letter: %w", err)
+	}
+	return InsertResult{DeadLetterID: deadLetterID}, nil
 }

--- a/internal/runtime/destructivereset/cleanup_catalog.go
+++ b/internal/runtime/destructivereset/cleanup_catalog.go
@@ -21,6 +21,7 @@ type CleanupPolicy struct {
 
 func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 	return []CleanupCatalogEntry{
+		{Table: "author_activity_occurrences", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "author_activity_occurrences.run_id", DeleteOrderGroup: 1},
 		{Table: "run_fork_fact_revisions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_fact_revisions.run_id", DeleteOrderGroup: 1},
 		{Table: "run_fork_revisions", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_revisions.run_id", DeleteOrderGroup: 2},
 		{Table: "run_fork_revision_heads", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "run_fork_revision_heads.run_id", DeleteOrderGroup: 3},
@@ -63,6 +64,7 @@ func DefaultPlatformCleanupCatalog() []CleanupCatalogEntry {
 		{Table: "events", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteByRunID, PredicateOwner: "events.run_id", DeleteOrderGroup: 5},
 		{Table: "runs", TableKind: CleanupTableKindPlatform, Classification: CleanupDeleteAll, PredicateOwner: "runs.run_id cleanup set", DeleteOrderGroup: 6},
 		{Table: "runtime_store_metadata", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "immutable runtime store creation origin", PreservationProof: "must survive destructive runtime cleanup unchanged"},
+		{Table: "author_activity_order", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "monotonic author activity cursor authority", PreservationProof: "cursor identity must never be reused after destructive cleanup"},
 		{Table: "api_idempotency", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "API idempotency/auth-like state", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "runtime_ingress_state", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "singleton runtime ingress owner", PreservationProof: "must survive destructive runtime cleanup"},
 		{Table: "agents", TableKind: CleanupTableKindPlatform, Classification: CleanupPreserve, PredicateOwner: "agent registry/config state", PreservationProof: "must survive destructive runtime cleanup"},

--- a/internal/runtime/diagnostics_test.go
+++ b/internal/runtime/diagnostics_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -81,20 +83,11 @@ func (s runtimeLogCapabilityStub) PersistRuntimeLog(ctx context.Context, record 
 		`, string(record.Payload), parentEventID)
 		return err
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return runRuntimeLogStoryForTest(ctx, s.db, func(storyctx context.Context, tx *sql.Tx) error {
+		if err := ensureRuntimeLogRunRowInStoryForTest(storyctx, tx, runID); err != nil {
+			return err
 		}
-	}()
-	if err := ensureRuntimeLogRunRowForTest(ctx, tx, runID); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `
+		if _, err := tx.ExecContext(storyctx, `
 		INSERT INTO events (
 			run_id, event_id, event_name, entity_id, flow_instance, scope, payload,
 			chain_depth, produced_by, produced_by_type, source_event_id, created_at
@@ -103,22 +96,43 @@ func (s runtimeLogCapabilityStub) PersistRuntimeLog(ctx context.Context, record 
 			NULLIF($1,'')::uuid, gen_random_uuid(), 'platform.runtime_log', NULL, NULL, 'global', $2::jsonb,
 			0, 'runtime', 'platform', NULLIF($3,'')::uuid, now()
 		)
-	`, runID, string(record.Payload), parentEventID); err != nil {
-		return err
-	}
-	if err := storerunlifecycle.SyncCounts(ctx, tx, runID); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	committed = true
-	return nil
+		`, runID, string(record.Payload), parentEventID); err != nil {
+			return err
+		}
+		return storerunlifecycle.SyncCounts(storyctx, tx, runID)
+	})
 }
 
 func newTestRuntimeLogger(db *sql.DB, stub runtimeLogCapabilityStub) *RuntimeLogger {
 	stub.db = db
 	return NewRuntimeLogger(stub)
+}
+
+func expectRuntimeLogStoryBegin(mock sqlmock.Sqlmock) {
+	mock.ExpectExec(`INSERT INTO author_activity_order`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`SELECT last_sequence FROM author_activity_order`).
+		WillReturnRows(sqlmock.NewRows([]string{"last_sequence"}).AddRow(0))
+}
+
+func expectRuntimeLogRunAbsent(mock sqlmock.Sqlmock, runID string) {
+	mock.ExpectQuery(`SELECT EXISTS \(SELECT 1 FROM runs`).
+		WithArgs(runID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+}
+
+func expectRuntimeLogStoryFinalize(mock sqlmock.Sqlmock, runID string) {
+	mock.ExpectQuery(`SELECT CAST\(occurrence_id AS TEXT\).*FROM author_activity_occurrences.*WHERE dedup_key`).
+		WithArgs("run-created:" + runID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"occurrence_id", "sequence", "kind", "version", "transition", "source_owner", "source_identity", "dedup_key",
+			"run_id", "entity_id", "agent_id", "flow_id", "projection", "failure", "occurred_at",
+		}))
+	mock.ExpectExec(`UPDATE author_activity_order SET last_sequence`).
+		WithArgs(int64(1), int64(0)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO author_activity_occurrences`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
 func TestRuntimeLogger_Log_AppendsSpecShapedFlightRecorderEntry(t *testing.T) {
@@ -372,6 +386,8 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 
 	mock.ExpectBegin()
+	expectRuntimeLogStoryBegin(mock)
+	expectRuntimeLogRunAbsent(mock, runID)
 	mock.ExpectExec(`INSERT INTO runs`).
 		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -381,6 +397,7 @@ func TestRuntimeLogger_Log_EnsuresRunRowBeforePersistingRunScopedEntry(t *testin
 	mock.ExpectExec(`UPDATE runs`).
 		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectRuntimeLogStoryFinalize(mock, runID)
 	mock.ExpectCommit()
 
 	logger := newTestRuntimeLogger(db, runtimeLogCapabilityStub{enabled: true, hasRunID: true})
@@ -708,6 +725,8 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnRunRowFailure(t *testing
 	runID := uuid.NewString()
 	runRowErr := errors.New("run row failed")
 	mock.ExpectBegin()
+	expectRuntimeLogStoryBegin(mock)
+	expectRuntimeLogRunAbsent(mock, runID)
 	mock.ExpectExec(`INSERT INTO runs`).
 		WithArgs(runID).
 		WillReturnError(runRowErr)
@@ -744,6 +763,8 @@ func TestRuntimeLogger_Log_DoesNotAppendFlightRecorderOnSyncCountsFailure(t *tes
 	runID := uuid.NewString()
 	syncErr := errors.New("sync failed")
 	mock.ExpectBegin()
+	expectRuntimeLogStoryBegin(mock)
+	expectRuntimeLogRunAbsent(mock, runID)
 	mock.ExpectExec(`INSERT INTO runs`).
 		WithArgs(runID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -1062,10 +1083,44 @@ func countRuntimeLogRowsForRun(t *testing.T, db *sql.DB, runID string) int {
 	return count
 }
 
-func ensureRuntimeLogRunRowForTest(ctx context.Context, db storerunlifecycle.DBTX, runID string) error {
+func ensureRuntimeLogRunRowForTest(ctx context.Context, db *sql.DB, runID string) error {
+	return runRuntimeLogStoryForTest(ctx, db, func(storyctx context.Context, tx *sql.Tx) error {
+		return ensureRuntimeLogRunRowInStoryForTest(storyctx, tx, runID)
+	})
+}
+
+func runRuntimeLogStoryForTest(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) error) error {
 	if db == nil {
 		return nil
 	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	storyctx, err := runtimeauthoractivity.Begin(runtimepipeline.WithPipelineSQLTxContext(ctx, tx), tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return err
+	}
+	if err := fn(storyctx, tx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func ensureRuntimeLogRunRowInStoryForTest(ctx context.Context, db storerunlifecycle.DBTX, runID string) error {
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
 		return nil

--- a/internal/runtime/mutationlog/mutationlog.go
+++ b/internal/runtime/mutationlog/mutationlog.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -55,6 +57,9 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 	if db == nil {
 		return ErrInvalidMutationLogWriter("mutation log DB is required")
 	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return ErrInvalidMutationLogWriter(err.Error())
+	}
 	tx, ok := db.(*sql.Tx)
 	if !ok {
 		return ErrInvalidMutationLogWriter("PostgreSQL mutation log writes require the existing persistence transaction")
@@ -100,20 +105,73 @@ func Insert(ctx context.Context, db DBTX, rec Record) error {
 		}
 	}
 
+	mutationID := uuid.NewString()
+	occurredAt := time.Now().UTC()
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO entity_mutations (
-			run_id, entity_id, field, old_value, new_value,
-			caused_by_event, writer_type, writer_id, handler_step
+			mutation_id, run_id, entity_id, field, old_value, new_value,
+			caused_by_event, writer_type, writer_id, handler_step, created_at
 		)
 		VALUES (
-			$1::uuid, $2::uuid, $3, $4::jsonb, $5::jsonb,
-			NULLIF($6, '')::uuid, $7, $8, NULLIF($9, '')
+			$1::uuid, $2::uuid, $3::uuid, $4, $5::jsonb, $6::jsonb,
+			NULLIF($7, '')::uuid, $8, $9, NULLIF($10, ''), $11
 		)
-	`, runID, entityID, field, oldValue, newValue, causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep))
+	`, mutationID, runID, entityID, field, oldValue, newValue, causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep), occurredAt)
 	if err != nil {
 		return err
 	}
-	return nil
+	if field != "current_state" {
+		return nil
+	}
+	draft, admitted, err := AuthorActivityDraft(runID, mutationID, rec, occurredAt)
+	if err != nil {
+		return err
+	}
+	if !admitted {
+		return nil
+	}
+	return runtimeauthoractivity.Record(ctx, draft)
+}
+
+func AuthorActivityDraft(runID, mutationID string, rec Record, occurredAt time.Time) (runtimeauthoractivity.Draft, bool, error) {
+	if strings.TrimSpace(rec.Field) != "current_state" {
+		return runtimeauthoractivity.Draft{}, false, nil
+	}
+	runID = strings.TrimSpace(runID)
+	mutationID = strings.TrimSpace(mutationID)
+	entityID := strings.TrimSpace(rec.EntityID)
+	writerType := strings.TrimSpace(rec.WriterType)
+	writerID := strings.TrimSpace(rec.WriterID)
+	if runID == "" || mutationID == "" || entityID == "" || writerType == "" || writerID == "" || occurredAt.IsZero() {
+		return runtimeauthoractivity.Draft{}, false, ErrInvalidMutationLogWriter("author activity requires run_id, mutation_id, entity_id, writer, and occurred_at")
+	}
+	oldState := authorActivityStateString(rec.OldValue)
+	newState := authorActivityStateString(rec.NewValue)
+	transition := "stage_changed"
+	if oldState == "" {
+		transition = "created"
+	}
+	return runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindEntityLifecycle, Transition: transition,
+		SourceOwner: "entity_mutations", SourceIdentity: mutationID, DedupKey: "entity-mutation:" + mutationID,
+		OccurredAt: occurredAt.UTC(), RunID: runID, EntityID: entityID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "entity", SubjectID: entityID, OldState: oldState, NewState: newState,
+			WriterType: writerType, WriterID: writerID,
+		},
+	}, true, nil
+}
+
+func authorActivityStateString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case *string:
+		if typed != nil {
+			return strings.TrimSpace(*typed)
+		}
+	}
+	return ""
 }
 
 func BuildEntityStateDiffRecords(entityID string, before, after EntityStateProjection, writer Writer) ([]Record, error) {

--- a/internal/runtime/mutationlog/mutationlog_test.go
+++ b/internal/runtime/mutationlog/mutationlog_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -163,10 +164,17 @@ func insertMutationLogRecord(t *testing.T, ctx context.Context, db *sql.DB, reco
 		t.Fatalf("begin mutation log transaction: %v", err)
 	}
 	defer tx.Rollback()
-	if err := Insert(ctx, tx, record); err != nil {
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
 		return err
 	}
-	if _, err := runforkrevision.CaptureCurrentTransaction(ctx, tx); err != nil {
+	if err := Insert(storyctx, tx, record); err != nil {
+		return err
+	}
+	if _, err := runforkrevision.CaptureCurrentTransaction(storyctx, tx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/internal/runtime/pipeline/activity_engine_test.go
+++ b/internal/runtime/pipeline/activity_engine_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/providerconnectors"
 	"github.com/division-sh/swarm/internal/providertriggers"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -1005,7 +1006,14 @@ func (r *activityCommitAckLossRunner) RunRuntimeMutationContext(ctx context.Cont
 	}()
 	postCommit := make([]func(), 0, 2)
 	txctx := withPipelinePostCommitActions(WithPipelineSQLTxContext(ctx, tx), &postCommit)
-	if err := fn(txctx); err != nil {
+	storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectSQLite)
+	if err != nil {
+		return err
+	}
+	if err := fn(storyctx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1466,6 +1474,27 @@ func createActivityJournalSQLiteSchema(t *testing.T, ctx context.Context, db *sq
 			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			completed_at TEXT,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE author_activity_order (
+			singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+			last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0)
+		)`,
+		`CREATE TABLE author_activity_occurrences (
+			occurrence_id TEXT PRIMARY KEY,
+			sequence BIGINT NOT NULL UNIQUE CHECK (sequence > 0),
+			kind TEXT NOT NULL,
+			version INTEGER NOT NULL CHECK (version = 1),
+			transition TEXT NOT NULL,
+			source_owner TEXT NOT NULL,
+			source_identity TEXT NOT NULL,
+			dedup_key TEXT NOT NULL UNIQUE,
+			run_id TEXT,
+			entity_id TEXT,
+			agent_id TEXT,
+			flow_id TEXT,
+			projection TEXT NOT NULL DEFAULT '{}',
+			failure TEXT,
+			occurred_at TIMESTAMP NOT NULL
 		)`,
 	} {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {

--- a/internal/runtime/pipeline/activity_journal.go
+++ b/internal/runtime/pipeline/activity_journal.go
@@ -104,7 +104,7 @@ func (s *WorkflowInstanceStore) StartActivityAttempt(ctx context.Context, rec Ac
 		if err := validateActivityAttemptClaimIdentity(out, rec); err != nil {
 			return err
 		}
-		return nil
+		return recordActivityAttemptStory(txctx, out, ActivityAttemptStatusStarted)
 	})
 	if err != nil {
 		return ActivityAttemptRecord{}, false, err
@@ -230,7 +230,7 @@ func (s *WorkflowInstanceStore) CompleteActivityAttempt(ctx context.Context, rec
 			return fmt.Errorf("activity attempt %s remained started after terminal update", rec.RequestEventID)
 		}
 		out = loaded
-		return nil
+		return recordActivityAttemptStory(txctx, out, out.Status)
 	})
 	if err != nil {
 		return ActivityAttemptRecord{}, err
@@ -291,7 +291,7 @@ func (s *WorkflowInstanceStore) MarkActivityAttemptUncertain(ctx context.Context
 			return fmt.Errorf("activity attempt %s was not found for uncertain transition", rec.RequestEventID)
 		}
 		out = loaded
-		return nil
+		return recordActivityAttemptStory(txctx, out, ActivityAttemptStatusUncertain)
 	})
 	if err != nil {
 		return ActivityAttemptRecord{}, err

--- a/internal/runtime/pipeline/author_activity.go
+++ b/internal/runtime/pipeline/author_activity.go
@@ -1,0 +1,204 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+)
+
+func runPostgresAuthorActivityMutation(ctx context.Context, db *sql.DB, label string, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if tx, ok := PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		if runtimeauthoractivity.InMutation(ctx, tx) {
+			return fn(ctx, tx)
+		}
+		if !runtimeauthoractivity.FinalizedMutation(ctx, tx) {
+			return fmt.Errorf("%s entered from a raw transaction without author activity ownership", label)
+		}
+		ctx = WithoutPipelineSQLTxContext(ctx)
+	}
+	if db == nil {
+		return fmt.Errorf("%s database is required", label)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("%s begin transaction: %w", label, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	txctx := withSQLTxContext(ctx, tx)
+	storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return err
+	}
+	if err := fn(storyctx, tx); err != nil {
+		return err
+	}
+	if err := CapturePipelineRunForkRevisionChanges(storyctx, tx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("%s commit transaction: %w", label, err)
+	}
+	committed = true
+	return nil
+}
+
+type systemNodeDeliveryStorySource struct {
+	DeliveryID string
+	RunID      string
+	EventType  string
+	EntityID   string
+	FlowID     string
+	RetryCount int
+}
+
+func loadSystemNodeDeliveryStorySource(ctx context.Context, tx *sql.Tx, nodeID, eventID, targetJSON string, postgres bool) (systemNodeDeliveryStorySource, error) {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return systemNodeDeliveryStorySource{}, err
+	}
+	query := `
+		SELECT CAST(d.delivery_id AS TEXT), COALESCE(CAST(d.run_id AS TEXT), ''), COALESCE(e.event_name, ''),
+		       COALESCE(CAST(e.entity_id AS TEXT), ''), COALESCE(e.flow_instance, ''), COALESCE(d.retry_count, 0)
+		FROM event_deliveries d
+		JOIN events e ON e.event_id = d.event_id
+		WHERE d.event_id = ? AND d.subscriber_type = 'node' AND d.subscriber_id = ?
+		  AND COALESCE(d.delivery_target_route, '{}') = ?
+	`
+	args := []any{eventID, nodeID, targetJSON}
+	if postgres {
+		query = `
+			SELECT d.delivery_id::text, COALESCE(d.run_id::text, ''), COALESCE(e.event_name, ''),
+			       COALESCE(e.entity_id::text, ''), COALESCE(e.flow_instance, ''), COALESCE(d.retry_count, 0)
+			FROM event_deliveries d
+			JOIN events e ON e.event_id = d.event_id
+			WHERE d.event_id = $1::uuid AND d.subscriber_type = 'node' AND d.subscriber_id = $2
+			  AND COALESCE(d.delivery_target_route, '{}'::jsonb) = $3::jsonb
+			FOR UPDATE OF d
+		`
+	}
+	var source systemNodeDeliveryStorySource
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&source.DeliveryID, &source.RunID, &source.EventType, &source.EntityID, &source.FlowID, &source.RetryCount); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return systemNodeDeliveryStorySource{}, fmt.Errorf("%w: node %s event %s", ErrSystemNodeDeliveryAuthorityMissing, nodeID, eventID)
+		}
+		return systemNodeDeliveryStorySource{}, err
+	}
+	return source, nil
+}
+
+func recordSystemNodeDeliveryStory(ctx context.Context, source systemNodeDeliveryStorySource, nodeID, transition, reasonCode string, retryCount int, failure *runtimefailures.Envelope, occurredAt time.Time) error {
+	dedupKey := fmt.Sprintf("delivery:%s:%s:%d", source.DeliveryID, transition, retryCount)
+	persistedAt, found, err := runtimeauthoractivity.PersistedOccurredAt(ctx, dedupKey)
+	if err != nil {
+		return err
+	}
+	if found {
+		occurredAt = persistedAt
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindDeliveryLifecycle, Transition: transition,
+		SourceOwner: "event_deliveries", SourceIdentity: source.DeliveryID,
+		DedupKey:   dedupKey,
+		OccurredAt: occurredAt, RunID: source.RunID, EntityID: source.EntityID, FlowID: source.FlowID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "node", SubjectID: strings.TrimSpace(nodeID), EventType: source.EventType,
+			SubscriberType: "node", SubscriberID: strings.TrimSpace(nodeID), RetryCount: intPointer(retryCount),
+			ReasonCode: strings.TrimSpace(reasonCode),
+		},
+		Failure: failure,
+	})
+}
+
+func recordActivityAttemptStory(ctx context.Context, rec ActivityAttemptRecord, transition string) error {
+	retry := rec.Attempt
+	eventType := rec.ResultEventType
+	failure := rec.Failure
+	if transition == ActivityAttemptStatusStarted {
+		eventType = ""
+		failure = nil
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindActivityLifecycle, Transition: transition,
+		SourceOwner: "activity_attempts", SourceIdentity: rec.RequestEventID,
+		DedupKey:   "activity:" + rec.RequestEventID + ":" + transition,
+		OccurredAt: activityOccurrenceTime(rec, transition), RunID: rec.RunID, EntityID: rec.EntityID, FlowID: rec.FlowInstance,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "activity", SubjectID: rec.ActivityID, NodeID: rec.NodeID, Activity: rec.ActivityID,
+			Tool: rec.Tool, EffectClass: rec.EffectClass, Attempt: intPointer(retry), EventType: eventType,
+		},
+		Failure: failure,
+	})
+}
+
+func activityOccurrenceTime(rec ActivityAttemptRecord, transition string) time.Time {
+	if transition == ActivityAttemptStatusStarted && !rec.StartedAt.IsZero() {
+		return rec.StartedAt.UTC()
+	}
+	if transition != "started" && rec.CompletedAt != nil && !rec.CompletedAt.IsZero() {
+		return rec.CompletedAt.UTC()
+	}
+	if !rec.UpdatedAt.IsZero() {
+		return rec.UpdatedAt.UTC()
+	}
+	if !rec.StartedAt.IsZero() {
+		return rec.StartedAt.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func intPointer(value int) *int { return &value }
+
+func recordPipelineDeadLetter(ctx context.Context, db *sql.DB, rec runtimedeadletters.Record) error {
+	return runPostgresAuthorActivityMutation(ctx, db, "pipeline dead letter", func(txctx context.Context, tx *sql.Tx) error {
+		if err := runtimeauthoractivity.Require(txctx); err != nil {
+			return err
+		}
+		var runID, entityID, flowID, eventType string
+		if err := tx.QueryRowContext(txctx, `SELECT COALESCE(run_id::text, ''), COALESCE(entity_id::text, ''), COALESCE(flow_instance, ''), event_name FROM events WHERE event_id = $1::uuid`, strings.TrimSpace(rec.OriginalEventID)).Scan(&runID, &entityID, &flowID, &eventType); err != nil {
+			return fmt.Errorf("load pipeline dead letter source event: %w", err)
+		}
+		result, err := runtimedeadletters.InsertTxWithResult(txctx, tx, rec)
+		if err != nil {
+			return err
+		}
+		if !result.Inserted {
+			return nil
+		}
+		identity := result.DeadLetterID
+		retry := rec.RetryCount
+		return runtimeauthoractivity.Record(txctx, runtimeauthoractivity.Draft{
+			Kind: runtimeauthoractivity.KindDeadLetterRecorded, Transition: "recorded",
+			SourceOwner: "dead_letters", SourceIdentity: identity, DedupKey: "dead-letter:" + identity,
+			OccurredAt: pipelineDeadLetterOccurredAt(rec.Timestamp), RunID: runID, EntityID: entityID, FlowID: flowID,
+			Projection: runtimeauthoractivity.Projection{
+				SubjectType: "event", SubjectID: strings.TrimSpace(rec.OriginalEventID), EventType: eventType,
+				RetryCount: &retry, ReasonCode: rec.Failure.Detail.Code, NodeID: strings.TrimSpace(rec.HandlerNode),
+			},
+			Failure: &rec.Failure,
+		})
+	})
+}
+
+func pipelineDeadLetterOccurredAt(raw string) time.Time {
+	if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw)); err == nil {
+		return parsed.UTC()
+	}
+	return time.Now().UTC()
+}

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -402,7 +402,7 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 		pc.notifyTestLifecycleHandlerCompleted(ctx, nodeID, evt, "failed")
 		failure := runtimefailures.FromError(err, runtimeWorkflowID, "execute_handler")
 		if errors.Is(err, runtimeengine.ErrChainDepthExceeded) {
-			_ = runtimedeadletters.Insert(ctx, pc.db, runtimedeadletters.Record{
+			_ = recordPipelineDeadLetter(ctx, pc.db, runtimedeadletters.Record{
 				OriginalEventID: strings.TrimSpace(evt.ID()),
 				Failure:         failure.Failure,
 				ChainDepth:      evt.ChainDepth(),
@@ -446,7 +446,7 @@ func (pc *PipelineCoordinator) recordWorkflowHandlerFailure(ctx context.Context,
 		})
 	}
 	if pc.db != nil {
-		_ = runtimedeadletters.Insert(ctx, pc.db, runtimedeadletters.Record{
+		_ = recordPipelineDeadLetter(ctx, pc.db, runtimedeadletters.Record{
 			OriginalEventID: strings.TrimSpace(evt.ID()),
 			OriginalEvent:   strings.TrimSpace(string(evt.Type())),
 			OriginalPayload: evt.Payload(),
@@ -484,19 +484,13 @@ func (pc *PipelineCoordinator) recordInterceptedEmitDeadLetters(ctx context.Cont
 			ChainDepth:      intercepted.ChainDepth,
 			HandlerNode:     firstNonEmptyString(nodeID+":"+eventType, nodeID),
 		}
-		recordDeadLetter := func() {
-			if pc.db == nil {
-				return
-			}
-			if err := runtimedeadletters.Insert(ctx, pc.db, rec); err != nil {
+		if pc.db != nil {
+			if err := recordPipelineDeadLetter(ctx, pc.db, rec); err != nil {
 				pc.logRuntimeWarn(ctx, "workflow-runtime", "intercepted_emit_dead_letter_persist_failed", strings.TrimSpace(trigger.ID()), strings.TrimSpace(string(trigger.Type())), runtimeWorkflowID, entityID, map[string]any{
 					"intercepted_event_type": eventType,
 					"handler_node":           nodeID,
 				}, err)
 			}
-		}
-		if !queuePipelinePostCommitAction(ctx, recordDeadLetter) {
-			recordDeadLetter()
 		}
 		deadLetterPayload := map[string]any{
 			"original_event":   eventType,

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -284,7 +284,7 @@ func (n *systemNodeRunner) emitDeadLetter(ctx context.Context, evt events.Event,
 		"timestamp":        time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if n.db != nil {
-		if err := runtimedeadletters.Insert(ctx, n.db, runtimedeadletters.Record{
+		if err := recordPipelineDeadLetter(ctx, n.db, runtimedeadletters.Record{
 			OriginalEventID: strings.TrimSpace(evt.ID()),
 			OriginalEvent:   strings.TrimSpace(string(evt.Type())),
 			OriginalPayload: evt.Payload(),
@@ -677,27 +677,9 @@ func persistSystemNodeProcessedReceiptAndSettleDelivery(ctx context.Context, db 
 	if nodeID == "" || eventID == "" {
 		return nil
 	}
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx, tx, nodeID, eventID, sideEffects)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin system node processed receipt tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx, tx, nodeID, eventID, sideEffects); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit system node processed receipt tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "system node processed receipt", func(txctx context.Context, tx *sql.Tx) error {
+		return persistSystemNodeProcessedReceiptAndSettleDeliveryTx(txctx, tx, nodeID, eventID, sideEffects)
+	})
 }
 
 func persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
@@ -713,27 +695,9 @@ func persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx context.Con
 	if nodeID == "" || eventID == "" {
 		return nil
 	}
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx, tx, nodeID, eventID, target, sideEffects)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin targeted system node processed receipt tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(ctx, tx, nodeID, eventID, target, sideEffects); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit targeted system node processed receipt tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "targeted system node processed receipt", func(txctx context.Context, tx *sql.Tx) error {
+		return persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(txctx, tx, nodeID, eventID, target, sideEffects)
+	})
 }
 
 func persistSystemNodeProcessedReceiptAndSettleDeliveryTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, sideEffects string) error {
@@ -870,27 +834,9 @@ func markPostgresSystemNodeDeliveryInProgress(ctx context.Context, db *sql.DB, n
 		return nil
 	}
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryInProgressTx(ctx, tx, nodeID, eventID, retryLimit)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin system node delivery start tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryInProgressTx(ctx, tx, nodeID, eventID, retryLimit); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit system node delivery start tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "system node delivery start", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryInProgressTx(txctx, tx, nodeID, eventID, retryLimit)
+	})
 }
 
 func markPostgresSystemNodeDeliveryInProgressForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
@@ -907,27 +853,9 @@ func markPostgresSystemNodeDeliveryInProgressForTarget(ctx context.Context, db *
 		return nil
 	}
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin targeted system node delivery start tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryInProgressForTargetTx(ctx, tx, nodeID, eventID, target, retryLimit); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit targeted system node delivery start tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "targeted system node delivery start", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryInProgressForTargetTx(txctx, tx, nodeID, eventID, target, retryLimit)
+	})
 }
 
 func markPostgresSystemNodeDeliveryInProgressTx(ctx context.Context, tx *sql.Tx, nodeID, eventID string, retryLimit int) error {
@@ -1020,27 +948,9 @@ func markPostgresSystemNodeDeliveryFailed(ctx context.Context, db *sql.DB, nodeI
 		return nil
 	}
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryFailedTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin system node delivery failure tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryFailedTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit system node delivery failure tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "system node delivery failure", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryFailedTx(txctx, tx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
+	})
 }
 
 func markPostgresSystemNodeDeliveryFailedForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, reasonCode string, failure *runtimefailures.Envelope, retryCount, retryLimit int) error {
@@ -1057,27 +967,9 @@ func markPostgresSystemNodeDeliveryFailedForTarget(ctx context.Context, db *sql.
 		return nil
 	}
 	retryLimit = normalizeSystemNodeRetryLimit(retryLimit)
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryFailedForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin targeted system node delivery failure tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryFailedForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit targeted system node delivery failure tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "targeted system node delivery failure", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryFailedForTargetTx(txctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
+	})
 }
 
 func markPostgresSystemNodeDeliveryFailedTx(ctx context.Context, tx *sql.Tx, nodeID, eventID, reasonCode string, failure *runtimefailures.Envelope, retryCount, retryLimit int) error {
@@ -1175,27 +1067,9 @@ func markPostgresSystemNodeDeliveryDeadLetter(ctx context.Context, db *sql.DB, n
 	if nodeID == "" || eventID == "" {
 		return nil
 	}
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryDeadLetterTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin system node delivery dead-letter tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryDeadLetterTx(ctx, tx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit system node delivery dead-letter tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "system node delivery dead-letter", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryDeadLetterTx(txctx, tx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
+	})
 }
 
 func markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, db *sql.DB, nodeID, eventID string, target events.RouteIdentity, reasonCode string, failure *runtimefailures.Envelope, retryCount int, sideEffects string) error {
@@ -1211,27 +1085,9 @@ func markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, db *
 	if nodeID == "" || eventID == "" {
 		return nil
 	}
-	if tx, ok := PipelineSQLTxFromContext(ctx); ok {
-		return markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin targeted system node delivery dead-letter tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := markPostgresSystemNodeDeliveryDeadLetterForTargetTx(ctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects); err != nil {
-		return err
-	}
-	if err := commitSystemNodeRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit targeted system node delivery dead-letter tx: %w", err)
-	}
-	committed = true
-	return nil
+	return runPostgresAuthorActivityMutation(ctx, db, "targeted system node delivery dead-letter", func(txctx context.Context, tx *sql.Tx) error {
+		return markPostgresSystemNodeDeliveryDeadLetterForTargetTx(txctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
+	})
 }
 
 func commitSystemNodeRevisionTx(ctx context.Context, tx *sql.Tx) error {

--- a/internal/runtime/pipeline/system_node_receipt_store.go
+++ b/internal/runtime/pipeline/system_node_receipt_store.go
@@ -229,10 +229,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDelivery(ctx con
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeProcessedAndSettleDelivery(ctx, nodeID, eventID, sideEffects)
-	}
-	return persistSystemNodeProcessedReceiptAndSettleDelivery(ctx, s.db, nodeID, eventID, sideEffects)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, "{}", !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeProcessedAndSettleDelivery(txctx, nodeID, eventID, sideEffects)
+		} else {
+			err = persistSystemNodeProcessedReceiptAndSettleDeliveryTx(txctx, tx, nodeID, eventID, sideEffects)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "delivered", "node_processed", source.RetryCount, nil, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDeliveryForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, sideEffects string) error {
@@ -245,10 +256,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeProcessedAndSettleDeliveryForTarge
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeProcessedAndSettleDeliveryForTarget(ctx, nodeID, eventID, target, sideEffects)
-	}
-	return persistSystemNodeProcessedReceiptAndSettleDeliveryForTarget(ctx, s.db, nodeID, eventID, target, sideEffects)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, systemNodeRouteIdentityJSON(target), !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeProcessedAndSettleDeliveryForTarget(txctx, nodeID, eventID, target, sideEffects)
+		} else {
+			err = persistSystemNodeProcessedReceiptAndSettleDeliveryForTargetTx(txctx, tx, nodeID, eventID, target, sideEffects)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "delivered", "node_processed", source.RetryCount, nil, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgress(ctx context.Context, nodeID, eventID string, retryLimit int) error {
@@ -258,10 +280,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgress(ctx context.Con
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryInProgress(ctx, nodeID, eventID, retryLimit)
-	}
-	return markPostgresSystemNodeDeliveryInProgress(ctx, s.db, nodeID, eventID, retryLimit)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, "{}", !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryInProgress(txctx, nodeID, eventID, retryLimit)
+		} else {
+			err = markPostgresSystemNodeDeliveryInProgressTx(txctx, tx, nodeID, eventID, retryLimit)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "in_progress", "node_processing", source.RetryCount, nil, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgressForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, retryLimit int) error {
@@ -275,10 +308,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryInProgressForTarget(ctx co
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryInProgressForTarget(ctx, nodeID, eventID, target, retryLimit)
-	}
-	return markPostgresSystemNodeDeliveryInProgressForTarget(ctx, s.db, nodeID, eventID, target, retryLimit)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, systemNodeRouteIdentityJSON(target), !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryInProgressForTarget(txctx, nodeID, eventID, target, retryLimit)
+		} else {
+			err = markPostgresSystemNodeDeliveryInProgressForTargetTx(txctx, tx, nodeID, eventID, target, retryLimit)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "in_progress", "node_processing", source.RetryCount, nil, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailed(ctx context.Context, nodeID, eventID, reasonCode string, failure *runtimefailures.Envelope, retryCount, retryLimit int) error {
@@ -288,10 +332,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailed(ctx context.Context
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryFailed(ctx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
-	}
-	return markPostgresSystemNodeDeliveryFailed(ctx, s.db, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, "{}", !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryFailed(txctx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
+		} else {
+			err = markPostgresSystemNodeDeliveryFailedTx(txctx, tx, nodeID, eventID, reasonCode, failure, retryCount, retryLimit)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "failed", sanitizeSystemNodeReasonCode(reasonCode, "handler_failure"), sanitizedSystemNodeRetryCount(retryCount), failure, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailedForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode string, failure *runtimefailures.Envelope, retryCount, retryLimit int) error {
@@ -305,10 +360,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryFailedForTarget(ctx contex
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryFailedForTarget(ctx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
-	}
-	return markPostgresSystemNodeDeliveryFailedForTarget(ctx, s.db, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, systemNodeRouteIdentityJSON(target), !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryFailedForTarget(txctx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
+		} else {
+			err = markPostgresSystemNodeDeliveryFailedForTargetTx(txctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, retryLimit)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "failed", sanitizeSystemNodeReasonCode(reasonCode, "handler_failure"), sanitizedSystemNodeRetryCount(retryCount), failure, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Context, nodeID, eventID, reasonCode string, failure *runtimefailures.Envelope, retryCount int, sideEffects string) error {
@@ -317,10 +383,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetter(ctx context.Con
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryDeadLetter(ctx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
-	}
-	return markPostgresSystemNodeDeliveryDeadLetter(ctx, s.db, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, "{}", !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryDeadLetter(txctx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
+		} else {
+			err = markPostgresSystemNodeDeliveryDeadLetterTx(txctx, tx, nodeID, eventID, reasonCode, failure, retryCount, sideEffects)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "dead_letter", sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted"), sanitizedSystemNodeRetryCount(retryCount), failure, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetterForTarget(ctx context.Context, nodeID, eventID string, target events.RouteIdentity, reasonCode string, failure *runtimefailures.Envelope, retryCount int, sideEffects string) error {
@@ -333,10 +410,21 @@ func (s *WorkflowInstanceStore) MarkSystemNodeDeliveryDeadLetterForTarget(ctx co
 	if s == nil || s.db == nil || nodeID == "" || eventID == "" {
 		return nil
 	}
-	if s.isSQLite() {
-		return s.markSQLiteSystemNodeDeliveryDeadLetterForTarget(ctx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
-	}
-	return markPostgresSystemNodeDeliveryDeadLetterForTarget(ctx, s.db, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		source, err := loadSystemNodeDeliveryStorySource(txctx, tx, nodeID, eventID, systemNodeRouteIdentityJSON(target), !s.isSQLite())
+		if err != nil {
+			return err
+		}
+		if s.isSQLite() {
+			err = s.markSQLiteSystemNodeDeliveryDeadLetterForTarget(txctx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
+		} else {
+			err = markPostgresSystemNodeDeliveryDeadLetterForTargetTx(txctx, tx, nodeID, eventID, target, reasonCode, failure, retryCount, sideEffects)
+		}
+		if err != nil {
+			return err
+		}
+		return recordSystemNodeDeliveryStory(txctx, source, nodeID, "dead_letter", sanitizeSystemNodeReasonCode(reasonCode, "retry_exhausted"), sanitizedSystemNodeRetryCount(retryCount), failure, time.Now().UTC())
+	})
 }
 
 func (s *WorkflowInstanceStore) markSQLiteSystemNodeProcessedAndSettleDelivery(ctx context.Context, nodeID, eventID, sideEffects string) error {

--- a/internal/runtime/pipeline/workflow_instance_store.go
+++ b/internal/runtime/pipeline/workflow_instance_store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
@@ -293,7 +294,9 @@ func (s *WorkflowInstanceStore) Upsert(ctx context.Context, instance WorkflowIns
 	if !ok {
 		return nil
 	}
-	return s.upsertSpec(ctx, identity.RowID(), identity.StorageRef, instance)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		return s.upsertSpec(txctx, identity.RowID(), identity.StorageRef, instance)
+	})
 }
 
 func (s *WorkflowInstanceStore) Create(ctx context.Context, instance WorkflowInstance) error {
@@ -310,7 +313,9 @@ func (s *WorkflowInstanceStore) Create(ctx context.Context, instance WorkflowIns
 	if !ok {
 		return nil
 	}
-	return s.createSpec(ctx, identity.RowID(), identity.StorageRef, instance)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, _ *sql.Tx) error {
+		return s.createSpec(txctx, identity.RowID(), identity.StorageRef, instance)
+	})
 }
 
 func normalizeWorkflowInstanceForPersistence(instance WorkflowInstance) (WorkflowInstance, runtimeflowidentity.Persisted, bool, error) {
@@ -383,49 +388,22 @@ func (s *WorkflowInstanceStore) MutateE(ctx context.Context, instanceID string, 
 	if s.isSQLite() {
 		return s.mutateSQLiteE(ctx, instanceID, fn)
 	}
-	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	committed := !ownedTx
-	if ownedTx {
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
-			}
-		}()
-	}
-	ctx = WithPipelineSQLTxContext(ctx, tx)
-	if err := lockWorkflowInstanceMutation(ctx, tx, instanceID); err != nil {
-		return err
-	}
-	instance, ok, err := s.loadSpec(ctx, workflowInstanceLookupKeys(instanceID), true)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		instance = WorkflowInstance{InstanceID: instanceID}
-	}
-	if err := fn(&instance); err != nil {
-		return err
-	}
-	if err := s.Upsert(ctx, instance); err != nil {
-		return err
-	}
-	if ownedTx {
-		runID, err := runtimecurrentstate.RequireRunID(ctx)
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		if err := lockWorkflowInstanceMutation(txctx, tx, instanceID); err != nil {
+			return err
+		}
+		instance, ok, err := s.loadSpec(txctx, workflowInstanceLookupKeys(instanceID), true)
 		if err != nil {
 			return err
 		}
-		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
+		if !ok {
+			instance = WorkflowInstance{InstanceID: instanceID}
+		}
+		if err := fn(&instance); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		committed = true
-	}
-	return nil
+		return s.Upsert(txctx, instance)
+	})
 }
 
 func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef string, terminatedAt time.Time) error {
@@ -457,41 +435,25 @@ func (s *WorkflowInstanceStore) MarkTerminated(ctx context.Context, storageRef s
 	if terminatedAt.IsZero() {
 		terminatedAt = time.Now().UTC()
 	}
-	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	committed := !ownedTx
-	if ownedTx {
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
-			}
-		}()
-	}
-	result, err := tx.ExecContext(ctx, `
-		UPDATE flow_instances
-		SET status = 'terminated',
-		    terminated_at = COALESCE(terminated_at, $2)
-		WHERE instance_id = $1
-	`, storageRef, terminatedAt)
-	if err != nil {
-		return err
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows == 0 {
-		return fmt.Errorf("flow instance not found: %s", storageRef)
-	}
-	if ownedTx {
-		if err := tx.Commit(); err != nil {
+	return s.runInPipelineTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		result, err := tx.ExecContext(txctx, `
+			UPDATE flow_instances
+			SET status = 'terminated',
+			    terminated_at = COALESCE(terminated_at, $2)
+			WHERE instance_id = $1
+		`, storageRef, terminatedAt)
+		if err != nil {
 			return err
 		}
-		committed = true
-	}
-	return nil
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return fmt.Errorf("flow instance not found: %s", storageRef)
+		}
+		return nil
+	})
 }
 
 func markWorkflowInstanceTerminatedSpecTx(ctx context.Context, tx *sql.Tx, storageRef string, terminatedAt time.Time) error {
@@ -742,7 +704,13 @@ func (s *WorkflowInstanceStore) runInPipelineTransaction(ctx context.Context, fn
 		return nil
 	}
 	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
-		return fn(ctx, tx)
+		if runtimeauthoractivity.InMutation(ctx, tx) {
+			return fn(ctx, tx)
+		}
+		if !runtimeauthoractivity.FinalizedMutation(ctx, tx) {
+			return fmt.Errorf("pipeline mutation entered from a raw transaction without author activity ownership")
+		}
+		ctx = WithoutPipelineSQLTxContext(ctx)
 	}
 	if s.isSQLite() {
 		if s.runtimeMutation != nil {
@@ -782,12 +750,22 @@ func (s *WorkflowInstanceStore) runInPipelineTransactionOnce(ctx context.Context
 	txctx = WithPipelineSQLTxContext(txctx, tx)
 	txctx = withPipelinePostCommitActions(txctx, &postCommit)
 	txctx = withPipelineRollbackActions(txctx, &rollbackActions)
-	if err := fn(txctx, tx); err != nil {
+	storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := fn(storyctx, tx); err != nil {
 		_ = tx.Rollback()
 		flushPipelineRollbackActions(rollbackActions)
 		return err
 	}
-	if err := CapturePipelineRunForkRevisionChanges(txctx, tx); err != nil {
+	if err := CapturePipelineRunForkRevisionChanges(storyctx, tx); err != nil {
+		_ = tx.Rollback()
+		flushPipelineRollbackActions(rollbackActions)
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
 		_ = tx.Rollback()
 		flushPipelineRollbackActions(rollbackActions)
 		return err
@@ -1144,17 +1122,9 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	if err != nil {
 		return err
 	}
-	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	committed := !ownedTx
-	if ownedTx {
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
-			}
-		}()
+	tx, ok := sqlTxFromContext(ctx)
+	if !ok || tx == nil || !runtimeauthoractivity.InMutation(ctx, tx) {
+		return fmt.Errorf("workflow instance upsert requires the pipeline story transaction owner")
 	}
 	previous, err := loadTrackedEntityStateProjection(ctx, tx, runID, rowID)
 	if err != nil {
@@ -1250,10 +1220,8 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 	}); err != nil {
 		return err
 	}
-	if !ownedTx {
-		if err := declarePipelineRunForkRevisionChange(ctx, runID, runforkrevision.FamilyTimers); err != nil {
-			return err
-		}
+	if err := declarePipelineRunForkRevisionChange(ctx, runID, runforkrevision.FamilyTimers); err != nil {
+		return err
 	}
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM timers
@@ -1292,15 +1260,6 @@ func (s *WorkflowInstanceStore) upsertSpec(ctx context.Context, rowID, storageRe
 			return err
 		}
 	}
-	if ownedTx {
-		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
-			return err
-		}
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		committed = true
-	}
 	return nil
 }
 
@@ -1309,17 +1268,9 @@ func (s *WorkflowInstanceStore) createSpec(ctx context.Context, rowID, storageRe
 	if err != nil {
 		return err
 	}
-	tx, ownedTx, err := workflowInstanceStoreTx(ctx, s.db)
-	if err != nil {
-		return err
-	}
-	committed := !ownedTx
-	if ownedTx {
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
-			}
-		}()
+	tx, ok := sqlTxFromContext(ctx)
+	if !ok || tx == nil || !runtimeauthoractivity.InMutation(ctx, tx) {
+		return fmt.Errorf("workflow instance create requires the pipeline story transaction owner")
 	}
 	if err := lockWorkflowInstanceMutation(ctx, tx, storageRef); err != nil {
 		return err
@@ -1428,15 +1379,6 @@ func (s *WorkflowInstanceStore) createSpec(ctx context.Context, rowID, storageRe
 			return err
 		}
 	}
-	if ownedTx {
-		if err := captureWorkflowInstanceRevision(ctx, tx, runID); err != nil {
-			return err
-		}
-		if err := tx.Commit(); err != nil {
-			return err
-		}
-		committed = true
-	}
 	return nil
 }
 
@@ -1465,25 +1407,6 @@ func workflowInstanceCreateTargetExists(ctx context.Context, tx *sql.Tx, runID, 
 		return false, err
 	}
 	return exists, nil
-}
-
-func workflowInstanceStoreTx(ctx context.Context, db *sql.DB) (*sql.Tx, bool, error) {
-	if tx, ok := sqlTxFromContext(ctx); ok && tx != nil {
-		return tx, false, nil
-	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, false, err
-	}
-	return tx, true, nil
-}
-
-func captureWorkflowInstanceRevision(ctx context.Context, tx *sql.Tx, runID string) error {
-	if err := CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
-		return err
-	}
-	_, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyTimers)
-	return err
 }
 
 func lockWorkflowInstanceMutation(ctx context.Context, tx *sql.Tx, instanceID string) error {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
@@ -616,6 +617,11 @@ func insertSQLiteEntityMutationRecord(ctx context.Context, tx *sql.Tx, runID str
 	if entityID == "" || field == "" || writerType == "" || writerID == "" {
 		return runtimemutationlog.ErrInvalidMutationLogWriter("entity_id, field, writer_type, and writer_id are required")
 	}
+	if field == "current_state" {
+		if err := runtimeauthoractivity.Require(ctx); err != nil {
+			return runtimemutationlog.ErrInvalidMutationLogWriter(err.Error())
+		}
+	}
 	oldValue, err := json.Marshal(rec.OldValue)
 	if err != nil {
 		return err
@@ -630,16 +636,28 @@ func insertSQLiteEntityMutationRecord(ctx context.Context, tx *sql.Tx, runID str
 			causedByEvent = parsed
 		}
 	}
+	mutationID := uuid.NewString()
+	occurredAt := time.Now().UTC()
 	if _, err := tx.ExecContext(ctx, `
 			INSERT INTO entity_mutations (
 				mutation_id, run_id, entity_id, field, old_value, new_value,
 				caused_by_event, writer_type, writer_id, handler_step, created_at
 			)
 			VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), ?)
-	`, uuid.NewString(), runID, entityID, field, string(oldValue), string(newValue), causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep), time.Now().UTC()); err != nil {
+	`, mutationID, runID, entityID, field, string(oldValue), string(newValue), causedByEvent, writerType, writerID, strings.TrimSpace(rec.HandlerStep), occurredAt); err != nil {
 		return err
 	}
-	return nil
+	if field != "current_state" {
+		return nil
+	}
+	draft, admitted, err := runtimemutationlog.AuthorActivityDraft(runID, mutationID, rec, occurredAt)
+	if err != nil {
+		return err
+	}
+	if !admitted {
+		return nil
+	}
+	return runtimeauthoractivity.Record(ctx, draft)
 }
 
 func (s *WorkflowInstanceStore) replaceWorkflowTimersSQLite(ctx context.Context, tx *sql.Tx, runID, entityID, storageRef string, timers []WorkflowTimerState) error {

--- a/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
+++ b/internal/runtime/pipeline/workflow_instance_store_sqlite_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 	_ "modernc.org/sqlite"
 )
@@ -220,7 +222,11 @@ func TestSQLiteWorkflowInstanceStore_RunPipelineMutationDoesNotRetryActiveTransa
 
 	busyErr := errors.New("SQLITE_BUSY: database is locked")
 	var attempts int32
-	err = store.RunPipelineMutation(WithPipelineSQLTxContext(ctx, tx), func(txctx context.Context) error {
+	txctx, err := runtimeauthoractivity.Begin(WithPipelineSQLTxContext(ctx, tx), tx, runtimeauthoractivity.DialectSQLite)
+	if err != nil {
+		t.Fatalf("begin author activity story: %v", err)
+	}
+	err = store.RunPipelineMutation(txctx, func(txctx context.Context) error {
 		atomic.AddInt32(&attempts, 1)
 		gotTx, ok := PipelineSQLTxFromContext(txctx)
 		if !ok {
@@ -239,8 +245,28 @@ func TestSQLiteWorkflowInstanceStore_RunPipelineMutationDoesNotRetryActiveTransa
 	}
 }
 
-func TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect(t *testing.T) {
+func TestSQLiteWorkflowInstanceStore_RunPipelineMutationRejectsUnownedRawTransaction(t *testing.T) {
 	db := newSQLiteWorkflowInstanceStoreTestDB(t)
+	store := NewSQLiteWorkflowInstanceStore(db)
+	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin raw tx: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	err = store.RunPipelineMutation(WithPipelineSQLTxContext(ctx, tx), func(context.Context) error {
+		t.Fatal("raw transaction callback must not run")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "raw transaction without author activity ownership") {
+		t.Fatalf("RunPipelineMutation error = %v, want unowned raw transaction rejection", err)
+	}
+}
+
+func TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect(t *testing.T) {
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
 	store := NewWorkflowInstanceStore(db)
 	ctx := runtimecorrelation.WithRunID(context.Background(), uuid.NewString())
 	busyErr := errors.New("SQLITE_BUSY: database is locked")
@@ -280,7 +306,14 @@ func (r *recordingRuntimeMutationRunner) RunRuntimeMutationContext(ctx context.C
 	}()
 	postCommit := make([]func(), 0, 4)
 	txctx := withPipelinePostCommitActions(WithPipelineSQLTxContext(ctx, tx), &postCommit)
-	if err := fn(txctx); err != nil {
+	storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectSQLite)
+	if err != nil {
+		return err
+	}
+	if err := fn(storyctx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -443,6 +476,27 @@ func createSQLiteWorkflowInstanceStoreTestSchema(t *testing.T, db *sql.DB) {
 			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			completed_at TEXT,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE author_activity_order (
+			singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+			last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0)
+		)`,
+		`CREATE TABLE author_activity_occurrences (
+			occurrence_id TEXT PRIMARY KEY,
+			sequence BIGINT NOT NULL UNIQUE CHECK (sequence > 0),
+			kind TEXT NOT NULL,
+			version INTEGER NOT NULL CHECK (version = 1),
+			transition TEXT NOT NULL,
+			source_owner TEXT NOT NULL,
+			source_identity TEXT NOT NULL,
+			dedup_key TEXT NOT NULL UNIQUE,
+			run_id TEXT,
+			entity_id TEXT,
+			agent_id TEXT,
+			flow_id TEXT,
+			projection TEXT NOT NULL DEFAULT '{}',
+			failure TEXT,
+			occurred_at TIMESTAMP NOT NULL
 		)`,
 	} {
 		if _, err := db.Exec(stmt); err != nil {

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
@@ -217,7 +218,11 @@ func testActivePipelineSQLTxContext(t *testing.T, db *sql.DB, ctx context.Contex
 		t.Fatalf("BeginTx: %v", err)
 	}
 	t.Cleanup(func() { _ = tx.Rollback() })
-	return WithPipelineSQLTxContext(ctx, tx)
+	storyctx, err := runtimeauthoractivity.Begin(WithPipelineSQLTxContext(ctx, tx), tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		t.Fatalf("begin pipeline author activity story: %v", err)
+	}
+	return storyctx
 }
 
 func TestWorkflowTimerFireAtSnapshotsPolicyDelayAtStart(t *testing.T) {
@@ -1490,6 +1495,10 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "root-collector")
+	ctx, err = runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		t.Fatalf("begin nested completion author activity story: %v", err)
+	}
 	passThrough, emitted, err := pc.Intercept(ctx, completion)
 	if err != nil {
 		t.Fatalf("Intercept: %v", err)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -186,6 +186,7 @@ type Runtime struct {
 	shutdownGate            shutdownAdmission
 	backgroundActive        atomic.Int64
 	payloadValidator        runtimebus.PayloadValidator
+	authorActivityEvents    []string
 
 	Config             *config.Config
 	Stores             Stores
@@ -583,6 +584,31 @@ func bindRuntimeStorePayloadValidator(stores Stores, payloadValidator runtimebus
 	}
 }
 
+func bindRuntimeStoreAuthorActivityCatalog(stores Stores, names []string) {
+	type binder interface{ SetAuthorActivityEventCatalog([]string) }
+	if target, ok := stores.EventStore.(binder); ok && target != nil {
+		target.SetAuthorActivityEventCatalog(names)
+	}
+	if target, ok := stores.InboundStore.(binder); ok && target != nil {
+		target.SetAuthorActivityEventCatalog(names)
+	}
+}
+
+func authoredEventNames(source semanticview.Source) []string {
+	if source == nil {
+		return nil
+	}
+	catalog := source.AuthoredResolvedEventCatalog()
+	names := make([]string, 0, len(catalog))
+	for name := range catalog {
+		if name = strings.TrimSpace(name); name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	boot, err := deps.validated()
 	if err != nil {
@@ -594,17 +620,18 @@ func NewRuntime(ctx context.Context, deps RuntimeDeps) (*Runtime, error) {
 	source := boot.Source
 	mcpTurns := runtimemcp.NewTurnContextRegistry(runtimeactors.ActorFromContext)
 	rt := &Runtime{
-		ownerID:            newRuntimeOwnerID(),
-		Config:             cfg,
-		Stores:             stores,
-		Options:            opts,
-		Workspace:          opts.WorkspaceLifecycle,
-		MCPTurns:           mcpTurns,
-		Authority:          boot.Authority,
-		EmitRegistry:       boot.EmitRegistry,
-		PromptResolver:     boot.PromptResolver,
-		Credentials:        boot.Credentials,
-		ManagedCredentials: boot.ManagedCredentials,
+		ownerID:              newRuntimeOwnerID(),
+		Config:               cfg,
+		Stores:               stores,
+		Options:              opts,
+		Workspace:            opts.WorkspaceLifecycle,
+		MCPTurns:             mcpTurns,
+		Authority:            boot.Authority,
+		EmitRegistry:         boot.EmitRegistry,
+		authorActivityEvents: authoredEventNames(source),
+		PromptResolver:       boot.PromptResolver,
+		Credentials:          boot.Credentials,
+		ManagedCredentials:   boot.ManagedCredentials,
 	}
 
 	if stores.RuntimeLogStore != nil {
@@ -1009,6 +1036,7 @@ func (rt *Runtime) Start(ctx context.Context) error {
 		rt.cleanupStartFailure()
 	}()
 	bindRuntimeStorePayloadValidator(rt.Stores, rt.payloadValidator)
+	bindRuntimeStoreAuthorActivityCatalog(rt.Stores, rt.authorActivityEvents)
 	if rt.RuntimeIngress != nil {
 		if err := rt.RuntimeIngress.SyncState(ctx); err != nil {
 			return fmt.Errorf("sync runtime ingress state: %w", err)

--- a/internal/store/active_run_quiescence.go
+++ b/internal/store/active_run_quiescence.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimedestructivereset "github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/preservationcleanup"
@@ -113,6 +114,11 @@ func (s *PostgresStore) ApplyActiveRunQuiescence(ctx context.Context, req runtim
 			_ = tx.Rollback()
 		}
 	}()
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
+	ctx = storyctx
 
 	var runs []runtimerunquiescence.QuiescedRun
 	if req.AllActiveRuns {
@@ -206,6 +212,9 @@ func (s *PostgresStore) ApplyActiveRunQuiescence(ctx context.Context, req runtim
 			return runtimerunquiescence.Result{}, err
 		}
 	}
+	if err := runtimeauthoractivity.Finalize(ctx); err != nil {
+		return runtimerunquiescence.Result{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return runtimerunquiescence.Result{}, fmt.Errorf("commit active run quiescence tx: %w", err)
 	}
@@ -264,7 +273,7 @@ func (s *SQLiteRuntimeStore) ApplyActiveRunQuiescence(ctx context.Context, req r
 	}
 
 	baseOut := out
-	if err := s.runRuntimeMutation(ctx, "sqlite active run quiescence", func(txctx context.Context, tx *sql.Tx) error {
+	if err := s.runAuthorActivityMutation(ctx, "sqlite active run quiescence", func(txctx context.Context, tx *sql.Tx) error {
 		attemptOut := baseOut
 		var runs []runtimerunquiescence.QuiescedRun
 		var err error
@@ -339,10 +348,7 @@ func (s *SQLiteRuntimeStore) ApplyActiveRunQuiescence(ctx context.Context, req r
 			if !activeRunQuiescenceRunStatusActive(run.Status) {
 				continue
 			}
-			if err := supersedeDecisionCardsForRun(txctx, tx, run.RunID, "run_quiesced", now, false); err != nil {
-				return err
-			}
-			if err := sqliteMarkActiveRunQuiescenceRunTerminalTx(txctx, tx, run.RunID, now); err != nil {
+			if _, err := s.sqliteMarkRunTerminalTx(txctx, tx, run.RunID, "cancelled", nil, now); err != nil {
 				return err
 			}
 			if err := sqliteUpsertActiveRunQuiescenceRunControlTx(txctx, tx, run.RunID, attemptOut.ReasonCode, attemptOut.ControlledBy, now); err != nil {

--- a/internal/store/agent_directive_operations.go
+++ b/internal/store/agent_directive_operations.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	runtimeagentcontrol "github.com/division-sh/swarm/internal/runtime/agentcontrol"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/google/uuid"
@@ -69,7 +70,7 @@ func (s *PostgresStore) ReserveDirectiveOperation(ctx context.Context, req runti
 		op.CreatedAt = req.Now
 		op.UpdatedAt = req.Now
 		reservation = runtimeagentcontrol.DirectiveOperationReservation{Operation: op, Created: true}
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, req.Now, nil)
 	})
 	return reservation, err
 }
@@ -84,7 +85,7 @@ func (s *SQLiteRuntimeStore) ReserveDirectiveOperation(ctx context.Context, req 
 		return runtimeagentcontrol.DirectiveOperationReservation{}, err
 	}
 	var reservation runtimeagentcontrol.DirectiveOperationReservation
-	err = s.runRuntimeMutation(ctx, "sqlite reserve directive operation", func(txctx context.Context, tx *sql.Tx) error {
+	err = s.runAuthorActivityMutation(ctx, "sqlite reserve directive operation", func(txctx context.Context, tx *sql.Tx) error {
 		if err := purgeExpiredSQLiteDirectiveOperationsTx(txctx, tx, req.Now); err != nil {
 			return err
 		}
@@ -116,7 +117,7 @@ func (s *SQLiteRuntimeStore) ReserveDirectiveOperation(ctx context.Context, req 
 		op.CreatedAt = req.Now
 		op.UpdatedAt = req.Now
 		reservation = runtimeagentcontrol.DirectiveOperationReservation{Operation: op, Created: true}
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, req.Now, nil)
 	})
 	return reservation, err
 }
@@ -304,14 +305,14 @@ func (s *PostgresStore) FinalizeDirectiveSuccess(ctx context.Context, operationI
 			op.ExpiresAt = now.Add(normalizeDirectiveTTL(ttl)).UTC()
 		}
 		out = op
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, op.UpdatedAt, nil)
 	})
 	return out, err
 }
 
 func (s *SQLiteRuntimeStore) FinalizeDirectiveSuccess(ctx context.Context, operationID string, now time.Time, ttl time.Duration) (runtimeagentcontrol.DirectiveOperation, error) {
 	var out runtimeagentcontrol.DirectiveOperation
-	err := s.runRuntimeMutation(ctx, "sqlite finalize directive success", func(txctx context.Context, tx *sql.Tx) error {
+	err := s.runAuthorActivityMutation(ctx, "sqlite finalize directive success", func(txctx context.Context, tx *sql.Tx) error {
 		op, ok, err := loadSQLiteDirectiveOperationByID(txctx, tx, operationID)
 		if err != nil || !ok {
 			if err == nil {
@@ -338,7 +339,7 @@ func (s *SQLiteRuntimeStore) FinalizeDirectiveSuccess(ctx context.Context, opera
 			op.ExpiresAt = now.Add(normalizeDirectiveTTL(ttl)).UTC()
 		}
 		out = op
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, op.UpdatedAt, nil)
 	})
 	return out, err
 }
@@ -441,7 +442,7 @@ func (s *PostgresStore) finalizePostgresDirectiveFailure(ctx context.Context, op
 			op.ExpiresAt = now.Add(normalizeDirectiveTTL(ttl)).UTC()
 		}
 		out = op
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, now, &failure)
 	})
 	return out, err
 }
@@ -452,7 +453,7 @@ func (s *SQLiteRuntimeStore) finalizeSQLiteDirectiveFailure(ctx context.Context,
 		return runtimeagentcontrol.DirectiveOperation{}, fmt.Errorf("validate directive operation failure: %w", err)
 	}
 	var out runtimeagentcontrol.DirectiveOperation
-	err = s.runRuntimeMutation(ctx, "sqlite finalize directive failure", func(txctx context.Context, tx *sql.Tx) error {
+	err = s.runAuthorActivityMutation(ctx, "sqlite finalize directive failure", func(txctx context.Context, tx *sql.Tx) error {
 		op, ok, err := loadSQLiteDirectiveOperationByID(txctx, tx, operationID)
 		if err != nil || !ok {
 			if err == nil {
@@ -484,7 +485,7 @@ func (s *SQLiteRuntimeStore) finalizeSQLiteDirectiveFailure(ctx context.Context,
 			op.ExpiresAt = now.Add(normalizeDirectiveTTL(ttl)).UTC()
 		}
 		out = op
-		return nil
+		return recordDirectiveAuthorActivity(txctx, op, now, &failure)
 	})
 	return out, err
 }
@@ -541,14 +542,17 @@ func (s *PostgresStore) transitionPostgresDirectiveOperation(ctx context.Context
 		if err == nil && !ok {
 			err = fmt.Errorf("directive operation not found")
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		return recordDirectiveAuthorActivity(txctx, out, out.UpdatedAt, out.Failure)
 	})
 	return out, err
 }
 
 func (s *SQLiteRuntimeStore) transitionSQLiteDirectiveOperation(ctx context.Context, operationID string, transition func(context.Context, *sql.Tx) error) (runtimeagentcontrol.DirectiveOperation, error) {
 	var out runtimeagentcontrol.DirectiveOperation
-	err := s.runRuntimeMutation(ctx, "sqlite transition directive operation", func(txctx context.Context, tx *sql.Tx) error {
+	err := s.runAuthorActivityMutation(ctx, "sqlite transition directive operation", func(txctx context.Context, tx *sql.Tx) error {
 		if err := transition(txctx, tx); err != nil {
 			if errors.Is(err, runtimeagentcontrol.ErrDirectiveTransitionConflict) {
 				op, ok, loadErr := loadSQLiteDirectiveOperationByID(txctx, tx, operationID)
@@ -567,9 +571,44 @@ func (s *SQLiteRuntimeStore) transitionSQLiteDirectiveOperation(ctx context.Cont
 		if err == nil && !ok {
 			err = fmt.Errorf("directive operation not found")
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		return recordDirectiveAuthorActivity(txctx, out, out.UpdatedAt, out.Failure)
 	})
 	return out, err
+}
+
+func recordDirectiveAuthorActivity(ctx context.Context, op runtimeagentcontrol.DirectiveOperation, occurredAt time.Time, failure *runtimefailures.Envelope) error {
+	transition := ""
+	switch op.State {
+	case runtimeagentcontrol.DirectiveOperationPrepared:
+		transition = "received"
+	case runtimeagentcontrol.DirectiveOperationExecuting:
+		transition = "in_flight"
+	case runtimeagentcontrol.DirectiveOperationSucceeded:
+		transition = "completed"
+	case runtimeagentcontrol.DirectiveOperationFailed:
+		transition = "failed"
+	case runtimeagentcontrol.DirectiveOperationIndeterminate:
+		transition = "outcome_uncertain"
+	case runtimeagentcontrol.DirectiveOperationExecuted:
+		return nil
+	default:
+		return fmt.Errorf("directive operation state %q has no author activity disposition", op.State)
+	}
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindDirectiveLifecycle, Transition: transition,
+		SourceOwner: "agent_directive_operations", SourceIdentity: op.OperationID + ":" + string(op.State),
+		DedupKey: "directive:" + op.OperationID + ":" + string(op.State), OccurredAt: occurredAt.UTC(),
+		RunID: op.ResolvedRunID, AgentID: op.AgentID, Failure: failure,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "agent", SubjectID: op.AgentID, Method: op.Method, Source: op.Source,
+		},
+	})
 }
 
 func (s *PostgresStore) ReconcileDirectiveOperations(ctx context.Context, now time.Time, ttl time.Duration) (runtimeagentcontrol.DirectiveOperationReconcileResult, error) {

--- a/internal/store/agent_lifecycle.go
+++ b/internal/store/agent_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
@@ -97,36 +98,37 @@ func (s *PostgresStore) CommitAgentLifecycleTransition(ctx context.Context, req 
 	if err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
+	var result runtimemanager.AgentLifecycleTransitionResult
+	err = s.runAuthorActivityMutation(ctx, "postgres commit agent lifecycle transition", func(txctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(txctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, "swarm:agent-lifecycle:"+req.AgentID); err != nil {
+			return err
+		}
+		var ok bool
+		var err error
+		if result, ok, err = loadPostgresLifecycleOperationResult(txctx, tx, req); err != nil || ok {
+			return err
+		}
+		previous, exists, err := loadPostgresLifecycleCell(txctx, tx, req.AgentID)
+		if err != nil {
+			return err
+		}
+		if err := validateLifecycleExpectation(req, previous, exists); err != nil {
+			return err
+		}
+		result = lifecycleResult(req, previous, exists)
+		result.Subordinate, err = applyPostgresLifecycleSubordinate(txctx, tx, req)
+		if err != nil {
+			return err
+		}
+		if err := applyPostgresLifecycleCell(txctx, tx, req, result); err != nil {
+			return err
+		}
+		if err := insertPostgresLifecycleEvidence(txctx, tx, req, result); err != nil {
+			return err
+		}
+		return recordAgentLifecycleAuthorActivity(txctx, req, result)
+	})
 	if err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, "swarm:agent-lifecycle:"+req.AgentID); err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	if result, ok, err := loadPostgresLifecycleOperationResult(ctx, tx, req); err != nil || ok {
-		return result, err
-	}
-	previous, exists, err := loadPostgresLifecycleCell(ctx, tx, req.AgentID)
-	if err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	if err := validateLifecycleExpectation(req, previous, exists); err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	result := lifecycleResult(req, previous, exists)
-	result.Subordinate, err = applyPostgresLifecycleSubordinate(ctx, tx, req)
-	if err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	if err := applyPostgresLifecycleCell(ctx, tx, req, result); err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	if err := insertPostgresLifecycleEvidence(ctx, tx, req, result); err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
 	return result, nil
@@ -139,7 +141,7 @@ func (s *SQLiteRuntimeStore) CommitAgentLifecycleTransition(ctx context.Context,
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
 	var result runtimemanager.AgentLifecycleTransitionResult
-	err = s.runRuntimeMutation(ctx, "sqlite commit agent lifecycle transition", func(txctx context.Context, tx *sql.Tx) error {
+	err = s.runAuthorActivityMutation(ctx, "sqlite commit agent lifecycle transition", func(txctx context.Context, tx *sql.Tx) error {
 		var ok bool
 		var err error
 		result, ok, err = loadSQLiteLifecycleOperationResult(txctx, tx, req)
@@ -161,9 +163,27 @@ func (s *SQLiteRuntimeStore) CommitAgentLifecycleTransition(ctx context.Context,
 		if err := applySQLiteLifecycleCellTx(txctx, tx, req, result); err != nil {
 			return err
 		}
-		return insertSQLiteLifecycleEvidenceTx(txctx, tx, req, result)
+		if err := insertSQLiteLifecycleEvidenceTx(txctx, tx, req, result); err != nil {
+			return err
+		}
+		return recordAgentLifecycleAuthorActivity(txctx, req, result)
 	})
 	return result, err
+}
+
+func recordAgentLifecycleAuthorActivity(ctx context.Context, req runtimemanager.AgentLifecycleTransition, result runtimemanager.AgentLifecycleTransitionResult) error {
+	previousGeneration := result.PreviousGeneration
+	nextGeneration := result.Generation
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindAgentLifecycle, Transition: string(result.Phase),
+		SourceOwner: "agent_lifecycle_transition_facts", SourceIdentity: result.TransitionID,
+		DedupKey: "agent-transition:" + result.TransitionID, OccurredAt: req.Now.UTC(), AgentID: result.AgentID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "agent", SubjectID: result.AgentID, PreviousPhase: string(result.PreviousPhase),
+			NextPhase: string(result.Phase), PreviousGeneration: &previousGeneration, NextGeneration: &nextGeneration,
+			RunMode: string(result.RunMode),
+		},
+	})
 }
 
 type lifecycleCell struct {

--- a/internal/store/author_activity_events.go
+++ b/internal/store/author_activity_events.go
@@ -1,0 +1,290 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+)
+
+type authorActivityCatalogBinder interface {
+	SetAuthorActivityEventCatalog([]string)
+}
+
+func (s *PostgresStore) SetAuthorActivityEventCatalog(names []string) {
+	if s == nil {
+		return
+	}
+	s.authorActivityCatalogMu.Lock()
+	defer s.authorActivityCatalogMu.Unlock()
+	s.authorActivityCatalog = normalizedEventNameSet(names)
+}
+
+func (s *SQLiteRuntimeStore) SetAuthorActivityEventCatalog(names []string) {
+	if s == nil {
+		return
+	}
+	s.authorActivityCatalogMu.Lock()
+	defer s.authorActivityCatalogMu.Unlock()
+	s.authorActivityCatalog = normalizedEventNameSet(names)
+}
+
+func normalizedEventNameSet(names []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func (s *PostgresStore) authoredAuthorActivityEvent(name string) bool {
+	s.authorActivityCatalogMu.RLock()
+	defer s.authorActivityCatalogMu.RUnlock()
+	_, ok := s.authorActivityCatalog[strings.TrimSpace(name)]
+	return ok
+}
+
+func (s *SQLiteRuntimeStore) authoredAuthorActivityEvent(name string) bool {
+	s.authorActivityCatalogMu.RLock()
+	defer s.authorActivityCatalogMu.RUnlock()
+	_, ok := s.authorActivityCatalog[strings.TrimSpace(name)]
+	return ok
+}
+
+type authoredEventClassifier interface {
+	authoredAuthorActivityEvent(string) bool
+}
+
+func recordPersistedEventAuthorActivity(ctx context.Context, classifier authoredEventClassifier, evt events.Event, producedBy, producedByType string) error {
+	name := strings.TrimSpace(string(evt.Type()))
+	if name == "platform.inbound_recorded" || platformEventHandledElsewhere(name) || platformEventDifferentConcept(name) {
+		return nil
+	}
+	if platformEventRegistered(name) {
+		return recordPlatformSignalAuthorActivity(ctx, evt)
+	}
+	if classifier == nil || !classifier.authoredAuthorActivityEvent(name) {
+		return nil
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindEventEmitted, Transition: "emitted",
+		SourceOwner: "events", SourceIdentity: evt.ID(), DedupKey: "emit:" + evt.ID(),
+		OccurredAt: evt.CreatedAt(), RunID: evt.RunID(), EntityID: evt.EntityID(), FlowID: evt.FlowInstance(),
+		Projection: runtimeauthoractivity.Projection{
+			EventType: name, ProducerType: strings.TrimSpace(producedByType), ProducerID: strings.TrimSpace(producedBy),
+		},
+	})
+}
+
+func recordInboundAuthorActivity(ctx context.Context, evt events.Event, provider string) error {
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindInboundReceived, Transition: "received",
+		SourceOwner: "events", SourceIdentity: evt.ID(), DedupKey: "inbound:" + evt.ID(),
+		OccurredAt: evt.CreatedAt(), RunID: evt.RunID(), EntityID: evt.EntityID(), FlowID: evt.FlowInstance(),
+		Projection: runtimeauthoractivity.Projection{SubjectType: "entity", SubjectID: evt.EntityID(), Provider: strings.TrimSpace(provider)},
+	})
+}
+
+const (
+	platformDispositionRegistered = "registered"
+	platformDispositionHandled    = "handled"
+	platformDispositionDifferent  = "different"
+)
+
+var platformEventDisposition = map[string]string{
+	"platform.agent_panic":              platformDispositionRegistered,
+	"platform.agent_failed":             platformDispositionRegistered,
+	"platform.event_quarantined":        platformDispositionRegistered,
+	"platform.dead_letter_escalation":   platformDispositionRegistered,
+	"platform.run_stalled":              platformDispositionRegistered,
+	"platform.reset":                    platformDispositionRegistered,
+	"platform.auth_required":            platformDispositionRegistered,
+	"platform.budget_threshold_crossed": platformDispositionRegistered,
+	"platform.paused":                   platformDispositionRegistered,
+	"platform.resumed":                  platformDispositionRegistered,
+	"platform.recovery_failed":          platformDispositionRegistered,
+	"platform.inbound_recorded":         platformDispositionHandled,
+	"platform.activity_requested":       platformDispositionHandled,
+	"platform.dead_letter":              platformDispositionHandled,
+	"platform.agent_directive":          platformDispositionHandled,
+	"platform.agent_started":            platformDispositionHandled,
+	"mailbox.card_decided":              platformDispositionHandled,
+	"mailbox.card_deferred":             platformDispositionHandled,
+	"mailbox.card_expired":              platformDispositionHandled,
+	"mailbox.card_superseded":           platformDispositionHandled,
+	"human_task.approved":               platformDispositionHandled,
+	"human_task.deferred":               platformDispositionHandled,
+	"human_task.expired":                platformDispositionHandled,
+	"human_task.rejected":               platformDispositionHandled,
+	"platform.runtime_log":              platformDispositionDifferent,
+	"platform.boot":                     platformDispositionDifferent,
+}
+
+func platformEventRegistered(name string) bool {
+	return platformEventDisposition[name] == platformDispositionRegistered
+}
+func platformEventHandledElsewhere(name string) bool {
+	return platformEventDisposition[name] == platformDispositionHandled
+}
+func platformEventDifferentConcept(name string) bool {
+	return platformEventDisposition[name] == platformDispositionDifferent
+}
+
+type platformSignalPayload struct {
+	AgentID          string                    `json:"agent_id"`
+	EntityID         string                    `json:"entity_id"`
+	FlowInstance     string                    `json:"flow_instance"`
+	RetryCount       int                       `json:"retry_count"`
+	LastEventType    string                    `json:"last_event_type"`
+	EventName        string                    `json:"event_name"`
+	ReasonCode       string                    `json:"reason_code"`
+	RunID            string                    `json:"run_id"`
+	OperationalState string                    `json:"operational_state"`
+	BlockingLayer    string                    `json:"blocking_layer"`
+	Reason           string                    `json:"reason"`
+	Source           string                    `json:"source"`
+	Tool             string                    `json:"tool"`
+	Action           string                    `json:"action"`
+	Level            string                    `json:"level"`
+	Spend            json.RawMessage           `json:"spend"`
+	Cap              json.RawMessage           `json:"cap"`
+	Percentage       json.RawMessage           `json:"percentage"`
+	Period           string                    `json:"period"`
+	FailedEventID    string                    `json:"failed_event_id"`
+	Failure          *runtimefailures.Envelope `json:"failure"`
+	LastFailure      *runtimefailures.Envelope `json:"last_failure"`
+}
+
+func recordPlatformSignalAuthorActivity(ctx context.Context, evt events.Event) error {
+	var payload platformSignalPayload
+	if err := json.Unmarshal(evt.Payload(), &payload); err != nil {
+		return fmt.Errorf("decode registered author activity platform event %s: %w", evt.Type(), err)
+	}
+	name := strings.TrimSpace(string(evt.Type()))
+	transition := ""
+	failure := payload.Failure
+	if failure == nil {
+		failure = payload.LastFailure
+	}
+	switch name {
+	case "platform.agent_panic":
+		transition = "agent_failed_retrying"
+	case "platform.agent_failed":
+		transition = "agent_failed"
+	case "platform.event_quarantined":
+		transition = "event_quarantined"
+	case "platform.dead_letter_escalation":
+		transition = "dead_letters_escalated"
+	case "platform.run_stalled":
+		transition = "run_stalled"
+	case "platform.reset":
+		transition = "runtime_reset"
+	case "platform.auth_required":
+		transition = "authorization_required"
+	case "platform.budget_threshold_crossed":
+		var err error
+		transition, err = budgetTransition(payload.Level)
+		if err != nil {
+			return err
+		}
+	case "platform.paused":
+		transition = "runtime_paused"
+	case "platform.resumed":
+		transition = "runtime_resumed"
+	case "platform.recovery_failed":
+		transition = "recovery_failed"
+	default:
+		return fmt.Errorf("registered author activity platform event %q has no typed adapter", name)
+	}
+	runID := firstString(evt.RunID(), payload.RunID)
+	entityID := firstString(evt.EntityID(), payload.EntityID)
+	flowID := firstString(evt.FlowInstance(), payload.FlowInstance)
+	subjectType, subjectID := platformSignalSubject(name, payload, runID, entityID)
+	projection := runtimeauthoractivity.Projection{
+		SubjectType: subjectType, SubjectID: subjectID, EventType: firstString(payload.EventName, payload.LastEventType),
+		RetryCount: intPointerIfNonZero(payload.RetryCount), ReasonCode: firstString(payload.ReasonCode, payload.Reason),
+		Source: payload.Source, Level: payload.Level, Spend: rawNumberString(payload.Spend), Cap: rawNumberString(payload.Cap),
+		Percentage: rawNumberString(payload.Percentage), Period: payload.Period, OperationalState: payload.OperationalState,
+		BlockingLayer: payload.BlockingLayer, Tool: payload.Tool,
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindPlatformSignal, Transition: transition,
+		SourceOwner: "events", SourceIdentity: evt.ID(), DedupKey: "platform-signal:" + evt.ID(),
+		OccurredAt: evt.CreatedAt(), RunID: runID, EntityID: entityID, AgentID: payload.AgentID, FlowID: flowID,
+		Projection: projection, Failure: failure,
+	})
+}
+
+func budgetTransition(level string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(level)) {
+	case "warning":
+		return "budget_warning", nil
+	case "throttle":
+		return "budget_throttle", nil
+	case "emergency":
+		return "budget_emergency", nil
+	case "ok":
+		return "budget_ok", nil
+	default:
+		return "", fmt.Errorf("registered budget threshold level %q is not supported", level)
+	}
+}
+
+func platformSignalSubject(name string, payload platformSignalPayload, runID, entityID string) (string, string) {
+	if payload.AgentID != "" {
+		return "agent", payload.AgentID
+	}
+	if entityID != "" {
+		return "entity", entityID
+	}
+	if runID != "" {
+		return "run", runID
+	}
+	if payload.FailedEventID != "" {
+		return "event", payload.FailedEventID
+	}
+	return "platform", name
+}
+
+func intPointerIfNonZero(value int) *int {
+	if value == 0 {
+		return nil
+	}
+	return &value
+}
+
+func rawNumberString(raw json.RawMessage) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text == "null" {
+		return ""
+	}
+	if value, err := strconv.Unquote(text); err == nil {
+		return value
+	}
+	return text
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func authorActivityEventOccurredAt(evt events.Event) time.Time {
+	if at := evt.CreatedAt(); !at.IsZero() {
+		return at.UTC()
+	}
+	return time.Now().UTC()
+}

--- a/internal/store/author_activity_receipt_parity_test.go
+++ b/internal/store/author_activity_receipt_parity_test.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+type authorActivityReceiptStore interface {
+	PersistEventWithDeliveries(context.Context, events.Event, []string) error
+	UpsertEventReceipt(context.Context, string, string, runtimemanager.ReceiptStatus, *runtimefailures.Envelope) error
+}
+
+type authorActivityReceiptFixture struct {
+	store   authorActivityReceiptStore
+	db      *sql.DB
+	dialect runtimeauthoractivity.Dialect
+	stamp   func(context.Context, string, string) [2]string
+	advance func()
+}
+
+func TestAuthorActivityDuplicateTerminalReceiptIsNoOpParity(t *testing.T) {
+	tests := []struct {
+		name string
+		open func(*testing.T) authorActivityReceiptFixture
+	}{
+		{name: "sqlite", open: openSQLiteAuthorActivityReceiptFixture},
+		{name: "postgres", open: openPostgresAuthorActivityReceiptFixture},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := tt.open(t)
+			ctx := context.Background()
+			eventID := uuid.NewString()
+			agentID := "normalizer"
+			event := eventtest.PersistedProjection(
+				eventID, events.EventType("test.delivery_receipt"), "runtime", "", []byte(`{}`), 0,
+				"", "", events.EventEnvelope{}, time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC),
+			)
+			if err := fixture.store.PersistEventWithDeliveries(ctx, event, []string{agentID}); err != nil {
+				t.Fatalf("PersistEventWithDeliveries: %v", err)
+			}
+			if err := fixture.store.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusProcessed, nil); err != nil {
+				t.Fatalf("first UpsertEventReceipt: %v", err)
+			}
+
+			before := listAuthorActivityForReceiptParity(t, fixture, ctx)
+			if len(before) != 1 || before[0].Kind != runtimeauthoractivity.KindDeliveryLifecycle || before[0].Transition != "delivered" {
+				t.Fatalf("first receipt occurrences = %#v, want one delivered occurrence", before)
+			}
+			beforeStamp := fixture.stamp(ctx, eventID, agentID)
+			fixture.advance()
+
+			if err := fixture.store.UpsertEventReceipt(ctx, eventID, agentID, runtimemanager.ReceiptStatusProcessed, nil); err != nil {
+				t.Fatalf("duplicate UpsertEventReceipt: %v", err)
+			}
+			after := listAuthorActivityForReceiptParity(t, fixture, ctx)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("duplicate receipt changed author activity:\nbefore: %#v\nafter:  %#v", before, after)
+			}
+			if afterStamp := fixture.stamp(ctx, eventID, agentID); afterStamp != beforeStamp {
+				t.Fatalf("duplicate receipt rewrote source timestamps: before=%v after=%v", beforeStamp, afterStamp)
+			}
+		})
+	}
+}
+
+func listAuthorActivityForReceiptParity(t *testing.T, fixture authorActivityReceiptFixture, ctx context.Context) []runtimeauthoractivity.Occurrence {
+	t.Helper()
+	page, err := runtimeauthoractivity.List(ctx, fixture.db, fixture.dialect, runtimeauthoractivity.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("List author activity: %v", err)
+	}
+	return page.Occurrences
+}
+
+func openSQLiteAuthorActivityReceiptFixture(t *testing.T) authorActivityReceiptFixture {
+	t.Helper()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	store.nowFn = func() time.Time { return now }
+	return authorActivityReceiptFixture{
+		store: store, db: store.DB, dialect: runtimeauthoractivity.DialectSQLite,
+		stamp: func(ctx context.Context, eventID, agentID string) [2]string {
+			return readAuthorActivityReceiptStamps(t, ctx, store.DB, `
+				SELECT CAST(d.delivered_at AS TEXT), CAST(r.processed_at AS TEXT)
+				FROM event_deliveries d
+				JOIN event_receipts r
+				  ON r.event_id = d.event_id AND r.subscriber_type = d.subscriber_type AND r.subscriber_id = d.subscriber_id
+				WHERE d.event_id = ? AND d.subscriber_type = 'agent' AND d.subscriber_id = ?
+			`, eventID, agentID)
+		},
+		advance: func() { now = now.Add(time.Hour) },
+	}
+}
+
+func openPostgresAuthorActivityReceiptFixture(t *testing.T) authorActivityReceiptFixture {
+	t.Helper()
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	store := &PostgresStore{DB: db}
+	return authorActivityReceiptFixture{
+		store: store, db: db, dialect: runtimeauthoractivity.DialectPostgres,
+		stamp: func(ctx context.Context, eventID, agentID string) [2]string {
+			return readAuthorActivityReceiptStamps(t, ctx, db, `
+				SELECT d.delivered_at::text, r.processed_at::text
+				FROM event_deliveries d
+				JOIN event_receipts r
+				  ON r.event_id = d.event_id AND r.subscriber_type = d.subscriber_type AND r.subscriber_id = d.subscriber_id
+				WHERE d.event_id = $1::uuid AND d.subscriber_type = 'agent' AND d.subscriber_id = $2
+			`, eventID, agentID)
+		},
+		advance: func() {},
+	}
+}
+
+func readAuthorActivityReceiptStamps(t *testing.T, ctx context.Context, db *sql.DB, query string, args ...any) [2]string {
+	t.Helper()
+	var stamps [2]string
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&stamps[0], &stamps[1]); err != nil {
+		t.Fatalf("read receipt timestamps: %v", err)
+	}
+	return stamps
+}

--- a/internal/store/author_activity_registry_test.go
+++ b/internal/store/author_activity_registry_test.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
+	"github.com/division-sh/swarm/internal/yamlsource"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+	_ "modernc.org/sqlite"
+)
+
+func TestAuthorActivityPlatformEventDispositionCoversSpecCatalog(t *testing.T) {
+	source, err := yamlsource.LoadFile(runtimecontracts.DefaultPlatformSpecFile(authorActivityRegistryRepoRoot(t)))
+	if err != nil {
+		t.Fatalf("load platform spec: %v", err)
+	}
+	var document struct {
+		PlatformEvents struct {
+			Catalog map[string]yaml.Node `yaml:"catalog"`
+		} `yaml:"platform_events"`
+	}
+	if err := source.Decode(&document); err != nil {
+		t.Fatalf("decode platform event catalog: %v", err)
+	}
+	if len(document.PlatformEvents.Catalog) == 0 {
+		t.Fatal("platform event catalog is empty")
+	}
+	for name := range document.PlatformEvents.Catalog {
+		disposition, ok := platformEventDisposition[name]
+		if !ok {
+			t.Errorf("platform event %q has no author activity disposition", name)
+			continue
+		}
+		switch disposition {
+		case platformDispositionRegistered, platformDispositionHandled, platformDispositionDifferent:
+		default:
+			t.Errorf("platform event %q has invalid author activity disposition %q", name, disposition)
+		}
+	}
+	for name := range platformEventDisposition {
+		if _, ok := document.PlatformEvents.Catalog[name]; !ok {
+			t.Errorf("author activity disposition names non-catalog platform event %q", name)
+		}
+	}
+}
+
+func TestAuthorActivityEffectDispositionCoversRegistrations(t *testing.T) {
+	registrations := runtimeeffects.Registrations()
+	seen := make(map[string]struct{}, len(registrations))
+	for _, registration := range registrations {
+		key := string(registration.Kind) + "/" + registration.Adapter
+		if _, duplicate := seen[key]; duplicate {
+			t.Errorf("duplicate effect registration %q", key)
+		}
+		seen[key] = struct{}{}
+		if _, ok := externalEffectStoryDispositions[key]; !ok {
+			t.Errorf("effect registration %q has no author activity disposition", key)
+		}
+	}
+	var stale []string
+	for key := range externalEffectStoryDispositions {
+		if _, ok := seen[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Fatalf("author activity effect dispositions without live registrations: %v", stale)
+	}
+}
+
+type authoredEventOutputClassifier struct{}
+
+func (authoredEventOutputClassifier) authoredAuthorActivityEvent(name string) bool {
+	return name == "phrase.completed"
+}
+
+func TestAuthorActivityEventAndEffectAdaptersRenderExactSubjects(t *testing.T) {
+	db := openAuthorActivityAdapterDB(t)
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	story, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectSQLite)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	event := eventtest.PersistedProjection(
+		uuid.NewString(), events.EventType("phrase.completed"), "phrase-completer", "", []byte(`{}`), 0,
+		"", "", events.EventEnvelope{}, now,
+	)
+	if err := recordPersistedEventAuthorActivity(story, authoredEventOutputClassifier{}, event, "phrase-completer", "agent"); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := recordExternalEffectStory(story, externalEffectStorySource{
+		AttemptID: uuid.NewString(), Kind: "provider_turn", Class: "provider_call", Adapter: "anthropic_api",
+		Transport: "https", AuthorityKind: "normal_agent", AuthorityID: "normalizer", AgentID: "normalizer", Ordinal: 1,
+	}, runtimeeffects.StateLaunched, nil, now.Add(time.Second)); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := runtimeauthoractivity.Finalize(story); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := runtimeauthoractivity.List(ctx, db, runtimeauthoractivity.DialectSQLite, runtimeauthoractivity.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Occurrences) != 2 {
+		t.Fatalf("occurrences = %#v, want event and effect", page.Occurrences)
+	}
+	if page.Occurrences[0].Projection.SubjectID != "" || page.Occurrences[1].Projection.SubjectID != "" {
+		t.Fatalf("internal identities entered author projections: %#v", page.Occurrences)
+	}
+	var output bytes.Buffer
+	if err := runtimeauthoractivity.Render(&output, page.Occurrences, runtimeauthoractivity.RenderOptions{Mode: runtimeauthoractivity.RenderPlain, Width: 120}); err != nil {
+		t.Fatal(err)
+	}
+	want := "12:00:00  phrase-completer  emitted phrase.completed\n12:00:01  anthropic_api  in flight\n"
+	if output.String() != want {
+		t.Fatalf("author activity output = %q, want %q", output.String(), want)
+	}
+}
+
+func openAuthorActivityAdapterDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+uuid.NewString()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	for _, ddl := range []string{
+		`CREATE TABLE author_activity_order (singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1), last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0))`,
+		`CREATE TABLE author_activity_occurrences (
+			occurrence_id TEXT PRIMARY KEY, sequence BIGINT NOT NULL UNIQUE CHECK (sequence > 0), kind TEXT NOT NULL,
+			version INTEGER NOT NULL CHECK (version = 1), transition TEXT NOT NULL, source_owner TEXT NOT NULL,
+			source_identity TEXT NOT NULL, dedup_key TEXT NOT NULL UNIQUE, run_id TEXT, entity_id TEXT, agent_id TEXT,
+			flow_id TEXT, projection TEXT NOT NULL DEFAULT '{}', failure TEXT, occurred_at TIMESTAMP NOT NULL
+		)`,
+	} {
+		if _, err := db.Exec(ddl); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return db
+}
+
+func authorActivityRegistryRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve author activity registry test path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/internal/store/author_activity_store.go
+++ b/internal/store/author_activity_store.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+)
+
+func (s *PostgresStore) runAuthorActivityMutation(ctx context.Context, label string, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		if runtimeauthoractivity.InMutation(ctx, tx) {
+			return fn(ctx, tx)
+		}
+		if !runtimeauthoractivity.FinalizedMutation(ctx, tx) {
+			return fmt.Errorf("%s entered from a raw transaction without author activity ownership", label)
+		}
+		ctx = runtimepipeline.WithoutPipelineSQLTxContext(ctx)
+	}
+	return s.runPostgresRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectPostgres)
+		if err != nil {
+			return err
+		}
+		if err := fn(storyctx, tx); err != nil {
+			return err
+		}
+		if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(storyctx, tx); err != nil {
+			return err
+		}
+		return runtimeauthoractivity.Finalize(storyctx)
+	})
+}
+
+func (s *SQLiteRuntimeStore) runAuthorActivityMutation(ctx context.Context, label string, fn func(context.Context, *sql.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		if runtimeauthoractivity.InMutation(ctx, tx) {
+			return fn(ctx, tx)
+		}
+		if !runtimeauthoractivity.FinalizedMutation(ctx, tx) {
+			return fmt.Errorf("%s entered from a raw transaction without author activity ownership", label)
+		}
+		ctx = runtimepipeline.WithoutPipelineSQLTxContext(ctx)
+	}
+	return s.runRuntimeMutation(ctx, label, func(txctx context.Context, tx *sql.Tx) error {
+		storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectSQLite)
+		if err != nil {
+			return err
+		}
+		if err := fn(storyctx, tx); err != nil {
+			return err
+		}
+		return runtimeauthoractivity.Finalize(storyctx)
+	})
+}
+
+func (s *PostgresStore) ListAuthorActivity(ctx context.Context, opts runtimeauthoractivity.ListOptions) (runtimeauthoractivity.ListResult, error) {
+	if s == nil || s.DB == nil {
+		return runtimeauthoractivity.ListResult{}, fmt.Errorf("postgres store is required")
+	}
+	return runtimeauthoractivity.List(ctx, s.DB, runtimeauthoractivity.DialectPostgres, opts)
+}
+
+func (s *SQLiteRuntimeStore) ListAuthorActivity(ctx context.Context, opts runtimeauthoractivity.ListOptions) (runtimeauthoractivity.ListResult, error) {
+	if s == nil || s.DB == nil {
+		return runtimeauthoractivity.ListResult{}, fmt.Errorf("sqlite runtime store is required")
+	}
+	return runtimeauthoractivity.List(ctx, s.DB, runtimeauthoractivity.DialectSQLite, opts)
+}

--- a/internal/store/author_activity_turns.go
+++ b/internal/store/author_activity_turns.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
+	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+)
+
+type authorActivityTurn struct {
+	TurnID           string
+	RunID            string
+	AgentID          string
+	SessionID        string
+	EntityID         string
+	FlowID           string
+	TriggerEventType string
+	Blocks           []runtimellm.TurnBlock
+	ParseOK          bool
+	DurationMS       int
+	RetryCount       int
+	UsageExactness   string
+	InputTokens      *int64
+	OutputTokens     *int64
+	Failure          *runtimefailures.Envelope
+	OccurredAt       time.Time
+}
+
+func recordAuthorActivityTurn(ctx context.Context, turn authorActivityTurn) error {
+	activity, _, _, err := projectAuthorSafeTurnActivity(turn.Blocks, turn.ParseOK)
+	if err != nil {
+		return err
+	}
+	transition := "completed"
+	if turn.Failure != nil {
+		transition = "failed"
+	}
+	parseOK := turn.ParseOK
+	duration := turn.DurationMS
+	retry := turn.RetryCount
+	identity := strings.TrimSpace(turn.TurnID) + ":" + transition
+	if err := runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindTurnLifecycle, Transition: transition,
+		SourceOwner: "agent_turns", SourceIdentity: identity, DedupKey: "turn:" + identity,
+		OccurredAt: turn.OccurredAt.UTC(), RunID: turn.RunID, EntityID: turn.EntityID, AgentID: turn.AgentID, FlowID: turn.FlowID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "agent", SubjectID: turn.AgentID, TurnID: turn.TurnID, DurationMS: &duration,
+			ParseOK: &parseOK, UsageExactness: turn.UsageExactness, InputTokens: turn.InputTokens,
+			OutputTokens: turn.OutputTokens, RetryCount: &retry, EventType: turn.TriggerEventType,
+		},
+		Failure: turn.Failure,
+	}); err != nil {
+		return err
+	}
+	for _, item := range activity {
+		if item.Kind != "tool_result" {
+			continue
+		}
+		ordinal := item.BlockOrdinal
+		blockIdentity := fmt.Sprintf("%s:block:%d", turn.TurnID, ordinal)
+		if err := runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+			Kind: runtimeauthoractivity.KindTurnToolCompleted, Transition: "completed",
+			SourceOwner: "agent_turns", SourceIdentity: blockIdentity, DedupKey: "turn-tool:" + blockIdentity,
+			OccurredAt: turn.OccurredAt.UTC(), RunID: turn.RunID, EntityID: turn.EntityID, AgentID: turn.AgentID, FlowID: turn.FlowID,
+			Projection: runtimeauthoractivity.Projection{
+				SubjectType: "agent", SubjectID: turn.AgentID, TurnID: turn.TurnID,
+				ToolName: item.ToolName, ToolUseID: item.ToolUseID,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recordCompletionTurnAuthorActivity(ctx context.Context, settlement runtimeeffects.CompletionSettlement) error {
+	if settlement.AgentTurn == nil {
+		return nil
+	}
+	var blocks []runtimellm.TurnBlock
+	if len(settlement.AgentTurn.TurnBlocks) > 0 {
+		if err := json.Unmarshal(settlement.AgentTurn.TurnBlocks, &blocks); err != nil {
+			return fmt.Errorf("decode completion author activity turn blocks: %w", err)
+		}
+	}
+	t := settlement.AgentTurn
+	return recordAuthorActivityTurn(ctx, authorActivityTurn{
+		TurnID: t.TurnID, RunID: t.RunID, AgentID: t.AgentID, SessionID: t.SessionID, EntityID: t.EntityID,
+		FlowID: settlement.Spend.FlowInstance, TriggerEventType: t.TriggerEventType, Blocks: blocks,
+		ParseOK: t.ParseOK, DurationMS: t.LatencyMS, RetryCount: t.RetryCount,
+		UsageExactness: string(settlement.Usage.Exactness), InputTokens: settlement.Usage.InputTokens,
+		OutputTokens: settlement.Usage.OutputTokens, Failure: t.Failure, OccurredAt: settlement.Now.UTC(),
+	})
+}

--- a/internal/store/completion_settlement.go
+++ b/internal/store/completion_settlement.go
@@ -16,42 +16,48 @@ var _ runtimeeffects.CompletionStore = (*PostgresStore)(nil)
 var _ runtimeeffects.CompletionStore = (*SQLiteRuntimeStore)(nil)
 
 func (s *PostgresStore) SettleCompletion(ctx context.Context, attempt runtimeeffects.Attempt, settlement runtimeeffects.CompletionSettlement) (runtimeeffects.CompletionSettlementResult, error) {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, fmt.Errorf("settle completion begin: %w", err)
-	}
-	defer tx.Rollback()
-	if err := requireExternalEffectAuthorityPostgres(ctx, tx, attempt.Authority, false); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, err
-	}
-	if err := requireCompletionAttemptPostgres(ctx, tx, attempt); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, err
-	}
 	var providerHeadErr error
-	if settlement.ProviderHead != nil {
-		req := completionProviderHeadSettlement(attempt, settlement)
-		if providerHeadErr = requireProviderHeadLifecyclePostgres(ctx, tx, req); providerHeadErr == nil {
-			providerHeadErr = promoteProviderHeadPostgres(ctx, tx, req)
+	var spendRecorded bool
+	err := s.runAuthorActivityMutation(ctx, "postgres settle completion", func(txctx context.Context, tx *sql.Tx) error {
+		providerHeadErr = nil
+		spendRecorded = false
+		attemptSettlement := settlement
+		if err := requireExternalEffectAuthorityPostgres(txctx, tx, attempt.Authority, false); err != nil {
+			return err
 		}
-		if providerHeadErr != nil {
-			settlement = completionProviderHeadUncertainty(settlement, providerHeadErr)
+		if err := requireCompletionAttemptPostgres(txctx, tx, attempt); err != nil {
+			return err
 		}
-	}
-	if err := insertCompletionTargetPostgres(ctx, tx, attempt, settlement); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, err
-	}
-	spendRecorded, err := insertCompletionSpendPostgres(ctx, tx, attempt, settlement)
+		if attemptSettlement.ProviderHead != nil {
+			req := completionProviderHeadSettlement(attempt, attemptSettlement)
+			if providerHeadErr = requireProviderHeadLifecyclePostgres(txctx, tx, req); providerHeadErr == nil {
+				providerHeadErr = promoteProviderHeadPostgres(txctx, tx, req)
+			}
+			if providerHeadErr != nil {
+				attemptSettlement = completionProviderHeadUncertainty(attemptSettlement, providerHeadErr)
+			}
+		}
+		if err := insertCompletionTargetPostgres(txctx, tx, attempt, attemptSettlement); err != nil {
+			return err
+		}
+		if err := recordCompletionTurnAuthorActivity(txctx, attemptSettlement); err != nil {
+			return err
+		}
+		var err error
+		spendRecorded, err = insertCompletionSpendPostgres(txctx, tx, attempt, attemptSettlement)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(txctx, `DELETE FROM runtime_effect_budget_reservations WHERE attempt_id=$1::uuid`, attempt.AttemptID); err != nil {
+			return fmt.Errorf("release completion budget reservations: %w", err)
+		}
+		if err := settleExternalAttemptPostgres(txctx, tx, attemptSettlement.Settlement); err != nil {
+			return err
+		}
+		return recordExternalEffectStory(txctx, externalEffectStorySourceFromAttempt(attempt), attemptSettlement.Settlement.State, attemptSettlement.Settlement.Failure, attemptSettlement.Now.UTC())
+	})
 	if err != nil {
 		return runtimeeffects.CompletionSettlementResult{}, err
-	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM runtime_effect_budget_reservations WHERE attempt_id=$1::uuid`, attempt.AttemptID); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, fmt.Errorf("release completion budget reservations: %w", err)
-	}
-	if err := settleExternalAttemptPostgres(ctx, tx, settlement.Settlement); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, err
-	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-		return runtimeeffects.CompletionSettlementResult{}, fmt.Errorf("settle completion commit: %w", err)
 	}
 	return runtimeeffects.CompletionSettlementResult{
 		Committed: true, SpendRecorded: spendRecorded, AttemptID: attempt.AttemptID, EntityID: settlement.Spend.EntityID,
@@ -61,7 +67,7 @@ func (s *PostgresStore) SettleCompletion(ctx context.Context, attempt runtimeeff
 func (s *SQLiteRuntimeStore) SettleCompletion(ctx context.Context, attempt runtimeeffects.Attempt, settlement runtimeeffects.CompletionSettlement) (runtimeeffects.CompletionSettlementResult, error) {
 	var providerHeadErr error
 	var spendRecorded bool
-	err := s.runRuntimeMutation(ctx, "sqlite settle completion", func(txctx context.Context, tx *sql.Tx) error {
+	err := s.runAuthorActivityMutation(ctx, "sqlite settle completion", func(txctx context.Context, tx *sql.Tx) error {
 		providerHeadErr = nil
 		spendRecorded = false
 		attemptSettlement := settlement
@@ -83,6 +89,9 @@ func (s *SQLiteRuntimeStore) SettleCompletion(ctx context.Context, attempt runti
 		if err := insertCompletionTargetSQLite(txctx, tx, attempt, attemptSettlement); err != nil {
 			return err
 		}
+		if err := recordCompletionTurnAuthorActivity(txctx, attemptSettlement); err != nil {
+			return err
+		}
 		var err error
 		spendRecorded, err = insertCompletionSpendSQLite(txctx, tx, attempt, attemptSettlement)
 		if err != nil {
@@ -91,7 +100,10 @@ func (s *SQLiteRuntimeStore) SettleCompletion(ctx context.Context, attempt runti
 		if _, err := tx.ExecContext(txctx, `DELETE FROM runtime_effect_budget_reservations WHERE attempt_id=?`, attempt.AttemptID); err != nil {
 			return fmt.Errorf("release sqlite completion budget reservations: %w", err)
 		}
-		return settleExternalAttemptSQLiteTx(txctx, tx, attemptSettlement.Settlement)
+		if err := settleExternalAttemptSQLiteTx(txctx, tx, attemptSettlement.Settlement); err != nil {
+			return err
+		}
+		return recordExternalEffectStory(txctx, externalEffectStorySourceFromAttempt(attempt), attemptSettlement.Settlement.State, attemptSettlement.Settlement.Failure, attemptSettlement.Now.UTC())
 	})
 	if err != nil {
 		return runtimeeffects.CompletionSettlementResult{}, err

--- a/internal/store/dead_letters.go
+++ b/internal/store/dead_letters.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimedeadletters "github.com/division-sh/swarm/internal/runtime/deadletters"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/google/uuid"
@@ -17,11 +18,27 @@ var _ eventMutationDeadLetterTxRecorder = (*PostgresStore)(nil)
 var _ eventMutationDeadLetterTxRecorder = (*SQLiteRuntimeStore)(nil)
 
 func (s *PostgresStore) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
-	return runtimedeadletters.Insert(ctx, s.DB, rec)
+	return s.runAuthorActivityMutation(ctx, "postgres record dead letter", func(txctx context.Context, tx *sql.Tx) error {
+		return s.RecordDeadLetterTx(txctx, tx, rec)
+	})
 }
 
 func (s *PostgresStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx, rec runtimedeadletters.Record) error {
-	return runtimedeadletters.InsertTx(ctx, tx, rec)
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
+	source, err := loadDeadLetterAuthorActivitySource(ctx, tx, rec.OriginalEventID, true)
+	if err != nil {
+		return err
+	}
+	result, err := runtimedeadletters.InsertTxWithResult(ctx, tx, rec)
+	if err != nil {
+		return err
+	}
+	if !result.Inserted {
+		return nil
+	}
+	return recordDeadLetterAuthorActivity(ctx, result.DeadLetterID, rec, source, deadLetterOccurredAt(rec.Timestamp))
 }
 
 func (s *SQLiteRuntimeStore) RecordDeadLetter(ctx context.Context, rec runtimedeadletters.Record) error {
@@ -30,15 +47,23 @@ func (s *SQLiteRuntimeStore) RecordDeadLetter(ctx context.Context, rec runtimede
 
 func (s *SQLiteRuntimeStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx, rec runtimedeadletters.Record) error {
 	if tx == nil {
-		return s.runRuntimeMutation(ctx, "sqlite record dead letter", func(txctx context.Context, tx *sql.Tx) error {
+		return s.runAuthorActivityMutation(ctx, "sqlite record dead letter", func(txctx context.Context, tx *sql.Tx) error {
 			return s.RecordDeadLetterTx(txctx, tx, rec)
 		})
+	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
 	}
 	rec, createdAt, err := normalizeSQLiteDeadLetterRecord(s, rec)
 	if err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `
+	source, err := loadDeadLetterAuthorActivitySource(ctx, tx, rec.OriginalEventID, false)
+	if err != nil {
+		return err
+	}
+	deadLetterID := uuid.NewString()
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO dead_letters (
 			dead_letter_id, original_event_id, original_event, original_payload, entity_id, flow_instance,
 			failure, retry_count, chain_depth, handler_node, created_at
@@ -63,7 +88,7 @@ func (s *SQLiteRuntimeStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx,
 			  AND COALESCE(dl.handler_node, '') = COALESCE(NULLIF(?, ''), '')
 		)
 	`,
-		uuid.NewString(),
+		deadLetterID,
 		rec.OriginalEventID,
 		rec.OriginalEvent,
 		rec.OriginalEventID,
@@ -80,10 +105,62 @@ func (s *SQLiteRuntimeStore) RecordDeadLetterTx(ctx context.Context, tx *sql.Tx,
 		rec.OriginalEventID,
 		mustFailureJSON(rec.Failure),
 		rec.HandlerNode,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("insert sqlite dead letter: %w", err)
 	}
-	return nil
+	inserted, err := rowsAffected(result)
+	if err != nil {
+		return err
+	}
+	if !inserted {
+		return nil
+	}
+	return recordDeadLetterAuthorActivity(ctx, deadLetterID, rec, source, createdAt)
+}
+
+type deadLetterAuthorActivitySource struct {
+	RunID     string
+	EntityID  string
+	FlowID    string
+	EventType string
+}
+
+func loadDeadLetterAuthorActivitySource(ctx context.Context, tx *sql.Tx, eventID string, postgres bool) (deadLetterAuthorActivitySource, error) {
+	query := `SELECT COALESCE(CAST(run_id AS TEXT), ''), COALESCE(CAST(entity_id AS TEXT), ''), COALESCE(flow_instance, ''), event_name FROM events WHERE event_id = ?`
+	if postgres {
+		query = `SELECT COALESCE(run_id::text, ''), COALESCE(entity_id::text, ''), COALESCE(flow_instance, ''), event_name FROM events WHERE event_id = $1::uuid`
+	}
+	var source deadLetterAuthorActivitySource
+	if err := tx.QueryRowContext(ctx, query, strings.TrimSpace(eventID)).Scan(&source.RunID, &source.EntityID, &source.FlowID, &source.EventType); err != nil {
+		return deadLetterAuthorActivitySource{}, fmt.Errorf("load dead letter source event: %w", err)
+	}
+	return source, nil
+}
+
+func recordDeadLetterAuthorActivity(ctx context.Context, deadLetterID string, rec runtimedeadletters.Record, source deadLetterAuthorActivitySource, occurredAt time.Time) error {
+	deadLetterID = strings.TrimSpace(deadLetterID)
+	if deadLetterID == "" {
+		return fmt.Errorf("dead letter author activity requires dead_letter_id")
+	}
+	retry := rec.RetryCount
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindDeadLetterRecorded, Transition: "recorded",
+		SourceOwner: "dead_letters", SourceIdentity: deadLetterID, DedupKey: "dead-letter:" + deadLetterID,
+		OccurredAt: occurredAt, RunID: source.RunID, EntityID: source.EntityID, FlowID: source.FlowID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "event", SubjectID: strings.TrimSpace(rec.OriginalEventID), EventType: source.EventType,
+			RetryCount: &retry, ReasonCode: rec.Failure.Detail.Code, NodeID: strings.TrimSpace(rec.HandlerNode),
+		},
+		Failure: &rec.Failure,
+	})
+}
+
+func deadLetterOccurredAt(raw string) time.Time {
+	if parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw)); err == nil {
+		return parsed.UTC()
+	}
+	return time.Now().UTC()
 }
 
 func normalizeSQLiteDeadLetterRecord(s *SQLiteRuntimeStore, rec runtimedeadletters.Record) (runtimedeadletters.Record, time.Time, error) {

--- a/internal/store/decision_cards.go
+++ b/internal/store/decision_cards.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	decisioncard "github.com/division-sh/swarm/internal/runtime/decisioncard"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
@@ -42,12 +43,15 @@ func (s *SQLiteRuntimeStore) CreateDecisionCard(ctx context.Context, card decisi
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
 		return insertDecisionCard(ctx, tx, card, false)
 	}
-	return s.runRuntimeMutation(ctx, "sqlite create decision card", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runDecisionCardMutation(ctx, "sqlite create decision card", func(txctx context.Context, tx *sql.Tx) error {
 		return insertDecisionCard(txctx, tx, card, false)
 	})
 }
 
 func insertDecisionCard(ctx context.Context, db decisionCardSQL, card decisioncard.Card, postgres bool) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
 	card.CreatedAt = decisioncard.CanonicalTimestamp(card.CreatedAt)
 	card.UpdatedAt = decisioncard.CanonicalTimestamp(card.UpdatedAt)
 	if err := card.Validate(); err != nil {
@@ -375,6 +379,9 @@ func (s *SQLiteRuntimeStore) DecideDecisionCard(ctx context.Context, req decisio
 }
 
 func decideDecisionCard(ctx context.Context, tx *sql.Tx, req decisioncard.DecideRequest, postgres bool) (decisioncard.DecisionOutcome, error) {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return decisioncard.DecisionOutcome{}, err
+	}
 	now := decisioncard.CanonicalTimestamp(req.Now)
 	if now.IsZero() {
 		now = decisioncard.CanonicalTimestamp(time.Now())
@@ -507,6 +514,9 @@ func (s *SQLiteRuntimeStore) DeferDecisionCard(ctx context.Context, req decision
 }
 
 func deferDecisionCard(ctx context.Context, tx *sql.Tx, req decisioncard.DeferRequest, postgres bool) (decisioncard.DecisionOutcome, error) {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return decisioncard.DecisionOutcome{}, err
+	}
 	now := decisioncard.CanonicalTimestamp(req.Now)
 	if now.IsZero() {
 		now = decisioncard.CanonicalTimestamp(time.Now())
@@ -823,6 +833,9 @@ func (s *SQLiteRuntimeStore) SupersedeDecisionCardsForStage(ctx context.Context,
 }
 
 func supersedeDecisionCardsForStage(ctx context.Context, tx *sql.Tx, runID, entityID, activationID, reason string, now time.Time, postgres bool) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
 	now = decisioncard.CanonicalTimestamp(now)
 	if now.IsZero() {
 		now = decisioncard.CanonicalTimestamp(time.Now())
@@ -864,6 +877,9 @@ func (s *SQLiteRuntimeStore) SupersedeDecisionCardsForRun(ctx context.Context, r
 }
 
 func supersedeDecisionCardsForRun(ctx context.Context, tx *sql.Tx, runID, reason string, now time.Time, postgres bool) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
 	runID = strings.TrimSpace(runID)
 	reason = strings.TrimSpace(reason)
 	now = decisioncard.CanonicalTimestamp(now)
@@ -1121,6 +1137,11 @@ func appendDecisionCardChangeDTO(ctx context.Context, db decisionCardSQL, runID,
 }
 
 func appendDecisionCardChange(ctx context.Context, db decisionCardSQL, runID, cardID, changeType string, payload semanticvalue.Value, now time.Time, postgres bool) (int64, error) {
+	if cardChangeRegistered(changeType) {
+		if err := runtimeauthoractivity.Require(ctx); err != nil {
+			return 0, err
+		}
+	}
 	now = decisioncard.CanonicalTimestamp(now)
 	if now.IsZero() {
 		return 0, fmt.Errorf("decision card change requires an authoritative timestamp")
@@ -1140,11 +1161,73 @@ func appendDecisionCardChange(ctx context.Context, db decisionCardSQL, runID, ca
 	if err := db.QueryRowContext(ctx, query, runID, cardID, changeType, string(raw), now).Scan(&id); err != nil {
 		return 0, fmt.Errorf("append decision card change: %w", err)
 	}
+	if cardChangeRegistered(changeType) {
+		if err := recordDecisionCardChangeAuthorActivity(ctx, db, id, runID, cardID, changeType, now, postgres); err != nil {
+			return 0, err
+		}
+	}
 	return id, nil
+}
+
+func cardChangeRegistered(changeType string) bool {
+	switch strings.TrimSpace(changeType) {
+	case decisioncard.ChangeCreated, decisioncard.ChangeDecided, decisioncard.ChangeDeferred, decisioncard.ChangeExpired, decisioncard.ChangeSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+func recordDecisionCardChangeAuthorActivity(ctx context.Context, db decisionCardSQL, changeID int64, runID, cardID, changeType string, now time.Time, postgres bool) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
+	card, err := loadDecisionCard(ctx, db, cardID, postgres, false)
+	if err != nil {
+		return err
+	}
+	anchorID := ""
+	entityID := ""
+	flowID := ""
+	switch card.Anchor.Kind() {
+	case decisioncard.AnchorKindStageGate:
+		anchor, err := card.Anchor.StageGate()
+		if err != nil {
+			return err
+		}
+		anchorID, entityID, flowID = anchor.StageActivationID, anchor.EntityID, anchor.FlowInstance
+	case decisioncard.AnchorKindHumanTask:
+		anchor, err := card.Anchor.HumanTask()
+		if err != nil {
+			return err
+		}
+		anchorID, entityID, flowID = anchor.OperationID, anchor.Scope.EntityID, anchor.Scope.FlowInstance
+	default:
+		return fmt.Errorf("decision card anchor kind %q has no author activity adapter", card.Anchor.Kind())
+	}
+	identity := strconv.FormatInt(changeID, 10)
+	projection := runtimeauthoractivity.Projection{
+		SubjectType: "card", SubjectID: card.CardID, CardID: card.CardID,
+		AnchorKind: string(card.Anchor.Kind()), AnchorID: anchorID, DecisionID: card.DecisionEventID,
+		Verdict: card.Verdict, SupersedeReason: card.SupersededReason,
+	}
+	if !card.DeferredUntil.IsZero() {
+		deferred := card.DeferredUntil.UTC()
+		projection.DeferUntil = &deferred
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindCardLifecycle, Transition: strings.TrimSpace(changeType),
+		SourceOwner: "decision_card_changes", SourceIdentity: identity, DedupKey: "card-change:" + identity,
+		OccurredAt: now.UTC(), RunID: strings.TrimSpace(runID), EntityID: entityID, FlowID: flowID,
+		Projection: projection,
+	})
 }
 
 func runPostgresDecisionCardMutation(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) error) error {
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		if !runtimeauthoractivity.InMutation(ctx, tx) {
+			return fmt.Errorf("decision card mutation entered from a raw transaction without author activity ownership")
+		}
 		return fn(ctx, tx)
 	}
 	conn, borrowed := runtimepipeline.PipelineSQLConnFromContext(ctx)
@@ -1163,17 +1246,30 @@ func runPostgresDecisionCardMutation(ctx context.Context, db *sql.DB, fn func(co
 	defer func() { _ = tx.Rollback() }()
 	txctx := runtimepipeline.WithPipelineSQLConnContext(ctx, conn)
 	txctx = runtimepipeline.WithPipelineSQLTxContext(txctx, tx)
-	if err := fn(txctx, tx); err != nil {
+	storyctx, err := runtimeauthoractivity.Begin(txctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
 		return err
 	}
-	return commitPostgresRunForkRevisionTx(txctx, tx)
+	if err := fn(storyctx, tx); err != nil {
+		return err
+	}
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(storyctx, tx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *SQLiteRuntimeStore) runDecisionCardMutation(ctx context.Context, label string, fn func(context.Context, *sql.Tx) error) error {
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
+		if !runtimeauthoractivity.InMutation(ctx, tx) {
+			return fmt.Errorf("%s entered from a raw transaction without author activity ownership", label)
+		}
 		return fn(ctx, tx)
 	}
-	return s.runRuntimeMutation(ctx, label, fn)
+	return s.runAuthorActivityMutation(ctx, label, fn)
 }
 
 func numberPostgresPlaceholders(query string) string {

--- a/internal/store/decision_cards_test.go
+++ b/internal/store/decision_cards_test.go
@@ -314,9 +314,8 @@ func TestDecisionCardStoreEnforcesSafeNumericSnapshotCarriersOnBothStores(t *tes
 			fieldNumber, _ := decided.Fields.Lookup("score")
 			assertStoreSnapshotNumber(t, "fields.score", fieldNumber.Interface(), float64(safeInteger))
 
-			db, postgres := decisionCardStoreDB(t, cardStore)
 			changePayload := admitDecisionCardTestObject(t, map[string]any{"safe_integer": safeInteger, "subnormal": math.SmallestNonzeroFloat64})
-			if _, err := appendDecisionCardChange(ctx, db, runID, card.CardID, decisioncard.ChangeDeferred, changePayload, card.CreatedAt.Add(2*time.Minute), postgres); err != nil {
+			if _, err := appendDecisionCardChangeInStore(ctx, cardStore, runID, card.CardID, decisioncard.ChangeDeferred, changePayload, card.CreatedAt.Add(2*time.Minute)); err != nil {
 				t.Fatalf("append semantic decision-card change: %v", err)
 			}
 			changes, err := cardStore.ListDecisionCardChanges(ctx, decisioncard.SubscriptionOptions{Limit: 10})
@@ -743,6 +742,27 @@ func decisionCardStoreDB(t *testing.T, cards decisioncard.Store) (*sql.DB, bool)
 		t.Fatalf("unexpected decision card store %T", cards)
 		return nil, false
 	}
+}
+
+func appendDecisionCardChangeInStore(ctx context.Context, cards decisioncard.Store, runID, cardID, changeType string, payload semanticvalue.Value, now time.Time) (int64, error) {
+	var changeID int64
+	appendChange := func(postgres bool) func(context.Context, *sql.Tx) error {
+		return func(txctx context.Context, tx *sql.Tx) error {
+			var err error
+			changeID, err = appendDecisionCardChange(txctx, tx, runID, cardID, changeType, payload, now, postgres)
+			return err
+		}
+	}
+	var err error
+	switch store := cards.(type) {
+	case *PostgresStore:
+		err = runPostgresDecisionCardMutation(ctx, store.DB, appendChange(true))
+	case *SQLiteRuntimeStore:
+		err = store.runDecisionCardMutation(ctx, "test append decision card change", appendChange(false))
+	default:
+		return 0, fmt.Errorf("unexpected decision card store %T", cards)
+	}
+	return changeID, err
 }
 
 func seedDecisionCardGateEntity(t *testing.T, db *sql.DB, postgres bool, runID, entityID string, activation gateruntime.Activation, now time.Time) {

--- a/internal/store/destructive_reset_cleanup.go
+++ b/internal/store/destructive_reset_cleanup.go
@@ -487,7 +487,7 @@ func destructiveResetCleanupQuery(table, mode string, runIDs []string, includeBu
 			return `SELECT COUNT(*) FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
 		}
 		return `DELETE FROM event_deliveries d WHERE d.run_id = ANY($1::uuid[]) OR EXISTS (SELECT 1 FROM events e WHERE e.event_id = d.event_id AND e.run_id = ANY($1::uuid[]))`, args, nil
-	case "run_fork_fact_revisions", "run_fork_revisions", "run_fork_revision_heads", "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
+	case "author_activity_occurrences", "run_fork_fact_revisions", "run_fork_revisions", "run_fork_revision_heads", "activity_attempts", "agent_turns", "agent_conversation_audits", "agent_sessions", "decision_card_lifecycle_outbox", "decision_card_route_obligations", "decision_card_changes", "decision_card_input_drafts", "human_task_continuations", "decision_cards", "entity_mutations", "entity_state", "run_control_state", "reply_contexts", "events", "runs":
 		if mode == "count" {
 			return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE run_id = ANY($1::uuid[])`, quoteIdent(table)), args, nil
 		}

--- a/internal/store/event_receipt_store.go
+++ b/internal/store/event_receipt_store.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	"github.com/division-sh/swarm/internal/runtime/destructivereset"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
-	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	runtimerunquiescence "github.com/division-sh/swarm/internal/runtime/runquiescence"
 	"github.com/lib/pq"
 )
@@ -136,12 +136,16 @@ type agentReceiptWriteState struct {
 }
 
 type lockedAgentDelivery struct {
+	deliveryID      string
+	runID           string
+	eventType       string
 	retryCount      int
 	status          string
 	reasonCode      string
 	activeSessionID string
 	entityID        string
 	flowInstance    string
+	startedAt       sql.NullTime
 	found           bool
 }
 
@@ -155,53 +159,51 @@ type deliveryBackedTerminalTransitionRequest struct {
 // never mint or repair delivery ownership from receipt state.
 func (s *PostgresStore) upsertAgentReceiptSpec(ctx context.Context, caps StoreSchemaCapabilities, eventID, agentID string, status runtimemanager.ReceiptStatus, failure *runtimefailures.Envelope) error {
 	if err := withEventStoreRetry(ctx, nil, func() error {
-		tx, err := s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin event receipt tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		delivery, err := s.lockAgentDeliveryTx(ctx, tx, eventID, agentID)
-		if err != nil {
-			return err
-		}
-		if !delivery.found {
-			return fmt.Errorf("upsert event receipt: delivery row required for event %s agent %s", strings.TrimSpace(eventID), strings.TrimSpace(agentID))
-		}
-		if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
-			return nil
-		}
-		state, err := buildAgentReceiptWriteState(delivery.retryCount, status, failure)
-		if err != nil {
-			return err
-		}
-		if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
-			if _, err := s.applyDeliveryBackedTerminalTransitionTx(ctx, tx, eventID, agentID, delivery, deliveryBackedTerminalTransitionRequest{
-				reasonCode:   state.reasonCode,
-				failure:      state.failure,
-				retryAdvance: state.retryCount - delivery.retryCount,
-			}); err != nil {
+		return s.runAuthorActivityMutation(ctx, "postgres upsert event receipt", func(txctx context.Context, tx *sql.Tx) error {
+			delivery, err := s.lockAgentDeliveryTx(txctx, tx, eventID, agentID)
+			if err != nil {
 				return err
 			}
-		} else {
-			if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
-				return err
+			if !delivery.found {
+				return fmt.Errorf("upsert event receipt: delivery row required for event %s agent %s", strings.TrimSpace(eventID), strings.TrimSpace(agentID))
 			}
-			if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
-				return err
+			if !activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
+				state, err := buildAgentReceiptWriteState(delivery.retryCount, status, failure)
+				if err != nil {
+					return err
+				}
+				changed := false
+				if state.finalStatus == runtimemanager.ReceiptStatusDeadLetter {
+					if _, changed, err = s.applyDeliveryBackedTerminalTransitionTx(txctx, tx, eventID, agentID, delivery, deliveryBackedTerminalTransitionRequest{
+						reasonCode:   state.reasonCode,
+						failure:      state.failure,
+						retryAdvance: state.retryCount - delivery.retryCount,
+					}); err != nil {
+						return err
+					}
+				} else {
+					changed, err = s.updateAgentDeliveryRowTx(txctx, tx, eventID, agentID, state)
+					if err != nil {
+						return err
+					}
+					if changed {
+						if err := s.upsertAgentReceiptRowTx(txctx, tx, eventID, agentID, state); err != nil {
+							return err
+						}
+					}
+				}
+				if changed {
+					if err := recordAgentDeliveryAuthorActivity(txctx, delivery, agentID, state, time.Now().UTC()); err != nil {
+						return err
+					}
+				}
 			}
-		}
-		if _, err := runforkrevision.CaptureForEvent(ctx, tx, eventID, runforkrevision.FamilyEventDeliveries, runforkrevision.FamilyEventReceipts); err != nil {
-			return err
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit event receipt tx: %w", err)
-		}
-		return nil
+			return s.convergeStandaloneRuntimePlatformRunByEventID(txctx, tx, caps, eventID)
+		})
 	}); err != nil {
 		return err
 	}
-	return s.convergeStandaloneRuntimePlatformRunByEventID(ctx, s.DB, caps, eventID)
+	return nil
 }
 
 func buildAgentReceiptWriteState(baseRetryCount int, status runtimemanager.ReceiptStatus, failure *runtimefailures.Envelope) (agentReceiptWriteState, error) {
@@ -268,19 +270,23 @@ func (s *PostgresStore) lockAgentDeliveryTx(
 	var delivery lockedAgentDelivery
 	err := tx.QueryRowContext(ctx, `
 		SELECT
+			d.delivery_id::text,
+			COALESCE(d.run_id::text, e.run_id::text, ''),
+			e.event_name,
 			d.retry_count,
 			COALESCE(d.status, ''),
 			COALESCE(d.reason_code, ''),
 			COALESCE(d.active_session_id::text, ''),
 			COALESCE(e.entity_id::text, ''),
-			COALESCE(e.flow_instance, '')
+			COALESCE(e.flow_instance, ''),
+			d.started_at
 		FROM event_deliveries d
 		INNER JOIN events e ON e.event_id = d.event_id
 		WHERE d.event_id = $1::uuid
 		  AND d.subscriber_type = 'agent'
 		  AND d.subscriber_id = $2
 		FOR UPDATE
-	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
+	`, eventID, agentID).Scan(&delivery.deliveryID, &delivery.runID, &delivery.eventType, &delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance, &delivery.startedAt)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return lockedAgentDelivery{}, nil
@@ -298,16 +304,16 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 	eventID, agentID string,
 	delivery lockedAgentDelivery,
 	req deliveryBackedTerminalTransitionRequest,
-) (runtimemanager.EventReceipt, error) {
+) (runtimemanager.EventReceipt, bool, error) {
 	if !delivery.found {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: delivery row required")
+		return runtimemanager.EventReceipt{}, false, fmt.Errorf("apply delivery-backed terminal transition: delivery row required")
 	}
 	reasonCode := strings.TrimSpace(req.reasonCode)
 	if reasonCode == "" {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: reason_code required")
+		return runtimemanager.EventReceipt{}, false, fmt.Errorf("apply delivery-backed terminal transition: reason_code required")
 	}
 	if req.retryAdvance < 0 {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply delivery-backed terminal transition: retry advance must be non-negative")
+		return runtimemanager.EventReceipt{}, false, fmt.Errorf("apply delivery-backed terminal transition: retry advance must be non-negative")
 	}
 	state := agentReceiptWriteState{
 		finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
@@ -316,11 +322,14 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 		failure:      runtimefailures.CloneEnvelope(req.failure),
 		deliveryCode: "dead_letter",
 	}
-	if err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state); err != nil {
-		return runtimemanager.EventReceipt{}, err
+	changed, err := s.updateAgentDeliveryRowTx(ctx, tx, eventID, agentID, state)
+	if err != nil {
+		return runtimemanager.EventReceipt{}, false, err
 	}
-	if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
-		return runtimemanager.EventReceipt{}, err
+	if changed {
+		if err := s.upsertAgentReceiptRowTx(ctx, tx, eventID, agentID, state); err != nil {
+			return runtimemanager.EventReceipt{}, false, err
+		}
 	}
 	return runtimemanager.EventReceipt{
 		EventID:    strings.TrimSpace(eventID),
@@ -328,7 +337,7 @@ func (s *PostgresStore) applyDeliveryBackedTerminalTransitionTx(
 		Status:     runtimemanager.ReceiptStatusDeadLetter,
 		RetryCount: state.retryCount,
 		Failure:    runtimefailures.CloneEnvelope(state.failure),
-	}, nil
+	}, changed, nil
 }
 
 func (s *PostgresStore) updateAgentDeliveryRowTx(
@@ -336,7 +345,7 @@ func (s *PostgresStore) updateAgentDeliveryRowTx(
 	tx *sql.Tx,
 	eventID, agentID string,
 	state agentReceiptWriteState,
-) error {
+) (bool, error) {
 	const q = `
 		UPDATE event_deliveries
 		SET
@@ -349,15 +358,27 @@ func (s *PostgresStore) updateAgentDeliveryRowTx(
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
 		  AND subscriber_id = $2
+		  AND (
+			COALESCE(status, '') IS DISTINCT FROM $3
+			OR COALESCE(retry_count, 0) IS DISTINCT FROM $4
+			OR COALESCE(reason_code, '') IS DISTINCT FROM $5
+			OR COALESCE(failure, 'null'::jsonb) IS DISTINCT FROM COALESCE(NULLIF($6, '')::jsonb, 'null'::jsonb)
+			OR active_session_id IS NOT NULL
+		  )
 	`
 	failureJSON, err := nullableFailureJSON(state.failure)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if _, err := tx.ExecContext(ctx, q, eventID, agentID, state.deliveryCode, state.retryCount, state.reasonCode, failureJSON); err != nil {
-		return fmt.Errorf("sync event delivery: %w", err)
+	result, err := tx.ExecContext(ctx, q, eventID, agentID, state.deliveryCode, state.retryCount, state.reasonCode, failureJSON)
+	if err != nil {
+		return false, fmt.Errorf("sync event delivery: %w", err)
 	}
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read event delivery transition result: %w", err)
+	}
+	return rows > 0, nil
 }
 
 func (s *PostgresStore) upsertAgentReceiptRowTx(ctx context.Context, tx *sql.Tx, eventID, agentID string, state agentReceiptWriteState) error {
@@ -408,7 +429,7 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 			reason_code = 'agent_processing',
 			failure = NULL,
 			active_session_id = COALESCE(NULLIF($3, '')::uuid, active_session_id),
-			started_at = COALESCE(started_at, now()),
+			started_at = COALESCE(started_at, $5),
 			delivered_at = NULL
 		WHERE event_id = $1::uuid
 		  AND subscriber_type = 'agent'
@@ -419,30 +440,50 @@ func (s *PostgresStore) markEventDeliveryInProgressSpec(ctx context.Context, eve
 		  )
 		  AND COALESCE(reason_code, '') <> ALL($4)
 	`
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin mark event delivery in progress: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	res, err := tx.ExecContext(ctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes()))
-	if err != nil {
-		return fmt.Errorf("mark event delivery in progress: %w", err)
-	}
-	if rows, _ := res.RowsAffected(); rows == 0 {
-		if _, ok, err := s.ActiveRunDeliveryQuiesced(ctx, eventID, "agent", agentID); err != nil {
+	return s.runAuthorActivityMutation(ctx, "postgres mark event delivery in progress", func(txctx context.Context, tx *sql.Tx) error {
+		delivery, err := s.lockAgentDeliveryTx(txctx, tx, eventID, agentID)
+		if err != nil {
 			return err
-		} else if ok {
+		}
+		if !delivery.found {
+			return fmt.Errorf("mark event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
+		}
+		if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
 			return nil
 		}
-		return fmt.Errorf("mark event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
+		transitionAt := time.Now().UTC()
+		res, err := tx.ExecContext(txctx, q, eventID, agentID, sessionID, pq.Array(activeRunQuiescenceTerminalReasonCodes()), transitionAt)
+		if err != nil {
+			return fmt.Errorf("mark event delivery in progress: %w", err)
+		}
+		if rows, _ := res.RowsAffected(); rows == 0 {
+			return fmt.Errorf("mark event delivery in progress: delivery transition conflict for event %s agent %s", eventID, agentID)
+		}
+		state := agentReceiptWriteState{deliveryCode: "in_progress", retryCount: delivery.retryCount, reasonCode: "agent_processing"}
+		if delivery.startedAt.Valid {
+			transitionAt = delivery.startedAt.Time.UTC()
+		}
+		return recordAgentDeliveryAuthorActivity(txctx, delivery, agentID, state, transitionAt)
+	})
+}
+
+func recordAgentDeliveryAuthorActivity(ctx context.Context, delivery lockedAgentDelivery, agentID string, state agentReceiptWriteState, occurredAt time.Time) error {
+	transition := strings.TrimSpace(state.deliveryCode)
+	if transition == "" {
+		return fmt.Errorf("agent delivery author activity transition is required")
 	}
-	if _, err := runforkrevision.CaptureForEvent(ctx, tx, eventID, runforkrevision.FamilyEventDeliveries); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit mark event delivery in progress: %w", err)
-	}
-	return nil
+	retry := state.retryCount
+	identity := delivery.deliveryID + ":" + transition + fmt.Sprintf(":%d", retry)
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindDeliveryLifecycle, Transition: transition,
+		SourceOwner: "event_deliveries", SourceIdentity: identity, DedupKey: "delivery:" + identity,
+		OccurredAt: occurredAt.UTC(), RunID: delivery.runID, EntityID: delivery.entityID, FlowID: delivery.flowInstance,
+		AgentID: agentID, Failure: state.failure,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "agent", SubjectID: agentID, EventType: delivery.eventType,
+			SubscriberType: "agent", SubscriberID: agentID, RetryCount: &retry, ReasonCode: state.reasonCode,
+		},
+	})
 }
 
 func (s *PostgresStore) ActiveRunDeliveryQuiesced(ctx context.Context, eventID, subscriberType, subscriberID string) (string, bool, error) {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimeownership "github.com/division-sh/swarm/internal/runtime/core/ownership"
@@ -759,6 +760,9 @@ func (s *PostgresStore) LoadCommittedReplayScope(
 }
 
 func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCapabilities, tx *sql.Tx, evt events.Event) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
 	id, runID, name, entityID, flowInstance, scope, payload, chainDepth, producedBy, producedByType, sourceEventID, createdAt, err := eventStorageEnvelope(evt)
 	if err != nil {
 		return err
@@ -840,11 +844,14 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 	if err != nil {
 		return fmt.Errorf("append event: %w", err)
 	}
+	rows, rowsErr := res.RowsAffected()
+	if rowsErr != nil {
+		return fmt.Errorf("read append event result: %w", rowsErr)
+	}
+	if rows == 0 {
+		return nil
+	}
 	if caps.Events.LogRunID {
-		rows, rowsErr := res.RowsAffected()
-		if rowsErr == nil && rows == 0 {
-			return nil
-		}
 		if err := s.ensureRunRow(ctx, caps, tx, runID, id, name, true); err != nil {
 			return err
 		}
@@ -854,26 +861,17 @@ func (s *PostgresStore) appendEventSpec(ctx context.Context, caps StoreSchemaCap
 			}
 		}
 	}
-	return nil
+	return recordPersistedEventAuthorActivity(ctx, s, evt, producedBy, producedByType)
 }
 
 func (s *PostgresStore) persistEventWithDeliveriesSpec(ctx context.Context, caps StoreSchemaCapabilities, evt events.Event, agentIDs []string) error {
 	return withEventStoreRetry(ctx, nil, func() error {
-		tx, err := s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin event tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
-			return err
-		}
-		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID(), agentIDs); err != nil {
-			return err
-		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-			return fmt.Errorf("commit event tx: %w", err)
-		}
-		return nil
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if err := s.appendEventSpec(txctx, caps, tx, evt); err != nil {
+				return err
+			}
+			return s.insertEventDeliveriesSpec(txctx, caps, tx, evt.ID(), agentIDs)
+		})
 	})
 }
 
@@ -885,24 +883,15 @@ func (s *PostgresStore) persistEventWithDeliveriesAndScopeSpec(
 	scope runtimereplayclaim.CommittedReplayScope,
 ) error {
 	return withEventStoreRetry(ctx, nil, func() error {
-		tx, err := s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin event tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
-			return err
-		}
-		if err := s.insertEventDeliveriesSpec(ctx, caps, tx, evt.ID(), agentIDs); err != nil {
-			return err
-		}
-		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
-			return err
-		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-			return fmt.Errorf("commit event tx: %w", err)
-		}
-		return nil
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if err := s.appendEventSpec(txctx, caps, tx, evt); err != nil {
+				return err
+			}
+			if err := s.insertEventDeliveriesSpec(txctx, caps, tx, evt.ID(), agentIDs); err != nil {
+				return err
+			}
+			return s.upsertCommittedReplayScopeSpec(txctx, caps, tx, evt.ID(), scope)
+		})
 	})
 }
 
@@ -915,24 +904,15 @@ func (s *PostgresStore) persistEventWithDeliveryRoutesAndScopeSpec(
 	scope runtimereplayclaim.CommittedReplayScope,
 ) error {
 	return withEventStoreRetry(ctx, nil, func() error {
-		tx, err := s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin event tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
-			return err
-		}
-		if err := s.insertEventDeliveriesWithTargetsSpec(ctx, caps, tx, evt.ID(), agentIDs, deliveryTargets); err != nil {
-			return err
-		}
-		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
-			return err
-		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-			return fmt.Errorf("commit event tx: %w", err)
-		}
-		return nil
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if err := s.appendEventSpec(txctx, caps, tx, evt); err != nil {
+				return err
+			}
+			if err := s.insertEventDeliveriesWithTargetsSpec(txctx, caps, tx, evt.ID(), agentIDs, deliveryTargets); err != nil {
+				return err
+			}
+			return s.upsertCommittedReplayScopeSpec(txctx, caps, tx, evt.ID(), scope)
+		})
 	})
 }
 
@@ -944,24 +924,15 @@ func (s *PostgresStore) persistEventWithDeliveryRouteSetAndScopeSpec(
 	scope runtimereplayclaim.CommittedReplayScope,
 ) error {
 	return withEventStoreRetry(ctx, nil, func() error {
-		tx, err := s.DB.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin event tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-		if err := s.appendEventSpec(ctx, caps, tx, evt); err != nil {
-			return err
-		}
-		if err := s.insertEventDeliveryRoutesSpec(ctx, caps, tx, evt.ID(), deliveryRoutes); err != nil {
-			return err
-		}
-		if err := s.upsertCommittedReplayScopeSpec(ctx, caps, tx, evt.ID(), scope); err != nil {
-			return err
-		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-			return fmt.Errorf("commit event tx: %w", err)
-		}
-		return nil
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+			if err := s.appendEventSpec(txctx, caps, tx, evt); err != nil {
+				return err
+			}
+			if err := s.insertEventDeliveryRoutesSpec(txctx, caps, tx, evt.ID(), deliveryRoutes); err != nil {
+				return err
+			}
+			return s.upsertCommittedReplayScopeSpec(txctx, caps, tx, evt.ID(), scope)
+		})
 	})
 }
 
@@ -1715,20 +1686,17 @@ func (s *PostgresStore) MarkRunTerminal(ctx context.Context, runID, status strin
 	if endedAt.IsZero() {
 		endedAt = time.Now().UTC()
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("begin run terminal tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	snap, err := storerunlifecycle.MarkTerminal(ctx, tx, runID, status, failure, endedAt, runLifecycleOptions(caps))
+	var snap storerunlifecycle.Snapshot
+	err = s.runAuthorActivityMutation(ctx, "postgres mark run terminal", func(txctx context.Context, tx *sql.Tx) error {
+		var err error
+		snap, err = storerunlifecycle.MarkTerminal(txctx, tx, runID, status, failure, endedAt, runLifecycleOptions(caps))
+		if err != nil {
+			return err
+		}
+		return supersedeDecisionCardsForRun(txctx, tx, runID, "run_"+status, endedAt, true)
+	})
 	if err != nil {
 		return runtimebus.RunLifecycleSnapshot{}, err
-	}
-	if err := supersedeDecisionCardsForRun(ctx, tx, runID, "run_"+status, endedAt, true); err != nil {
-		return runtimebus.RunLifecycleSnapshot{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("commit run terminal tx: %w", err)
 	}
 	return runtimebus.RunLifecycleSnapshot{
 		RunID:       snap.RunID,
@@ -1746,13 +1714,9 @@ func (s *PostgresStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Context
 	if err != nil {
 		return err
 	}
-	var db storerunlifecycle.DBTX = s.DB
-	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
-		db = tx
-	} else if conn, ok := runtimepipeline.PipelineSQLConnFromContext(ctx); ok {
-		db = conn
-	}
-	return s.convergeStandaloneRuntimePlatformRunByEventID(ctx, db, caps, strings.TrimSpace(evt.ID()))
+	return s.runAuthorActivityMutation(ctx, "postgres standalone platform run convergence", func(txctx context.Context, tx *sql.Tx) error {
+		return s.convergeStandaloneRuntimePlatformRunByEventID(txctx, tx, caps, strings.TrimSpace(evt.ID()))
+	})
 }
 
 func runLifecycleOptions(caps StoreSchemaCapabilities) storerunlifecycle.EnsureActiveOptions {

--- a/internal/store/human_task_cards.go
+++ b/internal/store/human_task_cards.go
@@ -31,7 +31,7 @@ func (s *SQLiteRuntimeStore) CreateHumanTaskCard(ctx context.Context, card decis
 	if tx, ok := runtimepipeline.PipelineSQLTxFromContext(ctx); ok && tx != nil {
 		return insertHumanTaskCard(ctx, tx, card, continuation, false)
 	}
-	return s.runRuntimeMutation(ctx, "sqlite create human-task card", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runDecisionCardMutation(ctx, "sqlite create human-task card", func(txctx context.Context, tx *sql.Tx) error {
 		return insertHumanTaskCard(txctx, tx, card, continuation, false)
 	})
 }
@@ -171,7 +171,7 @@ func (s *PostgresStore) ExpireHumanTaskCards(ctx context.Context, now time.Time,
 
 func (s *SQLiteRuntimeStore) ExpireHumanTaskCards(ctx context.Context, now time.Time, limit int) (int, error) {
 	count := 0
-	err := s.runRuntimeMutation(ctx, "sqlite expire human-task cards", func(txctx context.Context, tx *sql.Tx) error {
+	err := s.runDecisionCardMutation(ctx, "sqlite expire human-task cards", func(txctx context.Context, tx *sql.Tx) error {
 		var err error
 		count, err = expireHumanTaskCards(txctx, tx, now, limit, false)
 		return err

--- a/internal/store/inbound.go
+++ b/internal/store/inbound.go
@@ -146,6 +146,9 @@ func (s *PostgresStore) ClaimInboundEventTx(ctx context.Context, tx *sql.Tx, pro
 	if _, err := tx.ExecContext(ctx, insertQ, args...); err != nil {
 		return false, fmt.Errorf("record inbound event in events: %w", err)
 	}
+	if err := recordInboundAuthorActivity(ctx, evt, provider); err != nil {
+		return false, err
+	}
 	return true, nil
 }
 

--- a/internal/store/llm_store.go
+++ b/internal/store/llm_store.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/google/uuid"
 )
@@ -39,38 +41,30 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			return unsupportedSchemaCapability("agent_sessions", caps.Conversations.Sessions)
 		}
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("append agent turn begin tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	return s.runAuthorActivityMutation(ctx, "postgres append agent turn", func(txctx context.Context, tx *sql.Tx) error {
+		ctx = txctx
+
+		reqPayload := normalizeJSONPayload(rec.RequestPayload)
+		respPayload := normalizeJSONPayload(rec.ResponseRaw)
+		toolCallsPayload := normalizeJSONArray(rec.ToolCalls)
+		availableToolsPayload := normalizeJSONArray(rec.AvailableTools)
+		emittedEventsPayload := normalizeJSONArray(rec.EmittedEvents)
+		mcpServersPayload := normalizeJSONObject(rec.MCPServers)
+		mcpToolsListedPayload := normalizeJSONArray(rec.MCPToolsListed)
+		mcpToolsVisiblePayload := normalizeJSONArray(rec.MCPToolsVisible)
+		failurePayload := ""
+		if encodedFailure, err := encodeStoredFailure(rec.Failure); err != nil {
+			return fmt.Errorf("encode agent turn failure: %w", err)
+		} else if encodedFailure != nil {
+			failurePayload = encodedFailure.(string)
 		}
-	}()
+		latencyMS := int(rec.Latency / time.Millisecond)
+		if latencyMS < 0 {
+			latencyMS = 0
+		}
+		runID := strings.TrimSpace(rec.RunID)
 
-	reqPayload := normalizeJSONPayload(rec.RequestPayload)
-	respPayload := normalizeJSONPayload(rec.ResponseRaw)
-	toolCallsPayload := normalizeJSONArray(rec.ToolCalls)
-	availableToolsPayload := normalizeJSONArray(rec.AvailableTools)
-	emittedEventsPayload := normalizeJSONArray(rec.EmittedEvents)
-	mcpServersPayload := normalizeJSONObject(rec.MCPServers)
-	mcpToolsListedPayload := normalizeJSONArray(rec.MCPToolsListed)
-	mcpToolsVisiblePayload := normalizeJSONArray(rec.MCPToolsVisible)
-	failurePayload := ""
-	if encodedFailure, err := encodeStoredFailure(rec.Failure); err != nil {
-		return fmt.Errorf("encode agent turn failure: %w", err)
-	} else if encodedFailure != nil {
-		failurePayload = encodedFailure.(string)
-	}
-	latencyMS := int(rec.Latency / time.Millisecond)
-	if latencyMS < 0 {
-		latencyMS = 0
-	}
-	runID := strings.TrimSpace(rec.RunID)
-
-	updateQ := fmt.Sprintf(`
+		updateQ := fmt.Sprintf(`
 		UPDATE %s
 		SET runtime_state = COALESCE(runtime_state, '{}'::jsonb) || jsonb_build_object(
 				'last_turn',
@@ -91,23 +85,23 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 		  AND session_id = $3::uuid
 		  AND status = 'active'
 	`, targetTable)
-	updateArgs := []any{
-		rec.AgentID,
-		runtimeMode,
-		rec.SessionID,
-		rec.TaskID,
-		reqPayload,
-		respPayload,
-		rec.ParseOK,
-		latencyMS,
-		rec.RetryCount,
-		failurePayload,
-	}
-	if hasConversationRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
-			return err
+		updateArgs := []any{
+			rec.AgentID,
+			runtimeMode,
+			rec.SessionID,
+			rec.TaskID,
+			reqPayload,
+			respPayload,
+			rec.ParseOK,
+			latencyMS,
+			rec.RetryCount,
+			failurePayload,
 		}
-		updateQ = fmt.Sprintf(`
+		if hasConversationRunID {
+			if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
+				return err
+			}
+			updateQ = fmt.Sprintf(`
 			UPDATE %s
 			SET runtime_state = COALESCE(runtime_state, '{}'::jsonb) || jsonb_build_object(
 					'last_turn',
@@ -129,22 +123,22 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			  AND session_id = $3::uuid
 			  AND status = 'active'
 		`, targetTable)
-		updateArgs = []any{
-			rec.AgentID,
-			runtimeMode,
-			rec.SessionID,
-			nullUUIDString(runID),
-			rec.TaskID,
-			reqPayload,
-			respPayload,
-			rec.ParseOK,
-			latencyMS,
-			rec.RetryCount,
-			failurePayload,
+			updateArgs = []any{
+				rec.AgentID,
+				runtimeMode,
+				rec.SessionID,
+				nullUUIDString(runID),
+				rec.TaskID,
+				reqPayload,
+				respPayload,
+				rec.ParseOK,
+				latencyMS,
+				rec.RetryCount,
+				failurePayload,
+			}
 		}
-	}
-	if !runtimeMode.IsStateless() {
-		updateQ = `
+		if !runtimeMode.IsStateless() {
+			updateQ = `
 			UPDATE agent_sessions
 			SET updated_at = now()
 			WHERE agent_id = $1
@@ -152,16 +146,16 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			  AND session_id = $3::uuid
 			  AND status = 'active'
 		`
-		updateArgs = []any{
-			rec.AgentID,
-			runtimeMode,
-			rec.SessionID,
-		}
-		if hasConversationRunID {
-			if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
-				return err
+			updateArgs = []any{
+				rec.AgentID,
+				runtimeMode,
+				rec.SessionID,
 			}
-			updateQ = `
+			if hasConversationRunID {
+				if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
+					return err
+				}
+				updateQ = `
 				UPDATE agent_sessions
 				SET run_id = COALESCE(NULLIF($4,'')::uuid, run_id),
 				    updated_at = now()
@@ -170,49 +164,49 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 				  AND session_id = $3::uuid
 				  AND status = 'active'
 			`
-			updateArgs = []any{
-				rec.AgentID,
-				runtimeMode,
-				rec.SessionID,
-				nullUUIDString(runID),
+				updateArgs = []any{
+					rec.AgentID,
+					runtimeMode,
+					rec.SessionID,
+					nullUUIDString(runID),
+				}
 			}
 		}
-	}
-	res, err := tx.ExecContext(ctx, updateQ,
-		updateArgs...,
-	)
-	if err != nil {
-		return fmt.Errorf("append agent turn: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		if runtimeMode == runtimesessions.RuntimeModeTask {
-			if err := s.ensureTaskConversationAuditRowTx(ctx, tx, caps, rec); err != nil {
-				return err
-			}
-			res, err = tx.ExecContext(ctx, updateQ, updateArgs...)
-			if err != nil {
-				return fmt.Errorf("append agent turn: %w", err)
-			}
-			n, _ = res.RowsAffected()
+		res, err := tx.ExecContext(ctx, updateQ,
+			updateArgs...,
+		)
+		if err != nil {
+			return fmt.Errorf("append agent turn: %w", err)
 		}
+		n, _ := res.RowsAffected()
 		if n == 0 {
-			return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, rec.RuntimeMode, rec.SessionID)
+			if runtimeMode == runtimesessions.RuntimeModeTask {
+				if err := s.ensureTaskConversationAuditRowTx(ctx, tx, caps, rec); err != nil {
+					return err
+				}
+				res, err = tx.ExecContext(ctx, updateQ, updateArgs...)
+				if err != nil {
+					return fmt.Errorf("append agent turn: %w", err)
+				}
+				n, _ = res.RowsAffected()
+			}
+			if n == 0 {
+				return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, rec.RuntimeMode, rec.SessionID)
+			}
 		}
-	}
 
-	hasRunID := caps.Conversations.TurnRunID
-	hasTurnBlocks := caps.Conversations.TurnBlocks
-	turnBlocksPayload := ""
-	if hasTurnBlocks {
-		rec = runtimellm.CanonicalizeTurnForPersistence(rec)
-		if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocks(rec.TurnBlocks); err != nil {
-			return fmt.Errorf("validate canonical runtime_log turn_blocks: %w", err)
+		hasRunID := caps.Conversations.TurnRunID
+		hasTurnBlocks := caps.Conversations.TurnBlocks
+		turnBlocksPayload := ""
+		if hasTurnBlocks {
+			rec = runtimellm.CanonicalizeTurnForPersistence(rec)
+			if _, err := runtimellm.DecodeCanonicalRuntimeLogTurnBlocks(rec.TurnBlocks); err != nil {
+				return fmt.Errorf("validate canonical runtime_log turn_blocks: %w", err)
+			}
+			turnBlocksPayload = normalizeJSONArray(rec.TurnBlocks)
 		}
-		turnBlocksPayload = normalizeJSONArray(rec.TurnBlocks)
-	}
 
-	insertTurn := `
+		insertTurn := `
 		INSERT INTO agent_turns (
 			agent_id, session_id, runtime_mode, scope_key, entity_id,
 			trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
@@ -241,30 +235,30 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 			CASE WHEN $20 = '' THEN NULL ELSE $20::jsonb END
 		)
 	`
-	insertArgs := []any{
-		rec.AgentID,
-		rec.SessionID,
-		runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
-		rec.ScopeKey,
-		rec.EntityID,
-		rec.TriggerEventID,
-		rec.TriggerEventType,
-		rec.TaskID,
-		availableToolsPayload,
-		toolCallsPayload,
-		emittedEventsPayload,
-		mcpServersPayload,
-		mcpToolsListedPayload,
-		mcpToolsVisiblePayload,
-		reqPayload,
-		respPayload,
-		rec.ParseOK,
-		latencyMS,
-		rec.RetryCount,
-		failurePayload,
-	}
-	if hasTurnBlocks {
-		insertTurn = `
+		insertArgs := []any{
+			rec.AgentID,
+			rec.SessionID,
+			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
+			rec.ScopeKey,
+			rec.EntityID,
+			rec.TriggerEventID,
+			rec.TriggerEventType,
+			rec.TaskID,
+			availableToolsPayload,
+			toolCallsPayload,
+			emittedEventsPayload,
+			mcpServersPayload,
+			mcpToolsListedPayload,
+			mcpToolsVisiblePayload,
+			reqPayload,
+			respPayload,
+			rec.ParseOK,
+			latencyMS,
+			rec.RetryCount,
+			failurePayload,
+		}
+		if hasTurnBlocks {
+			insertTurn = `
 			INSERT INTO agent_turns (
 				agent_id, session_id, runtime_mode, scope_key, entity_id,
 				trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
@@ -294,35 +288,35 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 				CASE WHEN $21 = '' THEN NULL ELSE $21::jsonb END
 			)
 		`
-		insertArgs = []any{
-			rec.AgentID,
-			rec.SessionID,
-			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
-			rec.ScopeKey,
-			rec.EntityID,
-			rec.TriggerEventID,
-			rec.TriggerEventType,
-			rec.TaskID,
-			availableToolsPayload,
-			toolCallsPayload,
-			emittedEventsPayload,
-			mcpServersPayload,
-			mcpToolsListedPayload,
-			mcpToolsVisiblePayload,
-			reqPayload,
-			respPayload,
-			turnBlocksPayload,
-			rec.ParseOK,
-			latencyMS,
-			rec.RetryCount,
-			failurePayload,
+			insertArgs = []any{
+				rec.AgentID,
+				rec.SessionID,
+				runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
+				rec.ScopeKey,
+				rec.EntityID,
+				rec.TriggerEventID,
+				rec.TriggerEventType,
+				rec.TaskID,
+				availableToolsPayload,
+				toolCallsPayload,
+				emittedEventsPayload,
+				mcpServersPayload,
+				mcpToolsListedPayload,
+				mcpToolsVisiblePayload,
+				reqPayload,
+				respPayload,
+				turnBlocksPayload,
+				rec.ParseOK,
+				latencyMS,
+				rec.RetryCount,
+				failurePayload,
+			}
 		}
-	}
-	if hasRunID {
-		if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
-			return err
-		}
-		insertTurn = `
+		if hasRunID {
+			if err := s.ensureRunRow(ctx, caps, tx, runID, "", "", true); err != nil {
+				return err
+			}
+			insertTurn = `
 			INSERT INTO agent_turns (
 				run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
 				trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
@@ -352,31 +346,31 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 				CASE WHEN $21 = '' THEN NULL ELSE $21::jsonb END
 			)
 		`
-		insertArgs = []any{
-			nullUUIDString(runID),
-			rec.AgentID,
-			rec.SessionID,
-			runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
-			rec.ScopeKey,
-			rec.EntityID,
-			rec.TriggerEventID,
-			rec.TriggerEventType,
-			rec.TaskID,
-			availableToolsPayload,
-			toolCallsPayload,
-			emittedEventsPayload,
-			mcpServersPayload,
-			mcpToolsListedPayload,
-			mcpToolsVisiblePayload,
-			reqPayload,
-			respPayload,
-			rec.ParseOK,
-			latencyMS,
-			rec.RetryCount,
-			failurePayload,
-		}
-		if hasTurnBlocks {
-			insertTurn = `
+			insertArgs = []any{
+				nullUUIDString(runID),
+				rec.AgentID,
+				rec.SessionID,
+				runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
+				rec.ScopeKey,
+				rec.EntityID,
+				rec.TriggerEventID,
+				rec.TriggerEventType,
+				rec.TaskID,
+				availableToolsPayload,
+				toolCallsPayload,
+				emittedEventsPayload,
+				mcpServersPayload,
+				mcpToolsListedPayload,
+				mcpToolsVisiblePayload,
+				reqPayload,
+				respPayload,
+				rec.ParseOK,
+				latencyMS,
+				rec.RetryCount,
+				failurePayload,
+			}
+			if hasTurnBlocks {
+				insertTurn = `
 				INSERT INTO agent_turns (
 					run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
 					trigger_event_id, trigger_event_type, task_id, available_tools, tool_calls,
@@ -407,40 +401,43 @@ func (s *PostgresStore) AppendAgentTurn(ctx context.Context, rec runtimellm.Agen
 					CASE WHEN $22 = '' THEN NULL ELSE $22::jsonb END
 				)
 			`
-			insertArgs = []any{
-				nullUUIDString(runID),
-				rec.AgentID,
-				rec.SessionID,
-				runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
-				rec.ScopeKey,
-				rec.EntityID,
-				rec.TriggerEventID,
-				rec.TriggerEventType,
-				rec.TaskID,
-				availableToolsPayload,
-				toolCallsPayload,
-				emittedEventsPayload,
-				mcpServersPayload,
-				mcpToolsListedPayload,
-				mcpToolsVisiblePayload,
-				reqPayload,
-				respPayload,
-				turnBlocksPayload,
-				rec.ParseOK,
-				latencyMS,
-				rec.RetryCount,
-				failurePayload,
+				insertArgs = []any{
+					nullUUIDString(runID),
+					rec.AgentID,
+					rec.SessionID,
+					runtimesessions.NormalizeConversationRuntimeMode(rec.RuntimeMode).String(),
+					rec.ScopeKey,
+					rec.EntityID,
+					rec.TriggerEventID,
+					rec.TriggerEventType,
+					rec.TaskID,
+					availableToolsPayload,
+					toolCallsPayload,
+					emittedEventsPayload,
+					mcpServersPayload,
+					mcpToolsListedPayload,
+					mcpToolsVisiblePayload,
+					reqPayload,
+					respPayload,
+					turnBlocksPayload,
+					rec.ParseOK,
+					latencyMS,
+					rec.RetryCount,
+					failurePayload,
+				}
 			}
 		}
-	}
-	if _, err := tx.ExecContext(ctx, insertTurn, insertArgs...); err != nil {
-		return fmt.Errorf("insert agent turn: %w", err)
-	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("append agent turn commit: %w", err)
-	}
-	committed = true
-	return nil
+		var turnID string
+		if err := tx.QueryRowContext(ctx, insertTurn+` RETURNING turn_id::text`, insertArgs...).Scan(&turnID); err != nil {
+			return fmt.Errorf("insert agent turn: %w", err)
+		}
+		return recordAuthorActivityTurn(ctx, authorActivityTurn{
+			TurnID: turnID, RunID: runID, AgentID: rec.AgentID, SessionID: rec.SessionID, EntityID: rec.EntityID,
+			FlowID: rec.FlowInstance, TriggerEventType: rec.TriggerEventType, Blocks: rec.TurnBlocks,
+			ParseOK: rec.ParseOK, DurationMS: latencyMS, RetryCount: rec.RetryCount, UsageExactness: "unavailable",
+			Failure: rec.Failure, OccurredAt: time.Now().UTC(),
+		})
+	})
 }
 
 func (s *PostgresStore) ensureTaskConversationAuditRowTx(ctx context.Context, tx *sql.Tx, caps StoreSchemaCapabilities, rec runtimellm.AgentTurnRecord) error {
@@ -636,6 +633,10 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		return fmt.Errorf("upsert conversation begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	ctx, err = runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return err
+	}
 
 	if resolved.Stateless {
 		if sessionID == "" {
@@ -764,7 +765,13 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
 			return fmt.Errorf("insert stateless conversation: %w", err)
 		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+			return fmt.Errorf("capture stateless conversation revisions: %w", err)
+		}
+		if err := runtimeauthoractivity.Finalize(ctx); err != nil {
+			return fmt.Errorf("finalize stateless conversation story: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("upsert stateless conversation commit: %w", err)
 		}
 		return nil
@@ -835,7 +842,13 @@ func (s *PostgresStore) UpsertConversation(ctx context.Context, rec runtimellm.C
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		return fmt.Errorf("no active live session row found for agent=%s session=%s runtime=%s scope=%s", rec.AgentID, sessionID, mode.String(), resolved.ScopeKey)
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+		return fmt.Errorf("capture live conversation revisions: %w", err)
+	}
+	if err := runtimeauthoractivity.Finalize(ctx); err != nil {
+		return fmt.Errorf("finalize live conversation story: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("upsert live conversation commit: %w", err)
 	}
 	return nil

--- a/internal/store/operator_conversation_projection.go
+++ b/internal/store/operator_conversation_projection.go
@@ -39,13 +39,14 @@ type OperatorConversationTokenUsage struct {
 }
 
 type OperatorConversationActivity struct {
-	Kind      string `json:"kind"`
-	ToolName  string `json:"tool_name,omitempty"`
-	ToolUseID string `json:"tool_use_id,omitempty"`
-	EventID   string `json:"event_id,omitempty"`
-	EventType string `json:"event_type,omitempty"`
-	Text      string `json:"text,omitempty"`
-	OK        *bool  `json:"ok,omitempty"`
+	Kind         string `json:"kind"`
+	ToolName     string `json:"tool_name,omitempty"`
+	ToolUseID    string `json:"tool_use_id,omitempty"`
+	EventID      string `json:"event_id,omitempty"`
+	EventType    string `json:"event_type,omitempty"`
+	Text         string `json:"text,omitempty"`
+	OK           *bool  `json:"ok,omitempty"`
+	BlockOrdinal int    `json:"-"`
 }
 
 type OperatorConversationActivityCounts struct {
@@ -757,14 +758,14 @@ func projectAuthorSafeTurnActivity(blocks []runtimellm.TurnBlock, parseOK bool) 
 	activity := make([]OperatorConversationActivity, 0, len(blocks))
 	assistantOutput := ""
 	outcome := ""
-	for _, block := range blocks {
+	for ordinal, block := range blocks {
 		switch strings.TrimSpace(block.Kind) {
 		case "dispatch":
 			data, ok, err := block.DispatchData()
 			if err != nil || !ok {
 				return nil, "", "", fmt.Errorf("decode public dispatch activity: %w", firstNonNilError(err, errors.New("dispatch data is required")))
 			}
-			activity = append(activity, OperatorConversationActivity{Kind: "dispatch", EventID: strings.TrimSpace(data.TriggerEventID), EventType: strings.TrimSpace(data.TriggerEventType)})
+			activity = append(activity, OperatorConversationActivity{Kind: "dispatch", EventID: strings.TrimSpace(data.TriggerEventID), EventType: strings.TrimSpace(data.TriggerEventType), BlockOrdinal: ordinal})
 		case "tool_use":
 			name := strings.TrimSpace(block.ToolName)
 			if name == "" {
@@ -774,7 +775,7 @@ func projectAuthorSafeTurnActivity(blocks []runtimellm.TurnBlock, parseOK bool) 
 			if err != nil {
 				return nil, "", "", fmt.Errorf("decode public tool activity: %w", err)
 			}
-			activity = append(activity, OperatorConversationActivity{Kind: "tool", ToolName: name, ToolUseID: strings.TrimSpace(link.ToolUseID)})
+			activity = append(activity, OperatorConversationActivity{Kind: "tool", ToolName: name, ToolUseID: strings.TrimSpace(link.ToolUseID), BlockOrdinal: ordinal})
 		case "tool_result":
 			name := strings.TrimSpace(block.ToolName)
 			if name == "" {
@@ -785,17 +786,17 @@ func projectAuthorSafeTurnActivity(blocks []runtimellm.TurnBlock, parseOK bool) 
 				return nil, "", "", fmt.Errorf("decode public tool result activity: %w", err)
 			}
 			ok := parseOK
-			activity = append(activity, OperatorConversationActivity{Kind: "tool_result", ToolName: name, ToolUseID: strings.TrimSpace(link.ToolUseID), OK: &ok})
+			activity = append(activity, OperatorConversationActivity{Kind: "tool_result", ToolName: name, ToolUseID: strings.TrimSpace(link.ToolUseID), OK: &ok, BlockOrdinal: ordinal})
 		case "publish":
 			data, ok, err := block.PublishData()
 			if err != nil || !ok {
 				return nil, "", "", fmt.Errorf("decode public publish activity: %w", firstNonNilError(err, errors.New("publish data is required")))
 			}
-			activity = append(activity, OperatorConversationActivity{Kind: "publish", EventID: strings.TrimSpace(data.EventID), EventType: strings.TrimSpace(block.Title)})
+			activity = append(activity, OperatorConversationActivity{Kind: "publish", EventID: strings.TrimSpace(data.EventID), EventType: strings.TrimSpace(block.Title), BlockOrdinal: ordinal})
 		case "assistant_text":
 			if text := strings.TrimSpace(block.Text); text != "" {
 				assistantOutput = text
-				activity = append(activity, OperatorConversationActivity{Kind: "output", Text: text})
+				activity = append(activity, OperatorConversationActivity{Kind: "output", Text: text, BlockOrdinal: ordinal})
 			}
 		case "outcome":
 			if text := strings.TrimSpace(block.Text); text != "" {

--- a/internal/store/platformschema/platformschema.go
+++ b/internal/store/platformschema/platformschema.go
@@ -142,6 +142,10 @@ func platformTableOrder(name string) int {
 		return 3
 	case "runs":
 		return 5
+	case "author_activity_order":
+		return 6
+	case "author_activity_occurrences":
+		return 7
 	case "events":
 		return 10
 	case "run_fork_revision_heads":

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -20,8 +20,10 @@ type PostgresStore struct {
 	schemaCaps      StoreSchemaCapabilities
 	schemaCapsBound bool
 
-	eventPayloadValidator EventPayloadValidator
-	sessionLockTTL        time.Duration
+	eventPayloadValidator   EventPayloadValidator
+	authorActivityCatalogMu sync.RWMutex
+	authorActivityCatalog   map[string]struct{}
+	sessionLockTTL          time.Duration
 
 	scheduleClaimMu   sync.Mutex
 	scheduleClaimConn *sql.Conn

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -2655,31 +2655,23 @@ func TestPostgresStore_PipelineReceipts_MissingEventsQuery_QuarantinesNoRunIDCap
 	}
 }
 
-func TestPostgresStore_BeginEventTx_AppendAndDeliveriesTx(t *testing.T) {
+func TestPostgresStore_RunEventTransaction_AppendAndDeliveriesTx(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
 	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
-
-	tx, err := pg.BeginEventTx(ctx)
-	if err != nil {
-		t.Fatalf("BeginEventTx: %v", err)
-	}
 
 	eventID := uuid.NewString()
 	evt := eventtest.PersistedProjection(eventID,
 		events.EventType("system.started"),
 		"runtime", "", []byte(`{"ok":true}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
-	if err := pg.AppendEventTx(ctx, tx, evt); err != nil {
-		_ = tx.Rollback()
-		t.Fatalf("AppendEventTx: %v", err)
-	}
-	if err := pg.InsertEventDeliveriesTx(ctx, tx, eventID, []string{"control-plane", "reviewer"}); err != nil {
-		_ = tx.Rollback()
-		t.Fatalf("InsertEventDeliveriesTx: %v", err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit event tx: %v", err)
+	if err := pg.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		if err := pg.AppendEventTx(txctx, tx, evt); err != nil {
+			return err
+		}
+		return pg.InsertEventDeliveriesTx(txctx, tx, eventID, []string{"control-plane", "reviewer"})
+	}); err != nil {
+		t.Fatalf("RunEventTransaction: %v", err)
 	}
 
 	var nEvents, nDeliveries int
@@ -4682,7 +4674,7 @@ func TestManagerStore_AppendAgentTurn_PersistsTurnBlocksWhenColumnExists(t *test
 		RuntimeMode: "task",
 		SessionID:   sessionID,
 		TurnBlocks: []runtimellm.TurnBlock{
-			{Kind: "dispatch", Title: "scoring/vertical.marginal"},
+			{Kind: "dispatch", Title: "scoring/vertical.marginal", Data: json.RawMessage(`{"trigger_event_type":"scoring/vertical.marginal"}`)},
 			{Kind: "tool_use", ToolName: "schedule", Input: json.RawMessage(`{"delay_seconds":1209600}`)},
 			{Kind: "outcome", Text: "14-day review scheduled."},
 		},

--- a/internal/store/run_bundle_fingerprint_test.go
+++ b/internal/store/run_bundle_fingerprint_test.go
@@ -134,6 +134,7 @@ func TestPostgresStore_RunBundleSourceDoesNotPromoteLegacyFingerprintIntoBundleH
 
 func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
 	if _, err := db.ExecContext(ctx, `
@@ -143,12 +144,14 @@ func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) 
 		t.Fatalf("seed canonical bundle row: %v", err)
 	}
 
-	if err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{
-		HasStartedAtCol:    true,
-		HasBundleHashCol:   true,
-		HasBundleSourceCol: true,
-		BundleHash:         testCanonicalBundleHash,
-		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	if err := pg.runAuthorActivityMutation(ctx, "test ensure active run", func(txctx context.Context, tx *sql.Tx) error {
+		return storerunlifecycle.EnsureActive(txctx, tx, runID, "", "", storerunlifecycle.EnsureActiveOptions{
+			HasStartedAtCol:    true,
+			HasBundleHashCol:   true,
+			HasBundleSourceCol: true,
+			BundleHash:         testCanonicalBundleHash,
+			BundleSource:       storerunlifecycle.BundleSourcePersisted,
+		})
 	}); err != nil {
 		t.Fatalf("EnsureActive: %v", err)
 	}
@@ -157,10 +160,13 @@ func TestRunLifecycleOwnerPersistsCanonicalBundleHashWhenSupplied(t *testing.T) 
 
 func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	err := storerunlifecycle.EnsureActive(context.Background(), db, uuid.NewString(), "", "", storerunlifecycle.EnsureActiveOptions{
-		HasBundleHashCol:   true,
-		HasBundleSourceCol: true,
-		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	pg := &PostgresStore{DB: db}
+	err := pg.runAuthorActivityMutation(context.Background(), "test ensure invalid active run", func(txctx context.Context, tx *sql.Tx) error {
+		return storerunlifecycle.EnsureActive(txctx, tx, uuid.NewString(), "", "", storerunlifecycle.EnsureActiveOptions{
+			HasBundleHashCol:   true,
+			HasBundleSourceCol: true,
+			BundleSource:       storerunlifecycle.BundleSourcePersisted,
+		})
 	})
 	if err == nil {
 		t.Fatal("EnsureActive error = nil, want missing bundle_hash rejection")
@@ -169,14 +175,17 @@ func TestRunLifecycleOwnerRejectsNonLegacySourceWithoutBundleHash(t *testing.T) 
 
 func TestRunLifecycleOwnerRejectsPersistedSourceWithoutBundleRow(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
 	ctx := context.Background()
 	runID := uuid.NewString()
 
-	err := storerunlifecycle.EnsureActive(ctx, db, runID, "", "", storerunlifecycle.EnsureActiveOptions{
-		HasBundleHashCol:   true,
-		HasBundleSourceCol: true,
-		BundleHash:         testCanonicalBundleHash,
-		BundleSource:       storerunlifecycle.BundleSourcePersisted,
+	err := pg.runAuthorActivityMutation(ctx, "test ensure missing persisted run bundle", func(txctx context.Context, tx *sql.Tx) error {
+		return storerunlifecycle.EnsureActive(txctx, tx, runID, "", "", storerunlifecycle.EnsureActiveOptions{
+			HasBundleHashCol:   true,
+			HasBundleSourceCol: true,
+			BundleHash:         testCanonicalBundleHash,
+			BundleSource:       storerunlifecycle.BundleSourcePersisted,
+		})
 	})
 	if !errors.Is(err, storerunlifecycle.ErrPersistedBundleUnavailable) {
 		t.Fatalf("EnsureActive error = %v, want ErrPersistedBundleUnavailable", err)

--- a/internal/store/run_completion.go
+++ b/internal/store/run_completion.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 )
 
@@ -38,54 +37,32 @@ func (s *PostgresStore) ConvergeNormalRunCompletion(ctx context.Context, eventID
 		return nil
 	}
 	return withEventStoreRetry(ctx, nil, func() error {
-		conn, borrowed := runtimepipeline.PipelineSQLConnFromContext(ctx)
-		if !borrowed {
-			var err error
-			conn, err = s.DB.Conn(ctx)
-			if err != nil {
-				return fmt.Errorf("acquire normal run completion connection: %w", err)
+		return s.runAuthorActivityMutation(ctx, "postgres normal run completion", func(txctx context.Context, tx *sql.Tx) error {
+			candidate, found, err := lockNormalRunCompletionCandidateTx(txctx, tx, eventID)
+			if err != nil || !found {
+				return err
 			}
-			defer conn.Close()
-		}
-		tx, err := conn.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin normal run completion tx: %w", err)
-		}
-		committed := false
-		defer func() {
-			if !committed {
-				_ = tx.Rollback()
+			switch candidate.Status {
+			case "completed":
+				return nil
+			case "running":
+			default:
+				return nil
 			}
-		}()
-
-		candidate, found, err := lockNormalRunCompletionCandidateTx(ctx, tx, eventID)
-		if err != nil || !found {
-			return err
-		}
-		switch candidate.Status {
-		case "completed":
+			if platformRec, platformFound, err := loadStandaloneRuntimePlatformRunRecord(txctx, tx, eventID); err != nil {
+				return err
+			} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
+				return nil
+			}
+			ready, err := normalRunCompletionRunReadyTx(txctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
+			if err != nil || !ready {
+				return err
+			}
+			if _, err := storerunlifecycle.MarkTerminal(txctx, tx, candidate.RunID, "completed", nil, time.Now().UTC(), runLifecycleOptions(caps)); err != nil {
+				return fmt.Errorf("converge normal run completion: %w", err)
+			}
 			return nil
-		case "running":
-		default:
-			return nil
-		}
-		if platformRec, platformFound, err := loadStandaloneRuntimePlatformRunRecord(ctx, tx, eventID); err != nil {
-			return err
-		} else if platformFound && isStandaloneRuntimePlatformRunRecord(platformRec) {
-			return nil
-		}
-		ready, err := normalRunCompletionRunReadyTx(ctx, tx, candidate.RunID, workflowTerminals, flowTerminals)
-		if err != nil || !ready {
-			return err
-		}
-		if _, err := storerunlifecycle.MarkTerminal(ctx, tx, candidate.RunID, "completed", nil, time.Now().UTC(), runLifecycleOptions(caps)); err != nil {
-			return fmt.Errorf("converge normal run completion: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit normal run completion tx: %w", err)
-		}
-		committed = true
-		return nil
+		})
 	})
 }
 

--- a/internal/store/run_control.go
+++ b/internal/store/run_control.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimeruncontrol "github.com/division-sh/swarm/internal/runtime/runcontrol"
-	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
+	"github.com/google/uuid"
 )
 
 func (s *PostgresStore) StopRunControl(ctx context.Context, req runtimeruncontrol.TransitionRequest) (runtimeruncontrol.State, error) {
@@ -74,45 +75,44 @@ func (s *PostgresStore) runControlTransition(ctx context.Context, req runtimerun
 	if !caps.Events.HasRuns {
 		return runtimeruncontrol.State{}, fmt.Errorf("runs table is required")
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimeruncontrol.State{}, fmt.Errorf("begin run control transition: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+	var state runtimeruncontrol.State
+	err = s.runAuthorActivityMutation(ctx, "postgres run control transition", func(txctx context.Context, tx *sql.Tx) error {
+		var err error
+		state, err = lockRunControlState(txctx, tx, runID)
+		if err != nil {
+			return err
 		}
-	}()
-
-	state, err := lockRunControlState(ctx, tx, runID)
-	if err != nil {
-		return runtimeruncontrol.State{}, err
-	}
-
-	switch action {
-	case "stop":
-		state, err = s.stopRunControlTx(ctx, tx, caps, state, req)
-	case "pause":
-		state, err = pauseRunControlTx(ctx, tx, state, req)
-	case "continue":
-		state, err = continueRunControlTx(ctx, tx, state, req)
-	default:
-		err = fmt.Errorf("unsupported run control action %q", action)
-	}
-	if err != nil {
-		return runtimeruncontrol.State{}, err
-	}
-	if action == "stop" && state.AbandonedDeliveries > 0 {
-		if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.FamilyEventDeliveries, runforkrevision.FamilyEventReceipts); err != nil {
-			return runtimeruncontrol.State{}, err
+		switch action {
+		case "stop":
+			state, err = s.stopRunControlTx(txctx, tx, caps, state, req)
+		case "pause":
+			state, err = pauseRunControlTx(txctx, tx, state, req)
+		case "continue":
+			state, err = continueRunControlTx(txctx, tx, state, req)
+		default:
+			err = fmt.Errorf("unsupported run control action %q", action)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return runtimeruncontrol.State{}, fmt.Errorf("commit run control transition: %w", err)
-	}
-	committed = true
-	return state, nil
+		if err != nil {
+			return err
+		}
+		if action == "pause" || action == "continue" {
+			transition := "paused"
+			if action == "continue" {
+				transition = "resumed"
+			}
+			transitionID := uuid.NewString()
+			return runtimeauthoractivity.Record(txctx, runtimeauthoractivity.Draft{
+				Kind: runtimeauthoractivity.KindRunLifecycle, Transition: transition,
+				SourceOwner: "runs", SourceIdentity: transitionID, DedupKey: "run-transition:" + transitionID,
+				OccurredAt: req.Now.UTC(), RunID: runID,
+				Projection: runtimeauthoractivity.Projection{
+					SubjectType: "run", SubjectID: runID, ControlReason: req.Reason, Source: req.ControlledBy,
+				},
+			})
+		}
+		return nil
+	})
+	return state, err
 }
 
 func lockRunControlState(ctx context.Context, tx *sql.Tx, runID string) (runtimeruncontrol.State, error) {

--- a/internal/store/run_fork_activation.go
+++ b/internal/store/run_fork_activation.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/google/uuid"
 )
 
@@ -111,6 +113,11 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 			_ = tx.Rollback()
 		}
 	}()
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return RunForkActivation{}, err
+	}
+	ctx = storyctx
 
 	lineage, err := loadRunForkActivationLineage(ctx, tx, forkRunID)
 	if err != nil {
@@ -203,7 +210,7 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		ForkRunID:   lineage.ForkRunID,
 	}
 	if historicalReplayExecution.DeliveryEventReplayReady {
-		replayResult, err = applyRunForkDeliveryEventReplay(ctx, tx, lineage, historicalReplayExecution, now)
+		replayResult, err = applyRunForkDeliveryEventReplay(ctx, tx, s, lineage, historicalReplayExecution, now)
 		if err != nil {
 			return result, err
 		}
@@ -222,7 +229,10 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 	} else if affected != 1 {
 		return result, fmt.Errorf("fork activation blocked: fork_run_activation_not_applied")
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := recordRunForkActivationAuthorActivity(ctx, lineage, now, true); err != nil {
+		return result, err
+	}
+	if err := commitRunForkAuthorActivityTransaction(ctx, tx); err != nil {
 		return result, fmt.Errorf("commit fork activation: %w", err)
 	}
 	committed = true
@@ -236,6 +246,42 @@ func (s *PostgresStore) ActivateRunFork(ctx context.Context, req RunForkActivate
 		result.DeliveryEventReplay = &replayResult
 	}
 	return result, nil
+}
+
+func recordRunForkActivationAuthorActivity(ctx context.Context, lineage runForkActivationLineage, now time.Time, sourceFrozen bool) error {
+	occurrences := []struct {
+		runID, transition, parentRunID, forkRunID string
+	}{{runID: lineage.ForkRunID, transition: "fork_started", parentRunID: lineage.SourceRunID}}
+	if sourceFrozen {
+		occurrences = append(occurrences, struct {
+			runID, transition, parentRunID, forkRunID string
+		}{runID: lineage.SourceRunID, transition: "forked", forkRunID: lineage.ForkRunID})
+	}
+	for _, occurrence := range occurrences {
+		transitionID := uuid.NewString()
+		if err := runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+			Kind: runtimeauthoractivity.KindRunLifecycle, Transition: occurrence.transition,
+			SourceOwner: "runs", SourceIdentity: transitionID, DedupKey: "run-transition:" + transitionID,
+			OccurredAt: now.UTC(), RunID: occurrence.runID,
+			Projection: runtimeauthoractivity.Projection{
+				SubjectType: "run", SubjectID: occurrence.runID, ParentRunID: occurrence.parentRunID,
+				ForkRunID: occurrence.forkRunID, TriggerEventType: lineage.ForkEventName,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func commitRunForkAuthorActivityTransaction(ctx context.Context, tx *sql.Tx) error {
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+		return err
+	}
+	if err := runtimeauthoractivity.Finalize(ctx); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func requireRunForkHistoricalReplayExecution(

--- a/internal/store/run_fork_activity_generation.go
+++ b/internal/store/run_fork_activity_generation.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 )
 
@@ -206,6 +208,9 @@ func loadRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, request
 }
 
 func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRunID, flowInstance string, request runForkActivityRequestPayload, generations []attemptgeneration.Generation, evidence runForkActivityAttemptEvidence) error {
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
+	}
 	generation := request.Generation.Normalize()
 	for _, candidate := range generations {
 		if strings.TrimSpace(candidate.LoopID) == strings.TrimSpace(generation.LoopID) {
@@ -239,7 +244,7 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 	if raw := strings.TrimSpace(string(evidence.Failure)); raw != "" && raw != "null" {
 		failure = raw
 	}
-	_, err = tx.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO activity_attempts (
 			request_event_id, run_id, source_event_id, parent_event_id, entity_id, flow_instance,
 			node_id, handler_event_key, activity_id, tool, effect_class, attempt, status,
@@ -261,6 +266,10 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 	if err != nil {
 		return fmt.Errorf("copy fork-local activity evidence %s: %w", request.ActivityID, err)
 	}
+	inserted, err := rowsAffected(result)
+	if err != nil {
+		return err
+	}
 	var gotRunID, gotStatus, gotResultID string
 	var gotGeneration []byte
 	if err := tx.QueryRowContext(ctx, `SELECT run_id::text, status, result_event_id::text, loop_generation FROM activity_attempts WHERE request_event_id = $1::uuid`, requestEventID).
@@ -274,5 +283,27 @@ func copyRunForkActivityAttemptEvidence(ctx context.Context, tx *sql.Tx, forkRun
 	if gotRunID != forkRunID || gotStatus != evidence.Status || gotResultID != resultEventID || !got.Equal(generation) {
 		return fmt.Errorf("fork-local activity evidence %s conflicts with canonical fork identity", request.ActivityID)
 	}
-	return nil
+	if !inserted {
+		return nil
+	}
+	var canonicalFailure *runtimefailures.Envelope
+	if raw := strings.TrimSpace(string(evidence.Failure)); raw != "" && raw != "null" {
+		var decoded runtimefailures.Envelope
+		if err := json.Unmarshal(evidence.Failure, &decoded); err != nil {
+			return fmt.Errorf("decode fork-local activity failure %s: %w", request.ActivityID, err)
+		}
+		canonicalFailure = &decoded
+	}
+	attempt := 1
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindActivityLifecycle, Transition: evidence.Status,
+		SourceOwner: "activity_attempts", SourceIdentity: requestEventID + ":" + evidence.Status,
+		DedupKey:   "activity:" + requestEventID + ":" + evidence.Status,
+		OccurredAt: evidence.CompletedAt.UTC(), RunID: forkRunID, EntityID: request.EntityID, FlowID: strings.TrimSpace(flowInstance),
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "activity", SubjectID: request.ActivityID, NodeID: request.NodeID, Activity: request.ActivityID,
+			Tool: request.Tool, EffectClass: request.EffectClass, Attempt: &attempt, EventType: evidence.ResultEventType,
+		},
+		Failure: canonicalFailure,
+	})
 }

--- a/internal/store/run_fork_activity_generation_test.go
+++ b/internal/store/run_fork_activity_generation_test.go
@@ -9,6 +9,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/activityidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -255,7 +256,21 @@ func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `UPDATE events SET event_name = 'platform.activity_requested', flow_instance = '', payload = $3::jsonb WHERE run_id = $1::uuid AND event_id = $2::uuid`, sourceRunID, requestEventID, string(requestPayload)); err != nil {
 		t.Fatal(err)
 	}
-	failure := `{"class":"dependency_unavailable","code":"provider_unavailable","owner":"activity-runtime","operation":"execute","details":{"provider":"provider.write"}}`
+	failureEnvelope, ok := runtimefailures.EnvelopeFromError(runtimefailures.New(
+		runtimefailures.ClassDependencyUnavailable,
+		"dependency_unavailable",
+		"activity-runtime",
+		"execute",
+		map[string]any{"provider": "provider.write"},
+	))
+	if !ok {
+		t.Fatal("construct typed activity failure")
+	}
+	failureJSON, err := json.Marshal(failureEnvelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failure := string(failureJSON)
 	resultPayload, _ := json.Marshal(map[string]any{
 		"activity_id": "commit", "tool": "provider.write", "effect_class": "non_idempotent_write", "attempt": 1,
 		"failure": map[string]any{"code": "provider_unavailable"}, "revision_id": generation.RevisionID,
@@ -304,7 +319,8 @@ func TestSelectedContractForkPreservesTypedFailedWriteEvidence(t *testing.T) {
 	if err := json.Unmarshal(rawFailure, &typed); err != nil {
 		t.Fatalf("fork failure is not a typed JSON object: %v (%s)", err, rawFailure)
 	}
-	if typed["code"] != "provider_unavailable" || typed["class"] != "dependency_unavailable" {
+	detail, _ := typed["detail"].(map[string]any)
+	if detail["code"] != "dependency_unavailable" || typed["class"] != "platform.dependency_unavailable" {
 		t.Fatalf("fork failure = %#v", typed)
 	}
 }

--- a/internal/store/run_fork_delivery_event_replay.go
+++ b/internal/store/run_fork_delivery_event_replay.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	"github.com/google/uuid"
 )
 
@@ -37,7 +39,7 @@ type runForkReplaySourceEvent struct {
 	HandlerNode    sql.NullString
 }
 
-func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage runForkActivationLineage, execution RunForkHistoricalReplayExecution, now time.Time) (RunForkDeliveryEventReplayResult, error) {
+func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, classifier authoredEventClassifier, lineage runForkActivationLineage, execution RunForkHistoricalReplayExecution, now time.Time) (RunForkDeliveryEventReplayResult, error) {
 	result := RunForkDeliveryEventReplayResult{
 		Owner:       RunForkDeliveryEventReplayOwner,
 		SourceRunID: lineage.SourceRunID,
@@ -49,6 +51,9 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 		execution.EventDeliveriesAdmission.Fact != RunForkHistoricalReplayFactEventDeliveries ||
 		execution.EventDeliveriesAdmission.Admission != RunForkHistoricalReplayAdmissionExecutableForkWork {
 		return result, fmt.Errorf("store.run_fork.delivery_event_replay requires %s owner-authorized executable event_deliveries", RunForkHistoricalReplayExecutionOwner)
+	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return result, err
 	}
 	replayable := execution.DeliveryEventReplayWork
 	if len(replayable) == 0 {
@@ -83,6 +88,11 @@ func applyRunForkDeliveryEventReplay(ctx context.Context, tx *sql.Tx, lineage ru
 				return result, err
 			}
 			if inserted {
+				envelope := events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, nullStringText(sourceEvent.EntityID)), nullStringText(sourceEvent.FlowInstance))
+				replayed := events.NewReplayEvent(forkEventID, events.EventType(sourceEvent.EventName), nullStringText(sourceEvent.ProducedBy), "", sourceEvent.Payload, 0, events.EventLineage{RunID: lineage.ForkRunID}, envelope, now)
+				if err := recordPersistedEventAuthorActivity(ctx, classifier, replayed, nullStringText(sourceEvent.ProducedBy), nullStringText(sourceEvent.ProducedByType)); err != nil {
+					return result, err
+				}
 				result.ReplayedEventCount++
 			}
 			insertedEvents[sourceEventID] = forkEventID

--- a/internal/store/run_fork_gate_activation_test.go
+++ b/internal/store/run_fork_gate_activation_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -45,16 +46,10 @@ func TestMaterializeRunForkDecisionCardsCreatesForkLocalPendingAuthority(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := materializeRunForkDecisionCards(ctx, tx, forkRunID, entityID, []runForkGateActivationBinding{{Source: sourceActivation, Fork: forkActivation}}, now.Add(time.Minute)); err != nil {
-		_ = tx.Rollback()
+	if err := cardStore.runAuthorActivityMutation(ctx, "test materialize fork decision cards", func(txctx context.Context, tx *sql.Tx) error {
+		return materializeRunForkDecisionCards(txctx, tx, forkRunID, entityID, []runForkGateActivationBinding{{Source: sourceActivation, Fork: forkActivation}}, now.Add(time.Minute))
+	}); err != nil {
 		t.Fatalf("materialize fork cards: %v", err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatal(err)
 	}
 	forkCard, err := cardStore.GetDecisionCard(ctx, forkActivation.CardID)
 	if err != nil {
@@ -128,16 +123,10 @@ func TestMaterializeRunForkDecisionCardsPreservesCommittedSemanticFields(t *test
 	if err := forkActivation.CommitDecision(decisionEventID, now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := materializeRunForkDecisionCards(ctx, tx, forkRunID, entityID, []runForkGateActivationBinding{{Source: sourceActivation, Fork: forkActivation}}, now.Add(2*time.Minute)); err != nil {
-		_ = tx.Rollback()
+	if err := cardStore.runAuthorActivityMutation(ctx, "test materialize committed fork decision card", func(txctx context.Context, tx *sql.Tx) error {
+		return materializeRunForkDecisionCards(txctx, tx, forkRunID, entityID, []runForkGateActivationBinding{{Source: sourceActivation, Fork: forkActivation}}, now.Add(2*time.Minute))
+	}); err != nil {
 		t.Fatalf("materialize committed fork card: %v", err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatal(err)
 	}
 	forkCard, err := cardStore.GetDecisionCard(ctx, forkActivation.CardID)
 	if err != nil {

--- a/internal/store/run_fork_materializer.go
+++ b/internal/store/run_fork_materializer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/mutationlog"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -127,6 +128,11 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 			_ = tx.Rollback()
 		}
 	}()
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	ctx = storyctx
 
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
@@ -162,7 +168,7 @@ func (s *PostgresStore) MaterializeRunFork(ctx context.Context, req RunForkMater
 		}
 		selectedContractBinding = &binding
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := commitRunForkAuthorActivityTransaction(ctx, tx); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit fork materialization: %w", err)
 	}
 	committed = true

--- a/internal/store/run_fork_selected_contract_execution_mutation.go
+++ b/internal/store/run_fork_selected_contract_execution_mutation.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -256,6 +258,11 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 			_ = tx.Rollback()
 		}
 	}()
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return RunForkMaterialization{}, err
+	}
+	ctx = storyctx
 
 	if err := ensureRunForkNotAlreadyMaterialized(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID); err != nil {
 		return RunForkMaterialization{}, err
@@ -298,7 +305,7 @@ func (s *PostgresStore) MaterializeRunForkForSelectedContractExecution(ctx conte
 	if err := insertRunForkSelectedContractTimerReconstructions(ctx, tx, forkRunID, plan.SourceRunID, plan.ForkPoint.EventID, timerReconstruction, now); err != nil {
 		return RunForkMaterialization{}, err
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := commitRunForkAuthorActivityTransaction(ctx, tx); err != nil {
 		return RunForkMaterialization{}, fmt.Errorf("commit selected-contract fork materialization: %w", err)
 	}
 	committed = true
@@ -344,6 +351,11 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 			_ = tx.Rollback()
 		}
 	}()
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return RunForkActivation{}, err
+	}
+	ctx = storyctx
 
 	lineage, err := loadRunForkActivationLineage(ctx, tx, forkRunID)
 	if err != nil {
@@ -475,7 +487,10 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 		if err := insertRunForkSelectedContractBranchDivergence(ctx, tx, divergence); err != nil {
 			return result, err
 		}
-		if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+		if err := recordRunForkActivationAuthorActivity(ctx, lineage, now, false); err != nil {
+			return result, err
+		}
+		if err := commitRunForkAuthorActivityTransaction(ctx, tx); err != nil {
 			return result, fmt.Errorf("commit selected-contract branch activation: %w", err)
 		}
 		committed = true
@@ -515,7 +530,10 @@ func (s *PostgresStore) ActivateRunForkForSelectedContractExecution(ctx context.
 	} else if affected != 1 {
 		return result, fmt.Errorf("selected-contract fork activation blocked: fork_run_activation_not_applied")
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := recordRunForkActivationAuthorActivity(ctx, lineage, now, true); err != nil {
+		return result, err
+	}
+	if err := commitRunForkAuthorActivityTransaction(ctx, tx); err != nil {
 		return result, fmt.Errorf("commit selected-contract fork activation: %w", err)
 	}
 	committed = true
@@ -585,6 +603,11 @@ func (s *PostgresStore) DiscardMaterializedSelectedContractExecutionFork(ctx con
 	if catalog.hasColumns("agent_sessions", "run_id") {
 		if _, err := tx.ExecContext(ctx, `DELETE FROM agent_sessions WHERE run_id = $1::uuid`, forkRunID); err != nil {
 			return fmt.Errorf("delete selected-contract fork sessions: %w", err)
+		}
+	}
+	if catalog.hasColumns("author_activity_occurrences", "run_id") {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM author_activity_occurrences WHERE run_id = $1::uuid`, forkRunID); err != nil {
+			return fmt.Errorf("delete selected-contract fork author activity: %w", err)
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `
@@ -704,7 +727,11 @@ func (s *PostgresStore) LoadRunForkSelectedContractSourceEvents(ctx context.Cont
 			_ = tx.Rollback()
 		}
 	}()
-	rows, err := tx.QueryContext(ctx, `
+	storyctx, err := runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(storyctx, `
 		SELECT
 			event_id::text,
 			event_name,
@@ -742,13 +769,19 @@ func (s *PostgresStore) LoadRunForkSelectedContractSourceEvents(ctx context.Cont
 		return nil, fmt.Errorf("selected-contract source event lookup returned %d rows for %d requested events", len(out), len(ids))
 	}
 	for idx := range out {
-		prepared, err := prepareRunForkSelectedContractSourceEvent(ctx, tx, forkRunID, out[idx])
+		prepared, err := prepareRunForkSelectedContractSourceEvent(storyctx, tx, forkRunID, out[idx])
 		if err != nil {
 			return nil, err
 		}
 		out[idx] = prepared
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(storyctx, tx); err != nil {
+		return nil, fmt.Errorf("capture selected-contract source event preparation revisions: %w", err)
+	}
+	if err := runtimeauthoractivity.Finalize(storyctx); err != nil {
+		return nil, fmt.Errorf("finalize selected-contract source event author activity: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit selected-contract source event preparation: %w", err)
 	}
 	committed = true

--- a/internal/store/runlifecycle/fork.go
+++ b/internal/store/runlifecycle/fork.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 )
 
 type InsertForkOptions struct {
@@ -35,6 +37,9 @@ func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, fo
 	}
 	if forkEventID == "" {
 		return fmt.Errorf("fork event_id is required")
+	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return fmt.Errorf("insert fork run: %w", err)
 	}
 	bundleSource, err := CanonicalBundleSource(opts.BundleSource)
 	if err != nil {
@@ -71,5 +76,19 @@ func InsertFork(ctx context.Context, db DBTX, forkRunID, status, sourceRunID, fo
 		INSERT INTO runs (`+strings.Join(cols, ", ")+`)
 		VALUES (`+strings.Join(values, ", ")+`)
 	`, args...)
-	return err
+	if err != nil {
+		return err
+	}
+	transition := "started"
+	if status == "paused" {
+		transition = "fork_prepared"
+	}
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindRunLifecycle, Transition: transition,
+		SourceOwner: "runs", SourceIdentity: forkRunID, DedupKey: "run-created:" + forkRunID,
+		OccurredAt: startedAt.UTC(), RunID: forkRunID,
+		Projection: runtimeauthoractivity.Projection{
+			SubjectType: "run", SubjectID: forkRunID, ParentRunID: sourceRunID, TriggerEventType: "run.fork",
+		},
+	})
 }

--- a/internal/store/runlifecycle/owner.go
+++ b/internal/store/runlifecycle/owner.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 )
 
@@ -123,6 +124,9 @@ func ensureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
 		return nil
+	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return fmt.Errorf("ensure run row: %w", err)
 	}
 	triggerEventID = strings.TrimSpace(triggerEventID)
 	triggerEventType = strings.TrimSpace(triggerEventType)
@@ -241,9 +245,24 @@ func ensureActive(ctx context.Context, db DBTX, runID, triggerEventID, triggerEv
 			trigger_event_id = COALESCE(runs.trigger_event_id, NULLIF($2,'')::uuid),
 			trigger_event_type = COALESCE(NULLIF(runs.trigger_event_type, ''), NULLIF($3, ''))`
 	}
+	var existed bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS (SELECT 1 FROM runs WHERE run_id = $1::uuid)`, runID).Scan(&existed); err != nil {
+		return fmt.Errorf("ensure run row: inspect existing run: %w", err)
+	}
 	_, err = db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("ensure run row: %w", err)
+	}
+	if !existed {
+		occurredAt := time.Now().UTC()
+		return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+			Kind: runtimeauthoractivity.KindRunLifecycle, Transition: "started",
+			SourceOwner: "runs", SourceIdentity: runID, DedupKey: "run-created:" + runID,
+			OccurredAt: occurredAt, RunID: runID,
+			Projection: runtimeauthoractivity.Projection{
+				SubjectType: "run", SubjectID: runID, TriggerEventType: triggerEventType,
+			},
+		})
 	}
 	return nil
 }
@@ -443,6 +462,9 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status string, failure *r
 	if runID == "" {
 		return Snapshot{}, fmt.Errorf("run_id is required")
 	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return Snapshot{}, fmt.Errorf("mark run terminal: %w", err)
+	}
 	var err error
 	status, err = CanonicalTerminalStatus(status)
 	if err != nil {
@@ -513,7 +535,23 @@ func MarkTerminal(ctx context.Context, db DBTX, runID, status string, failure *r
 		}
 		return current, nil
 	}
-	return LoadSnapshot(ctx, db, runID, opts)
+	snapshot, err := LoadSnapshot(ctx, db, runID, opts)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	occurredAt := endedAt.UTC()
+	if snapshot.EndedAt != nil {
+		occurredAt = snapshot.EndedAt.UTC()
+	}
+	if err := runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindRunLifecycle, Transition: status,
+		SourceOwner: "runs", SourceIdentity: runID + ":" + status, DedupKey: "run-terminal:" + runID + ":" + status,
+		OccurredAt: occurredAt, RunID: runID, Failure: failure,
+		Projection: runtimeauthoractivity.Projection{SubjectType: "run", SubjectID: runID},
+	}); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
 }
 
 func ValidateStatusFailure(status string, failure *runtimefailures.Envelope) error {

--- a/internal/store/runtime_external_effects.go
+++ b/internal/store/runtime_external_effects.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 )
@@ -20,27 +21,33 @@ var _ runtimeeffects.RecoveryStore = (*PostgresStore)(nil)
 var _ runtimeeffects.RecoveryStore = (*SQLiteRuntimeStore)(nil)
 
 func (s *PostgresStore) ReconcileExternalEffectAttempts(ctx context.Context, now time.Time) (runtimeeffects.RecoverySummary, error) {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return runtimeeffects.RecoverySummary{}, err
-	}
-	defer tx.Rollback()
-	summary, err := reconcileExternalEffectAttemptsPostgres(ctx, tx, now.UTC())
-	if err != nil {
-		return runtimeeffects.RecoverySummary{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return runtimeeffects.RecoverySummary{}, err
-	}
-	return summary, nil
+	var summary runtimeeffects.RecoverySummary
+	err := s.runAuthorActivityMutation(ctx, "postgres reconcile external effect attempts", func(txctx context.Context, tx *sql.Tx) error {
+		candidates, err := loadExternalEffectRecoveryCandidates(txctx, tx, true)
+		if err != nil {
+			return err
+		}
+		summary, err = reconcileExternalEffectAttemptsPostgres(txctx, tx, now.UTC())
+		if err != nil {
+			return err
+		}
+		return recordRecoveredExternalEffectStories(txctx, tx, candidates, now.UTC(), true)
+	})
+	return summary, err
 }
 
 func (s *SQLiteRuntimeStore) ReconcileExternalEffectAttempts(ctx context.Context, now time.Time) (runtimeeffects.RecoverySummary, error) {
 	var summary runtimeeffects.RecoverySummary
-	err := s.runRuntimeMutation(ctx, "sqlite reconcile external effect attempts", func(txctx context.Context, tx *sql.Tx) error {
-		var err error
+	err := s.runAuthorActivityMutation(ctx, "sqlite reconcile external effect attempts", func(txctx context.Context, tx *sql.Tx) error {
+		candidates, err := loadExternalEffectRecoveryCandidates(txctx, tx, false)
+		if err != nil {
+			return err
+		}
 		summary, err = reconcileExternalEffectAttemptsSQLiteTx(txctx, tx, now.UTC())
-		return err
+		if err != nil {
+			return err
+		}
+		return recordRecoveredExternalEffectStories(txctx, tx, candidates, now.UTC(), false)
 	})
 	return summary, err
 }
@@ -155,6 +162,202 @@ type existingExternalAttempt struct {
 	attemptOrdinal int
 	launched       bool
 	failureJSON    string
+}
+
+type externalEffectStorySource struct {
+	AttemptID     string
+	Kind          string
+	Class         string
+	Adapter       string
+	Transport     string
+	AuthorityKind string
+	AuthorityID   string
+	AgentID       string
+	Ordinal       int
+}
+
+func externalEffectStorySourceFromAttempt(attempt runtimeeffects.Attempt) externalEffectStorySource {
+	return externalEffectStorySource{
+		AttemptID: attempt.AttemptID, Kind: string(attempt.Kind), Class: string(attempt.Class),
+		Adapter: attempt.Adapter, Transport: attempt.Transport, AuthorityKind: string(attempt.Authority.Kind),
+		AuthorityID: attempt.Authority.ID, AgentID: attempt.Authority.Normal.AgentID, Ordinal: attempt.Ordinal,
+	}
+}
+
+func loadExternalEffectStorySource(ctx context.Context, tx *sql.Tx, attemptID string, postgres bool) (externalEffectStorySource, error) {
+	query := `
+		SELECT CAST(a.attempt_id AS TEXT), o.effect_kind, o.effect_class, a.adapter, a.transport,
+		       o.authority_kind, o.authority_id, COALESCE(o.agent_id, ''), a.attempt_ordinal
+		FROM runtime_external_effect_attempts a
+		JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id
+		WHERE a.attempt_id = ?
+	`
+	if postgres {
+		query = `
+			SELECT a.attempt_id::text, o.effect_kind, o.effect_class, a.adapter, a.transport,
+			       o.authority_kind, o.authority_id, COALESCE(o.agent_id, ''), a.attempt_ordinal
+			FROM runtime_external_effect_attempts a
+			JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id
+			WHERE a.attempt_id = $1::uuid
+		`
+	}
+	var source externalEffectStorySource
+	if err := tx.QueryRowContext(ctx, query, strings.TrimSpace(attemptID)).Scan(
+		&source.AttemptID, &source.Kind, &source.Class, &source.Adapter, &source.Transport,
+		&source.AuthorityKind, &source.AuthorityID, &source.AgentID, &source.Ordinal,
+	); err != nil {
+		return externalEffectStorySource{}, fmt.Errorf("load external effect author activity source: %w", err)
+	}
+	return source, nil
+}
+
+type externalEffectStoryDisposition struct {
+	Launch bool
+}
+
+var externalEffectStoryDispositions = map[string]externalEffectStoryDisposition{
+	"provider_turn/anthropic_api":                       {Launch: true},
+	"provider_turn/openai_compatible":                   {Launch: true},
+	"provider_turn/openai_responses":                    {Launch: true},
+	"provider_turn/claude_cli":                          {Launch: true},
+	"http_tool_target/authored_http_tool":               {Launch: true},
+	"managed_credential_request/managed_credential":     {},
+	"native_web_search_http/native_web_search":          {Launch: true},
+	"mcp_http_request/mcp_tools_call_http":              {Launch: true},
+	"mcp_stdio_request/mcp_tools_call_stdio":            {Launch: true},
+	"native_command/native_bash":                        {Launch: true},
+	"native_command/native_read_file":                   {Launch: true},
+	"native_file_write/native_write_file":               {Launch: true},
+	"tool_result_relay/tool_result_relay":               {},
+	"claude_tool_result_relay/claude_tool_result_relay": {},
+}
+
+func externalEffectStoryDispositionFor(kind, adapter string) (externalEffectStoryDisposition, error) {
+	key := strings.TrimSpace(kind) + "/" + strings.TrimSpace(adapter)
+	disposition, ok := externalEffectStoryDispositions[key]
+	if !ok {
+		return externalEffectStoryDisposition{}, fmt.Errorf("external effect registration %q has no author activity disposition", key)
+	}
+	return disposition, nil
+}
+
+func recordExternalEffectStory(ctx context.Context, source externalEffectStorySource, state runtimeeffects.State, failure *runtimefailures.Envelope, occurredAt time.Time) error {
+	disposition, err := externalEffectStoryDispositionFor(source.Kind, source.Adapter)
+	if err != nil {
+		return err
+	}
+	if state == runtimeeffects.StateLaunched {
+		if !disposition.Launch {
+			return nil
+		}
+	}
+	if state != runtimeeffects.StateLaunched && state != runtimeeffects.StateTerminalFailure && state != runtimeeffects.StateOutcomeUncertain {
+		return nil
+	}
+	transition := string(state)
+	attempt := source.Ordinal
+	identity := source.AttemptID + ":" + transition
+	return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindEffectLifecycle, Transition: transition,
+		SourceOwner: "runtime_external_effect_attempts", SourceIdentity: identity, DedupKey: "effect:" + identity,
+		OccurredAt: occurredAt.UTC(), AgentID: source.AgentID,
+		Projection: runtimeauthoractivity.Projection{
+			EffectClass: source.Class, Attempt: &attempt, Adapter: source.Adapter, Transport: source.Transport,
+			AuthorityKind: source.AuthorityKind, AuthorityID: source.AuthorityID,
+		},
+		Failure: failure,
+	})
+}
+
+func recordSettledExternalEffectStory(ctx context.Context, tx *sql.Tx, settlement runtimeeffects.Settlement, postgres bool) error {
+	if settlement.State != runtimeeffects.StateTerminalFailure && settlement.State != runtimeeffects.StateOutcomeUncertain {
+		return nil
+	}
+	source, err := loadExternalEffectStorySource(ctx, tx, settlement.AttemptID, postgres)
+	if err != nil {
+		return err
+	}
+	state, failure, occurredAt, err := loadExternalEffectStorySettlement(ctx, tx, settlement.AttemptID, settlement.OperationID, postgres)
+	if err != nil {
+		return err
+	}
+	return recordExternalEffectStory(ctx, source, state, failure, occurredAt)
+}
+
+func loadExternalEffectStorySettlement(ctx context.Context, tx *sql.Tx, attemptID, operationID string, postgres bool) (runtimeeffects.State, *runtimefailures.Envelope, time.Time, error) {
+	query := `SELECT state, COALESCE(failure, 'null'), completed_at FROM runtime_external_effect_attempts WHERE attempt_id = ? AND operation_id = ?`
+	if postgres {
+		query = `SELECT state, COALESCE(failure, 'null'::jsonb), completed_at FROM runtime_external_effect_attempts WHERE attempt_id = $1::uuid AND operation_id = $2::uuid`
+	}
+	var state string
+	var failureRaw []byte
+	var completedAtRaw any
+	if err := tx.QueryRowContext(ctx, query, strings.TrimSpace(attemptID), strings.TrimSpace(operationID)).Scan(&state, &failureRaw, &completedAtRaw); err != nil {
+		return "", nil, time.Time{}, fmt.Errorf("load settled external effect author activity source: %w", err)
+	}
+	completedAt, ok, err := sqliteTimeValue(completedAtRaw)
+	if err != nil || !ok {
+		return "", nil, time.Time{}, fmt.Errorf("load settled external effect completion time: %w", firstNonNilError(err, fmt.Errorf("completed_at is required")))
+	}
+	var failure *runtimefailures.Envelope
+	if raw := strings.TrimSpace(string(failureRaw)); raw != "" && raw != "null" {
+		decoded, err := runtimefailures.UnmarshalEnvelope(failureRaw)
+		if err != nil {
+			return "", nil, time.Time{}, fmt.Errorf("decode settled external effect failure: %w", err)
+		}
+		failure = &decoded
+	}
+	return runtimeeffects.State(strings.TrimSpace(state)), failure, completedAt.UTC(), nil
+}
+
+func loadExternalEffectRecoveryCandidates(ctx context.Context, tx *sql.Tx, postgres bool) ([]string, error) {
+	query := `SELECT CAST(attempt_id AS TEXT) FROM runtime_external_effect_attempts WHERE state IN ('authorized','launched','response_observed') ORDER BY attempt_id`
+	if postgres {
+		query = `SELECT attempt_id::text FROM runtime_external_effect_attempts WHERE state IN ('authorized','launched','response_observed') ORDER BY attempt_id`
+	}
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var candidates []string
+	for rows.Next() {
+		var attemptID string
+		if err := rows.Scan(&attemptID); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, attemptID)
+	}
+	return candidates, rows.Err()
+}
+
+func recordRecoveredExternalEffectStories(ctx context.Context, tx *sql.Tx, candidates []string, occurredAt time.Time, postgres bool) error {
+	query := `SELECT state, failure FROM runtime_external_effect_attempts WHERE attempt_id = ?`
+	if postgres {
+		query = `SELECT state, failure FROM runtime_external_effect_attempts WHERE attempt_id = $1::uuid`
+	}
+	for _, attemptID := range candidates {
+		var state string
+		var failureRaw []byte
+		if err := tx.QueryRowContext(ctx, query, attemptID).Scan(&state, &failureRaw); err != nil {
+			return err
+		}
+		if state != string(runtimeeffects.StateTerminalFailure) && state != string(runtimeeffects.StateOutcomeUncertain) {
+			continue
+		}
+		failure, err := runtimefailures.UnmarshalEnvelope(failureRaw)
+		if err != nil {
+			return fmt.Errorf("decode recovered external effect failure: %w", err)
+		}
+		source, err := loadExternalEffectStorySource(ctx, tx, attemptID, postgres)
+		if err != nil {
+			return err
+		}
+		if err := recordExternalEffectStory(ctx, source, runtimeeffects.State(state), &failure, occurredAt); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (e existingExternalAttempt) matchesAuthorityIdentity(authority runtimeeffects.Authority) bool {
@@ -392,32 +595,33 @@ func externalAuthorizedAttempt(authority runtimeeffects.Authority, req runtimeef
 }
 
 func (s *PostgresStore) MarkExternalAttemptLaunched(ctx context.Context, attempt runtimeeffects.Attempt, now time.Time) error {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	if err := requireExternalEffectAuthorityPostgres(ctx, tx, attempt.Authority, false); err != nil {
-		return err
-	}
-	res, err := tx.ExecContext(ctx, `UPDATE runtime_external_effect_attempts SET state = 'launched', launched_at = $2, updated_at = $2 WHERE attempt_id = $1::uuid AND operation_id = $3::uuid AND execution_owner=$4 AND fence_generation=$5 AND state = 'authorized'`, attempt.AttemptID, now.UTC(), attempt.OperationID, attempt.Authority.ExecutionOwner, attempt.Authority.FenceGeneration)
-	if err := requireExternalAttemptTransition(res, err); err == nil {
-		operationRes, err := tx.ExecContext(ctx, `UPDATE runtime_external_effect_operations SET state = 'launched', updated_at = $2 WHERE operation_id = $1::uuid AND state = 'authorized'`, attempt.OperationID, now.UTC())
-		if err := requireExternalAttemptTransition(operationRes, err); err != nil {
+	return s.runAuthorActivityMutation(ctx, "postgres mark external attempt launched", func(txctx context.Context, tx *sql.Tx) error {
+		if err := requireExternalEffectAuthorityPostgres(txctx, tx, attempt.Authority, false); err != nil {
 			return err
 		}
-		return tx.Commit()
-	}
-	var state string
-	var operationState string
-	if queryErr := tx.QueryRowContext(ctx, `SELECT a.state, o.state FROM runtime_external_effect_attempts a JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id WHERE a.attempt_id = $1::uuid AND a.operation_id = $2::uuid`, attempt.AttemptID, attempt.OperationID).Scan(&state, &operationState); queryErr == nil && state == string(runtimeeffects.StateLaunched) && operationState == string(runtimeeffects.StateLaunched) {
-		return nil
-	}
-	return runtimefailures.New(runtimefailures.ClassLifecycleConflict, "lifecycle_transition_conflict", "external-effects", "launch_attempt", map[string]any{"attempt_id": attempt.AttemptID})
+		res, err := tx.ExecContext(txctx, `UPDATE runtime_external_effect_attempts SET state = 'launched', launched_at = $2, updated_at = $2 WHERE attempt_id = $1::uuid AND operation_id = $3::uuid AND execution_owner=$4 AND fence_generation=$5 AND state = 'authorized'`, attempt.AttemptID, now.UTC(), attempt.OperationID, attempt.Authority.ExecutionOwner, attempt.Authority.FenceGeneration)
+		if err := requireExternalAttemptTransition(res, err); err == nil {
+			operationRes, err := tx.ExecContext(txctx, `UPDATE runtime_external_effect_operations SET state = 'launched', updated_at = $2 WHERE operation_id = $1::uuid AND state = 'authorized'`, attempt.OperationID, now.UTC())
+			if err := requireExternalAttemptTransition(operationRes, err); err != nil {
+				return err
+			}
+		} else {
+			var state string
+			var operationState string
+			if queryErr := tx.QueryRowContext(txctx, `SELECT a.state, o.state FROM runtime_external_effect_attempts a JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id WHERE a.attempt_id = $1::uuid AND a.operation_id = $2::uuid`, attempt.AttemptID, attempt.OperationID).Scan(&state, &operationState); queryErr != nil || state != string(runtimeeffects.StateLaunched) || operationState != string(runtimeeffects.StateLaunched) {
+				return runtimefailures.New(runtimefailures.ClassLifecycleConflict, "lifecycle_transition_conflict", "external-effects", "launch_attempt", map[string]any{"attempt_id": attempt.AttemptID})
+			}
+		}
+		launchedAt, err := loadExternalEffectLaunchTime(txctx, tx, attempt.AttemptID, attempt.OperationID, true)
+		if err != nil {
+			return err
+		}
+		return recordExternalEffectStory(txctx, externalEffectStorySourceFromAttempt(attempt), runtimeeffects.StateLaunched, nil, launchedAt)
+	})
 }
 
 func (s *SQLiteRuntimeStore) MarkExternalAttemptLaunched(ctx context.Context, attempt runtimeeffects.Attempt, now time.Time) error {
-	return s.runRuntimeMutation(ctx, "sqlite mark external attempt launched", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite mark external attempt launched", func(txctx context.Context, tx *sql.Tx) error {
 		if err := requireExternalEffectAuthoritySQLite(txctx, tx, attempt.Authority, false); err != nil {
 			return err
 		}
@@ -427,15 +631,35 @@ func (s *SQLiteRuntimeStore) MarkExternalAttemptLaunched(ctx context.Context, at
 			if err := requireExternalAttemptTransition(operationRes, err); err != nil {
 				return err
 			}
-			return nil
+		} else {
+			var state string
+			var operationState string
+			if queryErr := tx.QueryRowContext(txctx, `SELECT a.state, o.state FROM runtime_external_effect_attempts a JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id WHERE a.attempt_id = ? AND a.operation_id = ?`, attempt.AttemptID, attempt.OperationID).Scan(&state, &operationState); queryErr != nil || state != string(runtimeeffects.StateLaunched) || operationState != string(runtimeeffects.StateLaunched) {
+				return runtimefailures.New(runtimefailures.ClassLifecycleConflict, "lifecycle_transition_conflict", "external-effects", "launch_attempt", map[string]any{"attempt_id": attempt.AttemptID})
+			}
 		}
-		var state string
-		var operationState string
-		if queryErr := tx.QueryRowContext(txctx, `SELECT a.state, o.state FROM runtime_external_effect_attempts a JOIN runtime_external_effect_operations o ON o.operation_id = a.operation_id WHERE a.attempt_id = ? AND a.operation_id = ?`, attempt.AttemptID, attempt.OperationID).Scan(&state, &operationState); queryErr == nil && state == string(runtimeeffects.StateLaunched) && operationState == string(runtimeeffects.StateLaunched) {
-			return nil
+		launchedAt, err := loadExternalEffectLaunchTime(txctx, tx, attempt.AttemptID, attempt.OperationID, false)
+		if err != nil {
+			return err
 		}
-		return runtimefailures.New(runtimefailures.ClassLifecycleConflict, "lifecycle_transition_conflict", "external-effects", "launch_attempt", map[string]any{"attempt_id": attempt.AttemptID})
+		return recordExternalEffectStory(txctx, externalEffectStorySourceFromAttempt(attempt), runtimeeffects.StateLaunched, nil, launchedAt)
 	})
+}
+
+func loadExternalEffectLaunchTime(ctx context.Context, tx *sql.Tx, attemptID, operationID string, postgres bool) (time.Time, error) {
+	query := `SELECT launched_at FROM runtime_external_effect_attempts WHERE attempt_id = ? AND operation_id = ?`
+	if postgres {
+		query = `SELECT launched_at FROM runtime_external_effect_attempts WHERE attempt_id = $1::uuid AND operation_id = $2::uuid`
+	}
+	var launchedAtRaw any
+	if err := tx.QueryRowContext(ctx, query, strings.TrimSpace(attemptID), strings.TrimSpace(operationID)).Scan(&launchedAtRaw); err != nil {
+		return time.Time{}, fmt.Errorf("load launched external effect author activity source: %w", err)
+	}
+	launchedAt, ok, err := sqliteTimeValue(launchedAtRaw)
+	if err != nil || !ok {
+		return time.Time{}, fmt.Errorf("load launched external effect time: %w", firstNonNilError(err, fmt.Errorf("launched_at is required")))
+	}
+	return launchedAt.UTC(), nil
 }
 
 func (s *PostgresStore) HeartbeatCompletionAttempt(ctx context.Context, attempt runtimeeffects.Attempt, now time.Time, lease time.Duration) error {
@@ -546,30 +770,30 @@ func requireExternalAttemptTransition(res sql.Result, err error) error {
 }
 
 func (s *PostgresStore) SettleExternalAttempt(ctx context.Context, settlement runtimeeffects.Settlement) error {
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	if settlement.Authority.Valid() {
-		if err := requireExternalEffectAuthorityPostgres(ctx, tx, settlement.Authority, false); err != nil {
+	return s.runAuthorActivityMutation(ctx, "postgres settle external attempt", func(txctx context.Context, tx *sql.Tx) error {
+		if settlement.Authority.Valid() {
+			if err := requireExternalEffectAuthorityPostgres(txctx, tx, settlement.Authority, false); err != nil {
+				return err
+			}
+		}
+		if err := settleExternalAttemptPostgres(txctx, tx, settlement); err != nil {
 			return err
 		}
-	}
-	if err := settleExternalAttemptPostgres(ctx, tx, settlement); err != nil {
-		return err
-	}
-	return tx.Commit()
+		return recordSettledExternalEffectStory(txctx, tx, settlement, true)
+	})
 }
 
 func (s *SQLiteRuntimeStore) SettleExternalAttempt(ctx context.Context, settlement runtimeeffects.Settlement) error {
-	return s.runRuntimeMutation(ctx, "sqlite settle external attempt", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite settle external attempt", func(txctx context.Context, tx *sql.Tx) error {
 		if settlement.Authority.Valid() {
 			if err := requireExternalEffectAuthoritySQLite(txctx, tx, settlement.Authority, false); err != nil {
 				return err
 			}
 		}
-		return settleExternalAttemptSQLiteTx(txctx, tx, settlement)
+		if err := settleExternalAttemptSQLiteTx(txctx, tx, settlement); err != nil {
+			return err
+		}
+		return recordSettledExternalEffectStory(txctx, tx, settlement, false)
 	})
 }
 

--- a/internal/store/runtime_mutation.go
+++ b/internal/store/runtime_mutation.go
@@ -29,16 +29,20 @@ func (s *SQLiteRuntimeStore) RunRuntimeMutationContext(ctx context.Context, fn f
 	if fn == nil {
 		return nil
 	}
-	return s.runRuntimeMutation(ctx, "sqlite runtime mutation", func(txctx context.Context, _ *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite pipeline mutation", func(txctx context.Context, _ *sql.Tx) error {
 		return fn(txctx)
 	})
 }
 
 func (s *SQLiteRuntimeStore) RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
-	return s.runRuntimeMutation(ctx, "sqlite event transaction", fn)
+	return s.runAuthorActivityMutation(ctx, "sqlite event transaction", fn)
 }
 
 func (s *PostgresStore) RunEventTransaction(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return s.runAuthorActivityMutation(ctx, "postgres event transaction", fn)
+}
+
+func (s *PostgresStore) runPostgresRuntimeMutation(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	if fn == nil {
 		return nil
 	}
@@ -71,11 +75,6 @@ func (s *PostgresStore) RunEventTransaction(ctx context.Context, fn func(context
 	txctx = runtimepipeline.WithPipelinePostCommitActions(txctx, &postCommit)
 	txctx = runtimepipeline.WithPipelineRollbackActions(txctx, &rollbackActions)
 	if err := fn(txctx, tx); err != nil {
-		_ = tx.Rollback()
-		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
-		return err
-	}
-	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(txctx, tx); err != nil {
 		_ = tx.Rollback()
 		runtimepipeline.FlushPipelineRollbackActions(rollbackActions)
 		return err

--- a/internal/store/runtime_mutation_guard_test.go
+++ b/internal/store/runtime_mutation_guard_test.go
@@ -394,7 +394,7 @@ func collectRuntimeWriterCallSitesFromSource(path, src string) ([]runtimeWriterC
 				return true
 			}
 			switch primitive {
-			case "RunRuntimeMutation", "RunRuntimeMutationContext":
+			case "RunRuntimeMutation", "RunRuntimeMutationContext", "runAuthorActivityMutation", "runDecisionCardMutation":
 				info.callsRuntimeMutation = true
 			case "runRuntimeMutation":
 				info.callsRuntimeMutation = true
@@ -489,7 +489,7 @@ func runtimeWriterPrimitive(call *ast.CallExpr) (string, runtimeWriterPrimitiveK
 		return name, primitiveWrite, true
 	case "Query", "QueryContext", "QueryRow", "QueryRowContext", "Prepare", "PrepareContext":
 		return name, primitiveRead, true
-	case "RunPipelineMutation", "runInPipelineTransaction", "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "RunEventTransaction", "RunEventMutation", "PipelineSQLTxFromContext", "sqlTxFromContext":
+	case "RunPipelineMutation", "runInPipelineTransaction", "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "runAuthorActivityMutation", "runDecisionCardMutation", "RunEventTransaction", "RunEventMutation", "PipelineSQLTxFromContext", "sqlTxFromContext":
 		return name, primitiveBoundary, true
 	default:
 		return "", "", false
@@ -509,7 +509,7 @@ func collectRuntimeWriterBoundaryCallbackScopes(body ast.Node) []runtimeWriterBo
 		}
 		scope := runtimeWriterBoundaryCallbackScope{}
 		switch primitive {
-		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation":
+		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "runAuthorActivityMutation", "runDecisionCardMutation":
 			scope.runtime = true
 		case "RunEventTransaction", "RunEventMutation":
 			scope.event = true
@@ -683,9 +683,12 @@ func classifyRuntimeWriterCallSite(site runtimeWriterCallSite) (runtimeWriterCla
 	if site.Path == "internal/store/failure_schema_migration.go" {
 		return classDifferentConcept, "boot-time canonical failure schema migration owns its isolated transaction", true
 	}
+	if strings.HasPrefix(site.Path, "internal/runtime/authoractivity/") {
+		return classConsumesCanonical, "canonical author activity transaction, persistence, and read owner", true
+	}
 	if site.Kind == primitiveBoundary {
 		switch site.Primitive {
-		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "RunEventTransaction", "RunEventMutation":
+		case "RunRuntimeMutation", "RunRuntimeMutationContext", "runRuntimeMutation", "runAuthorActivityMutation", "runDecisionCardMutation", "RunEventTransaction", "RunEventMutation":
 			return classConsumesCanonical, "canonical runtime mutation/event transaction boundary", true
 		case "RunPipelineMutation", "runInPipelineTransaction":
 			return classConsumesCanonical, "pipeline mutation owner delegates production SQLite writes to RunRuntimeMutationContext", true
@@ -804,7 +807,7 @@ func classifySQLiteRuntimeStoreCallSite(site runtimeWriterCallSite) (runtimeWrit
 		}
 	}
 	switch site.Function {
-	case "RunRuntimeMutation", "RunRuntimeMutationContext", "RunEventTransaction", "RunEventMutation", "runRuntimeMutation", "runRuntimeMutationOnce", "runRuntimeMutationOnceLocked":
+	case "RunRuntimeMutation", "RunRuntimeMutationContext", "RunEventTransaction", "RunEventMutation", "runRuntimeMutation", "runAuthorActivityMutation", "runDecisionCardMutation", "runRuntimeMutationOnce", "runRuntimeMutationOnceLocked":
 		return classConsumesCanonical, "canonical SQLite runtime mutation owner", true
 	case "CompleteDecisionRouteObligation", "QuarantineDecisionRouteObligation", "CompleteDecisionCardLifecycleEvent":
 		return classConsumesCanonical, "decision-card obligation completion consumes the serialized decision-card mutation owner", true

--- a/internal/store/runtime_mutation_test.go
+++ b/internal/store/runtime_mutation_test.go
@@ -237,46 +237,58 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationPostCommitCanReenterRuntimeMutatio
 	}
 }
 
-func TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks(t *testing.T) {
+func TestPostgresStore_RunEventTransactionSerializesStoryCommitOrder(t *testing.T) {
 	_, db, cleanup := testutil.StartPostgres(t)
 	t.Cleanup(cleanup)
 	store := &PostgresStore{DB: db}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	started := make(chan struct{}, 2)
-	release := make(chan struct{})
-	done := make(chan error, 2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			done <- store.RunEventTransaction(ctx, func(context.Context, *sql.Tx) error {
-				started <- struct{}{}
-				select {
-				case <-release:
-					return nil
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			})
-		}()
-	}
-	for i := 0; i < 2; i++ {
-		select {
-		case <-started:
-		case <-ctx.Done():
-			t.Fatalf("postgres event transaction callback %d did not enter concurrently: %v", i+1, ctx.Err())
-		}
-	}
-	close(release)
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Fatalf("RunEventTransaction %d: %v", i+1, err)
+	firstStarted := make(chan struct{})
+	firstRelease := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- store.RunEventTransaction(ctx, func(context.Context, *sql.Tx) error {
+			close(firstStarted)
+			select {
+			case <-firstRelease:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
 			}
-		case <-ctx.Done():
-			t.Fatalf("wait for postgres event transaction %d: %v", i+1, ctx.Err())
-		}
+		})
+	}()
+	select {
+	case <-firstStarted:
+	case <-ctx.Done():
+		t.Fatalf("first postgres story transaction did not start: %v", ctx.Err())
+	}
+
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- store.RunEventTransaction(ctx, func(context.Context, *sql.Tx) error {
+			close(secondStarted)
+			return nil
+		})
+	}()
+	select {
+	case <-secondStarted:
+		t.Fatal("second postgres story callback entered before the first committed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(firstRelease)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first RunEventTransaction: %v", err)
+	}
+	select {
+	case <-secondStarted:
+	case <-ctx.Done():
+		t.Fatalf("second postgres story callback did not start after first commit: %v", ctx.Err())
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second RunEventTransaction: %v", err)
 	}
 }
 

--- a/internal/store/scenario_setup.go
+++ b/internal/store/scenario_setup.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimemutationlog "github.com/division-sh/swarm/internal/runtime/mutationlog"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
@@ -65,6 +67,10 @@ func (s *PostgresStore) SetupScenarioEntities(ctx context.Context, req ScenarioS
 			_ = tx.Rollback()
 		}
 	}()
+	ctx, err = runtimeauthoractivity.Begin(ctx, tx, runtimeauthoractivity.DialectPostgres)
+	if err != nil {
+		return ScenarioSetupResult{}, err
+	}
 	if err := s.ensureRunRow(ctx, caps, tx, req.RunID, "", "test.setup_entities", false); err != nil {
 		return ScenarioSetupResult{}, err
 	}
@@ -107,7 +113,13 @@ func (s *PostgresStore) SetupScenarioEntities(ctx context.Context, req ScenarioS
 			return ScenarioSetupResult{}, fmt.Errorf("record postgres scenario setup entity mutation %s: %w", entity.Alias, err)
 		}
 	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
+	if err := runtimepipeline.CapturePipelineRunForkRevisionChanges(ctx, tx); err != nil {
+		return ScenarioSetupResult{}, fmt.Errorf("capture postgres scenario setup revisions: %w", err)
+	}
+	if err := runtimeauthoractivity.Finalize(ctx); err != nil {
+		return ScenarioSetupResult{}, fmt.Errorf("finalize postgres scenario setup story: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
 		return ScenarioSetupResult{}, fmt.Errorf("commit postgres scenario setup: %w", err)
 	}
 	committed = true
@@ -123,7 +135,7 @@ func (s *SQLiteRuntimeStore) SetupScenarioEntities(ctx context.Context, req Scen
 		return ScenarioSetupResult{}, err
 	}
 	ctx = runtimecorrelation.WithRunID(ctx, req.RunID)
-	if err := s.runRuntimeMutation(ctx, "sqlite scenario setup", func(txctx context.Context, tx *sql.Tx) error {
+	if err := s.runAuthorActivityMutation(ctx, "sqlite scenario setup", func(txctx context.Context, tx *sql.Tx) error {
 		if err := sqliteEnsureRunRow(txctx, tx, req.RunID, "", "test.setup_entities", req.CreatedAt); err != nil {
 			return err
 		}

--- a/internal/store/sqlite_inbound.go
+++ b/internal/store/sqlite_inbound.go
@@ -116,6 +116,9 @@ func (s *SQLiteRuntimeStore) ClaimInboundEventTx(ctx context.Context, tx *sql.Tx
 	if err != nil {
 		return false, fmt.Errorf("record sqlite inbound event in events: %w", err)
 	}
+	if err := recordInboundAuthorActivity(ctx, evt, provider); err != nil {
+		return false, err
+	}
 	return true, nil
 }
 

--- a/internal/store/sqlite_run_completion.go
+++ b/internal/store/sqlite_run_completion.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -52,7 +53,7 @@ func (s *SQLiteRuntimeStore) MarkRunTerminal(ctx context.Context, runID, status 
 		return runtimebus.RunLifecycleSnapshot{}, fmt.Errorf("run terminal persistence requires canonical runs.failure and ended_at")
 	}
 	var snap storerunlifecycle.Snapshot
-	err = s.runRuntimeMutation(ctx, "sqlite mark run terminal", func(txctx context.Context, tx *sql.Tx) error {
+	err = s.runAuthorActivityMutation(ctx, "sqlite mark run terminal", func(txctx context.Context, tx *sql.Tx) error {
 		var err error
 		snap, err = s.sqliteMarkRunTerminalTx(txctx, tx, runID, status, failure, endedAt)
 		return err
@@ -79,7 +80,7 @@ func (s *SQLiteRuntimeStore) ConvergeStandaloneRuntimePlatformRun(ctx context.Co
 	if eventID == "" {
 		return nil
 	}
-	return s.runRuntimeMutation(ctx, "sqlite standalone platform run convergence", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite standalone platform run convergence", func(txctx context.Context, tx *sql.Tx) error {
 		rec, found, err := sqliteLoadStandaloneRuntimePlatformRunRecord(txctx, tx, eventID)
 		if err != nil || !found || !isStandaloneRuntimePlatformRunRecord(rec) {
 			return err
@@ -119,7 +120,7 @@ func (s *SQLiteRuntimeStore) ConvergeNormalRunCompletion(ctx context.Context, ev
 	if !normalRunCompletionSupported(caps) {
 		return nil
 	}
-	return s.runRuntimeMutation(ctx, "sqlite normal run completion", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite normal run completion", func(txctx context.Context, tx *sql.Tx) error {
 		candidate, found, err := sqliteNormalRunCompletionCandidateTx(txctx, tx, eventID)
 		if err != nil || !found {
 			return err
@@ -215,6 +216,9 @@ func (s *SQLiteRuntimeStore) sqliteMarkRunTerminalTx(ctx context.Context, tx *sq
 	if runID == "" {
 		return storerunlifecycle.Snapshot{}, fmt.Errorf("run_id is required")
 	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return storerunlifecycle.Snapshot{}, fmt.Errorf("mark sqlite run terminal: %w", err)
+	}
 	var err error
 	status, err = canonicalRunTerminalStatus(status)
 	if err != nil {
@@ -276,7 +280,23 @@ func (s *SQLiteRuntimeStore) sqliteMarkRunTerminalTx(ctx context.Context, tx *sq
 	if err := supersedeDecisionCardsForRun(ctx, tx, runID, "run_"+status, endedAt, false); err != nil {
 		return storerunlifecycle.Snapshot{}, err
 	}
-	return s.sqliteLoadRunLifecycleSnapshot(ctx, tx, runID)
+	snapshot, err := s.sqliteLoadRunLifecycleSnapshot(ctx, tx, runID)
+	if err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	}
+	occurredAt := endedAt.UTC()
+	if snapshot.EndedAt != nil {
+		occurredAt = snapshot.EndedAt.UTC()
+	}
+	if err := runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+		Kind: runtimeauthoractivity.KindRunLifecycle, Transition: status,
+		SourceOwner: "runs", SourceIdentity: runID + ":" + status, DedupKey: "run-terminal:" + runID + ":" + status,
+		OccurredAt: occurredAt, RunID: runID, Failure: failure,
+		Projection: runtimeauthoractivity.Projection{SubjectType: "run", SubjectID: runID},
+	}); err != nil {
+		return storerunlifecycle.Snapshot{}, err
+	}
+	return snapshot, nil
 }
 
 func sameSQLiteRunFailure(left, right *runtimefailures.Envelope) bool {

--- a/internal/store/sqlite_runtime.go
+++ b/internal/store/sqlite_runtime.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecurrentstate "github.com/division-sh/swarm/internal/runtime/currentstate"
@@ -32,15 +33,17 @@ import (
 type SQLiteRuntimeStore struct {
 	*SQLiteSchemaStore
 
-	eventPayloadValidator EventPayloadValidator
-	startupMu             sync.Mutex
-	mutationMu            sync.Mutex
-	sessionMu             sync.Mutex
-	replayMu              sync.Mutex
-	startupOwner          string
-	replayClaims          map[string]struct{}
-	sessionLockTTL        time.Duration
-	nowFn                 func() time.Time
+	eventPayloadValidator   EventPayloadValidator
+	authorActivityCatalogMu sync.RWMutex
+	authorActivityCatalog   map[string]struct{}
+	startupMu               sync.Mutex
+	mutationMu              sync.Mutex
+	sessionMu               sync.Mutex
+	replayMu                sync.Mutex
+	startupOwner            string
+	replayClaims            map[string]struct{}
+	sessionLockTTL          time.Duration
+	nowFn                   func() time.Time
 }
 
 var _ SchemaBootstrapper = (*SQLiteRuntimeStore)(nil)
@@ -138,7 +141,7 @@ func (s *SQLiteRuntimeStore) CanonicalEventReceiptsCapability(ctx context.Contex
 }
 
 func (s *SQLiteRuntimeStore) AppendEvent(ctx context.Context, evt events.Event) error {
-	return s.runRuntimeMutation(ctx, "sqlite append event", func(txctx context.Context, tx *sql.Tx) error {
+	return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 		return s.AppendEventTx(txctx, tx, evt)
 	})
 }
@@ -152,9 +155,12 @@ func (s *SQLiteRuntimeStore) BeginEventTx(ctx context.Context) (*sql.Tx, error) 
 
 func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt events.Event) error {
 	if tx == nil {
-		return s.runRuntimeMutation(ctx, "sqlite append event", func(txctx context.Context, tx *sql.Tx) error {
+		return s.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
 			return s.AppendEventTx(txctx, tx, evt)
 		})
+	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return err
 	}
 	caps, err := s.schemaCapabilities(ctx)
 	if err != nil {
@@ -183,7 +189,7 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 			return err
 		}
 	}
-	_, err = tx.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO events (
 			event_id, run_id, event_name, entity_id, flow_instance, source_route, target_route, target_set,
 			scope, payload, chain_depth, produced_by, produced_by_type, source_event_id, created_at
@@ -194,7 +200,14 @@ func (s *SQLiteRuntimeStore) AppendEventTx(ctx context.Context, tx *sql.Tx, evt 
 	if err != nil {
 		return fmt.Errorf("append sqlite event: %w", err)
 	}
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read append sqlite event result: %w", err)
+	}
+	if rows == 0 {
+		return nil
+	}
+	return recordPersistedEventAuthorActivity(ctx, s, evt, producedBy, producedByType)
 }
 
 func (s *SQLiteRuntimeStore) eventPersistenceAdmissionOptions(ctx context.Context, caps StoreSchemaCapabilities, q rowQueryer, evt events.Event) events.AdmissionOptions {
@@ -595,7 +608,7 @@ func (s *SQLiteRuntimeStore) sqliteRunControlTransition(ctx context.Context, req
 		req.ControlledBy = "api.v1"
 	}
 	var state runtimeruncontrol.State
-	if err := s.runRuntimeMutation(ctx, "sqlite run control transition", func(txctx context.Context, tx *sql.Tx) error {
+	if err := s.runAuthorActivityMutation(ctx, "sqlite run control transition", func(txctx context.Context, tx *sql.Tx) error {
 		var err error
 		state, err = sqliteLoadRunControlState(txctx, tx, runID)
 		if err != nil {
@@ -611,7 +624,25 @@ func (s *SQLiteRuntimeStore) sqliteRunControlTransition(ctx context.Context, req
 		default:
 			err = fmt.Errorf("unsupported run control action %q", action)
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		if action == "pause" || action == "continue" {
+			transition := "paused"
+			if action == "continue" {
+				transition = "resumed"
+			}
+			transitionID := uuid.NewString()
+			return runtimeauthoractivity.Record(txctx, runtimeauthoractivity.Draft{
+				Kind: runtimeauthoractivity.KindRunLifecycle, Transition: transition,
+				SourceOwner: "runs", SourceIdentity: transitionID, DedupKey: "run-transition:" + transitionID,
+				OccurredAt: req.Now.UTC(), RunID: runID,
+				Projection: runtimeauthoractivity.Projection{
+					SubjectType: "run", SubjectID: runID, ControlReason: req.Reason, Source: req.ControlledBy,
+				},
+			})
+		}
+		return nil
 	}); err != nil {
 		return runtimeruncontrol.State{}, err
 	}
@@ -778,6 +809,9 @@ func sqliteEnsureRunRow(ctx context.Context, tx *sql.Tx, runID, triggerEventID, 
 	if runID == "" {
 		return nil
 	}
+	if err := runtimeauthoractivity.Require(ctx); err != nil {
+		return fmt.Errorf("ensure sqlite run row: %w", err)
+	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -793,7 +827,7 @@ func sqliteEnsureRunRow(ctx context.Context, tx *sql.Tx, runID, triggerEventID, 
 	if bundleSource == "" {
 		bundleSource = storerunlifecycle.BundleSourceLegacy
 	}
-	_, err := tx.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO runs (
 			run_id, status, bundle_hash, bundle_source, bundle_fingerprint,
 			trigger_event_id, trigger_event_type, started_at
@@ -802,6 +836,18 @@ func sqliteEnsureRunRow(ctx context.Context, tx *sql.Tx, runID, triggerEventID, 
 	`, runID, sqliteNullString(bundleHash), bundleSource, sqliteNullString(bundleFingerprint), sqliteNullUUID(triggerEventID), sqliteNullString(triggerEventType), now.UTC())
 	if err != nil {
 		return fmt.Errorf("ensure sqlite run row: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read ensure sqlite run row result: %w", err)
+	}
+	if rows == 1 {
+		return runtimeauthoractivity.Record(ctx, runtimeauthoractivity.Draft{
+			Kind: runtimeauthoractivity.KindRunLifecycle, Transition: "started",
+			SourceOwner: "runs", SourceIdentity: runID, DedupKey: "run-created:" + runID,
+			OccurredAt: now.UTC(), RunID: runID,
+			Projection: runtimeauthoractivity.Projection{SubjectType: "run", SubjectID: runID, TriggerEventType: strings.TrimSpace(triggerEventType)},
+		})
 	}
 	return nil
 }

--- a/internal/store/sqlite_runtime_delivery_replay.go
+++ b/internal/store/sqlite_runtime_delivery_replay.go
@@ -194,7 +194,7 @@ func (s *SQLiteRuntimeStore) PersistEventWithDeliveries(ctx context.Context, evt
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveriesAndScope(ctx context.Context, evt events.Event, agentIDs []string, scope runtimereplayclaim.CommittedReplayScope) error {
-	return s.runRuntimeMutation(ctx, "sqlite event/delivery", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite event/delivery", func(txctx context.Context, tx *sql.Tx) error {
 		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
 			return err
 		}
@@ -206,7 +206,7 @@ func (s *SQLiteRuntimeStore) PersistEventWithDeliveriesAndScope(ctx context.Cont
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRoutesAndScope(ctx context.Context, evt events.Event, agentIDs []string, deliveryTargets map[string]events.RouteIdentity, scope runtimereplayclaim.CommittedReplayScope) error {
-	return s.runRuntimeMutation(ctx, "sqlite event/routes", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite event/routes", func(txctx context.Context, tx *sql.Tx) error {
 		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRoutesAndScope(ctx context.
 }
 
 func (s *SQLiteRuntimeStore) PersistEventWithDeliveryRouteSetAndScope(ctx context.Context, evt events.Event, deliveryRoutes []events.DeliveryRoute, scope runtimereplayclaim.CommittedReplayScope) error {
-	return s.runRuntimeMutation(ctx, "sqlite event/route-set", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite event/route-set", func(txctx context.Context, tx *sql.Tx) error {
 		if err := s.AppendEventTx(txctx, tx, evt); err != nil {
 			return err
 		}
@@ -667,12 +667,23 @@ func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, ev
 		return fmt.Errorf("mark sqlite event delivery in progress: eventID and agentID required")
 	}
 	terminalReasons := activeRunQuiescenceTerminalReasonCodes()
-	args := []any{sqliteNullUUID(sessionID), s.now(), eventID, agentID}
+	transitionAt := s.now()
+	args := []any{sqliteNullUUID(sessionID), transitionAt, eventID, agentID}
 	for _, reason := range terminalReasons {
 		args = append(args, reason)
 	}
 	var rows int64
-	if err := s.runRuntimeMutation(ctx, "sqlite delivery in progress", func(txctx context.Context, tx *sql.Tx) error {
+	if err := s.runAuthorActivityMutation(ctx, "sqlite delivery in progress", func(txctx context.Context, tx *sql.Tx) error {
+		delivery, err := s.sqliteLockAgentDeliveryTx(txctx, tx, eventID, agentID)
+		if err != nil {
+			return err
+		}
+		if !delivery.found {
+			return fmt.Errorf("mark sqlite event delivery in progress: delivery row required for event %s agent %s", eventID, agentID)
+		}
+		if activeRunQuiescenceDeliveryTerminal(delivery.status, delivery.reasonCode) {
+			return nil
+		}
 		res, err := tx.ExecContext(txctx, `
 			UPDATE event_deliveries
 			SET status = 'in_progress',
@@ -688,7 +699,14 @@ func (s *SQLiteRuntimeStore) MarkEventDeliveryInProgress(ctx context.Context, ev
 			return err
 		}
 		rows, _ = res.RowsAffected()
-		return nil
+		if rows == 0 {
+			return fmt.Errorf("mark sqlite event delivery in progress: delivery transition conflict for event %s agent %s", eventID, agentID)
+		}
+		state := agentReceiptWriteState{deliveryCode: "in_progress", retryCount: delivery.retryCount, reasonCode: "agent_processing"}
+		if delivery.startedAt.Valid {
+			transitionAt = delivery.startedAt.Time.UTC()
+		}
+		return recordAgentDeliveryAuthorActivity(txctx, delivery, agentID, state, transitionAt)
 	}); err != nil {
 		return fmt.Errorf("mark sqlite event delivery in progress: %w", err)
 	}
@@ -712,7 +730,7 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, ag
 	if status == "" {
 		return fmt.Errorf("upsert sqlite event receipt: status required")
 	}
-	return s.runRuntimeMutation(ctx, "sqlite event receipt", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite event receipt", func(txctx context.Context, tx *sql.Tx) error {
 		delivery, err := s.sqliteLockAgentDeliveryTx(txctx, tx, eventID, agentID)
 		if err != nil {
 			return err
@@ -727,123 +745,95 @@ func (s *SQLiteRuntimeStore) UpsertEventReceipt(ctx context.Context, eventID, ag
 		if err != nil {
 			return err
 		}
-		failureJSON, err := nullableFailureJSON(state.failure)
+		now := s.now()
+		changed, err := s.updateAgentDeliveryRowTx(txctx, tx, eventID, agentID, state, now)
 		if err != nil {
 			return err
 		}
-		now := s.now()
-		if _, err := tx.ExecContext(txctx, `
+		if !changed {
+			return nil
+		}
+		if err := s.upsertAgentReceiptRowTx(txctx, tx, eventID, agentID, delivery, state, now); err != nil {
+			return err
+		}
+		return recordAgentDeliveryAuthorActivity(txctx, delivery, agentID, state, now)
+	})
+}
+
+func (s *SQLiteRuntimeStore) updateAgentDeliveryRowTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	eventID, agentID string,
+	state agentReceiptWriteState,
+	transitionAt time.Time,
+) (bool, error) {
+	failureJSON, err := nullableFailureJSON(state.failure)
+	if err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, `
 			UPDATE event_deliveries
 			SET status = ?,
 			    retry_count = ?,
 			    reason_code = ?,
 			    failure = NULLIF(?, ''),
+			    active_session_id = NULL,
 			    delivered_at = ?
 			WHERE event_id = ?
 			  AND subscriber_type = 'agent'
 			  AND subscriber_id = ?
-		`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), failureJSON, now, eventID, agentID); err != nil {
-			return fmt.Errorf("update sqlite event delivery receipt state: %w", err)
-		}
-		sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount))
-		if err != nil {
-			return fmt.Errorf("marshal sqlite agent receipt side effects: %w", err)
-		}
-		if _, err := tx.ExecContext(txctx, `
-			INSERT INTO event_receipts (
-				receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
-				outcome, reason_code, failure, side_effects, processed_at
-			)
-			VALUES (?, ?, 'agent', ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
-				outcome = excluded.outcome,
-				reason_code = excluded.reason_code,
-				failure = excluded.failure,
-				side_effects = excluded.side_effects,
-				processed_at = excluded.processed_at
-		`, uuid.NewString(), eventID, agentID, sqliteNullUUID(delivery.entityID), sqliteNullString(delivery.flowInstance),
-			mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), sqliteNullString(failureJSON), string(sideEffects), now); err != nil {
-			return fmt.Errorf("upsert sqlite event receipt row: %w", err)
-		}
-		return nil
-	})
+			  AND (
+				COALESCE(status, '') <> ?
+				OR COALESCE(retry_count, 0) <> ?
+				OR COALESCE(reason_code, '') <> ?
+				OR COALESCE(failure, '') <> ?
+				OR active_session_id IS NOT NULL
+			  )
+		`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), failureJSON, transitionAt.UTC(), eventID, agentID,
+		state.deliveryCode, state.retryCount, strings.TrimSpace(state.reasonCode), failureJSON)
+	if err != nil {
+		return false, fmt.Errorf("update sqlite event delivery receipt state: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read sqlite event delivery transition result: %w", err)
+	}
+	return rows > 0, nil
 }
 
-func (s *SQLiteRuntimeStore) applySQLiteDeliveryBackedTerminalTransitionTx(
+func (s *SQLiteRuntimeStore) upsertAgentReceiptRowTx(
 	ctx context.Context,
 	tx *sql.Tx,
 	eventID, agentID string,
 	delivery lockedAgentDelivery,
-	req deliveryBackedTerminalTransitionRequest,
-) (runtimemanager.EventReceipt, error) {
-	if !delivery.found {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: delivery row required")
-	}
-	reasonCode := strings.TrimSpace(req.reasonCode)
-	if reasonCode == "" {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: reason_code required")
-	}
-	if req.retryAdvance < 0 {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("apply sqlite delivery-backed terminal transition: retry advance must be non-negative")
-	}
-	state := agentReceiptWriteState{
-		finalStatus:  runtimemanager.ReceiptStatusDeadLetter,
-		retryCount:   delivery.retryCount + req.retryAdvance,
-		reasonCode:   reasonCode,
-		failure:      runtimefailures.CloneEnvelope(req.failure),
-		deliveryCode: "dead_letter",
-	}
-	now := s.now()
+	state agentReceiptWriteState,
+	processedAt time.Time,
+) error {
 	failureJSON, err := nullableFailureJSON(state.failure)
 	if err != nil {
-		return runtimemanager.EventReceipt{}, err
-	}
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE event_deliveries
-		SET status = ?,
-		    retry_count = ?,
-		    reason_code = ?,
-		    failure = NULLIF(?, ''),
-		    active_session_id = NULL,
-		    delivered_at = ?
-		WHERE event_id = ?
-		  AND subscriber_type = 'agent'
-		  AND subscriber_id = ?
-	`, state.deliveryCode, state.retryCount, sqliteNullString(state.reasonCode), failureJSON, now, eventID, agentID); err != nil {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("sync sqlite event delivery terminal state: %w", err)
+		return err
 	}
 	sideEffects, err := marshalAgentReceiptSideEffects(newAgentReceiptSideEffects(state.finalStatus, state.reasonCode, state.retryCount))
 	if err != nil {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("marshal sqlite terminal agent receipt side effects: %w", err)
+		return fmt.Errorf("marshal sqlite agent receipt side effects: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO event_receipts (
 			receipt_id, event_id, subscriber_type, subscriber_id, entity_id, flow_instance,
 			outcome, reason_code, failure, side_effects, processed_at
 		)
-		SELECT
-			?, e.event_id, 'agent', ?, e.entity_id, e.flow_instance,
-			?, ?, ?, ?, ?
-		FROM events e
-		WHERE e.event_id = ?
+		VALUES (?, ?, 'agent', ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(event_id, subscriber_type, subscriber_id) DO UPDATE SET
-			entity_id = excluded.entity_id,
-			flow_instance = excluded.flow_instance,
 			outcome = excluded.outcome,
 			reason_code = excluded.reason_code,
 			failure = excluded.failure,
 			side_effects = excluded.side_effects,
 			processed_at = excluded.processed_at
-	`, uuid.NewString(), agentID, mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), sqliteNullString(failureJSON), string(sideEffects), now, eventID); err != nil {
-		return runtimemanager.EventReceipt{}, fmt.Errorf("upsert sqlite terminal event receipt row: %w", err)
+	`, uuid.NewString(), eventID, agentID, sqliteNullUUID(delivery.entityID), sqliteNullString(delivery.flowInstance),
+		mapManagerReceiptStatusToOutcome(state.finalStatus), sqliteNullString(state.reasonCode), sqliteNullString(failureJSON), string(sideEffects), processedAt.UTC()); err != nil {
+		return fmt.Errorf("upsert sqlite event receipt row: %w", err)
 	}
-	return runtimemanager.EventReceipt{
-		EventID:    strings.TrimSpace(eventID),
-		AgentID:    strings.TrimSpace(agentID),
-		Status:     runtimemanager.ReceiptStatusDeadLetter,
-		RetryCount: state.retryCount,
-		Failure:    runtimefailures.CloneEnvelope(state.failure),
-	}, nil
+	return nil
 }
 
 func (s *SQLiteRuntimeStore) GetEventReceipt(ctx context.Context, eventID, agentID string) (runtimemanager.EventReceipt, bool, error) {
@@ -1255,26 +1245,36 @@ func (s *SQLiteRuntimeStore) listSQLitePendingAgentDeliveryRecords(ctx context.C
 
 func (s *SQLiteRuntimeStore) sqliteLockAgentDeliveryTx(ctx context.Context, tx *sql.Tx, eventID, agentID string) (lockedAgentDelivery, error) {
 	var delivery lockedAgentDelivery
+	var startedAtRaw any
 	err := tx.QueryRowContext(ctx, `
 		SELECT
+			d.delivery_id,
+			COALESCE(d.run_id, e.run_id, ''),
+			e.event_name,
 			COALESCE(d.retry_count, 0),
 			COALESCE(d.status, ''),
 			COALESCE(d.reason_code, ''),
 			COALESCE(d.active_session_id, ''),
 			COALESCE(e.entity_id, ''),
-			COALESCE(e.flow_instance, '')
+			COALESCE(e.flow_instance, ''),
+			d.started_at
 		FROM event_deliveries d
 		INNER JOIN events e ON e.event_id = d.event_id
 		WHERE d.event_id = ?
 		  AND d.subscriber_type = 'agent'
 		  AND d.subscriber_id = ?
-	`, eventID, agentID).Scan(&delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance)
+	`, eventID, agentID).Scan(&delivery.deliveryID, &delivery.runID, &delivery.eventType, &delivery.retryCount, &delivery.status, &delivery.reasonCode, &delivery.activeSessionID, &delivery.entityID, &delivery.flowInstance, &startedAtRaw)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return lockedAgentDelivery{}, nil
 	case err != nil:
 		return lockedAgentDelivery{}, fmt.Errorf("lock sqlite event delivery row: %w", err)
 	default:
+		if startedAt, valid, parseErr := sqliteTimeValue(startedAtRaw); parseErr != nil {
+			return lockedAgentDelivery{}, fmt.Errorf("parse sqlite event delivery started_at: %w", parseErr)
+		} else if valid {
+			delivery.startedAt = sql.NullTime{Time: startedAt.UTC(), Valid: true}
+		}
 		delivery.found = true
 		return delivery, nil
 	}

--- a/internal/store/sqlite_runtime_llm.go
+++ b/internal/store/sqlite_runtime_llm.go
@@ -51,7 +51,7 @@ func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm
 	runID := nullUUIDString(rec.RunID)
 	now := s.now()
 
-	return s.runRuntimeMutation(ctx, "sqlite append agent turn", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite append agent turn", func(txctx context.Context, tx *sql.Tx) error {
 		if err := sqliteEnsureRunRow(txctx, tx, runID, rec.TriggerEventID, rec.TriggerEventType, now); err != nil {
 			return err
 		}
@@ -76,6 +76,7 @@ func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm
 				return fmt.Errorf("no persisted conversation row found for agent=%s runtime=%s session=%s", rec.AgentID, mode.String(), rec.SessionID)
 			}
 		}
+		turnID := uuid.NewString()
 		_, err := tx.ExecContext(txctx, `
 			INSERT INTO agent_turns (
 				turn_id, run_id, agent_id, session_id, runtime_mode, scope_key, entity_id,
@@ -88,7 +89,7 @@ func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm
 				?, ?, ?, ?,
 				?, ?, ?, ?, ?, ?, ?, ?
 			)
-		`, uuid.NewString(), sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), strings.TrimSpace(rec.SessionID),
+		`, turnID, sqliteNullUUID(runID), strings.TrimSpace(rec.AgentID), strings.TrimSpace(rec.SessionID),
 			mode.String(), sqliteNullString(rec.ScopeKey), sqliteNullUUID(rec.EntityID), sqliteNullUUID(rec.TriggerEventID),
 			sqliteNullString(rec.TriggerEventType), sqliteNullString(rec.TaskID), availableToolsPayload, toolCallsPayload,
 			emittedEventsPayload, mcpServersPayload, mcpToolsListedPayload, mcpToolsVisiblePayload,
@@ -97,7 +98,12 @@ func (s *SQLiteRuntimeStore) AppendAgentTurn(ctx context.Context, rec runtimellm
 		if err != nil {
 			return fmt.Errorf("insert sqlite agent turn: %w", err)
 		}
-		return nil
+		return recordAuthorActivityTurn(txctx, authorActivityTurn{
+			TurnID: turnID, RunID: rec.RunID, AgentID: rec.AgentID, SessionID: rec.SessionID, EntityID: rec.EntityID,
+			FlowID: rec.FlowInstance, TriggerEventType: rec.TriggerEventType, Blocks: rec.TurnBlocks,
+			ParseOK: rec.ParseOK, DurationMS: latencyMS, RetryCount: rec.RetryCount, UsageExactness: "unavailable",
+			Failure: rec.Failure, OccurredAt: now,
+		})
 	})
 }
 
@@ -129,7 +135,7 @@ func (s *SQLiteRuntimeStore) UpsertConversation(ctx context.Context, rec runtime
 	runID := nullUUIDString(rec.RunID)
 	now := s.now()
 
-	return s.runRuntimeMutation(ctx, "sqlite conversation upsert", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite conversation upsert", func(txctx context.Context, tx *sql.Tx) error {
 		if resolved.Stateless {
 			if err := sqliteEnsureRunRow(txctx, tx, runID, "", "", now); err != nil {
 				return err

--- a/internal/store/sqlite_runtime_mailbox_schedule.go
+++ b/internal/store/sqlite_runtime_mailbox_schedule.go
@@ -517,11 +517,8 @@ func (s *SQLiteRuntimeStore) sqliteStopRunControl(ctx context.Context, tx *sql.T
 	if err != nil {
 		return runtimeruncontrol.State{}, err
 	}
-	if err := supersedeDecisionCardsForRun(ctx, tx, state.RunID, "run_stopped", req.Now.UTC(), false); err != nil {
+	if _, err := s.sqliteMarkRunTerminalTx(ctx, tx, state.RunID, "cancelled", nil, req.Now.UTC()); err != nil {
 		return runtimeruncontrol.State{}, err
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE runs SET status = 'cancelled', failure = NULL, ended_at = COALESCE(ended_at, ?) WHERE run_id = ?`, req.Now.UTC(), state.RunID); err != nil {
-		return runtimeruncontrol.State{}, fmt.Errorf("stop sqlite run: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO run_control_state (run_id, control_status, reason, controlled_by, updated_at, paused_at, stopped_at)

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"os"
@@ -888,40 +889,28 @@ func TestSQLiteRuntimeStoreAPIIdempotencySerializesAcrossSamePathHandles(t *test
 	assertSQLiteRuntimeCount(t, storeA, `SELECT COUNT(*) FROM api_idempotency WHERE method = ? AND idempotency_key = ?`, 1, req.Method, req.IdempotencyKey)
 }
 
-func TestSQLiteRuntimeStoreAppendEventTxEnsuresFreshRunRow(t *testing.T) {
+func TestSQLiteRuntimeStoreRunEventTransactionEnsuresFreshRunRow(t *testing.T) {
 	ctx := context.Background()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
-	tx, err := store.BeginEventTx(ctx)
-	if err != nil {
-		t.Fatalf("BeginEventTx: %v", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
 
 	runID := uuid.NewString()
 	eventID := uuid.NewString()
-	if err := store.AppendEventTx(ctx, tx, eventtest.PersistedProjection(
-		eventID,
-		events.EventType("item.received"),
-		"api.v1",
-		"",
-		json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`),
-		0,
-		runID,
-		"",
-		events.EnvelopeForEntityID(events.EventEnvelope{}, "33333333-3333-3333-3333-333333333333"),
-		time.Now().UTC(),
-	)); err != nil {
-		t.Fatalf("AppendEventTx: %v", err)
+	if err := store.RunEventTransaction(ctx, func(txctx context.Context, tx *sql.Tx) error {
+		return store.AppendEventTx(txctx, tx, eventtest.PersistedProjection(
+			eventID,
+			events.EventType("item.received"),
+			"api.v1",
+			"",
+			json.RawMessage(`{"entity_id":"33333333-3333-3333-3333-333333333333"}`),
+			0,
+			runID,
+			"",
+			events.EnvelopeForEntityID(events.EventEnvelope{}, "33333333-3333-3333-3333-333333333333"),
+			time.Now().UTC(),
+		))
+	}); err != nil {
+		t.Fatalf("RunEventTransaction: %v", err)
 	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit event tx: %v", err)
-	}
-	committed = true
 
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM runs WHERE run_id = ?`, 1, runID)
 	assertSQLiteRuntimeCount(t, store, `SELECT COUNT(*) FROM events WHERE event_id = ?`, 1, eventID)

--- a/internal/store/sqlite_schema_test.go
+++ b/internal/store/sqlite_schema_test.go
@@ -21,8 +21,8 @@ func TestSQLiteSchemaStoreBootstrapsPlatformAndGeneratedTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlatformTableDDLs: %v", err)
 	}
-	if len(platformPlans) != 50 {
-		t.Fatalf("platform table plan count = %d, want 50", len(platformPlans))
+	if len(platformPlans) != 52 {
+		t.Fatalf("platform table plan count = %d, want 52", len(platformPlans))
 	}
 	entityPlans, err := GenerateEntityTableDDLs(runtimecontracts.EntitySchema{
 		Groups: []runtimecontracts.EntitySchemaGroup{{

--- a/internal/store/store_abstraction_guard_matrix_test.go
+++ b/internal/store/store_abstraction_guard_matrix_test.go
@@ -292,7 +292,7 @@ func expectedSelectedStoreAbstractionRowShapes() map[string]selectedStoreAbstrac
 			Tier:                   "required_smoke",
 			RequiresGuardProofRefs: true,
 		},
-		"postgres_not_forced_through_sqlite_serialization_guard": {
+		"postgres_story_order_serialization_guard": {
 			Classification:         "guard",
 			Tier:                   "required_smoke",
 			RequiresGuardProofRefs: true,
@@ -489,7 +489,7 @@ func requiredSelectedStoreAbstractionRows() map[string]struct{} {
 		"producer_backend_branching_guard",
 		"raw_selected_runtime_writer_boundary_guard",
 		"sqlite_runtime_sqldb_omission_guard",
-		"postgres_not_forced_through_sqlite_serialization_guard",
+		"postgres_story_order_serialization_guard",
 		"default_sqlite_required_smoke",
 		"explicit_postgres_required_smoke",
 		"api_idempotency_public_surface_accounting",

--- a/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
+++ b/internal/store/testdata/selected_store_abstraction_guard_matrix.yaml
@@ -105,27 +105,28 @@ rows:
       SQLite construction must keep runtime.Stores.SQLDB nil; promoted stores
       consume typed selected owners instead.
 
-  - id: postgres_not_forced_through_sqlite_serialization_guard
+  - id: postgres_story_order_serialization_guard
     classification: guard
     tier: required_smoke
     concepts:
-      - Postgres must not inherit SQLite global serialization or retry policy
+      - PostgreSQL story mutations serialize on the author-activity singleton without inheriting SQLite retry policy
     owners:
       - internal/store.PostgresStore transaction methods
       - internal/runtime/pipeline.WorkflowInstanceStore Postgres dialect
     proof_refs:
       - kind: go_test
-        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+        name: TestPostgresStore_RunEventTransactionSerializesStoryCommitOrder
       - kind: go_test
         name: TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect
     guard_proof_refs:
       - kind: go_test
-        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+        name: TestPostgresStore_RunEventTransactionSerializesStoryCommitOrder
       - kind: go_test
         name: TestWorkflowInstanceStore_RunPipelineMutationDoesNotRetryPostgresDialect
     notes: >
-      SQLite-local busy handling is a store-internal backend policy; Postgres
-      keeps normal transaction behavior.
+      SQLite-local busy handling remains a store-internal backend policy.
+      PostgreSQL does not inherit that retry policy, but story-bearing writes
+      intentionally serialize before domain work to own commit-visible order.
 
   - id: default_sqlite_required_smoke
     classification: required_smoke
@@ -238,7 +239,7 @@ rows:
       - kind: go_test
         name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner
       - kind: go_test
-        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+        name: TestPostgresStore_RunEventTransactionSerializesStoryCommitOrder
       - kind: go_test
         name: TestSelectedSQLiteRuntimeWriterBoundaryAudit
     guard_proof_refs:
@@ -279,7 +280,7 @@ rows:
       - kind: go_test
         name: TestSQLiteWorkflowInstanceStore_RunPipelineMutationUsesRuntimeMutationRunner
       - kind: go_test
-        name: TestPostgresStore_RunEventTransactionDoesNotSerializeCallbacks
+        name: TestPostgresStore_RunEventTransactionSerializesStoryCommitOrder
     guard_proof_refs:
       - kind: go_test
         name: TestSelectedSQLiteRuntimeConstructionConsumesMutationBoundary

--- a/internal/store/tool_persistence.go
+++ b/internal/store/tool_persistence.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 	runtimemutationlog "github.com/division-sh/swarm/internal/runtime/mutationlog"
@@ -113,32 +114,23 @@ func (s *PostgresStore) SaveEntityField(ctx context.Context, update runtimetools
 	if err != nil {
 		return 0, err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("begin postgres entity field update: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	pathArray := pq.Array(segments)
-	var oldValue []byte
-	if err := tx.QueryRowContext(ctx, `
+	var revision int
+	err = s.runAuthorActivityMutation(ctx, "postgres entity field update", func(txctx context.Context, tx *sql.Tx) error {
+		pathArray := pq.Array(segments)
+		var oldValue []byte
+		if err := tx.QueryRowContext(txctx, `
 		SELECT COALESCE(COALESCE(fields, '{}'::jsonb) #> $3::text[], 'null'::jsonb)
 		FROM entity_state
 		WHERE run_id = $1::uuid
 		  AND entity_id = $2::uuid
 		FOR UPDATE
 	`, runID, entityID, pathArray).Scan(&oldValue); err != nil {
-		if err == sql.ErrNoRows {
-			return 0, fmt.Errorf("entity not found: %s", entityID)
+			if err == sql.ErrNoRows {
+				return fmt.Errorf("entity not found: %s", entityID)
+			}
+			return fmt.Errorf("load postgres entity field: %w", err)
 		}
-		return 0, fmt.Errorf("load postgres entity field: %w", err)
-	}
-	var revision int
-	if err := tx.QueryRowContext(ctx, `
+		if err := tx.QueryRowContext(txctx, `
 		UPDATE entity_state
 		SET
 			fields = jsonb_set(COALESCE(fields, '{}'::jsonb), $2::text[], $3::jsonb, true),
@@ -148,19 +140,20 @@ func (s *PostgresStore) SaveEntityField(ctx context.Context, update runtimetools
 		  AND run_id = $4::uuid
 		RETURNING revision
 	`, entityID, pathArray, string(valueJSON), runID).Scan(&revision); err != nil {
-		return 0, fmt.Errorf("update postgres entity field: %w", err)
+			return fmt.Errorf("update postgres entity field: %w", err)
+		}
+		if err := runtimemutationlog.InsertEntityStateDiff(txctx, tx, entityID, runtimemutationlog.EntityStateProjection{
+			Fields: map[string]any{update.FieldPath: toolNullableJSONBytes(oldValue)},
+		}, runtimemutationlog.EntityStateProjection{
+			Fields: map[string]any{update.FieldPath: json.RawMessage(valueJSON)},
+		}, mutationWriter(update.Writer)); err != nil {
+			return fmt.Errorf("record postgres entity mutation: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
 	}
-	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, entityID, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{update.FieldPath: toolNullableJSONBytes(oldValue)},
-	}, runtimemutationlog.EntityStateProjection{
-		Fields: map[string]any{update.FieldPath: json.RawMessage(valueJSON)},
-	}, mutationWriter(update.Writer)); err != nil {
-		return 0, fmt.Errorf("record postgres entity mutation: %w", err)
-	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-		return 0, fmt.Errorf("commit postgres entity field update: %w", err)
-	}
-	committed = true
 	return revision, nil
 }
 
@@ -173,7 +166,7 @@ func (s *SQLiteRuntimeStore) SaveEntityField(ctx context.Context, update runtime
 		return 0, err
 	}
 	var revision int
-	if err := s.runRuntimeMutation(ctx, "sqlite entity field update", func(txctx context.Context, tx *sql.Tx) error {
+	if err := s.runAuthorActivityMutation(ctx, "sqlite entity field update", func(txctx context.Context, tx *sql.Tx) error {
 		var fieldsRaw any
 		if err := tx.QueryRowContext(txctx, `
 			SELECT COALESCE(fields, '{}')
@@ -236,17 +229,8 @@ func (s *PostgresStore) CreateEntity(ctx context.Context, rec runtimetools.Entit
 	if err != nil {
 		return err
 	}
-	tx, err := s.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin postgres entity create: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if _, err := tx.ExecContext(ctx, `
+	return s.runAuthorActivityMutation(ctx, "postgres entity create", func(txctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(txctx, `
 		INSERT INTO entity_state (
 			run_id, entity_id, flow_instance, entity_type, name,
 			current_state, gates, fields, accumulator, revision,
@@ -258,19 +242,16 @@ func (s *PostgresStore) CreateEntity(ctx context.Context, rec runtimetools.Entit
 			$8, $8, $8
 		)
 	`, rec.RunID, rec.EntityID, rec.FlowInstance, rec.EntityType, rec.Name, rec.CurrentState, string(rec.FieldsJSON), rec.CreatedAt); err != nil {
-		return fmt.Errorf("insert postgres entity: %w", err)
-	}
-	if err := runtimemutationlog.InsertEntityStateDiff(ctx, tx, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
-		CurrentState: rec.CurrentState,
-		Fields:       fields,
-	}, mutationWriter(rec.Writer)); err != nil {
-		return fmt.Errorf("record postgres entity create mutation: %w", err)
-	}
-	if err := commitPostgresRunForkRevisionTx(ctx, tx); err != nil {
-		return fmt.Errorf("commit postgres entity create: %w", err)
-	}
-	committed = true
-	return nil
+			return fmt.Errorf("insert postgres entity: %w", err)
+		}
+		if err := runtimemutationlog.InsertEntityStateDiff(txctx, tx, rec.EntityID, runtimemutationlog.EntityStateProjection{}, runtimemutationlog.EntityStateProjection{
+			CurrentState: rec.CurrentState,
+			Fields:       fields,
+		}, mutationWriter(rec.Writer)); err != nil {
+			return fmt.Errorf("record postgres entity create mutation: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *SQLiteRuntimeStore) CreateEntity(ctx context.Context, rec runtimetools.EntityCreateRecord) error {
@@ -281,7 +262,7 @@ func (s *SQLiteRuntimeStore) CreateEntity(ctx context.Context, rec runtimetools.
 	if err != nil {
 		return err
 	}
-	return s.runRuntimeMutation(ctx, "sqlite entity create", func(txctx context.Context, tx *sql.Tx) error {
+	return s.runAuthorActivityMutation(ctx, "sqlite entity create", func(txctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(txctx, `
 			INSERT INTO entity_state (
 				run_id, entity_id, flow_instance, entity_type, name,
@@ -724,6 +705,11 @@ func insertSQLiteEntityStateDiff(ctx context.Context, tx *sql.Tx, runID string, 
 		createdAt = time.Now().UTC()
 	}
 	for _, rec := range records {
+		if strings.TrimSpace(rec.Field) == "current_state" {
+			if err := runtimeauthoractivity.Require(ctx); err != nil {
+				return err
+			}
+		}
 		oldValue, err := toolJSONSQLArg(rec.OldValue)
 		if err != nil {
 			return err
@@ -732,15 +718,25 @@ func insertSQLiteEntityStateDiff(ctx context.Context, tx *sql.Tx, runID string, 
 		if err != nil {
 			return err
 		}
+		mutationID := uuid.NewString()
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO entity_mutations (
 				mutation_id, run_id, entity_id, field, old_value, new_value,
 				caused_by_event, writer_type, writer_id, handler_step, created_at
 			)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, uuid.NewString(), runID, rec.EntityID, rec.Field, oldValue, newValue,
+		`, mutationID, runID, rec.EntityID, rec.Field, oldValue, newValue,
 			sqliteNullUUID(causedByEvent), rec.WriterType, rec.WriterID, sqliteNullString(rec.HandlerStep), createdAt.UTC()); err != nil {
 			return fmt.Errorf("insert sqlite entity mutation: %w", err)
+		}
+		draft, admitted, err := runtimemutationlog.AuthorActivityDraft(runID, mutationID, rec, createdAt)
+		if err != nil {
+			return err
+		}
+		if admitted {
+			if err := runtimeauthoractivity.Record(ctx, draft); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10590,6 +10590,7 @@ platform_tables:
         - run_fork_selected_contract_route_recoveries
         - run_fork_selected_contract_bindings
       delete_by_run_id:
+        - author_activity_occurrences
         - run_fork_fact_revisions
         - run_fork_revisions
         - run_fork_revision_heads
@@ -10621,6 +10622,7 @@ platform_tables:
         - runs
       preserve:
         - runtime_store_metadata
+        - author_activity_order
         - api_idempotency
         - runtime_ingress_state
         - agents
@@ -10641,6 +10643,61 @@ platform_tables:
         - spend_ledger
         - generated node-state tables from GenerateNodeStateTableDDLs
         - legacy/future contract-driven product optimization tables
+  author_activity_story:
+    owner: author_activity_order and author_activity_occurrences in the selected store, consumed through the typed AuthorActivity registry
+    purpose: >-
+      Own immutable author-facing occurrence identity, commit-visible cross-source order, and metadata-only safe projections.
+      Runtime source tables remain authoritative for execution outcomes. This journal MUST NOT reinterpret those outcomes.
+    transaction_contract:
+      - A story-bearing outer transaction MUST lock author_activity_order singleton_id=1 before any domain lock or domain database action.
+      - Nested registered producers MUST join the exact outer transaction and draft batch. A registered producer reached through a raw transaction without the story context MUST fail closed.
+      - Source transitions, story rows, and counter advancement MUST commit or roll back atomically.
+      - Sequence ranges MUST be assigned only while the singleton is locked. BIGSERIAL, allocation-order cursors, timestamps, UUID order, post-commit appends, and fallback readers are forbidden.
+      - Replayed source identities MUST return the existing identical occurrence or fail on conflict. ON CONFLICT DO NOTHING MUST NOT hide a conflicting story registration.
+      - Mutable source helpers MUST report whether the authoritative source transition changed. A semantic no-op or duplicate receipt MUST NOT draft, append, or rewrite author activity; only a real source transition may produce an occurrence.
+      - No domain mutation may occur after story finalization.
+    read_contract:
+      cursor: author_activity_occurrences.sequence
+      ordering: strictly ascending sequence after an exclusive cursor
+      filters: [run_id, entity_id, agent_id, flow_id]
+      parity: SQLite and PostgreSQL MUST return the same typed rows and cursor behavior.
+    privacy_contract:
+      allowed: Exact registry-owned metadata fields and a validated platform.failure/v1 envelope.
+      forbidden: Raw payloads, prompts, transcripts, provider responses, credentials, arbitrary tool results, stacks, hidden reasoning, and generic evidence maps.
+      rule: Allowlisting and redaction happen before persistence. Rendering may truncate only after that boundary.
+    registry:
+      closed_kinds:
+        - inbound.received/v1
+        - event.emitted/v1
+        - entity.lifecycle/v1
+        - delivery.lifecycle/v1
+        - dead_letter.recorded/v1
+        - activity.lifecycle/v1
+        - effect.lifecycle/v1
+        - turn.lifecycle/v1
+        - turn.tool_completed/v1
+        - card.lifecycle/v1
+        - agent.lifecycle/v1
+        - directive.lifecycle/v1
+        - run.lifecycle/v1
+        - platform.signal/v1
+      extension_rule: New platform-event and effect registrations require an explicit admitted, handled-by-other-owner, or different-concept disposition.
+      kind_contract: >-
+        One closed per-kind registry row MUST own the admitted transitions, exact source owner and required source identity,
+        allowed and required projection fields, failure-bearing transitions, author-facing subject strategy, and any typed
+        subject vocabulary. Producers and renderers MUST consume that same row; parallel source, field, or subject registries are forbidden.
+      subject_rules:
+        event_emitted: The subject is the exact canonical producer identity and type paired with the exact event type. The event UUID is source evidence and MUST NOT render as the subject.
+        effect_lifecycle: The subject is derived from exact adapter, transport, and authority metadata. The effect-attempt UUID is source evidence and MUST NOT render as the subject.
+      failure_rule: Every admitted failure transition renders a stable subject and failed term with an exact diagnostic route even when optional detail is absent.
+    rendering:
+      shared_owner: internal/runtime/authoractivity typed renderer with CLI-owned palette callbacks
+      human: One metadata-only line capped at min(terminal width, 120); a failure diagnostic route is the only continuation line.
+      plain: Append-only text with no ANSI, emoji, footer, or cursor rewrite.
+      ndjson: One complete typed AuthorActivity occurrence per line; machine output MUST NOT scrape human prose.
+      vocabulary: [received, in flight, emitted, sent, completed, failed, outcome uncertain]
+      missing_facts: Omit unavailable phases, summaries, and content. Never render placeholders or infer them from elapsed time or logs.
+    legacy_policy: Fresh authoritative schema only. Old selected stores are unsupported; no migration, adoption, backfill, dual reader, log fallback, or compatibility cursor is allowed.
   tables:
     bundles:
       description: 'Content-addressed bundle catalog. The primary key is the canonical bundle_hash
@@ -10668,6 +10725,38 @@ platform_tables:
         \ idx_events_flow (flow_instance, event_name) WHERE flow_instance IS NOT NULL,\n    INDEX idx_events_source_route ((source_route->>'flow_instance'), (source_route->>'entity_id')) WHERE source_route <> '{}'::jsonb,\n    INDEX idx_events_target_route ((target_route->>'flow_instance'), (target_route->>'entity_id')) WHERE target_route <> '{}'::jsonb,\n    INDEX idx_events_global (event_name,\
         \ created_at) WHERE scope = 'global',\n    INDEX idx_events_idempotency (idempotency_key) WHERE idempotency_key\
         \ IS NOT NULL,\n    INDEX idx_events_source (source_event_id) WHERE source_event_id IS NOT NULL\n);"
+    author_activity_order:
+      description: Singleton commit-order owner for author activity. It is locked before every admitted source mutation and never exposed as runtime outcome truth.
+      ddl: |
+        CREATE TABLE author_activity_order (
+            singleton_id  INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+            last_sequence BIGINT NOT NULL CHECK (last_sequence >= 0)
+        );
+    author_activity_occurrences:
+      description: Append-only metadata-only author activity journal ordered by the transactionally locked singleton counter.
+      ddl: |
+        CREATE TABLE author_activity_occurrences (
+            occurrence_id   UUID PRIMARY KEY,
+            sequence        BIGINT NOT NULL UNIQUE CHECK (sequence > 0),
+            kind            TEXT NOT NULL,
+            version         INTEGER NOT NULL CHECK (version = 1),
+            transition      TEXT NOT NULL,
+            source_owner    TEXT NOT NULL,
+            source_identity TEXT NOT NULL,
+            dedup_key       TEXT NOT NULL UNIQUE,
+            run_id          UUID REFERENCES runs(run_id),
+            entity_id       UUID,
+            agent_id        TEXT,
+            flow_id         TEXT,
+            projection      JSONB NOT NULL DEFAULT '{}',
+            failure         JSONB,
+            occurred_at     TIMESTAMPTZ NOT NULL,
+            INDEX idx_author_activity_run (run_id, sequence) WHERE run_id IS NOT NULL,
+            INDEX idx_author_activity_entity (entity_id, sequence) WHERE entity_id IS NOT NULL,
+            INDEX idx_author_activity_agent (agent_id, sequence) WHERE agent_id IS NOT NULL,
+            INDEX idx_author_activity_flow (flow_id, sequence) WHERE flow_id IS NOT NULL,
+            INDEX idx_author_activity_kind (kind, sequence)
+        );
     run_fork_revision_heads:
       description: >-
         Canonical per-run counter for the bounded supported-fork historical projection. The existing


### PR DESCRIPTION
## Summary

- add the selected-store `author_activity_order` and `author_activity_occurrences` canonical owner for immutable author-facing occurrence identity and commit-visible cross-source order
- add the closed typed `AuthorActivity` registry, fail-closed transactional draft protocol, cursor reader, and safe human/plain/NDJSON renderers
- move every admitted producer family into the outer transaction on SQLite and PostgreSQL, with nested producers joining that owner and raw-transaction bypasses rejected
- add derived platform-event/effect disposition guards, backend parity, ordering, rollback, replay, conflict, privacy, and rendering proof

## Governing Contract

Authoritative sections changed in this PR:

- `platform-spec.yaml#platform_tables.author_activity_story`
- `platform-spec.yaml#platform_tables.tables.author_activity_order`
- `platform-spec.yaml#platform_tables.tables.author_activity_occurrences`
- `platform-spec.yaml#platform_tables.destructive_reset`

Binding gate context:

- [Pre-Implementation Coverage Audit](https://github.com/division-sh/swarm/issues/2010#issuecomment-4970918395)
- [independent gate outcome and conditions](https://github.com/division-sh/swarm/issues/2010#issuecomment-4971020919)

## Semantic Migration

**New canonical owner:** selected-store `author_activity_order` plus `author_activity_occurrences`, consumed through `internal/runtime/authoractivity`.

**Old paths now invalid:** post-commit story appends; timestamp, UUID, BIGSERIAL, or allocation-order cursors; current-state/log reconstruction; same-concept per-surface readers; registered producers operating through raw transactions; and nested producers opening a second transaction.

**Production paths checked:** inbound/events, entity mutations, delivery/dead letters, activity, effects, turns/tool completion, cards, agent lifecycle, directives, run lifecycle/fork/control/quiescence, and admitted platform signals. Runtime diagnostic logs, receipt evidence, migration/cleanup, and administrative settlement were independently classified as different concepts or represented by their canonical transition.

The migration is complete for the approved S1 failure class. Transport/feed attachment remains the explicitly approved S2 child of #2010; safe content summaries remain #2012 and liveness/detail facts remain #1564/#2031.

## Validation

- `go run ./cmd/swarm-test-postgres -- go test -p 1 ./... -count=1 -timeout=20m`
- focused SQLite/PostgreSQL semantic proof for serialization, parity, rollback, replay, conflicts, nested ownership, raw-writer rejection, registry coverage, privacy, and rendering

Part of #2010