### PR TITLE
[agent-a][issue #1828] Complete routing example index

### DIFF
--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -8,9 +8,11 @@ These directories are the positive authoring owners for supported routing patter
 | Deliver between static child flows | `parent-connect` | Declare output/input pins and one parent `connect`. |
 | Require an existing keyed child | `template-select-existing` | Use receiver `resolution.mode: select`; a miss never creates. |
 | Reuse or create one keyed child | `template-select-or-create` | Use receiver `resolution.mode: select-or-create`. |
+| Collect arrivals into one receiver | `fan-in/stream` or `fan-in/barrier` | Use stream for immediate windowed processing; use barrier for finite member completion. |
 | Return to the exact requester | `template-reply` | Pair request/reply pins; correlation defaults to request event identity. |
 | Create a child with a platform-minted key | `template-create-minted-key` | Use receiver `resolution.mode: create` with `mint: uuid` or `event_id`. |
 | Validate an intentionally harness-produced input | `harness-injection` | Declare `source: harness`; verify labels it non-production-valid and serve rejects it. |
+| Notify every known child independently | `notify-all-children` | Expand the owner's persisted child-key collection, then route each item through receiver `resolution.mode: select`. |
 
 Verify any example with:
 

--- a/internal/runtime/testfixtures/canonicalrouting/fixture_test.go
+++ b/internal/runtime/testfixtures/canonicalrouting/fixture_test.go
@@ -99,6 +99,16 @@ func canonicalRoutingTeachingContractSource(t *testing.T) SourceToken {
 				t.Fatalf("canonical routing inventory = %v, want %v", got, want)
 			}
 
+			index, err := os.ReadFile(filepath.Join(RepoRoot(t), "examples", "routing", "README.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, root := range append(artifactIDs, ArtifactID("notify-all-children")) {
+				if !strings.Contains(string(index), "`"+string(root)+"`") {
+					t.Fatalf("routing example index does not expose %q", root)
+				}
+			}
+
 			for _, id := range artifactIDs {
 				t.Run(string(id), func(t *testing.T) {
 					root := ExampleRoot(t, id)


### PR DESCRIPTION
## Summary

- expose the missing fan-in and notify-all-children rows in the canonical routing decision table
- make the existing executable teaching-contract test require every checked-in root representing #1828's nine conceptual rows to remain discoverable from that index

Part of #1828. The final E1a release decision remains on the parent after this repair merges and is revalidated from `master`.

## Governing context

- `platform-spec.yaml#contract_formats.event_schema.routing_derivation`
- `platform-spec.yaml#engine.cross_flow_routing`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1835`
- `platform-spec.yaml#flow_model.flow_instance_authoring`
- binding #1828 nine-row inventory and final supported-surface acceptance

This PR changes no platform/runtime semantics and requires no `platform-spec.yaml` update.

## Audit result

All routing semantics and supported execution proofs are green. The final census found one closure-bearing documentation defect: `examples/routing/README.md` listed seven conceptual rows and omitted fan-in plus notify-all-children. The existing per-example guard could not catch that index omission. This PR closes that bounded gap and adds the missing invariant.

A separate load-sensitive async Postgres teardown panic observed during the repository suite is tracked as #2073; it is a different lifecycle/conformance class and is not claimed fixed here.

## Proof

- `go test ./internal/runtime/testfixtures/canonicalrouting ./internal/runtime/conformance -count=3`
- focused root-ingress, parent-connect, select, select-or-create, create, fork, and harness runtime/CLI proofs: `-count=3`
- `go test ./internal/runtime/testfixtures/canonicalrouting -run 'TestCanonicalRoutingExampleInventoryAndTeachingContract|TestCanonicalRoutingExamplesLoadAndVerify' -count=5`
- `GOMAXPROCS=1 go test -json ./internal/runtime -count=20`
- `go test ./... -count=1` with host PostgreSQL: pass after removing incompatible ignored local SQLite stores

The first whole-suite attempt was blocked by stale ignored fixture stores and a later attempt exposed #2073; neither failure is hidden from the parent audit.