### PR TITLE
[agent-a][issue #2085] Consolidate cross-boundary delivery authority

### DIFF
--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -148,6 +148,10 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 	if !sequenceContainsScalar(mustMappingValue(t, slice1475, "produces"), "producer_broadcast_common_path_forbidden for loaded flow-scope broadcast:true common-path composition") {
 		t.Fatal("implementation_slice_1475 missing producer_broadcast_common_path_forbidden proof surface")
 	}
+	slice1508 := mustYAMLPath(t, composition, "route_plan_lowering", "implementation_slice_1508")
+	if !sequenceContainsScalar(mustMappingValue(t, slice1508, "proof_obligations"), "semanticview exposes package-aware root connect facts through ResolvedCompositionConnectsFrom, and runtime delivery consumes the same endpoints through lowered ConnectRoutePlan authority") {
+		t.Fatal("implementation_slice_1508 must name the package-aware resolved relation and lowered route-plan owner")
+	}
 
 	entityContracts := mustYAMLPath(t, root, "entity_contracts")
 	assertScalarContains(t, mustYAMLPath(t, entityContracts, "routing_indexes", "rule"), "indexed: true")

--- a/internal/apispec/platform_spec_composition_routing_test.go
+++ b/internal/apispec/platform_spec_composition_routing_test.go
@@ -88,7 +88,7 @@ func TestPlatformSpecCompositionRoutingSourceAuthority(t *testing.T) {
 		}
 	}
 
-	assertScalarContains(t, mustYAMLPath(t, composition, "pin_alias_delivery_composition", "owner_consumed"), "pin_alias_delivery")
+	assertScalarContains(t, mustYAMLPath(t, composition, "pin_alias_interface_adaptation", "owner_consumed"), "pin_alias_interface_adaptation")
 	assertScalarContains(t, mustYAMLPath(t, composition, "emit_target_escape_hatch", "role"), "not a compatibility path")
 	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "#1473 closes supported EventBus publish/preflight/outbox")
 	assertScalarContains(t, mustYAMLPath(t, composition, "split_boundaries", "runtime_route_consumption"), "selected-contract runfork readiness")

--- a/internal/apispec/platform_spec_routing_topology_test.go
+++ b/internal/apispec/platform_spec_routing_topology_test.go
@@ -61,7 +61,10 @@ func TestPlatformSpecPromotesVersionedRoutingTopologyArtifact(t *testing.T) {
 	assertScalarContains(t, mustMappingValue(t, routing, "typed_pubsub_rule"), "low-level event.publish")
 	assertScalarContains(t, mustMappingValue(t, routing, "connect_source_rule"), "exact authored package.yaml file:line")
 	assertScalarContains(t, mustMappingValue(t, routing, "connect_source_rule"), "connect_source_location_missing")
-	assertScalarContains(t, mustMappingValue(t, routing, "legacy_qualified_subscription_rule"), "any root or child flow authors stages")
+	qualifiedRetirement := mustMappingValue(t, routing, "qualified_cross_flow_subscription_retirement")
+	assertScalarContains(t, qualifiedRetirement, "hard invalidity")
+	assertScalarContains(t, qualifiedRetirement, "never creates a route")
+	assertScalarContains(t, qualifiedRetirement, "parent connect")
 	deliveryScopes := mustMappingValue(t, routing, "delivery_scopes")
 	if deliveryScopes.Kind != yaml.SequenceNode || len(deliveryScopes.Content) != 2 {
 		t.Fatalf("delivery_scopes = %#v, want exactly two scopes for delivery between authored producers and consumers", deliveryScopes)

--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -303,7 +303,19 @@ func TestOperatorEventPublishResolvesFlowScopedContractEventName(t *testing.T) {
 	}
 	ctx := context.Background()
 	seedActiveAPIV1RuntimeBusAgent(t, ctx, pg, "repo-observer")
-	ch := bus.Subscribe("repo-observer", events.EventType(canonicalEventName))
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "repo-observer",
+		FlowID:        "repo-scaffold",
+		FlowPath:      "repo-scaffold",
+		Subscriptions: []string{"repo_scaffold.repo_commit_succeeded"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	ch := bus.SubscribeAgent(admission)
+	if ch == nil {
+		t.Fatal("SubscribeAgent returned nil admitted carrier")
+	}
 	defer bus.Unsubscribe("repo-observer")
 	handler := eventPublishTestHandler(t, pg, bus, source)
 	body := eventPublishBody("", runStartTestFingerprint, "repo-scaffold/repo_scaffold.repo_commit_succeeded", `{"topic":"medicine"}`, "", "idem-flow-scoped")

--- a/internal/cliapp/describe.go
+++ b/internal/cliapp/describe.go
@@ -513,18 +513,6 @@ func writeRoutingTopologyText(out io.Writer, topology routingtopology.Topology) 
 			fmt.Fprintf(out, "    - %s: %s -> output %s.%s\n", exposure.Event.Canonical, routingEndpointText(exposure.Producer), routingFlowLabel(exposure.Output.FlowID), exposure.Output.PinName)
 		}
 	}
-	if len(topology.LegacyQualifiedSubscriptions) > 0 {
-		fmt.Fprintln(out, "  legacy qualified subscriptions:")
-		for _, subscription := range topology.LegacyQualifiedSubscriptions {
-			fmt.Fprintf(out, "    - disposition=%s event=%s consumer=%s at %s\n", formatCLIHumanCode(cliHumanCodeRoutingTopology, subscription.Disposition), subscription.Event.Canonical, routingEndpointText(subscription.Consumer), subscription.AuthoredLocation)
-			fmt.Fprintf(out, "      runtime delivery=%t canonical edge=%t", subscription.RuntimeDelivery, subscription.CanonicalEdge)
-			if subscription.FindingID != "" {
-				fmt.Fprintf(out, " finding=%s", subscription.FindingID)
-			}
-			fmt.Fprintln(out)
-			fmt.Fprintf(out, "      migration: %s\n", subscription.Migration)
-		}
-	}
 	if len(topology.Issues) > 0 {
 		fmt.Fprintln(out, "  route issues:")
 		for _, issue := range topology.Issues {

--- a/internal/cliapp/describe_test.go
+++ b/internal/cliapp/describe_test.go
@@ -258,7 +258,7 @@ func TestDescribeRoutesHumanRendersTypedConnectIssueWithExactSource(t *testing.T
 	}
 }
 
-func TestDescribeRoutesRendersFindingLinkedLegacyQualifiedSubscriptions(t *testing.T) {
+func TestDescribeRoutesRendersCanonicalRootConnectWithoutLegacyDebt(t *testing.T) {
 	contractsRoot := filepath.Join(RepoRoot(), "tests", "tier11-flow-composition", "test-child-flow-absolute-path")
 	var jsonOut, jsonErr bytes.Buffer
 	if code := executeRootCommandWithOptions(context.Background(), RepoRoot(), []string{"describe", "routes", "--contracts", contractsRoot, "--json"}, &jsonOut, &jsonErr, defaultRootCommandOptions()); code != 0 {
@@ -268,31 +268,27 @@ func TestDescribeRoutesRendersFindingLinkedLegacyQualifiedSubscriptions(t *testi
 	if err := json.Unmarshal(jsonOut.Bytes(), &topology); err != nil {
 		t.Fatalf("decode routes topology: %v", err)
 	}
-	if len(topology.LegacyQualifiedSubscriptions) != 1 {
-		t.Fatalf("legacy subscriptions = %#v, want one", topology.LegacyQualifiedSubscriptions)
-	}
-	legacy := topology.LegacyQualifiedSubscriptions[0]
-	if legacy.FindingID == "" || legacy.CanonicalEdge || !legacy.RuntimeDelivery {
-		t.Fatalf("legacy subscription = %#v, want finding-linked non-edge runtime debt", legacy)
-	}
-	linked := false
-	for _, issue := range topology.Issues {
-		if issue.ID == legacy.FindingID && issue.CheckID == "legacy_qualified_subscription" {
-			linked = true
+	foundConnect := false
+	for _, edge := range topology.Edges {
+		if edge.Scope == routingtopology.DeliveryScopeInterFlowConnect && edge.Boundary != nil && edge.Boundary.To == ".task_done" {
+			foundConnect = true
 		}
 	}
-	if !linked {
-		t.Fatalf("legacy finding %q not present in issues: %#v", legacy.FindingID, topology.Issues)
+	if !foundConnect {
+		t.Fatalf("topology edges = %#v, want canonical root connect", topology.Edges)
 	}
 
 	var humanOut, humanErr bytes.Buffer
 	if code := executeRootCommandWithOptions(context.Background(), RepoRoot(), []string{"describe", "routes", "--contracts", contractsRoot}, &humanOut, &humanErr, defaultRootCommandOptions()); code != 0 {
 		t.Fatalf("describe routes code=%d stderr=%s", code, humanErr.String())
 	}
-	for _, want := range []string{"legacy qualified subscriptions:", "disposition=legacy_qualified_subscription", "runtime delivery=true canonical edge=false", "finding="} {
+	for _, want := range []string{"[inter_flow_connect]", "connect: child.task_done -> .task_done"} {
 		if !strings.Contains(humanOut.String(), want) {
 			t.Fatalf("human routes missing %q:\n%s", want, humanOut.String())
 		}
+	}
+	if strings.Contains(humanOut.String(), "legacy qualified subscriptions:") {
+		t.Fatalf("human routes retained legacy debt projection:\n%s", humanOut.String())
 	}
 }
 

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -1021,16 +1021,7 @@ func NormalizeDeliveryRoutes(in []DeliveryRoute) []DeliveryRoute {
 		if route.SubscriberType == "" || route.SubscriberID == "" {
 			continue
 		}
-		target := route.Target
-		key := strings.Join([]string{
-			route.SubscriberType,
-			route.SubscriberID,
-			target.FlowID,
-			target.FlowInstance,
-			target.EntityID,
-			route.Context.ReplyContextID(),
-			route.PayloadProjection.Fingerprint(),
-		}, "\x00")
+		key := deliveryRouteIdentityKey(route)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -1038,6 +1029,32 @@ func NormalizeDeliveryRoutes(in []DeliveryRoute) []DeliveryRoute {
 		out = append(out, route)
 	}
 	return out
+}
+
+// SameDeliveryRouteIdentity reports whether two routes collapse to one durable
+// event-delivery row. Receiver-local pin identity is deliberately not part of
+// that model.
+func SameDeliveryRouteIdentity(left, right DeliveryRoute) bool {
+	left = left.Normalized()
+	right = right.Normalized()
+	if left.SubscriberType == "" || left.SubscriberID == "" || right.SubscriberType == "" || right.SubscriberID == "" {
+		return false
+	}
+	return deliveryRouteIdentityKey(left) == deliveryRouteIdentityKey(right)
+}
+
+func deliveryRouteIdentityKey(route DeliveryRoute) string {
+	route = route.Normalized()
+	target := route.Target
+	return strings.Join([]string{
+		route.SubscriberType,
+		route.SubscriberID,
+		target.FlowID,
+		target.FlowInstance,
+		target.EntityID,
+		route.Context.ReplyContextID(),
+		route.PayloadProjection.Fingerprint(),
+	}, "\x00")
 }
 
 func ValidateDeliveryRouteProjections(in []DeliveryRoute) error {

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -212,7 +212,7 @@ var bootCheckRegistry = []Check{
 	{ID: semanticview.TypedPubSubFailureAuthorizationAmbiguous, Severity: SeverityHardInvalidity, Run: checkTypedPubSubAuthorization},
 	{ID: "event_consumer_exists", Severity: "warning", Run: checkEventConsumerExists},
 	{ID: "event_producer_exists", Severity: "warning", Run: checkEventProducerExists},
-	{ID: "legacy_qualified_subscription", Severity: "warning", Run: checkLegacyQualifiedSubscription},
+	{ID: "legacy_qualified_subscription", Severity: SeverityHardInvalidity, Run: checkLegacyQualifiedSubscription},
 	{ID: "semantic_drift_dead_event_schema", Severity: "warning", Run: checkSemanticDriftDeadEventSchema},
 	{ID: "entity_writer_coverage", Severity: SeverityHardInvalidity, Run: checkEntityWriterCoverage},
 	{ID: "payload_field_coverage", Severity: "error", Run: checkPayloadFieldCoverage},

--- a/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
+++ b/internal/runtime/bootverify/flow_package_import_completeness_checks_test.go
@@ -203,8 +203,8 @@ func TestRun_FlowPackagePinBindAliasValidationAcceptsValidAliases(t *testing.T) 
 	if got := report.HardInvalidities(); reportContains(got, "flow_package_pin_bind_alias_validation", "invalid") {
 		t.Fatalf("unexpected flow_package_pin_bind_alias_validation invalidity: %#v", got)
 	}
-	if reportContains(report.Errors(), "input_pin_wiring", "work.requested") {
-		t.Fatalf("input alias should satisfy input pin wiring, got errors %#v", report.Errors())
+	if !reportContains(report.Errors(), "input_pin_wiring", "work.requested") {
+		t.Fatalf("bind-only input must not satisfy input pin wiring, got errors %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -136,7 +136,7 @@ var routingRemediationSplitCheckIDs = map[string]struct{}{
 	"receiver_instance_key_invalid":          {},
 	"receiver_instance_key_unavailable":      {},
 	"receiver_reference_invalid":             {},
-	"receiver_root_unsupported":              {},
+	"root_receiver_resolution_invalid":       {},
 	"receiver_route_key_missing":             {},
 }
 

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4551,6 +4551,39 @@ func TestRun_RejectsExactQualifiedNodeAndAgentSubscriptions(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsAbsoluteSiblingQualifiedSubscription(t *testing.T) {
+	producer := runtimecontracts.FlowContractView{
+		Paths:  runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer", PackageKey: "flows/producer"},
+		Path:   "producer",
+		Events: map[string]runtimecontracts.EventCatalogEntry{"task.done": {}},
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer", PackageKey: "flows/consumer"},
+		Path:  "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"listener": {
+				ID:               "listener",
+				SubscribesTo:     []string{"producer/task.done"},
+				EventHandlers:    map[string]runtimecontracts.SystemNodeEventHandler{"producer/task.done": {}},
+				ProducesDeclared: true,
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, consumer}}
+	bundle := &runtimecontracts.WorkflowContractBundle{FlowTree: runtimecontracts.FlowTree{
+		Root: &root,
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"producer": &root.Children[0],
+			"consumer": &root.Children[1],
+		},
+	}}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.HardInvalidities(), "legacy_qualified_subscription", "producer/task.done") {
+		t.Fatalf("hard invalidities = %#v, want absolute sibling qualified subscription rejection", report.HardInvalidities())
+	}
+}
+
 func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
 	bundle := loadWave1ExpressionFixtureBundle(t)
 	flowID, nodeID, eventType, handler := firstFlowHandlerInFlowView(t, bundle)

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -4504,65 +4504,48 @@ func TestRun_DoesNotWarnForFlowOwnedAgentEmissionsDeclaredAsFlowOutputs(t *testi
 	}
 }
 
-func TestRun_ReportsLegacyQualifiedSubscriptionWithExactRuntimeEvidence(t *testing.T) {
-	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-absolute-path"))
+func TestRun_RejectsExactQualifiedNodeAndAgentSubscriptions(t *testing.T) {
+	for _, kind := range []string{"node", "agent"} {
+		t.Run(kind, func(t *testing.T) {
+			child := runtimecontracts.FlowContractView{
+				Paths:  runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
+				Path:   "child",
+				Events: map[string]runtimecontracts.EventCatalogEntry{"task.done": {}},
+			}
+			root := runtimecontracts.FlowContractView{
+				Nodes:    map[string]runtimecontracts.SystemNodeContract{},
+				Children: []runtimecontracts.FlowContractView{child},
+			}
+			bundle := &runtimecontracts.WorkflowContractBundle{
+				FlowTree: runtimecontracts.FlowTree{
+					Root: &root,
+					ByID: map[string]*runtimecontracts.FlowContractView{"child": &root.Children[0]},
+				},
+				Nodes:  map[string]runtimecontracts.SystemNodeContract{},
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{},
+			}
+			switch kind {
+			case "node":
+				listener := runtimecontracts.SystemNodeContract{
+					ID:               "listener",
+					SubscribesTo:     []string{"child/task.done"},
+					EventHandlers:    map[string]runtimecontracts.SystemNodeEventHandler{"child/task.done": {}},
+					ProducesDeclared: true,
+				}
+				bundle.Nodes["listener"] = listener
+				bundle.FlowTree.Root.Nodes["listener"] = listener
+			case "agent":
+				bundle.Agents["retired-agent"] = runtimecontracts.AgentRegistryEntry{ID: "retired-agent", Subscriptions: []string{"child/task.done"}}
+			}
 
-	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
-
-	var found *Finding
-	for i := range report.Findings {
-		finding := &report.Findings[i]
-		if finding.CheckID == "event_consumer_exists" && finding.Location == "child/task.done" {
-			found = finding
-			break
-		}
-	}
-	if found == nil {
-		t.Fatalf("findings = %#v, want legacy qualified subscription finding", report.Findings)
-	}
-	if found.Severity != SeveritySemanticDriftWarn || !strings.Contains(found.Message, "no canonical consumer") || !strings.Contains(found.Message, "nodes.yaml:13 still delivers at runtime") {
-		t.Fatalf("legacy finding = %#v, want warning with exact runtime evidence", *found)
-	}
-	if !strings.Contains(found.Remediation, "output/input pins and a connect") || len(found.Evidence) != 1 || !strings.Contains(found.Evidence[0], `"child/task.done"`) {
-		t.Fatalf("legacy remediation/evidence = %#v / %#v", found.Remediation, found.Evidence)
-	}
-}
-
-func TestRun_PromotesLegacyQualifiedSubscriptionToErrorForStagesFlow(t *testing.T) {
-	bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-absolute-path"))
-	schema := bundle.FlowSchemas["child"]
-	schema.StageDeclarations = runtimecontracts.FlowStageDeclarations{Declared: true}
-	bundle.FlowSchemas["child"] = schema
-
-	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
-
-	if !reportContains(report.Errors(), "event_consumer_exists", "child/task.done") {
-		t.Fatalf("errors = %#v, want stages-era legacy subscription hard invalidity", report.Errors())
-	}
-	if !reportContains(report.Errors(), "legacy_qualified_subscription", "child/task.done") {
-		t.Fatalf("errors = %#v, want dedicated stages-era legacy finding", report.Errors())
-	}
-}
-
-func TestRun_PromotesLegacyQualifiedSubscriptionForStagedConsumerOrUnrelatedFlow(t *testing.T) {
-	tests := []struct {
-		name  string
-		stage func(*runtimecontracts.WorkflowContractBundle)
-	}{
-		{name: "root consumer staged", stage: func(bundle *runtimecontracts.WorkflowContractBundle) {
-			bundle.RootSchema.StageDeclarations = runtimecontracts.FlowStageDeclarations{Declared: true}
-		}},
-		{name: "unrelated sibling staged", stage: func(bundle *runtimecontracts.WorkflowContractBundle) {
-			bundle.FlowSchemas["unrelated"] = runtimecontracts.FlowSchemaDocument{StageDeclarations: runtimecontracts.FlowStageDeclarations{Declared: true}}
-		}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			bundle := loadFixtureBundle(t, filepath.Join("tests", "tier11-flow-composition", "test-child-flow-absolute-path"))
-			tc.stage(bundle)
 			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
-			if !reportContains(report.Errors(), "event_consumer_exists", "child/task.done") || !reportContains(report.Errors(), "legacy_qualified_subscription", "child/task.done") {
-				t.Fatalf("errors = %#v, want bundle-wide hard findings", report.Errors())
+			if !reportContains(report.HardInvalidities(), "legacy_qualified_subscription", "child/task.done") {
+				t.Fatalf("hard invalidities = %#v, want exact qualified %s rejection", report.HardInvalidities(), kind)
+			}
+			for _, finding := range report.HardInvalidities() {
+				if finding.CheckID == "legacy_qualified_subscription" && (!strings.Contains(finding.Remediation, "package.yaml connect") || !strings.Contains(finding.Remediation, "receiver-local")) {
+					t.Fatalf("teaching remediation = %q, want connect plus local subscription", finding.Remediation)
+				}
 			}
 		})
 	}

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -406,19 +406,19 @@ func validateReplyInputPinResolution(source semanticview.Source, flowID string, 
 	if correlationKey != "" && !containsTrimmedString(requestPin.Carries, correlationKey) {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply correlation_key %q must name a carry declared by output pin %s", correlationKey, requestPinName), location))
 	}
-	requestConnects := source.CompositionConnectsFrom(flowID, requestPinName)
+	requestConnects := semanticview.ResolvedCompositionConnectsFrom(source, flowID, requestPinName)
 	if len(requestConnects) != 1 {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply request pin %s.%s must have exactly one connected counterpart, got %d", flowID, requestPinName, len(requestConnects)), location))
 		return findings
 	}
-	replyConnects := source.CompositionConnectsTo(flowID, pin.PinName())
+	replyConnects := semanticview.ResolvedCompositionConnectsTo(source, flowID, pin.PinName())
 	if len(replyConnects) != 1 {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", fmt.Sprintf("resolution mode reply input pin %s.%s must have exactly one connected provider output, got %d", flowID, pin.PinName(), len(replyConnects)), location))
 		return findings
 	}
-	requestTarget, requestErr := requestConnects[0].ToRef()
-	replySource, replyErr := replyConnects[0].FromRef()
-	if requestErr != nil || replyErr != nil || requestTarget.Root || replySource.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(replySource.FlowID) {
+	requestTarget := requestConnects[0].To
+	replySource := replyConnects[0].From
+	if requestTarget.Root || replySource.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(replySource.FlowID) {
 		findings = append(findings, inputPinResolutionFinding(flowID, pin, "reply_lineage_missing", "resolution mode reply request and reply edges must connect the same provider flow", location))
 	}
 	return findings

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -38,6 +38,22 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 	if fromErr != nil || toErr != nil {
 		return findings
 	}
+	if from.Root {
+		flowID, ok := semanticview.PackageRootFlowID(source, connect.PackageKey)
+		if !ok {
+			findings = append(findings, compositionConnectFinding(connect, "producer_flow_missing", fmt.Sprintf("package %s has no owning flow for root output pin %s", connect.PackageKey, from.Pin), connect.PackageKey))
+			return findings
+		}
+		from.FlowID, from.Root = flowID, flowID == ""
+	}
+	if to.Root {
+		flowID, ok := semanticview.PackageRootFlowID(source, connect.PackageKey)
+		if !ok {
+			findings = append(findings, compositionConnectFinding(connect, "receiver_flow_missing", fmt.Sprintf("package %s has no owning flow for root input pin %s", connect.PackageKey, to.Pin), connect.PackageKey))
+			return findings
+		}
+		to.FlowID, to.Root = flowID, flowID == ""
+	}
 
 	if !from.Root {
 		if _, ok := source.FlowSchemaByID(from.FlowID); !ok {
@@ -45,14 +61,14 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 			return findings
 		}
 	}
-	if to.Root {
-		findings = append(findings, compositionConnectFinding(connect, "receiver_root_unsupported", "root receiver endpoints are not supported by this composition-routing slice", "root"))
-		return findings
-	}
-	receiverSchema, ok := source.FlowSchemaByID(to.FlowID)
-	if !ok {
-		findings = append(findings, compositionConnectFinding(connect, "receiver_flow_missing", fmt.Sprintf("receiver flow %s does not exist", to.FlowID), to.FlowID))
-		return findings
+	receiverSchema := runtimecontracts.FlowSchemaDocument{}
+	if !to.Root {
+		var ok bool
+		receiverSchema, ok = source.FlowSchemaByID(to.FlowID)
+		if !ok {
+			findings = append(findings, compositionConnectFinding(connect, "receiver_flow_missing", fmt.Sprintf("receiver flow %s does not exist", to.FlowID), to.FlowID))
+			return findings
+		}
 	}
 
 	outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
@@ -68,7 +84,13 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 	}
 	inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
 	if !ok {
-		findings = append(findings, compositionConnectFinding(connect, "receiver_input_pin_missing", fmt.Sprintf("receiver flow %s does not declare input pin %s", to.FlowID, to.Pin), to.FlowID))
+		receiverLabel := fmt.Sprintf("receiver flow %s", to.FlowID)
+		location := to.FlowID
+		if to.Root {
+			receiverLabel = "root schema"
+			location = "root"
+		}
+		findings = append(findings, compositionConnectFinding(connect, "receiver_input_pin_missing", fmt.Sprintf("%s does not declare input pin %s", receiverLabel, to.Pin), location))
 		return findings
 	}
 
@@ -81,6 +103,12 @@ func validateCompositionConnect(source semanticview.Source, connect runtimecontr
 		))
 	}
 	findings = append(findings, validateCompositionConnectSyntheticCarryCollisions(source, connect, from, outputPin, inputPin)...)
+	if to.Root {
+		if inputPin.Address != nil || !inputPin.Resolution.Empty() {
+			findings = append(findings, compositionConnectFinding(connect, "root_receiver_resolution_invalid", "root input pins are static receivers and cannot declare address or instance resolution", "root"))
+		}
+		return findings
+	}
 
 	instanceKeyFindings := validateCompositionConnectInstanceKey(source, connect, outputPin, inputPin, from.FlowID, to.FlowID)
 	findings = append(findings, validateCompositionConnectReceiverAddress(connect, inputPin, receiverSchema, to.FlowID, len(instanceKeyFindings) == 0)...)

--- a/internal/runtime/bootverify/workflow_composition_connect_checks.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks.go
@@ -22,6 +22,23 @@ func checkCompositionConnectValidation(c *checkerContext) []Finding {
 	for _, connect := range c.source.CompositionConnects() {
 		findings = append(findings, validateCompositionConnect(c.source, connect)...)
 	}
+	for _, issue := range routingtopology.Build(c.source).Issues {
+		if strings.TrimSpace(issue.Failure) != routingtopology.FailureConnectReceiverPinCollision {
+			continue
+		}
+		findings = append(findings, Finding{
+			CheckID:     "composition_connect_validation",
+			Severity:    "error",
+			Location:    strings.TrimSpace(issue.Location),
+			Message:     strings.TrimSpace(issue.Message),
+			Remediation: strings.TrimSpace(issue.Remediation),
+			Evidence: []string{
+				"classification: " + routingtopology.FailureConnectReceiverPinCollision,
+				"source: " + strings.TrimSpace(issue.From),
+				"subscriber: " + strings.TrimSpace(issue.To),
+			},
+		})
+	}
 	return findings
 }
 

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -582,7 +582,6 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 		{name: "missing producer output pin", variant: canonicalrouting.CompositionConnectMissingProducerPin, want: "producer_output_pin_missing"},
 		{name: "missing receiver flow", variant: canonicalrouting.CompositionConnectMissingReceiverFlow, want: "receiver_flow_missing"},
 		{name: "missing receiver input pin", variant: canonicalrouting.CompositionConnectMissingReceiverPin, want: "receiver_input_pin_missing"},
-		{name: "root receiver unsupported", variant: canonicalrouting.CompositionConnectRootReceiver, want: "receiver_root_unsupported"},
 		{name: "event names differ without adapter", variant: canonicalrouting.CompositionConnectMissingAdapter, want: "event_alias_or_adapter_invalid"},
 		{name: "missing address key", variant: canonicalrouting.CompositionConnectMissingAddressKey, want: "output_carries_address_key", wantExtra: "missing_vertical_id"},
 		{name: "incompatible address key types", variant: canonicalrouting.CompositionConnectIncompatibleKeyType, want: "key_types_incompatible"},
@@ -605,6 +604,19 @@ func TestRun_FailsClosedForInvalidParentCompositionConnect(t *testing.T) {
 				t.Fatalf("expected composition_connect_validation detail %q, got %#v", tc.wantExtra, report.Errors())
 			}
 		})
+	}
+}
+
+func TestRun_AcceptsParentCompositionConnectToRootInput(t *testing.T) {
+	root := writeCompositionConnectBootverifyFixture(t, canonicalrouting.CompositionConnectRootReceiver)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	for _, finding := range append(report.Errors(), report.Warnings()...) {
+		if finding.CheckID == "composition_connect_validation" {
+			t.Fatalf("unexpected composition connect finding: %#v", finding)
+		}
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+++ b/internal/runtime/bootverify/workflow_composition_connect_checks_test.go
@@ -28,6 +28,19 @@ func TestRun_AllowsParentCompositionConnectAsVerifyRouteProof(t *testing.T) {
 	}
 }
 
+func TestRun_RejectsSameSubscriberThroughDistinctReceiverPins(t *testing.T) {
+	root := canonicalrouting.CopyCompositionConnect(t, canonicalrouting.CompositionConnectValid)
+	canonicalrouting.ApplyCompositionConnectReceiverPinCollisionMutation(t, root)
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+	if !reportContains(report.Errors(), "composition_connect_validation", "multiple receiver pins") ||
+		!reportContains(report.Errors(), "composition_connect_validation", "deploy.completed") ||
+		!reportContains(report.Errors(), "composition_connect_validation", "deploy.audited") {
+		t.Fatalf("receiver-pin collision findings = %#v", report.Errors())
+	}
+}
+
 func TestRun_AllowsRootProducerCompositionConnectAsRouteProof(t *testing.T) {
 	root := writeRootCompositionConnectBootverifyFixture(t)
 	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), root, runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))

--- a/internal/runtime/bootverify/workflow_event_topology_checks.go
+++ b/internal/runtime/bootverify/workflow_event_topology_checks.go
@@ -50,7 +50,6 @@ func (c *checkerContext) eventWarnings() []Finding {
 	c.eventWarningLoaded = true
 	census := semanticview.BuildAuthoredEventEndpointCensus(c.source)
 	topology := routingtopology.Build(c.source)
-	stagedBundle := bundleUsesAuthoredStages(c.source)
 	rejectedProducers := map[string]struct{}{}
 	for _, issue := range topology.Issues {
 		if strings.TrimSpace(issue.Failure) != semanticview.TypedPubSubFailureAuthorizationAmbiguous {
@@ -75,22 +74,12 @@ func (c *checkerContext) eventWarnings() []Finding {
 			rejectedProducers[producerID] = struct{}{}
 		}
 	}
-	for _, subscription := range topology.LegacyQualifiedSubscriptions {
-		message := fmt.Sprintf("legacy qualified subscription '%s' at %s still delivers at runtime but is outside canonical same-flow pub/sub and pin/connect topology; migrate to pins/connect", subscription.Consumer.Event.Authored, subscription.AuthoredLocation)
-		remediation := subscription.Migration
-		evidence := []string{fmt.Sprintf("legacy qualified subscription %q at %q", subscription.Consumer.Event.Authored, subscription.AuthoredLocation)}
-		if stagedBundle {
-			c.eventWarningFindings = append(c.eventWarningFindings, NewHardInvalidityFinding("legacy_qualified_subscription", subscription.AuthoredLocation, message, remediation, evidence...))
-		} else {
-			c.eventWarningFindings = append(c.eventWarningFindings, Finding{
-				CheckID:     "legacy_qualified_subscription",
-				Severity:    SeveritySemanticDriftWarn,
-				Message:     message,
-				Location:    subscription.AuthoredLocation,
-				Remediation: remediation,
-				Evidence:    evidence,
-			})
-		}
+	for _, subscription := range census.LegacyQualifiedSubscriptions() {
+		location := legacyQualifiedSubscriptionLocation(subscription)
+		message := fmt.Sprintf("qualified subscription '%s' at %s crosses a flow boundary and cannot create an inter-flow route", subscription.Consumer.Event.Authored, location)
+		remediation := "Declare output/input pins and package.yaml connect for the boundary edge, then subscribe to the receiver-local input event. Exact qualified subscriptions cannot replace connect."
+		evidence := []string{fmt.Sprintf("retired qualified subscription %q at %q", subscription.Consumer.Event.Authored, location)}
+		c.eventWarningFindings = append(c.eventWarningFindings, NewHardInvalidityFinding("legacy_qualified_subscription", location, message, remediation, evidence...))
 	}
 	emitted := topologyWarningEndpoints(census.Producers(), true)
 	subscribed := topologyWarningEndpoints(append(census.Consumers(), census.InputPins()...), false)
@@ -121,26 +110,15 @@ func (c *checkerContext) eventWarnings() []Finding {
 		if topologyRoutesProducer(topology, entry.ID) || eventHasExternalConsumerLocal(ref.Entry) {
 			continue
 		}
-		if legacy := legacyQualifiedConsumersForEvent(topology, ref.Canonical); len(legacy) > 0 {
-			location := legacy[0].AuthoredLocation
-			message := fmt.Sprintf("'%s' has no canonical consumer (same-flow subscriber or connected pin); legacy qualified subscription '%s' at %s still delivers at runtime; migrate to pins/connect", ref.Canonical, legacy[0].Consumer.Event.Authored, location)
+		if legacy := legacyQualifiedConsumersForEvent(census, ref.Canonical); len(legacy) > 0 {
+			location := legacyQualifiedSubscriptionLocation(legacy[0])
+			message := fmt.Sprintf("'%s' has no canonical consumer (same-flow subscriber or connected pin); retired qualified subscription '%s' at %s cannot provide delivery authority", ref.Canonical, legacy[0].Consumer.Event.Authored, location)
 			remediation := fmt.Sprintf("Declare output/input pins and a connect for %s, then replace every legacy qualified subscription with a flow-local subscription.", ref.Canonical)
 			evidence := make([]string, 0, len(legacy))
 			for _, subscription := range legacy {
-				evidence = append(evidence, fmt.Sprintf("legacy qualified subscription %q at %q", subscription.Consumer.Event.Authored, subscription.AuthoredLocation))
+				evidence = append(evidence, fmt.Sprintf("retired qualified subscription %q at %q", subscription.Consumer.Event.Authored, legacyQualifiedSubscriptionLocation(subscription)))
 			}
-			if stagedBundle {
-				c.eventWarningFindings = append(c.eventWarningFindings, NewHardInvalidityFinding("event_consumer_exists", ref.Canonical, message, remediation, evidence...))
-			} else {
-				c.eventWarningFindings = append(c.eventWarningFindings, Finding{
-					CheckID:     "event_consumer_exists",
-					Severity:    SeveritySemanticDriftWarn,
-					Message:     message,
-					Location:    ref.Canonical,
-					Remediation: remediation,
-					Evidence:    evidence,
-				})
-			}
+			c.eventWarningFindings = append(c.eventWarningFindings, NewHardInvalidityFinding("event_consumer_exists", ref.Canonical, message, remediation, evidence...))
 			continue
 		}
 		c.eventWarningFindings = append(c.eventWarningFindings, Finding{
@@ -208,15 +186,26 @@ func generatedActivityResultEventNamesLocal(source semanticview.Source) map[stri
 	return out
 }
 
-func legacyQualifiedConsumersForEvent(topology routingtopology.Topology, canonical string) []routingtopology.LegacyQualifiedSubscription {
+func legacyQualifiedConsumersForEvent(census semanticview.AuthoredEventEndpointCensus, canonical string) []semanticview.LegacyQualifiedSubscription {
 	canonical = strings.TrimSpace(canonical)
-	out := make([]routingtopology.LegacyQualifiedSubscription, 0)
-	for _, subscription := range topology.LegacyQualifiedSubscriptions {
+	out := make([]semanticview.LegacyQualifiedSubscription, 0)
+	for _, subscription := range census.LegacyQualifiedSubscriptions() {
 		if strings.TrimSpace(subscription.Event.Canonical) == canonical {
 			out = append(out, subscription)
 		}
 	}
 	return out
+}
+
+func legacyQualifiedSubscriptionLocation(subscription semanticview.LegacyQualifiedSubscription) string {
+	file := strings.TrimSpace(subscription.Consumer.SourceFile)
+	if file != "" && subscription.Consumer.SourceLine > 0 {
+		return fmt.Sprintf("%s:%d", file, subscription.Consumer.SourceLine)
+	}
+	if file != "" {
+		return file
+	}
+	return strings.TrimSpace(subscription.Consumer.SourceLocation)
 }
 
 func topologyWarningEndpoints(endpoints []semanticview.AuthoredEventEndpoint, producers bool) map[string]semanticview.AuthoredEventEndpoint {

--- a/internal/runtime/bus/agent_subscription_admission_test.go
+++ b/internal/runtime/bus/agent_subscription_admission_test.go
@@ -1,0 +1,91 @@
+package bus
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func testAgentSubscriptionAdmission(t *testing.T, agentID string, eventTypes ...events.EventType) semanticview.FlowOwnedAgentSubscriptionAdmission {
+	return testAgentSubscriptionAdmissionForFlow(t, agentID, "", eventTypes...)
+}
+
+func TestEventBusRawSubscribeRejectsQualifiedExactAuthority(t *testing.T) {
+	eb, err := NewEventBus(InMemoryEventStore{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventType := events.EventType("producer/task.done")
+	if ch := eb.Subscribe("raw-agent", eventType); ch != nil {
+		t.Fatalf("raw Subscribe(%q) returned a live channel", eventType)
+	}
+	if recipients := eb.ResolveSubscribedRecipients(string(eventType)); len(recipients) != 0 {
+		t.Fatalf("raw Subscribe(%q) recipients = %#v, want none", eventType, recipients)
+	}
+}
+
+func TestEventBusRawSubscribeConsumesRootAdmissionForExactAndWildcard(t *testing.T) {
+	eb, err := NewEventBus(InMemoryEventStore{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, eventType := range []events.EventType{"task.ready", "task.*"} {
+		agentID := fmt.Sprintf("root-agent-%d", index)
+		if ch := eb.Subscribe(agentID, eventType); ch == nil {
+			t.Fatalf("raw root Subscribe(%q) returned nil channel", eventType)
+		}
+		if recipients := eb.ResolveSubscribedRecipients("task.ready"); !slices.Contains(recipients, agentID) {
+			t.Fatalf("raw root Subscribe(%q) recipients = %#v, want %s", eventType, recipients, agentID)
+		}
+	}
+}
+
+func TestEventBusTypedAdmissionExecutesSameScopeExactAndWildcard(t *testing.T) {
+	eb, err := NewEventBus(InMemoryEventStore{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admission := testAgentSubscriptionAdmissionForFlow(t, "reviewer", "review/inst-1",
+		events.EventType("task.ready"), events.EventType("task.*"))
+	ch := eb.SubscribeAgent(admission)
+	if ch == nil {
+		t.Fatal("typed admission returned nil channel")
+	}
+	defer eb.Unsubscribe("reviewer")
+
+	for index, eventType := range []events.EventType{"review/inst-1/task.ready", "review/inst-1/task.done"} {
+		evt := eventtest.RootIngress("evt-admitted-"+string(rune('a'+index)), eventType, "test", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+		if err := eb.Publish(context.Background(), evt); err != nil {
+			t.Fatalf("Publish(%s): %v", eventType, err)
+		}
+		select {
+		case got := <-ch:
+			if got.ID() != evt.ID() {
+				t.Fatalf("received %s, want %s", got.ID(), evt.ID())
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s", eventType)
+		}
+	}
+}
+
+func testAgentSubscriptionAdmissionForFlow(t *testing.T, agentID, flowPath string, eventTypes ...events.EventType) semanticview.FlowOwnedAgentSubscriptionAdmission {
+	t.Helper()
+	values := make([]string, 0, len(eventTypes))
+	for _, eventType := range eventTypes {
+		values = append(values, string(eventType))
+	}
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID: agentID, FlowPath: flowPath, Subscriptions: values,
+	})
+	if err != nil {
+		t.Fatalf("admit test agent subscriptions: %v", err)
+	}
+	return admission
+}

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
@@ -322,6 +323,13 @@ func (r connectRoutePlanResolver) materializeReplyResponse(ctx context.Context, 
 }
 
 func (r connectRoutePlanResolver) materializeConnectRoutePlan(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, values map[string]string, descriptors []runtimepinrouting.Descriptor) (runtimepinrouting.ConnectRoutePlanMaterialization, TemplateInstanceLifecycleDecision, error) {
+	if plan.Receiver.Root {
+		target := evt.TargetRoute().Normalized()
+		if target.EntityID == "" {
+			return runtimepinrouting.ConnectRoutePlanMaterialization{Failure: runtimepinrouting.ConnectFailureTargetUnresolved}, TemplateInstanceLifecycleDecision{}, nil
+		}
+		return runtimepinrouting.ConnectRoutePlanMaterialization{Target: target}, TemplateInstanceLifecycleDecision{}, nil
+	}
 	if materialized, decision, handled, err := r.lifecycle.Materialize(ctx, evt, plan, values, descriptors); handled || err != nil {
 		return materialized, decision, err
 	}
@@ -386,6 +394,9 @@ func (r connectRoutePlanResolver) descriptorsForPlans(ctx context.Context, plans
 
 func (r connectRoutePlanResolver) deliveryRoutesForMaterialization(ctx context.Context, plan runtimepinrouting.ConnectRoutePlan, materialized runtimepinrouting.ConnectRoutePlanMaterialization, decision TemplateInstanceLifecycleDecision) ([]events.DeliveryRoute, []Subscriber, error) {
 	targets := connectMaterializedTargets(materialized)
+	if plan.Receiver.Root && len(targets) == 0 {
+		targets = []events.RouteIdentity{{}}
+	}
 	if len(targets) == 0 {
 		return nil, nil, nil
 	}
@@ -455,6 +466,7 @@ func (r connectRoutePlanResolver) resolveSelectedReceiverCarriers(ctx context.Co
 				if !connectSubscriberMatchesPlanTarget(plan, subscriber, target) {
 					continue
 				}
+				subscriber.LocalizedEvent = eventidentity.Normalize(plan.Receiver.Event)
 				out = append(out, subscriber)
 			}
 		}
@@ -485,6 +497,13 @@ func (r connectRoutePlanResolver) connectIssueMatchesEvent(ctx context.Context, 
 	from, err := issue.Connect.FromRef()
 	if err != nil {
 		return false
+	}
+	if from.Root {
+		flowID, ok := semanticview.PackageRootFlowID(r.source, issue.Connect.PackageKey)
+		if !ok {
+			return false
+		}
+		from.FlowID, from.Root = flowID, flowID == ""
 	}
 	outputPin, ok := r.source.FlowOutputEventPin(from.FlowID, from.Pin)
 	if !ok {
@@ -551,7 +570,7 @@ func eventFlowInstanceMatchesSourcePath(flowInstance, sourcePath string) bool {
 	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
 	sourcePath = strings.Trim(strings.TrimSpace(sourcePath), "/")
 	if sourcePath == "" {
-		return flowInstance == ""
+		return flowInstance == "" || runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == ""
 	}
 	if flowInstance == sourcePath {
 		return true

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -101,6 +101,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			"connect_route_plans_count": len(matched),
 		},
 	}
+	receiverPinFacts := make([]connectReceiverPinFact, 0, len(matched))
 	for _, plan := range matched {
 		if plan.ReplyResolution != nil && plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleResponse {
 			routes, subscribers, failure, detail, err := r.materializeReplyResponse(ctx, evt, plan, values)
@@ -112,6 +113,12 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 				for key, value := range detail {
 					out.ExtraDetail[key] = value
 				}
+				return out, nil
+			}
+			if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Event); collision {
+				out.Failure = connectRoutePlanTargetFailure(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
+				out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
+				out.ExtraDetail["connect_route_plan_receiver_pin_collision"] = []string{previous, current}
 				return out, nil
 			}
 			out.ReplyContextConsumed = true
@@ -168,6 +175,12 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
 			return out, nil
 		}
+		if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Event); collision {
+			out.Failure = connectRoutePlanTargetFailure(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
+			out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
+			out.ExtraDetail["connect_route_plan_receiver_pin_collision"] = []string{previous, current}
+			return out, nil
+		}
 		out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConnectRoutePlan)...)
 		out.LiveRecipients = append(out.LiveRecipients, connectRoutePlanLiveRecipients(routes)...)
 		out.RoutedRecipients = append(out.RoutedRecipients, subscribers...)
@@ -176,6 +189,31 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	out.DeliveryIntents = normalizeRoutePlanDeliveryIntents(out.DeliveryIntents)
 	out.RoutedRecipients = dedupeSubscribers(out.RoutedRecipients)
 	return out, nil
+}
+
+type connectReceiverPinFact struct {
+	route              events.DeliveryRoute
+	receiverLocalEvent string
+}
+
+func admitConnectReceiverPinFacts(admitted *[]connectReceiverPinFact, routes []events.DeliveryRoute, receiverLocalEvent string) (string, string, bool) {
+	receiverLocalEvent = eventidentity.Normalize(receiverLocalEvent)
+	if admitted == nil || receiverLocalEvent == "" {
+		return "", "", false
+	}
+	for _, route := range routes {
+		route = route.Normalized()
+		if route.SubscriberType == "" || route.SubscriberID == "" {
+			continue
+		}
+		for _, previous := range *admitted {
+			if events.SameDeliveryRouteIdentity(previous.route, route) && previous.receiverLocalEvent != receiverLocalEvent {
+				return previous.receiverLocalEvent, receiverLocalEvent, true
+			}
+		}
+		*admitted = append(*admitted, connectReceiverPinFact{route: route, receiverLocalEvent: receiverLocalEvent})
+	}
+	return "", "", false
 }
 
 func (r connectRoutePlanResolver) materializeReplyRequest(ctx context.Context, evt events.Event, plan runtimepinrouting.ConnectRoutePlan, routes []events.DeliveryRoute, values map[string]string) ([]events.DeliveryRoute, error) {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -11,7 +11,6 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
-	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
@@ -517,65 +516,14 @@ func (r connectRoutePlanResolver) connectIssueMatchesEvent(ctx context.Context, 
 		Event:         strings.TrimSpace(outputPin.EventType()),
 		ResolvedEvent: strings.TrimSpace(r.source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),
 	}
-	if !connectEndpointMatchesEvent(endpoint, evt) {
+	if !runtimepinrouting.ConnectSourceEndpointMatchesEvent(endpoint, evt) {
 		return false
 	}
 	return providerOutputAuthorizationMatches(ctx, issue.ProviderOutputAuthorization)
 }
 
 func connectRoutePlanMatchesEvent(ctx context.Context, plan runtimepinrouting.ConnectRoutePlan, evt events.Event) bool {
-	return connectEndpointMatchesEvent(plan.Source, evt) && providerOutputAuthorizationMatches(ctx, plan.ProviderOutputAuthorization)
-}
-
-func connectEndpointMatchesEvent(endpoint runtimepinrouting.ConnectRoutePlanEndpoint, evt events.Event) bool {
-	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
-	if eventType == "" {
-		return false
-	}
-	if endpoint.Root && !eventFlowInstanceMatchesSourcePath(evt.FlowInstance(), "") {
-		return false
-	}
-	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
-	sourceResolved := strings.Trim(strings.TrimSpace(endpoint.ResolvedEvent), "/")
-	sourcePath := strings.Trim(strings.TrimSpace(endpoint.FlowPath), "/")
-	if sourcePath == "" {
-		sourcePath = strings.Trim(strings.TrimSpace(endpoint.FlowID), "/")
-	}
-	sourceScoped := sourceLocal
-	if sourcePath != "" && sourceLocal != "" {
-		sourceScoped = sourcePath + "/" + sourceLocal
-	}
-	for _, candidate := range uniqueStrings([]string{sourceResolved, sourceScoped}) {
-		if candidate != "" && eventType == candidate {
-			return true
-		}
-	}
-	if sourceLocal != "" && eventType == sourceLocal {
-		return eventFlowInstanceMatchesSourcePath(evt.FlowInstance(), sourcePath)
-	}
-	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
-	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
-		return eventFlowInstanceMatchesSourcePath(flowInstance, sourcePath)
-	}
-	for _, key := range routedEventKeysForPlan(evt) {
-		key = strings.Trim(strings.TrimSpace(key), "/")
-		if key != "" && (key == sourceResolved || key == sourceScoped) {
-			return true
-		}
-	}
-	return false
-}
-
-func eventFlowInstanceMatchesSourcePath(flowInstance, sourcePath string) bool {
-	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
-	sourcePath = strings.Trim(strings.TrimSpace(sourcePath), "/")
-	if sourcePath == "" {
-		return flowInstance == "" || runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == ""
-	}
-	if flowInstance == sourcePath {
-		return true
-	}
-	return runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == sourcePath
+	return runtimepinrouting.ConnectSourceEndpointMatchesEvent(plan.Source, evt) && providerOutputAuthorizationMatches(ctx, plan.ProviderOutputAuthorization)
 }
 
 func connectMaterializedTargets(materialized runtimepinrouting.ConnectRoutePlanMaterialization) []events.RouteIdentity {

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -21,6 +21,12 @@ import (
 
 type connectRoutePlanDescriptorLoader func(context.Context) ([]runtimepinrouting.Descriptor, error)
 
+type connectRoutePlanPreviewRoutesKey struct{}
+
+type connectRoutePlanPreviewRoutes struct {
+	table *RouteTable
+}
+
 type connectRoutePlanResolver struct {
 	source          semanticview.Source
 	routeTable      *RouteTable
@@ -95,6 +101,16 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		return connectRoutePlanDispatch{}, err
 	}
 	values := connectRoutePlanMatchValues(evt)
+	previewCtx := withTemplateInstanceLifecyclePreview(ctx)
+	previewCtx = context.WithValue(previewCtx, connectRoutePlanPreviewRoutesKey{}, &connectRoutePlanPreviewRoutes{})
+	preview, err := r.planMatched(previewCtx, evt, matched, descriptors, values)
+	if err != nil || preview.Failure != "" || templateInstanceLifecyclePreview(ctx) {
+		return preview, err
+	}
+	return r.planMatched(ctx, evt, matched, descriptors, values)
+}
+
+func (r connectRoutePlanResolver) planMatched(ctx context.Context, evt events.Event, matched []runtimepinrouting.ConnectRoutePlan, descriptors []runtimepinrouting.Descriptor, values map[string]string) (connectRoutePlanDispatch, error) {
 	out := connectRoutePlanDispatch{
 		Matched: true,
 		ExtraDetail: map[string]any{
@@ -102,6 +118,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		},
 	}
 	receiverPinFacts := make([]connectReceiverPinFact, 0, len(matched))
+	replyContextConsumed := false
 	for _, plan := range matched {
 		if plan.ReplyResolution != nil && plan.ReplyResolution.Role == runtimepinrouting.ConnectReplyRoleResponse {
 			routes, subscribers, failure, detail, err := r.materializeReplyResponse(ctx, evt, plan, values)
@@ -115,13 +132,13 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 				}
 				return out, nil
 			}
-			if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Event); collision {
+			if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Pin, plan.Receiver.Event); collision {
 				out.Failure = connectRoutePlanTargetFailure(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
 				out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
 				out.ExtraDetail["connect_route_plan_receiver_pin_collision"] = []string{previous, current}
 				return out, nil
 			}
-			out.ReplyContextConsumed = true
+			replyContextConsumed = true
 			out.DeliveryIntents = append(out.DeliveryIntents, routePlanDeliveryIntentsFromRoutes(routes, routeIntentProducerConnectRoutePlan)...)
 			out.LiveRecipients = append(out.LiveRecipients, connectRoutePlanLiveRecipients(routes)...)
 			out.RoutedRecipients = append(out.RoutedRecipients, subscribers...)
@@ -144,8 +161,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 		if !decision.Empty() {
 			out.ExtraDetail["connect_route_plan_template_instance_lifecycle"] = decision.Detail()
 		}
-		cleanupPreview, err := r.installTemplateInstanceLifecyclePreview(decision)
-		if err != nil {
+		if err := r.installTemplateInstanceLifecyclePreview(ctx, decision); err != nil {
 			return connectRoutePlanDispatch{}, err
 		}
 		routes, subscribers, err := r.deliveryRoutesForMaterialization(ctx, plan, materialized, decision)
@@ -157,9 +173,6 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			if err != nil {
 				return connectRoutePlanDispatch{}, err
 			}
-		}
-		if cleanupPreview != nil {
-			cleanupPreview()
 		}
 		if strings.TrimSpace(decision.Action) == templateInstanceLifecycleActionCreated {
 			refreshed, err := r.descriptorsForPlans(ctx, matched)
@@ -175,7 +188,7 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 			out.ExtraDetail["connect_route_plan_receiver_event"] = plan.Receiver.ResolvedEvent
 			return out, nil
 		}
-		if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Event); collision {
+		if previous, current, collision := admitConnectReceiverPinFacts(&receiverPinFacts, routes, plan.Receiver.Pin, plan.Receiver.Event); collision {
 			out.Failure = connectRoutePlanTargetFailure(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
 			out.ExtraDetail["connect_route_plan_failure"] = string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid)
 			out.ExtraDetail["connect_route_plan_receiver_pin_collision"] = []string{previous, current}
@@ -188,30 +201,35 @@ func (r connectRoutePlanResolver) Plan(ctx context.Context, evt events.Event) (c
 	out.LiveRecipients = normalizeRoutePlanLiveRecipients(out.LiveRecipients)
 	out.DeliveryIntents = normalizeRoutePlanDeliveryIntents(out.DeliveryIntents)
 	out.RoutedRecipients = dedupeSubscribers(out.RoutedRecipients)
+	out.ReplyContextConsumed = replyContextConsumed
 	return out, nil
 }
 
 type connectReceiverPinFact struct {
 	route              events.DeliveryRoute
+	receiverPin        string
 	receiverLocalEvent string
 }
 
-func admitConnectReceiverPinFacts(admitted *[]connectReceiverPinFact, routes []events.DeliveryRoute, receiverLocalEvent string) (string, string, bool) {
+func admitConnectReceiverPinFacts(admitted *[]connectReceiverPinFact, routes []events.DeliveryRoute, receiverPin, receiverLocalEvent string) (string, string, bool) {
+	receiverPin = strings.TrimSpace(receiverPin)
 	receiverLocalEvent = eventidentity.Normalize(receiverLocalEvent)
-	if admitted == nil || receiverLocalEvent == "" {
+	if admitted == nil || receiverPin == "" || receiverLocalEvent == "" {
 		return "", "", false
 	}
+	currentIdentity := receiverPin + ":" + receiverLocalEvent
 	for _, route := range routes {
 		route = route.Normalized()
 		if route.SubscriberType == "" || route.SubscriberID == "" {
 			continue
 		}
 		for _, previous := range *admitted {
-			if events.SameDeliveryRouteIdentity(previous.route, route) && previous.receiverLocalEvent != receiverLocalEvent {
-				return previous.receiverLocalEvent, receiverLocalEvent, true
+			previousIdentity := previous.receiverPin + ":" + previous.receiverLocalEvent
+			if events.SameDeliveryRouteIdentity(previous.route, route) && previousIdentity != currentIdentity {
+				return previousIdentity, currentIdentity, true
 			}
 		}
-		*admitted = append(*admitted, connectReceiverPinFact{route: route, receiverLocalEvent: receiverLocalEvent})
+		*admitted = append(*admitted, connectReceiverPinFact{route: route, receiverPin: receiverPin, receiverLocalEvent: receiverLocalEvent})
 	}
 	return "", "", false
 }
@@ -377,29 +395,38 @@ func (r connectRoutePlanResolver) materializeConnectRoutePlan(ctx context.Contex
 	}), TemplateInstanceLifecycleDecision{}, nil
 }
 
-func (r connectRoutePlanResolver) installTemplateInstanceLifecyclePreview(decision TemplateInstanceLifecycleDecision) (func(), error) {
+func (r connectRoutePlanResolver) installTemplateInstanceLifecyclePreview(ctx context.Context, decision TemplateInstanceLifecycleDecision) error {
 	if strings.TrimSpace(decision.Action) != templateInstanceLifecycleActionPreviewCreate {
-		return nil, nil
+		return nil
 	}
-	if r.routeTable == nil {
-		return nil, nil
+	var preview *connectRoutePlanPreviewRoutes
+	if ctx != nil {
+		preview, _ = ctx.Value(connectRoutePlanPreviewRoutesKey{}).(*connectRoutePlanPreviewRoutes)
+	}
+	if preview == nil {
+		return errors.New("connect route planning preview table is required before lifecycle materialization")
+	}
+	if preview.table == nil {
+		table, err := DeriveRouteTable(r.source)
+		if err != nil {
+			return fmt.Errorf("derive connect route planning preview table: %w", err)
+		}
+		preview.table = table
 	}
 	identity := decision.Route()
 	if !identity.Valid() {
-		return nil, nil
+		return nil
 	}
-	if len(r.routeTable.MaterializedRoutes(identity)) > 0 {
-		return nil, nil
+	if len(preview.table.MaterializedRoutes(identity)) > 0 {
+		return nil
 	}
-	if err := r.routeTable.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
+	if err := preview.table.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{
 		Identity:            identity,
 		ActivationVariables: decision.ActivationVariables(),
 	}); err != nil {
-		return nil, err
+		return err
 	}
-	return func() {
-		_ = r.routeTable.RemoveFlowInstanceRoute(identity)
-	}, nil
+	return nil
 }
 
 func (r connectRoutePlanResolver) matchedPlans(ctx context.Context, evt events.Event) []runtimepinrouting.ConnectRoutePlan {
@@ -488,6 +515,11 @@ func (r connectRoutePlanResolver) resolveSelectedReceiverCarriers(ctx context.Co
 	tables := []*RouteTable{r.routeTable}
 	if staged := transactionRouteTableFromContext(ctx); staged != nil && staged != r.routeTable {
 		tables = append(tables, staged)
+	}
+	if ctx != nil {
+		if preview, _ := ctx.Value(connectRoutePlanPreviewRoutesKey{}).(*connectRoutePlanPreviewRoutes); preview != nil && preview.table != nil {
+			tables = append(tables, preview.table)
+		}
 	}
 	if len(tables) == 0 {
 		return nil

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -508,10 +508,19 @@ func (r connectRoutePlanResolver) connectIssueMatchesEvent(ctx context.Context, 
 	if !ok {
 		return false
 	}
+	mode := "root"
+	if !from.Root {
+		scope, ok := r.source.FlowScopeByID(from.FlowID)
+		if !ok {
+			return false
+		}
+		mode = strings.TrimSpace(scope.Mode)
+	}
 	endpoint := runtimepinrouting.ConnectRoutePlanEndpoint{
 		Root:          from.Root,
 		FlowID:        strings.TrimSpace(from.FlowID),
 		FlowPath:      strings.Trim(strings.TrimSpace(routeFlowPath(r.source, from.FlowID)), "/"),
+		Mode:          mode,
 		Pin:           strings.TrimSpace(from.Pin),
 		Event:         strings.TrimSpace(outputPin.EventType()),
 		ResolvedEvent: strings.TrimSpace(r.source.ResolveFlowEventReference(from.FlowID, outputPin.EventType())),

--- a/internal/runtime/bus/connect_route_plan_dispatch.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch.go
@@ -164,6 +164,14 @@ func (r connectRoutePlanResolver) planMatched(ctx context.Context, evt events.Ev
 		if err := r.installTemplateInstanceLifecyclePreview(ctx, decision); err != nil {
 			return connectRoutePlanDispatch{}, err
 		}
+		if strings.TrimSpace(decision.Action) == templateInstanceLifecycleActionPreviewCreate {
+			descriptors = append(descriptors, runtimepinrouting.Descriptor{
+				ID:            strings.TrimSpace(decision.InstanceID),
+				EntityID:      strings.TrimSpace(decision.EntityID),
+				FlowInstance:  strings.Trim(strings.TrimSpace(decision.InstancePath), "/"),
+				AddressFields: decision.ActivationVariables(),
+			})
+		}
 		routes, subscribers, err := r.deliveryRoutesForMaterialization(ctx, plan, materialized, decision)
 		if err != nil {
 			return connectRoutePlanDispatch{}, err

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -138,9 +138,221 @@ func TestConnectRoutePlanEventConsumersEnforceProducerMode(t *testing.T) {
 	}
 }
 
+func TestConnectRoutePlanReceiverPinCollisionFailsClosedAcrossSupportedSurfaces(t *testing.T) {
+	for _, producerMode := range []string{"static", "template"} {
+		for _, rootReceiver := range []bool{false, true} {
+			for _, subscriberType := range []string{"node", "agent"} {
+				name := strings.Join([]string{producerMode, map[bool]string{false: "flow", true: "root"}[rootReceiver], subscriberType}, "/")
+				t.Run(name, func(t *testing.T) {
+					source := connectReceiverPinCollisionSource(producerMode, rootReceiver, subscriberType, false)
+					store := newTargetRouteMemoryStore()
+					routeTable, err := DeriveRouteTable(source)
+					if err != nil {
+						t.Fatalf("DeriveRouteTable: %v", err)
+					}
+					if rootReceiver {
+						for _, localEvent := range []string{"work.accepted", "work.audited"} {
+							routeTable.rootInputRoutes[localEvent] = appendUniqueRootInputSubscriber(routeTable.rootInputRoutes[localEvent], Subscriber{
+								ID: "receiver", Type: subscriberType, MatchPattern: localEvent, RouteSource: "root_input_project",
+							})
+						}
+						routeTable.rebuildLocked()
+					}
+					eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source, RouteTable: routeTable})
+					if err != nil {
+						t.Fatalf("NewEventBusWithOptions: %v", err)
+					}
+					if rootReceiver && subscriberType == "agent" {
+						if ch := eb.SubscribeAgent(testAgentSubscriptionAdmission(t, "receiver", "work.accepted", "work.audited")); ch == nil {
+							t.Fatal("install typed root-agent subscription")
+						}
+					}
+					eventType := events.EventType("producer/work.ready")
+					sourceRoute := events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}
+					if producerMode == "template" {
+						eventType = "producer/inst-1/work.ready"
+						sourceRoute.FlowInstance = "producer/inst-1"
+					}
+					envelope := events.EventEnvelope{Source: sourceRoute}
+					if rootReceiver {
+						envelope = events.EnvelopeForTargetRoute(envelope, events.RouteIdentity{EntityID: "root-entity"})
+					}
+					eventID := uuid.NewString()
+					evt := eventtest.RootIngress(eventID, eventType, "", "", []byte(`{}`), 0, "", "", envelope, time.Now().UTC())
+
+					plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+					if err != nil {
+						t.Fatalf("CheckPublishRecipientPlan: %v", err)
+					}
+					if got, want := plan.TargetFailure, string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid); got != want {
+						t.Fatalf("target failure = %q, want %q; plan=%#v", got, want, plan)
+					}
+					if len(plan.DeliveryRoutes) != 0 {
+						t.Fatalf("delivery routes = %#v, want none", plan.DeliveryRoutes)
+					}
+					if err := eb.Publish(context.Background(), evt); err != nil {
+						t.Fatalf("Publish classified target failure: %v", err)
+					}
+					if routes := store.routes[eventID]; len(routes) != 0 {
+						t.Fatalf("persisted delivery routes = %#v, want none", routes)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestConnectRoutePlanReceiverPinCollisionGuardPreservesLegalFanoutAndDuplicateEdges(t *testing.T) {
+	targetA := events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/a", EntityID: "a"}
+	targetB := events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/b", EntityID: "b"}
+	for _, tc := range []struct {
+		name   string
+		first  events.DeliveryRoute
+		second events.DeliveryRoute
+		localA string
+		localB string
+		want   bool
+	}{
+		{name: "duplicate same edge", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, localA: "work.accepted", localB: "work.accepted"},
+		{name: "different subscriber", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "accept", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "audit", Target: targetA}, localA: "work.accepted", localB: "work.audited"},
+		{name: "different target", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetB}, localA: "work.accepted", localB: "work.audited"},
+		{name: "same delivery identity", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, localA: "work.accepted", localB: "work.audited", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var admitted []connectReceiverPinFact
+			if _, _, collision := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.first}, tc.localA); collision {
+				t.Fatal("first fact collided")
+			}
+			_, _, got := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.second}, tc.localB)
+			if got != tc.want {
+				t.Fatalf("collision = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	source := connectReceiverPinCollisionSource("static", false, "node", true)
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	evt := eventtest.RootIngress(uuid.NewString(), "producer/work.ready", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{Source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if got, want := plan.TargetFailure, string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid); got != want {
+		t.Fatalf("mixed fanout target failure = %q, want %q", got, want)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		shape      string
+		wantRoutes int
+	}{
+		{name: "distinct subscribers", shape: "distinct_subscribers", wantRoutes: 2},
+		{name: "duplicate same edge", shape: "duplicate_edge", wantRoutes: 1},
+	} {
+		t.Run("public "+tc.name, func(t *testing.T) {
+			store := newTargetRouteMemoryStore()
+			eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: connectReceiverPinLegalSource(tc.shape)})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			eventID := uuid.NewString()
+			evt := eventtest.RootIngress(eventID, "producer/work.ready", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{Source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}}, time.Now().UTC())
+			plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if plan.TargetFailure != "" || len(plan.DeliveryRoutes) != tc.wantRoutes {
+				t.Fatalf("preflight = failure:%q routes:%#v, want %d legal routes", plan.TargetFailure, plan.DeliveryRoutes, tc.wantRoutes)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if routes := store.routes[eventID]; len(routes) != tc.wantRoutes {
+				t.Fatalf("persisted routes = %#v, want %d", routes, tc.wantRoutes)
+			}
+		})
+	}
+}
+
 func connectRoutePlanEndpointWithMode(endpoint runtimepinrouting.ConnectRoutePlanEndpoint, mode string) runtimepinrouting.ConnectRoutePlanEndpoint {
 	endpoint.Mode = mode
 	return endpoint
+}
+
+func connectReceiverPinCollisionSource(producerMode string, rootReceiver bool, subscriberType string, mixed bool) semanticview.Source {
+	inputs := []runtimecontracts.FlowInputEventPin{
+		{Name: "work_accepted", Event: "work.accepted"},
+		{Name: "work_audited", Event: "work.audited"},
+	}
+	producer := connectRoutePlanTestFlow{
+		id: "producer", mode: producerMode,
+		outputs: []runtimecontracts.FlowOutputEventPin{{Name: "work_ready", Event: "work.ready"}},
+	}
+	connects := []runtimecontracts.FlowPackageConnect{
+		{From: "producer.work_ready", To: "consumer.work_accepted"},
+		{From: "producer.work_ready", To: "consumer.work_audited"},
+	}
+	consumer := connectRoutePlanTestFlow{id: "consumer", mode: "static", inputs: inputs}
+	if subscriberType == "agent" {
+		consumer.agents = map[string]runtimecontracts.AgentRegistryEntry{
+			"receiver": {ID: "receiver", Subscriptions: []string{"work.accepted", "work.audited"}},
+		}
+	} else {
+		consumer.nodes = map[string]runtimecontracts.SystemNodeContract{
+			"receiver": {ID: "receiver", EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.accepted": {}, "work.audited": {}}},
+		}
+		if mixed {
+			consumer.agents = map[string]runtimecontracts.AgentRegistryEntry{
+				"legal-agent": {ID: "legal-agent", Subscriptions: []string{"work.accepted"}},
+			}
+		}
+	}
+	bundle := connectRoutePlanTestBundle([]connectRoutePlanTestFlow{producer, consumer}, connects)
+	if !rootReceiver {
+		return semanticview.Wrap(bundle)
+	}
+	bundle.Semantics.CompositionConnects[0].To = ".work_accepted"
+	bundle.Semantics.CompositionConnects[1].To = ".work_audited"
+	bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{Pins: runtimecontracts.FlowPins{Inputs: runtimecontracts.FlowInputPins{Events: connectRoutePlanInputEvents(inputs), EventPins: inputs}}}
+	bundle.Semantics.FlowInputs[""] = connectRoutePlanInputEvents(inputs)
+	bundle.Semantics.FlowInputEventPins[""] = inputs
+	bundle.Nodes = consumer.nodes
+	bundle.Agents = consumer.agents
+	bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
+	for _, node := range consumer.nodes {
+		bundle.Semantics.NodeHandlers[node.ID] = node.EventHandlers
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func connectReceiverPinLegalSource(shape string) semanticview.Source {
+	inputs := []runtimecontracts.FlowInputEventPin{
+		{Name: "work_accepted", Event: "work.accepted"},
+		{Name: "work_audited", Event: "work.audited"},
+	}
+	connects := []runtimecontracts.FlowPackageConnect{
+		{From: "producer.work_ready", To: "consumer.work_accepted"},
+		{From: "producer.work_ready", To: "consumer.work_audited"},
+	}
+	nodes := map[string]runtimecontracts.SystemNodeContract{
+		"accept-node": {ID: "accept-node", EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.accepted": {}}},
+		"audit-node":  {ID: "audit-node", EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.audited": {}}},
+	}
+	if shape == "duplicate_edge" {
+		inputs = inputs[:1]
+		connects[1] = connects[0]
+		nodes = map[string]runtimecontracts.SystemNodeContract{
+			"accept-node": {ID: "accept-node", EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"work.accepted": {}}},
+		}
+	}
+	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{id: "producer", mode: "static", outputs: []runtimecontracts.FlowOutputEventPin{{Name: "work_ready", Event: "work.ready"}}},
+		{id: "consumer", mode: "static", inputs: inputs, nodes: nodes},
+	}, connects))
 }
 
 func (s *connectRoutePlanMutationStore) RunEventMutation(ctx context.Context, fn func(EventMutation) error) error {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -1519,6 +1519,82 @@ func TestEventBusPublish_ConnectRoutePlanCreatesTemplateInstanceOnMissingCreate(
 	}
 }
 
+func TestEventBusPublish_ConnectRoutePlanPreviewCreateFeedsLaterSelect(t *testing.T) {
+	repoRoot := canonicalrouting.RepoRoot(t)
+	fixtureRoot := canonicalrouting.CopyTemplateCreateThenSelectSameEvent(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	store := &connectRoutePlanLifecycleStore{
+		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+			targetRouteMemoryStore: newTargetRouteMemoryStore(),
+		},
+	}
+	eb, err := newScopedTestEventBus(store, EventBusOptions{
+		ContractBundle:            semanticview.Wrap(bundle),
+		TemplateInstanceActivator: store.Activate,
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	store.bus = eb
+	evt := eventtest.RootIngress(uuid.NewString(),
+		events.EventType("producer/account.setup"), "", "", json.RawMessage(`{"account_id":"acct-preview"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != 2 {
+		t.Fatalf("preflight failure/routes = %q/%#v, want create and later-select routes", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
+	if len(store.activations) != 0 {
+		t.Fatalf("preflight activations = %#v, want request-local preview only", store.activations)
+	}
+	previewTarget := preflight.DeliveryRoutes[0].Target.Normalized()
+	for _, route := range preflight.DeliveryRoutes {
+		if route.Target.Normalized() != previewTarget {
+			t.Fatalf("preflight route target = %#v, want shared preview-created target %#v", route.Target, previewTarget)
+		}
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(store.activations) != 1 {
+		t.Fatalf("activations = %#v, want one create followed by select", store.activations)
+	}
+	activation := store.activations[0]
+	wantTarget := events.RouteIdentity{
+		FlowID:       "account",
+		FlowInstance: activation.Instance.InstancePath,
+		EntityID:     activation.Instance.EntityID,
+	}.Normalized()
+	routes := store.routes[evt.ID()]
+	if len(routes) != 2 {
+		t.Fatalf("persisted routes = %#v, want two distinct consumers", routes)
+	}
+	wantSubscribers := map[string]bool{
+		"account-setup-node-" + activation.Instance.InstanceID: false,
+		"account-ready-node-" + activation.Instance.InstanceID: false,
+	}
+	for _, route := range routes {
+		if route.Target.Normalized() != wantTarget {
+			t.Fatalf("persisted route target = %#v, want %#v", route.Target, wantTarget)
+		}
+		if _, ok := wantSubscribers[route.SubscriberID]; !ok {
+			t.Fatalf("persisted subscriber = %q, want one of %#v", route.SubscriberID, wantSubscribers)
+		}
+		wantSubscribers[route.SubscriberID] = true
+	}
+	for subscriber, found := range wantSubscribers {
+		if !found {
+			t.Fatalf("persisted routes = %#v, missing subscriber %s", routes, subscriber)
+		}
+	}
+}
+
 func TestCommittedReplayReusesPersistedSyntheticCarryWithoutReminting(t *testing.T) {
 	source := connectRoutePlanCreateResolutionSource(t, runtimecontracts.FlowInputResolutionMintUUID)
 	store := &connectRoutePlanLifecycleStore{

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -79,6 +79,70 @@ type targetRouteMemoryEventMutation struct {
 	store *connectRoutePlanMutationStore
 }
 
+func TestConnectRoutePlanEventConsumersEnforceProducerMode(t *testing.T) {
+	baseEndpoint := runtimepinrouting.ConnectRoutePlanEndpoint{
+		FlowID: "producer", FlowPath: "producer", Event: "deploy.done", ResolvedEvent: "producer/deploy.done",
+	}
+	for _, tc := range []struct {
+		name      string
+		endpoint  runtimepinrouting.ConnectRoutePlanEndpoint
+		eventType string
+		source    events.RouteIdentity
+		want      bool
+	}{
+		{name: "root accepts root event", endpoint: runtimepinrouting.ConnectRoutePlanEndpoint{Root: true, Mode: "root", Event: "deploy.done", ResolvedEvent: "deploy.done"}, eventType: "deploy.done", want: true},
+		{name: "root rejects child evidence", endpoint: runtimepinrouting.ConnectRoutePlanEndpoint{Root: true, Mode: "root", Event: "deploy.done", ResolvedEvent: "deploy.done"}, eventType: "deploy.done", source: events.RouteIdentity{FlowID: "producer"}},
+		{name: "static accepts exact scope", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "static"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "static rejects descendant", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "static"), eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "singleton accepts exact scope", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "singleton"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "singleton rejects descendant", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "singleton"), eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "template accepts concrete instance", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "template"), eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}, want: true},
+		{name: "template rejects base scope", endpoint: connectRoutePlanEndpointWithMode(baseEndpoint, "template"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}},
+	} {
+		t.Run("plan/"+tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", events.EventType(tc.eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{Source: tc.source}, time.Unix(1, 0).UTC())
+			plan := runtimepinrouting.ConnectRoutePlan{Source: tc.endpoint}
+			if got := connectRoutePlanMatchesEvent(context.Background(), plan, evt); got != tc.want {
+				t.Fatalf("connectRoutePlanMatchesEvent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name      string
+		mode      string
+		eventType string
+		source    events.RouteIdentity
+		want      bool
+	}{
+		{name: "static exact scope", mode: "static", eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "static descendant", mode: "static", eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "template concrete instance", mode: "template", eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}, want: true},
+		{name: "template base scope", mode: "template", eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}},
+	} {
+		t.Run("issue/"+tc.name, func(t *testing.T) {
+			source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{{
+				id: "producer", mode: tc.mode,
+				outputs: []runtimecontracts.FlowOutputEventPin{{Name: "deploy_done", Event: "deploy.done"}},
+			}}, nil))
+			resolver := connectRoutePlanResolver{source: source}
+			issue := runtimepinrouting.ConnectRoutePlanIssue{
+				Failure: runtimepinrouting.ConnectFailureReceiverFlowMissing,
+				Connect: runtimecontracts.FlowPackageConnect{From: "producer.deploy_done"},
+			}
+			evt := eventtest.RootIngress("", events.EventType(tc.eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{Source: tc.source}, time.Unix(1, 0).UTC())
+			if got := resolver.connectIssueMatchesEvent(context.Background(), issue, evt); got != tc.want {
+				t.Fatalf("connectIssueMatchesEvent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func connectRoutePlanEndpointWithMode(endpoint runtimepinrouting.ConnectRoutePlanEndpoint, mode string) runtimepinrouting.ConnectRoutePlanEndpoint {
+	endpoint.Mode = mode
+	return endpoint
+}
+
 func (s *connectRoutePlanMutationStore) RunEventMutation(ctx context.Context, fn func(EventMutation) error) error {
 	postCommit := make([]func(), 0, 2)
 	rollback := make([]func(), 0, 2)

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -476,7 +476,10 @@ func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEv
 		0,
 		"",
 		"",
-		events.EnvelopeForFlowInstance(events.EventEnvelope{}, "producer/child-1"),
+		events.EnvelopeForSourceRoute(
+			events.EnvelopeForFlowInstance(events.EventEnvelope{}, "consumer/inst-9"),
+			events.RouteIdentity{FlowID: "child", FlowInstance: "child"},
+		),
 		time.Now().UTC(),
 	)
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
+	runtimereplycontext "github.com/division-sh/swarm/internal/runtime/replycontext"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/google/uuid"
@@ -72,6 +73,47 @@ type connectRoutePlanLifecycleStore struct {
 type connectRoutePlanConcurrentLifecycleStore struct {
 	*connectRoutePlanLifecycleStore
 	mu sync.Mutex
+}
+
+type connectRoutePlanNodeInterceptor struct {
+	mu    sync.Mutex
+	count int
+}
+
+type connectRoutePlanReplyMutationStore struct {
+	creates int
+	claims  int
+}
+
+func (s *connectRoutePlanReplyMutationStore) CreateReplyContext(context.Context, runtimereplycontext.Record) error {
+	s.creates++
+	return nil
+}
+
+func (*connectRoutePlanReplyMutationStore) LoadReplyContext(context.Context, string) (runtimereplycontext.Record, error) {
+	return runtimereplycontext.Record{}, runtimereplycontext.ErrNotFound
+}
+
+func (s *connectRoutePlanReplyMutationStore) ClaimReplyContext(context.Context, string, string) (runtimereplycontext.Record, runtimereplycontext.ClaimOutcome, error) {
+	s.claims++
+	return runtimereplycontext.Record{}, runtimereplycontext.ClaimAccepted, nil
+}
+
+func (*connectRoutePlanNodeInterceptor) Intercept(context.Context, events.Event) (bool, []events.Event, error) {
+	return true, nil, nil
+}
+
+func (i *connectRoutePlanNodeInterceptor) InterceptDeliveryRoute(context.Context, events.Event, events.DeliveryRoute) (bool, []events.Event, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.count++
+	return false, nil, nil
+}
+
+func (i *connectRoutePlanNodeInterceptor) Count() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.count
 }
 
 type targetRouteMemoryEventMutation struct {
@@ -209,21 +251,24 @@ func TestConnectRoutePlanReceiverPinCollisionGuardPreservesLegalFanoutAndDuplica
 		name   string
 		first  events.DeliveryRoute
 		second events.DeliveryRoute
+		pinA   string
+		pinB   string
 		localA string
 		localB string
 		want   bool
 	}{
-		{name: "duplicate same edge", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, localA: "work.accepted", localB: "work.accepted"},
-		{name: "different subscriber", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "accept", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "audit", Target: targetA}, localA: "work.accepted", localB: "work.audited"},
-		{name: "different target", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetB}, localA: "work.accepted", localB: "work.audited"},
-		{name: "same delivery identity", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, localA: "work.accepted", localB: "work.audited", want: true},
+		{name: "duplicate same edge", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, pinA: "work_accepted", pinB: "work_accepted", localA: "work.accepted", localB: "work.accepted"},
+		{name: "different subscriber", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "accept", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "audit", Target: targetA}, pinA: "work_accepted", pinB: "work_audited", localA: "work.accepted", localB: "work.audited"},
+		{name: "different target", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetB}, pinA: "work_accepted", pinB: "work_audited", localA: "work.accepted", localB: "work.audited"},
+		{name: "distinct local events", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, pinA: "work_accepted", pinB: "work_audited", localA: "work.accepted", localB: "work.audited", want: true},
+		{name: "distinct pins same local event", first: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, second: events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker", Target: targetA}, pinA: "work_primary", pinB: "work_secondary", localA: "work.accepted", localB: "work.accepted", want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var admitted []connectReceiverPinFact
-			if _, _, collision := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.first}, tc.localA); collision {
+			if _, _, collision := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.first}, tc.pinA, tc.localA); collision {
 				t.Fatal("first fact collided")
 			}
-			_, _, got := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.second}, tc.localB)
+			_, _, got := admitConnectReceiverPinFacts(&admitted, []events.DeliveryRoute{tc.second}, tc.pinB, tc.localB)
 			if got != tc.want {
 				t.Fatalf("collision = %v, want %v", got, tc.want)
 			}
@@ -275,6 +320,118 @@ func TestConnectRoutePlanReceiverPinCollisionGuardPreservesLegalFanoutAndDuplica
 				t.Fatalf("persisted routes = %#v, want %d", routes, tc.wantRoutes)
 			}
 		})
+	}
+}
+
+func TestEventBusPublish_ConnectRoutePlanAddressCollisionRejectsRuntimeResolvedNodeAgentAndMixedFanout(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		subscriberType string
+		distinctEvents bool
+		mixed          bool
+	}{
+		{name: "node/same local event", subscriberType: "node"},
+		{name: "node/distinct local events", subscriberType: "node", distinctEvents: true},
+		{name: "agent/same local event", subscriberType: "agent"},
+		{name: "agent/distinct local events", subscriberType: "agent", distinctEvents: true},
+		{name: "mixed legal and colliding recipients", subscriberType: "node", distinctEvents: true, mixed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := connectReceiverPinAddressCollisionSource(tc.subscriberType, tc.distinctEvents, tc.mixed)
+			interceptor := &connectRoutePlanNodeInterceptor{}
+			store := &connectRoutePlanDescriptorStore{
+				targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				flowInstances: []ActiveFlowInstanceDescriptor{{
+					InstanceID:    "one",
+					EntityID:      "ent-1",
+					FlowInstance:  "consumer/one",
+					AddressFields: map[string]string{"entity.vertical_id": "v-1"},
+				}},
+			}
+			eb, err := newScopedTestEventBus(store, EventBusOptions{ContractBundle: source, Interceptors: []EventInterceptor{interceptor}})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			if err := eb.AddFlowInstanceRoute(FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("consumer", "one")}); err != nil {
+				t.Fatalf("AddFlowInstanceRoute: %v", err)
+			}
+			var agentEvents <-chan events.Event
+			if tc.subscriberType == "agent" {
+				if tc.distinctEvents {
+					agentEvents = eb.SubscribeAgent(testAgentSubscriptionAdmission(t, "receiver-one", "work.accepted", "work.audited"))
+				} else {
+					agentEvents = eb.SubscribeAgent(testAgentSubscriptionAdmission(t, "receiver-one", "work.accepted"))
+				}
+			} else if tc.mixed {
+				agentEvents = eb.SubscribeAgent(testAgentSubscriptionAdmission(t, "legal-agent-one", "work.accepted"))
+			}
+			eventID := uuid.NewString()
+			evt := eventtest.RootIngress(eventID, "producer/work.ready", "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+			preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if got, want := preflight.TargetFailure, string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid); got != want {
+				t.Fatalf("preflight target failure = %q, want %q; routes=%#v", got, want, preflight.DeliveryRoutes)
+			}
+			if len(preflight.DeliveryRoutes) != 0 {
+				t.Fatalf("preflight delivery routes = %#v, want none", preflight.DeliveryRoutes)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if len(store.routes[eventID]) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none", store.routes[eventID])
+			}
+			if got := interceptor.Count(); got != 0 {
+				t.Fatalf("node handler interceptions = %d, want none", got)
+			}
+			if agentEvents != nil {
+				select {
+				case delivered := <-agentEvents:
+					t.Fatalf("agent delivery = %#v, want none", delivered)
+				default:
+				}
+			}
+			if len(store.flowInstances) != 1 {
+				t.Fatalf("flow instance descriptors = %#v, want unchanged existing target", store.flowInstances)
+			}
+		})
+	}
+}
+
+func TestConnectRoutePlanReceiverPinCollisionFailsBeforeReplyContextMutation(t *testing.T) {
+	source := connectReceiverPinCollisionSource("static", false, "node", false)
+	routeTable, err := DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	replyStore := &connectRoutePlanReplyMutationStore{}
+	resolver := newConnectRoutePlanResolver(source, routeTable, nil, nil, replyStore)
+	for i := range resolver.plans {
+		resolver.plans[i].ReplyResolution = &runtimepinrouting.ConnectRoutePlanReplyResolution{
+			Role:             runtimepinrouting.ConnectReplyRoleRequest,
+			RequesterFlowID:  "producer",
+			RequestOutputPin: "work_ready",
+			ReplyInputPin:    "work_reply",
+			ProviderFlowID:   "consumer",
+			ProviderInputPin: resolver.plans[i].Receiver.Pin,
+		}
+	}
+	evt := eventtest.RootIngress(uuid.NewString(), "producer/work.ready", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+		Source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer", EntityID: "producer-entity"},
+	}, time.Now().UTC())
+
+	dispatch, err := resolver.Plan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got, want := dispatch.Failure, connectRoutePlanTargetFailure(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid); got != want {
+		t.Fatalf("dispatch failure = %q, want %q", got, want)
+	}
+	if replyStore.creates != 0 || replyStore.claims != 0 || dispatch.ReplyContextConsumed {
+		t.Fatalf("reply mutations = create:%d claim:%d consumed:%v, want none", replyStore.creates, replyStore.claims, dispatch.ReplyContextConsumed)
 	}
 }
 
@@ -353,6 +510,50 @@ func connectReceiverPinLegalSource(shape string) semanticview.Source {
 		{id: "producer", mode: "static", outputs: []runtimecontracts.FlowOutputEventPin{{Name: "work_ready", Event: "work.ready"}}},
 		{id: "consumer", mode: "static", inputs: inputs, nodes: nodes},
 	}, connects))
+}
+
+func connectReceiverPinAddressCollisionSource(subscriberType string, distinctEvents, mixed bool) semanticview.Source {
+	secondEvent := "work.accepted"
+	if distinctEvents {
+		secondEvent = "work.audited"
+	}
+	inputs := []runtimecontracts.FlowInputEventPin{
+		{Name: "work_primary", Event: "work.accepted", Address: &runtimecontracts.FlowInputPinAddress{By: "vertical_id", Source: "payload.vertical_id", Target: "entity.vertical_id", Cardinality: "one"}},
+		{Name: "work_secondary", Event: secondEvent, Address: &runtimecontracts.FlowInputPinAddress{By: "vertical_id", Source: "payload.vertical_id", Target: "entity.vertical_id", Cardinality: "one"}},
+	}
+	consumer := connectRoutePlanTestFlow{
+		id: "consumer", mode: "template", inputs: inputs,
+		entityFields: map[string]runtimecontracts.EntityFieldDecl{"vertical_id": {Type: "string", Indexed: true}},
+	}
+	subscriptions := []string{"work.accepted"}
+	if distinctEvents {
+		subscriptions = append(subscriptions, secondEvent)
+	}
+	if subscriberType == "agent" {
+		consumer.agents = map[string]runtimecontracts.AgentRegistryEntry{
+			"receiver": {ID: "receiver-{instance_id}", Subscriptions: subscriptions},
+		}
+	} else {
+		handlers := map[string]runtimecontracts.SystemNodeEventHandler{"work.accepted": {}}
+		if distinctEvents {
+			handlers[secondEvent] = runtimecontracts.SystemNodeEventHandler{}
+		}
+		consumer.nodes = map[string]runtimecontracts.SystemNodeContract{
+			"receiver": {ID: "receiver-{instance_id}", EventHandlers: handlers},
+		}
+		if mixed {
+			consumer.agents = map[string]runtimecontracts.AgentRegistryEntry{
+				"legal-agent": {ID: "legal-agent-{instance_id}", Subscriptions: []string{"work.accepted"}},
+			}
+		}
+	}
+	return semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{id: "producer", mode: "static", outputs: []runtimecontracts.FlowOutputEventPin{{Name: "work_ready", Event: "work.ready"}}},
+		consumer,
+	}, []runtimecontracts.FlowPackageConnect{
+		{From: "producer.work_ready", To: "consumer.work_primary"},
+		{From: "producer.work_ready", To: "consumer.work_secondary"},
+	}))
 }
 
 func (s *connectRoutePlanMutationStore) RunEventMutation(ctx context.Context, fn func(EventMutation) error) error {
@@ -963,6 +1164,7 @@ func TestEngineOutbox_ConnectRoutePlanPersistsSharedRoutePlan(t *testing.T) {
 
 func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 	source := connectRoutePlanFanoutSource()
+	interceptor := &connectRoutePlanNodeInterceptor{}
 	store := &connectRoutePlanDescriptorStore{
 		targetRouteMemoryStore: newTargetRouteMemoryStore(),
 		flowInstances: []ActiveFlowInstanceDescriptor{
@@ -971,7 +1173,7 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 			{InstanceID: "gamma", EntityID: "team-b", FlowInstance: "worker/gamma"},
 		},
 	}
-	eb, err := newScopedTestEventBus(store, EventBusOptions{ContractBundle: source})
+	eb, err := newScopedTestEventBus(store, EventBusOptions{ContractBundle: source, Interceptors: []EventInterceptor{interceptor}})
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
@@ -993,6 +1195,13 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 	wantAlpha := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-alpha", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/alpha", EntityID: "team-a"}}
 	wantBeta := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "worker-beta", Target: events.RouteIdentity{FlowID: "worker", FlowInstance: "worker/beta", EntityID: "team-a"}}
 
+	preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if preflight.TargetFailure != "" || !deliveryRoutesContain(preflight.DeliveryRoutes, wantAlpha) || !deliveryRoutesContain(preflight.DeliveryRoutes, wantBeta) || len(preflight.DeliveryRoutes) != 2 {
+		t.Fatalf("preflight = failure:%q routes:%#v, want two distinct legal targets", preflight.TargetFailure, preflight.DeliveryRoutes)
+	}
 	if err := eb.Publish(context.Background(), evt); err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
@@ -1005,6 +1214,9 @@ func TestEventBusPublish_ConnectRoutePlanPersistsTargetSetFanout(t *testing.T) {
 	}
 	if len(routes) != 2 {
 		t.Fatalf("persisted delivery routes = %#v, want exactly two team-a fanout routes", routes)
+	}
+	if got := interceptor.Count(); got != 2 {
+		t.Fatalf("node handler interceptions = %d, want two distinct-target executions", got)
 	}
 }
 
@@ -1936,42 +2148,145 @@ func TestEventBusPublish_ConnectRoutePlanSelectOrCreateResolutionConcurrentSameK
 	}
 }
 
-func TestEventBusPublish_ConnectRoutePlanLifecycleCreateRefreshesDescriptorsForLaterPlans(t *testing.T) {
-	source := connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t, "create", "reuse")
-	store := &connectRoutePlanLifecycleStore{
-		connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
-			targetRouteMemoryStore: newTargetRouteMemoryStore(),
-		},
-	}
-	eb, err := newScopedTestEventBus(store, EventBusOptions{
-		ContractBundle:            source,
-		TemplateInstanceActivator: store.Activate,
-	})
-	if err != nil {
-		t.Fatalf("NewEventBusWithOptions: %v", err)
-	}
-	store.bus = eb
-	evt := eventtest.RootIngress(uuid.NewString(),
-		events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+func TestEventBusPublish_ConnectRoutePlanLifecycleCollisionFailsBeforeActivation(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		secondPin canonicalrouting.LegacyInstanceSecondPin
+		consumer  canonicalrouting.LegacyInstanceConsumer
+	}{
+		{name: "node/same local event", secondPin: canonicalrouting.LegacyInstanceSecondPinSameEvent, consumer: canonicalrouting.LegacyInstanceNodeConsumer},
+		{name: "node/distinct local events", secondPin: canonicalrouting.LegacyInstanceSecondPinDistinctEvent, consumer: canonicalrouting.LegacyInstanceNodeConsumer},
+		{name: "agent/same local event", secondPin: canonicalrouting.LegacyInstanceSecondPinSameEvent, consumer: canonicalrouting.LegacyInstanceAgentConsumer},
+		{name: "agent/distinct local events", secondPin: canonicalrouting.LegacyInstanceSecondPinDistinctEvent, consumer: canonicalrouting.LegacyInstanceAgentConsumer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t, "create", "reuse", tc.secondPin, tc.consumer)
+			store := &connectRoutePlanLifecycleStore{
+				connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+					targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				},
+			}
+			eb, err := newScopedTestEventBus(store, EventBusOptions{
+				ContractBundle:            source,
+				TemplateInstanceActivator: store.Activate,
+			})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			store.bus = eb
+			evt := eventtest.RootIngress(uuid.NewString(),
+				events.EventType("producer/deploy.done"), "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
 
-	if err := eb.Publish(context.Background(), evt); err != nil {
-		t.Fatalf("Publish: %v", err)
+			preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if got, want := preflight.TargetFailure, string(runtimepinrouting.ConnectFailureDeliveryTopologyInvalid); got != want {
+				t.Fatalf("preflight target failure = %q, want %q; plan=%#v", got, want, preflight)
+			}
+			if len(preflight.DeliveryRoutes) != 0 {
+				t.Fatalf("preflight delivery routes = %#v, want none", preflight.DeliveryRoutes)
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if len(store.activations) != 0 {
+				t.Fatalf("activations = %#v, want none before rejecting receiver-pin collision", store.activations)
+			}
+			if len(store.flowInstances) != 0 {
+				t.Fatalf("flow instance descriptors = %#v, want none", store.flowInstances)
+			}
+			if len(store.routes[evt.ID()]) != 0 {
+				t.Fatalf("persisted delivery routes = %#v, want none", store.routes[evt.ID()])
+			}
+			eb.RouteTable().mu.RLock()
+			materialized := len(eb.RouteTable().instanceOwners)
+			eb.RouteTable().mu.RUnlock()
+			if materialized != 0 {
+				t.Fatalf("materialized route owners = %d, want none", materialized)
+			}
+		})
 	}
-	if len(store.activations) != 1 {
-		t.Fatalf("activations = %d, want exactly one lifecycle create for both connect plans", len(store.activations))
-	}
-	activation := store.activations[0]
-	want := events.DeliveryRoute{
-		SubscriberType: "node",
-		SubscriberID:   "consumer-node-" + activation.Instance.InstanceID,
-		Target: events.RouteIdentity{
-			FlowID:       "consumer",
-			FlowInstance: activation.Instance.InstancePath,
-			EntityID:     activation.Instance.EntityID,
-		},
-	}
-	if !deliveryRoutesContain(store.routes[evt.ID()], want) || len(store.routes[evt.ID()]) != 1 {
-		t.Fatalf("persisted delivery routes = %#v, want one deduplicated route %#v", store.routes[evt.ID()], want)
+}
+
+func TestEventBusPublish_ConnectRoutePlanLifecycleAdmissionPreservesDuplicateEdgeAndDistinctSubscriber(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		secondPin  canonicalrouting.LegacyInstanceSecondPin
+		consumer   canonicalrouting.LegacyInstanceConsumer
+		wantRoutes int
+		wantNodes  int
+		wantAgent  bool
+	}{
+		{name: "duplicate identical edge", secondPin: canonicalrouting.LegacyInstanceSecondPinDuplicateEdge, consumer: canonicalrouting.LegacyInstanceNodeConsumer, wantRoutes: 1, wantNodes: 1},
+		{name: "distinct node and agent subscribers", consumer: canonicalrouting.LegacyInstanceNodeAndAgentConsumer, wantRoutes: 2, wantAgent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t, "create", "reuse", tc.secondPin, tc.consumer)
+			store := &connectRoutePlanLifecycleStore{
+				connectRoutePlanDescriptorStore: &connectRoutePlanDescriptorStore{
+					targetRouteMemoryStore: newTargetRouteMemoryStore(),
+				},
+			}
+			interceptor := &connectRoutePlanNodeInterceptor{}
+			opts := EventBusOptions{
+				ContractBundle:            source,
+				TemplateInstanceActivator: store.Activate,
+			}
+			if !tc.wantAgent {
+				opts.Interceptors = []EventInterceptor{interceptor}
+			}
+			eb, err := newScopedTestEventBus(store, opts)
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			store.bus = eb
+			evt := eventtest.RootIngress(uuid.NewString(), "producer/deploy.done", "", "", json.RawMessage(`{"vertical_id":"v-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+
+			preflight, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+			if err != nil {
+				t.Fatalf("CheckPublishRecipientPlan: %v", err)
+			}
+			if preflight.TargetFailure != "" || len(preflight.DeliveryRoutes) != tc.wantRoutes {
+				t.Fatalf("preflight = failure:%q routes:%#v, want %d legal routes", preflight.TargetFailure, preflight.DeliveryRoutes, tc.wantRoutes)
+			}
+			var agentEvents <-chan events.Event
+			if tc.wantAgent {
+				var agentID string
+				for _, route := range preflight.DeliveryRoutes {
+					if route.SubscriberType == "agent" {
+						agentID = route.SubscriberID
+						break
+					}
+				}
+				if agentID == "" {
+					t.Fatalf("preflight routes = %#v, want agent subscriber", preflight.DeliveryRoutes)
+				}
+				agentEvents = eb.SubscribeAgent(testAgentSubscriptionAdmission(t, agentID, "deploy.done"))
+			}
+			if err := eb.Publish(context.Background(), evt); err != nil {
+				t.Fatalf("Publish: %v", err)
+			}
+			if len(store.activations) != 1 || len(store.flowInstances) != 1 {
+				t.Fatalf("activations/descriptors = %d/%d, want one admitted lifecycle instance", len(store.activations), len(store.flowInstances))
+			}
+			if routes := store.routes[evt.ID()]; len(routes) != tc.wantRoutes {
+				t.Fatalf("persisted routes = %#v, want %d", routes, tc.wantRoutes)
+			}
+			if got := interceptor.Count(); got != tc.wantNodes {
+				t.Fatalf("node handler interceptions = %d, want %d", got, tc.wantNodes)
+			}
+			if agentEvents != nil {
+				select {
+				case delivered := <-agentEvents:
+					if delivered.ID() != evt.ID() {
+						t.Fatalf("agent delivered event = %s, want %s", delivered.ID(), evt.ID())
+					}
+				case <-time.After(time.Second):
+					t.Fatal("timed out waiting for admitted agent delivery")
+				}
+			}
+		})
 	}
 }
 
@@ -3023,14 +3338,14 @@ func connectRoutePlanInstanceKeySourceWithPolicyLines(t testing.TB, policyLines 
 	return semanticview.Wrap(bundle)
 }
 
-func connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t testing.TB, onMissing, onConflict string) semanticview.Source {
+func connectRoutePlanInstanceKeyMultiInputSourceWithPolicy(t testing.TB, onMissing, onConflict string, secondPin canonicalrouting.LegacyInstanceSecondPin, consumer canonicalrouting.LegacyInstanceConsumer) semanticview.Source {
 	t.Helper()
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t, onMissing, onConflict)
+	root := writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t, onMissing, onConflict, secondPin, consumer)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -3157,12 +3472,13 @@ func writeConnectRoutePlanInstanceKeyFixtureWithPolicyLines(t testing.TB, policy
 	})
 }
 
-func writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t testing.TB, onMissing, onConflict string) string {
+func writeConnectRoutePlanInstanceKeyMultiInputFixtureWithPolicy(t testing.TB, onMissing, onConflict string, secondPin canonicalrouting.LegacyInstanceSecondPin, consumer canonicalrouting.LegacyInstanceConsumer) string {
 	t.Helper()
 	return canonicalrouting.CopyLegacyInstanceRoute(t, canonicalrouting.LegacyInstanceRouteOptions{
-		Missing:  legacyInstancePolicy(t, onMissing),
-		Conflict: legacyInstancePolicy(t, onConflict),
-		MultiPin: true,
+		Missing:   legacyInstancePolicy(t, onMissing),
+		Conflict:  legacyInstancePolicy(t, onConflict),
+		SecondPin: secondPin,
+		Consumer:  consumer,
 	})
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -178,6 +178,30 @@ func TestConnectRoutePlanEventConsumersEnforceProducerMode(t *testing.T) {
 			}
 		})
 	}
+
+	rootSource := connectRoutePlanRootProducerStaticSource()
+	rootResolver := connectRoutePlanResolver{source: rootSource}
+	rootIssue := runtimepinrouting.ConnectRoutePlanIssue{
+		Failure: runtimepinrouting.ConnectFailureReceiverFlowMissing,
+		Connect: runtimecontracts.FlowPackageConnect{From: ".root_ready"},
+	}
+	for _, tc := range []struct {
+		name         string
+		flowInstance string
+		want         bool
+	}{
+		{name: "empty-source child context", flowInstance: "child/inst-1"},
+		{name: "UUID root context", flowInstance: "11111111-1111-4111-8111-111111111111", want: true},
+	} {
+		t.Run("issue/root/"+tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", "root.ready", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+				FlowInstance: tc.flowInstance,
+			}, time.Unix(1, 0).UTC())
+			if got := rootResolver.connectIssueMatchesEvent(context.Background(), rootIssue, evt); got != tc.want {
+				t.Fatalf("connectIssueMatchesEvent = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }
 
 func TestConnectRoutePlanReceiverPinCollisionFailsClosedAcrossSupportedSurfaces(t *testing.T) {
@@ -953,10 +977,7 @@ func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEv
 		0,
 		"",
 		"",
-		events.EnvelopeForSourceRoute(
-			events.EnvelopeForFlowInstance(events.EventEnvelope{}, "consumer/inst-9"),
-			events.RouteIdentity{FlowID: "child", FlowInstance: "child"},
-		),
+		events.EnvelopeForFlowInstance(events.EventEnvelope{}, "child/inst-9"),
 		time.Now().UTC(),
 	)
 
@@ -987,6 +1008,13 @@ func TestEventBusPublish_RootConnectRoutePlanDoesNotCaptureChildScopedSameNameEv
 	}
 	if deliveryRoutesContain(plan.DeliveryRoutes, forbidden) {
 		t.Fatalf("preflight delivery routes = %#v, must not include root-connect receiver for child-scoped same-name event", plan.DeliveryRoutes)
+	}
+
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if routes := store.routes[eventID]; deliveryRoutesContain(routes, forbidden) {
+		t.Fatalf("persisted delivery routes = %#v, must not include root-connect receiver for child-scoped same-name event", routes)
 	}
 }
 

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -34,6 +34,7 @@ type connectRoutePlanTestFlow struct {
 	mode         string
 	inputs       []runtimecontracts.FlowInputEventPin
 	outputs      []runtimecontracts.FlowOutputEventPin
+	agents       map[string]runtimecontracts.AgentRegistryEntry
 	nodes        map[string]runtimecontracts.SystemNodeContract
 	entityFields map[string]runtimecontracts.EntityFieldDecl
 }
@@ -331,6 +332,70 @@ func TestEventBusPublish_ConnectRoutePlanPersistsSingularTargetWithoutLiveSubscr
 	}
 }
 
+func TestEventBusConnectRouteDeliversToLiveAgentCarrier(t *testing.T) {
+	source := semanticview.Wrap(connectRoutePlanTestBundle([]connectRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "static",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+		{
+			id:   "consumer",
+			mode: "static",
+			inputs: []runtimecontracts.FlowInputEventPin{{
+				Name:  "deploy_completed",
+				Event: "deploy.completed",
+			}},
+			agents: map[string]runtimecontracts.AgentRegistryEntry{
+				"consumer-agent": {
+					ID:            "consumer-agent",
+					Subscriptions: []string{"deploy.completed"},
+				},
+			},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From: "producer.deploy_done",
+		To:   "consumer.deploy_completed",
+	}}))
+	store := newTargetRouteMemoryStore()
+	eb, err := NewEventBusWithOptions(store, EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	admission := testAgentSubscriptionAdmissionForFlow(t, "consumer-agent", "consumer", events.EventType("deploy.completed")).CarrierOnly()
+	ch := eb.SubscribeAgent(admission)
+	if ch == nil {
+		t.Fatal("typed carrier-only agent admission returned no channel")
+	}
+	defer eb.Unsubscribe("consumer-agent")
+
+	evt := eventtest.RootIngress(uuid.NewString(), events.EventType("producer/deploy.done"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if len(plan.SubscriptionRecipients) != 0 {
+		t.Fatalf("subscription recipients = %#v, want none for carrier-only agent", plan.SubscriptionRecipients)
+	}
+	if len(plan.DeliveryRoutes) != 1 || plan.DeliveryRoutes[0].SubscriberType != "agent" || plan.DeliveryRoutes[0].SubscriberID != "consumer-agent" {
+		t.Fatalf("delivery routes = %#v, want canonical connect route to agent/consumer-agent", plan.DeliveryRoutes)
+	}
+	if err := eb.Publish(context.Background(), evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case got := <-ch:
+		if got.ID() != evt.ID() {
+			t.Fatalf("delivered event = %q, want %q", got.ID(), evt.ID())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canonical connect did not wake live agent carrier")
+	}
+}
+
 func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T) {
 	source := connectRoutePlanRootProducerStaticSource()
 	store := newTargetRouteMemoryStore()
@@ -343,8 +408,10 @@ func TestEventBusPublish_RootConnectRoutePlanPersistsSingularTarget(t *testing.T
 		t.Fatalf("receiver carrier route consumer/root.ready = %#v, want consumer-node receiver_carrier", receiverCarriers)
 	}
 	eventID := uuid.NewString()
+	rootInstanceID := uuid.NewString()
 	evt := eventtest.RootIngress(eventID,
-		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
+		events.EventType("root.ready"), "", "", json.RawMessage(`{"entity_id":"entity-1"}`), 0, "", "",
+		events.EnvelopeForFlowInstance(events.EventEnvelope{}, rootInstanceID), time.Now().UTC())
 
 	want := events.DeliveryRoute{
 		SubscriberType: "node",
@@ -3048,6 +3115,7 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 			Paths:  runtimecontracts.FlowContractPaths{ID: flow.id, Flow: flow.id},
 			Schema: schema,
 			Path:   flow.id,
+			Agents: flow.agents,
 			Nodes:  flow.nodes,
 		}
 		children = append(children, view)

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 )
@@ -866,7 +867,7 @@ func routedRootInputFlowNodeMatchesNoTargetEvent(evt events.Event, subscriber Su
 		return false
 	}
 	switch strings.TrimSpace(subscriber.RouteSource) {
-	case "root_input_flow", "pin_bind_input_alias":
+	case "root_input_flow":
 	default:
 		return false
 	}
@@ -912,9 +913,6 @@ func routedRootNodeMatchesNoTargetEvent(evt events.Event, subscriber Subscriber)
 	if !strings.Contains(eventType, "/") {
 		return true
 	}
-	if strings.TrimSpace(subscriber.RouteSource) == "pin_bind_output_alias" {
-		return true
-	}
 	matchPattern := strings.Trim(strings.TrimSpace(subscriber.MatchPattern), "/")
 	return matchPattern != "" && !strings.Contains(matchPattern, "*") && eventType == matchPattern
 }
@@ -932,6 +930,12 @@ func routedNodeInternalSubscriptionAliases(evt events.Event, routed []Subscriber
 		out = append(out, concrete)
 	}
 	for _, subscriber := range routed {
+		if localized := eventidentity.Normalize(subscriber.LocalizedEvent); localized != "" {
+			out = append(out, localized)
+			if path := eventidentity.Normalize(subscriber.Path); path != "" {
+				out = append(out, path+"/"+localized)
+			}
+		}
 		if !routedNodeMatchesConcreteFlowInstanceEvent(evt, subscriber) {
 			continue
 		}

--- a/internal/runtime/bus/eventbus.go
+++ b/internal/runtime/bus/eventbus.go
@@ -586,16 +586,34 @@ func (eb *EventBus) PendingAgentDeliveries() int {
 }
 
 func (eb *EventBus) Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event {
-	return eb.subscribe(agentID, inMemorySubscriberAgent, eventTypes...)
+	values := make([]string, 0, len(eventTypes))
+	for _, eventType := range eventTypes {
+		values = append(values, string(eventType))
+	}
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID: agentID, Subscriptions: values,
+	})
+	if err != nil {
+		return nil
+	}
+	return eb.SubscribeAgent(admission)
+}
+
+func (eb *EventBus) SubscribeAgent(admission semanticview.FlowOwnedAgentSubscriptionAdmission) <-chan events.Event {
+	if eb == nil || !admission.ValidForAgent(admission.AgentID()) {
+		return nil
+	}
+	return eb.subscribe(admission.AgentID(), inMemorySubscriberAgent, admittedAgentEventTypes(admission)...)
 }
 
 // ReplaceAgentRoute installs one exact lifecycle-generation route. The old
 // channel is detached, not closed: publishers may retain a lock-free snapshot
 // of it and must be allowed to finish without a send-on-closed panic.
-func (eb *EventBus) ReplaceAgentRoute(token runtimeeffects.LifecycleToken, eventTypes ...events.EventType) <-chan events.Event {
-	if eb == nil || !token.Valid() {
+func (eb *EventBus) ReplaceAgentRoute(token runtimeeffects.LifecycleToken, admission semanticview.FlowOwnedAgentSubscriptionAdmission) <-chan events.Event {
+	if eb == nil || !token.Valid() || !admission.ValidForAgent(token.AgentID) {
 		return nil
 	}
+	eventTypes := admittedAgentEventTypes(admission)
 	agentID := strings.TrimSpace(token.AgentID)
 	ch := make(chan events.Event, 128)
 	route := newAgentRouteHandle(token, ch)
@@ -617,6 +635,15 @@ func (eb *EventBus) ReplaceAgentRoute(token runtimeeffects.LifecycleToken, event
 		eb.channels[eventType][agentID] = ch
 	}
 	return ch
+}
+
+func admittedAgentEventTypes(admission semanticview.FlowOwnedAgentSubscriptionAdmission) []events.EventType {
+	patterns := admission.RoutePatterns()
+	out := make([]events.EventType, 0, len(patterns))
+	for _, pattern := range patterns {
+		out = append(out, events.EventType(pattern))
+	}
+	return out
 }
 
 // RemoveAgentRoute removes only the exact generation that owns the route.

--- a/internal/runtime/bus/eventbus_agent_route_test.go
+++ b/internal/runtime/bus/eventbus_agent_route_test.go
@@ -17,13 +17,13 @@ func TestEventBusAgentRouteReplacementIsExactFreshAndTokenFenced(t *testing.T) {
 	}
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "agent-a", Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "agent-a", Generation: 2}
-	oldCh := eb.ReplaceAgentRoute(oldToken, events.EventType("test.old"), events.EventType("test.retained"))
+	oldCh := eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.old"), events.EventType("test.retained")))
 	queued := eventtest.RuntimeControl("queued", events.EventType("test.old"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eb.deliverToAgents(context.Background(), queued, []string{"agent-a"}); err != nil {
 		t.Fatalf("deliver predecessor event: %v", err)
 	}
 
-	newCh := eb.ReplaceAgentRoute(newToken, events.EventType("test.retained"), events.EventType("test.new"))
+	newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, events.EventType("test.retained"), events.EventType("test.new")))
 	if oldCh == newCh {
 		t.Fatal("replacement reused predecessor channel")
 	}

--- a/internal/runtime/bus/eventbus_agent_route_test.go
+++ b/internal/runtime/bus/eventbus_agent_route_test.go
@@ -99,7 +99,7 @@ func TestEventBusAgentRouteRemovalRetiresOnlyExactGenerationDeliveries(t *testin
 	}
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "agent-a", Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "agent-a", Generation: 2}
-	eb.ReplaceAgentRoute(oldToken, events.EventType("test.work"))
+	eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.work")))
 	oldEvent := eventtest.RuntimeControl("work-old", events.EventType("test.work"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eb.deliverToAgents(context.Background(), oldEvent, []string{"agent-a"}); err != nil {
 		t.Fatalf("deliver predecessor event: %v", err)
@@ -113,7 +113,7 @@ func TestEventBusAgentRouteRemovalRetiresOnlyExactGenerationDeliveries(t *testin
 		t.Fatalf("pending predecessor deliveries after removal = %d, want 0", got)
 	}
 
-	newCh := eb.ReplaceAgentRoute(newToken, events.EventType("test.work"))
+	newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, events.EventType("test.work")))
 	newEvent := eventtest.RuntimeControl("work-new", events.EventType("test.work"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eb.deliverToAgents(context.Background(), newEvent, []string{"agent-a"}); err != nil {
 		t.Fatalf("deliver successor event: %v", err)
@@ -142,7 +142,7 @@ func TestEventBusAgentRouteDeliveryRemainsPendingAfterDequeueUntilCompletion(t *
 		t.Fatalf("NewEventBus: %v", err)
 	}
 	token := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "agent-a", Generation: 1}
-	ch := eb.ReplaceAgentRoute(token, events.EventType("test.work"))
+	ch := eb.ReplaceAgentRoute(token, testAgentSubscriptionAdmission(t, token.AgentID, events.EventType("test.work")))
 	evt := eventtest.RuntimeControl("work-1", events.EventType("test.work"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eb.deliverToAgents(context.Background(), evt, []string{"agent-a"}); err != nil {
 		t.Fatalf("deliver event: %v", err)

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -31,6 +31,7 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimereplayclaim "github.com/division-sh/swarm/internal/runtime/replayclaim"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/store"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
 	"github.com/division-sh/swarm/internal/store/storetest"
@@ -435,6 +436,106 @@ func newFixtureWorkflowModule(t *testing.T, bundle *runtimecontracts.WorkflowCon
 		workflowNodes:  workflowNodes,
 		guardRegistry:  runtimepipeline.NewContractGuardRegistry(source),
 		actionRegistry: runtimepipeline.NewContractActionRegistry(source),
+	}
+}
+
+func TestEventBusPublish_AgentOnlyConnectDoesNotAuthorizeUnrelatedNode(t *testing.T) {
+	repoRoot := canonicalrouting.RepoRoot(t)
+	fixtureRoot := canonicalrouting.CopyTemplateSelectAgentOnlyWithUnrelatedNode(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, fixtureRoot, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := semanticview.Wrap(bundle)
+	module := newFixtureWorkflowModule(t, bundle)
+	_, db, cleanup := testutil.StartPostgres(t)
+	t.Cleanup(cleanup)
+	pg := &store.PostgresStore{DB: db}
+	ctx := eventBusTestRunContext(t, db)
+	instanceRoute := runtimeflowidentity.DeriveRoute("account", "one")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO flow_instances (instance_id, flow_template, mode, config, status, created_at)
+		VALUES ($1, 'account', 'template', '{}'::jsonb, 'active', NOW())
+	`, instanceRoute.InstancePath); err != nil {
+		t.Fatalf("seed account flow instance: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO entity_state (entity_id, run_id, flow_instance, entity_type, current_state, fields, created_at, updated_at)
+		VALUES ($1::uuid, $2::uuid, $3, 'account', 'active', '{"account_id":"acct-agent"}'::jsonb, NOW(), NOW())
+	`, runtimeflowidentity.EntityID(instanceRoute.InstancePath), eventBusTestRunID, instanceRoute.InstancePath); err != nil {
+		t.Fatalf("seed account entity state: %v", err)
+	}
+
+	var pc *runtimepipeline.PipelineCoordinator
+	eb, err := newScopedTestEventBus(pg, runtimebus.EventBusOptions{
+		ContractBundle: source,
+		InterceptorProvider: func() []runtimebus.EventInterceptor {
+			if pc == nil {
+				return nil
+			}
+			return []runtimebus.EventInterceptor{pc}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	pc = runtimepipeline.NewPipelineCoordinatorWithOptions(eb, db, runtimepipeline.PipelineCoordinatorOptions{
+		Module:                  module,
+		EventReceiptsCapability: pg.CanonicalEventReceiptsCapability,
+	})
+	if pc == nil {
+		t.Fatal("expected pipeline coordinator")
+	}
+	if err := eb.AddFlowInstanceRouteContext(ctx, runtimebus.FlowInstanceRouteMaterializationRequest{Identity: instanceRoute}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	agentID := "account-agent-one"
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       agentID,
+		FlowID:        "account",
+		FlowPath:      instanceRoute.InstancePath,
+		Subscriptions: []string{"account.ready"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	agentEvents := eb.SubscribeAgent(admission.CarrierOnly())
+	if agentEvents == nil {
+		t.Fatal("agent carrier admission returned no channel")
+	}
+	defer eb.Unsubscribe(agentID)
+
+	evt := eventtest.RootIngress(uuid.NewString(), events.EventType("producer/account.ready"), "producer", "", json.RawMessage(`{"account_id":"acct-agent"}`), 0, eventBusTestRunID, "", events.EventEnvelope{}, time.Now().UTC())
+	plan, err := eb.CheckPublishRecipientPlan(ctx, evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
+	}
+	if plan.TargetFailure != "" || len(plan.DeliveryRoutes) != 1 || plan.DeliveryRoutes[0].SubscriberType != "agent" || plan.DeliveryRoutes[0].SubscriberID != agentID {
+		t.Fatalf("preflight failure/routes = %q/%#v, want agent-only connect route", plan.TargetFailure, plan.DeliveryRoutes)
+	}
+	if err := eb.Publish(ctx, evt); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case delivered := <-agentEvents:
+		if delivered.ID() != evt.ID() {
+			t.Fatalf("delivered event = %q, want %q", delivered.ID(), evt.ID())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for agent-only connect delivery")
+	}
+	var nodeDeliveries int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM event_deliveries
+		WHERE event_id = $1::uuid
+		  AND subscriber_type = 'node'
+		  AND subscriber_id = 'account-setup-node-one'
+	`, evt.ID()).Scan(&nodeDeliveries); err != nil {
+		t.Fatalf("count node deliveries: %v", err)
+	}
+	if nodeDeliveries != 0 {
+		t.Fatalf("node deliveries = %d, want none without node route authority", nodeDeliveries)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -3081,7 +3081,7 @@ func TestEventBusPublish_HumanTaskEventsRouteBySubscriptionOnly(t *testing.T) {
 	requireNoBusEvent(t, ch, "human task event without subscription")
 }
 
-func TestEventBusPublish_DoesNotLogRoutedRecipientForRetiredSiblingAutoWire(t *testing.T) {
+func TestEventBusSubscribe_RejectsUnadmittedQualifiedAgentRoute(t *testing.T) {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
@@ -3124,56 +3124,16 @@ func TestEventBusPublish_DoesNotLogRoutedRecipientForRetiredSiblingAutoWire(t *t
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	eb.Subscribe("direct-agent", events.EventType("producer/scan.requested"))
-	eb.Subscribe("scan-orchestrator")
-	defer eb.Unsubscribe("direct-agent")
-	defer eb.Unsubscribe("scan-orchestrator")
-
-	if err := eb.Publish(context.Background(), eventtest.RootIngress("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})); err != nil {
-		t.Fatalf("Publish: %v", err)
+	if ch := eb.Subscribe("direct-agent", events.EventType("producer/scan.requested")); ch != nil {
+		t.Fatal("unadmitted qualified subscription installed a live agent route")
 	}
-
-	var delivered any
-	for _, entry := range hook.entries {
-		if entry.Action == "delivered" {
-			delivered = entry.Detail
-		}
+	evt := eventtest.RootIngress("", events.EventType("producer/scan.requested"), "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{})
+	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("CheckPublishRecipientPlan: %v", err)
 	}
-	if delivered == nil {
-		t.Fatal("expected delivered log entry")
-	}
-	detail, ok := delivered.(map[string]any)
-	if !ok {
-		t.Fatalf("delivered detail type = %T, want map[string]any", delivered)
-	}
-	routed, _ := detail["routed_recipients"].([]map[string]any)
-	if len(routed) == 0 {
-		// logger detail may pass through as []any after interface widening
-		if raw, ok := detail["routed_recipients"].([]any); ok {
-			routed = make([]map[string]any, 0, len(raw))
-			for _, item := range raw {
-				if cast, ok := item.(map[string]any); ok {
-					routed = append(routed, cast)
-				}
-			}
-		}
-	}
-	if len(routed) != 0 {
-		t.Fatalf("routed_recipients = %#v, want none for retired sibling auto-wire", detail["routed_recipients"])
-	}
-	subs, _ := detail["subscription_recipients"].([]string)
-	if len(subs) == 0 {
-		if raw, ok := detail["subscription_recipients"].([]any); ok {
-			subs = make([]string, 0, len(raw))
-			for _, item := range raw {
-				if cast, ok := item.(string); ok {
-					subs = append(subs, cast)
-				}
-			}
-		}
-	}
-	if len(subs) != 1 || subs[0] != "direct-agent" {
-		t.Fatalf("subscription_recipients = %#v, want [direct-agent]", detail["subscription_recipients"])
+	if len(plan.Recipients) != 0 {
+		t.Fatalf("recipients = %#v, want none without typed connect authority", plan.Recipients)
 	}
 }
 
@@ -3237,7 +3197,7 @@ func TestEventBusPublish_RecordsNoRoutedDiagnosticsForRetiredSiblingAutoWire(t *
 	}
 }
 
-func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(t *testing.T) {
+func TestEventBusPublish_NestedDescendantCompletionFollowsDeclaredAncestorConnects(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
@@ -3272,8 +3232,8 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 	}
 
 	const rootEntityID = "11111111-1111-1111-1111-111111111111"
-	childEntityID := runtimepipeline.FlowInstanceEntityID("child/inst-1")
-	grandchildEntityID := runtimepipeline.FlowInstanceEntityID("child/grandchild/inst-1")
+	childEntityID := runtimepipeline.FlowInstanceEntityID("child")
+	grandchildEntityID := runtimepipeline.FlowInstanceEntityID("child/grandchild")
 	store := runtimepipeline.NewWorkflowInstanceStore(db)
 	ctx := eventBusTestRunContext(t, db)
 	for _, instance := range []runtimepipeline.WorkflowInstance{
@@ -3289,27 +3249,20 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 		},
 		{
 			InstanceID:      childEntityID,
-			StorageRef:      "child/inst-1",
+			StorageRef:      "child",
 			WorkflowName:    "child",
 			WorkflowVersion: bundle.WorkflowVersion(),
-			CurrentState:    "waiting",
+			CurrentState:    "delegated",
 			Metadata: map[string]any{
-				"entity_id":        childEntityID,
-				"flow_path":        "child/inst-1",
 				"parent_entity_id": rootEntityID,
 			},
 		},
 		{
 			InstanceID:      grandchildEntityID,
-			StorageRef:      "child/grandchild/inst-1",
+			StorageRef:      "child/grandchild",
 			WorkflowName:    "grandchild",
 			WorkflowVersion: bundle.WorkflowVersion(),
 			CurrentState:    "finished",
-			Metadata: map[string]any{
-				"entity_id":        grandchildEntityID,
-				"flow_path":        "child/grandchild/inst-1",
-				"parent_entity_id": childEntityID,
-			},
 		},
 	} {
 		if err := store.Upsert(ctx, instance); err != nil {
@@ -3342,8 +3295,8 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 	if !found {
 		t.Fatal("expected child instance")
 	}
-	if got := strings.TrimSpace(child.CurrentState); got != "waiting" {
-		t.Fatalf("child current_state = %q, want waiting", got)
+	if got := strings.TrimSpace(child.CurrentState); got != "completed" {
+		t.Fatalf("child current_state = %q, want completed", got)
 	}
 
 	root, found, err := store.Load(ctx, rootEntityID)
@@ -3353,8 +3306,8 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 	if !found {
 		t.Fatal("expected root instance")
 	}
-	if got := strings.TrimSpace(root.CurrentState); got != "idle" {
-		t.Fatalf("root current_state = %q, want idle without subject-link back-propagation", got)
+	if got := strings.TrimSpace(root.CurrentState); got != "done" {
+		t.Fatalf("root current_state = %q, want done through declared ancestor connects", got)
 	}
 
 	var emitted []string
@@ -3376,8 +3329,8 @@ func TestEventBusPublish_NestedDescendantCompletionDoesNotEmitChildContinuation(
 	if contains(emitted, "child/step.result") {
 		t.Fatalf("events = %v, do not want child/step.result", emitted)
 	}
-	if contains(emitted, "pipeline.complete") {
-		t.Fatalf("events = %v, do not want pipeline.complete without subject-link back-propagation", emitted)
+	if !contains(emitted, "pipeline.complete") {
+		t.Fatalf("events = %v, want pipeline.complete through declared ancestor connects", emitted)
 	}
 }
 
@@ -3627,7 +3580,7 @@ func assertNodeDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want st
 		}
 		deadLetters := make([]string, 0)
 		deadRows, err := db.QueryContext(context.Background(), `
-			SELECT COALESCE(handler_node, ''), COALESCE(failure->>'class', ''), COALESCE(failure->'detail'->>'code', '')
+			SELECT COALESCE(handler_node, ''), COALESCE(failure->>'class', ''), COALESCE(failure::text, '')
 			FROM dead_letters
 			WHERE original_event_id = $1::uuid
 			ORDER BY created_at ASC
@@ -3649,7 +3602,7 @@ func assertNodeDeliveryStatus(t *testing.T, db *sql.DB, eventID, nodeID, want st
 	}
 }
 
-func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChildContinuation(t *testing.T) {
+func TestEventBusPublish_NestedThreeLevelConnectChainExecutesEndToEnd(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
@@ -3686,13 +3639,134 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 	const rootEntityID = "11111111-1111-1111-1111-111111111111"
 	ctx := eventBusTestRunContext(t, db)
 	workflowStore := runtimepipeline.NewWorkflowInstanceStore(db)
-	if err := workflowStore.Upsert(ctx, runtimepipeline.WorkflowInstance{
-		InstanceID:      rootEntityID,
-		WorkflowName:    bundle.WorkflowName(),
-		WorkflowVersion: bundle.WorkflowVersion(),
-		CurrentState:    "idle",
-	}); err != nil {
-		t.Fatalf("seed root instance: %v", err)
+	for _, instance := range []runtimepipeline.WorkflowInstance{
+		{
+			InstanceID:      rootEntityID,
+			StorageRef:      rootEntityID,
+			WorkflowName:    bundle.WorkflowName(),
+			WorkflowVersion: bundle.WorkflowVersion(),
+			CurrentState:    "idle",
+		},
+		{
+			InstanceID:      runtimeflowidentity.EntityID("child"),
+			StorageRef:      "child",
+			WorkflowName:    "child",
+			WorkflowVersion: bundle.WorkflowVersion(),
+			CurrentState:    "waiting",
+			Metadata: map[string]any{
+				"parent_entity_id": rootEntityID,
+			},
+		},
+		{
+			InstanceID:      runtimeflowidentity.EntityID("child/grandchild"),
+			StorageRef:      "child/grandchild",
+			WorkflowName:    "grandchild",
+			WorkflowVersion: bundle.WorkflowVersion(),
+			CurrentState:    "ready",
+		},
+	} {
+		if err := workflowStore.Upsert(ctx, instance); err != nil {
+			t.Fatalf("seed workflow instance %q: %v", instance.InstanceID, err)
+		}
+	}
+	rootConnectProbe := eventtest.RootIngress(
+		"bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		events.EventType("step.begin"),
+		"cataloge2e",
+		"",
+		[]byte(`{"entity_id":"`+rootEntityID+`"}`),
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForEntityID(events.EnvelopeForFlowInstance(events.EventEnvelope{}, rootEntityID), rootEntityID),
+		time.Now().UTC(),
+	)
+	rootConnectPlan, err := eb.CheckPublishRecipientPlan(ctx, rootConnectProbe)
+	if err != nil {
+		t.Fatalf("root connect preflight: %v", err)
+	}
+	if rootConnectPlan.TargetFailure != "" || len(rootConnectPlan.DeliveryRoutes) == 0 {
+		t.Fatalf("root connect preflight failure=%q routes=%#v", rootConnectPlan.TargetFailure, rootConnectPlan.DeliveryRoutes)
+	}
+	if got := rootConnectPlan.DeliveryRoutes[0]; got.SubscriberID != "child-relay" {
+		t.Fatalf("root connect preflight route=%#v, want child-relay", got)
+	}
+	childTarget := rootConnectPlan.DeliveryRoutes[0].Target.Normalized()
+	previewEnvelope := events.EnvelopeForEntityID(events.EventEnvelope{}, rootEntityID)
+	previewEnvelope = events.EnvelopeForTargetRoute(previewEnvelope, childTarget)
+	previewEvent := eventtest.RootIngress("", events.EventType("step.begin"), "cataloge2e", "", []byte(`{"entity_id":"`+rootEntityID+`"}`), 0,
+		eventBusTestRunID, "", previewEnvelope, time.Now().UTC())
+	if _, err := runtimepipeline.PreviewContractHandlerExecution(ctx, bundle, "child-relay", previewEvent, runtimepipeline.WorkflowState{
+		EntityID: childTarget.EntityID,
+		Stage:    "waiting",
+	}, nil); err != nil {
+		t.Fatalf("preview child connect delivery: %v", err)
+	}
+	grandchildConnectProbe := eventtest.RootIngress(
+		"cccccccc-dddd-eeee-ffff-000000000000",
+		events.EventType("child/micro.start"),
+		"child-relay",
+		"",
+		nil,
+		0,
+		eventBusTestRunID,
+		"",
+		events.EnvelopeForSourceRoute(events.EventEnvelope{}, childTarget),
+		time.Now().UTC(),
+	)
+	grandchildConnectPlan, err := eb.CheckPublishRecipientPlan(ctx, grandchildConnectProbe)
+	if err != nil {
+		t.Fatalf("grandchild connect preflight: %v", err)
+	}
+	if grandchildConnectPlan.TargetFailure != "" || len(grandchildConnectPlan.DeliveryRoutes) == 0 {
+		t.Fatalf("grandchild connect preflight failure=%q routes=%#v", grandchildConnectPlan.TargetFailure, grandchildConnectPlan.DeliveryRoutes)
+	}
+	grandchildTarget := grandchildConnectPlan.DeliveryRoutes[0].Target.Normalized()
+	storedGrandchild, found, err := workflowStore.Load(ctx, grandchildTarget.EntityID)
+	if err != nil {
+		t.Fatalf("load grandchild connect target: %v", err)
+	}
+	if !found {
+		t.Fatalf("grandchild connect target %#v has no stored instance", grandchildTarget)
+	}
+	storedGrandchildIdentity := runtimepipeline.StoredFlowInstance(semanticview.Wrap(bundle), storedGrandchild)
+	if storedGrandchildIdentity.ScopeKey != "child/grandchild" {
+		t.Fatalf("grandchild stored identity = %#v, want child/grandchild scope; instance=%#v", storedGrandchildIdentity, storedGrandchild)
+	}
+	grandchildPreviewEnvelope := events.EnvelopeForTargetRoute(events.EventEnvelope{}, grandchildTarget)
+	grandchildPreviewEvent := eventtest.RootIngress("", events.EventType("micro.start"), "child-relay", "", nil, 0,
+		eventBusTestRunID, "", grandchildPreviewEnvelope, time.Now().UTC())
+	if _, err := runtimepipeline.PreviewContractHandlerExecution(ctx, bundle, "grandchild-worker", grandchildPreviewEvent, runtimepipeline.WorkflowState{
+		EntityID: grandchildTarget.EntityID,
+		Stage:    "ready",
+	}, nil); err != nil {
+		t.Fatalf("preview grandchild connect delivery: %v", err)
+	}
+	rootReturnEnvelope := events.EnvelopeForSourceRoute(events.EventEnvelope{}, childTarget)
+	rootReturnEnvelope = events.EnvelopeForTargetRoute(rootReturnEnvelope, events.RouteIdentity{
+		EntityID: rootEntityID,
+	})
+	rootReturnProbe := eventtest.RootIngress(
+		"dddddddd-eeee-ffff-0000-111111111111",
+		events.EventType("child/micro.relayed"),
+		"child-relay",
+		"",
+		nil,
+		0,
+		eventBusTestRunID,
+		"",
+		rootReturnEnvelope,
+		time.Now().UTC(),
+	)
+	rootReturnPlan, err := eb.CheckPublishRecipientPlan(ctx, rootReturnProbe)
+	if err != nil {
+		t.Fatalf("root return preflight: %v", err)
+	}
+	if rootReturnPlan.TargetFailure != "" || len(rootReturnPlan.DeliveryRoutes) == 0 {
+		t.Fatalf("root return preflight failure=%q routes=%#v", rootReturnPlan.TargetFailure, rootReturnPlan.DeliveryRoutes)
+	}
+	if got := rootReturnPlan.DeliveryRoutes[0].SubscriberID; got != "root-collector" {
+		t.Fatalf("root return preflight subscriber = %q, want root-collector", got)
 	}
 
 	if err := eb.Publish(ctx, eventtest.RootIngress(
@@ -3712,6 +3786,21 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 	if err := eb.WaitForQuiescence(ctx); err != nil {
 		t.Fatalf("WaitForQuiescence: %v", err)
 	}
+	var stepBeginEventID string
+	if err := db.QueryRowContext(ctx, `SELECT event_id::text FROM events WHERE event_name = 'step.begin' ORDER BY created_at DESC LIMIT 1`).Scan(&stepBeginEventID); err != nil {
+		t.Fatalf("load step.begin event id: %v", err)
+	}
+	assertNodeDeliveryStatus(t, db, stepBeginEventID, "child-relay", "delivered")
+	var microStartEventID string
+	if err := db.QueryRowContext(ctx, `SELECT event_id::text FROM events WHERE event_name = 'child/micro.start' ORDER BY created_at DESC LIMIT 1`).Scan(&microStartEventID); err != nil {
+		t.Fatalf("load child/micro.start event id: %v", err)
+	}
+	assertNodeDeliveryStatus(t, db, microStartEventID, "grandchild-worker", "delivered")
+	var microRelayedEventID string
+	if err := db.QueryRowContext(ctx, `SELECT event_id::text FROM events WHERE event_name = 'child/micro.relayed' ORDER BY created_at DESC LIMIT 1`).Scan(&microRelayedEventID); err != nil {
+		t.Fatalf("load child/micro.relayed event id: %v", err)
+	}
+	assertNodeDeliveryStatus(t, db, microRelayedEventID, "root-collector", "delivered")
 
 	root, found, err := workflowStore.Load(ctx, rootEntityID)
 	if err != nil {
@@ -3720,7 +3809,7 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 	if !found {
 		t.Fatal("expected root instance")
 	}
-	if got := strings.TrimSpace(root.CurrentState); got != "idle" {
+	if got := strings.TrimSpace(root.CurrentState); got != "done" {
 		rows, _ := db.QueryContext(context.Background(), `SELECT event_name, COALESCE(entity_id::text,''), COALESCE(flow_instance,'') FROM events ORDER BY created_at ASC, event_id ASC`)
 		dump := make([]string, 0)
 		if rows != nil {
@@ -3733,7 +3822,7 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 			}
 		}
 		instances, _ := workflowStore.List(ctx)
-		t.Fatalf("root current_state = %q, want idle without subject-link back-propagation; events=%v instances=%#v", got, dump, instances)
+		t.Fatalf("root current_state = %q, want done through declared ancestor connects; events=%v instances=%#v", got, dump, instances)
 	}
 
 	instances, err := workflowStore.List(ctx)
@@ -3769,16 +3858,16 @@ func TestEventBusPublish_NestedThreeLevelChain_FromRootStartCompletesWithoutChil
 		}
 	}
 	if childState != "completed" {
-		t.Fatalf("child current_state = %q, want completed", childState)
+		t.Fatalf("child current_state = %q, want completed; events=%v instances=%#v", childState, emitted, instances)
 	}
 	if grandchildState != "finished" {
-		t.Fatalf("grandchild current_state = %q, want finished; events=%v instances=%#v", grandchildState, emitted, instances)
+		t.Fatalf("grandchild current_state = %q, want finished; events=%v instances=%#v nodes=%#v", grandchildState, emitted, instances, module.WorkflowNodes())
 	}
 	if contains(emitted, "child/step.result") {
 		t.Fatalf("events = %v, do not want child/step.result", emitted)
 	}
-	if contains(emitted, "pipeline.complete") {
-		t.Fatalf("events = %v, do not want pipeline.complete without subject-link back-propagation", emitted)
+	if !contains(emitted, "pipeline.complete") {
+		t.Fatalf("events = %v, want pipeline.complete through declared ancestor connects", emitted)
 	}
 }
 
@@ -3874,12 +3963,12 @@ func TestEventBusPublish_GatedChildFlowCompletionAdvancesRoot(t *testing.T) {
 	}
 }
 
-func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
+func TestEventBusPublish_RecordsNestedPackageConnectLocalizedEvent(t *testing.T) {
 	grandchild := runtimecontracts.FlowContractView{
-		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild"},
+		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild", PackageKey: "flows/child/flows/grandchild"},
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
-				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"micro.done"}},
+				Outputs: runtimecontracts.FlowOutputPins{EventPins: []runtimecontracts.FlowOutputEventPin{{Name: "micro_done", Event: "micro.done"}}},
 			},
 		},
 		Path: "child/grandchild",
@@ -3888,9 +3977,10 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 		},
 	}
 	child := runtimecontracts.FlowContractView{
-		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child"},
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
+				Inputs:  runtimecontracts.FlowInputPins{EventPins: []runtimecontracts.FlowInputEventPin{{Name: "micro_done", Event: "micro.done"}}},
 				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"step.result"}},
 			},
 		},
@@ -3898,9 +3988,10 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"child-aggregator": {
 				ID:           "child-aggregator",
-				SubscribesTo: []string{"grandchild/micro.done"},
+				SubscribesTo: []string{"micro.done"},
 			},
 		},
+		Events:   map[string]runtimecontracts.EventCatalogEntry{"micro.done": {}},
 		Children: []runtimecontracts.FlowContractView{grandchild},
 	}
 	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{child}}
@@ -3912,6 +4003,17 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 				"grandchild": &root.Children[0].Children[0],
 			},
 		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"child":      child.Schema,
+			"grandchild": grandchild.Schema,
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+			PackageKey: "flows/child",
+			SourceFile: "flows/child/package.yaml",
+			SourceLine: 10,
+			From:       "grandchild.micro_done",
+			To:         ".micro_done",
+		}}},
 	}
 	eb, err := newScopedTestEventBus(newRouteSetEventStore(), runtimebus.EventBusOptions{
 		ContractBundle: semanticview.Wrap(bundle),
@@ -3919,7 +4021,7 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	eb.Subscribe("child-aggregator")
+	eb.SubscribeInternal("child-aggregator")
 	defer eb.Unsubscribe("child-aggregator")
 	recorder := runtimebus.NewEmittedEventsRecorder()
 	ctx := runtimebus.WithEmittedEventsRecorder(context.Background(), recorder)
@@ -3930,8 +4032,8 @@ func TestEventBusPublish_RecordsNestedDescendantLocalizedEvent(t *testing.T) {
 	if len(diags) != 1 || len(diags[0].RoutedRecipients) != 1 {
 		t.Fatalf("publish diagnostics = %#v", diags)
 	}
-	if got := diags[0].RoutedRecipients[0].LocalizedEvent; got != "grandchild/micro.done" {
-		t.Fatalf("localized_event = %q, want grandchild/micro.done", got)
+	if got := diags[0].RoutedRecipients[0].LocalizedEvent; got != "micro.done" {
+		t.Fatalf("localized_event = %q, want child-local micro.done", got)
 	}
 }
 

--- a/internal/runtime/bus/eventbus_route_generation_plan_test.go
+++ b/internal/runtime/bus/eventbus_route_generation_plan_test.go
@@ -43,14 +43,14 @@ func TestEventBusSubscribedPublishDoesNotCrossAgentRouteGenerations(t *testing.T
 			const agentID = "route-generation-agent"
 			oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 11, AgentID: agentID, Generation: 1}
 			newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 11, AgentID: agentID, Generation: 2}
-			oldCh := eb.ReplaceAgentRoute(oldToken, events.EventType("test.route_generation"))
+			oldCh := eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.route_generation")))
 			evt := routeGenerationTestEvent("route-generation-publish", "test.route_generation")
 
 			publishDone := make(chan error, 1)
 			go func() { publishDone <- eb.Publish(context.Background(), evt) }()
 			requireRouteGenerationSignal(t, barrier.started, "publish interceptor")
 
-			newCh := eb.ReplaceAgentRoute(newToken, test.successorEventTypes...)
+			newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, test.successorEventTypes...))
 			close(barrier.release)
 			if err := requireRouteGenerationResult(t, publishDone, "Publish"); !errors.Is(err, errAuthoritativeDeliveryIncomplete) {
 				t.Fatalf("Publish error = %v, want authoritative delivery incomplete", err)
@@ -86,7 +86,7 @@ func TestEventBusPublishInMutationDoesNotCrossAgentRouteGenerations(t *testing.T
 	const agentID = "route-generation-mutation-agent"
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 12, AgentID: agentID, Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 12, AgentID: agentID, Generation: 2}
-	oldCh := eb.ReplaceAgentRoute(oldToken, events.EventType("test.route_generation_mutation"))
+	oldCh := eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.route_generation_mutation")))
 	evt := routeGenerationTestEvent("route-generation-mutation", "test.route_generation_mutation")
 
 	mutationDone := make(chan error, 1)
@@ -96,7 +96,7 @@ func TestEventBusPublishInMutationDoesNotCrossAgentRouteGenerations(t *testing.T
 		})
 	}()
 	requireRouteGenerationSignal(t, barrier.started, "post-commit interceptor")
-	newCh := eb.ReplaceAgentRoute(newToken, events.EventType("test.route_generation_mutation"))
+	newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, events.EventType("test.route_generation_mutation")))
 	close(barrier.release)
 	if err := requireRouteGenerationResult(t, mutationDone, "RunEventMutation"); err != nil {
 		t.Fatalf("RunEventMutation: %v", err)
@@ -116,14 +116,14 @@ func TestEventBusPublishAcknowledgedDoesNotCrossAgentRouteGenerations(t *testing
 	const agentID = "route-generation-ack-agent"
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 13, AgentID: agentID, Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 13, AgentID: agentID, Generation: 2}
-	oldCh := eb.ReplaceAgentRoute(oldToken, events.EventType("test.route_generation_ack"))
+	oldCh := eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.route_generation_ack")))
 	evt := routeGenerationTestEvent("route-generation-ack", "test.route_generation_ack")
 
 	if err := eb.PublishAcknowledged(context.Background(), evt); err != nil {
 		t.Fatalf("PublishAcknowledged: %v", err)
 	}
 	requireRouteGenerationSignal(t, barrier.started, "acknowledged interceptor")
-	newCh := eb.ReplaceAgentRoute(newToken, events.EventType("test.route_generation_ack"))
+	newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, events.EventType("test.route_generation_ack")))
 	close(barrier.release)
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -143,7 +143,7 @@ func TestEventBusIdentityRoutePlanResolvesCurrentAgentGenerationAtDispatch(t *te
 	const agentID = "identity-route-generation-agent"
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 14, AgentID: agentID, Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 14, AgentID: agentID, Generation: 2}
-	oldCh := eb.ReplaceAgentRoute(oldToken, events.EventType("test.identity_route"))
+	oldCh := eb.ReplaceAgentRoute(oldToken, testAgentSubscriptionAdmission(t, oldToken.AgentID, events.EventType("test.identity_route")))
 	evt := routeGenerationTestEvent("identity-route-generation", "test.identity_route")
 	plan, err := eb.planDirectRoutePlan(context.Background(), evt, []string{agentID})
 	if err != nil {
@@ -152,7 +152,7 @@ func TestEventBusIdentityRoutePlanResolvesCurrentAgentGenerationAtDispatch(t *te
 	if len(plan.LiveRecipients) != 1 || plan.LiveRecipients[0].liveAuthority != liveRecipientAuthorityIdentity {
 		t.Fatalf("direct live recipients = %#v, want one identity-authoritative recipient", plan.LiveRecipients)
 	}
-	newCh := eb.ReplaceAgentRoute(newToken, events.EventType("test.identity_route"))
+	newCh := eb.ReplaceAgentRoute(newToken, testAgentSubscriptionAdmission(t, newToken.AgentID, events.EventType("test.identity_route")))
 	if err := eb.deliverRoutePlanWithRoutes(context.Background(), evt, plan); err != nil {
 		t.Fatalf("deliverRoutePlanWithRoutes: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestEventBusIdentityRouteAuthorityDominatesDuplicateExactSubscription(t *te
 	}
 	const agentID = "duplicate-route-authority-agent"
 	token := runtimeeffects.LifecycleToken{RuntimeEpoch: 15, AgentID: agentID, Generation: 1}
-	eb.ReplaceAgentRoute(token, events.EventType("test.duplicate_route"))
+	eb.ReplaceAgentRoute(token, testAgentSubscriptionAdmission(t, token.AgentID, events.EventType("test.duplicate_route")))
 	eb.mu.RLock()
 	route := eb.agentRouteHandles[agentID]
 	eb.mu.RUnlock()

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -281,7 +281,7 @@ func TestEventBusPublish_TargetedNodeConsumeSuppressesLiveRecipientDelivery(t *t
 	if err != nil {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	live := eb.Subscribe("target-node", events.EventType(eventType))
+	live := eb.SubscribeAgent(testAgentSubscriptionAdmissionForFlow(t, "target-node", "worker", events.EventType(eventType)))
 	defer eb.Unsubscribe("target-node")
 	evt := eventtest.RootIngress(
 		eventID,
@@ -375,7 +375,7 @@ func TestEventBusAgentDispatchIgnoresSameIDNodeRouteTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEventBus: %v", err)
 	}
-	ch := eb.Subscribe("shared-subscriber", events.EventType("review/inst-1/task.started"))
+	ch := eb.SubscribeAgent(testAgentSubscriptionAdmissionForFlow(t, "shared-subscriber", "review/inst-1", events.EventType("review/inst-1/task.started")))
 	defer eb.Unsubscribe("shared-subscriber")
 
 	evt := eventtest.RootIngress(uuid.NewString(),

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -12,130 +12,47 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
-func TestImportBoundaryInputAliasRoutesParentEventToPackageInputPin(t *testing.T) {
+func TestImportBoundaryInputBindingDoesNotRouteWithoutConnect(t *testing.T) {
 	source := loadBusImportBoundaryAliasSource(t)
 	rt, err := runtimebus.DeriveRouteTable(source)
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
 	routes := rt.Resolve("parent.lead_captured")
-	if len(routes) != 1 || routes[0].ID != "worker-node" {
-		t.Fatalf("Resolve(parent.lead_captured) = %#v, want worker-node", routes)
-	}
-	if got := routes[0].LocalizedEvent; got != "work.requested" {
-		t.Fatalf("localized event = %q, want work.requested", got)
-	}
-	if got := rt.Resolve("work.requested"); len(got) != 0 {
-		t.Fatalf("Resolve(work.requested) = %#v, want no raw fallback", got)
-	}
-
-	store := &routePersistenceTestStore{}
-	eb, err := newScopedTestEventBus(store, runtimebus.EventBusOptions{ContractBundle: source})
-	if err != nil {
-		t.Fatalf("NewEventBusWithOptions: %v", err)
-	}
-	evt := eventtest.RootIngress("evt-input-alias", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
-	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
-	if err != nil {
-		t.Fatalf("CheckPublishRecipientPlan: %v", err)
-	}
-	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "worker-node" {
-		t.Fatalf("routed recipients = %#v, want worker-node", plan.RoutedRecipients)
-	}
-	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "work.requested" {
-		t.Fatalf("plan localized event = %q, want work.requested", got)
-	}
-	if err := eb.Publish(context.Background(), evt); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	if got := store.deliveries["evt-input-alias"]; len(got) != 1 || got[0] != "worker-node" {
-		t.Fatalf("persisted deliveries = %#v, want worker-node", got)
+	if len(routes) != 0 {
+		t.Fatalf("Resolve(parent.lead_captured) = %#v, want bind-only input to be inert", routes)
 	}
 }
 
-func TestImportBoundaryOutputAliasRoutesPackageOutputToParentEvent(t *testing.T) {
+func TestImportBoundaryOutputBindingDoesNotRouteWithoutConnect(t *testing.T) {
 	source := loadBusImportBoundaryAliasSource(t)
 	rt, err := runtimebus.DeriveRouteTable(source)
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
 	routes := rt.Resolve("worker/work.completed")
-	if len(routes) != 1 || routes[0].ID != "parent-listener" {
-		t.Fatalf("Resolve(worker/work.completed) = %#v, want parent-listener", routes)
-	}
-	if got := routes[0].LocalizedEvent; got != "parent.lead_enriched" {
-		t.Fatalf("localized event = %q, want parent.lead_enriched", got)
-	}
-
-	store := &routePersistenceTestStore{}
-	eb, err := newScopedTestEventBus(store, runtimebus.EventBusOptions{ContractBundle: source})
-	if err != nil {
-		t.Fatalf("NewEventBusWithOptions: %v", err)
-	}
-	evt := eventtest.RootIngress("evt-output-alias", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
-	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
-	if err != nil {
-		t.Fatalf("CheckPublishRecipientPlan: %v", err)
-	}
-	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "parent-listener" {
-		t.Fatalf("routed recipients = %#v, want parent-listener", plan.RoutedRecipients)
-	}
-	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "parent.lead_enriched" {
-		t.Fatalf("plan localized event = %q, want parent.lead_enriched", got)
-	}
-	if err := eb.Publish(context.Background(), evt); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	if got := store.deliveries["evt-output-alias"]; len(got) != 1 || got[0] != "parent-listener" {
-		t.Fatalf("persisted deliveries = %#v, want parent-listener", got)
+	if len(routes) != 0 {
+		t.Fatalf("Resolve(worker/work.completed) = %#v, want bind-only output to be inert", routes)
 	}
 }
 
-func TestImportBoundaryOutputAliasRoutesPackageOutputToWildcardParentSubscriber(t *testing.T) {
+func TestImportBoundaryOutputBindingDoesNotAuthorizeWildcardWithoutConnect(t *testing.T) {
 	source := loadBusImportBoundaryAliasWildcardOutputSource(t)
 	rt, err := runtimebus.DeriveRouteTable(source)
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
 	routes := rt.Resolve("worker/work.completed")
-	if len(routes) != 1 || routes[0].ID != "parent-listener" {
-		t.Fatalf("Resolve(worker/work.completed) = %#v, want parent-listener", routes)
-	}
-	if got := routes[0].MatchPattern; got != "parent.*" {
-		t.Fatalf("match pattern = %q, want parent.*", got)
-	}
-	if got := routes[0].LocalizedEvent; got != "parent.lead_enriched" {
-		t.Fatalf("localized event = %q, want parent.lead_enriched", got)
-	}
-
-	store := &routePersistenceTestStore{}
-	eb, err := newScopedTestEventBus(store, runtimebus.EventBusOptions{ContractBundle: source})
-	if err != nil {
-		t.Fatalf("NewEventBusWithOptions: %v", err)
-	}
-	evt := eventtest.RootIngress("evt-output-alias-wildcard", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Now().UTC())
-	plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
-	if err != nil {
-		t.Fatalf("CheckPublishRecipientPlan: %v", err)
-	}
-	if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != "parent-listener" {
-		t.Fatalf("routed recipients = %#v, want parent-listener", plan.RoutedRecipients)
-	}
-	if got := plan.RoutedRecipients[0].LocalizedEvent; got != "parent.lead_enriched" {
-		t.Fatalf("plan localized event = %q, want parent.lead_enriched", got)
-	}
-	if err := eb.Publish(context.Background(), evt); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	if got := store.deliveries["evt-output-alias-wildcard"]; len(got) != 1 || got[0] != "parent-listener" {
-		t.Fatalf("persisted deliveries = %#v, want parent-listener", got)
+	if len(routes) != 0 {
+		t.Fatalf("Resolve(worker/work.completed) = %#v, want bind-only output to grant no wildcard route", routes)
 	}
 }
 
-func TestImportBoundaryInputAliasMaterializesTemplateRoute(t *testing.T) {
+func TestImportBoundaryInputBindingDoesNotMaterializeTemplateRouteWithoutConnect(t *testing.T) {
 	source := loadBusImportBoundaryAliasTemplateSource(t)
 	rt, err := runtimebus.DeriveRouteTable(source)
 	if err != nil {
@@ -150,17 +67,50 @@ func TestImportBoundaryInputAliasMaterializesTemplateRoute(t *testing.T) {
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	routes := rt.Resolve("parent.lead_captured")
-	if len(routes) != 1 || routes[0].ID != "worker-node" {
-		t.Fatalf("Resolve(parent.lead_captured) = %#v, want worker-node", routes)
+	if len(routes) != 0 {
+		t.Fatalf("Resolve(parent.lead_captured) = %#v, want bind-only template route to remain inert", routes)
 	}
-	if got := routes[0].Path; got != "worker/inst-1" {
-		t.Fatalf("route path = %q, want worker/inst-1", got)
+}
+
+func TestImportBoundaryConnectConsumesBindingsForInputAndRootOutputDelivery(t *testing.T) {
+	source := loadBusImportBoundaryConnectedSource(t)
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	if len(issues) != 0 || len(plans) != 2 {
+		t.Fatalf("connect plans = %#v, issues = %#v, want two valid plans", plans, issues)
 	}
-	if got := routes[0].LocalizedEvent; got != "work.requested" {
-		t.Fatalf("localized event = %q, want work.requested", got)
+	store := &routePersistenceTestStore{}
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
-	if got := rt.Resolve("work.requested"); len(got) != 0 {
-		t.Fatalf("Resolve(work.requested) = %#v, want no raw template fallback", got)
+	for _, tc := range []struct {
+		id        string
+		eventType string
+		recipient string
+		envelope  events.EventEnvelope
+	}{
+		{id: "evt-input-connect", eventType: "parent.lead_captured", recipient: "worker-node"},
+		{
+			id:        "evt-output-connect",
+			eventType: "worker/work.completed",
+			recipient: "parent-listener",
+			envelope:  events.EnvelopeForTargetRoute(events.EventEnvelope{}, events.RouteIdentity{EntityID: "root-entity"}),
+		},
+	} {
+		evt := eventtest.RootIngress(tc.id, events.EventType(tc.eventType), "", "", []byte(`{}`), 0, "", "", tc.envelope, time.Now().UTC())
+		plan, err := eb.CheckPublishRecipientPlan(context.Background(), evt)
+		if err != nil {
+			t.Fatalf("CheckPublishRecipientPlan(%s): %v", tc.eventType, err)
+		}
+		if len(plan.RoutedRecipients) != 1 || plan.RoutedRecipients[0].ID != tc.recipient {
+			t.Fatalf("routed recipients for %s = %#v, want %s", tc.eventType, plan.RoutedRecipients, tc.recipient)
+		}
+		if err := eb.Publish(context.Background(), evt); err != nil {
+			t.Fatalf("Publish(%s): %v", tc.eventType, err)
+		}
+		if got := store.deliveries[tc.id]; len(got) != 1 || got[0] != tc.recipient {
+			t.Fatalf("persisted deliveries for %s = %#v, want %s", tc.eventType, got, tc.recipient)
+		}
 	}
 }
 
@@ -186,6 +136,21 @@ func loadBusImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	}
 	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
 	root := writeBusImportBoundaryAliasFixture(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func loadBusImportBoundaryConnectedSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := writeBusImportBoundaryConnectedFixture(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -224,12 +189,43 @@ func loadBusImportBoundaryAliasTemplateSource(t *testing.T) semanticview.Source 
 }
 
 func writeBusImportBoundaryAliasFixture(t *testing.T) string {
-	return writeBusImportBoundaryAliasFixtureWithParentSubscription(t, "parent.lead_enriched")
+	return writeBusImportBoundaryAliasFixtureWithOptions(t, "parent.lead_enriched", false)
 }
 
 func writeBusImportBoundaryAliasFixtureWithParentSubscription(t *testing.T, parentSubscription string) string {
+	return writeBusImportBoundaryAliasFixtureWithOptions(t, parentSubscription, false)
+}
+
+func writeBusImportBoundaryConnectedFixture(t *testing.T) string {
+	return writeBusImportBoundaryAliasFixtureWithOptions(t, "parent.lead_enriched", true)
+}
+
+func writeBusImportBoundaryAliasFixtureWithOptions(t *testing.T, parentSubscription string, connected bool) string {
 	t.Helper()
 	root := t.TempDir()
+	connect := ""
+	rootSchema := "name: bus-import-boundary-alias\n"
+	if connected {
+		connect = `
+connect:
+  - from: .lead_captured
+    to: worker.work_requested
+  - from: worker.work_completed
+    to: .lead_enriched
+`
+		rootSchema = `
+name: bus-import-boundary-alias
+pins:
+  inputs:
+    events:
+      - name: lead_enriched
+        event: parent.lead_enriched
+  outputs:
+    events:
+      - name: lead_captured
+        event: parent.lead_captured
+`
+	}
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: bus-import-boundary-alias
 version: "1.0.0"
@@ -243,8 +239,8 @@ flows:
         work.requested: parent.lead_captured
       outputs:
         work.completed: parent.lead_enriched
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: bus-import-boundary-alias\n")
+`+connect)
+	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
@@ -272,9 +268,13 @@ name: worker
 mode: static
 pins:
   inputs:
-    events: [work.requested]
+    events:
+      - name: work_requested
+        event: work.requested
   outputs:
-    events: [work.completed]
+    events:
+      - name: work_completed
+        event: work.completed
 `)
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
 	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
@@ -314,9 +314,13 @@ name: worker
 mode: template
 pins:
   inputs:
-    events: [work.requested]
+    events:
+      - name: work_requested
+        event: work.requested
   outputs:
-    events: [work.completed]
+    events:
+      - name: work_completed
+        event: work.completed
 `)
 	return root
 }

--- a/internal/runtime/bus/import_boundary_alias_routing_test.go
+++ b/internal/runtime/bus/import_boundary_alias_routing_test.go
@@ -2,8 +2,6 @@ package bus_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,6 +12,7 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 )
 
 func TestImportBoundaryInputBindingDoesNotRouteWithoutConnect(t *testing.T) {
@@ -130,207 +129,31 @@ func (s *routePersistenceTestStore) InsertEventDeliveryRoutes(_ context.Context,
 
 func loadBusImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeBusImportBoundaryAliasFixture(t)
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
-	}
-	return semanticview.Wrap(bundle)
+	return loadBusImportBoundaryVariant(t, canonicalrouting.ImportBoundaryAliasBindOnly)
 }
 
 func loadBusImportBoundaryConnectedSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeBusImportBoundaryConnectedFixture(t)
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
-	}
-	return semanticview.Wrap(bundle)
+	return loadBusImportBoundaryVariant(t, canonicalrouting.ImportBoundaryAliasConnected)
 }
 
 func loadBusImportBoundaryAliasWildcardOutputSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeBusImportBoundaryAliasFixtureWithParentSubscription(t, "parent.*")
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
-	if err != nil {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
-	}
-	return semanticview.Wrap(bundle)
+	return loadBusImportBoundaryVariant(t, canonicalrouting.ImportBoundaryAliasBindOnlyWildcardOutput)
 }
 
 func loadBusImportBoundaryAliasTemplateSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	repoRoot, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
-	root := writeBusImportBoundaryAliasTemplateFixture(t)
+	return loadBusImportBoundaryVariant(t, canonicalrouting.ImportBoundaryAliasTemplateBindOnly)
+}
+
+func loadBusImportBoundaryVariant(t *testing.T, variant canonicalrouting.ImportBoundaryAliasVariant) semanticview.Source {
+	t.Helper()
+	repoRoot := canonicalrouting.RepoRoot(t)
+	root := canonicalrouting.CopyImportBoundaryAlias(t, variant)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	return semanticview.Wrap(bundle)
-}
-
-func writeBusImportBoundaryAliasFixture(t *testing.T) string {
-	return writeBusImportBoundaryAliasFixtureWithOptions(t, "parent.lead_enriched", false)
-}
-
-func writeBusImportBoundaryAliasFixtureWithParentSubscription(t *testing.T, parentSubscription string) string {
-	return writeBusImportBoundaryAliasFixtureWithOptions(t, parentSubscription, false)
-}
-
-func writeBusImportBoundaryConnectedFixture(t *testing.T) string {
-	return writeBusImportBoundaryAliasFixtureWithOptions(t, "parent.lead_enriched", true)
-}
-
-func writeBusImportBoundaryAliasFixtureWithOptions(t *testing.T, parentSubscription string, connected bool) string {
-	t.Helper()
-	root := t.TempDir()
-	connect := ""
-	rootSchema := "name: bus-import-boundary-alias\n"
-	if connected {
-		connect = `
-connect:
-  - from: .lead_captured
-    to: worker.work_requested
-  - from: worker.work_completed
-    to: .lead_enriched
-`
-		rootSchema = `
-name: bus-import-boundary-alias
-pins:
-  inputs:
-    events:
-      - name: lead_enriched
-        event: parent.lead_enriched
-  outputs:
-    events:
-      - name: lead_captured
-        event: parent.lead_captured
-`
-	}
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
-name: bus-import-boundary-alias
-version: "1.0.0"
-platform_version: ">=0.7.0 <0.8.0"
-flows:
-  - id: worker
-    flow: worker
-    mode: static
-    bind:
-      inputs:
-        work.requested: parent.lead_captured
-      outputs:
-        work.completed: parent.lead_enriched
-`+connect)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "events.yaml"), `
-parent.lead_captured: {}
-parent.lead_enriched: {}
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
-parent-listener:
-  id: parent-listener
-  execution_type: system_node
-  subscribes_to: [`+parentSubscription+`]
-  event_handlers:
-    parent.lead_enriched: {}
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
-name: worker
-version: "1.0.0"
-requires:
-  inputs: [work.requested]
-  outputs: [work.completed]
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
-name: worker
-mode: static
-pins:
-  inputs:
-    events:
-      - name: work_requested
-        event: work.requested
-  outputs:
-    events:
-      - name: work_completed
-        event: work.completed
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "work.completed: {}\n")
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
-worker-node:
-  id: worker-node
-  execution_type: system_node
-  subscribes_to: [work.requested]
-  produces: [work.completed]
-  event_handlers:
-    work.requested:
-      emit: work.completed
-`)
-	return root
-}
-
-func writeBusImportBoundaryAliasTemplateFixture(t *testing.T) string {
-	t.Helper()
-	root := writeBusImportBoundaryAliasFixture(t)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "package.yaml"), `
-name: bus-import-boundary-alias
-version: "1.0.0"
-platform_version: ">=0.7.0 <0.8.0"
-flows:
-  - id: worker
-    flow: worker
-    mode: template
-    bind:
-      inputs:
-        work.requested: parent.lead_captured
-      outputs:
-        work.completed: parent.lead_enriched
-`)
-	writeBusImportBoundaryFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
-name: worker
-mode: template
-pins:
-  inputs:
-    events:
-      - name: work_requested
-        event: work.requested
-  outputs:
-    events:
-      - name: work_completed
-        event: work.completed
-`)
-	return root
-}
-
-func writeBusImportBoundaryFixtureFile(t *testing.T, path, contents string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir fixture dir: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-		t.Fatalf("write fixture %s: %v", path, err)
-	}
 }

--- a/internal/runtime/bus/import_boundary_wildcard_routing_test.go
+++ b/internal/runtime/bus/import_boundary_wildcard_routing_test.go
@@ -60,6 +60,60 @@ func TestImportBoundaryWildcardScopesImportedPackageToOwnSubtreeByDefault(t *tes
 	}
 }
 
+func TestFlowOwnedAgentAdmissionScopesImportedWildcardToOwnSubtree(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{})
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "worker-agent",
+		FlowID:        "worker",
+		FlowPath:      "worker",
+		PackageKey:    "flows/worker",
+		LocalEvents:   map[string]struct{}{"task.done": {}},
+		Subscriptions: []string{"**/task.done"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	if got := admission.RoutePatterns(); len(got) != 1 || got[0] != "worker/**/task.done" {
+		t.Fatalf("route patterns = %#v, want only worker/**/task.done", got)
+	}
+}
+
+func TestFlowOwnedAgentAdmissionRejectsImportedSiblingWildcardWithoutGrant(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{})
+	_, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "worker-agent",
+		FlowID:        "worker",
+		FlowPath:      "worker",
+		PackageKey:    "flows/worker",
+		LocalEvents:   map[string]struct{}{"task.done": {}},
+		Subscriptions: []string{"producer/**/task.done"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no imported-package subtree candidate or bind.observe grant") {
+		t.Fatalf("error = %v, want missing typed wildcard/grant rejection", err)
+	}
+}
+
+func TestFlowOwnedAgentAdmissionConsumesImportedObserveGrant(t *testing.T) {
+	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{
+		ObserveGrant: "      observe:\n        - source: producer\n          events: [task.done]\n",
+	})
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "worker-agent",
+		FlowID:        "worker",
+		FlowPath:      "worker",
+		PackageKey:    "flows/worker",
+		LocalEvents:   map[string]struct{}{"task.done": {}},
+		Subscriptions: []string{"**/task.done"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	got := strings.Join(admission.RoutePatterns(), ",")
+	if !strings.Contains(got, "worker/**/task.done") || !strings.Contains(got, "producer/task.done") {
+		t.Fatalf("route patterns = %#v, want own subtree and granted producer candidate", admission.RoutePatterns())
+	}
+}
+
 func TestImportBoundaryWildcardObserveGrantAddsNarrowSiblingCandidate(t *testing.T) {
 	source := loadBusImportBoundaryWildcardSource(t, importBoundaryWildcardFixtureOptions{
 		ObserveGrant: "      observe:\n        - source: producer\n          events: [task.done]\n",

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -9,6 +9,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -693,7 +694,7 @@ func (rt *RouteTable) addAgentPatternsLocked(source semanticview.Source, package
 			Path: strings.Trim(strings.TrimSpace(basePath), "/"),
 		}
 		for _, rawPattern := range normalizeStringList(entry.Subscriptions) {
-			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) && !routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
+			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) {
 				rt.addReceiverCarrierPatternsLocked(inputEvents, basePath, subscriber, rawPattern)
 			}
 			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
@@ -724,7 +725,7 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 			patterns = source.NodeRuntimeSubscriptions(semanticNodeID)
 		}
 		for _, rawPattern := range patterns {
-			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) && !routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
+			if routeFlowInputHasLoweredConnectReceiver(source, flowID, rawPattern) {
 				rt.addReceiverCarrierPatternsLocked(inputEvents, basePath, subscriber, rawPattern)
 			}
 			for _, resolved := range routeResolveSubscriberPatterns(source, packageKey, flowID, inputEvents, basePath, localEvents, rawPattern) {
@@ -732,9 +733,6 @@ func (rt *RouteTable) addNodePatternsLocked(source semanticview.Source, packageK
 					continue
 				}
 				rt.addResolvedPatternLocked(subscriber, resolved, "")
-			}
-			if routeInputAliasRequiresExclusivePatterns(source, flowID, rawPattern) {
-				continue
 			}
 			if resolved := routeResolveNodeCanonicalPattern(source, basePath, semanticNodeID, rawPattern); strings.TrimSpace(resolved.EventPattern) != "" {
 				rt.addResolvedPatternLocked(subscriber, resolved, "")
@@ -897,10 +895,23 @@ func routeResolveNodeCanonicalPattern(source semanticview.Source, basePath, node
 	if resolved == "" || resolved == rawPattern || strings.Contains(resolved, "*") {
 		return routeResolvedPattern{}
 	}
+	if !routeExactPatternOwnedByScope(basePath, resolved) {
+		return routeResolvedPattern{}
+	}
 	return routeResolvedPattern{
 		EventPattern: resolved,
 		RouteSource:  "subscription",
 	}
+}
+
+func routeExactPatternOwnedByScope(basePath, pattern string) bool {
+	basePath = eventidentity.Normalize(basePath)
+	pattern = eventidentity.Normalize(pattern)
+	if basePath == "" || pattern == "" || !strings.HasPrefix(pattern, basePath+"/") {
+		return false
+	}
+	local := strings.TrimPrefix(pattern, basePath+"/")
+	return local != "" && !strings.Contains(local, "/")
 }
 
 func (rt *RouteTable) rebuildLocked() {
@@ -982,31 +993,16 @@ func routeFlowInputHasLoweredConnectReceiver(source semanticview.Source, flowID,
 	if eventType == "" {
 		return false
 	}
-	for _, connect := range source.CompositionConnects() {
-		to, err := connect.ToRef()
-		if err != nil || strings.TrimSpace(to.FlowID) != strings.TrimSpace(flowID) {
+	plans, _ := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	for _, plan := range plans {
+		if strings.TrimSpace(plan.Receiver.FlowID) != strings.TrimSpace(flowID) {
 			continue
 		}
-		inputPin, ok := source.FlowInputEventPin(to.FlowID, to.Pin)
-		if !ok {
-			continue
-		}
-		if eventidentity.Normalize(inputPin.EventType()) == eventType {
+		if eventidentity.Normalize(plan.Receiver.Event) == eventType {
 			return true
 		}
 	}
 	return false
-}
-
-func routeInputAliasRequiresExclusivePatterns(source semanticview.Source, flowID, eventType string) bool {
-	if source == nil || strings.TrimSpace(flowID) == "" {
-		return false
-	}
-	eventType = eventidentity.Normalize(eventType)
-	if eventType == "" || !source.FlowHasInputEvent(flowID, eventType) {
-		return false
-	}
-	return semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType)
 }
 
 func routeNodeLocalEventSet(node runtimecontracts.SystemNodeContract) map[string]struct{} {
@@ -1126,57 +1122,10 @@ func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flow
 	if flowID != "" && source != nil && source.FlowHasInputEvent(flowID, raw) {
 		patterns := routeInputProducerPatterns(source.ResolveFlowInputAutoWire(flowID, raw))
 		if len(patterns) > 0 {
-			if len(semanticview.ImportBoundaryInputAliases(source, flowID, raw)) > 0 {
-				for i := range patterns {
-					patterns[i].RouteSource = "pin_bind_input_alias"
-					patterns[i].LocalizedEvent = raw
-				}
-			}
 			return patterns
-		}
-		if semanticview.ImportBoundaryInputAliasRequired(source, flowID, raw) {
-			return nil
 		}
 	}
 	if source != nil {
-		outputAliases := semanticview.ImportBoundaryOutputAliasesForParentEvent(source, packageKey, flowID, raw)
-		if len(outputAliases) > 0 {
-			out := make([]routeResolvedPattern, 0, len(outputAliases))
-			for _, alias := range outputAliases {
-				pattern := eventidentity.Normalize(alias.EventPattern)
-				if pattern == "" {
-					continue
-				}
-				out = append(out, routeResolvedPattern{
-					EventPattern:   pattern,
-					RouteSource:    "pin_bind_output_alias",
-					LocalizedEvent: raw,
-				})
-			}
-			if len(out) > 0 {
-				return out
-			}
-		}
-		if strings.Contains(raw, "*") {
-			outputAliases := semanticview.ImportBoundaryOutputAliasesForParent(source, packageKey, flowID)
-			out := make([]routeResolvedPattern, 0, len(outputAliases))
-			for _, alias := range outputAliases {
-				parentEvent := eventidentity.Normalize(alias.ParentEvent)
-				pattern := eventidentity.Normalize(alias.EventPattern)
-				if parentEvent == "" || pattern == "" || !RouteMatches(raw, parentEvent) {
-					continue
-				}
-				out = append(out, routeResolvedPattern{
-					EventPattern:   pattern,
-					MatchPattern:   raw,
-					RouteSource:    "pin_bind_output_alias",
-					LocalizedEvent: parentEvent,
-				})
-			}
-			if len(out) > 0 {
-				return out
-			}
-		}
 		if strings.Contains(raw, "*") {
 			resolution := semanticview.ResolveImportBoundaryWildcardSubscription(source, packageKey, flowID, basePath, localEvents, raw)
 			if resolution.Scoped {
@@ -1199,6 +1148,9 @@ func routeResolveSubscriberPatterns(source semanticview.Source, packageKey, flow
 				return out
 			}
 		}
+	}
+	if !strings.Contains(raw, "*") && strings.Contains(raw, "/") && !routeExactPatternOwnedByScope(basePath, raw) {
+		return nil
 	}
 	scope := routeEventIdentityScope(basePath, localEvents, inputEvents)
 	pattern := scope.ResolveSubscriptionPattern(raw, routeDescendantScopes(source, flowID))

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -11,6 +11,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"time"
@@ -636,25 +637,36 @@ func TestDeriveRouteTable_StaticChildFlowInputSubscriptionsResolveCanonicalNodeO
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
 	for _, tc := range []struct {
-		fixture    string
-		eventType  string
-		nodeID     string
-		flowPath   string
-		routeMatch string
+		fixture     string
+		eventType   string
+		nodeID      string
+		flowPath    string
+		routeMatch  string
+		routeSource string
 	}{
 		{
-			fixture:    "test-child-flow-local-events",
-			eventType:  "child/child.start",
-			nodeID:     "child-intake",
-			flowPath:   "child",
-			routeMatch: "child/child.start",
+			fixture:     "test-child-flow-local-events",
+			eventType:   "child/child.start",
+			nodeID:      "child-intake",
+			flowPath:    "child",
+			routeMatch:  "child/child.start",
+			routeSource: "subscription",
 		},
 		{
-			fixture:    "test-nested-three-levels",
-			eventType:  "child/step.begin",
-			nodeID:     "child-relay",
-			flowPath:   "child",
-			routeMatch: "child/step.begin",
+			fixture:     "test-nested-three-levels",
+			eventType:   "child/step.begin",
+			nodeID:      "child-relay",
+			flowPath:    "child",
+			routeMatch:  "step.begin",
+			routeSource: "receiver_carrier",
+		},
+		{
+			fixture:     "test-nested-three-levels",
+			eventType:   "child/grandchild/micro.start",
+			nodeID:      "grandchild-worker",
+			flowPath:    "child/grandchild",
+			routeMatch:  "micro.start",
+			routeSource: "receiver_carrier",
 		},
 	} {
 		t.Run(tc.fixture, func(t *testing.T) {
@@ -673,8 +685,8 @@ func TestDeriveRouteTable_StaticChildFlowInputSubscriptionsResolveCanonicalNodeO
 				got[0].Type != "node" ||
 				got[0].Path != tc.flowPath ||
 				got[0].MatchPattern != tc.routeMatch ||
-				got[0].RouteSource != "subscription" {
-				t.Fatalf("Resolve(%s) = %#v, want %s %s %s", tc.eventType, got, tc.nodeID, tc.flowPath, tc.routeMatch)
+				got[0].RouteSource != tc.routeSource {
+				t.Fatalf("Resolve(%s) = %#v, want %s %s %s from %s", tc.eventType, got, tc.nodeID, tc.flowPath, tc.routeMatch, tc.routeSource)
 			}
 		})
 	}
@@ -835,12 +847,12 @@ func TestDeriveRouteTable_InputPinsStayLocalWithoutExternalProducer(t *testing.T
 	}
 }
 
-func TestDeriveRouteTable_DescendantSubscriptionsExternalizeWithinParentFlow(t *testing.T) {
+func TestDeriveRouteTable_NestedPackageConnectLocalizesWithinParentFlow(t *testing.T) {
 	grandchild := runtimecontracts.FlowContractView{
-		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild"},
+		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild", PackageKey: "flows/child/flows/grandchild"},
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
-				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"micro.done"}},
+				Outputs: runtimecontracts.FlowOutputPins{EventPins: []runtimecontracts.FlowOutputEventPin{{Name: "micro_done", Event: "micro.done"}}},
 			},
 		},
 		Path: "child/grandchild",
@@ -849,10 +861,10 @@ func TestDeriveRouteTable_DescendantSubscriptionsExternalizeWithinParentFlow(t *
 		},
 	}
 	child := runtimecontracts.FlowContractView{
-		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child"},
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
 		Schema: runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
-				Inputs:  runtimecontracts.FlowInputPins{Events: []string{"step.begin"}},
+				Inputs:  runtimecontracts.FlowInputPins{EventPins: []runtimecontracts.FlowInputEventPin{{Name: "micro_done", Event: "micro.done"}}},
 				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"step.result"}},
 			},
 		},
@@ -860,9 +872,10 @@ func TestDeriveRouteTable_DescendantSubscriptionsExternalizeWithinParentFlow(t *
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"child-aggregator": {
 				ID:           "child-aggregator",
-				SubscribesTo: []string{"grandchild/micro.done"},
+				SubscribesTo: []string{"micro.done"},
 			},
 		},
+		Events:   map[string]runtimecontracts.EventCatalogEntry{"micro.done": {}},
 		Children: []runtimecontracts.FlowContractView{grandchild},
 	}
 	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{child}}
@@ -874,17 +887,35 @@ func TestDeriveRouteTable_DescendantSubscriptionsExternalizeWithinParentFlow(t *
 				"grandchild": &root.Children[0].Children[0],
 			},
 		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
+			"child":      child.Schema,
+			"grandchild": grandchild.Schema,
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+			PackageKey: "flows/child",
+			SourceFile: "flows/child/package.yaml",
+			SourceLine: 10,
+			From:       "grandchild.micro_done",
+			To:         ".micro_done",
+		}}},
+	}
+	plans, issues := runtimepinrouting.LowerCompositionConnectRoutePlans(semanticview.Wrap(bundle))
+	if len(issues) != 0 || len(plans) != 1 {
+		t.Fatalf("nested connect plans = %#v issues = %#v, want one valid plan", plans, issues)
 	}
 	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(bundle))
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
 	}
-	got := rt.Resolve("child/grandchild/micro.done")
-	if len(got) != 1 || got[0].ID != "child-aggregator" {
-		t.Fatalf("Resolve(child/grandchild/micro.done) = %#v, want child-aggregator", got)
+	if got := rt.Resolve("child/grandchild/micro.done"); len(got) != 0 {
+		t.Fatalf("direct descendant route = %#v, connect dispatch must own the boundary edge", got)
 	}
-	if got := rt.Resolve("grandchild/micro.done"); len(got) != 0 {
-		t.Fatalf("Resolve(grandchild/micro.done) = %#v, want none", got)
+	got := rt.Resolve("child/micro.done")
+	if len(got) != 1 || got[0].ID != "child-aggregator" {
+		t.Fatalf("Resolve(child/micro.done) = %#v, want receiver-local child-aggregator carrier", got)
+	}
+	if got[0].Path != "child" {
+		t.Fatalf("receiver carrier path = %q, want child", got[0].Path)
 	}
 }
 

--- a/internal/runtime/bus/sealed_flow_package_fixture_test.go
+++ b/internal/runtime/bus/sealed_flow_package_fixture_test.go
@@ -135,10 +135,19 @@ func assertSealedFlowPackageConnectPlan(t *testing.T, source semanticview.Source
 	if len(issues) != 0 {
 		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
 	}
-	if len(plans) != 1 {
-		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one parent connect plan", plans)
+	if len(plans) != 3 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want three explicit parent connect plans", plans)
 	}
-	plan := plans[0]
+	var plan runtimepinrouting.ConnectRoutePlan
+	for _, candidate := range plans {
+		if candidate.Source.FlowID == "producer" && candidate.Receiver.FlowID == "consumer" {
+			plan = candidate
+			break
+		}
+	}
+	if plan.Source.FlowID == "" {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, missing producer-to-consumer plan", plans)
+	}
 	if got, want := plan.Source.ResolvedEvent, "producer/work.ready"; got != want {
 		t.Fatalf("source resolved event = %q, want %q", got, want)
 	}

--- a/internal/runtime/conformance/fan_in_stream_conformance_test.go
+++ b/internal/runtime/conformance/fan_in_stream_conformance_test.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -374,6 +375,9 @@ func fanInStreamPublishAndExecute(
 }
 
 func fanInStreamEvent(eventType, id, flowInstance, reportID, periodID string, revenue int) events.Event {
+	if prefix := templatefanin.ProducerFlowID + "/"; strings.HasPrefix(eventType, prefix) {
+		eventType = strings.Trim(strings.TrimSpace(flowInstance), "/") + "/" + strings.TrimPrefix(eventType, prefix)
+	}
 	payload, _ := json.Marshal(map[string]any{
 		"portfolio_id": "portfolio-default",
 		"report_id":    reportID,

--- a/internal/runtime/conformance/reply_resolution_conformance_test.go
+++ b/internal/runtime/conformance/reply_resolution_conformance_test.go
@@ -974,6 +974,11 @@ func replyConformanceEvent(eventType, id, flowID, flowInstance string, payload m
 }
 
 func replyConformanceEventForRun(eventType, id, runID, flowID, flowInstance string, payload map[string]any) events.Event {
+	flowID = strings.Trim(strings.TrimSpace(flowID), "/")
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	if flowInstance != "" && flowInstance != flowID && strings.HasPrefix(eventType, flowID+"/") {
+		eventType = flowInstance + "/" + strings.TrimPrefix(eventType, flowID+"/")
+	}
 	raw, _ := json.Marshal(payload)
 	return eventtest.RootIngress(
 		id,

--- a/internal/runtime/conformance/sealed_flow_package_conformance_test.go
+++ b/internal/runtime/conformance/sealed_flow_package_conformance_test.go
@@ -123,10 +123,19 @@ func assertSealedPackageConformanceConnectRoutePlan(t *testing.T, source semanti
 	if len(issues) != 0 {
 		t.Fatalf("LowerCompositionConnectRoutePlans issues = %#v, want none", issues)
 	}
-	if len(plans) != 1 {
-		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want one parent connect route plan", plans)
+	if len(plans) != 3 {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, want three explicit connect route plans", plans)
 	}
-	plan := plans[0]
+	var plan runtimepinrouting.ConnectRoutePlan
+	for _, candidate := range plans {
+		if candidate.Source.ResolvedEvent == "producer/work.ready" && candidate.Receiver.ResolvedEvent == "consumer/work.ready" {
+			plan = candidate
+			break
+		}
+	}
+	if plan.Source.ResolvedEvent == "" {
+		t.Fatalf("LowerCompositionConnectRoutePlans = %#v, missing producer/work.ready -> consumer/work.ready", plans)
+	}
 	if got, want := plan.Source.ResolvedEvent, "producer/work.ready"; got != want {
 		t.Fatalf("source resolved event = %q, want %q", got, want)
 	}

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -1,8 +1,8 @@
 version: 1
 kind: route_authority_drift_inventory
 issue: 1364
-implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1552, 1577, 1826]
-parent_issues: [1340, 1353, 1481, 1493]
+implementation_issues: [1364, 1494, 1495, 1496, 1545, 1546, 1552, 1577, 1826, 2085]
+parent_issues: [1340, 1353, 1481, 1493, 1738, 1786, 1827, 2084]
 watchlist: runtime_operations.delivery_and_replay_ownership
 policy:
   closure_level: route_authority_seam_inventory_guardrail_first_slice
@@ -15,7 +15,11 @@ policy:
     readers/writers, public readback, and test fixtures across the repository.
     It explicitly covers event name/type, semantic scope, entity/run/source
     event context, route/event-key derivation helpers, lowered ConnectRoutePlan
-    artifacts, RouteTable.Resolve role boundaries, receiver-carrier evidence,
+    artifacts, import-boundary pin interface adaptation versus invalid
+    pin_bind_input_alias/pin_bind_output_alias route authority, flow-owned
+    exact/pattern subscription admission versus invalid live cross-flow routes,
+    required internal pipeline carriers versus raw agent-kind fallbacks,
+    RouteTable.Resolve role boundaries, receiver-carrier evidence,
     descriptor evidence, direct-delivery paths, removed legacy
     eventDeliveryPlan compatibility, and RoutePlan source/reason constants.
     It must not be used by itself as proof that runtime behavior changed.
@@ -60,11 +64,76 @@ search_dimensions:
       - platform-spec.yaml
       - internal/runtime/core/pinrouting/connect_route_plan.go
       - internal/runtime/core/pinrouting/connect_route_plan_test.go
+      - internal/runtime/core/pinrouting/pinrouting.go
+      - internal/runtime/core/pinrouting/pinrouting_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/routing_derivation_test.go
       - internal/runtime/bus/route_plan.go
       - internal/apispec/platform_spec_composition_routing_test.go
     canonical_layer: route_plan_authority
+    classified_paths_required: true
+  - id: import_boundary_pin_alias_route_authority
+    pattern: 'pin_bind_input_alias|pin_bind_output_alias|ImportBoundary(Input|Output)Alias|bind\.inputs|bind\.outputs'
+    minimum_matching_files: 7
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/contracts/workflow_contract_yaml_wave1.go
+      - internal/runtime/semanticview/import_boundary_aliases.go
+      - internal/runtime/bootverify/workflow_composition_connect_checks.go
+      - internal/runtime/semanticview/import_boundary_aliases_test.go
+    canonical_layer: invalid_old_authority
+    classified_paths_required: true
+  - id: live_agent_subscription_route_authority
+    pattern: 'type AgentConfig struct|\bnewLLMAgent\b|\bnewGenericAgent\b|\bbuildFlowAgentConfig\b|\bbuildStaticFlowAgentConfig\b|\bSpawnAgentForEntity\b|\bReconfigureAgent\b|\bReplaceAgentRoute\b|\bresolveSubscribedRecipientsForPlanning\b|\bpendingEventsForAgent\b|TestEventBusSubscribe_RejectsUnadmittedQualifiedAgentRoute'
+    minimum_matching_files: 21
+    required_paths:
+      - internal/runtime/core/actors/agent_config.go
+      - internal/runtime/agents/agent_llm.go
+      - internal/runtime/manager/generic_agent_support.go
+      - internal/runtime/manager/flow_activation.go
+      - internal/runtime/manager/agent_manager.go
+      - internal/runtime/manager/runtime.go
+      - internal/runtime/tools/executor_agents.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_publish_test.go
+    canonical_layer: invalid_old_authority
+    classified_paths_required: true
+  - id: pending_agent_subscription_recovery_authority
+    pattern: '\bListPendingSubscribedEvents\b|\bpendingEventsForAgent\b'
+    minimum_matching_files: 19
+    required_paths:
+      - internal/runtime/manager/runtime.go
+      - internal/runtime/manager/types.go
+      - internal/store/event_receipt_store.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+    canonical_layer: invalid_old_authority
+    classified_paths_required: true
+  - id: flow_owned_subscription_pattern_authority
+    pattern: 'wildcard_subscription_scope|ResolveImportBoundaryWildcardSubscription|ImportBoundaryWildcardSubscriptionMatches|\bbuildFlowAgentConfig\b|\bbuildStaticFlowAgentConfig\b|\bresolveSubscribedRecipientsForPlanning\b|\brouteMatches\b'
+    minimum_matching_files: 13
+    required_paths:
+      - platform-spec.yaml
+      - internal/runtime/semanticview/import_boundary_wildcards.go
+      - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/bus/import_boundary_wildcard_routing_test.go
+      - internal/runtime/manager/flow_activation.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/bus/delivery_planner.go
+    canonical_layer: invalid_old_authority
+    classified_paths_required: true
+  - id: pipeline_internal_carrier_registration
+    pattern: 'type Bus interface \{\n[[:space:]]*SubscribeInternal|type systemNodeBus interface|pc\.bus\.SubscribeInternal|n\.bus\.SubscribeInternal|Test(PipelineCoordinator|SystemNodeRunner|ActivityDispatcher)Subscribe_UsesInternalSubscribers'
+    minimum_matching_files: 5
+    required_paths:
+      - internal/runtime/pipeline/runtime_support.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/pipeline/node_system_runner.go
+      - internal/runtime/pipeline/activity_background.go
+      - internal/runtime/pipeline/internal_subscription_test.go
+    canonical_layer: invalid_old_authority
     classified_paths_required: true
   - id: route_table_resolve
     pattern: '\bRouteTable\.Resolve\b|\brouteTable\.Resolve\b'
@@ -365,9 +434,12 @@ seam_families:
       - internal/apispec/platform_spec_composition_routing_test.go
       - internal/runtime/core/pinrouting/connect_route_plan.go
       - internal/runtime/core/pinrouting/connect_route_plan_test.go
+      - internal/runtime/core/pinrouting/pinrouting.go
+      - internal/runtime/core/pinrouting/pinrouting_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/routing_derivation_test.go
       - internal/runtime/bus/eventbus_delivery_projection_test.go
       - internal/runtime/bus/final_flow_instance_authoring_route_test.go
       - internal/runtime/bus/route_plan.go
@@ -386,6 +458,188 @@ seam_families:
       connect.map remains non-authoritative for that class. #1577 adds the
       connect-time template lifecycle owner that consumes the lowered instance
       key plan and creates, reuses, or fails closed before delivery rows commit.
+  - id: import_boundary_pin_interface_adaptation
+    layer: route_plan_consumers
+    classification: valid_consumer
+    paths:
+      - internal/runtime/contracts/workflow_contract_yaml_wave1.go
+      - internal/runtime/contracts/workflow_contract_yaml_test.go
+      - internal/runtime/semanticview/import_boundary_aliases.go
+      - internal/runtime/semanticview/import_boundary_aliases_test.go
+      - internal/runtime/bootverify/workflow_composition_connect_checks.go
+      - internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+    search_dimensions: [import_boundary_pin_alias_route_authority, connect_route_plan]
+    notes: >
+      Binding input/output pins remains canonical interface and event-name
+      adaptation evidence. Under the #1786 ruling for #2085, a bind may validate
+      or adapt an explicit FlowPackageConnect lowered to ConnectRoutePlan, but
+      cannot create an inter-flow route by itself.
+  - id: import_boundary_pin_alias_route_engines
+    layer: invalid_old_authority
+    classification: invalid_old_authority_path
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/semanticview/flow_input_producer.go
+      - internal/runtime/semanticview/flow_input_producer_test.go
+      - internal/runtime/semanticview/import_boundary_wildcards.go
+      - internal/runtime/pipeline/workflow_nodes.go
+      - internal/runtime/pipeline/workflow_nodes_test.go
+      - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/import_boundary_alias_routing_test.go
+    search_dimensions: [import_boundary_pin_alias_route_authority, connect_route_plan]
+    invalid_authority:
+      - bind.inputs creating pin_bind_input_alias RouteTable or recipient authority without explicit connect
+      - bind.outputs creating pin_bind_output_alias RouteTable or recipient authority without explicit connect
+      - import bindings being reported as parent-connect producer proof without an explicit connect edge
+      - workflow-node subscription rewriting reconstructing an inter-flow edge from a bind alone
+    notes: >
+      #1786 makes FlowPackageConnect lowered to ConnectRoutePlan the sole
+      inter-flow edge owner and adds symmetric connect.to root-input syntax.
+      #2085 must delete both alias route engines together; direction is not an
+      owner boundary. Old bind-only delivery is unsupported and receives no
+      compatibility route, migration reader, or dual-write period.
+  - id: live_agent_cross_flow_subscription_routes
+    layer: invalid_old_authority
+    classification: invalid_old_authority_path
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/agents/agent_llm.go
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus.go
+      - internal/runtime/bus/eventbus_agent_route_test.go
+      - internal/runtime/bus/eventbus_publish_test.go
+      - internal/runtime/bus/eventbus_route_generation_plan_test.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/core/actors/agent_config.go
+      - internal/events/construction_test.go
+      - internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+      - internal/runtime/conformance/persisted_surfaces_test.go
+      - internal/runtime/manager/agent_manager.go
+      - internal/runtime/manager/execution_projection_test.go
+      - internal/runtime/manager/flow_activation.go
+      - internal/runtime/manager/flow_activation_test.go
+      - internal/runtime/manager/generic_agent_support.go
+      - internal/runtime/manager/lifecycle_coordinator.go
+      - internal/runtime/manager/native_tool_admission_test.go
+      - internal/runtime/manager/receipts_test.go
+      - internal/runtime/manager/reconfigure_test.go
+      - internal/runtime/manager/recovery_test.go
+      - internal/runtime/manager/runtime.go
+      - internal/runtime/manager/runtime_chat_test.go
+      - internal/runtime/manager/runtime_shutdown_admission_test.go
+      - internal/runtime/manager/types.go
+      - internal/runtime/runtime_operational_config_test.go
+      - internal/runtime/runtime_recovery_diagnostics_test.go
+      - internal/runtime/runtime_shutdown_admission_test.go
+      - internal/runtime/tools/deps.go
+      - internal/runtime/tools/executor_agents.go
+      - internal/runtime/tools/executor_agents_test.go
+      - internal/store/agent_lifecycle_subordinate_test.go
+      - internal/store/delivery_receipt_invariants_test.go
+      - internal/store/event_receipt_store.go
+      - internal/store/manager_retry_policy_test.go
+      - internal/store/postgres_store_additional_test.go
+      - internal/store/sqlite_runtime_delivery_replay.go
+      - internal/store/sqlite_runtime_test.go
+    search_dimensions: [live_agent_subscription_route_authority, pending_agent_subscription_recovery_authority, connect_route_plan]
+    invalid_authority:
+      - flow-owned static or dynamic agents authoring a producer-qualified exact or pattern subscription instead of an admitted local identity
+      - ad-hoc agent creation or reconfiguration installing an exact or wildcard cross-flow live route outside ConnectRoutePlan or the typed wildcard/grant owner
+      - ReplaceAgentRoute and direct EventBus subscription matching recreating an inter-flow recipient from an unadmitted exact or pattern string
+      - pending subscribed-delivery recovery reviving exact or wildcard cross-flow authority from a forbidden persisted agent subscription
+    notes: >
+      #1786 makes authored flow-owned subscriptions scope-local. Admission must
+      classify exact and pattern subscriptions, derive canonical same-scope
+      identities only for the agent's own flow, and consume the typed import
+      wildcard/grant owner for cross-boundary patterns. Live agent channels
+      remain carriers for admitted same-flow pub/sub, supported root/non-import
+      wildcard behavior, governed observation, and typed connect recipients;
+      raw matching is not inter-flow authority. #2085 must reject before
+      registration, reconfiguration mutation, or recovery and retain no
+      old-run migration or compatibility path.
+  - id: flow_owned_agent_subscription_admission
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/semanticview/agent_subscription_admission.go
+      - internal/runtime/semanticview/agent_subscription_admission_test.go
+      - internal/runtime/manager/agent_subscription_admission.go
+      - internal/runtime/manager/agent_subscription_admission_test.go
+      - internal/runtime/manager/agent_manager.go
+      - internal/runtime/manager/agent_manager_llm_backend_test.go
+      - internal/runtime/manager/flow_activation.go
+      - internal/runtime/manager/flow_activation_test.go
+      - internal/runtime/manager/lifecycle_coordinator.go
+      - internal/runtime/manager/recovery_test.go
+      - internal/runtime/manager/runtime.go
+      - internal/runtime/bus/agent_subscription_admission_test.go
+      - internal/store/postgres_store_additional_test.go
+      - internal/store/sqlite_runtime_test.go
+    search_dimensions: [flow_owned_subscription_pattern_authority, live_agent_subscription_route_authority, pending_agent_subscription_recovery_authority]
+    notes: >
+      One typed admission derives canonical same-scope exact and pattern
+      identities, consumes imported wildcard/grant evidence, and rejects
+      foreign authority before lifecycle mutation, live route installation, or
+      pending recovery. Private admission state is the only capability accepted
+      by agent route APIs; live channels remain non-authoritative carriers.
+  - id: import_boundary_wildcard_pattern_authority
+    layer: route_plan_consumers
+    classification: valid_consumer
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/accprojection/resolver.go
+      - internal/runtime/bus/import_boundary_wildcard_routing_test.go
+      - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/pipeline/workflow_nodes.go
+      - internal/runtime/semanticview/bundle_source.go
+      - internal/runtime/semanticview/endpoint_census.go
+      - internal/runtime/semanticview/endpoint_census_test.go
+      - internal/runtime/semanticview/import_boundary_wildcards.go
+    search_dimensions: [flow_owned_subscription_pattern_authority, route_table_resolve]
+    notes: >
+      The platform-spec wildcard scope/grant resolver owns imported-package
+      pattern candidate sets and bind.observe grants. Low-level route matching
+      is only a primitive within those candidates. Same-scope and supported
+      root/non-import wildcard behavior remain canonical and must be preserved.
+  - id: unadmitted_live_agent_pattern_routes
+    layer: invalid_old_authority
+    classification: invalid_old_authority_path
+    paths:
+      - internal/runtime/bus/delivery_planner.go
+      - internal/runtime/bus/eventbus_routing.go
+      - internal/runtime/manager/flow_activation.go
+      - internal/runtime/manager/flow_activation_test.go
+    search_dimensions: [flow_owned_subscription_pattern_authority, live_agent_subscription_route_authority]
+    invalid_authority:
+      - an imported or flow-owned agent wildcard selecting a foreign event solely through global EventBus pattern matching
+      - static or dynamic materialization preserving an unmatched cross-boundary wildcard as live route authority
+      - recovery or pending replay treating an unadmitted pattern as a global event selector
+    notes: >
+      #2085 must make pattern admission consume semanticview's typed wildcard
+      scope/grant resolution or fail closed before persistence/lifecycle
+      mutation. Root/non-import and same-scope wildcard behavior are retained
+      through their canonical owner, not through an unrestricted live pattern.
+  - id: pipeline_raw_agent_subscription_fallbacks
+    layer: invalid_old_authority
+    classification: invalid_old_authority_path
+    paths:
+      - internal/runtime/pipeline/activity_background.go
+      - internal/runtime/pipeline/coordinator.go
+      - internal/runtime/pipeline/internal_subscription_test.go
+      - internal/runtime/pipeline/node_system_runner.go
+      - internal/runtime/pipeline/runtime_support.go
+    search_dimensions: [pipeline_internal_carrier_registration, live_agent_subscription_route_authority]
+    invalid_authority:
+      - workflow runtime registration downgrading to raw agent-kind Subscribe when SubscribeInternal is absent
+      - system-node runner registration downgrading to raw agent-kind Subscribe when SubscribeInternal is absent
+      - activity dispatcher registration downgrading to raw agent-kind Subscribe when SubscribeInternal is absent
+    notes: >
+      Internal carriers are required consumers of already-selected canonical
+      recipients. The pipeline boundary must require internal registration and
+      delete all three raw Subscribe compatibility fallbacks so carrier state
+      cannot become persisted direct-recipient authority.
   - id: authoring_routing_topology_projection
     layer: public_projection_non_authority
     classification: non_authoritative_observer_projection
@@ -435,6 +689,7 @@ seam_families:
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/eventbus_target_routes_test.go
       - internal/runtime/bus/routing_derivation.go
+      - internal/runtime/bus/routing_derivation_test.go
       - internal/runtime/conformance/route_authority_matrix_test.go
       - internal/runtime/conformance/testdata/route_authority_matrix.yaml
     search_dimensions: [receiver_carrier, connect_route_plan]

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -531,6 +531,34 @@ seam_families:
       static/root rows while classifying the event fail-closed when any sibling
       receiver still requires runtime resolution. Dynamic resolution remains
       separately tracked and is not implemented here.
+  - id: connect_receiver_pin_delivery_collision
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - platform-spec.yaml
+      - internal/runtime/routingtopology/topology.go
+      - internal/runtime/routingtopology/topology_test.go
+      - internal/runtime/bootverify/workflow_composition_connect_checks.go
+      - internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/pipeline/workflow_nodes.go
+      - internal/runtime/pipeline/workflow_nodes_test.go
+      - internal/runtime/testfixtures/canonicalrouting/negative.go
+    search_dimensions: [connect_route_plan, delivery_route_model, route_plan]
+    invalid_authority:
+      - distinct receiver pins collapsing onto one event x subscriber delivery identity
+      - DeliveryRoute normalization silently erasing receiver-local identity
+      - workflow execution selecting the first source-matching receiver handler
+      - adding receiver pin to the durable delivery or receipt identity
+    notes: >
+      Routing topology classifies a source edge that reaches the same normalized
+      subscriber and target through distinct receiver-local events as hard
+      invalid. EventBus repeats the invariant before delivery normalization, and
+      workflow execution requires exactly one connected-input handler candidate.
+      Duplicate same-edge declarations remain idempotent; distinct subscribers
+      and distinct targets remain legal fanout under the existing one event x
+      subscriber durable model.
   - id: import_boundary_pin_interface_adaptation
     layer: route_plan_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -538,6 +538,7 @@ seam_families:
       - internal/runtime/tools/executor_agents_test.go
       - internal/store/agent_lifecycle_subordinate_test.go
       - internal/store/delivery_receipt_invariants_test.go
+      - internal/store/event_producer_identity_lifecycle_parity_test.go
       - internal/store/event_receipt_store.go
       - internal/store/manager_retry_policy_test.go
       - internal/store/postgres_store_additional_test.go

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -468,6 +468,7 @@ seam_families:
       - internal/runtime/semanticview/import_boundary_aliases_test.go
       - internal/runtime/bootverify/workflow_composition_connect_checks.go
       - internal/runtime/bootverify/workflow_composition_connect_checks_test.go
+      - internal/runtime/testfixtures/canonicalrouting/import_boundary_variants.go
     search_dimensions: [import_boundary_pin_alias_route_authority, connect_route_plan]
     notes: >
       Binding input/output pins remains canonical interface and event-name
@@ -671,7 +672,7 @@ seam_families:
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runstart/root_inputs.go
-    search_dimensions: [route_table_resolve, route_event_key_derivation]
+    search_dimensions: [route_table_resolve, route_event_key_derivation, connect_route_plan, receiver_carrier]
     notes: >
       RouteTable.Resolve must be classified by role. EventBus lowered-connect
       use is post-identity receiver-carrier lookup; runstart/runfork uses are

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -542,23 +542,33 @@ seam_families:
       - internal/runtime/bootverify/workflow_composition_connect_checks_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/pipeline/coordinator.go
       - internal/runtime/pipeline/workflow_nodes.go
       - internal/runtime/pipeline/workflow_nodes_test.go
+      - internal/runtime/pipeline/workflow_node_delivery_authority_test.go
       - internal/runtime/testfixtures/canonicalrouting/negative.go
+      - internal/runtime/testfixtures/canonicalrouting/legacy_instance_routes.go
+      - internal/runtime/testfixtures/canonicalrouting/remaining_variants.go
     search_dimensions: [connect_route_plan, delivery_route_model, route_plan]
     invalid_authority:
       - distinct receiver pins collapsing onto one event x subscriber delivery identity
       - DeliveryRoute normalization silently erasing receiver-local identity
       - workflow execution selecting the first source-matching receiver handler
+      - receiver-pin admission after template lifecycle or reply-context mutation
+      - interception converting connected-input resolution failure into passthrough
       - adding receiver pin to the durable delivery or receipt identity
     notes: >
       Routing topology classifies a source edge that reaches the same normalized
-      subscriber and target through distinct receiver-local events as hard
-      invalid. EventBus repeats the invariant before delivery normalization, and
-      workflow execution requires exactly one connected-input handler candidate.
-      Duplicate same-edge declarations remain idempotent; distinct subscribers
-      and distinct targets remain legal fanout under the existing one event x
-      subscriber durable model.
+      subscriber and target through distinct receiver pins or receiver-local
+      events as hard invalid. EventBus previews every matched runtime-resolved
+      plan on request-local route state, admits the complete pin/event plus
+      durable-delivery-identity set before lifecycle or reply mutation, and then
+      repeats the invariant before delivery normalization. Workflow execution
+      requires exactly one connected-input handler candidate and propagates
+      ambiguity through public delivery interception without passthrough or
+      receipt settlement. Duplicate same-edge declarations remain idempotent;
+      distinct subscribers and distinct targets remain legal fanout under the
+      existing one event x subscriber durable model.
   - id: import_boundary_pin_interface_adaptation
     layer: route_plan_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -470,6 +470,8 @@ seam_families:
       - internal/runtime/pipeline/workflow_nodes_test.go
       - internal/runtime/engine/executor.go
       - internal/runtime/engine/executor_test.go
+      - internal/runtime/tools/executor_emit.go
+      - internal/runtime/tools/executor_emit_test.go
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/contract_frontier_test.go
       - internal/runtime/runforkadmission/selected_route_history.go
@@ -490,8 +492,8 @@ seam_families:
       descendant evidence. Pipeline execution preserves its already-admitted
       producer route when constructing output events. EventBus plans and issues,
       workflow-node connect localization, selected-contract frontier admission,
-      route-history admission, and supported fan-in/reply/fan-out runtime proofs
-      consume the same owner.
+      route-history admission, agent-tool output construction, and supported
+      fan-in/reply/fan-out runtime proofs consume the same owner.
   - id: selected_contract_connect_receiver_policy
     layer: replay_recovery_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -895,6 +895,7 @@ seam_families:
       - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runforkexecution/recipient_planning.go
       - internal/store/run_fork_delivery_event_replay.go
+      - internal/store/run_fork_revision_projection.go
       - internal/store/run_fork_selected_contract_execution.go
       - internal/store/run_fork_replay_resume_admission.go
     search_dimensions: [event_deliveries, replay_scope, connect_route_plan]
@@ -905,7 +906,10 @@ seam_families:
     notes: >
       Replay, recovery, and fork paths consume persisted RoutePlan output or an
       explicitly gated replay/fork owner. Source rows are lineage or blockers
-      unless their owner produces fresh authority.
+      unless their owner produces fresh authority. Revision projection decodes
+      event source_route once into typed emitter identity; top-level event
+      flow_instance remains receiver or timer context and cannot supply source
+      connect authority.
   - id: public_operator_readback_projection
     layer: public_projection_non_authority
     classification: non_authoritative_observer_projection

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -488,6 +488,7 @@ seam_families:
       - executor state metadata overriding the admitted producer route
       - suffix or same-leaf event-name fallback
       - an empty fork-point source route recovered from event-name text or a delivery row
+      - a package-root source selected by local event name when source_route is empty and flow_instance identifies semantic child-flow context
     notes: >
       ConnectSourceEndpointMatches is the canonical producer endpoint matcher.
       It consumes the lowered producer Mode: template sources require exact
@@ -499,7 +500,12 @@ seam_families:
       fan-in/reply/fan-out runtime proofs consume the same owner. RunForkPoint
       carries the exact normalized source_route from the fixed revision so
       no-delivery selected history and dynamic instance evidence do not depend
-      on PendingWork or event-name reconstruction.
+      on PendingWork or event-name reconstruction. The event-aware wrapper also
+      fails closed before package-root matching when source_route is absent and
+      flow_instance identifies semantic child-flow context, while preserving
+      UUID root instances and explicit source-route precedence. The canonical
+      owner matrix, EventBus plan/preflight/publish, connect-issue matching, and
+      workflow connected-input localization prove that rule directly.
   - id: selected_contract_connect_receiver_policy
     layer: replay_recovery_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -458,6 +458,77 @@ seam_families:
       connect.map remains non-authoritative for that class. #1577 adds the
       connect-time template lifecycle owner that consumes the lowered instance
       key plan and creates, reuses, or fails closed before delivery rows commit.
+  - id: connect_source_endpoint_mode_authority
+    layer: route_plan_authority
+    classification: canonical_owner
+    paths:
+      - internal/runtime/core/pinrouting/connect_route_plan.go
+      - internal/runtime/core/pinrouting/connect_route_plan_test.go
+      - internal/runtime/bus/connect_route_plan_dispatch.go
+      - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/pipeline/workflow_nodes.go
+      - internal/runtime/pipeline/workflow_nodes_test.go
+      - internal/runtime/engine/executor.go
+      - internal/runtime/engine/executor_test.go
+      - internal/runtime/runforkadmission/contract_frontier.go
+      - internal/runtime/runforkadmission/contract_frontier_test.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/conformance/fan_in_stream_conformance_test.go
+      - internal/runtime/conformance/reply_resolution_conformance_test.go
+      - internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
+    search_dimensions: [connect_route_plan, route_event_key_derivation]
+    invalid_authority:
+      - template base identity without concrete source-route provenance
+      - static or singleton descendant identity
+      - target-route identity substituted for producer identity
+      - executor state metadata overriding the admitted producer route
+      - suffix or same-leaf event-name fallback
+    notes: >
+      ConnectSourceEndpointMatches is the canonical producer endpoint matcher.
+      It consumes the lowered producer Mode: template sources require exact
+      concrete instance provenance, while static and singleton sources reject
+      descendant evidence. Pipeline execution preserves its already-admitted
+      producer route when constructing output events. EventBus plans and issues,
+      workflow-node connect localization, selected-contract frontier admission,
+      route-history admission, and supported fan-in/reply/fan-out runtime proofs
+      consume the same owner.
+  - id: selected_contract_connect_receiver_policy
+    layer: replay_recovery_consumers
+    classification: valid_consumer
+    paths:
+      - internal/runtime/core/pinrouting/connect_route_plan.go
+      - internal/runtime/runforkadmission/contract_frontier.go
+      - internal/runtime/runforkadmission/contract_frontier_test.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+    search_dimensions: [connect_route_plan, route_table_resolve, receiver_carrier]
+    invalid_authority:
+      - applying receiver_carrier filtering to a global-root connect receiver
+      - treating a nested package-root receiver as the repository root
+      - admitting non-carrier routes for a non-root connect receiver
+    notes: >
+      Selected-contract connect lookup preserves receiver kind per lowered plan.
+      A repository-root receiver consumes ordinary root node/agent routes;
+      nested and non-root receivers remain receiver-carrier-only. The shared
+      per-plan lookup is consumed by both frontier and route-history admission.
+  - id: selected_contract_connect_fanout_completeness
+    layer: replay_recovery_consumers
+    classification: valid_consumer
+    paths:
+      - internal/runtime/core/pinrouting/connect_route_plan.go
+      - internal/runtime/runforkadmission/contract_frontier.go
+      - internal/runtime/runforkadmission/contract_frontier_test.go
+      - internal/runtime/runforkadmission/selected_route_history.go
+    search_dimensions: [connect_route_plan, route_table_resolve, receiver_carrier]
+    invalid_authority:
+      - a proven static sibling suppressing an unresolved runtime receiver
+      - discarding proven root or static-child recipients because another plan is unresolved
+      - dynamically resolving template receivers inside selected-contract admission
+    notes: >
+      Each matched connect row retains its own runtime-resolution state.
+      Frontier and route-history admission preserve recipients from proven
+      static/root rows while classifying the event fail-closed when any sibling
+      receiver still requires runtime resolution. Dynamic resolution remains
+      separately tracked and is not implemented here.
   - id: import_boundary_pin_interface_adaptation
     layer: route_plan_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -554,6 +554,7 @@ seam_families:
       - internal/runtime/bootverify/workflow_composition_connect_checks_test.go
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
+      - internal/runtime/bus/eventbus_publish_test.go
       - internal/runtime/pipeline/coordinator.go
       - internal/runtime/pipeline/workflow_nodes.go
       - internal/runtime/pipeline/workflow_nodes_test.go
@@ -561,6 +562,7 @@ seam_families:
       - internal/runtime/testfixtures/canonicalrouting/negative.go
       - internal/runtime/testfixtures/canonicalrouting/legacy_instance_routes.go
       - internal/runtime/testfixtures/canonicalrouting/remaining_variants.go
+      - internal/runtime/testfixtures/canonicalrouting/resolution_variants.go
     search_dimensions: [connect_route_plan, delivery_route_model, route_plan]
     invalid_authority:
       - distinct receiver pins collapsing onto one event x subscriber delivery identity
@@ -568,6 +570,8 @@ seam_families:
       - workflow execution selecting the first source-matching receiver handler
       - receiver-pin admission after template lifecycle or reply-context mutation
       - interception converting connected-input resolution failure into passthrough
+      - preview-created route state without matching request-local descriptor evidence for later plans
+      - agent-only connect delivery treated as node handler or node delivery authority
       - adding receiver pin to the durable delivery or receipt identity
     notes: >
       Routing topology classifies a source edge that reaches the same normalized
@@ -575,12 +579,16 @@ seam_families:
       events as hard invalid. EventBus previews every matched runtime-resolved
       plan on request-local route state, admits the complete pin/event plus
       durable-delivery-identity set before lifecycle or reply mutation, and then
-      repeats the invariant before delivery normalization. Workflow execution
-      requires exactly one connected-input handler candidate and propagates
-      ambiguity through public delivery interception without passthrough or
-      receipt settlement. Duplicate same-edge declarations remain idempotent;
-      distinct subscribers and distinct targets remain legal fanout under the
-      existing one event x subscriber durable model.
+      repeats the invariant before delivery normalization. A preview-created
+      instance contributes request-local descriptor evidence to later matched
+      plans without mutating live or persisted state. Workflow execution requires
+      exactly one connected-input handler candidate only for the node selected by
+      a typed delivery route or committed node authority; agent-only connect
+      delivery cannot fail through an unrelated receiver node. Ambiguity on an
+      authorized node propagates through public delivery interception without
+      passthrough or receipt settlement. Duplicate same-edge declarations remain
+      idempotent; distinct subscribers and distinct targets remain legal fanout
+      under the existing one event x subscriber durable model.
   - id: import_boundary_pin_interface_adaptation
     layer: route_plan_consumers
     classification: valid_consumer

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -472,9 +472,11 @@ seam_families:
       - internal/runtime/engine/executor_test.go
       - internal/runtime/tools/executor_emit.go
       - internal/runtime/tools/executor_emit_test.go
+      - internal/store/run_fork_planner.go
       - internal/runtime/runforkadmission/contract_frontier.go
       - internal/runtime/runforkadmission/contract_frontier_test.go
       - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/runforkadmission/revision_source_route_test.go
       - internal/runtime/conformance/fan_in_stream_conformance_test.go
       - internal/runtime/conformance/reply_resolution_conformance_test.go
       - internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
@@ -485,6 +487,7 @@ seam_families:
       - target-route identity substituted for producer identity
       - executor state metadata overriding the admitted producer route
       - suffix or same-leaf event-name fallback
+      - an empty fork-point source route recovered from event-name text or a delivery row
     notes: >
       ConnectSourceEndpointMatches is the canonical producer endpoint matcher.
       It consumes the lowered producer Mode: template sources require exact
@@ -493,7 +496,10 @@ seam_families:
       producer route when constructing output events. EventBus plans and issues,
       workflow-node connect localization, selected-contract frontier admission,
       route-history admission, agent-tool output construction, and supported
-      fan-in/reply/fan-out runtime proofs consume the same owner.
+      fan-in/reply/fan-out runtime proofs consume the same owner. RunForkPoint
+      carries the exact normalized source_route from the fixed revision so
+      no-delivery selected history and dynamic instance evidence do not depend
+      on PendingWork or event-name reconstruction.
   - id: selected_contract_connect_receiver_policy
     layer: replay_recovery_consumers
     classification: valid_consumer
@@ -1005,7 +1011,9 @@ seam_families:
       - internal/runtime/bus/committed_replay_scope.go
       - internal/runtime/bus/outbox.go
       - internal/runtime/bus/sweeper_test.go
+      - internal/store/run_fork_planner.go
       - internal/runtime/runforkadmission/selected_route_history.go
+      - internal/runtime/runforkadmission/revision_source_route_test.go
       - internal/runtime/runforkexecution/recipient_planning.go
       - internal/store/run_fork_delivery_event_replay.go
       - internal/store/run_fork_revision_projection.go
@@ -1016,13 +1024,16 @@ seam_families:
       - replay markers alone
       - source event_deliveries as fresh fork truth
       - current live subscriptions as recovery truth
+      - delivery-row presence as the only carrier of a fork-point source route
     notes: >
       Replay, recovery, and fork paths consume persisted RoutePlan output or an
       explicitly gated replay/fork owner. Source rows are lineage or blockers
       unless their owner produces fresh authority. Revision projection decodes
       event source_route once into typed emitter identity; top-level event
       flow_instance remains receiver or timer context and cannot supply source
-      connect authority.
+      connect authority. The exact selected revision event also stamps the
+      normalized identity on RunForkPoint, which route-history lookup and
+      dynamic-instance accounting consume whether or not PendingWork exists.
   - id: public_operator_readback_projection
     layer: public_projection_non_authority
     classification: non_authoritative_observer_projection

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -70,6 +70,7 @@ search_dimensions:
       - internal/runtime/bus/connect_route_plan_dispatch_test.go
       - internal/runtime/bus/routing_derivation_test.go
       - internal/runtime/bus/route_plan.go
+      - internal/runtime/runforkadmission/selected_route_history.go
       - internal/apispec/platform_spec_composition_routing_test.go
     canonical_layer: route_plan_authority
     classified_paths_required: true
@@ -142,7 +143,6 @@ search_dimensions:
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/runforkadmission/contract_frontier.go
-      - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runstart/root_inputs.go
     canonical_layer: route_topology
     classified_paths_required: true
@@ -670,7 +670,6 @@ seam_families:
       - internal/runtime/bus/connect_route_plan_dispatch.go
       - internal/runtime/bus/template_instance_lifecycle.go
       - internal/runtime/runforkadmission/contract_frontier.go
-      - internal/runtime/runforkadmission/selected_route_history.go
       - internal/runtime/runstart/root_inputs.go
     search_dimensions: [route_table_resolve, route_event_key_derivation, connect_route_plan, receiver_carrier]
     notes: >
@@ -898,7 +897,7 @@ seam_families:
       - internal/store/run_fork_delivery_event_replay.go
       - internal/store/run_fork_selected_contract_execution.go
       - internal/store/run_fork_replay_resume_admission.go
-    search_dimensions: [event_deliveries, replay_scope]
+    search_dimensions: [event_deliveries, replay_scope, connect_route_plan]
     invalid_authority:
       - replay markers alone
       - source event_deliveries as fresh fork truth

--- a/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
+++ b/internal/runtime/conformance/testdata/route_authority_drift_inventory.yaml
@@ -648,6 +648,7 @@ seam_families:
       - internal/runtime/manager/recovery_test.go
       - internal/runtime/manager/runtime.go
       - internal/runtime/bus/agent_subscription_admission_test.go
+      - internal/runtime/runforkexecution/agent_runtime_materialization_test.go
       - internal/store/postgres_store_additional_test.go
       - internal/store/sqlite_runtime_test.go
     search_dimensions: [flow_owned_subscription_pattern_authority, live_agent_subscription_route_authority, pending_agent_subscription_recovery_authority]

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -579,54 +579,6 @@ func (b *WorkflowContractBundle) CompositionConnects() []FlowPackageConnect {
 	}
 	return cloneFlowPackageConnects(b.Semantics.CompositionConnects)
 }
-func (b *WorkflowContractBundle) CompositionConnectsTo(flowID, pinName string) []FlowPackageConnect {
-	flowID = strings.TrimSpace(flowID)
-	pinName = strings.TrimSpace(pinName)
-	if b == nil || pinName == "" {
-		return nil
-	}
-	var out []FlowPackageConnect
-	for _, connect := range b.CompositionConnects() {
-		ref, err := connect.ToRef()
-		if err != nil {
-			continue
-		}
-		if flowPackagePinRefMatches(ref, flowID, pinName) {
-			out = append(out, connect)
-		}
-	}
-	return out
-}
-func (b *WorkflowContractBundle) CompositionConnectsFrom(flowID, pinName string) []FlowPackageConnect {
-	flowID = strings.TrimSpace(flowID)
-	pinName = strings.TrimSpace(pinName)
-	if b == nil || pinName == "" {
-		return nil
-	}
-	var out []FlowPackageConnect
-	for _, connect := range b.CompositionConnects() {
-		ref, err := connect.FromRef()
-		if err != nil {
-			continue
-		}
-		if flowPackagePinRefMatches(ref, flowID, pinName) {
-			out = append(out, connect)
-		}
-	}
-	return out
-}
-
-func flowPackagePinRefMatches(ref FlowPackagePinRef, flowID, pinName string) bool {
-	flowID = strings.TrimSpace(flowID)
-	pinName = strings.TrimSpace(pinName)
-	if pinName == "" {
-		return false
-	}
-	if ref.Root {
-		return flowID == "" && strings.TrimSpace(ref.Pin) == pinName
-	}
-	return strings.TrimSpace(ref.FlowID) == flowID && strings.TrimSpace(ref.Pin) == pinName
-}
 func (b *WorkflowContractBundle) FlowReadPins(flowID string) []string {
 	if b == nil {
 		return nil

--- a/internal/runtime/core/flowidentity/flowidentity.go
+++ b/internal/runtime/core/flowidentity/flowidentity.go
@@ -285,8 +285,12 @@ func Stored(
 	workflowName = strings.TrimSpace(workflowName)
 	materializedPath = normalizeRef(materializedPath)
 	instancePath := materializedPath
+	scopeKey := ""
 	if instancePath == "" {
-		instancePath = normalizeRef(ScopeKey(source, workflowName))
+		scopeKey = normalizeRef(ScopeKey(source, workflowName))
+		instancePath = scopeKey
+	} else {
+		scopeKey = normalizeRef(storedScopeKey(source, workflowName, instancePath))
 	}
 	if strings.TrimSpace(instanceID) == "" && materializedPath != "" {
 		instanceID = LogicalInstanceID(materializedPath)
@@ -296,7 +300,7 @@ func Stored(
 	}
 	return Instance{
 		TemplateID:     workflowName,
-		ScopeKey:       normalizeRef(storedScopeKey(source, workflowName, instancePath)),
+		ScopeKey:       scopeKey,
 		InstanceID:     strings.TrimSpace(instanceID),
 		InstancePath:   instancePath,
 		EntityID:       strings.TrimSpace(entityID),

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -109,12 +109,13 @@ func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt ev
 		sourcePath = source.FlowID
 	}
 	if sourcePath == "" {
-		if !endpoint.Root {
-			return false
+		if endpoint.Root {
+			// Root ingress predates source-route stamping. Its envelope instance is
+			// used only to reject child scope, never as a producer identity.
+			sourcePath = evt.FlowInstance()
 		}
-		// Root ingress predates source-route stamping. Its envelope instance is
-		// used only to reject child scope, never as a producer identity.
-		sourcePath = evt.FlowInstance()
+		// A fully scoped static event name is sufficient without an instance.
+		// Concrete template matching still fails closed without SourceRoute.
 	}
 	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), sourcePath)
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -40,7 +40,6 @@ const (
 	ConnectFailurePinRefInvalid              ConnectRoutePlanFailure = "connect_pin_ref_invalid"
 	ConnectFailureProducerFlowMissing        ConnectRoutePlanFailure = "producer_flow_missing"
 	ConnectFailureProducerOutputPinMissing   ConnectRoutePlanFailure = "producer_output_pin_missing"
-	ConnectFailureReceiverRootUnsupported    ConnectRoutePlanFailure = "receiver_root_unsupported"
 	ConnectFailureReceiverFlowMissing        ConnectRoutePlanFailure = "receiver_flow_missing"
 	ConnectFailureReceiverInputPinMissing    ConnectRoutePlanFailure = "receiver_input_pin_missing"
 	ConnectFailureReceiverAddressRuleMissing ConnectRoutePlanFailure = "receiver_address_rule_missing"
@@ -297,12 +296,45 @@ func lowerCompositionConnectRoutePlan(source semanticview.Source, connect runtim
 	if err != nil {
 		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailurePinRefInvalid, Detail: err.Error()}
 	}
+	if from.Root {
+		flowID, ok := semanticview.PackageRootFlowID(source, connect.PackageKey)
+		if !ok {
+			return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureProducerFlowMissing, Detail: strings.TrimSpace(connect.PackageKey)}
+		}
+		from.FlowID, from.Root = flowID, flowID == ""
+	}
+	if to.Root {
+		flowID, ok := semanticview.PackageRootFlowID(source, connect.PackageKey)
+		if !ok {
+			return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverFlowMissing, Detail: strings.TrimSpace(connect.PackageKey)}
+		}
+		to.FlowID, to.Root = flowID, flowID == ""
+	}
 	sourceEndpoint, outputPin, sourceIssue := connectRoutePlanSourceEndpoint(source, from, connect)
 	if sourceIssue.Failure != "" {
 		return ConnectRoutePlan{}, sourceIssue
 	}
 	if to.Root {
-		return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverRootUnsupported, Detail: strings.TrimSpace(connect.To)}
+		inputPin, ok := source.FlowInputEventPin("", to.Pin)
+		if !ok {
+			return ConnectRoutePlan{}, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReceiverInputPinMissing, Detail: connect.To}
+		}
+		return ConnectRoutePlan{
+			PackageKey:       strings.TrimSpace(connect.PackageKey),
+			AuthoredLocation: connect.AuthoredLocation(),
+			Source:           sourceEndpoint,
+			Receiver: ConnectRoutePlanEndpoint{
+				Root:          true,
+				Mode:          "root",
+				Pin:           strings.TrimSpace(to.Pin),
+				Event:         eventidentity.Normalize(inputPin.EventType()),
+				ResolvedEvent: eventidentity.Normalize(source.ResolveFlowEventReference("", inputPin.EventType())),
+			},
+			Adapter:        strings.TrimSpace(connect.Adapter),
+			TargetKind:     ConnectTargetKindTarget,
+			ResolutionKind: ConnectResolutionStatic,
+			Map:            connectMapEntries(connect.Map),
+		}, ConnectRoutePlanIssue{}
 	}
 	receiverScope, ok := source.FlowScopeByID(to.FlowID)
 	if !ok {
@@ -415,6 +447,9 @@ func connectRoutePlanSourceEndpoint(source semanticview.Source, from runtimecont
 }
 
 func MaterializeConnectRoutePlan(plan ConnectRoutePlan, input ConnectRoutePlanMaterializationInput) ConnectRoutePlanMaterialization {
+	if plan.Receiver.Root {
+		return ConnectRoutePlanMaterialization{}
+	}
 	if !plan.Target.Empty() {
 		return ConnectRoutePlanMaterialization{Target: plan.Target}
 	}

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -70,14 +70,6 @@ type ConnectRoutePlanEndpoint struct {
 // ConnectSourceEndpointMatches is the canonical source-side identity matcher
 // for lowered connect plans.
 func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, flowInstance string) bool {
-	return connectSourceEndpointMatches(endpoint, eventType, flowInstance, nil)
-}
-
-func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
-	return connectSourceEndpointMatches(endpoint, string(evt.Type()), evt.FlowInstance(), connectSourceEventRouteKeys(evt))
-}
-
-func connectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, flowInstance string, routeKeys []string) bool {
 	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
 	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
 	if eventType == "" {
@@ -107,13 +99,19 @@ func connectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, 
 	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
 		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
 	}
-	for _, key := range routeKeys {
-		key = strings.Trim(strings.TrimSpace(key), "/")
-		if key != "" && (key == sourceResolved || key == sourceScoped) {
-			return true
-		}
-	}
 	return false
+}
+
+func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
+	source := evt.SourceRoute().Normalized()
+	sourcePath := source.FlowInstance
+	if sourcePath == "" {
+		sourcePath = source.FlowID
+	}
+	if sourcePath == "" && strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
+		return false
+	}
+	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), sourcePath)
 }
 
 func connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath string) bool {
@@ -126,60 +124,6 @@ func connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath string) bool 
 		return true
 	}
 	return runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == sourcePath
-}
-
-func connectSourceEventRouteKeys(evt events.Event) []string {
-	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
-	if eventType == "" {
-		return nil
-	}
-	out := []string{eventType}
-	if concrete := connectSourceConcreteEventKey(eventType, evt.FlowInstance()); concrete != "" {
-		out = append(out, concrete)
-	}
-	targets := evt.TargetRoutes()
-	if target := evt.TargetRoute(); !target.Empty() {
-		targets = []events.RouteIdentity{target}
-	}
-	for _, target := range targets {
-		flowInstance := strings.Trim(strings.TrimSpace(target.Normalized().FlowInstance), "/")
-		staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
-		localEvent := connectSourceLocalEvent(eventType, staticScope)
-		if flowInstance == "" || localEvent == "" {
-			continue
-		}
-		out = append(out, flowInstance+"/"+localEvent, localEvent)
-	}
-	return out
-}
-
-func connectSourceConcreteEventKey(eventType, flowInstance string) string {
-	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
-	staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
-	localEvent := connectSourceLocalEvent(eventType, staticScope)
-	if flowInstance == "" || localEvent == "" {
-		return ""
-	}
-	return flowInstance + "/" + localEvent
-}
-
-func connectSourceLocalEvent(eventType, staticScope string) string {
-	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
-	staticScope = strings.Trim(strings.TrimSpace(staticScope), "/")
-	if eventType == "" || staticScope == "" {
-		return ""
-	}
-	if strings.HasPrefix(eventType, staticScope+"/") {
-		localEvent := strings.TrimPrefix(eventType, staticScope+"/")
-		if localEvent == "" || strings.Contains(localEvent, "/") {
-			return ""
-		}
-		return localEvent
-	}
-	if strings.Contains(eventType, "/") {
-		return ""
-	}
-	return eventType
 }
 
 type ConnectRoutePlanAddress struct {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -765,12 +765,12 @@ func connectReplyResolution(source semanticview.Source, connect runtimecontracts
 		if correlationKey != "" && !stringListContains(normalizedPinCarries(requestOutput.Carries), correlationKey) {
 			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("resolution mode reply correlation_key %q must name a carry declared by output pin %s", correlationKey, requestOutputPin)}
 		}
-		requestConnects := source.CompositionConnectsFrom(receiverRef.FlowID, requestOutputPin)
+		requestConnects := semanticview.ResolvedCompositionConnectsFrom(source, receiverRef.FlowID, requestOutputPin)
 		if len(requestConnects) != 1 {
 			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: fmt.Sprintf("resolution mode reply request pin %s.%s must have exactly one connected counterpart, got %d", receiverRef.FlowID, requestOutputPin, len(requestConnects))}
 		}
-		requestTarget, err := requestConnects[0].ToRef()
-		if err != nil || requestTarget.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(sourceEndpoint.FlowID) {
+		requestTarget := requestConnects[0].To
+		if requestTarget.Root || strings.TrimSpace(requestTarget.FlowID) != strings.TrimSpace(sourceEndpoint.FlowID) {
 			return nil, ConnectRoutePlanIssue{Connect: connect, Failure: ConnectFailureReplyLineageMissing, Detail: "resolution mode reply request and reply edges must connect the same provider flow"}
 		}
 		return &ConnectRoutePlanReplyResolution{
@@ -790,9 +790,9 @@ func connectReplyResolution(source semanticview.Source, connect runtimecontracts
 		if replyInput.Resolution.Mode != runtimecontracts.FlowInputResolutionModeReply || strings.TrimSpace(replyInput.Resolution.RepliesTo) != strings.TrimSpace(sourceEndpoint.Pin) {
 			continue
 		}
-		for _, replyConnect := range source.CompositionConnectsTo(sourceEndpoint.FlowID, replyInput.PinName()) {
-			from, err := replyConnect.FromRef()
-			if err != nil || from.Root || strings.TrimSpace(from.FlowID) != strings.TrimSpace(receiverRef.FlowID) {
+		for _, replyConnect := range semanticview.ResolvedCompositionConnectsTo(source, sourceEndpoint.FlowID, replyInput.PinName()) {
+			from := replyConnect.From
+			if from.Root || strings.TrimSpace(from.FlowID) != strings.TrimSpace(receiverRef.FlowID) {
 				continue
 			}
 			matches = append(matches, ConnectRoutePlanReplyResolution{

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -67,6 +67,113 @@ type ConnectRoutePlanEndpoint struct {
 	Carries       []string
 }
 
+// ConnectSourceEndpointMatchesEvent is the canonical source-side identity
+// matcher for lowered connect plans.
+func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
+	if eventType == "" {
+		return false
+	}
+	if endpoint.Root && !connectSourceFlowInstanceMatchesPath(evt.FlowInstance(), "") {
+		return false
+	}
+	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
+	sourceResolved := strings.Trim(strings.TrimSpace(endpoint.ResolvedEvent), "/")
+	sourcePath := strings.Trim(strings.TrimSpace(endpoint.FlowPath), "/")
+	if sourcePath == "" {
+		sourcePath = strings.Trim(strings.TrimSpace(endpoint.FlowID), "/")
+	}
+	sourceScoped := sourceLocal
+	if sourcePath != "" && sourceLocal != "" {
+		sourceScoped = sourcePath + "/" + sourceLocal
+	}
+	for _, candidate := range []string{sourceResolved, sourceScoped} {
+		if candidate != "" && eventType == candidate {
+			return true
+		}
+	}
+	if sourceLocal != "" && eventType == sourceLocal {
+		return connectSourceFlowInstanceMatchesPath(evt.FlowInstance(), sourcePath)
+	}
+	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
+		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
+	}
+	for _, key := range connectSourceEventRouteKeys(evt) {
+		key = strings.Trim(strings.TrimSpace(key), "/")
+		if key != "" && (key == sourceResolved || key == sourceScoped) {
+			return true
+		}
+	}
+	return false
+}
+
+func connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath string) bool {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	sourcePath = strings.Trim(strings.TrimSpace(sourcePath), "/")
+	if sourcePath == "" {
+		return flowInstance == "" || runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == ""
+	}
+	if flowInstance == sourcePath {
+		return true
+	}
+	return runtimeflowidentity.SemanticScopeFromInstancePath(flowInstance) == sourcePath
+}
+
+func connectSourceEventRouteKeys(evt events.Event) []string {
+	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
+	if eventType == "" {
+		return nil
+	}
+	out := []string{eventType}
+	if concrete := connectSourceConcreteEventKey(eventType, evt.FlowInstance()); concrete != "" {
+		out = append(out, concrete)
+	}
+	targets := evt.TargetRoutes()
+	if target := evt.TargetRoute(); !target.Empty() {
+		targets = []events.RouteIdentity{target}
+	}
+	for _, target := range targets {
+		flowInstance := strings.Trim(strings.TrimSpace(target.Normalized().FlowInstance), "/")
+		staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
+		localEvent := connectSourceLocalEvent(eventType, staticScope)
+		if flowInstance == "" || localEvent == "" {
+			continue
+		}
+		out = append(out, flowInstance+"/"+localEvent, localEvent)
+	}
+	return out
+}
+
+func connectSourceConcreteEventKey(eventType, flowInstance string) string {
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+	staticScope := runtimeflowidentity.SemanticScopeFromFlowInstanceRef(flowInstance)
+	localEvent := connectSourceLocalEvent(eventType, staticScope)
+	if flowInstance == "" || localEvent == "" {
+		return ""
+	}
+	return flowInstance + "/" + localEvent
+}
+
+func connectSourceLocalEvent(eventType, staticScope string) string {
+	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
+	staticScope = strings.Trim(strings.TrimSpace(staticScope), "/")
+	if eventType == "" || staticScope == "" {
+		return ""
+	}
+	if strings.HasPrefix(eventType, staticScope+"/") {
+		localEvent := strings.TrimPrefix(eventType, staticScope+"/")
+		if localEvent == "" || strings.Contains(localEvent, "/") {
+			return ""
+		}
+		return localEvent
+	}
+	if strings.Contains(eventType, "/") {
+		return ""
+	}
+	return eventType
+}
+
 type ConnectRoutePlanAddress struct {
 	By          string
 	Source      string

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -67,14 +67,23 @@ type ConnectRoutePlanEndpoint struct {
 	Carries       []string
 }
 
-// ConnectSourceEndpointMatchesEvent is the canonical source-side identity
-// matcher for lowered connect plans.
+// ConnectSourceEndpointMatches is the canonical source-side identity matcher
+// for lowered connect plans.
+func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, flowInstance string) bool {
+	return connectSourceEndpointMatches(endpoint, eventType, flowInstance, nil)
+}
+
 func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
-	eventType := strings.Trim(strings.TrimSpace(string(evt.Type())), "/")
+	return connectSourceEndpointMatches(endpoint, string(evt.Type()), evt.FlowInstance(), connectSourceEventRouteKeys(evt))
+}
+
+func connectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, flowInstance string, routeKeys []string) bool {
+	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
+	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
 	if eventType == "" {
 		return false
 	}
-	if endpoint.Root && !connectSourceFlowInstanceMatchesPath(evt.FlowInstance(), "") {
+	if endpoint.Root && !connectSourceFlowInstanceMatchesPath(flowInstance, "") {
 		return false
 	}
 	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
@@ -93,13 +102,12 @@ func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt ev
 		}
 	}
 	if sourceLocal != "" && eventType == sourceLocal {
-		return connectSourceFlowInstanceMatchesPath(evt.FlowInstance(), sourcePath)
+		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
 	}
-	flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
 	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
 		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
 	}
-	for _, key := range connectSourceEventRouteKeys(evt) {
+	for _, key := range routeKeys {
 		key = strings.Trim(strings.TrimSpace(key), "/")
 		if key != "" && (key == sourceResolved || key == sourceScoped) {
 			return true

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -84,6 +84,9 @@ func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType s
 	if sourcePath == "" {
 		sourcePath = strings.Trim(strings.TrimSpace(endpoint.FlowID), "/")
 	}
+	if connectSourceEndpointIsTemplate(endpoint) {
+		return source.FlowInstance != "" && sourceLocal != "" && eventType == source.FlowInstance+"/"+sourceLocal
+	}
 	sourceScoped := sourceLocal
 	if sourcePath != "" && sourceLocal != "" {
 		sourceScoped = sourcePath + "/" + sourceLocal
@@ -131,10 +134,17 @@ func connectSourceRouteMatchesEndpoint(endpoint ConnectRoutePlanEndpoint, source
 			return false
 		}
 	}
-	if source.FlowInstance != "" && !connectSourceFlowInstanceMatchesPath(source.FlowInstance, sourcePath) {
+	if connectSourceEndpointIsTemplate(endpoint) {
+		return source.FlowInstance != "" && source.FlowInstance != sourcePath && connectSourceFlowInstanceMatchesPath(source.FlowInstance, sourcePath)
+	}
+	if source.FlowInstance != "" && source.FlowInstance != sourcePath {
 		return false
 	}
 	return true
+}
+
+func connectSourceEndpointIsTemplate(endpoint ConnectRoutePlanEndpoint) bool {
+	return strings.EqualFold(strings.TrimSpace(endpoint.Mode), "template")
 }
 
 func connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath string) bool {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -106,7 +106,13 @@ func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType s
 }
 
 func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
-	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), evt.SourceRoute())
+	source := evt.SourceRoute().Normalized()
+	// Legacy flow context can describe a child target; it cannot stand in for
+	// missing producer provenance when selecting a package-root source.
+	if endpoint.Root && source.Empty() && runtimeflowidentity.SemanticScopeFromFlowInstanceRef(evt.FlowInstance()) != "" {
+		return false
+	}
+	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), source)
 }
 
 func connectSourceRouteMatchesEndpoint(endpoint ConnectRoutePlanEndpoint, source events.RouteIdentity) bool {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -108,8 +108,13 @@ func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt ev
 	if sourcePath == "" {
 		sourcePath = source.FlowID
 	}
-	if sourcePath == "" && strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") != "" {
-		return false
+	if sourcePath == "" {
+		if !endpoint.Root {
+			return false
+		}
+		// Root ingress predates source-route stamping. Its envelope instance is
+		// used only to reject child scope, never as a producer identity.
+		sourcePath = evt.FlowInstance()
 	}
 	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), sourcePath)
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -69,13 +69,13 @@ type ConnectRoutePlanEndpoint struct {
 
 // ConnectSourceEndpointMatches is the canonical source-side identity matcher
 // for lowered connect plans.
-func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, flowInstance string) bool {
+func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType string, source events.RouteIdentity) bool {
 	eventType = strings.Trim(strings.TrimSpace(eventType), "/")
-	flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
 	if eventType == "" {
 		return false
 	}
-	if endpoint.Root && !connectSourceFlowInstanceMatchesPath(flowInstance, "") {
+	source = source.Normalized()
+	if !source.Empty() && !connectSourceRouteMatchesEndpoint(endpoint, source) {
 		return false
 	}
 	sourceLocal := strings.Trim(strings.TrimSpace(endpoint.Event), "/")
@@ -94,30 +94,47 @@ func ConnectSourceEndpointMatches(endpoint ConnectRoutePlanEndpoint, eventType, 
 		}
 	}
 	if sourceLocal != "" && eventType == sourceLocal {
-		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
+		return !source.Empty()
 	}
-	if flowInstance != "" && sourceLocal != "" && eventType == flowInstance+"/"+sourceLocal {
-		return connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath)
+	if source.FlowInstance != "" && sourceLocal != "" && eventType == source.FlowInstance+"/"+sourceLocal {
+		return true
 	}
 	return false
 }
 
 func ConnectSourceEndpointMatchesEvent(endpoint ConnectRoutePlanEndpoint, evt events.Event) bool {
-	source := evt.SourceRoute().Normalized()
-	sourcePath := source.FlowInstance
-	if sourcePath == "" {
-		sourcePath = source.FlowID
+	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), evt.SourceRoute())
+}
+
+func connectSourceRouteMatchesEndpoint(endpoint ConnectRoutePlanEndpoint, source events.RouteIdentity) bool {
+	source = source.Normalized()
+	if source.Empty() {
+		return true
 	}
+	if endpoint.Root {
+		// Root ownership has no child flow identity to agree with. Entity-only
+		// lineage is compatible, but any flow evidence names a non-root source.
+		return source.FlowID == "" && source.FlowInstance == ""
+	}
+
+	sourcePath := strings.Trim(strings.TrimSpace(endpoint.FlowPath), "/")
+	endpointFlowID := strings.Trim(strings.TrimSpace(endpoint.FlowID), "/")
 	if sourcePath == "" {
-		if endpoint.Root {
-			// Root ingress predates source-route stamping. Its envelope instance is
-			// used only to reject child scope, never as a producer identity.
-			sourcePath = evt.FlowInstance()
+		sourcePath = endpointFlowID
+	}
+	if source.FlowID == "" && source.FlowInstance == "" {
+		return false
+	}
+	if source.FlowID != "" {
+		sourceFlowID := strings.Trim(strings.TrimSpace(source.FlowID), "/")
+		if sourceFlowID != endpointFlowID && sourceFlowID != sourcePath {
+			return false
 		}
-		// A fully scoped static event name is sufficient without an instance.
-		// Concrete template matching still fails closed without SourceRoute.
 	}
-	return ConnectSourceEndpointMatches(endpoint, string(evt.Type()), sourcePath)
+	if source.FlowInstance != "" && !connectSourceFlowInstanceMatchesPath(source.FlowInstance, sourcePath) {
+		return false
+	}
+	return true
 }
 
 func connectSourceFlowInstanceMatchesPath(flowInstance, sourcePath string) bool {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -5,7 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimeprovideroutput "github.com/division-sh/swarm/internal/runtime/core/provideroutput"
@@ -14,6 +17,52 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatefanin"
 )
+
+func TestConnectSourceEndpointMatchesEventUsesImmutableSourceAcrossTargetProjection(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	source := events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "producer-entity"}
+	for _, tc := range []struct {
+		name   string
+		target events.RouteIdentity
+	}{
+		{name: "root receiver", target: events.RouteIdentity{EntityID: "root-entity"}},
+		{name: "different template target", target: events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/inst-9", EntityID: "consumer-entity"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+				FlowInstance: tc.target.FlowInstance,
+				Source:       source,
+				Target:       tc.target,
+			}, time.Unix(1, 0).UTC())
+			if !ConnectSourceEndpointMatchesEvent(endpoint, evt) {
+				t.Fatalf("source endpoint did not match immutable producer route; envelope = %#v", evt.NormalizedEnvelope())
+			}
+		})
+	}
+}
+
+func TestConnectSourceEndpointMatchesEventRejectsTargetIdentityAsSource(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "consumer",
+		FlowPath:      "consumer",
+		Event:         "deploy.done",
+		ResolvedEvent: "consumer/deploy.done",
+	}
+	target := events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/inst-9", EntityID: "consumer-entity"}
+	evt := eventtest.RootIngress("", "deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+		FlowInstance: target.FlowInstance,
+		Source:       events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "producer-entity"},
+		Target:       target,
+	}, time.Unix(1, 0).UTC())
+	if ConnectSourceEndpointMatchesEvent(endpoint, evt) {
+		t.Fatalf("consumer target matched as producer source; envelope = %#v", evt.NormalizedEnvelope())
+	}
+}
 
 func TestLowerTargetFreeInputRoutePlans_RejectsHarnessSource(t *testing.T) {
 	repoRoot := canonicalrouting.RepoRoot(t)

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -22,6 +22,7 @@ func TestConnectSourceEndpointMatchesEventUsesImmutableSourceAcrossTargetProject
 	endpoint := ConnectRoutePlanEndpoint{
 		FlowID:        "producer",
 		FlowPath:      "producer",
+		Mode:          "template",
 		Event:         "deploy.done",
 		ResolvedEvent: "producer/deploy.done",
 	}
@@ -68,6 +69,7 @@ func TestConnectSourceEndpointMatchesEventRejectsConcreteInstanceWithoutSourceRo
 	endpoint := ConnectRoutePlanEndpoint{
 		FlowID:        "producer",
 		FlowPath:      "producer",
+		Mode:          "template",
 		Event:         "deploy.done",
 		ResolvedEvent: "producer/deploy.done",
 	}
@@ -75,6 +77,47 @@ func TestConnectSourceEndpointMatchesEventRejectsConcreteInstanceWithoutSourceRo
 	if ConnectSourceEndpointMatchesEvent(endpoint, evt) {
 		t.Fatalf("concrete instance event matched without authoritative source route; envelope = %#v", evt.NormalizedEnvelope())
 	}
+}
+
+func TestConnectSourceEndpointMatchesEnforcesProducerModeMatrix(t *testing.T) {
+	flowEndpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	tests := []struct {
+		name      string
+		endpoint  ConnectRoutePlanEndpoint
+		eventType string
+		source    events.RouteIdentity
+		want      bool
+	}{
+		{name: "root static name", endpoint: ConnectRoutePlanEndpoint{Root: true, Mode: "root", Event: "deploy.done", ResolvedEvent: "deploy.done"}, eventType: "deploy.done", want: true},
+		{name: "root rejects child evidence", endpoint: ConnectRoutePlanEndpoint{Root: true, Mode: "root", Event: "deploy.done", ResolvedEvent: "deploy.done"}, eventType: "deploy.done", source: events.RouteIdentity{FlowID: "producer"}},
+		{name: "static scoped without route", endpoint: flowEndpoint, eventType: "producer/deploy.done", want: true},
+		{name: "static exact instance", endpoint: flowEndpoint, eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "static rejects descendant instance", endpoint: flowEndpoint, eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "singleton exact instance", endpoint: withConnectSourceMode(flowEndpoint, "singleton"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "singleton rejects descendant instance", endpoint: withConnectSourceMode(flowEndpoint, "singleton"), eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "template concrete instance", endpoint: withConnectSourceMode(flowEndpoint, "template"), eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}, want: true},
+		{name: "template rejects base without route", endpoint: withConnectSourceMode(flowEndpoint, "template"), eventType: "producer/deploy.done"},
+		{name: "template rejects base instance", endpoint: withConnectSourceMode(flowEndpoint, "template"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}},
+		{name: "template rejects base name with concrete route", endpoint: withConnectSourceMode(flowEndpoint, "template"), eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "template rejects concrete name without route", endpoint: withConnectSourceMode(flowEndpoint, "template"), eventType: "producer/inst-1/deploy.done"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ConnectSourceEndpointMatches(tc.endpoint, tc.eventType, tc.source); got != tc.want {
+				t.Fatalf("ConnectSourceEndpointMatches(%#v, %q, %#v) = %v, want %v", tc.endpoint, tc.eventType, tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+func withConnectSourceMode(endpoint ConnectRoutePlanEndpoint, mode string) ConnectRoutePlanEndpoint {
+	endpoint.Mode = mode
+	return endpoint
 }
 
 func TestConnectSourceEndpointMatchesRejectsStaticEventWhenSourceRouteContradicts(t *testing.T) {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -79,6 +79,80 @@ func TestConnectSourceEndpointMatchesEventRejectsConcreteInstanceWithoutSourceRo
 	}
 }
 
+func TestConnectSourceEndpointMatchesEventEnforcesRootSourceContextMatrix(t *testing.T) {
+	rootEndpoint := ConnectRoutePlanEndpoint{
+		Root:          true,
+		Mode:          "root",
+		Event:         "root.ready",
+		ResolvedEvent: "root.ready",
+	}
+	staticEndpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Mode:          "static",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	templateEndpoint := staticEndpoint
+	templateEndpoint.Mode = "template"
+
+	tests := []struct {
+		name         string
+		endpoint     ConnectRoutePlanEndpoint
+		eventType    string
+		flowInstance string
+		source       events.RouteIdentity
+		target       events.RouteIdentity
+		want         bool
+	}{
+		{name: "empty root context", endpoint: rootEndpoint, eventType: "root.ready", want: true},
+		{name: "UUID root instance", endpoint: rootEndpoint, eventType: "root.ready", flowInstance: "11111111-1111-4111-8111-111111111111", want: true},
+		{name: "concrete child context without source", endpoint: rootEndpoint, eventType: "root.ready", flowInstance: "child/inst-1"},
+		{name: "static child context without source", endpoint: rootEndpoint, eventType: "root.ready", flowInstance: "child"},
+		{
+			name:      "entity-only root source projected to child target",
+			endpoint:  rootEndpoint,
+			eventType: "root.ready",
+			source:    events.RouteIdentity{EntityID: "root-entity"},
+			target:    events.RouteIdentity{FlowID: "child", FlowInstance: "child/inst-1", EntityID: "child-entity"},
+			want:      true,
+		},
+		{
+			name:         "explicit child source remains authoritative",
+			endpoint:     rootEndpoint,
+			eventType:    "root.ready",
+			flowInstance: "11111111-1111-4111-8111-111111111111",
+			source:       events.RouteIdentity{FlowID: "child", FlowInstance: "child/inst-1"},
+		},
+		{
+			name:      "static source control",
+			endpoint:  staticEndpoint,
+			eventType: "producer/deploy.done",
+			source:    events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"},
+			want:      true,
+		},
+		{
+			name:      "template source control",
+			endpoint:  templateEndpoint,
+			eventType: "producer/inst-1/deploy.done",
+			source:    events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"},
+			want:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", events.EventType(tc.eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+				FlowInstance: tc.flowInstance,
+				Source:       tc.source,
+				Target:       tc.target,
+			}, time.Unix(1, 0).UTC())
+			if got := ConnectSourceEndpointMatchesEvent(tc.endpoint, evt); got != tc.want {
+				t.Fatalf("ConnectSourceEndpointMatchesEvent = %v, want %v; envelope = %#v", got, tc.want, evt.NormalizedEnvelope())
+			}
+		})
+	}
+}
+
 func TestConnectSourceEndpointMatchesEnforcesProducerModeMatrix(t *testing.T) {
 	flowEndpoint := ConnectRoutePlanEndpoint{
 		FlowID:        "producer",

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -64,6 +64,19 @@ func TestConnectSourceEndpointMatchesEventRejectsTargetIdentityAsSource(t *testi
 	}
 }
 
+func TestConnectSourceEndpointMatchesEventRejectsConcreteInstanceWithoutSourceRoute(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	if ConnectSourceEndpointMatchesEvent(endpoint, evt) {
+		t.Fatalf("concrete instance event matched without authoritative source route; envelope = %#v", evt.NormalizedEnvelope())
+	}
+}
+
 func TestLowerTargetFreeInputRoutePlans_RejectsHarnessSource(t *testing.T) {
 	repoRoot := canonicalrouting.RepoRoot(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -858,8 +858,8 @@ func TestLowerCompositionConnectRoutePlansRootProducerToStaticReceiver(t *testin
 	}
 }
 
-func TestLowerCompositionConnectRoutePlansRejectsRootReceiverEndpoint(t *testing.T) {
-	source := testRootConnectRoutePlanSource([]runtimecontracts.FlowOutputEventPin{{
+func TestLowerCompositionConnectRoutePlansSupportsRootReceiverEndpoint(t *testing.T) {
+	source := testRootReceiverConnectRoutePlanSource([]runtimecontracts.FlowInputEventPin{{
 		Name:  "root_ready",
 		Event: "root.ready",
 	}}, []connectRoutePlanFlow{
@@ -877,11 +877,18 @@ func TestLowerCompositionConnectRoutePlansRejectsRootReceiverEndpoint(t *testing
 	}})
 
 	plans, issues := LowerCompositionConnectRoutePlans(source)
-	if len(plans) != 0 {
-		t.Fatalf("plans = %#v, want none", plans)
+	if len(issues) != 0 {
+		t.Fatalf("issues = %#v, want none", issues)
 	}
-	if len(issues) != 1 || issues[0].Failure != ConnectFailureReceiverRootUnsupported {
-		t.Fatalf("issues = %#v, want receiver_root_unsupported", issues)
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v, want one", plans)
+	}
+	plan := plans[0]
+	if !plan.Receiver.Root || plan.Receiver.FlowID != "" || plan.Receiver.Pin != "root_ready" {
+		t.Fatalf("Receiver = %#v, want root input root_ready", plan.Receiver)
+	}
+	if plan.Target.FlowInstance != "" || plan.Target.EntityID != "" || plan.RequiresRuntimeResolution {
+		t.Fatalf("root target = %#v (runtime=%t), want root-static target", plan.Target, plan.RequiresRuntimeResolution)
 	}
 }
 
@@ -1091,6 +1098,14 @@ func testConnectRoutePlanSource(flows []connectRoutePlanFlow, connects []runtime
 }
 
 func testRootConnectRoutePlanSource(rootOutputs []runtimecontracts.FlowOutputEventPin, flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return testRootInputOutputConnectRoutePlanSource(nil, rootOutputs, flows, connects)
+}
+
+func testRootReceiverConnectRoutePlanSource(rootInputs []runtimecontracts.FlowInputEventPin, flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	return testRootInputOutputConnectRoutePlanSource(rootInputs, nil, flows, connects)
+}
+
+func testRootInputOutputConnectRoutePlanSource(rootInputs []runtimecontracts.FlowInputEventPin, rootOutputs []runtimecontracts.FlowOutputEventPin, flows []connectRoutePlanFlow, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
 	connects = append([]runtimecontracts.FlowPackageConnect(nil), connects...)
 	for i := range connects {
 		connects[i].SourceFile = "package.yaml"
@@ -1136,6 +1151,10 @@ func testRootConnectRoutePlanSource(rootOutputs []runtimecontracts.FlowOutputEve
 	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		RootSchema: &runtimecontracts.FlowSchemaDocument{
 			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events:    inputEventNames(rootInputs),
+					EventPins: rootInputs,
+				},
 				Outputs: runtimecontracts.FlowOutputPins{
 					Events:    outputEventNames(rootOutputs),
 					EventPins: rootOutputs,

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -77,6 +77,44 @@ func TestConnectSourceEndpointMatchesEventRejectsConcreteInstanceWithoutSourceRo
 	}
 }
 
+func TestConnectSourceEndpointMatchesRejectsStaticEventWhenSourceRouteContradicts(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	if ConnectSourceEndpointMatches(endpoint, "producer/deploy.done", events.RouteIdentity{
+		FlowID:       "unrelated",
+		FlowInstance: "unrelated/inst-1",
+	}) {
+		t.Fatal("static producer event matched contradictory source route")
+	}
+}
+
+func TestConnectSourceEndpointMatchesAllowsStaticEventWithoutSourceRoute(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		FlowID:        "producer",
+		FlowPath:      "producer",
+		Event:         "deploy.done",
+		ResolvedEvent: "producer/deploy.done",
+	}
+	if !ConnectSourceEndpointMatches(endpoint, "producer/deploy.done", events.RouteIdentity{}) {
+		t.Fatal("fully scoped static producer event did not match without source route")
+	}
+}
+
+func TestConnectSourceEndpointMatchesRejectsRootEventWithChildFlowEvidence(t *testing.T) {
+	endpoint := ConnectRoutePlanEndpoint{
+		Root:          true,
+		Event:         "deploy.done",
+		ResolvedEvent: "deploy.done",
+	}
+	if ConnectSourceEndpointMatches(endpoint, "deploy.done", events.RouteIdentity{FlowID: "child"}) {
+		t.Fatal("root endpoint matched child/static FlowID evidence")
+	}
+}
+
 func TestLowerTargetFreeInputRoutePlans_RejectsHarnessSource(t *testing.T) {
 	repoRoot := canonicalrouting.RepoRoot(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(

--- a/internal/runtime/core/pinrouting/pinrouting.go
+++ b/internal/runtime/core/pinrouting/pinrouting.go
@@ -135,15 +135,7 @@ func ProducerRouteCommonPathFailure(source semanticview.Source, flowID, eventTyp
 }
 
 func compositionConnectsFromOutputEvent(source semanticview.Source, flowID, eventType string) bool {
-	if source == nil {
-		return false
-	}
-	for _, pin := range outputPinsForEvent(source, flowID, eventType) {
-		if len(source.CompositionConnectsFrom(flowID, pin.PinName())) > 0 {
-			return true
-		}
-	}
-	return false
+	return len(compositionConnectRoutePlansFromOutputEvent(source, flowID, eventType)) > 0
 }
 
 func compositionConnectsFromOutputEventToFlow(source semanticview.Source, flowID, eventType, targetFlowID string) bool {
@@ -157,15 +149,34 @@ func compositionConnectsFromOutputEventToFlow(source semanticview.Source, flowID
 	if _, ok := source.FlowScopeByID(targetFlowID); !ok {
 		return false
 	}
-	for _, pin := range outputPinsForEvent(source, flowID, eventType) {
-		for _, connect := range source.CompositionConnectsFrom(flowID, pin.PinName()) {
-			to, err := connect.ToRef()
-			if err == nil && strings.TrimSpace(to.FlowID) == targetFlowID {
-				return true
-			}
+	for _, plan := range compositionConnectRoutePlansFromOutputEvent(source, flowID, eventType) {
+		if strings.TrimSpace(plan.Receiver.FlowID) == targetFlowID {
+			return true
 		}
 	}
 	return false
+}
+
+func compositionConnectRoutePlansFromOutputEvent(source semanticview.Source, flowID, eventType string) []ConnectRoutePlan {
+	if source == nil {
+		return nil
+	}
+	flowID = strings.TrimSpace(flowID)
+	eventType = eventidentity.Normalize(eventType)
+	if eventType == "" {
+		return nil
+	}
+	plans, _ := LowerCompositionConnectRoutePlans(source)
+	out := make([]ConnectRoutePlan, 0)
+	for _, plan := range plans {
+		if strings.TrimSpace(plan.Source.FlowID) != flowID {
+			continue
+		}
+		if eventReferencesOverlap(source, flowID, []string{eventType}, flowID, []string{plan.Source.Event, plan.Source.ResolvedEvent}) {
+			out = append(out, plan)
+		}
+	}
+	return out
 }
 
 func outputPinsForEvent(source semanticview.Source, flowID, eventType string) []runtimecontracts.FlowOutputEventPin {
@@ -316,9 +327,20 @@ func ResolveEnvelope(input ResolutionInput, envelope events.EventEnvelope) Resol
 	if failure := ProducerRouteCommonPathFailure(input.Source, input.FlowID, input.EventType, input.Emit); failure != "" {
 		return Resolution{Envelope: envelope.Normalized(), Failure: failure}
 	}
-	if compositionConnectsFromOutputEvent(input.Source, input.FlowID, input.EventType) {
+	connectPlans := compositionConnectRoutePlansFromOutputEvent(input.Source, input.FlowID, input.EventType)
+	if len(connectPlans) > 0 {
 		if failure := ValidateTargetSpec(input.Source, input.FlowID, input.Emit, true); failure != "" {
 			return Resolution{Envelope: envelope.Normalized(), Failure: failure}
+		}
+		if connectPlansContainRootReceiver(connectPlans) {
+			parentRoute := input.ParentRoute.Normalized()
+			if parentRoute.EntityID == "" {
+				return Resolution{Envelope: envelope.Normalized(), Failure: FailureParentRouteIncomplete}
+			}
+			return Resolution{
+				Envelope: events.EnvelopeForTargetRoute(envelope, parentRoute),
+				Target:   parentRoute,
+			}
 		}
 		return Resolution{Envelope: envelope.Normalized()}
 	}
@@ -372,6 +394,15 @@ func ResolveEnvelope(input ResolutionInput, envelope events.EventEnvelope) Resol
 	default:
 		return Resolution{Envelope: envelope.Normalized(), Failure: FailureTargetMalformed}
 	}
+}
+
+func connectPlansContainRootReceiver(plans []ConnectRoutePlan) bool {
+	for _, plan := range plans {
+		if plan.Receiver.Root {
+			return true
+		}
+	}
+	return false
 }
 
 func TargetMechanismPresent(spec runtimecontracts.EmitSpec, structuralParentRouteEligible bool) bool {

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -2,6 +2,7 @@ package pinrouting
 
 import (
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
@@ -9,7 +10,7 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
-	"time"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 )
 
 func TestResolveTargetsCompleteParentRouteForPinDeclaredOutput(t *testing.T) {
@@ -295,6 +296,69 @@ func TestResolveAllowsParentConnectToOwnPinDeclaredOutput(t *testing.T) {
 	}
 }
 
+func TestResolveAllowsNestedPackageRootConnectToOwnPinDeclaredOutput(t *testing.T) {
+	source := testNestedPackageConnectSource(t)
+
+	result := Resolve(ResolutionInput{
+		Source:    source,
+		FlowID:    "child",
+		EventType: "micro.start",
+	}, eventtest.RootIngress("", "micro.start", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want nested package connect authority", result.Failure)
+	}
+	if got := result.Event.TargetRoute(); !got.Empty() {
+		t.Fatalf("Event target = %#v, want EventBus ConnectRoutePlan authority", got)
+	}
+}
+
+func TestResolveRootReceiverConnectCarriesCompleteParentRoute(t *testing.T) {
+	parent := events.RouteIdentity{
+		EntityID: "11111111-1111-1111-1111-111111111111",
+	}
+	result := Resolve(ResolutionInput{
+		Source:      testNestedPackageConnectSource(t),
+		FlowID:      "child",
+		EventType:   "micro.relayed",
+		ParentRoute: parent,
+	}, eventtest.RootIngress("", "micro.relayed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != "" {
+		t.Fatalf("Failure = %q, want complete parent route", result.Failure)
+	}
+	if got := result.Event.TargetRoute(); got != parent {
+		t.Fatalf("Event target = %#v, want parent %#v", got, parent)
+	}
+}
+
+func TestResolveRootReceiverConnectRejectsMissingParentRoute(t *testing.T) {
+	result := Resolve(ResolutionInput{
+		Source:    testNestedPackageConnectSource(t),
+		FlowID:    "child",
+		EventType: "micro.relayed",
+	}, eventtest.RootIngress("", "micro.relayed", "", "", nil, 0, "", "", events.EventEnvelope{}, time.Time{}))
+
+	if result.Failure != FailureParentRouteIncomplete {
+		t.Fatalf("Failure = %q, want %q", result.Failure, FailureParentRouteIncomplete)
+	}
+}
+
+func testNestedPackageConnectSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := canonicalrouting.RepoRoot(t)
+	fixtureRoot := repoRoot + "/tests/tier11-flow-composition/test-nested-three-levels"
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(
+		repoRoot,
+		fixtureRoot,
+		runtimecontracts.DefaultPlatformSpecFile(repoRoot),
+	)
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func TestResolveFailsClosedForUnknownProducerTargetFlowEvenWithParentConnect(t *testing.T) {
 	result := Resolve(ResolutionInput{
 		Source:    testProducerConnectSource(),
@@ -554,6 +618,10 @@ func testProducerRouteSource(connects []runtimecontracts.FlowPackageConnect) sem
 }
 
 func testProducerRouteSourceWithEvents(outputEvent, inputEvent string, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	for i := range connects {
+		connects[i].SourceFile = "package.yaml"
+		connects[i].SourceLine = i + 1
+	}
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{
 			ID:   "producer",
@@ -707,8 +775,10 @@ func testRootConnectPinRoutingSource() semanticview.Source {
 				"consumer": {{Name: "ready", Event: "root.ready"}},
 			},
 			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
-				From: ".root_ready",
-				To:   "consumer.ready",
+				From:       ".root_ready",
+				To:         "consumer.ready",
+				SourceFile: "package.yaml",
+				SourceLine: 1,
 			}},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{

--- a/internal/runtime/effects/source_manifest_test.go
+++ b/internal/runtime/effects/source_manifest_test.go
@@ -26,6 +26,9 @@ const (
 	ownerDiagnostic          primitiveOwner = "diagnostic"
 	ownerComputeSandbox      primitiveOwner = "compute_sandbox"
 	ownerBuildTest           primitiveOwner = "build_test_infrastructure"
+
+	canonicalImportBoundaryAliasWrite    = "internal/runtime/testfixtures/canonicalrouting/import_boundary_variants.go:CopyImportBoundaryAlias:filesystem_write:1"
+	canonicalImportBoundaryWildcardWrite = "internal/runtime/testfixtures/canonicalrouting/import_boundary_variants.go:CopyImportBoundaryWildcard:filesystem_write:1"
 )
 
 // sourcePrimitiveOwners is an exact source-derived ledger. Keys include the
@@ -87,6 +90,8 @@ var sourcePrimitiveOwners = map[string]primitiveOwner{
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:writeFixtureFile:filesystem_write:1":                       ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:writeFixtureFile:filesystem_write:2":                       ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:writeYAMLDocument:filesystem_write:1":                      ownerBuildTest,
+	canonicalImportBoundaryAliasWrite:    ownerBuildTest,
+	canonicalImportBoundaryWildcardWrite: ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/specialized_variants.go:removeInheritedScenarios:filesystem_write:1":  ownerBuildTest,
 	"internal/runtime/tools/executor_http.go:execHTTPRequestOnce:http_do:1":                                               ownerManagedAgent,
 	"internal/runtime/tools/executor_native.go:doNormalizedSearch:http_do:1":                                              ownerManagedAgent,

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -3284,6 +3284,9 @@ func emitSourceRoute(frame *executionFrame) events.RouteIdentity {
 	if frame == nil {
 		return events.RouteIdentity{}
 	}
+	if admitted := frame.req.ProducerRoute.Normalized(); !admitted.Empty() {
+		return admitted
+	}
 	flowInstance := firstNonEmpty(
 		normalizedFlowInstanceCandidate(asString(frame.req.State.StateCarrier.Metadata["flow_path"])),
 		normalizedFlowInstanceCandidate(frame.req.Event.FlowInstance()),

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -4593,6 +4593,59 @@ func TestExecutor_EmitIntentUsesTargetStateFlowIdentityBeforeInboundSource(t *te
 	}
 }
 
+func TestExecutor_EmitIntentUsesAdmittedProducerRouteBeforeStateMetadata(t *testing.T) {
+	exec, err := NewExecutor(RuntimeDependencies{
+		Source:     stubSource(),
+		StateRepo:  stubStateRepo{},
+		TxRunner:   stubRunner{},
+		Locker:     stubLocker{},
+		Outbox:     stubOutbox{},
+		Dispatcher: stubDispatcher{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewExecutor error: %v", err)
+	}
+
+	admitted := events.RouteIdentity{
+		FlowID:       "validation",
+		FlowInstance: "validation",
+		EntityID:     "validation-entity",
+	}
+	result, err := exec.Execute(context.Background(), ExecutionRequest{
+		EntityID:      identity.NormalizeEntityID(admitted.EntityID),
+		NodeID:        "validation-router",
+		FlowID:        "validation",
+		ProducerRoute: admitted,
+		Event: eventtest.RootIngress(
+			"evt-1",
+			"validation.started",
+			"",
+			"",
+			json.RawMessage(`{}`),
+			0,
+			"",
+			"",
+			events.EnvelopeForFlowInstance(events.EventEnvelope{}, "validation/validation"),
+			time.Time{},
+		),
+		Handler: runtimecontracts.SystemNodeEventHandler{
+			Emit: runtimecontracts.EmitSpec{Event: "validation.completed"},
+		},
+		State: testStateSnapshot("researching", map[string]any{
+			"flow_path": "validation/validation",
+		}, nil, map[string]map[string]any{}),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := len(result.EmitIntents); got != 1 {
+		t.Fatalf("EmitIntents count = %d, want 1", got)
+	}
+	if got := result.EmitIntents[0].Event.SourceRoute(); got != admitted.Normalized() {
+		t.Fatalf("emitted source route = %#v, want admitted %#v", got, admitted.Normalized())
+	}
+}
+
 func TestExecutor_EmitIntentFallsBackToInboundFlowWhenStateFlowPathNormalizesEmpty(t *testing.T) {
 	exec, err := NewExecutor(RuntimeDependencies{
 		Source:     stubSource(),

--- a/internal/runtime/manager/agent_manager.go
+++ b/internal/runtime/manager/agent_manager.go
@@ -316,6 +316,10 @@ func (am *AgentManager) spawnAgentInternal(ctx context.Context, rec PersistedAge
 	if err := am.resolveAgentModel(&rec.Config); err != nil {
 		return err
 	}
+	subscriptionAdmission, err := admitAgentConfigSubscriptions(am.semanticSource, &rec.Config, nil)
+	if err != nil {
+		return err
+	}
 	if err := am.validateNativeToolAdmission(ctx, rec.Config); err != nil {
 		return err
 	}
@@ -341,7 +345,7 @@ func (am *AgentManager) spawnAgentInternal(ctx context.Context, rec PersistedAge
 			}
 			postCommitCtx := runtimepipeline.WithoutPipelineSQLTxContext(context.WithoutCancel(ctx))
 			if !runtimepipeline.QueuePipelinePostCommitAction(ctx, func() {
-				if err := am.publishCommittedAgent(postCommitCtx, rec, a, result); err != nil && am.bus != nil {
+				if err := am.publishCommittedAgent(postCommitCtx, rec, a, subscriptionAdmission, result); err != nil && am.bus != nil {
 					_ = am.bus.LogRuntime(postCommitCtx, runtimepipeline.RuntimeLogEntry{
 						Level: "error", Message: "Post-commit agent publication failed",
 						Component: "flow_activation", Action: "agent_post_commit_publish_failed",
@@ -354,7 +358,7 @@ func (am *AgentManager) spawnAgentInternal(ctx context.Context, rec PersistedAge
 			return nil
 		}
 	}
-	if err := am.lifecycle.registerExecution(ctx, rec, persist, a); err != nil {
+	if err := am.lifecycle.registerExecution(ctx, rec, persist, a, subscriptionAdmission); err != nil {
 		return err
 	}
 	if persist && am.lifecycle.store == nil && am.store != nil {
@@ -376,12 +380,12 @@ func (am *AgentManager) spawnAgentInternal(ctx context.Context, rec PersistedAge
 	return nil
 }
 
-func (am *AgentManager) publishCommittedAgent(ctx context.Context, rec PersistedAgent, a Agent, result AgentLifecycleTransitionResult) error {
+func (am *AgentManager) publishCommittedAgent(ctx context.Context, rec PersistedAgent, a Agent, subscriptionAdmission semanticview.FlowOwnedAgentSubscriptionAdmission, result AgentLifecycleTransitionResult) error {
 	rec.LifecycleEpoch = result.RuntimeEpoch
 	rec.LifecycleGeneration = result.Generation
 	rec.LifecyclePhase = result.Phase
 	rec.LifecycleRunMode = result.RunMode
-	if err := am.lifecycle.registerExecution(ctx, rec, false, a); err != nil {
+	if err := am.lifecycle.registerExecution(ctx, rec, false, a, subscriptionAdmission); err != nil {
 		return err
 	}
 	_ = am.projectLifecycleDiagnostics(ctx)

--- a/internal/runtime/manager/agent_subscription_admission.go
+++ b/internal/runtime/manager/agent_subscription_admission.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func admitAgentConfigSubscriptions(source semanticview.Source, cfg *runtimeactors.AgentConfig, localEvents map[string]struct{}) (semanticview.FlowOwnedAgentSubscriptionAdmission, error) {
+	if cfg == nil {
+		return semanticview.FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf("agent config is required")
+	}
+	cfg.NormalizeRuntimeDescriptor()
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(source, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       cfg.ID,
+		FlowID:        cfg.FlowID,
+		FlowPath:      cfg.CanonicalFlowPath(),
+		LocalEvents:   localEvents,
+		Subscriptions: cfg.Subscriptions,
+	})
+	if err != nil {
+		return semanticview.FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf("agent subscription admission failed: %w", err)
+	}
+	cfg.Subscriptions = admission.PersistedSubscriptions()
+	return admission, nil
+}
+
+func admittedSubscriptionEventTypes(admission semanticview.FlowOwnedAgentSubscriptionAdmission) []events.EventType {
+	patterns := admission.RoutePatterns()
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]events.EventType, 0, len(patterns))
+	for _, pattern := range patterns {
+		out = append(out, events.EventType(pattern))
+	}
+	return out
+}

--- a/internal/runtime/manager/agent_subscription_admission_test.go
+++ b/internal/runtime/manager/agent_subscription_admission_test.go
@@ -1,0 +1,97 @@
+package manager
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type subscriptionAdmissionTestAgent struct{ id string }
+
+func (a subscriptionAdmissionTestAgent) ID() string                      { return a.id }
+func (subscriptionAdmissionTestAgent) Type() string                      { return "test" }
+func (subscriptionAdmissionTestAgent) Subscriptions() []events.EventType { return nil }
+func (subscriptionAdmissionTestAgent) OnEvent(context.Context, events.Event) ([]events.Event, error) {
+	return nil, nil
+}
+
+func testManagerSubscriptionAdmission(t *testing.T, cfg runtimeactors.AgentConfig) semanticview.FlowOwnedAgentSubscriptionAdmission {
+	t.Helper()
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID: cfg.ID, FlowID: cfg.FlowID, FlowPath: cfg.CanonicalFlowPath(), Subscriptions: cfg.Subscriptions,
+	})
+	if err != nil {
+		t.Fatalf("admit test manager subscriptions: %v", err)
+	}
+	return admission
+}
+
+func TestSpawnAgentRejectsForeignExactAndPatternBeforeRegistration(t *testing.T) {
+	for _, subscription := range []string{"foreign/task.ready", "foreign/**/task.ready"} {
+		t.Run(strings.ReplaceAll(subscription, "/", "_"), func(t *testing.T) {
+			eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			am := NewAgentManager(eb, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+				return subscriptionAdmissionTestAgent{id: cfg.ID}, nil
+			})
+			err = am.SpawnAgent(runtimeactors.AgentConfig{
+				ExecutionMode: "live",
+				ID:            "reviewer",
+				FlowPath:      "review/inst-1",
+				Subscriptions: []string{subscription},
+			})
+			if err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+				t.Fatalf("SpawnAgent error = %v, want admission rejection", err)
+			}
+			if am.Count() != 0 {
+				t.Fatalf("registered agent count = %d, want zero", am.Count())
+			}
+		})
+	}
+}
+
+func TestReconfigureAgentRejectsForeignSubscriptionWithoutReplacingCurrentAdmission(t *testing.T) {
+	eb, err := runtimebus.NewEventBus(runtimebus.InMemoryEventStore{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	am := NewAgentManager(eb, func(cfg runtimeactors.AgentConfig) (Agent, error) {
+		return subscriptionAdmissionTestAgent{id: cfg.ID}, nil
+	})
+	initial := runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		ID:            "reviewer",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready"},
+	}
+	if err := am.SpawnAgent(initial); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	before, ok := am.lifecycle.executionSnapshot(initial.ID)
+	if !ok {
+		t.Fatal("initial execution missing")
+	}
+
+	err = am.ReconfigureAgent(initial.ID, runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		Subscriptions: []string{"foreign/**/task.ready"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+		t.Fatalf("ReconfigureAgent error = %v, want admission rejection", err)
+	}
+	after, ok := am.lifecycle.executionSnapshot(initial.ID)
+	if !ok {
+		t.Fatal("execution disappeared after rejected reconfigure")
+	}
+	if after.Token != before.Token || !reflect.DeepEqual(after.Config, before.Config) || !reflect.DeepEqual(after.Admission.RoutePatterns(), before.Admission.RoutePatterns()) {
+		t.Fatalf("rejected reconfigure changed execution: before=%#v after=%#v", before, after)
+	}
+}

--- a/internal/runtime/manager/execution_projection_test.go
+++ b/internal/runtime/manager/execution_projection_test.go
@@ -292,7 +292,9 @@ func TestSelectedForkEphemeralRegistrationInstallsCarrierOnlyRoute(t *testing.T)
 
 	runCtx, cancelRun := context.WithCancel(context.Background())
 	defer cancelRun()
-	am.RunAuthoritativeDeliveryOnly(runCtx)
+	if err := am.RunAuthoritativeDeliveryOnly(managedExecutionTestContext(t, runCtx)); err != nil {
+		t.Fatalf("RunAuthoritativeDeliveryOnly: %v", err)
+	}
 	route, ok := bus.current(agentID)
 	if !ok {
 		t.Fatal("selected-fork execution did not install its typed carrier")
@@ -338,7 +340,9 @@ func TestEphemeralCloneConsumesAdmittedBaseSubscriptions(t *testing.T) {
 
 	runCtx, cancelRun := context.WithCancel(context.Background())
 	defer cancelRun()
-	am.Run(runCtx)
+	if err := am.Run(managedExecutionTestContext(t, runCtx)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 	route, ok := bus.current("clone-agent")
 	if !ok {
 		t.Fatal("clone route missing")

--- a/internal/runtime/manager/execution_projection_test.go
+++ b/internal/runtime/manager/execution_projection_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 type projectionTestRoute struct {
@@ -54,9 +56,14 @@ func (*projectionTestBus) ResetInMemoryState() error      { return nil }
 func (*projectionTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLogEntry) error {
 	return nil
 }
-func (b *projectionTestBus) ReplaceAgentRoute(token runtimeeffects.LifecycleToken, subscriptions ...events.EventType) <-chan events.Event {
+func (b *projectionTestBus) ReplaceAgentRoute(token runtimeeffects.LifecycleToken, admission semanticview.FlowOwnedAgentSubscriptionAdmission) <-chan events.Event {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	patterns := admission.RoutePatterns()
+	subscriptions := make([]events.EventType, 0, len(patterns))
+	for _, pattern := range patterns {
+		subscriptions = append(subscriptions, events.EventType(pattern))
+	}
 	route := projectionTestRoute{
 		token: token, channel: make(chan events.Event, 128),
 		subscriptions: append([]events.EventType(nil), subscriptions...),
@@ -168,7 +175,7 @@ func TestExecutionProjectionReconfigureSerializesRestartSelection(t *testing.T) 
 	factory := &projectionTestFactory{secondStarted: make(chan struct{}), releaseSecond: releaseBuild, handled: handled}
 	am := NewAgentManager(bus, factory.Build)
 	const agentID = "projection-restart"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -177,7 +184,7 @@ func TestExecutionProjectionReconfigureSerializesRestartSelection(t *testing.T) 
 
 	reconfigureDone := make(chan error, 1)
 	go func() {
-		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}})
+		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}, Subscriptions: []string{"test.new"}})
 	}()
 	<-factory.secondStarted
 	restartDone := make(chan error, 1)
@@ -231,12 +238,12 @@ func TestExecutionProjectionReconfigureSerializesBothRunModes(t *testing.T) {
 			factory := &projectionTestFactory{secondStarted: make(chan struct{}), releaseSecond: releaseBuild, handled: handled}
 			am := NewAgentManager(bus, factory.Build)
 			const agentID = "projection-run"
-			if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+			if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 				t.Fatalf("SpawnAgent: %v", err)
 			}
 			reconfigureDone := make(chan error, 1)
 			go func() {
-				reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}})
+				reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}, Subscriptions: []string{"test.new"}})
 			}()
 			<-factory.secondStarted
 			runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -268,6 +275,79 @@ func TestExecutionProjectionReconfigureSerializesBothRunModes(t *testing.T) {
 	}
 }
 
+func TestSelectedForkEphemeralRegistrationInstallsCarrierOnlyRoute(t *testing.T) {
+	bus := newProjectionTestBus()
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return &projectionTestAgent{id: cfg.ID, subs: []events.EventType{"foreign/task.ready"}, handled: make(chan int, 1)}, nil
+	})
+	const agentID = "selected-fork-agent"
+	if err := am.RegisterEphemeralAgentForExecution(context.Background(), PersistedAgent{Config: models.AgentConfig{
+		ExecutionMode: "live",
+		ID:            agentID,
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*"},
+	}}); err != nil {
+		t.Fatalf("RegisterEphemeralAgentForExecution: %v", err)
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+	am.RunAuthoritativeDeliveryOnly(runCtx)
+	route, ok := bus.current(agentID)
+	if !ok {
+		t.Fatal("selected-fork execution did not install its typed carrier")
+	}
+	if len(route.subscriptions) != 0 {
+		t.Fatalf("selected-fork carrier subscriptions = %#v, want none", route.subscriptions)
+	}
+	execution, ok := am.lifecycle.executionSnapshot(agentID)
+	if !ok {
+		t.Fatal("selected-fork execution projection missing")
+	}
+	want := []events.EventType{"review/inst-1/task.*", "review/inst-1/task.ready"}
+	if !reflect.DeepEqual(execution.Subscriptions, want) {
+		t.Fatalf("selected-fork admitted subscriptions = %#v, want %#v", execution.Subscriptions, want)
+	}
+}
+
+func TestEphemeralCloneConsumesAdmittedBaseSubscriptions(t *testing.T) {
+	bus := newProjectionTestBus()
+	am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+		return &projectionTestAgent{id: cfg.ID, handled: make(chan int, 1)}, nil
+	})
+	if err := am.SpawnAgent(models.AgentConfig{
+		ExecutionMode: "live",
+		ID:            "base-agent",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*"},
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	if err := am.SpawnEphemeralClone("base-agent", "clone-agent"); err != nil {
+		t.Fatalf("SpawnEphemeralClone: %v", err)
+	}
+
+	base, baseOK := am.lifecycle.executionSnapshot("base-agent")
+	clone, cloneOK := am.lifecycle.executionSnapshot("clone-agent")
+	if !baseOK || !cloneOK {
+		t.Fatalf("execution snapshots: base=%v clone=%v", baseOK, cloneOK)
+	}
+	if !reflect.DeepEqual(clone.Subscriptions, base.Subscriptions) || clone.Admission.FlowPath() != base.Admission.FlowPath() {
+		t.Fatalf("clone admission = %#v/%q, want base %#v/%q", clone.Subscriptions, clone.Admission.FlowPath(), base.Subscriptions, base.Admission.FlowPath())
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+	am.Run(runCtx)
+	route, ok := bus.current("clone-agent")
+	if !ok {
+		t.Fatal("clone route missing")
+	}
+	if !reflect.DeepEqual(route.subscriptions, base.Subscriptions) {
+		t.Fatalf("clone route subscriptions = %#v, want admitted base %#v", route.subscriptions, base.Subscriptions)
+	}
+}
+
 func TestExecutionProjectionDirectiveLeaseFencesReplacement(t *testing.T) {
 	bus := newProjectionTestBus()
 	bus.store = &directiveEventStore{}
@@ -284,7 +364,7 @@ func TestExecutionProjectionDirectiveLeaseFencesReplacement(t *testing.T) {
 	targetStore := &directiveTargetStore{target: runtimeagentcontrol.RunTargetResolution{RunID: "00000000-0000-0000-0000-000000009901", Mode: runtimeagentcontrol.RunResolutionSpecified}}
 	am := NewAgentManager(bus, factory, targetStore)
 	const agentID = "projection-directive"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -307,7 +387,7 @@ func TestExecutionProjectionDirectiveLeaseFencesReplacement(t *testing.T) {
 	}
 	reconfigureDone := make(chan error, 1)
 	go func() {
-		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}})
+		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}, Subscriptions: []string{"test.new"}})
 	}()
 	select {
 	case <-runCtx.Done():
@@ -336,7 +416,7 @@ func TestExecutionProjectionRunCancellationRemovesExactRoute(t *testing.T) {
 	factory := &projectionTestFactory{handled: make(chan int, 1)}
 	am := NewAgentManager(bus, factory.Build)
 	const agentID = "projection-shutdown"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -375,7 +455,7 @@ func TestExecutionProjectionTeardownRemovesExactRoute(t *testing.T) {
 	factory := &projectionTestFactory{handled: make(chan int, 1)}
 	am := NewAgentManager(bus, factory.Build)
 	const agentID = "projection-teardown"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -413,7 +493,7 @@ func TestExecutionProjectionNaturalLoopExitRemovesExactRoute(t *testing.T) {
 	factory := &projectionTestFactory{handled: make(chan int, 1)}
 	am := NewAgentManager(bus, factory.Build)
 	const agentID = "projection-self-release"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	runCtx, cancelRun := context.WithCancel(testAuthorActivityContext(context.Background()))
@@ -474,7 +554,7 @@ func TestExecutionProjectionBacklogLeaseFencesReplacement(t *testing.T) {
 		}, nil
 	}
 	am := NewAgentManager(bus, factory, store)
-	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{Config: models.AgentConfig{ExecutionMode: "live", ID: agentID}}, false); err != nil {
+	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{Config: models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.backlog"}}}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
 	predecessor, ok := am.lifecycle.executionSnapshot(agentID)
@@ -488,7 +568,7 @@ func TestExecutionProjectionBacklogLeaseFencesReplacement(t *testing.T) {
 	}
 	reconfigureDone := make(chan error, 1)
 	go func() {
-		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}})
+		reconfigureDone <- am.ReconfigureAgent(agentID, models.AgentConfig{ExecutionMode: "live", Tools: []string{"tool-new"}, Subscriptions: []string{"test.backlog"}})
 	}()
 	select {
 	case err := <-reconfigureDone:
@@ -515,7 +595,7 @@ func TestExecutionProjectionRecoveryStartsPersistedRunningCell(t *testing.T) {
 	am := NewAgentManager(bus, factory.Build)
 	const agentID = "projection-recovery"
 	rec := PersistedAgent{
-		Config: models.AgentConfig{ExecutionMode: "live", ID: agentID}, LifecycleEpoch: runtimebus.CurrentRuntimeEpoch(),
+		Config: models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}, LifecycleEpoch: runtimebus.CurrentRuntimeEpoch(),
 		LifecycleGeneration: 4, LifecyclePhase: AgentLifecycleRunning, LifecycleRunMode: AgentRunModeStandard,
 	}
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), rec, false); err != nil {
@@ -554,7 +634,7 @@ func TestExecutionProjectionSpawnDuringRunActivatesRegisteredProjection(t *testi
 	defer cancelRun()
 	am.Run(managedExecutionTestContext(t, runCtx))
 	const agentID = "projection-flow-activation"
-	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID}); err != nil {
+	if err := am.SpawnAgent(models.AgentConfig{ExecutionMode: "live", ID: agentID, Subscriptions: []string{"test.old"}}); err != nil {
 		t.Fatalf("SpawnAgent while running: %v", err)
 	}
 	route, live := bus.current(agentID)

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -712,6 +712,9 @@ func buildFlowAgentConfig(
 		Config:          rawConfig,
 	}
 	cfg.NormalizeRuntimeDescriptor()
+	if _, err := admitAgentConfigSubscriptions(source, &cfg, localEvents); err != nil {
+		return models.AgentConfig{}, fmt.Errorf("flow agent %s: %w", key, err)
+	}
 	return cfg, nil
 }
 
@@ -898,6 +901,9 @@ func buildStaticFlowAgentConfig(
 		Config:          rawConfig,
 	}
 	cfg.NormalizeRuntimeDescriptor()
+	if _, err := admitAgentConfigSubscriptions(source, &cfg, localEvents); err != nil {
+		return models.AgentConfig{}, fmt.Errorf("static flow agent %s: %w", logicalID, err)
+	}
 	return cfg, nil
 }
 

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -1413,7 +1413,7 @@ func TestDeactivateFlowInstanceModel_PersistsTerminalStateInFlowInstances(t *tes
 		EntityID:      req.Instance.EntityID,
 		FlowPath:      "review/other-inst",
 	}
-	if err := am.lifecycle.registerExecution(ctx, PersistedAgent{Config: sharedConfig, Status: "active", HiredBy: "test"}, false, sharedAgent); err != nil {
+	if err := am.lifecycle.registerExecution(ctx, PersistedAgent{Config: sharedConfig, Status: "active", HiredBy: "test"}, false, sharedAgent, testManagerSubscriptionAdmission(t, sharedConfig)); err != nil {
 		t.Fatalf("register shared-subject-agent: %v", err)
 	}
 
@@ -1978,6 +1978,21 @@ func TestBuildFlowAgentConfig_PassesContractToolsAndEmitEvents(t *testing.T) {
 	}
 	if !cfg.NativeTools.Bash || !cfg.NativeTools.FileIO {
 		t.Fatalf("native_tools = %#v, want bash/file_io true", cfg.NativeTools)
+	}
+}
+
+func TestStaticAndDynamicFlowAgentConfigRejectForeignExactAndPattern(t *testing.T) {
+	source := semanticview.Wrap(testFlowBundle(""))
+	for _, subscription := range []string{"foreign/task.ready", "foreign/**/task.ready"} {
+		t.Run(strings.ReplaceAll(subscription, "/", "_"), func(t *testing.T) {
+			entry := runtimecontracts.AgentRegistryEntry{ID: "reviewer", Type: "generic", Subscriptions: []string{subscription}}
+			if _, err := buildStaticFlowAgentConfig(source, "review", "review", "reviewer", entry, map[string]struct{}{"task.started": {}}); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+				t.Fatalf("buildStaticFlowAgentConfig error = %v, want admission rejection", err)
+			}
+			if _, err := buildFlowAgentConfig(source, "review", "inst-1", "ent-1", "review/inst-1", "reviewer", entry, nil, map[string]struct{}{"task.started": {}}, nil); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+				t.Fatalf("buildFlowAgentConfig error = %v, want admission rejection", err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/manager/lifecycle_coordinator.go
+++ b/internal/runtime/manager/lifecycle_coordinator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/managedexecution"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/google/uuid"
 )
@@ -44,6 +45,7 @@ type agentExecutionProjection struct {
 	agent            Agent
 	config           models.AgentConfig
 	subscriptions    []events.EventType
+	admission        semanticview.FlowOwnedAgentSubscriptionAdmission
 	startedAt        time.Time
 	token            runtimeeffects.LifecycleToken
 	generationCtx    context.Context
@@ -58,7 +60,7 @@ type agentExecutionProjection struct {
 }
 
 type agentRouteBus interface {
-	ReplaceAgentRoute(runtimeeffects.LifecycleToken, ...events.EventType) <-chan events.Event
+	ReplaceAgentRoute(runtimeeffects.LifecycleToken, semanticview.FlowOwnedAgentSubscriptionAdmission) <-chan events.Event
 	RemoveAgentRoute(runtimeeffects.LifecycleToken)
 }
 
@@ -70,6 +72,7 @@ type agentExecutionSnapshot struct {
 	Agent         Agent
 	Config        models.AgentConfig
 	Subscriptions []events.EventType
+	Admission     semanticview.FlowOwnedAgentSubscriptionAdmission
 	StartedAt     time.Time
 	Token         runtimeeffects.LifecycleToken
 }
@@ -168,14 +171,23 @@ func lifecycleReconfigureOperationID(agentID string, epoch int64, generation uin
 }
 
 func (c *agentLifecycleCoordinator) register(ctx context.Context, rec PersistedAgent, persist bool) error {
-	return c.registerExecution(ctx, rec, persist, nil)
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID: rec.Config.ID, FlowID: rec.Config.FlowID, FlowPath: rec.Config.CanonicalFlowPath(), Subscriptions: rec.Config.Subscriptions,
+	})
+	if err != nil {
+		return err
+	}
+	return c.registerExecution(ctx, rec, persist, nil, admission)
 }
 
-func (c *agentLifecycleCoordinator) registerExecution(ctx context.Context, rec PersistedAgent, persist bool, agent Agent) error {
+func (c *agentLifecycleCoordinator) registerExecution(ctx context.Context, rec PersistedAgent, persist bool, agent Agent, admission semanticview.FlowOwnedAgentSubscriptionAdmission) error {
 	if c == nil {
 		return fmt.Errorf("agent lifecycle coordinator is required")
 	}
 	agentID := strings.TrimSpace(rec.Config.ID)
+	if !admission.ValidForAgent(agentID) {
+		return fmt.Errorf("agent %s missing subscription admission", agentID)
+	}
 	revision, err := lifecycleConfigRevision(rec)
 	if err != nil {
 		return err
@@ -238,13 +250,11 @@ func (c *agentLifecycleCoordinator) registerExecution(ctx context.Context, rec P
 		startedAt = time.Now()
 	}
 	execution := &agentExecutionProjection{
-		agent: agent, config: rec.Config, startedAt: startedAt,
+		agent: agent, config: rec.Config, admission: admission, startedAt: startedAt,
 		token:         runtimeeffects.LifecycleToken{RuntimeEpoch: epoch, AgentID: agentID, Generation: generation},
 		generationCtx: generationCtx, cancelGeneration: cancelGeneration,
 	}
-	if agent != nil {
-		execution.subscriptions = append([]events.EventType(nil), agent.Subscriptions()...)
-	}
+	execution.subscriptions = admittedSubscriptionEventTypes(admission)
 	c.cells[agentID] = &agentLifecycleCell{epoch: epoch, generation: generation, phase: phase, configRevision: revision, runMode: mode, execution: execution}
 	return nil
 }
@@ -470,6 +480,7 @@ func snapshotExecution(execution *agentExecutionProjection) agentExecutionSnapsh
 	return agentExecutionSnapshot{
 		Agent: execution.agent, Config: execution.config,
 		Subscriptions: append([]events.EventType(nil), execution.subscriptions...),
+		Admission:     execution.admission,
 		StartedAt:     execution.startedAt, Token: execution.token,
 	}
 }

--- a/internal/runtime/manager/lifecycle_coordinator_test.go
+++ b/internal/runtime/manager/lifecycle_coordinator_test.go
@@ -289,7 +289,7 @@ func TestLifecycleCoordinatorRecoveredGenerationZeroAdvancesFromDurableValue(t *
 	rec.LifecycleGeneration = 0
 	rec.LifecyclePhase = AgentLifecycleRegistered
 	rec.LifecycleRunMode = AgentRunModeStopped
-	if err := coordinator.registerExecution(testAuthorActivityContext(context.Background()), rec, false, reconfigureTestAgent{id: rec.Config.ID}); err != nil {
+	if err := coordinator.registerExecution(testAuthorActivityContext(context.Background()), rec, false, reconfigureTestAgent{id: rec.Config.ID}, testManagerSubscriptionAdmission(t, rec.Config)); err != nil {
 		t.Fatalf("register recovered agent: %v", err)
 	}
 	coordinator.beginRun(testAuthorActivityContext(context.Background()), AgentRunModeStandard)
@@ -311,7 +311,7 @@ func TestLifecycleCoordinatorInMemoryEffectContextCarriesCurrentToken(t *testing
 	registry := runtimesessions.NewInMemoryRegistry(0)
 	coordinator := newAgentLifecycleCoordinator(nil, registry)
 	rec := lifecycleTestPersistedAgent()
-	if err := coordinator.registerExecution(testAuthorActivityContext(context.Background()), rec, false, reconfigureTestAgent{id: rec.Config.ID}); err != nil {
+	if err := coordinator.registerExecution(testAuthorActivityContext(context.Background()), rec, false, reconfigureTestAgent{id: rec.Config.ID}, testManagerSubscriptionAdmission(t, rec.Config)); err != nil {
 		t.Fatalf("register: %v", err)
 	}
 	coordinator.beginRun(managedExecutionTestContext(t, testAuthorActivityContext(context.Background())), AgentRunModeStandard)

--- a/internal/runtime/manager/receipts_test.go
+++ b/internal/runtime/manager/receipts_test.go
@@ -202,7 +202,7 @@ func (a panicStubAgent) OnEvent(context.Context, events.Event) ([]events.Event, 
 
 func registerReceiptTestAgent(t *testing.T, am *AgentManager, cfg runtimeactors.AgentConfig) {
 	t.Helper()
-	if err := am.lifecycle.registerExecution(testAuthorActivityContext(context.Background()), PersistedAgent{Config: cfg, Status: "active", HiredBy: "test"}, false, panicStubAgent{id: cfg.ID}); err != nil {
+	if err := am.lifecycle.registerExecution(testAuthorActivityContext(context.Background()), PersistedAgent{Config: cfg, Status: "active", HiredBy: "test"}, false, panicStubAgent{id: cfg.ID}, testManagerSubscriptionAdmission(t, cfg)); err != nil {
 		t.Fatalf("register receipt test agent: %v", err)
 	}
 }

--- a/internal/runtime/manager/recovery_test.go
+++ b/internal/runtime/manager/recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +26,8 @@ import (
 type recoveryTestBus struct {
 	storedRoutes            []runtimebus.FlowInstanceRouteRecord
 	selectedRouteRecoveries []SelectedContractRouteRecoveryRecord
+	routeListQueries        int
+	replayQueries           int
 	restored                []string
 	restoredRequests        []runtimebus.FlowInstanceRouteMaterializationRequest
 	replayable              []events.PersistedReplayEvent
@@ -107,6 +110,7 @@ func (*recoveryTestBus) ClaimPipelineReplay(context.Context, string) (runtimeown
 	return recoveryTestReplayLease{}, true, nil
 }
 func (b *recoveryTestBus) ListEventsMissingPipelineReceipt(context.Context, time.Time, int) ([]events.PersistedReplayEvent, error) {
+	b.replayQueries++
 	return append([]events.PersistedReplayEvent(nil), b.replayable...), nil
 }
 func (b *recoveryTestBus) UpsertFlowInstanceRoute(context.Context, runtimebus.FlowInstanceRouteRecord) error {
@@ -116,6 +120,7 @@ func (b *recoveryTestBus) DeleteFlowInstanceRoute(context.Context, runtimeflowid
 	return nil
 }
 func (b *recoveryTestBus) ListFlowInstanceRoutes(context.Context) ([]runtimeflowidentity.Route, error) {
+	b.routeListQueries++
 	out := make([]runtimeflowidentity.Route, 0, len(b.storedRoutes))
 	for _, route := range b.storedRoutes {
 		out = append(out, route.Identity)
@@ -134,7 +139,8 @@ func (b *recoveryTestBus) RestorePersistedFlowInstanceRoute(req runtimebus.FlowI
 }
 
 type recoveryTestStore struct {
-	agents []PersistedAgent
+	agents                  []PersistedAgent
+	pendingSubscriptionArgs [][]events.EventType
 }
 
 func (s *recoveryTestStore) UpsertAgent(context.Context, PersistedAgent) error { return nil }
@@ -148,8 +154,63 @@ func (s *recoveryTestStore) UpsertEventReceipt(context.Context, string, string, 
 func (s *recoveryTestStore) ListPendingEventsForAgent(context.Context, string, time.Time, int) ([]events.Event, error) {
 	return nil, nil
 }
-func (s *recoveryTestStore) ListPendingSubscribedEvents(context.Context, string, []events.EventType, time.Time, int) ([]events.Event, error) {
+
+func (s *recoveryTestStore) ListPendingSubscribedEvents(_ context.Context, _ string, subscriptions []events.EventType, _ time.Time, _ int) ([]events.Event, error) {
+	s.pendingSubscriptionArgs = append(s.pendingSubscriptionArgs, append([]events.EventType(nil), subscriptions...))
 	return nil, nil
+}
+
+func TestRecoverRejectsPersistedForeignExactAndPatternBeforeRouteOrPendingQuery(t *testing.T) {
+	for _, subscription := range []string{"foreign/task.ready", "foreign/**/task.ready"} {
+		t.Run(strings.ReplaceAll(subscription, "/", "_"), func(t *testing.T) {
+			store := &recoveryTestStore{agents: []PersistedAgent{{Config: models.AgentConfig{
+				ExecutionMode: "live",
+				ID:            "reviewer",
+				FlowPath:      "review/inst-1",
+				Subscriptions: []string{subscription},
+			}}}}
+			bus := &recoveryTestBus{}
+			am := NewAgentManager(bus, func(cfg models.AgentConfig) (Agent, error) {
+				return recoveryTestAgent{id: cfg.ID}, nil
+			}, store)
+			err := am.Recover(context.Background())
+			if err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+				t.Fatalf("Recover error = %v, want admission rejection", err)
+			}
+			if am.Count() != 0 || len(store.pendingSubscriptionArgs) != 0 || bus.routeListQueries != 0 || bus.replayQueries != 0 {
+				t.Fatalf("recovery side effects: agents=%d pending_queries=%#v route_queries=%d replay_queries=%d, want none", am.Count(), store.pendingSubscriptionArgs, bus.routeListQueries, bus.replayQueries)
+			}
+		})
+	}
+}
+
+func TestPendingSubscribedRecoveryUsesAdmittedSameScopeSubscriptions(t *testing.T) {
+	store := &recoveryTestStore{}
+	am := NewAgentManager(&recoveryTestBus{}, func(cfg models.AgentConfig) (Agent, error) {
+		return recoveryTestAgent{id: cfg.ID}, nil
+	}, store)
+	if err := am.SpawnAgent(models.AgentConfig{
+		ExecutionMode: "live",
+		ID:            "reviewer",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*"},
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+	execution, ok := am.lifecycle.executionSnapshot("reviewer")
+	if !ok {
+		t.Fatal("admitted execution missing")
+	}
+	if _, err := am.pendingEventsForAgent(context.Background(), "reviewer", execution.Subscriptions, time.Time{}); err != nil {
+		t.Fatalf("pendingEventsForAgent: %v", err)
+	}
+	if len(store.pendingSubscriptionArgs) != 1 {
+		t.Fatalf("pending subscription queries = %#v, want one", store.pendingSubscriptionArgs)
+	}
+	want := []events.EventType{"review/inst-1/task.*", "review/inst-1/task.ready"}
+	if got := store.pendingSubscriptionArgs[0]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pending query subscriptions = %#v, want %#v", got, want)
+	}
 }
 
 type startupReplayTestStore struct {
@@ -525,8 +586,8 @@ func TestRecover_UsesCanonicalLoadedAgentMetadata(t *testing.T) {
 	if hydrated.Memory != agentmemory.Authored(true) {
 		t.Fatalf("memory = %+v, want authored true", hydrated.Memory)
 	}
-	if len(hydrated.Subscriptions) != 1 || hydrated.Subscriptions[0] != "review.ready" {
-		t.Fatalf("subscriptions = %#v, want [review.ready]", hydrated.Subscriptions)
+	if len(hydrated.Subscriptions) != 1 || hydrated.Subscriptions[0] != "review/inst-1/review.ready" {
+		t.Fatalf("subscriptions = %#v, want [review/inst-1/review.ready]", hydrated.Subscriptions)
 	}
 	if hydrated.ManagerFallback != "control-plane" {
 		t.Fatalf("manager_fallback = %q, want control-plane", hydrated.ManagerFallback)

--- a/internal/runtime/manager/runtime.go
+++ b/internal/runtime/manager/runtime.go
@@ -1464,6 +1464,7 @@ func (am *AgentManager) replaceExecution(parent context.Context, agentID, trigge
 	}
 
 	candidate := current
+	candidateAdmission := current.Admission
 	var rec *PersistedAgent
 	subordinate := sessions.LifecycleMutationPlan{}
 	if patch != nil {
@@ -1475,6 +1476,10 @@ func (am *AgentManager) replaceExecution(parent context.Context, agentID, trigge
 			return replaceExecutionResult{}, fmt.Errorf("agent id mismatch: target=%s config.id=%s", strings.TrimSpace(agentID), updated.ID)
 		}
 		if err := am.resolveAgentModel(&updated); err != nil {
+			return replaceExecutionResult{}, err
+		}
+		subscriptionAdmission, err := admitAgentConfigSubscriptions(am.semanticSource, &updated, nil)
+		if err != nil {
 			return replaceExecutionResult{}, err
 		}
 		if err := am.validateNativeToolAdmission(am.runtimeContext(), updated); err != nil {
@@ -1497,9 +1502,11 @@ func (am *AgentManager) replaceExecution(parent context.Context, agentID, trigge
 		}
 		candidate = agentExecutionSnapshot{
 			Agent: candidateAgent, Config: updated,
-			Subscriptions: append([]events.EventType(nil), candidateAgent.Subscriptions()...),
+			Subscriptions: admittedSubscriptionEventTypes(subscriptionAdmission),
+			Admission:     subscriptionAdmission,
 			StartedAt:     current.StartedAt,
 		}
+		candidateAdmission = subscriptionAdmission
 		rec = &candidateRecord
 		subordinate = reconfigureSessionMutationPlan(current.Config, updated)
 	}
@@ -1528,6 +1535,7 @@ func (am *AgentManager) replaceExecution(parent context.Context, agentID, trigge
 	successor.agent = candidate.Agent
 	successor.config = candidate.Config
 	successor.subscriptions = append([]events.EventType(nil), candidate.Subscriptions...)
+	successor.admission = candidateAdmission
 	successor.startedAt = candidate.StartedAt
 	runMode := cell.runMode
 	am.lifecycle.mu.Unlock()
@@ -1537,11 +1545,11 @@ func (am *AgentManager) replaceExecution(parent context.Context, agentID, trigge
 		if routeBus == nil {
 			return replaceExecutionResult{}, errors.New("event bus does not support generation-owned agent routes")
 		}
-		routeSubscriptions := candidate.Subscriptions
+		routeAdmission := candidateAdmission
 		if runMode == AgentRunModeAuthoritativeDeliveryOnly {
-			routeSubscriptions = nil
+			routeAdmission = routeAdmission.CarrierOnly()
 		}
-		ch = routeBus.ReplaceAgentRoute(token, routeSubscriptions...)
+		ch = routeBus.ReplaceAgentRoute(token, routeAdmission)
 		if ch == nil {
 			return replaceExecutionResult{}, errors.New("failed to install generation-owned agent route")
 		}

--- a/internal/runtime/manager/runtime_chat_test.go
+++ b/internal/runtime/manager/runtime_chat_test.go
@@ -115,7 +115,7 @@ func (b *directiveTestBus) LogRuntime(context.Context, runtimepipeline.RuntimeLo
 func installDirectiveTestAgent(t *testing.T, am *AgentManager, agent Agent) {
 	t.Helper()
 	rec := PersistedAgent{Config: models.AgentConfig{ExecutionMode: "live", ID: agent.ID()}, Status: "active", HiredBy: "test"}
-	if err := am.lifecycle.registerExecution(testAuthorActivityContext(context.Background()), rec, false, agent); err != nil {
+	if err := am.lifecycle.registerExecution(testAuthorActivityContext(context.Background()), rec, false, agent, testManagerSubscriptionAdmission(t, rec.Config)); err != nil {
 		t.Fatalf("register directive test agent: %v", err)
 	}
 	am.lifecycle.mu.Lock()

--- a/internal/runtime/manager/runtime_shutdown_admission_test.go
+++ b/internal/runtime/manager/runtime_shutdown_admission_test.go
@@ -135,7 +135,7 @@ func TestResetRuntimeState_KeepsManagerAdmissionClosedDuringManagerLocalShutdown
 		RuntimeShutdownAdmissionClosed: func() bool { return false },
 	}, store)
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestAuthBreakerShutdown_KeepsManagerAdmissionClosedDuringManagerLocalShutdo
 		RuntimeShutdownAdmissionClosed: func() bool { return false },
 	}, store)
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}

--- a/internal/runtime/manager/shutdown_test.go
+++ b/internal/runtime/manager/shutdown_test.go
@@ -67,7 +67,7 @@ func TestShutdown_DrainsInFlightWorkBeforeCancellingLoopContext(t *testing.T) {
 		return agent, nil
 	})
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestShutdownWithOptions_TimesOutAfterConfiguredGraceAndCancelsLoopContext(t
 		return agent, nil
 	})
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestShutdown_DoesNotStartQueuedWorkAfterDrainBegins(t *testing.T) {
 		return agent, nil
 	})
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestShutdown_DoesNotAllowRunToReplaceActiveRunContextDuringDrain(t *testing
 		return agent, nil
 	})
 	if err := am.spawnAgentInternal(testAuthorActivityContext(context.Background()), PersistedAgent{
-		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id},
+		Config: runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id, Subscriptions: []string{"test.in"}},
 	}, false); err != nil {
 		t.Fatalf("spawnAgentInternal: %v", err)
 	}

--- a/internal/runtime/manager/types.go
+++ b/internal/runtime/manager/types.go
@@ -36,7 +36,6 @@ type Bus interface {
 	Publish(ctx context.Context, evt events.Event) error
 	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
 	PublishPersistedRecipients(ctx context.Context, evt events.Event, recipients []string) error
-	Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event
 	Unsubscribe(agentID string)
 	Store() runtimebus.EventStore
 	ResetInMemoryState() error

--- a/internal/runtime/pipeline/activity_background.go
+++ b/internal/runtime/pipeline/activity_background.go
@@ -3,8 +3,6 @@ package pipeline
 import (
 	"context"
 	"sync"
-
-	"github.com/division-sh/swarm/internal/events"
 )
 
 const activityDispatcherSubscriberID = "workflow-activity-dispatcher"
@@ -33,14 +31,7 @@ func (n *activityBackgroundNode) Run(ctx context.Context) {
 	if n == nil || n.coordinator == nil || n.bus == nil {
 		return
 	}
-	var ch <-chan events.Event
-	if internal, ok := any(n.bus).(interface {
-		SubscribeInternal(string, ...events.EventType) <-chan events.Event
-	}); ok {
-		ch = internal.SubscribeInternal(activityDispatcherSubscriberID, activityRequestEventType)
-	} else {
-		ch = n.bus.Subscribe(activityDispatcherSubscriberID, activityRequestEventType)
-	}
+	ch := n.bus.SubscribeInternal(activityDispatcherSubscriberID, activityRequestEventType)
 	n.mu.Lock()
 	hooks := append([]func(){}, n.readyHooks...)
 	n.mu.Unlock()

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -354,12 +354,7 @@ func (pc *PipelineCoordinator) interceptPolicy(ctx context.Context, eventType st
 
 func (pc *PipelineCoordinator) subscribe() <-chan events.Event {
 	subscriptions := workflowRuntimeSubscriptions(pc.WorkflowNodes())
-	if internalBus, ok := any(pc.bus).(interface {
-		SubscribeInternal(string, ...events.EventType) <-chan events.Event
-	}); ok {
-		return internalBus.SubscribeInternal(runtimeWorkflowID, subscriptions...)
-	}
-	return pc.bus.Subscribe(runtimeWorkflowID, subscriptions...)
+	return pc.bus.SubscribeInternal(runtimeWorkflowID, subscriptions...)
 }
 
 func (pc *PipelineCoordinator) handleEvent(ctx context.Context, evt events.Event) bool {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -391,6 +391,9 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResult(ctx context.Context,
 		return false, nil
 	}
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, nodeID, evt)
+	if resolved.Failure != "" {
+		return false, fmt.Errorf("resolve workflow handler for node %s: %s", nodeID, resolved.Failure)
+	}
 	handler := resolved.Handler
 	handlerEventKey := resolved.HandlerEventKey
 	ok := resolved.Matched

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -312,7 +312,10 @@ func (pc *PipelineCoordinator) Intercept(ctx context.Context, evt events.Event) 
 	if stageTimer && (!firedStageTimer || eventType == runtimecontracts.WorkflowStageTimerInternalEvent) {
 		return false, nil, nil
 	}
-	consume, handled := pc.interceptPolicy(ctx, eventType, evt)
+	consume, handled, err := pc.interceptPolicy(ctx, eventType, evt)
+	if err != nil {
+		return false, nil, err
+	}
 	if !handled {
 		return true, nil, nil
 	}
@@ -345,9 +348,9 @@ func (pc *PipelineCoordinator) InterceptDeliveryRoute(ctx context.Context, evt e
 	return pc.Intercept(withWorkflowNodeDeliveryRoute(ctx, route), evt)
 }
 
-func (pc *PipelineCoordinator) interceptPolicy(ctx context.Context, eventType string, evt events.Event) (consume bool, handled bool) {
+func (pc *PipelineCoordinator) interceptPolicy(ctx context.Context, eventType string, evt events.Event) (consume bool, handled bool, err error) {
 	if strings.TrimSpace(eventType) == "" {
-		return false, false
+		return false, false, nil
 	}
 	return pc.workflowNodeInterceptPolicy(ctx, eventType, evt)
 }

--- a/internal/runtime/pipeline/dead_letters_test.go
+++ b/internal/runtime/pipeline/dead_letters_test.go
@@ -581,7 +581,7 @@ func TestCoordinator_InterceptHandlerErrorDoesNotSilentlyFallback(t *testing.T) 
 
 type deadLetterTestBus struct{}
 
-func (deadLetterTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (deadLetterTestBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 
@@ -592,7 +592,7 @@ type capturingDeadLetterBus struct {
 	events []events.Event
 }
 
-func (b *capturingDeadLetterBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (b *capturingDeadLetterBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -74,6 +74,9 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 	)
 	for _, owner := range owners {
 		resolved := workflowNodeEventHandlerResolutionForDelivery(source, owner, evt)
+		if resolved.Failure != "" {
+			return contractHandlerExecutionResult{}, fmt.Errorf("resolve workflow handler for node %s: %s", strings.TrimSpace(owner), resolved.Failure)
+		}
 		if !resolved.Matched {
 			continue
 		}

--- a/internal/runtime/pipeline/fixture_module_test.go
+++ b/internal/runtime/pipeline/fixture_module_test.go
@@ -11,7 +11,7 @@ import (
 
 type noopPipelineBus struct{}
 
-func (noopPipelineBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (noopPipelineBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 func (noopPipelineBus) Publish(context.Context, events.Event) error { return nil }

--- a/internal/runtime/pipeline/flow_instance_identity_test.go
+++ b/internal/runtime/pipeline/flow_instance_identity_test.go
@@ -168,6 +168,25 @@ func TestWorkflowInstanceCoordinates_KeepNestedInstancePathDistinctFromScope(t *
 	}
 }
 
+func TestWorkflowInstanceCoordinates_DeriveNestedStaticScopeWithoutTruncation(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
+
+	instance := WorkflowInstance{
+		WorkflowName: "grandchild",
+	}
+	identity := StoredFlowInstance(source, instance)
+
+	if identity.ScopeKey != "child/grandchild" {
+		t.Fatalf("StoredFlowInstance(static nested).ScopeKey = %q, want child/grandchild", identity.ScopeKey)
+	}
+	if identity.InstancePath != "child/grandchild" {
+		t.Fatalf("StoredFlowInstance(static nested).InstancePath = %q, want child/grandchild", identity.InstancePath)
+	}
+	if identity.HasStoredPath {
+		t.Fatal("StoredFlowInstance(static nested).HasStoredPath = true, want derived path")
+	}
+}
+
 func TestWorkflowInstanceOwnedByFlow_UsesExactSemanticScope(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -1721,8 +1721,12 @@ func assertCreatedChildFlowIdentityCoherent(t *testing.T, db *sql.DB, flowID, en
 	if got := entityID; got != FlowInstanceEntityID(flowPath) {
 		t.Fatalf("created %s entity id = %q, want %q for flow path %q", flowID, got, FlowInstanceEntityID(flowPath), flowPath)
 	}
-	if got := emitted.FlowInstance(); got != flowPath {
-		t.Fatalf("created %s emitted flow_instance = %q, want %q", flowID, got, flowPath)
+	if got := emitted.FlowInstance(); got != flowID {
+		t.Fatalf("created %s emitted flow_instance = %q, want static scope %q", flowID, got, flowID)
+	}
+	wantSource := (events.RouteIdentity{FlowID: flowID, FlowInstance: flowID, EntityID: entityID}).Normalized()
+	if got := emitted.SourceRoute(); got != wantSource {
+		t.Fatalf("created %s emitted source route = %#v, want static scope %#v", flowID, got, wantSource)
 	}
 	var rowOwner string
 	if err := db.QueryRowContext(testAuthorActivityContext(context.Background()), `

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2211,7 +2211,7 @@ func TestExecuteNodeHandlerPlanResult_NestedPackageRootConnectDoesNotAuthorizeRe
 	}); err != nil {
 		t.Fatalf("seed grandchild instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy(testAuthorActivityContext(context.Background()), "child/grandchild/micro.done", eventtest.RootIngress(
+	if consume, handled, err := pc.workflowNodeInterceptPolicy(testAuthorActivityContext(context.Background()), "child/grandchild/micro.done", eventtest.RootIngress(
 		"",
 		events.EventType("child/grandchild/micro.done"),
 		"",
@@ -2222,8 +2222,8 @@ func TestExecuteNodeHandlerPlanResult_NestedPackageRootConnectDoesNotAuthorizeRe
 		"",
 		events.EnvelopeForEntityID(events.EventEnvelope{}, grandchildEntityID),
 		time.Time{},
-	)); !handled {
-		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
+	)); err != nil || !handled {
+		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, err = %v, want handled", handled, consume, err)
 	}
 
 	evt := eventtest.RootIngress(

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -79,7 +79,7 @@ func (b *recordingPipelineBus) PublishInMutation(ctx context.Context, evt events
 	return nil
 }
 
-func (*recordingPipelineBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (*recordingPipelineBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -2150,7 +2150,7 @@ node-a:
 	}
 }
 
-func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropagateToRoot(t *testing.T) {
+func TestExecuteNodeHandlerPlanResult_NestedPackageRootConnectDoesNotAuthorizeRepositoryRootHandler(t *testing.T) {
 	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
 	bundle, ok := semanticview.Bundle(source)
 	if !ok {
@@ -2240,8 +2240,8 @@ func TestExecuteNodeHandlerPlanResult_NestedDescendantCompletionDoesNotBackPropa
 	if err != nil {
 		t.Fatalf("executeNodeHandlerPlanResult: %v", err)
 	}
-	if !handled {
-		t.Fatal("expected handler to execute")
+	if handled {
+		t.Fatal("nested package-root connect must not authorize the repository-root handler")
 	}
 	child, found, err := store.Load(testWorkflowStoreRunContext(t, store), childEntityID)
 	if err != nil {

--- a/internal/runtime/pipeline/internal_subscription_test.go
+++ b/internal/runtime/pipeline/internal_subscription_test.go
@@ -14,13 +14,6 @@ type recordingInternalSubscriptionBus struct {
 	eventTypes []events.EventType
 }
 
-func (b *recordingInternalSubscriptionBus) Subscribe(subscriber string, eventTypes ...events.EventType) <-chan events.Event {
-	b.mode = "subscribe"
-	b.subscriber = subscriber
-	b.eventTypes = append([]events.EventType(nil), eventTypes...)
-	return make(chan events.Event, 1)
-}
-
 func (b *recordingInternalSubscriptionBus) SubscribeInternal(subscriber string, eventTypes ...events.EventType) <-chan events.Event {
 	b.mode = "internal"
 	b.subscriber = subscriber
@@ -80,5 +73,31 @@ func TestSystemNodeRunnerSubscribe_UsesInternalSubscribers(t *testing.T) {
 	}
 	if len(bus.eventTypes) != 1 || bus.eventTypes[0] != "custom.trigger" {
 		t.Fatalf("event types = %#v, want [custom.trigger]", bus.eventTypes)
+	}
+}
+
+func TestActivityDispatcherSubscribe_UsesInternalSubscribers(t *testing.T) {
+	bus := &recordingInternalSubscriptionBus{}
+	node := newActivityBackgroundNode(&PipelineCoordinator{}, bus)
+	ready := make(chan struct{})
+	node.AddSubscriptionReadyHook(func() { close(ready) })
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		node.Run(ctx)
+	}()
+	<-ready
+	cancel()
+	<-done
+
+	if bus.mode != "internal" {
+		t.Fatalf("subscription mode = %q, want internal", bus.mode)
+	}
+	if bus.subscriber != activityDispatcherSubscriberID {
+		t.Fatalf("subscriber = %q, want %q", bus.subscriber, activityDispatcherSubscriberID)
+	}
+	if len(bus.eventTypes) != 1 || bus.eventTypes[0] != activityRequestEventType {
+		t.Fatalf("event types = %#v, want [%s]", bus.eventTypes, activityRequestEventType)
 	}
 }

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -176,7 +176,11 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 	}
 	eventType := strings.TrimSpace(string(evt.Type()))
 	handlerEventKey := eventType
-	handler, ok := n.resolvedHandlerForDelivery(evt)
+	resolved := workflowNodeEventHandlerResolutionForDelivery(n.source, n.NodeID(), evt)
+	if resolved.Failure != "" {
+		return nil, fmt.Errorf("resolve workflow handler for node %s: %s", n.NodeID(), resolved.Failure)
+	}
+	handler, ok := resolved.Handler, resolved.Matched
 	denyRawHandlerFallback := n.source != nil && semanticview.ImportBoundaryWildcardHandlerFallbackDenied(n.source, n.NodeID(), eventType)
 	if !ok {
 		if !denyRawHandlerFallback {

--- a/internal/runtime/pipeline/node_system_runner.go
+++ b/internal/runtime/pipeline/node_system_runner.go
@@ -20,7 +20,7 @@ import (
 )
 
 type systemNodeBus interface {
-	Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event
+	SubscribeInternal(subscriberID string, eventTypes ...events.EventType) <-chan events.Event
 	Publish(ctx context.Context, evt events.Event) error
 }
 
@@ -247,12 +247,7 @@ func (n *systemNodeRunner) subscribe() <-chan events.Event {
 	if n.subscriptionsFn != nil {
 		subscriptions = n.subscriptionsFn()
 	}
-	if internalBus, ok := any(n.bus).(interface {
-		SubscribeInternal(string, ...events.EventType) <-chan events.Event
-	}); ok {
-		return internalBus.SubscribeInternal(n.nodeID, subscriptions...)
-	}
-	return n.bus.Subscribe(n.nodeID, subscriptions...)
+	return n.bus.SubscribeInternal(n.nodeID, subscriptions...)
 }
 
 func (n *systemNodeRunner) handle(ctx context.Context, evt events.Event) error {

--- a/internal/runtime/pipeline/node_system_runner_completion_test.go
+++ b/internal/runtime/pipeline/node_system_runner_completion_test.go
@@ -19,7 +19,7 @@ type systemNodeCompletionBus struct {
 	converged []string
 }
 
-func (*systemNodeCompletionBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (*systemNodeCompletionBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 

--- a/internal/runtime/pipeline/runtime_support.go
+++ b/internal/runtime/pipeline/runtime_support.go
@@ -37,7 +37,7 @@ func pipelineDependencyFailure(err error, detailCode, component, operation strin
 }
 
 type Bus interface {
-	Subscribe(agentID string, eventTypes ...events.EventType) <-chan events.Event
+	SubscribeInternal(subscriberID string, eventTypes ...events.EventType) <-chan events.Event
 	Publish(ctx context.Context, evt events.Event) error
 	PublishDirect(ctx context.Context, evt events.Event, recipients []string) error
 	ResolveSubscribedRecipients(eventType string) []string

--- a/internal/runtime/pipeline/workflow_conformance_test.go
+++ b/internal/runtime/pipeline/workflow_conformance_test.go
@@ -11,7 +11,7 @@ import (
 type pipelineTestBus struct{}
 
 func (pipelineTestBus) Publish(context.Context, events.Event) error { return nil }
-func (pipelineTestBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (pipelineTestBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 func (pipelineTestBus) DirectSubscribe(string) <-chan events.Event { return make(chan events.Event) }

--- a/internal/runtime/pipeline/workflow_execution_plan.go
+++ b/internal/runtime/pipeline/workflow_execution_plan.go
@@ -45,6 +45,9 @@ func workflowEventEntityID(evt events.Event) string {
 }
 
 func workflowEventEntityIDWithPayload(evt events.Event, payload map[string]any) string {
+	if target := evt.TargetRoute().Normalized(); target.EntityID != "" {
+		return target.EntityID
+	}
 	return strings.TrimSpace(evt.EntityID())
 }
 

--- a/internal/runtime/pipeline/workflow_execution_plan_test.go
+++ b/internal/runtime/pipeline/workflow_execution_plan_test.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+)
+
+func TestWorkflowEventEntityIDPrefersTypedDeliveryTarget(t *testing.T) {
+	envelope := events.EnvelopeForEntityID(events.EventEnvelope{}, "source-entity")
+	envelope = events.EnvelopeForTargetRoute(envelope, events.RouteIdentity{
+		FlowID:       "child",
+		FlowInstance: "child",
+		EntityID:     "receiver-entity",
+	})
+	evt := eventtest.RootIngress("", "task.ready", "", "", nil, 0, "", "", envelope, time.Time{})
+
+	if got := workflowEventEntityID(evt); got != "receiver-entity" {
+		t.Fatalf("workflowEventEntityID = %q, want receiver-entity", got)
+	}
+}
+
+func TestWorkflowEventEntityIDFallsBackToJournalEntity(t *testing.T) {
+	evt := eventtest.RootIngress("", "task.ready", "", "", nil, 0, "", "",
+		events.EnvelopeForEntityID(events.EventEnvelope{}, "source-entity"), time.Time{})
+
+	if got := workflowEventEntityID(evt); got != "source-entity" {
+		t.Fatalf("workflowEventEntityID = %q, want source-entity", got)
+	}
+}

--- a/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
+++ b/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
@@ -97,7 +97,7 @@ type proposedEffectRouteProofBus struct {
 type proposedEffectRouteProofOutbox struct{ bus *proposedEffectRouteProofBus }
 type proposedEffectRouteProofDispatcher struct{ bus *proposedEffectRouteProofBus }
 
-func (*proposedEffectRouteProofBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (*proposedEffectRouteProofBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 func (*proposedEffectRouteProofBus) Publish(context.Context, events.Event) error { return nil }

--- a/internal/runtime/pipeline/workflow_handler_preview.go
+++ b/internal/runtime/pipeline/workflow_handler_preview.go
@@ -62,7 +62,7 @@ func (m *previewWorkflowModule) ActionRegistry() ActionRegistry {
 
 type previewBus struct{}
 
-func (previewBus) Subscribe(string, ...events.EventType) <-chan events.Event {
+func (previewBus) SubscribeInternal(string, ...events.EventType) <-chan events.Event {
 	return make(chan events.Event)
 }
 

--- a/internal/runtime/pipeline/workflow_handler_preview_test.go
+++ b/internal/runtime/pipeline/workflow_handler_preview_test.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 )
 
 func TestPreviewContractHandlerExecution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
-	bundle := loadPipelineImportBoundaryWildcardBundle(t, "")
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, canonicalrouting.ImportBoundaryWildcardDenied)
 	_, err := PreviewContractHandlerExecution(
 		testAuthorActivityContext(context.Background()),
 		bundle,
@@ -29,7 +30,7 @@ func TestPreviewContractHandlerExecution_DeniesImportBoundaryWildcardRawFallback
 }
 
 func TestPreviewContractHandlerExecution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
-	bundle := loadPipelineImportBoundaryWildcardBundle(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, canonicalrouting.ImportBoundaryWildcardObserveGranted)
 	preview, err := PreviewContractHandlerExecution(
 		testAuthorActivityContext(context.Background()),
 		bundle,

--- a/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
+++ b/internal/runtime/pipeline/workflow_node_delivery_authority_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -73,6 +75,77 @@ func TestPipelineCoordinatorInterceptDeliveryRouteConsumesTargetWithoutGenericAu
 		t.Fatalf("target runtime logs = %#v, want no false delivery_authority_missing log", bus.runtimeLogEntries())
 	}
 	assertDeliveryAuthorityReceiptCount(t, db, evt.ID(), route.SubscriberID, 1)
+}
+
+func TestPipelineCoordinatorInterceptDeliveryRouteRejectsAmbiguousConnectedInputReplayWithoutReceiptOrHandler(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	source := testWorkflowNodeConnectedInputCollisionSource()
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("connected-input collision source has no contract bundle")
+	}
+	bus := &recordingPipelineBus{}
+	pc := NewPipelineCoordinatorWithOptions(bus, db, PipelineCoordinatorOptions{
+		Module: &previewWorkflowModule{
+			bundle: bundle,
+			workflowNodes: []WorkflowNode{{
+				ID:            "receiver-node",
+				Subscriptions: []events.EventType{"deploy.accepted", "deploy.audited"},
+			}},
+		},
+		EventReceiptsCapability: eventReceiptsCapabilityStub{enabled: true}.resolve,
+	})
+	testPipelineCoordinatorRunContext(t, pc)
+
+	entityID := uuid.NewString()
+	eventID := uuid.NewString()
+	target := events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: entityID}
+	evt := eventtest.RootIngress(eventID, "producer/deploy.done", "producer", "", []byte(`{}`), 0, testPipelineRunID, "", events.EventEnvelope{
+		Source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"},
+		Target: target,
+	}, time.Now().UTC())
+	ctx := testAuthorActivityContext(context.Background())
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (execution_mode,
+			event_id, run_id, event_name, entity_id, flow_instance, scope, payload,
+			produced_by, produced_by_type, created_at
+		) VALUES ('live',
+			$1::uuid, $2::uuid, $3, $4::uuid, $5, 'entity', '{}'::jsonb,
+			'producer', 'node', now()
+		)
+	`, eventID, testPipelineRunID, string(evt.Type()), entityID, target.FlowInstance); err != nil {
+		t.Fatalf("seed ambiguous connected-input event: %v", err)
+	}
+	route := events.DeliveryRoute{SubscriberType: "node", SubscriberID: "receiver-node", Target: target}
+	seedDeliveryAuthorityNodeDeliveryForTarget(t, db, eventID, route.SubscriberID, target)
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		passthrough, deferred, err := pc.InterceptDeliveryRoute(ctx, evt, route)
+		if err == nil || !strings.Contains(err.Error(), "multiple connected input events") {
+			t.Fatalf("attempt %d InterceptDeliveryRoute error = %v, want explicit receiver-pin ambiguity", attempt, err)
+		}
+		if passthrough {
+			t.Fatalf("attempt %d passthrough = true, want fail-closed interception", attempt)
+		}
+		if len(deferred) != 0 {
+			t.Fatalf("attempt %d deferred events = %#v, want none", attempt, deferred)
+		}
+	}
+	assertDeliveryAuthorityReceiptCount(t, db, eventID, route.SubscriberID, 0)
+	var status string
+	if err := db.QueryRowContext(ctx, `
+		SELECT status
+		FROM event_deliveries
+		WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = $2
+	`, eventID, route.SubscriberID).Scan(&status); err != nil {
+		t.Fatalf("load ambiguous connected-input delivery: %v", err)
+	}
+	if status != "pending" {
+		t.Fatalf("delivery status = %q, want pending after rejected replay", status)
+	}
+	if got := bus.publishedCount(); got != 0 {
+		t.Fatalf("published handler events = %d, want zero", got)
+	}
 }
 
 func TestPipelineCoordinatorInterceptReplayScopeMarkerDoesNotAuthorizeConcreteNode(t *testing.T) {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -911,6 +911,13 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 		var err error
 		policy, ok, err = workflowNodePolicyForDelivery(source, node, evt)
 		if err != nil {
+			applies, authorityErr := pc.workflowNodeConnectedInputFailureApplies(ctx, strings.TrimSpace(node.ID), evt)
+			if authorityErr != nil {
+				return false, true, authorityErr
+			}
+			if !applies {
+				continue
+			}
 			return false, true, err
 		}
 		if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
@@ -928,6 +935,13 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 		}
 	}
 	return false, false, nil
+}
+
+func (pc *PipelineCoordinator) workflowNodeConnectedInputFailureApplies(ctx context.Context, nodeID string, evt events.Event) (bool, error) {
+	if _, ok := workflowNodeDeliveryRoute(ctx); ok {
+		return true, nil
+	}
+	return pc.workflowNodeDeliveryAuthority(ctx, nodeID, evt)
 }
 
 func (pc *PipelineCoordinator) dispatchWorkflowNodeEvent(ctx context.Context, evt events.Event) bool {
@@ -1087,21 +1101,10 @@ func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Contex
 		return false
 	}
 	nodeID = strings.TrimSpace(nodeID)
-	if nodeID == "" {
-		return false
-	}
-	if !pc.eventReceiptsAvailable(ctx) {
-		return false
-	}
-	if pc.workflowStore == nil {
-		return false
-	}
 	eventID := strings.TrimSpace(evt.ID())
-	if eventID == "" {
-		return false
-	}
-	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
-		ok, err := pc.workflowStore.SystemNodeDeliveryAuthorizedForTarget(ctx, nodeID, eventID, target, DefaultSystemNodeRetryLimit)
+	target := systemNodeDeliveryTarget(evt)
+	ok, err := pc.workflowNodeDeliveryAuthority(ctx, nodeID, evt)
+	if !target.Empty() {
 		if err != nil {
 			if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
 				logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -1132,7 +1135,6 @@ func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Contex
 		}
 		return ok
 	}
-	ok, err := pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit)
 	if err != nil {
 		if logger, logOK := pc.bus.(systemNodeRuntimeLogger); logOK && logger != nil {
 			logger.LogRuntime(ctx, RuntimeLogEntry{
@@ -1162,6 +1164,21 @@ func (pc *PipelineCoordinator) workflowNodeDeliveryAuthorized(ctx context.Contex
 		}
 	}
 	return ok
+}
+
+func (pc *PipelineCoordinator) workflowNodeDeliveryAuthority(ctx context.Context, nodeID string, evt events.Event) (bool, error) {
+	if pc == nil || !pc.eventReceiptsAvailable(ctx) || pc.workflowStore == nil {
+		return false, nil
+	}
+	nodeID = strings.TrimSpace(nodeID)
+	eventID := strings.TrimSpace(evt.ID())
+	if nodeID == "" || eventID == "" {
+		return false, nil
+	}
+	if target := systemNodeDeliveryTarget(evt); !target.Empty() {
+		return pc.workflowStore.SystemNodeDeliveryAuthorizedForTarget(ctx, nodeID, eventID, target, DefaultSystemNodeRetryLimit)
+	}
+	return pc.workflowStore.SystemNodeDeliveryAuthorized(ctx, nodeID, eventID, DefaultSystemNodeRetryLimit)
 }
 
 func (pc *PipelineCoordinator) workflowNodeEventProcessed(ctx context.Context, nodeID string, evt events.Event) bool {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -176,7 +176,7 @@ func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, n
 	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
 		return resolved
 	}
-	if resolved := workflowNodeConnectedInputEventHandlerResolution(source, nodeID, rawEventType); resolved.Matched {
+	if resolved := workflowNodeConnectedInputEventHandlerResolution(source, nodeID, evt); resolved.Matched {
 		return resolved
 	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
@@ -250,7 +250,7 @@ func workflowNodeMatchedHandlerEventKey(source semanticview.Source, nodeID, even
 	return eventType
 }
 
-func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
+func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source, nodeID string, evt events.Event) workflowNodeEventHandlerResolution {
 	if source == nil {
 		return workflowNodeEventHandlerResolution{}
 	}
@@ -269,7 +269,7 @@ func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source
 			if strings.TrimSpace(plan.Receiver.FlowID) != flowID || strings.TrimSpace(plan.Receiver.Pin) != strings.TrimSpace(inputPin.PinName()) {
 				continue
 			}
-			if eventidentity.Normalize(plan.Source.ResolvedEvent) == eventidentity.Normalize(rawEventType) {
+			if runtimepinrouting.ConnectSourceEndpointMatchesEvent(plan.Source, evt) {
 				return resolved
 			}
 		}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -163,6 +163,7 @@ type workflowNodeEventHandlerResolution struct {
 	Handler         runtimecontracts.SystemNodeEventHandler
 	HandlerEventKey string
 	Matched         bool
+	Failure         string
 }
 
 func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, nodeID string, evt events.Event) workflowNodeEventHandlerResolution {
@@ -173,10 +174,10 @@ func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, n
 	if rawEventType == "" {
 		return workflowNodeEventHandlerResolution{}
 	}
-	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
+	if resolved := workflowNodeConnectedInputEventHandlerResolution(source, nodeID, evt); resolved.Matched || resolved.Failure != "" {
 		return resolved
 	}
-	if resolved := workflowNodeConnectedInputEventHandlerResolution(source, nodeID, evt); resolved.Matched {
+	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
 		return resolved
 	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
@@ -260,19 +261,50 @@ func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source
 	}
 	flowID := strings.TrimSpace(contractSource.FlowID)
 	plans, _ := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
+	candidates := map[string]workflowNodeEventHandlerResolution{}
+	matchedSourcePlan := false
 	for _, inputPin := range source.FlowInputEventPins(flowID) {
 		resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, inputPin.EventType())
-		if !resolved.Matched {
-			continue
-		}
 		for _, plan := range plans {
 			if strings.TrimSpace(plan.Receiver.FlowID) != flowID || strings.TrimSpace(plan.Receiver.Pin) != strings.TrimSpace(inputPin.PinName()) {
 				continue
 			}
 			if runtimepinrouting.ConnectSourceEndpointMatchesEvent(plan.Source, evt) {
-				return resolved
+				matchedSourcePlan = true
+				if resolved.Matched {
+					localEvent := eventidentity.Normalize(plan.Receiver.Event)
+					if localEvent == "" {
+						localEvent = eventidentity.Normalize(inputPin.EventType())
+					}
+					candidates[localEvent] = resolved
+				}
 			}
 		}
+	}
+	if len(candidates) == 1 {
+		for _, resolved := range candidates {
+			return resolved
+		}
+	}
+	if len(candidates) > 1 {
+		locals := make([]string, 0, len(candidates))
+		for localEvent := range candidates {
+			locals = append(locals, localEvent)
+		}
+		sort.Strings(locals)
+		return workflowNodeEventHandlerResolution{Failure: fmt.Sprintf(
+			"event %s reaches node %s through multiple connected input events: %s",
+			eventidentity.Normalize(string(evt.Type())),
+			strings.TrimSpace(nodeID),
+			strings.Join(locals, ", "),
+		)}
+	}
+	if matchedSourcePlan {
+		return workflowNodeEventHandlerResolution{Failure: fmt.Sprintf(
+			"event %s reaches node %s through a connected input with no matching handler",
+			eventidentity.Normalize(string(evt.Type())),
+			strings.TrimSpace(nodeID),
+		)}
 	}
 	return workflowNodeEventHandlerResolution{}
 }

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -114,14 +114,17 @@ func workflowNodeEventPolicy(nodes []WorkflowNode, nodeID, eventType string) (Wo
 	return WorkflowEventPolicy{}, false
 }
 
-func workflowNodePolicyForDelivery(source semanticview.Source, node WorkflowNode, evt events.Event) (WorkflowEventPolicy, bool) {
+func workflowNodePolicyForDelivery(source semanticview.Source, node WorkflowNode, evt events.Event) (WorkflowEventPolicy, bool, error) {
 	eventType := strings.TrimSpace(string(evt.Type()))
 	if policy, ok := workflowNodePolicyForEventType(node.Policies, eventType); ok {
-		return policy, true
+		return policy, true, nil
 	}
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, strings.TrimSpace(node.ID), evt)
+	if resolved.Failure != "" {
+		return WorkflowEventPolicy{}, false, fmt.Errorf("resolve workflow handler for node %s: %s", strings.TrimSpace(node.ID), resolved.Failure)
+	}
 	if !resolved.Matched {
-		return WorkflowEventPolicy{}, false
+		return WorkflowEventPolicy{}, false, nil
 	}
 	candidates := []string{resolved.HandlerEventKey}
 	if source != nil {
@@ -129,10 +132,10 @@ func workflowNodePolicyForDelivery(source semanticview.Source, node WorkflowNode
 	}
 	for _, candidate := range candidates {
 		if policy, ok := workflowNodePolicyForEventType(node.Policies, candidate); ok {
-			return policy, true
+			return policy, true, nil
 		}
 	}
-	return deriveWorkflowEventPolicy(source, resolved.HandlerEventKey, strings.TrimSpace(resolved.Handler.AdvancesTo) != ""), true
+	return deriveWorkflowEventPolicy(source, resolved.HandlerEventKey, strings.TrimSpace(resolved.Handler.AdvancesTo) != ""), true, nil
 }
 
 func workflowNodePolicyForEventType(policies map[string]WorkflowEventPolicy, eventType string) (WorkflowEventPolicy, bool) {
@@ -894,7 +897,7 @@ func (pc *PipelineCoordinator) workflowNodeExecutors() []workflowNodeExecutor {
 	return out
 }
 
-func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, eventType string, evt events.Event) (bool, bool) {
+func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, eventType string, evt events.Event) (bool, bool, error) {
 	eventType = strings.TrimSpace(eventType)
 	source := pc.SemanticSource()
 	for _, node := range pc.WorkflowNodes() {
@@ -905,7 +908,11 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 			policy WorkflowEventPolicy
 			ok     bool
 		)
-		policy, ok = workflowNodePolicyForDelivery(source, node, evt)
+		var err error
+		policy, ok, err = workflowNodePolicyForDelivery(source, node, evt)
+		if err != nil {
+			return false, true, err
+		}
 		if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
 			if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == strings.TrimSpace(node.ID) {
 				if node.Policies != nil {
@@ -917,10 +924,10 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 			if policy.RequireEntity && workflowEventEntityID(evt) == "" {
 				continue
 			}
-			return policy.Consume, true
+			return policy.Consume, true, nil
 		}
 	}
-	return false, false
+	return false, false, nil
 }
 
 func (pc *PipelineCoordinator) dispatchWorkflowNodeEvent(ctx context.Context, evt events.Event) bool {

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -258,22 +259,17 @@ func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source
 		return workflowNodeEventHandlerResolution{}
 	}
 	flowID := strings.TrimSpace(contractSource.FlowID)
+	plans, _ := runtimepinrouting.LowerCompositionConnectRoutePlans(source)
 	for _, inputPin := range source.FlowInputEventPins(flowID) {
 		resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, inputPin.EventType())
 		if !resolved.Matched {
 			continue
 		}
-		for _, connect := range source.CompositionConnectsTo(flowID, inputPin.PinName()) {
-			from, err := connect.FromRef()
-			if err != nil {
+		for _, plan := range plans {
+			if strings.TrimSpace(plan.Receiver.FlowID) != flowID || strings.TrimSpace(plan.Receiver.Pin) != strings.TrimSpace(inputPin.PinName()) {
 				continue
 			}
-			outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
-			if !ok {
-				continue
-			}
-			producerEvent := eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType()))
-			if producerEvent == eventidentity.Normalize(rawEventType) {
+			if eventidentity.Normalize(plan.Source.ResolvedEvent) == eventidentity.Normalize(rawEventType) {
 				return resolved
 			}
 		}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -175,17 +175,17 @@ func workflowNodeEventHandlerResolutionForDelivery(source semanticview.Source, n
 	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, rawEventType); resolved.Matched {
 		return resolved
 	}
-	if resolved := workflowNodeInputAliasEventHandlerResolution(source, nodeID, rawEventType); resolved.Matched {
+	if resolved := workflowNodeConnectedInputEventHandlerResolution(source, nodeID, rawEventType); resolved.Matched {
 		return resolved
 	}
 	localizedEventType := workflowNodeConcreteInstanceLocalEventType(source, nodeID, evt)
 	if localizedEventType == "" || localizedEventType == rawEventType {
-		return workflowNodeOutputAliasEventHandlerResolution(source, nodeID, rawEventType)
+		return workflowNodeEventHandlerResolution{}
 	}
 	if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, localizedEventType); resolved.Matched {
 		return resolved
 	}
-	return workflowNodeOutputAliasEventHandlerResolution(source, nodeID, rawEventType)
+	return workflowNodeEventHandlerResolution{}
 }
 
 func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, nodeID, eventType string) workflowNodeEventHandlerResolution {
@@ -249,7 +249,7 @@ func workflowNodeMatchedHandlerEventKey(source semanticview.Source, nodeID, even
 	return eventType
 }
 
-func workflowNodeInputAliasEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
+func workflowNodeConnectedInputEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
 	if source == nil {
 		return workflowNodeEventHandlerResolution{}
 	}
@@ -257,9 +257,25 @@ func workflowNodeInputAliasEventHandlerResolution(source semanticview.Source, no
 	if !ok {
 		return workflowNodeEventHandlerResolution{}
 	}
-	for _, alias := range semanticview.ImportBoundaryInputAliasesForParentEvent(source, strings.TrimSpace(contractSource.FlowID), rawEventType) {
-		if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, alias.Pin); resolved.Matched {
-			return resolved
+	flowID := strings.TrimSpace(contractSource.FlowID)
+	for _, inputPin := range source.FlowInputEventPins(flowID) {
+		resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, inputPin.EventType())
+		if !resolved.Matched {
+			continue
+		}
+		for _, connect := range source.CompositionConnectsTo(flowID, inputPin.PinName()) {
+			from, err := connect.FromRef()
+			if err != nil {
+				continue
+			}
+			outputPin, ok := source.FlowOutputEventPin(from.FlowID, from.Pin)
+			if !ok {
+				continue
+			}
+			producerEvent := eventidentity.Normalize(source.ResolveFlowEventReference(from.FlowID, outputPin.EventType()))
+			if producerEvent == eventidentity.Normalize(rawEventType) {
+				return resolved
+			}
 		}
 	}
 	return workflowNodeEventHandlerResolution{}
@@ -488,9 +504,6 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 		return out
 	}
 	flowID := strings.TrimSpace(contractSource.FlowID)
-	for _, alias := range semanticview.ImportBoundaryOutputAliasesForParentEvent(source, contractSource.PackageKey, flowID, eventType) {
-		appendAlias(alias.EventPattern)
-	}
 	if strings.Contains(eventType, "*") {
 		if resolution := semanticview.ResolveImportBoundaryWildcardSubscriptionForNode(source, nodeID, eventType); resolution.Scoped {
 			for _, pattern := range resolution.Patterns {
@@ -498,26 +511,13 @@ func workflowNodeSubscriptionAliases(source semanticview.Source, nodeID, eventTy
 			}
 			return out
 		}
-		for _, alias := range semanticview.ImportBoundaryOutputAliasesForParent(source, contractSource.PackageKey, flowID) {
-			parentEvent := eventidentity.Normalize(alias.ParentEvent)
-			if parentEvent == "" || !eventidentity.MatchPattern(eventType, parentEvent) {
-				continue
-			}
-			appendAlias(alias.EventPattern)
+	}
+	if source.FlowHasInputEvent(flowID, eventType) {
+		for _, pattern := range source.FlowInputProducerPatterns(flowID, eventType) {
+			appendAlias(pattern)
 		}
-	}
-	if flowID == "" {
+	} else {
 		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
-		return out
-	}
-	if !source.FlowHasInputEvent(flowID, eventType) {
-		appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
-		return out
-	}
-	for _, pattern := range source.FlowInputProducerPatterns(flowID, eventType) {
-		appendAlias(pattern)
-	}
-	if semanticview.ImportBoundaryInputAliasRequired(source, flowID, eventType) {
 		return out
 	}
 	appendAlias(source.ResolveNodeEventReference(nodeID, eventType))
@@ -530,22 +530,6 @@ func workflowFlowInputProducerAliases(source semanticview.Source, targetFlowID, 
 		return nil
 	}
 	return append([]string{}, source.ResolveFlowInputAutoWire(targetFlowID, eventType).Patterns...)
-}
-
-func workflowNodeOutputAliasEventHandlerResolution(source semanticview.Source, nodeID, rawEventType string) workflowNodeEventHandlerResolution {
-	if source == nil {
-		return workflowNodeEventHandlerResolution{}
-	}
-	contractSource, ok := source.NodeContractSource(nodeID)
-	if !ok {
-		return workflowNodeEventHandlerResolution{}
-	}
-	for _, parentEvent := range semanticview.ImportBoundaryOutputParentEventsForEvent(source, contractSource.PackageKey, strings.TrimSpace(contractSource.FlowID), rawEventType) {
-		if resolved := workflowNodeEventHandlerResolutionForEventType(source, nodeID, parentEvent); resolved.Matched {
-			return resolved
-		}
-	}
-	return workflowNodeEventHandlerResolution{}
 }
 
 func workflowFlowHasInputEvent(source semanticview.Source, flowID, eventType string) bool {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -391,6 +392,30 @@ func TestWorkflowNodeConnectedInputHandlerEnforcesProducerMode(t *testing.T) {
 	}
 }
 
+func TestWorkflowNodeConnectedInputHandlerRejectsAmbiguousReceiverPins(t *testing.T) {
+	source := testWorkflowNodeConnectedInputCollisionSource()
+	evt := eventtest.RootIngress("", "producer/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+		Source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"},
+		Target: events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: "receiver-entity"},
+	}, time.Unix(1, 0).UTC())
+
+	resolved := workflowNodeConnectedInputEventHandlerResolution(source, "receiver-node", evt)
+	if resolved.Matched || !strings.Contains(resolved.Failure, "multiple connected input events") || !strings.Contains(resolved.Failure, "deploy.accepted") || !strings.Contains(resolved.Failure, "deploy.audited") {
+		t.Fatalf("ambiguous connected-input resolution = %#v", resolved)
+	}
+
+	node := NewNode(runtimecontracts.SystemNodeContract{
+		ID: "receiver-node",
+		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+			"deploy.accepted": {},
+			"deploy.audited":  {},
+		},
+	}, source, nil, nil).(*DeclarativeNode)
+	if _, err := node.HandleEvent(context.Background(), evt); err == nil || !strings.Contains(err.Error(), "multiple connected input events") {
+		t.Fatalf("HandleEvent error = %v, want explicit receiver-pin ambiguity", err)
+	}
+}
+
 func testWorkflowNodeConnectedInputSource(producerMode string) semanticview.Source {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
@@ -435,6 +460,57 @@ func testWorkflowNodeConnectedInputSource(producerMode string) semanticview.Sour
 			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
 				"receiver-node": {"deploy.requested": {}},
 			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"receiver": &root.Children[1],
+			},
+		},
+	})
+}
+
+func testWorkflowNodeConnectedInputCollisionSource() semanticview.Source {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "static",
+			Pins: runtimecontracts.FlowPins{Outputs: runtimecontracts.FlowOutputPins{EventPins: []runtimecontracts.FlowOutputEventPin{{Name: "deploy_done", Event: "deploy.done"}}}},
+		},
+		Path: "producer",
+	}
+	receiverInputs := []runtimecontracts.FlowInputEventPin{
+		{Name: "deploy_accepted", Event: "deploy.accepted"},
+		{Name: "deploy_audited", Event: "deploy.audited"},
+	}
+	receiverHandlers := map[string]runtimecontracts.SystemNodeEventHandler{
+		"deploy.accepted": {},
+		"deploy.audited":  {},
+	}
+	receiver := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "receiver", Flow: "receiver"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "static",
+			Pins: runtimecontracts.FlowPins{Inputs: runtimecontracts.FlowInputPins{EventPins: receiverInputs}},
+		},
+		Path: "receiver",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"receiver-node": {ID: "receiver-node", EventHandlers: receiverHandlers},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, receiver}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
+				"producer": {{Name: "deploy_done", Event: "deploy.done"}},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{"receiver": receiverInputs},
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{
+				{SourceFile: "package.yaml", SourceLine: 1, From: "producer.deploy_done", To: "receiver.deploy_accepted"},
+				{SourceFile: "package.yaml", SourceLine: 2, From: "producer.deploy_done", To: "receiver.deploy_audited"},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{"receiver-node": receiverHandlers},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: &root,

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -350,6 +350,31 @@ func TestWorkflowNodeConnectedInputEventHandlerResolution_ConsumesLoweredPackage
 	}
 }
 
+func TestWorkflowNodeConnectedInputEventHandlerResolution_RootSourceRejectsEmptySourceChildContext(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
+	for _, tc := range []struct {
+		name         string
+		flowInstance string
+		wantMatched  bool
+	}{
+		{name: "child context", flowInstance: "child/inst-1"},
+		{name: "UUID root context", flowInstance: "11111111-1111-4111-8111-111111111111", wantMatched: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", "step.begin", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+				FlowInstance: tc.flowInstance,
+			}, time.Unix(1, 0).UTC())
+			resolved := workflowNodeConnectedInputEventHandlerResolution(source, "child-relay", evt)
+			if resolved.Matched != tc.wantMatched {
+				t.Fatalf("connected-input resolution = %#v, want matched %v", resolved, tc.wantMatched)
+			}
+			if tc.wantMatched && resolved.HandlerEventKey != "step.begin" {
+				t.Fatalf("connected-input handler = %q, want step.begin", resolved.HandlerEventKey)
+			}
+		})
+	}
+}
+
 func TestWorkflowNodeConnectedInputHandlerMatchesConcreteTemplateProducer(t *testing.T) {
 	source := testWorkflowNodeConnectedInputSource("template")
 	evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -334,6 +334,20 @@ func TestWorkflowNodeHandlerResolution_ConnectConsumesImportBindings(t *testing.
 	}
 }
 
+func TestWorkflowNodeConnectedInputEventHandlerResolution_ConsumesLoweredPackageRootConnect(t *testing.T) {
+	source := loadWorkflowFixtureSource(t, "test-nested-three-levels")
+	producerEvent := source.ResolveFlowEventReference("grandchild", "micro.done")
+	receiverEvent := source.ResolveFlowEventReference("child", "micro.done")
+	if producerEvent == receiverEvent {
+		t.Fatalf("producer event %q must differ from receiver event %q for this proof", producerEvent, receiverEvent)
+	}
+
+	resolved := workflowNodeConnectedInputEventHandlerResolution(source, "child-relay", producerEvent)
+	if !resolved.Matched || resolved.HandlerEventKey != "micro.done" {
+		t.Fatalf("package-root connect handler resolution = %#v, want child-relay micro.done", resolved)
+	}
+}
+
 func TestWorkflowNodeHandlerResolution_LocalizesProducerScopedEventThroughTargetRoute(t *testing.T) {
 	accountCase := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "account_case", Flow: "account_case"},

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -420,7 +420,7 @@ func TestWorkflowNodeHandlerResolution_PreservesAuthoredKeyForCanonicalCrossFlow
 }
 
 func TestWorkflowNodeHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t *testing.T) {
-	source := loadPipelineImportBoundaryWildcardSource(t, "")
+	source := loadPipelineImportBoundaryWildcardSource(t, canonicalrouting.ImportBoundaryWildcardDenied)
 	evt := eventtest.RootIngress("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
 	if resolved.Matched {
@@ -432,7 +432,7 @@ func TestWorkflowNodeHandlerResolution_DeniesImportBoundaryWildcardRawFallback(t
 }
 
 func TestWorkflowNodeHandlerResolution_AllowsGrantedImportBoundaryWildcard(t *testing.T) {
-	source := loadPipelineImportBoundaryWildcardSource(t, "      observe:\n        - source: producer\n          events: [task.done]\n")
+	source := loadPipelineImportBoundaryWildcardSource(t, canonicalrouting.ImportBoundaryWildcardObserveGranted)
 	evt := eventtest.RootIngress("", "producer/task.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-listener", evt)
 	if !resolved.Matched {
@@ -445,201 +445,45 @@ func TestWorkflowNodeHandlerResolution_AllowsGrantedImportBoundaryWildcard(t *te
 
 func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	return loadPipelineImportBoundaryAliasSourceWithParentSubscription(t, "parent.lead_enriched")
+	return loadPipelineImportBoundaryAliasVariant(t, canonicalrouting.ImportBoundaryAliasBindOnly)
 }
 
 func loadPipelineImportBoundaryAliasSourceWithParentSubscription(t *testing.T, parentSubscription string) semanticview.Source {
 	t.Helper()
-	root := writePipelineImportBoundaryAliasFixture(t, parentSubscription, false)
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
-	if err != nil {
-		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	if parentSubscription != "parent.*" {
+		t.Fatalf("unsupported import-boundary parent subscription %q", parentSubscription)
 	}
-	return semanticview.Wrap(bundle)
+	return loadPipelineImportBoundaryAliasVariant(t, canonicalrouting.ImportBoundaryAliasBindOnlyWildcardOutput)
 }
 
 func loadPipelineImportBoundaryConnectedSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	root := writePipelineImportBoundaryAliasFixture(t, "parent.lead_enriched", true)
+	return loadPipelineImportBoundaryAliasVariant(t, canonicalrouting.ImportBoundaryAliasConnected)
+}
+
+func loadPipelineImportBoundaryAliasVariant(t *testing.T, variant canonicalrouting.ImportBoundaryAliasVariant) semanticview.Source {
+	t.Helper()
+	root := canonicalrouting.CopyImportBoundaryAlias(t, variant)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	return semanticview.Wrap(bundle)
 }
-
-func writePipelineImportBoundaryAliasFixture(t *testing.T, parentSubscription string, connected bool) string {
+func loadPipelineImportBoundaryWildcardSource(t *testing.T, variant canonicalrouting.ImportBoundaryWildcardVariant) semanticview.Source {
 	t.Helper()
-	root := t.TempDir()
-	connect := ""
-	rootSchema := "name: pipeline-import-boundary-alias\n"
-	if connected {
-		connect = `
-connect:
-  - from: .lead_captured
-    to: worker.work_requested
-  - from: worker.work_completed
-    to: .lead_enriched
-`
-		rootSchema = `
-name: pipeline-import-boundary-alias
-pins:
-  inputs:
-    events:
-      - name: lead_enriched
-        event: parent.lead_enriched
-  outputs:
-    events:
-      - name: lead_captured
-        event: parent.lead_captured
-`
-	}
-	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
-name: pipeline-import-boundary-alias
-version: "1.0.0"
-platform_version: ">=0.7.0 <0.8.0"
-flows:
-  - id: worker
-    flow: worker
-    mode: static
-    bind:
-      inputs:
-        work.requested: parent.lead_captured
-      outputs:
-        work.completed: parent.lead_enriched
-`+connect)
-	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
-	writePipelineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "events.yaml"), `
-parent.lead_captured: {}
-parent.lead_enriched: {}
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
-parent-listener:
-  id: parent-listener
-  execution_type: system_node
-  subscribes_to: [`+parentSubscription+`]
-  event_handlers:
-    parent.lead_enriched: {}
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
-name: worker
-version: "1.0.0"
-requires:
-  inputs: [work.requested]
-  outputs: [work.completed]
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
-name: worker
-mode: static
-pins:
-  inputs:
-    events:
-      - name: work_requested
-        event: work.requested
-  outputs:
-    events:
-      - name: work_completed
-        event: work.completed
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "work.completed: {}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
-worker-node:
-  id: worker-node
-  execution_type: system_node
-  subscribes_to: [work.requested]
-  produces: [work.completed]
-  event_handlers:
-    work.requested:
-      emit: work.completed
-`)
-	return root
-}
-
-func loadPipelineImportBoundaryWildcardSource(t *testing.T, observeGrant string) semanticview.Source {
-	t.Helper()
-	bundle := loadPipelineImportBoundaryWildcardBundle(t, observeGrant)
+	bundle := loadPipelineImportBoundaryWildcardBundle(t, variant)
 	return semanticview.Wrap(bundle)
 }
 
-func loadPipelineImportBoundaryWildcardBundle(t *testing.T, observeGrant string) *runtimecontracts.WorkflowContractBundle {
+func loadPipelineImportBoundaryWildcardBundle(t *testing.T, variant canonicalrouting.ImportBoundaryWildcardVariant) *runtimecontracts.WorkflowContractBundle {
 	t.Helper()
-	root := writePipelineImportBoundaryWildcardFixture(t, observeGrant)
+	root := canonicalrouting.CopyImportBoundaryWildcard(t, variant)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
 	}
 	return bundle
-}
-
-func writePipelineImportBoundaryWildcardFixture(t *testing.T, observeGrant string) string {
-	t.Helper()
-	root := t.TempDir()
-	workerBind := ""
-	if strings.TrimSpace(observeGrant) != "" {
-		workerBind = "    bind:\n" + observeGrant
-	}
-	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
-name: pipeline-import-boundary-wildcard
-version: "1.0.0"
-platform_version: ">=0.7.0 <0.8.0"
-flows:
-  - id: worker
-    flow: worker
-    mode: static
-`+workerBind+`  - id: producer
-    flow: producer
-    mode: static
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: pipeline-import-boundary-wildcard\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), "name: worker\nversion: \"1.0.0\"\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
-name: worker
-mode: static
-initial_state: active
-terminal_states: [done]
-states: [active, done]
-pins:
-  outputs:
-    events: [task.done]
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "task.done: {}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
-worker-listener:
-  id: worker-listener
-  execution_type: system_node
-  subscribes_to: ["**/task.done"]
-  event_handlers:
-    "**/task.done":
-      clear_gates: [sibling_gate]
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "package.yaml"), "name: producer\nversion: \"1.0.0\"\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "schema.yaml"), `
-name: producer
-mode: static
-initial_state: active
-terminal_states: [done]
-states: [active, done]
-pins:
-  outputs:
-    events: [task.done]
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "policy.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "agents.yaml"), "{}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "events.yaml"), "task.done: {}\n")
-	writePipelineFixtureFile(t, filepath.Join(root, "flows", "producer", "nodes.yaml"), "{}\n")
-	return root
 }
 
 func workflowNodeByIDForTest(nodes []WorkflowNode, id string) *WorkflowNode {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -253,7 +253,7 @@ func TestLoadWorkflowNodes_UsesEffectiveFactsForMinimizedSystemNode(t *testing.T
 	}
 }
 
-func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
+func TestLoadWorkflowNodes_ImportInputBindingRequiresEffectiveConnect(t *testing.T) {
 	source := loadPipelineImportBoundaryAliasSource(t)
 	nodes, err := LoadWorkflowNodes(source)
 	if err != nil {
@@ -263,23 +263,20 @@ func TestLoadWorkflowNodes_UsesImportBoundaryInputAlias(t *testing.T) {
 	if worker == nil {
 		t.Fatalf("worker-node missing from %#v", nodes)
 	}
-	if !workflowNodeHasSubscriptionForTest(*worker, "parent.lead_captured") {
-		t.Fatalf("worker-node subscriptions = %#v, want parent.lead_captured", worker.Subscriptions)
+	if !workflowNodeHasSubscriptionForTest(*worker, "work.requested") {
+		t.Fatalf("worker-node subscriptions = %#v, want receiver-local work.requested", worker.Subscriptions)
 	}
-	if workflowNodeHasSubscriptionForTest(*worker, "work.requested") || workflowNodeHasSubscriptionForTest(*worker, "worker/work.requested") {
-		t.Fatalf("worker-node subscriptions = %#v, should not preserve raw required-import input fallback", worker.Subscriptions)
+	if workflowNodeHasSubscriptionForTest(*worker, "parent.lead_captured") {
+		t.Fatalf("worker-node subscriptions = %#v, bind must not add producer authority", worker.Subscriptions)
 	}
 	evt := eventtest.RootIngress("", "parent.lead_captured", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "worker-node", evt)
-	if !resolved.Matched {
-		t.Fatal("expected worker-node handler to resolve through input alias")
-	}
-	if got := resolved.HandlerEventKey; got != "work.requested" {
-		t.Fatalf("handler event key = %q, want work.requested", got)
+	if resolved.Matched {
+		t.Fatalf("bind-only producer event resolved handler: %#v", resolved)
 	}
 }
 
-func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *testing.T) {
+func TestLoadWorkflowNodes_ImportOutputBindingRequiresEffectiveConnect(t *testing.T) {
 	source := loadPipelineImportBoundaryAliasSource(t)
 	nodes, err := LoadWorkflowNodes(source)
 	if err != nil {
@@ -289,20 +286,17 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForParentHandler(t *test
 	if parent == nil {
 		t.Fatalf("parent-listener missing from %#v", nodes)
 	}
-	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
-		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias", parent.Subscriptions)
+	if !workflowNodeHasSubscriptionForTest(*parent, "parent.lead_enriched") {
+		t.Fatalf("parent-listener subscriptions = %#v, want receiver-local parent.lead_enriched", parent.Subscriptions)
 	}
 	evt := eventtest.RootIngress("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
-	if !resolved.Matched {
-		t.Fatal("expected parent-listener handler to resolve through output alias")
-	}
-	if got := resolved.HandlerEventKey; got != "parent.lead_enriched" {
-		t.Fatalf("handler event key = %q, want parent.lead_enriched", got)
+	if resolved.Matched {
+		t.Fatalf("bind-only child event resolved parent handler: %#v", resolved)
 	}
 }
 
-func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscription(t *testing.T) {
+func TestLoadWorkflowNodes_ImportOutputWildcardRequiresEffectiveConnect(t *testing.T) {
 	source := loadPipelineImportBoundaryAliasSourceWithParentSubscription(t, "parent.*")
 	nodes, err := LoadWorkflowNodes(source)
 	if err != nil {
@@ -312,16 +306,31 @@ func TestLoadWorkflowNodes_UsesImportBoundaryOutputAliasForWildcardParentSubscri
 	if parent == nil {
 		t.Fatalf("parent-listener missing from %#v", nodes)
 	}
-	if !workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
-		t.Fatalf("parent-listener subscriptions = %#v, want worker/work.completed output alias for wildcard parent subscription", parent.Subscriptions)
+	if workflowNodeHasSubscriptionForTest(*parent, "worker/work.completed") {
+		t.Fatalf("parent-listener subscriptions = %#v, bind must not authorize child output", parent.Subscriptions)
 	}
 	evt := eventtest.RootIngress("", "worker/work.completed", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
 	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "parent-listener", evt)
-	if !resolved.Matched {
-		t.Fatal("expected parent-listener handler to resolve through output alias")
+	if resolved.Matched {
+		t.Fatalf("bind-only child event resolved wildcard parent handler: %#v", resolved)
 	}
-	if got := resolved.HandlerEventKey; got != "parent.lead_enriched" {
-		t.Fatalf("handler event key = %q, want parent.lead_enriched", got)
+}
+
+func TestWorkflowNodeHandlerResolution_ConnectConsumesImportBindings(t *testing.T) {
+	source := loadPipelineImportBoundaryConnectedSource(t)
+	for _, tc := range []struct {
+		nodeID    string
+		eventType events.EventType
+		wantKey   string
+	}{
+		{nodeID: "worker-node", eventType: "parent.lead_captured", wantKey: "work.requested"},
+		{nodeID: "parent-listener", eventType: "worker/work.completed", wantKey: "parent.lead_enriched"},
+	} {
+		evt := eventtest.RootIngress("", tc.eventType, "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+		resolved := workflowNodeEventHandlerResolutionForDelivery(source, tc.nodeID, evt)
+		if !resolved.Matched || resolved.HandlerEventKey != tc.wantKey {
+			t.Fatalf("handler resolution for %s = %#v, want %s", tc.eventType, resolved, tc.wantKey)
+		}
 	}
 }
 
@@ -441,7 +450,7 @@ func loadPipelineImportBoundaryAliasSource(t *testing.T) semanticview.Source {
 
 func loadPipelineImportBoundaryAliasSourceWithParentSubscription(t *testing.T, parentSubscription string) semanticview.Source {
 	t.Helper()
-	root := writePipelineImportBoundaryAliasFixture(t, parentSubscription)
+	root := writePipelineImportBoundaryAliasFixture(t, parentSubscription, false)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
@@ -449,9 +458,42 @@ func loadPipelineImportBoundaryAliasSourceWithParentSubscription(t *testing.T, p
 	return semanticview.Wrap(bundle)
 }
 
-func writePipelineImportBoundaryAliasFixture(t *testing.T, parentSubscription string) string {
+func loadPipelineImportBoundaryConnectedSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	root := writePipelineImportBoundaryAliasFixture(t, "parent.lead_enriched", true)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(contractComplianceRepoRoot(t), root, runtimecontracts.DefaultPlatformSpecFile(contractComplianceRepoRoot(t)))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writePipelineImportBoundaryAliasFixture(t *testing.T, parentSubscription string, connected bool) string {
 	t.Helper()
 	root := t.TempDir()
+	connect := ""
+	rootSchema := "name: pipeline-import-boundary-alias\n"
+	if connected {
+		connect = `
+connect:
+  - from: .lead_captured
+    to: worker.work_requested
+  - from: worker.work_completed
+    to: .lead_enriched
+`
+		rootSchema = `
+name: pipeline-import-boundary-alias
+pins:
+  inputs:
+    events:
+      - name: lead_enriched
+        event: parent.lead_enriched
+  outputs:
+    events:
+      - name: lead_captured
+        event: parent.lead_captured
+`
+	}
 	writePipelineFixtureFile(t, filepath.Join(root, "package.yaml"), `
 name: pipeline-import-boundary-alias
 version: "1.0.0"
@@ -465,8 +507,8 @@ flows:
         work.requested: parent.lead_captured
       outputs:
         work.completed: parent.lead_enriched
-`)
-	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: pipeline-import-boundary-alias\n")
+`+connect)
+	writePipelineFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
 	writePipelineFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writePipelineFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writePipelineFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
@@ -494,9 +536,13 @@ name: worker
 mode: static
 pins:
   inputs:
-    events: [work.requested]
+    events:
+      - name: work_requested
+        event: work.requested
   outputs:
-    events: [work.completed]
+    events:
+      - name: work_completed
+        event: work.completed
 `)
 	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
 	writePipelineFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -350,10 +350,52 @@ func TestWorkflowNodeConnectedInputEventHandlerResolution_ConsumesLoweredPackage
 }
 
 func TestWorkflowNodeConnectedInputHandlerMatchesConcreteTemplateProducer(t *testing.T) {
+	source := testWorkflowNodeConnectedInputSource("template")
+	evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+		FlowInstance: "receiver",
+		Source:       events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "producer-entity"},
+		Target:       events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: "receiver-entity"},
+	}, time.Unix(1, 0).UTC())
+
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "receiver-node", evt)
+	if !resolved.Matched || resolved.HandlerEventKey != "deploy.requested" {
+		t.Fatalf("concrete template connect handler resolution = %#v, want receiver deploy.requested", resolved)
+	}
+}
+
+func TestWorkflowNodeConnectedInputHandlerEnforcesProducerMode(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      string
+		eventType string
+		source    events.RouteIdentity
+		want      bool
+	}{
+		{name: "static exact scope", mode: "static", eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}, want: true},
+		{name: "static descendant", mode: "static", eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "template concrete instance", mode: "template", eventType: "producer/inst-1/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}, want: true},
+		{name: "template base scope", mode: "template", eventType: "producer/deploy.done", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}},
+		{name: "template concrete name without route", mode: "template", eventType: "producer/inst-1/deploy.done"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evt := eventtest.RootIngress("", events.EventType(tc.eventType), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+				FlowInstance: "receiver",
+				Source:       tc.source,
+				Target:       events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: "receiver-entity"},
+			}, time.Unix(1, 0).UTC())
+			resolved := workflowNodeEventHandlerResolutionForDelivery(testWorkflowNodeConnectedInputSource(tc.mode), "receiver-node", evt)
+			if resolved.Matched != tc.want {
+				t.Fatalf("handler resolution = %#v, want matched %v", resolved, tc.want)
+			}
+		})
+	}
+}
+
+func testWorkflowNodeConnectedInputSource(producerMode string) semanticview.Source {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
-			Mode: "template",
+			Mode: producerMode,
 			Pins: runtimecontracts.FlowPins{Outputs: runtimecontracts.FlowOutputPins{EventPins: []runtimecontracts.FlowOutputEventPin{{
 				Name: "deploy_done", Event: "deploy.done",
 			}}}},
@@ -379,7 +421,7 @@ func TestWorkflowNodeConnectedInputHandlerMatchesConcreteTemplateProducer(t *tes
 		},
 	}
 	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, receiver}}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
 				"producer": {{Name: "deploy_done", Event: "deploy.done"}},
@@ -402,16 +444,6 @@ func TestWorkflowNodeConnectedInputHandlerMatchesConcreteTemplateProducer(t *tes
 			},
 		},
 	})
-	evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
-		FlowInstance: "receiver",
-		Source:       events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "producer-entity"},
-		Target:       events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: "receiver-entity"},
-	}, time.Unix(1, 0).UTC())
-
-	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "receiver-node", evt)
-	if !resolved.Matched || resolved.HandlerEventKey != "deploy.requested" {
-		t.Fatalf("concrete template connect handler resolution = %#v, want receiver deploy.requested", resolved)
-	}
 }
 
 func TestWorkflowNodeHandlerResolution_LocalizesProducerScopedEventThroughTargetRoute(t *testing.T) {

--- a/internal/runtime/pipeline/workflow_nodes_test.go
+++ b/internal/runtime/pipeline/workflow_nodes_test.go
@@ -342,9 +342,75 @@ func TestWorkflowNodeConnectedInputEventHandlerResolution_ConsumesLoweredPackage
 		t.Fatalf("producer event %q must differ from receiver event %q for this proof", producerEvent, receiverEvent)
 	}
 
-	resolved := workflowNodeConnectedInputEventHandlerResolution(source, "child-relay", producerEvent)
+	evt := eventtest.RootIngress("", events.EventType(producerEvent), "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{}, time.Unix(1, 0).UTC())
+	resolved := workflowNodeConnectedInputEventHandlerResolution(source, "child-relay", evt)
 	if !resolved.Matched || resolved.HandlerEventKey != "micro.done" {
 		t.Fatalf("package-root connect handler resolution = %#v, want child-relay micro.done", resolved)
+	}
+}
+
+func TestWorkflowNodeConnectedInputHandlerMatchesConcreteTemplateProducer(t *testing.T) {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{Outputs: runtimecontracts.FlowOutputPins{EventPins: []runtimecontracts.FlowOutputEventPin{{
+				Name: "deploy_done", Event: "deploy.done",
+			}}}},
+		},
+		Path: "producer",
+	}
+	receiver := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "receiver", Flow: "receiver"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{Inputs: runtimecontracts.FlowInputPins{EventPins: []runtimecontracts.FlowInputEventPin{{
+				Name: "deploy_requested", Event: "deploy.requested",
+			}}}},
+		},
+		Path: "receiver",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"receiver-node": {
+				ID:           "receiver-node",
+				SubscribesTo: []string{"deploy.requested"},
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"deploy.requested": {},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, receiver}}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
+				"producer": {{Name: "deploy_done", Event: "deploy.done"}},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"receiver": {{Name: "deploy_requested", Event: "deploy.requested"}},
+			},
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				SourceFile: "package.yaml", SourceLine: 1, From: "producer.deploy_done", To: "receiver.deploy_requested",
+			}},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{
+				"receiver-node": {"deploy.requested": {}},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer": &root.Children[0],
+				"receiver": &root.Children[1],
+			},
+		},
+	})
+	evt := eventtest.RootIngress("", "producer/inst-1/deploy.done", "", "", []byte(`{}`), 0, "", "", events.EventEnvelope{
+		FlowInstance: "receiver",
+		Source:       events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "producer-entity"},
+		Target:       events.RouteIdentity{FlowID: "receiver", FlowInstance: "receiver", EntityID: "receiver-entity"},
+	}, time.Unix(1, 0).UTC())
+
+	resolved := workflowNodeEventHandlerResolutionForDelivery(source, "receiver-node", evt)
+	if !resolved.Matched || resolved.HandlerEventKey != "deploy.requested" {
+		t.Fatalf("concrete template connect handler resolution = %#v, want receiver deploy.requested", resolved)
 	}
 }
 

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -329,7 +329,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	listenerCtx := withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child")
 	completion := eventtest.RootIngress(
 		uuid.NewString(),
-		events.EventType("child/work.completed"),
+		events.EventType("work.completed"),
 		"cataloge2e",
 		"",
 		[]byte(`{"entity_id":"ent-001"}`),
@@ -341,9 +341,9 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	)
 
 	seedPipelineNodeDeliveryAuthority(t, db, completion, "parent-listener")
-	handler, ok := pc.SemanticSource().NodeEventHandler("parent-listener", "child/work.completed")
+	handler, ok := pc.SemanticSource().NodeEventHandler("parent-listener", "work.completed")
 	if !ok {
-		t.Fatal("parent-listener handler missing for child/work.completed")
+		t.Fatal("parent-listener handler missing for root-local work.completed")
 	}
 	result, err := pc.executeNodeContractHandler(withPipelineFlowScope(testPipelineCoordinatorRunContext(t, pc), "child"), "parent-listener", handler, workflowTriggerContext{
 		Event: completion,
@@ -357,7 +357,7 @@ func TestExecuteNodeHandlerPlan_PreservesRootStateForChildFlowTransitions(t *tes
 	}
 
 	if handled := pc.executeNodeHandlerPlan(listenerCtx, "parent-listener", completion); !handled {
-		t.Fatal("parent-listener should clear inherited child flow scope and handle child/work.completed")
+		t.Fatal("parent-listener should clear inherited child flow scope and handle root-local work.completed")
 	}
 	instance, ok, err = pc.workflowStore.Load(testPipelineCoordinatorRunContext(t, pc), "ent-001")
 	if err != nil {
@@ -406,7 +406,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 
 	completion := eventtest.RootIngress(
 		uuid.NewString(),
-		events.EventType("child/work.completed"),
+		events.EventType("work.completed"),
 		"cataloge2e",
 		"",
 		[]byte(`{"entity_id":"ent-001"}`),
@@ -423,7 +423,7 @@ func TestPipelineIntercept_HandlesChildFlowOutputForRootListener(t *testing.T) {
 		t.Fatalf("Intercept: %v", err)
 	}
 	if !passThrough {
-		t.Fatal("expected child/work.completed to remain visible downstream")
+		t.Fatal("expected root-local work.completed to remain visible downstream")
 	}
 	if len(emitted) != 1 || string(emitted[0].Type()) != "job.done" {
 		t.Fatalf("emitted = %#v, want [job.done]", emitted)

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -522,7 +522,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionDoesNotEmitChild
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedToParentStillEmitsRootResult(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedPackageRootConnectDoesNotAuthorizeRootResult(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
@@ -608,15 +608,12 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionAlreadyTargetedT
 	if !passThrough {
 		t.Fatal("expected nested descendant completion to remain visible downstream")
 	}
-	if len(emitted) != 1 || string(emitted[0].Type()) != "pipeline.complete" {
-		t.Fatalf("emitted = %#v, want [pipeline.complete]", emitted)
-	}
-	if got := emitted[0].EntityID(); got != childRowID {
-		t.Fatalf("emitted entity_id = %q, want child target %q", got, childRowID)
+	if len(emitted) != 0 {
+		t.Fatalf("emitted = %#v, want none from an unauthorized repository-root handler", emitted)
 	}
 }
 
-func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTxStillEmitsRootResult(t *testing.T) {
+func TestPipelineCoordinatorIntercept_NestedPackageRootConnectInsideOuterSQLTxDoesNotAuthorizeRootResult(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixtureRoot := filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-nested-three-levels")
 	platformSpec := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
@@ -698,10 +695,7 @@ func TestPipelineCoordinatorIntercept_NestedDescendantCompletionInsideOuterSQLTx
 	if !passThrough {
 		t.Fatal("expected nested descendant completion to remain visible downstream")
 	}
-	if len(emitted) != 1 || string(emitted[0].Type()) != "pipeline.complete" {
-		t.Fatalf("emitted = %#v, want [pipeline.complete]", emitted)
-	}
-	if got := emitted[0].EntityID(); got != childRowID {
-		t.Fatalf("emitted entity_id = %q, want child target %q", got, childRowID)
+	if len(emitted) != 0 {
+		t.Fatalf("emitted = %#v, want none from an unauthorized repository-root handler", emitted)
 	}
 }

--- a/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_timer_lifecycle_test.go
@@ -572,7 +572,7 @@ func TestPipelineCoordinatorIntercept_NestedPackageRootConnectDoesNotAuthorizeRo
 	}); err != nil {
 		t.Fatalf("seed child instance: %v", err)
 	}
-	if consume, handled := pc.workflowNodeInterceptPolicy(testAuthorActivityContext(context.Background()), "child/grandchild/micro.done", eventtest.RootIngress(
+	if consume, handled, err := pc.workflowNodeInterceptPolicy(testAuthorActivityContext(context.Background()), "child/grandchild/micro.done", eventtest.RootIngress(
 		"",
 		events.EventType("child/grandchild/micro.done"),
 		"",
@@ -583,8 +583,8 @@ func TestPipelineCoordinatorIntercept_NestedPackageRootConnectDoesNotAuthorizeRo
 		"",
 		events.EnvelopeForEntityID(events.EventEnvelope{}, childRowID),
 		time.Time{},
-	)); !handled {
-		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, want handled", handled, consume)
+	)); err != nil || !handled {
+		t.Fatalf("workflowNodeInterceptPolicy handled = %v, consume = %v, err = %v, want handled", handled, consume, err)
 	}
 
 	completion := eventtest.RootIngress(

--- a/internal/runtime/routingtopology/topology.go
+++ b/internal/runtime/routingtopology/topology.go
@@ -3,6 +3,7 @@ package routingtopology
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,6 +16,8 @@ import (
 const (
 	SchemaVersion   = "routing-topology/v1"
 	SourceAuthority = "projection_only_existing_contract_owners"
+
+	FailureConnectReceiverPinCollision = "connect_receiver_pin_delivery_collision"
 )
 
 type DeliveryScope string
@@ -221,7 +224,7 @@ func Build(source semanticview.Source) Topology {
 	builder.addTypedPubSubRelations(relations)
 	builder.addBoundaryExposures()
 	builder.addConnectEdges(plans)
-	return Topology{
+	topology := Topology{
 		SchemaVersion:     SchemaVersion,
 		ProjectionOnly:    true,
 		SourceAuthority:   SourceAuthority,
@@ -234,6 +237,147 @@ func Build(source semanticview.Source) Topology {
 		Edges:             builder.sortedEdges(),
 		Issues:            issueViews(planIssues, builder.relationIssues),
 	}
+	topology.Issues = append(topology.Issues, connectReceiverPinCollisionIssues(topology.Edges)...)
+	sort.SliceStable(topology.Issues, func(i, j int) bool { return topology.Issues[i].ID < topology.Issues[j].ID })
+	return topology
+}
+
+type connectReceiverPinDeliveryFact struct {
+	sourceKey        string
+	subscriberType   string
+	subscriberID     string
+	targetKey        string
+	receiverLocalKey string
+	receiverLabel    string
+	authoredLocation string
+}
+
+func connectReceiverPinCollisionIssues(edges []Edge) []Issue {
+	typedConsumers := make(map[string][]Edge)
+	for _, edge := range edges {
+		if edge.Scope == DeliveryScopeTypedPubSub {
+			typedConsumers[edge.Producer.ID] = append(typedConsumers[edge.Producer.ID], edge)
+		}
+	}
+
+	type collision struct {
+		fact   connectReceiverPinDeliveryFact
+		locals map[string]string
+	}
+	byDelivery := make(map[string]*collision)
+	for _, edge := range edges {
+		if edge.Scope != DeliveryScopeInterFlowConnect || edge.Boundary == nil {
+			continue
+		}
+		for _, local := range typedConsumers[edge.Consumer.ID] {
+			fact, ok := connectReceiverPinFact(edge, local)
+			if !ok {
+				continue
+			}
+			key := strings.Join([]string{fact.sourceKey, fact.subscriberType, fact.subscriberID, fact.targetKey}, "\x00")
+			entry := byDelivery[key]
+			if entry == nil {
+				entry = &collision{fact: fact, locals: map[string]string{}}
+				byDelivery[key] = entry
+			}
+			entry.locals[fact.receiverLocalKey] = fact.receiverLabel
+		}
+	}
+
+	keys := make([]string, 0, len(byDelivery))
+	for key, entry := range byDelivery {
+		if len(entry.locals) > 1 {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	issues := make([]Issue, 0, len(keys))
+	for _, key := range keys {
+		entry := byDelivery[key]
+		locals := make([]string, 0, len(entry.locals))
+		for _, label := range entry.locals {
+			locals = append(locals, label)
+		}
+		sort.Strings(locals)
+		message := fmt.Sprintf(
+			"source event %s reaches %s %s at target %s through multiple receiver pins: %s",
+			entry.fact.sourceKey,
+			entry.fact.subscriberType,
+			entry.fact.subscriberID,
+			entry.fact.targetKey,
+			strings.Join(locals, ", "),
+		)
+		issue := Issue{
+			CheckID:          FailureConnectReceiverPinCollision,
+			Severity:         "error",
+			Failure:          FailureConnectReceiverPinCollision,
+			Location:         entry.fact.targetKey,
+			From:             entry.fact.sourceKey,
+			To:               entry.fact.subscriberType + ":" + entry.fact.subscriberID,
+			Detail:           message,
+			Message:          message,
+			Remediation:      "Route the source event to distinct subscribers or targets, or consolidate the receiver pins behind one handler. One event x subscriber cannot select multiple receiver-local handlers.",
+			AuthoredLocation: entry.fact.authoredLocation,
+		}
+		issue.ID = issueID(issue)
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+func connectReceiverPinFact(connect Edge, local Edge) (connectReceiverPinDeliveryFact, bool) {
+	subscriberType := ""
+	subscriberID := ""
+	switch local.Consumer.Kind {
+	case semanticview.EventEndpointNodeHandler:
+		subscriberType = "node"
+		subscriberID = strings.TrimSpace(local.Consumer.NodeID)
+	case semanticview.EventEndpointAgent:
+		subscriberType = "agent"
+		subscriberID = strings.TrimSpace(local.Consumer.AgentID)
+	default:
+		return connectReceiverPinDeliveryFact{}, false
+	}
+	if subscriberID == "" {
+		return connectReceiverPinDeliveryFact{}, false
+	}
+	sourceKey := strings.Join([]string{
+		strings.TrimSpace(connect.Boundary.PackageKey),
+		strings.TrimSpace(connect.Boundary.From),
+		strings.TrimSpace(connect.Event.Canonical),
+	}, ":")
+	targetKey, targetProven := connectReceiverPinStaticTargetKey(connect, local)
+	if !targetProven {
+		return connectReceiverPinDeliveryFact{}, false
+	}
+	receiverLocalKey := strings.Join([]string{
+		strings.TrimSpace(connect.Boundary.To),
+		strings.TrimSpace(connect.Consumer.Event.Canonical),
+	}, "\x00")
+	receiverLabel := strings.TrimSpace(connect.Boundary.To)
+	if eventName := strings.TrimSpace(connect.Consumer.Event.Canonical); eventName != "" {
+		receiverLabel += " (" + eventName + ")"
+	}
+	return connectReceiverPinDeliveryFact{
+		sourceKey:        sourceKey,
+		subscriberType:   subscriberType,
+		subscriberID:     subscriberID,
+		targetKey:        targetKey,
+		receiverLocalKey: receiverLocalKey,
+		receiverLabel:    receiverLabel,
+		authoredLocation: strings.TrimSpace(connect.Boundary.AuthoredLocation),
+	}, true
+}
+
+func connectReceiverPinStaticTargetKey(connect Edge, local Edge) (string, bool) {
+	targetKey := strings.Trim(strings.TrimSpace(local.Consumer.FlowPath), "/")
+	if targetKey == "" {
+		return "<global-root>", true
+	}
+	if connect.RequiresRuntimeResolution || connect.Resolution == nil || strings.TrimSpace(connect.Resolution.Mode) != string(pinrouting.ConnectResolutionStatic) {
+		return "", false
+	}
+	return targetKey, true
 }
 
 func rootInputSourceViews(source semanticview.Source) []RootInputSource {

--- a/internal/runtime/routingtopology/topology.go
+++ b/internal/runtime/routingtopology/topology.go
@@ -53,22 +53,6 @@ type Endpoint struct {
 	ResolutionMode string                              `json:"resolution_mode,omitempty"`
 }
 
-const LegacyQualifiedSubscriptionDisposition = "legacy_qualified_subscription"
-
-type LegacyQualifiedSubscription struct {
-	ID               string        `json:"id"`
-	Disposition      string        `json:"disposition"`
-	Event            EventIdentity `json:"event"`
-	Consumer         Endpoint      `json:"consumer"`
-	TargetFlowID     string        `json:"target_flow_id"`
-	TargetFlowPath   string        `json:"target_flow_path"`
-	AuthoredLocation string        `json:"authored_location"`
-	RuntimeDelivery  bool          `json:"runtime_delivery"`
-	CanonicalEdge    bool          `json:"canonical_edge"`
-	FindingID        string        `json:"finding_id,omitempty"`
-	Migration        string        `json:"migration"`
-}
-
 type BoundaryExposure struct {
 	ID       string        `json:"id"`
 	Event    EventIdentity `json:"event"`
@@ -212,18 +196,17 @@ type Issue struct {
 }
 
 type Topology struct {
-	SchemaVersion                string                        `json:"schema_version"`
-	ProjectionOnly               bool                          `json:"projection_only"`
-	SourceAuthority              string                        `json:"source_authority"`
-	Producers                    []Endpoint                    `json:"producers"`
-	Consumers                    []Endpoint                    `json:"consumers"`
-	InputPins                    []Endpoint                    `json:"input_pins"`
-	OutputPins                   []Endpoint                    `json:"output_pins"`
-	RootInputSources             []RootInputSource             `json:"root_input_sources"`
-	BoundaryExposures            []BoundaryExposure            `json:"boundary_exposures"`
-	Edges                        []Edge                        `json:"edges"`
-	LegacyQualifiedSubscriptions []LegacyQualifiedSubscription `json:"legacy_qualified_subscriptions"`
-	Issues                       []Issue                       `json:"issues"`
+	SchemaVersion     string             `json:"schema_version"`
+	ProjectionOnly    bool               `json:"projection_only"`
+	SourceAuthority   string             `json:"source_authority"`
+	Producers         []Endpoint         `json:"producers"`
+	Consumers         []Endpoint         `json:"consumers"`
+	InputPins         []Endpoint         `json:"input_pins"`
+	OutputPins        []Endpoint         `json:"output_pins"`
+	RootInputSources  []RootInputSource  `json:"root_input_sources"`
+	BoundaryExposures []BoundaryExposure `json:"boundary_exposures"`
+	Edges             []Edge             `json:"edges"`
+	Issues            []Issue            `json:"issues"`
 }
 
 func Build(source semanticview.Source) Topology {
@@ -239,18 +222,17 @@ func Build(source semanticview.Source) Topology {
 	builder.addBoundaryExposures()
 	builder.addConnectEdges(plans)
 	return Topology{
-		SchemaVersion:                SchemaVersion,
-		ProjectionOnly:               true,
-		SourceAuthority:              SourceAuthority,
-		Producers:                    endpointViews(census.Producers()),
-		Consumers:                    endpointViews(census.Consumers()),
-		InputPins:                    endpointViews(census.InputPins()),
-		OutputPins:                   endpointViews(census.OutputPins()),
-		RootInputSources:             rootInputSourceViews(source),
-		BoundaryExposures:            builder.sortedExposures(),
-		Edges:                        builder.sortedEdges(),
-		LegacyQualifiedSubscriptions: legacyQualifiedSubscriptionViews(census.LegacyQualifiedSubscriptions()),
-		Issues:                       issueViews(planIssues, builder.relationIssues),
+		SchemaVersion:     SchemaVersion,
+		ProjectionOnly:    true,
+		SourceAuthority:   SourceAuthority,
+		Producers:         endpointViews(census.Producers()),
+		Consumers:         endpointViews(census.Consumers()),
+		InputPins:         endpointViews(census.InputPins()),
+		OutputPins:        endpointViews(census.OutputPins()),
+		RootInputSources:  rootInputSourceViews(source),
+		BoundaryExposures: builder.sortedExposures(),
+		Edges:             builder.sortedEdges(),
+		Issues:            issueViews(planIssues, builder.relationIssues),
 	}
 }
 
@@ -471,41 +453,6 @@ func endpointView(endpoint semanticview.AuthoredEventEndpoint) Endpoint {
 	}
 }
 
-func legacyQualifiedSubscriptionViews(subscriptions []semanticview.LegacyQualifiedSubscription) []LegacyQualifiedSubscription {
-	out := make([]LegacyQualifiedSubscription, 0, len(subscriptions))
-	for _, subscription := range subscriptions {
-		consumer := endpointView(subscription.Consumer)
-		out = append(out, LegacyQualifiedSubscription{
-			ID:               subscription.ID,
-			Disposition:      LegacyQualifiedSubscriptionDisposition,
-			Event:            eventView(subscription.Event),
-			Consumer:         consumer,
-			TargetFlowID:     strings.TrimSpace(subscription.TargetFlowID),
-			TargetFlowPath:   strings.TrimSpace(subscription.TargetFlowPath),
-			AuthoredLocation: endpointAuthoredLocation(consumer),
-			RuntimeDelivery:  true,
-			CanonicalEdge:    false,
-			Migration:        "Declare output/input pins and a connect, then replace the qualified cross-flow subscription with a flow-local event subscription.",
-		})
-	}
-	if out == nil {
-		return []LegacyQualifiedSubscription{}
-	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
-	return out
-}
-
-func endpointAuthoredLocation(endpoint Endpoint) string {
-	file := strings.TrimSpace(endpoint.SourceFile)
-	if file == "" {
-		return strings.TrimSpace(endpoint.SourceLocation)
-	}
-	if endpoint.SourceLine > 0 {
-		return file + ":" + strconv.Itoa(endpoint.SourceLine)
-	}
-	return file
-}
-
 func eventView(proof semanticview.FlowEventProof) EventIdentity {
 	canonical := strings.TrimSpace(proof.Canonical)
 	if canonical == "" {
@@ -680,42 +627,7 @@ func WithIssues(topology Topology, additional ...Issue) Topology {
 	}
 	sort.SliceStable(issues, func(i, j int) bool { return issues[i].ID < issues[j].ID })
 	topology.Issues = issues
-	topology.LegacyQualifiedSubscriptions = linkLegacyQualifiedSubscriptionFindings(topology.LegacyQualifiedSubscriptions, issues)
 	return topology
-}
-
-func linkLegacyQualifiedSubscriptionFindings(subscriptions []LegacyQualifiedSubscription, issues []Issue) []LegacyQualifiedSubscription {
-	out := append([]LegacyQualifiedSubscription(nil), subscriptions...)
-	for i := range out {
-		best := -1
-		for j := range issues {
-			issue := issues[j]
-			if issue.CheckID != "legacy_qualified_subscription" || strings.TrimSpace(issue.Location) != strings.TrimSpace(out[i].AuthoredLocation) {
-				continue
-			}
-			if best < 0 || legacyFindingSeverityRank(issue.Severity) > legacyFindingSeverityRank(issues[best].Severity) {
-				best = j
-			}
-		}
-		if best >= 0 {
-			out[i].FindingID = issues[best].ID
-		}
-	}
-	if out == nil {
-		return []LegacyQualifiedSubscription{}
-	}
-	return out
-}
-
-func legacyFindingSeverityRank(severity string) int {
-	switch strings.TrimSpace(severity) {
-	case "hard_invalidity", "error":
-		return 2
-	case "semantic_drift_warning", "warning":
-		return 1
-	default:
-		return 0
-	}
 }
 
 func issueID(issue Issue) string {

--- a/internal/runtime/routingtopology/topology_test.go
+++ b/internal/runtime/routingtopology/topology_test.go
@@ -478,6 +478,123 @@ func TestBuildEmptyTopologyUsesStableEmptyCollections(t *testing.T) {
 	}
 }
 
+func TestConnectReceiverPinCollisionIssuesRespectDurableDeliveryIdentity(t *testing.T) {
+	connect := func(inputID, to, event, location string) Edge {
+		return Edge{
+			Scope:      DeliveryScopeInterFlowConnect,
+			Event:      EventIdentity{Canonical: "producer/work.ready"},
+			Consumer:   Endpoint{ID: inputID, Event: EventIdentity{Canonical: event}},
+			Boundary:   &Boundary{PackageKey: ".", From: "producer.work_ready", To: to, AuthoredLocation: location},
+			Resolution: &Resolution{Mode: string(pinrouting.ConnectResolutionStatic)},
+		}
+	}
+	consumer := func(inputID string, kind semanticview.EventEndpointKind, subscriberID, target string) Edge {
+		endpoint := Endpoint{Kind: kind, FlowPath: target}
+		if kind == semanticview.EventEndpointAgent {
+			endpoint.AgentID = subscriberID
+		} else {
+			endpoint.Kind = semanticview.EventEndpointNodeHandler
+			endpoint.NodeID = subscriberID
+		}
+		return Edge{Scope: DeliveryScopeTypedPubSub, Producer: Endpoint{ID: inputID}, Consumer: endpoint}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		edges []Edge
+		want  int
+	}{
+		{
+			name: "same node and target through distinct receiver pins",
+			edges: []Edge{
+				connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:10"),
+				connect("input-b", "consumer.work_audited", "consumer/work.audited", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+				consumer("input-b", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+			},
+			want: 1,
+		},
+		{
+			name: "same root agent through distinct receiver pins",
+			edges: []Edge{
+				connect("input-a", ".work_accepted", "work.accepted", "package.yaml:10"),
+				connect("input-b", ".work_audited", "work.audited", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointAgent, "root-agent", ""),
+				consumer("input-b", semanticview.EventEndpointAgent, "root-agent", ""),
+			},
+			want: 1,
+		},
+		{
+			name: "duplicate same edge is idempotent",
+			edges: []Edge{
+				connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:10"),
+				connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+			},
+		},
+		{
+			name: "different subscribers are legal fanout",
+			edges: []Edge{
+				connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:10"),
+				connect("input-b", "consumer.work_audited", "consumer/work.audited", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "accept-node", "consumer"),
+				consumer("input-b", semanticview.EventEndpointNodeHandler, "audit-node", "consumer"),
+			},
+		},
+		{
+			name: "same subscriber at different targets is legal fanout",
+			edges: []Edge{
+				connect("input-a", "alpha.work_accepted", "alpha/work.accepted", "package.yaml:10"),
+				connect("input-b", "beta.work_audited", "beta/work.audited", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "worker-node", "alpha"),
+				consumer("input-b", semanticview.EventEndpointNodeHandler, "worker-node", "beta"),
+			},
+		},
+		{
+			name: "mixed legal and colliding fanout reports collision",
+			edges: []Edge{
+				connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:10"),
+				connect("input-b", "consumer.work_audited", "consumer/work.audited", "package.yaml:12"),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+				consumer("input-b", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+				consumer("input-a", semanticview.EventEndpointAgent, "legal-agent", "consumer"),
+			},
+			want: 1,
+		},
+		{
+			name: "runtime-resolved targets remain guarded at materialization",
+			edges: []Edge{
+				func() Edge {
+					edge := connect("input-a", "consumer.work_accepted", "consumer/work.accepted", "package.yaml:10")
+					edge.RequiresRuntimeResolution = true
+					edge.Resolution.Mode = runtimecontracts.FlowInputResolutionModeSelect
+					return edge
+				}(),
+				func() Edge {
+					edge := connect("input-b", "consumer.work_audited", "consumer/work.audited", "package.yaml:12")
+					edge.RequiresRuntimeResolution = true
+					edge.Resolution.Mode = runtimecontracts.FlowInputResolutionModeSelect
+					return edge
+				}(),
+				consumer("input-a", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+				consumer("input-b", semanticview.EventEndpointNodeHandler, "consumer-node", "consumer"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := connectReceiverPinCollisionIssues(tc.edges)
+			if len(issues) != tc.want {
+				t.Fatalf("collision issues = %#v, want %d", issues, tc.want)
+			}
+			for _, issue := range issues {
+				if issue.Failure != FailureConnectReceiverPinCollision || !strings.Contains(issue.Remediation, "One event x subscriber") {
+					t.Fatalf("collision issue = %#v", issue)
+				}
+			}
+		})
+	}
+}
+
 func firstInterFlowEdge(t *testing.T, topology Topology) Edge {
 	t.Helper()
 	for _, edge := range topology.Edges {

--- a/internal/runtime/routingtopology/topology_test.go
+++ b/internal/runtime/routingtopology/topology_test.go
@@ -298,7 +298,7 @@ func TestBuildDoesNotInventDeliveryEdgesForMetadataSources(t *testing.T) {
 	}
 }
 
-func TestBuildProjectsLegacyQualifiedSubscriptionAsNonCanonicalDebt(t *testing.T) {
+func TestBuildProjectsCanonicalRootConnectInsteadOfQualifiedSubscriptionDebt(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(
 		repoRoot,
@@ -306,37 +306,33 @@ func TestBuildProjectsLegacyQualifiedSubscriptionAsNonCanonicalDebt(t *testing.T
 		runtimecontracts.DefaultPlatformSpecFile(repoRoot),
 	)
 	if err != nil {
-		t.Fatalf("load legacy fixture: %v", err)
+		t.Fatalf("load migrated fixture: %v", err)
 	}
 	topology := Build(semanticview.Wrap(bundle))
-	if len(topology.LegacyQualifiedSubscriptions) != 1 {
-		t.Fatalf("legacy subscriptions = %#v, want one", topology.LegacyQualifiedSubscriptions)
-	}
-	legacy := topology.LegacyQualifiedSubscriptions[0]
-	if legacy.Disposition != LegacyQualifiedSubscriptionDisposition || !legacy.RuntimeDelivery || legacy.CanonicalEdge || legacy.AuthoredLocation == "" {
-		t.Fatalf("legacy disposition = %#v, want visible runtime debt outside canonical edges", legacy)
-	}
+	found := false
 	for _, edge := range topology.Edges {
-		if edge.Consumer.ID == legacy.Consumer.ID {
-			t.Fatalf("legacy qualified consumer leaked into canonical edges: %#v", edge)
+		if edge.Scope == DeliveryScopeInterFlowConnect && edge.Boundary != nil && edge.Boundary.To == ".task_done" {
+			found = true
 		}
+	}
+	if !found {
+		t.Fatalf("topology edges = %#v, want canonical connect to root task_done", topology.Edges)
 	}
 }
 
-func TestLegacyQualifiedSubscriptionInventoryMatchesE1aRetirementTracker(t *testing.T) {
+func TestExactQualifiedSubscriptionFixturesUseCanonicalAncestorEdge(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	tests := []struct {
-		fixture  string
-		event    string
-		consumer string
-		location string
+		fixture      string
+		minimumEdges int
 	}{
-		{fixture: "test-child-flow-absolute-path", event: "child/task.done", consumer: "listener", location: "nodes.yaml:13"},
-		{fixture: "test-child-flow-pin-wiring", event: "child/work.completed", consumer: "parent-listener", location: "nodes.yaml:13"},
-		{fixture: "test-data-pin-wiring", event: "processor/process.done", consumer: "result-listener", location: "nodes.yaml:20"},
-		{fixture: "test-gates-in-child-flow", event: "child/validation.done", consumer: "router", location: "nodes.yaml:5"},
-		{fixture: "test-nested-three-levels", event: "child/grandchild/micro.done", consumer: "root-collector", location: "nodes.yaml:13"},
-		{fixture: "test-tool-override", event: "child/child.done", consumer: "root-node", location: "nodes.yaml:4"},
+		{fixture: "test-child-flow-absolute-path", minimumEdges: 1},
+		{fixture: "test-child-flow-pin-wiring", minimumEdges: 1},
+		{fixture: "test-data-pin-wiring", minimumEdges: 1},
+		{fixture: "test-gates-in-child-flow", minimumEdges: 1},
+		{fixture: "test-nested-three-levels", minimumEdges: 2},
+		{fixture: "test-tool-override", minimumEdges: 1},
+		{fixture: "test-wildcard-deep-subscription", minimumEdges: 1},
 	}
 	for _, tc := range tests {
 		t.Run(tc.fixture, func(t *testing.T) {
@@ -344,9 +340,18 @@ func TestLegacyQualifiedSubscriptionInventoryMatchesE1aRetirementTracker(t *test
 			if err != nil {
 				t.Fatalf("load fixture: %v", err)
 			}
-			legacy := Build(semanticview.Wrap(bundle)).LegacyQualifiedSubscriptions
-			if len(legacy) != 1 || legacy[0].Event.Canonical != tc.event || legacy[0].Consumer.NodeID != tc.consumer || !strings.HasSuffix(legacy[0].AuthoredLocation, tc.location) {
-				t.Fatalf("legacy inventory = %#v, want %s/%s/%s", legacy, tc.event, tc.consumer, tc.location)
+			source := semanticview.Wrap(bundle)
+			if legacy := semanticview.BuildAuthoredEventEndpointCensus(source).LegacyQualifiedSubscriptions(); len(legacy) != 0 {
+				t.Fatalf("retired qualified subscriptions survive: %#v", legacy)
+			}
+			connectEdges := 0
+			for _, edge := range Build(source).Edges {
+				if edge.Scope == DeliveryScopeInterFlowConnect {
+					connectEdges++
+				}
+			}
+			if connectEdges < tc.minimumEdges {
+				t.Fatalf("connect edges = %d, want at least %d", connectEdges, tc.minimumEdges)
 			}
 		})
 	}
@@ -356,9 +361,18 @@ func TestLegacyQualifiedSubscriptionInventoryMatchesE1aRetirementTracker(t *test
 		if err != nil {
 			t.Fatalf("load fixture: %v", err)
 		}
-		legacy := Build(semanticview.Wrap(bundle)).LegacyQualifiedSubscriptions
-		if len(legacy) != 1 || legacy[0].Event.Canonical != "child/task.result" || legacy[0].Consumer.NodeID != "dispatcher" || !strings.HasSuffix(legacy[0].AuthoredLocation, "nodes.yaml:4") {
-			t.Fatalf("legacy inventory = %#v, want child/task.result dispatcher nodes.yaml:4", legacy)
+		source := semanticview.Wrap(bundle)
+		if legacy := semanticview.BuildAuthoredEventEndpointCensus(source).LegacyQualifiedSubscriptions(); len(legacy) != 0 {
+			t.Fatalf("retired qualified subscriptions survive: %#v", legacy)
+		}
+		connectEdges := 0
+		for _, edge := range Build(source).Edges {
+			if edge.Scope == DeliveryScopeInterFlowConnect {
+				connectEdges++
+			}
+		}
+		if connectEdges < 1 {
+			t.Fatalf("connect edges = %d, want at least one", connectEdges)
 		}
 	})
 }
@@ -431,20 +445,6 @@ func TestEdgeIDIncludesTypedPubSubAuthorizationProof(t *testing.T) {
 	}
 }
 
-func TestWithIssuesLinksLegacySubscriptionOnlyToStrongestDedicatedFinding(t *testing.T) {
-	topology := Topology{LegacyQualifiedSubscriptions: []LegacyQualifiedSubscription{{
-		ID: "legacy", AuthoredLocation: "nodes.yaml:13", Event: EventIdentity{Canonical: "child/task.done"},
-	}}}
-	warning := NewDiagnosticIssue("legacy_qualified_subscription", "semantic_drift_warning", "nodes.yaml:13", "warning", "migrate", "nodes.yaml:13")
-	hard := NewDiagnosticIssue("legacy_qualified_subscription", "hard_invalidity", "nodes.yaml:13", "hard", "migrate", "nodes.yaml:13")
-	unrelated := NewDiagnosticIssue("event_consumer_exists", "hard_invalidity", "child/task.done", "unrelated", "migrate", "nodes.yaml:13")
-
-	got := WithIssues(topology, warning, unrelated, hard)
-	if got.LegacyQualifiedSubscriptions[0].FindingID != hard.ID {
-		t.Fatalf("finding id = %q, want strongest dedicated finding %q", got.LegacyQualifiedSubscriptions[0].FindingID, hard.ID)
-	}
-}
-
 func TestBuildIsDeterministic(t *testing.T) {
 	source := templatefanin.LoadSource(t, templatefanin.Options{})
 	first, err := json.Marshal(Build(source))
@@ -471,7 +471,7 @@ func TestBuildEmptyTopologyUsesStableEmptyCollections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal empty topology: %v", err)
 	}
-	for _, field := range []string{"producers", "consumers", "input_pins", "output_pins", "root_input_sources", "boundary_exposures", "edges", "legacy_qualified_subscriptions", "issues"} {
+	for _, field := range []string{"producers", "consumers", "input_pins", "output_pins", "root_input_sources", "boundary_exposures", "edges", "issues"} {
 		if !strings.Contains(string(encoded), `"`+field+`":[]`) {
 			t.Fatalf("empty topology field %s is not a stable array: %s", field, encoded)
 		}

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -7,6 +7,7 @@ import (
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
@@ -56,13 +57,17 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 	if err != nil {
 		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract workflow nodes: %w", err)
 	}
-
+	connectPlans, connectIssues := runtimepinrouting.LowerCompositionConnectRoutePlans(req.Source)
+	if len(connectIssues) != 0 {
+		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract connect routes: %#v", connectIssues)
+	}
 	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
 	for i := range frontier {
 		eventName := frontier[i].EventName
+		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, connectPlans)
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
-		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, eventName)
-		frontier[i].DerivedRecipients = contractFrontierRecipients(routeTable.Resolve(eventName))
+		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, routeKeys...)
+		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned))
 	}
 	sort.Slice(frontier, func(i, j int) bool {
 		if frontier[i].EventName != frontier[j].EventName {
@@ -313,15 +318,65 @@ func inferContractFrontierFlowInstanceFromEvent(source semanticview.Source, even
 	return ""
 }
 
-func workflowNodeSubscribers(nodes []runtimepipeline.WorkflowNode, eventName string) []string {
-	eventName = strings.TrimSpace(eventName)
+func contractFrontierRouteKeys(eventName string, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
+	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
 	if eventName == "" {
+		return nil, false
+	}
+	matched := false
+	receiverEvents := map[string]struct{}{}
+	for _, plan := range plans {
+		if eventName != strings.Trim(strings.TrimSpace(plan.Source.ResolvedEvent), "/") {
+			continue
+		}
+		matched = true
+		if plan.RequiresRuntimeResolution {
+			continue
+		}
+		local := strings.Trim(strings.TrimSpace(plan.Receiver.Event), "/")
+		receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
+		if receiverPath == "" {
+			receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
+		}
+		addString(receiverEvents, plan.Receiver.ResolvedEvent)
+		if receiverPath != "" && local != "" {
+			addString(receiverEvents, receiverPath+"/"+local)
+		}
+		if target := plan.Target.Normalized(); target.FlowInstance != "" && local != "" {
+			addString(receiverEvents, target.FlowInstance+"/"+local)
+		}
+	}
+	if matched {
+		return sortedSet(receiverEvents), true
+	}
+	return []string{eventName}, false
+}
+
+func resolveContractFrontierRoutes(routeTable *runtimebus.RouteTable, eventNames []string, connectOwned bool) []runtimebus.Subscriber {
+	var out []runtimebus.Subscriber
+	for _, eventName := range eventNames {
+		for _, subscriber := range routeTable.Resolve(eventName) {
+			if connectOwned && strings.TrimSpace(subscriber.RouteSource) != "receiver_carrier" {
+				continue
+			}
+			out = append(out, subscriber)
+		}
+	}
+	return out
+}
+
+func workflowNodeSubscribers(nodes []runtimepipeline.WorkflowNode, eventNames ...string) []string {
+	wanted := map[string]struct{}{}
+	for _, eventName := range eventNames {
+		addString(wanted, eventName)
+	}
+	if len(wanted) == 0 {
 		return nil
 	}
 	seen := map[string]struct{}{}
 	for _, node := range nodes {
 		for _, subscription := range node.Subscriptions {
-			if strings.TrimSpace(string(subscription)) != eventName {
+			if _, ok := wanted[strings.TrimSpace(string(subscription))]; !ok {
 				continue
 			}
 			addString(seen, node.ID)

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
@@ -324,13 +323,12 @@ func contractFrontierRouteKeys(eventName string, flowInstances []string, plans [
 	if eventName == "" {
 		return nil, false
 	}
-	probe := events.NewRouteProbeEvent(events.EventType(eventName))
 	matchesSource := func(endpoint runtimepinrouting.ConnectRoutePlanEndpoint) bool {
 		if len(flowInstances) == 0 {
-			return runtimepinrouting.ConnectSourceEndpointMatchesEvent(endpoint, probe)
+			return runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, "")
 		}
 		for _, flowInstance := range flowInstances {
-			if runtimepinrouting.ConnectSourceEndpointMatchesEvent(endpoint, probe.WithFlowInstance(flowInstance)) {
+			if runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, flowInstance) {
 				return true
 			}
 		}

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
@@ -64,7 +65,7 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
 	for i := range frontier {
 		eventName := frontier[i].EventName
-		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, connectPlans)
+		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, frontier[i].SourceFlowInstances, connectPlans)
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
 		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, routeKeys...)
 		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned))
@@ -318,15 +319,27 @@ func inferContractFrontierFlowInstanceFromEvent(source semanticview.Source, even
 	return ""
 }
 
-func contractFrontierRouteKeys(eventName string, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
+func contractFrontierRouteKeys(eventName string, flowInstances []string, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
 	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
 	if eventName == "" {
 		return nil, false
 	}
+	probe := events.NewRouteProbeEvent(events.EventType(eventName))
+	matchesSource := func(endpoint runtimepinrouting.ConnectRoutePlanEndpoint) bool {
+		if len(flowInstances) == 0 {
+			return runtimepinrouting.ConnectSourceEndpointMatchesEvent(endpoint, probe)
+		}
+		for _, flowInstance := range flowInstances {
+			if runtimepinrouting.ConnectSourceEndpointMatchesEvent(endpoint, probe.WithFlowInstance(flowInstance)) {
+				return true
+			}
+		}
+		return false
+	}
 	matched := false
 	receiverEvents := map[string]struct{}{}
 	for _, plan := range plans {
-		if eventName != strings.Trim(strings.TrimSpace(plan.Source.ResolvedEvent), "/") {
+		if !matchesSource(plan.Source) {
 			continue
 		}
 		matched = true

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -63,13 +63,16 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 		return store.RunForkContractFrontierAdmission{}, fmt.Errorf("derive selected-contract connect routes: %#v", connectIssues)
 	}
 	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
+	incompleteRoutes := map[string]bool{}
 	for i := range frontier {
 		eventName := frontier[i].EventName
 		sourceRoute := contractFrontierSourceRoute(req.Plan.PendingWork, frontier[i].SourceEventID)
-		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, sourceRoute, connectPlans)
+		lookups := contractFrontierRouteLookups(eventName, sourceRoute, connectPlans)
+		routeKeys := contractFrontierLookupEventNames(lookups)
+		incompleteRoutes[frontier[i].SourceEventID] = incompleteRoutes[frontier[i].SourceEventID] || contractFrontierLookupsRequireRuntimeResolution(lookups)
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
 		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, routeKeys...)
-		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned))
+		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, lookups))
 	}
 	sort.Slice(frontier, func(i, j int) bool {
 		if frontier[i].EventName != frontier[j].EventName {
@@ -86,6 +89,13 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 		})
 	}
 	for _, event := range frontier {
+		if incompleteRoutes[event.SourceEventID] {
+			blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
+				Code:    store.RunForkBlockerContractFrontierRouteUnresolved,
+				Message: "selected-contract frontier has a matched connect receiver that still requires runtime resolution",
+			})
+			continue
+		}
 		if len(event.DerivedRecipients) > 0 || len(event.RuntimeEventOwners) > 0 || len(event.WorkflowNodeSubscribers) > 0 {
 			continue
 		}
@@ -272,51 +282,107 @@ func contractFrontierSourceRoute(pending []store.RunForkPendingWork, eventID str
 	return events.RouteIdentity{}
 }
 
-func contractFrontierRouteKeys(eventName string, sourceRoute events.RouteIdentity, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
+type contractFrontierReceiverPolicy uint8
+
+const (
+	contractFrontierReceiverDirect contractFrontierReceiverPolicy = iota
+	contractFrontierReceiverRoot
+	contractFrontierReceiverCarrier
+)
+
+type contractFrontierRouteLookup struct {
+	eventNames                []string
+	receiverPolicy            contractFrontierReceiverPolicy
+	requiresRuntimeResolution bool
+}
+
+func contractFrontierRouteLookups(eventName string, sourceRoute events.RouteIdentity, plans []runtimepinrouting.ConnectRoutePlan) []contractFrontierRouteLookup {
 	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
 	if eventName == "" {
-		return nil, false
-	}
-	matchesSource := func(endpoint runtimepinrouting.ConnectRoutePlanEndpoint) bool {
-		return runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, sourceRoute)
+		return nil
 	}
 	matched := false
-	receiverEvents := map[string]struct{}{}
+	lookups := make([]contractFrontierRouteLookup, 0)
 	for _, plan := range plans {
-		if !matchesSource(plan.Source) {
+		if !runtimepinrouting.ConnectSourceEndpointMatches(plan.Source, eventName, sourceRoute) {
 			continue
 		}
 		matched = true
-		if plan.RequiresRuntimeResolution {
-			continue
+		lookup := contractFrontierRouteLookup{
+			receiverPolicy:            contractFrontierReceiverCarrier,
+			requiresRuntimeResolution: plan.RequiresRuntimeResolution,
 		}
-		local := strings.Trim(strings.TrimSpace(plan.Receiver.Event), "/")
-		receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
-		if receiverPath == "" {
-			receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
+		if plan.Receiver.Root {
+			lookup.receiverPolicy = contractFrontierReceiverRoot
 		}
-		addString(receiverEvents, plan.Receiver.ResolvedEvent)
-		if receiverPath != "" && local != "" {
-			addString(receiverEvents, receiverPath+"/"+local)
+		if !plan.RequiresRuntimeResolution {
+			lookup.eventNames = contractFrontierReceiverEventNames(plan)
 		}
-		if target := plan.Target.Normalized(); target.FlowInstance != "" && local != "" {
+		lookups = append(lookups, lookup)
+	}
+	if matched {
+		return lookups
+	}
+	return []contractFrontierRouteLookup{{eventNames: []string{eventName}, receiverPolicy: contractFrontierReceiverDirect}}
+}
+
+func contractFrontierReceiverEventNames(plan runtimepinrouting.ConnectRoutePlan) []string {
+	receiverEvents := map[string]struct{}{}
+	local := strings.Trim(strings.TrimSpace(plan.Receiver.Event), "/")
+	receiverPath := strings.Trim(strings.TrimSpace(plan.Receiver.FlowPath), "/")
+	if receiverPath == "" {
+		receiverPath = strings.Trim(strings.TrimSpace(plan.Receiver.FlowID), "/")
+	}
+	addString(receiverEvents, plan.Receiver.ResolvedEvent)
+	if receiverPath != "" && local != "" {
+		addString(receiverEvents, receiverPath+"/"+local)
+	}
+	if target := plan.Target.Normalized(); target.FlowInstance != "" && local != "" {
+		addString(receiverEvents, target.FlowInstance+"/"+local)
+	}
+	for _, target := range plan.TargetSet {
+		if target = target.Normalized(); target.FlowInstance != "" && local != "" {
 			addString(receiverEvents, target.FlowInstance+"/"+local)
 		}
 	}
-	if matched {
-		return sortedSet(receiverEvents), true
+	if plan.Receiver.Root {
+		addString(receiverEvents, local)
 	}
-	return []string{eventName}, false
+	return sortedSet(receiverEvents)
 }
 
-func resolveContractFrontierRoutes(routeTable *runtimebus.RouteTable, eventNames []string, connectOwned bool) []runtimebus.Subscriber {
+func contractFrontierLookupEventNames(lookups []contractFrontierRouteLookup) []string {
+	eventNames := map[string]struct{}{}
+	for _, lookup := range lookups {
+		for _, eventName := range lookup.eventNames {
+			addString(eventNames, eventName)
+		}
+	}
+	return sortedSet(eventNames)
+}
+
+func contractFrontierLookupsRequireRuntimeResolution(lookups []contractFrontierRouteLookup) bool {
+	for _, lookup := range lookups {
+		if lookup.requiresRuntimeResolution {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveContractFrontierRoutes(routeTable *runtimebus.RouteTable, lookups []contractFrontierRouteLookup) []runtimebus.Subscriber {
 	var out []runtimebus.Subscriber
-	for _, eventName := range eventNames {
-		for _, subscriber := range routeTable.Resolve(eventName) {
-			if connectOwned && strings.TrimSpace(subscriber.RouteSource) != "receiver_carrier" {
-				continue
+	for _, lookup := range lookups {
+		if lookup.requiresRuntimeResolution {
+			continue
+		}
+		for _, eventName := range lookup.eventNames {
+			for _, subscriber := range routeTable.Resolve(eventName) {
+				if lookup.receiverPolicy == contractFrontierReceiverCarrier && strings.TrimSpace(subscriber.RouteSource) != "receiver_carrier" {
+					continue
+				}
+				out = append(out, subscriber)
 			}
-			out = append(out, subscriber)
 		}
 	}
 	return out

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
@@ -64,8 +65,8 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
 	for i := range frontier {
 		eventName := frontier[i].EventName
-		effectiveFlowInstances := contractFrontierEffectiveFlowInstances(req.Source, eventName, frontier[i].SourceFlowInstances)
-		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, effectiveFlowInstances, connectPlans)
+		sourceRoute := contractFrontierSourceRoute(req.Plan.PendingWork, frontier[i].SourceEventID)
+		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, sourceRoute, connectPlans)
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
 		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, routeKeys...)
 		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned))
@@ -151,7 +152,7 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) ([]store.RunForkC
 				lineageByEvent[eventID] = agg
 			}
 			addString(agg.classifications, item.Classification)
-			addString(agg.flowInstances, item.FlowInstance)
+			addString(agg.flowInstances, item.SourceRoute.Normalized().FlowInstance)
 			addString(agg.subscriberTypes, item.SubscriberType)
 			addString(agg.subscriberIDs, item.SubscriberID)
 			continue
@@ -171,7 +172,7 @@ func runForkFrontierEvents(pending []store.RunForkPendingWork) ([]store.RunForkC
 			byEvent[eventID] = agg
 		}
 		addString(agg.classifications, item.Classification)
-		addString(agg.flowInstances, item.FlowInstance)
+		addString(agg.flowInstances, item.SourceRoute.Normalized().FlowInstance)
 		addString(agg.subscriberTypes, item.SubscriberType)
 		addString(agg.subscriberIDs, item.SubscriberID)
 	}
@@ -234,25 +235,9 @@ func contractFrontierFlowInstanceRoutes(source semanticview.Source, pending []st
 }
 
 func contractFrontierFlowInstances(source semanticview.Source, item store.RunForkPendingWork) []string {
-	out := make([]string, 0, 1)
-	for _, instancePath := range contractFrontierEffectiveFlowInstances(source, item.EventName, []string{item.FlowInstance}) {
-		if isContractFrontierTemplateInstancePath(source, instancePath) {
-			out = append(out, instancePath)
-		}
-	}
-	return out
-}
-
-func contractFrontierEffectiveFlowInstances(source semanticview.Source, eventName string, persisted []string) []string {
-	explicit := map[string]struct{}{}
-	for _, instancePath := range persisted {
-		addString(explicit, strings.Trim(strings.TrimSpace(instancePath), "/"))
-	}
-	if len(explicit) > 0 {
-		return sortedSet(explicit)
-	}
-	if inferred := inferContractFrontierFlowInstanceFromEvent(source, eventName); inferred != "" {
-		return []string{inferred}
+	instancePath := item.SourceRoute.Normalized().FlowInstance
+	if isContractFrontierTemplateInstancePath(source, instancePath) {
+		return []string{instancePath}
 	}
 	return nil
 }
@@ -277,74 +262,23 @@ func isContractFrontierTemplateInstancePath(source semanticview.Source, instance
 	return false
 }
 
-func inferContractFrontierFlowInstanceFromEvent(source semanticview.Source, eventName string) string {
-	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
-	if source == nil || eventName == "" {
-		return ""
-	}
-	type templateScope struct {
-		path        string
-		localEvents []string
-	}
-	templates := make([]templateScope, 0)
-	for _, scope := range source.FlowScopes() {
-		if !strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
-			continue
-		}
-		path := strings.Trim(strings.TrimSpace(scope.Path), "/")
-		if path == "" {
-			continue
-		}
-		localEvents := map[string]struct{}{}
-		for eventType := range scope.Events {
-			addString(localEvents, eventType)
-		}
-		for _, eventType := range scope.InputEvents {
-			addString(localEvents, eventType)
-		}
-		for _, eventType := range scope.OutputEvents {
-			addString(localEvents, eventType)
-		}
-		addString(localEvents, scope.AutoEmitEvent)
-		templates = append(templates, templateScope{path: path, localEvents: sortedSet(localEvents)})
-	}
-	sort.Slice(templates, func(i, j int) bool {
-		return len(templates[i].path) > len(templates[j].path)
-	})
-	for _, template := range templates {
-		if !strings.HasPrefix(eventName, template.path+"/") {
-			continue
-		}
-		for _, localEvent := range template.localEvents {
-			suffix := "/" + strings.Trim(strings.TrimSpace(localEvent), "/")
-			if suffix == "/" || !strings.HasSuffix(eventName, suffix) {
-				continue
-			}
-			instancePath := strings.Trim(strings.TrimSuffix(eventName, suffix), "/")
-			if instancePath == template.path || !strings.HasPrefix(instancePath, template.path+"/") {
-				continue
-			}
-			return instancePath
+func contractFrontierSourceRoute(pending []store.RunForkPendingWork, eventID string) events.RouteIdentity {
+	eventID = strings.TrimSpace(eventID)
+	for _, item := range pending {
+		if strings.TrimSpace(item.EventID) == eventID {
+			return item.SourceRoute.Normalized()
 		}
 	}
-	return ""
+	return events.RouteIdentity{}
 }
 
-func contractFrontierRouteKeys(eventName string, flowInstances []string, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
+func contractFrontierRouteKeys(eventName string, sourceRoute events.RouteIdentity, plans []runtimepinrouting.ConnectRoutePlan) ([]string, bool) {
 	eventName = strings.Trim(strings.TrimSpace(eventName), "/")
 	if eventName == "" {
 		return nil, false
 	}
 	matchesSource := func(endpoint runtimepinrouting.ConnectRoutePlanEndpoint) bool {
-		if len(flowInstances) == 0 {
-			return runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, "")
-		}
-		for _, flowInstance := range flowInstances {
-			if runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, flowInstance) {
-				return true
-			}
-		}
-		return false
+		return runtimepinrouting.ConnectSourceEndpointMatches(endpoint, eventName, sourceRoute)
 	}
 	matched := false
 	receiverEvents := map[string]struct{}{}

--- a/internal/runtime/runforkadmission/contract_frontier.go
+++ b/internal/runtime/runforkadmission/contract_frontier.go
@@ -64,7 +64,8 @@ func AdmitContractFrontier(req ContractFrontierRequest) (store.RunForkContractFr
 	frontier, lineageOnly := runForkFrontierEvents(req.Plan.PendingWork)
 	for i := range frontier {
 		eventName := frontier[i].EventName
-		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, frontier[i].SourceFlowInstances, connectPlans)
+		effectiveFlowInstances := contractFrontierEffectiveFlowInstances(req.Source, eventName, frontier[i].SourceFlowInstances)
+		routeKeys, connectOwned := contractFrontierRouteKeys(eventName, effectiveFlowInstances, connectPlans)
 		frontier[i].RuntimeEventOwners = sortedUnique(req.Source.RuntimeEventOwners(eventName))
 		frontier[i].WorkflowNodeSubscribers = workflowNodeSubscribers(workflowNodes, routeKeys...)
 		frontier[i].DerivedRecipients = contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned))
@@ -233,16 +234,27 @@ func contractFrontierFlowInstanceRoutes(source semanticview.Source, pending []st
 }
 
 func contractFrontierFlowInstances(source semanticview.Source, item store.RunForkPendingWork) []string {
-	seen := map[string]struct{}{}
-	add := func(value string) {
-		value = strings.Trim(strings.TrimSpace(value), "/")
-		if value != "" && isContractFrontierTemplateInstancePath(source, value) {
-			seen[value] = struct{}{}
+	out := make([]string, 0, 1)
+	for _, instancePath := range contractFrontierEffectiveFlowInstances(source, item.EventName, []string{item.FlowInstance}) {
+		if isContractFrontierTemplateInstancePath(source, instancePath) {
+			out = append(out, instancePath)
 		}
 	}
-	add(item.FlowInstance)
-	add(inferContractFrontierFlowInstanceFromEvent(source, item.EventName))
-	return sortedSet(seen)
+	return out
+}
+
+func contractFrontierEffectiveFlowInstances(source semanticview.Source, eventName string, persisted []string) []string {
+	explicit := map[string]struct{}{}
+	for _, instancePath := range persisted {
+		addString(explicit, strings.Trim(strings.TrimSpace(instancePath), "/"))
+	}
+	if len(explicit) > 0 {
+		return sortedSet(explicit)
+	}
+	if inferred := inferContractFrontierFlowInstanceFromEvent(source, eventName); inferred != "" {
+		return []string{inferred}
+	}
+	return nil
 }
 
 func isContractFrontierTemplateInstancePath(source semanticview.Source, instancePath string) bool {

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -81,6 +81,50 @@ func TestAdmitContractFrontier_SelectedContractChangesRecipients(t *testing.T) {
 	}
 }
 
+func TestAdmitContractFrontier_ConnectMatchesConcreteTemplateSourceEndpoint(t *testing.T) {
+	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "producer/inst-1"
+	source := testContractFrontierTemplateConnectSource()
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	event := admission.FrontierEvents[0]
+	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("derived recipients = %#v, want consumer-node through producer connect", event.DerivedRecipients)
+	}
+	if hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want concrete template source connect to resolve", admission.UnsupportedBlockers)
+	}
+}
+
+func TestAdmitContractFrontier_ConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
+	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	source := testContractFrontierTemplateConnectSource()
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	event := admission.FrontierEvents[0]
+	if len(event.DerivedRecipients) != 0 {
+		t.Fatalf("derived recipients = %#v, want unrelated same-leaf template excluded", event.DerivedRecipients)
+	}
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want unrelated same-leaf template to remain unresolved", admission.UnsupportedBlockers)
+	}
+}
+
 func TestAdmitContractFrontier_DeliveredCompletedHistoryIsNotFrontierWork(t *testing.T) {
 	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
 	source := testContractFrontierSource("consumer-node")
@@ -374,6 +418,78 @@ func testContractFrontierTemplateSource() semanticview.Source {
 			Root: &root,
 			ByID: map[string]*runtimecontracts.FlowContractView{
 				"review": &root.Children[0],
+			},
+		},
+	})
+}
+
+func testContractFrontierTemplateConnectSource() semanticview.Source {
+	producer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "producer",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.requested": {},
+		},
+	}
+	unrelated := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "unrelated", Flow: "unrelated"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Mode: "template",
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "unrelated",
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.requested": {},
+		},
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{Events: []string{"scan.requested"}},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": {
+				ID:           "consumer-node",
+				SubscribesTo: []string{"scan.requested"},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, unrelated, consumer}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name:    "test-workflow",
+			Version: "v-test",
+			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
+				"producer":  {{Name: "scan_requested", Event: "scan.requested"}},
+				"unrelated": {{Name: "scan_requested", Event: "scan.requested"}},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"consumer": {{Name: "scan_requested", Event: "scan.requested"}},
+			},
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				SourceFile: "package.yaml",
+				SourceLine: 1,
+				From:       "producer.scan_requested",
+				To:         "consumer.scan_requested",
+			}},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"producer":  &root.Children[0],
+				"unrelated": &root.Children[1],
+				"consumer":  &root.Children[2],
 			},
 		},
 	})

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -314,7 +314,7 @@ func testContractFrontierSource(nodeID string) semanticview.Source {
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			nodeID: {
 				ID:           nodeID,
-				SubscribesTo: []string{"producer/scan.requested"},
+				SubscribesTo: []string{"scan.requested"},
 			},
 		},
 	}
@@ -323,9 +323,17 @@ func testContractFrontierSource(nodeID string) semanticview.Source {
 		Semantics: runtimecontracts.WorkflowSemanticView{
 			Name:    "test-workflow",
 			Version: "v-test",
+			FlowOutputEventPins: map[string][]runtimecontracts.FlowOutputEventPin{
+				"producer": {{Name: "scan_requested", Event: "scan.requested"}},
+			},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"consumer": {{Name: "scan_requested", Event: "scan.requested"}},
+			},
 			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
-				From: "producer.scan.requested",
-				To:   "consumer.scan.requested",
+				SourceFile: "package.yaml",
+				SourceLine: 1,
+				From:       "producer.scan_requested",
+				To:         "consumer.scan_requested",
 			}},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -586,6 +586,51 @@ func testContractFrontierTemplateConnectSource() semanticview.Source {
 	return testContractFrontierConnectSource("template")
 }
 
+func testContractFrontierRootConnectSource() semanticview.Source {
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer"},
+		Schema: runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events:    []string{"root.ready"},
+					EventPins: []runtimecontracts.FlowInputEventPin{{Name: "ready", Event: "root.ready"}},
+				},
+			},
+		},
+		Path: "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"consumer-node": {ID: "consumer-node", SubscribesTo: []string{"root.ready"}},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{consumer}}
+	return semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Outputs: runtimecontracts.FlowOutputPins{
+					Events:    []string{"root.ready"},
+					EventPins: []runtimecontracts.FlowOutputEventPin{{Name: "root_ready", Event: "root.ready"}},
+				},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{"root.ready": {}},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "test-workflow", Version: "v-test",
+			FlowInputs: map[string][]string{"consumer": {"root.ready"}},
+			FlowInputEventPins: map[string][]runtimecontracts.FlowInputEventPin{
+				"consumer": {{Name: "ready", Event: "root.ready"}},
+			},
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				SourceFile: "package.yaml", SourceLine: 1, From: ".root_ready", To: "consumer.ready",
+			}},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{"consumer": consumer.Schema},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{"consumer": &root.Children[0]},
+		},
+	})
+}
+
 func testContractFrontierConnectSource(producerMode string) semanticview.Source {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -103,6 +103,27 @@ func TestAdmitContractFrontier_ConnectMatchesConcreteTemplateSourceEndpoint(t *t
 	}
 }
 
+func TestAdmitContractFrontier_ConnectInfersTemplateIdentityWhenPersistedIdentityIsAbsent(t *testing.T) {
+	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	source := testContractFrontierTemplateConnectSource()
+
+	admission, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	event := admission.FrontierEvents[0]
+	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("derived recipients = %#v, want consumer-node through inferred producer identity", event.DerivedRecipients)
+	}
+	if hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want inferred template source connect to resolve", admission.UnsupportedBlockers)
+	}
+}
+
 func TestAdmitContractFrontier_ConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
 	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
 	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -8,6 +8,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/google/uuid"
 )
@@ -144,6 +145,142 @@ func TestAdmitContractFrontier_ConnectRejectsUnrelatedTemplateSameLeaf(t *testin
 	}
 	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
 		t.Fatalf("blockers = %#v, want unrelated same-leaf template to remain unresolved", admission.UnsupportedBlockers)
+	}
+}
+
+func TestSelectedContractAdmissionsEnforceProducerMode(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      string
+		eventName string
+		source    events.RouteIdentity
+	}{
+		{name: "template rejects base identity", mode: "template", eventName: "producer/scan.requested", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"}},
+		{name: "static rejects descendant identity", mode: "static", eventName: "producer/inst-1/scan.requested", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+		{name: "singleton rejects descendant identity", mode: "singleton", eventName: "producer/inst-1/scan.requested", source: events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := testContractFrontierConnectSource(tc.mode)
+			frontierPlan := testRunForkPlan(tc.eventName, store.RunForkPendingClassificationPending, "node", "source-node")
+			frontierPlan.PendingWork[0].SourceRoute = tc.source
+			frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+				Plan:              frontierPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+			})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier: %v", err)
+			}
+			if len(frontier.FrontierEvents) != 1 || len(frontier.FrontierEvents[0].DerivedRecipients) != 0 {
+				t.Fatalf("frontier events = %#v, want producer mode mismatch rejected", frontier.FrontierEvents)
+			}
+			if !hasBlocker(frontier.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+				t.Fatalf("frontier blockers = %#v, want unresolved route", frontier.UnsupportedBlockers)
+			}
+
+			historyPlan := testRunForkPlan(tc.eventName, store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+			historyPlan.PendingWork[0].SourceRoute = tc.source
+			historyFrontier, err := AdmitContractFrontier(ContractFrontierRequest{
+				Plan:              historyPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+			})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier history: %v", err)
+			}
+			history, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+				Plan:              historyPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+				FrontierAdmission: historyFrontier,
+			})
+			if err != nil {
+				t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+			}
+			if len(history.SelectedRouteEvents) != 1 || len(history.SelectedRouteEvents[0].DerivedRecipients) != 0 {
+				t.Fatalf("selected route events = %#v, want producer mode mismatch rejected", history.SelectedRouteEvents)
+			}
+		})
+	}
+}
+
+func TestSelectedContractAdmissionsPreserveRootAndCarrierPoliciesAndRuntimeIncompleteFanout(t *testing.T) {
+	for _, includeRuntimeReceiver := range []bool{false, true} {
+		name := "static root and child"
+		if includeRuntimeReceiver {
+			name = "static root and child plus runtime receiver"
+		}
+		t.Run(name, func(t *testing.T) {
+			source := testContractFrontierMixedReceiverSource(t, includeRuntimeReceiver)
+			frontierPlan := testRunForkPlan("producer/work.ready", store.RunForkPendingClassificationPending, "node", "source-node")
+			frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+				Plan:              frontierPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+			})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier: %v", err)
+			}
+			if len(frontier.FrontierEvents) != 1 {
+				t.Fatalf("frontier events = %#v, want one", frontier.FrontierEvents)
+			}
+			assertContractFrontierMixedRecipients(t, frontier.FrontierEvents[0].DerivedRecipients)
+			if got := hasBlocker(frontier.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved); got != includeRuntimeReceiver {
+				t.Fatalf("frontier unresolved blocker = %v, want %v: %#v", got, includeRuntimeReceiver, frontier.UnsupportedBlockers)
+			}
+
+			historyPlan := testRunForkPlan("producer/work.ready", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+			historyFrontier, err := AdmitContractFrontier(ContractFrontierRequest{
+				Plan:              historyPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+			})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier history: %v", err)
+			}
+			history, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+				Plan:              historyPlan,
+				Source:            source,
+				ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+				FrontierAdmission: historyFrontier,
+			})
+			if err != nil {
+				t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+			}
+			if len(history.SelectedRouteEvents) != 1 {
+				t.Fatalf("selected route events = %#v, want one", history.SelectedRouteEvents)
+			}
+			assertContractFrontierMixedRecipients(t, history.SelectedRouteEvents[0].DerivedRecipients)
+			wantDisposition := store.RunForkSelectedContractDispositionEvidenceOnly
+			if includeRuntimeReceiver {
+				wantDisposition = store.RunForkSelectedContractDispositionFailClosed
+			}
+			if history.SelectedRouteEvents[0].Disposition != wantDisposition {
+				t.Fatalf("history disposition = %q, want %q", history.SelectedRouteEvents[0].Disposition, wantDisposition)
+			}
+			if got := hasBlocker(history.UnsupportedBlockers, store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven); got != includeRuntimeReceiver {
+				t.Fatalf("history dynamic blocker = %v, want %v: %#v", got, includeRuntimeReceiver, history.UnsupportedBlockers)
+			}
+		})
+	}
+}
+
+func assertContractFrontierMixedRecipients(t *testing.T, recipients []store.RunForkContractFrontierRecipient) {
+	t.Helper()
+	want := map[string]bool{
+		"node/root-node":     false,
+		"agent/root-agent":   false,
+		"node/consumer-node": true,
+	}
+	if len(recipients) != len(want) {
+		t.Fatalf("recipients = %#v, want root node, root agent, and child carrier", recipients)
+	}
+	for _, recipient := range recipients {
+		key := recipient.SubscriberType + "/" + recipient.SubscriberID
+		wantCarrier, ok := want[key]
+		if !ok || (recipient.RouteSource == "receiver_carrier") != wantCarrier {
+			t.Fatalf("recipient = %#v, want root routes non-carrier and child route carrier", recipient)
+		}
 	}
 }
 
@@ -446,10 +583,14 @@ func testContractFrontierTemplateSource() semanticview.Source {
 }
 
 func testContractFrontierTemplateConnectSource() semanticview.Source {
+	return testContractFrontierConnectSource("template")
+}
+
+func testContractFrontierConnectSource(producerMode string) semanticview.Source {
 	producer := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer"},
 		Schema: runtimecontracts.FlowSchemaDocument{
-			Mode: "template",
+			Mode: producerMode,
 			Pins: runtimecontracts.FlowPins{
 				Outputs: runtimecontracts.FlowOutputPins{Events: []string{"scan.requested"}},
 			},
@@ -515,6 +656,25 @@ func testContractFrontierTemplateConnectSource() semanticview.Source {
 			},
 		},
 	})
+}
+
+func testContractFrontierMixedReceiverSource(t testing.TB, includeRuntimeReceiver bool) semanticview.Source {
+	t.Helper()
+	variant := canonicalrouting.CompositionConnectReceiverFanoutStatic
+	if includeRuntimeReceiver {
+		variant = canonicalrouting.CompositionConnectReceiverFanoutRuntimeIncomplete
+	}
+	repoRoot := canonicalrouting.RepoRoot(t)
+	bundleRoot := canonicalrouting.CopyCompositionConnectReceiverFanout(t, variant)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(
+		repoRoot,
+		bundleRoot,
+		runtimecontracts.DefaultPlatformSpecFile(repoRoot),
+	)
+	if err != nil {
+		t.Fatalf("load composition connect receiver fanout: %v", err)
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func hasString(values []string, want string) bool {

--- a/internal/runtime/runforkadmission/contract_frontier_test.go
+++ b/internal/runtime/runforkadmission/contract_frontier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -83,7 +84,7 @@ func TestAdmitContractFrontier_SelectedContractChangesRecipients(t *testing.T) {
 
 func TestAdmitContractFrontier_ConnectMatchesConcreteTemplateSourceEndpoint(t *testing.T) {
 	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "producer/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}
 	source := testContractFrontierTemplateConnectSource()
 
 	admission, err := AdmitContractFrontier(ContractFrontierRequest{
@@ -103,7 +104,7 @@ func TestAdmitContractFrontier_ConnectMatchesConcreteTemplateSourceEndpoint(t *t
 	}
 }
 
-func TestAdmitContractFrontier_ConnectInfersTemplateIdentityWhenPersistedIdentityIsAbsent(t *testing.T) {
+func TestAdmitContractFrontier_ConnectRejectsConcreteTemplateIdentityWhenSourceRouteIsAbsent(t *testing.T) {
 	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
 	source := testContractFrontierTemplateConnectSource()
 
@@ -116,17 +117,17 @@ func TestAdmitContractFrontier_ConnectInfersTemplateIdentityWhenPersistedIdentit
 		t.Fatalf("AdmitContractFrontier: %v", err)
 	}
 	event := admission.FrontierEvents[0]
-	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "consumer-node" {
-		t.Fatalf("derived recipients = %#v, want consumer-node through inferred producer identity", event.DerivedRecipients)
+	if len(event.DerivedRecipients) != 0 {
+		t.Fatalf("derived recipients = %#v, want concrete template source without route rejected", event.DerivedRecipients)
 	}
-	if hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
-		t.Fatalf("blockers = %#v, want inferred template source connect to resolve", admission.UnsupportedBlockers)
+	if !hasBlocker(admission.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("blockers = %#v, want concrete template source without route unresolved", admission.UnsupportedBlockers)
 	}
 }
 
 func TestAdmitContractFrontier_ConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
 	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "unrelated", FlowInstance: "unrelated/inst-1"}
 	source := testContractFrontierTemplateConnectSource()
 
 	admission, err := AdmitContractFrontier(ContractFrontierRequest{
@@ -277,7 +278,7 @@ func TestAdmitContractFrontier_SelectedDeadLetterRemainsExecutableFrontier(t *te
 
 func TestAdmitContractFrontier_MaterializesSourceFlowInstanceRoutes(t *testing.T) {
 	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "review/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "review", FlowInstance: "review/inst-1"}
 	source := testContractFrontierTemplateSource()
 
 	admission, err := AdmitContractFrontier(ContractFrontierRequest{
@@ -315,7 +316,7 @@ func TestAdmitContractFrontier_FailsClosedWithoutSelectedSource(t *testing.T) {
 	}
 }
 
-func TestAdmitContractFrontier_InfersFlowInstanceRouteFromEventName(t *testing.T) {
+func TestAdmitContractFrontier_DoesNotInferFlowInstanceRouteFromEventName(t *testing.T) {
 	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationPending, "node", "source-node")
 	source := testContractFrontierTemplateSource()
 
@@ -328,8 +329,8 @@ func TestAdmitContractFrontier_InfersFlowInstanceRouteFromEventName(t *testing.T
 		t.Fatalf("AdmitContractFrontier: %v", err)
 	}
 	event := admission.FrontierEvents[0]
-	if len(event.DerivedRecipients) != 1 || event.DerivedRecipients[0].SubscriberID != "reviewer-inst-1" {
-		t.Fatalf("derived recipients = %#v, want inferred materialized reviewer-inst-1", event.DerivedRecipients)
+	if len(event.DerivedRecipients) != 0 {
+		t.Fatalf("derived recipients = %#v, want no inferred materialized route", event.DerivedRecipients)
 	}
 }
 

--- a/internal/runtime/runforkadmission/revision_source_route_test.go
+++ b/internal/runtime/runforkadmission/revision_source_route_test.go
@@ -1,0 +1,121 @@
+package runforkadmission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestRevisionProjectedSourceRouteDrivesFrontierAndHistoryAcrossReceiverContext(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	runID := uuid.NewString()
+	pendingEventID := uuid.NewString()
+	completedEventID := uuid.NewString()
+	sourceEntityID := uuid.NewString()
+	targetEntityID := uuid.NewString()
+	at := time.Unix(1700001000, 0).UTC()
+	sourceRoute := events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: sourceEntityID}
+	targetRoute := events.RouteIdentity{FlowID: "consumer", FlowInstance: "consumer/inst-9", EntityID: targetEntityID}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO runs (run_id, status, started_at)
+		VALUES ($1::uuid, 'running', $2)
+	`, runID, at.Add(-time.Minute)); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO events (
+			execution_mode, run_id, event_id, event_name, entity_id, flow_instance,
+			source_route, target_route, scope, payload, produced_by, produced_by_type, created_at
+		)
+		VALUES
+			('live', $1::uuid, $2::uuid, 'producer/inst-1/scan.requested', $4::uuid, 'consumer/inst-9', $5::jsonb, $6::jsonb, 'flow', '{}'::jsonb, 'producer-node', 'node', $7),
+			('live', $1::uuid, $3::uuid, 'producer/inst-1/scan.requested', $4::uuid, 'consumer/inst-9', $5::jsonb, $6::jsonb, 'flow', '{}'::jsonb, 'producer-node', 'node', $8)
+	`, runID, pendingEventID, completedEventID, targetEntityID, mustJSON(t, sourceRoute), mustJSON(t, targetRoute), at, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed routed events: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_deliveries (
+			delivery_id, run_id, event_id, subscriber_type, subscriber_id,
+			status, retry_count, reason_code, delivered_at, created_at
+		)
+		VALUES
+			($1::uuid, $2::uuid, $3::uuid, 'node', 'pending-source-node', 'pending', 0, 'matched_node_subscription', NULL, $5),
+			($4::uuid, $2::uuid, $6::uuid, 'node', 'completed-source-node', 'delivered', 0, 'ok', $7, $7)
+	`, uuid.NewString(), runID, pendingEventID, uuid.NewString(), at, completedEventID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed deliveries: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO event_receipts (
+			event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at
+		)
+		VALUES ($1::uuid, 'node', 'completed-source-node', 'success', 'ok', '{}'::jsonb, $2)
+	`, completedEventID, at.Add(time.Second)); err != nil {
+		t.Fatalf("seed completed receipt: %v", err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin revision capture: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.AllFamilies()...); err != nil {
+		t.Fatalf("capture revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit revision: %v", err)
+	}
+
+	plan, err := (&store.PostgresStore{DB: db}).PlanRunFork(ctx, store.RunForkPlanRequest{
+		SourceRunID: runID,
+		At:          completedEventID,
+	})
+	if err != nil {
+		t.Fatalf("PlanRunFork: %v", err)
+	}
+	if len(plan.PendingWork) != 2 {
+		t.Fatalf("pending work = %#v, want pending and completed revision rows", plan.PendingWork)
+	}
+	for _, item := range plan.PendingWork {
+		if item.SourceRoute != sourceRoute || item.FlowInstance != targetRoute.FlowInstance {
+			t.Fatalf("revision projection = source:%#v receiver:%q, want source %#v and receiver %q", item.SourceRoute, item.FlowInstance, sourceRoute, targetRoute.FlowInstance)
+		}
+	}
+
+	source := testContractFrontierTemplateConnectSource()
+	selection := SelectedContractSelection(source, "/tmp/contracts-a")
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{Plan: plan, Source: source, ContractSelection: selection})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if len(frontier.FrontierEvents) != 1 || len(frontier.FrontierEvents[0].DerivedRecipients) != 1 || frontier.FrontierEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("frontier = %#v, want producer/inst-1 source routed independently of consumer/inst-9 receiver context", frontier.FrontierEvents)
+	}
+
+	history, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan: plan, Source: source, ContractSelection: selection, FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(history.SelectedRouteEvents) != 1 || len(history.SelectedRouteEvents[0].DerivedRecipients) != 1 || history.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("history = %#v, want revisioned producer source routed independently of receiver context", history.SelectedRouteEvents)
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(raw)
+}

--- a/internal/runtime/runforkadmission/revision_source_route_test.go
+++ b/internal/runtime/runforkadmission/revision_source_route_test.go
@@ -2,12 +2,15 @@ package runforkadmission
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 	"github.com/division-sh/swarm/internal/testutil"
 	"github.com/google/uuid"
@@ -109,6 +112,254 @@ func TestRevisionProjectedSourceRouteDrivesFrontierAndHistoryAcrossReceiverConte
 	if len(history.SelectedRouteEvents) != 1 || len(history.SelectedRouteEvents[0].DerivedRecipients) != 1 || history.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
 		t.Fatalf("history = %#v, want revisioned producer source routed independently of receiver context", history.SelectedRouteEvents)
 	}
+}
+
+func TestRunForkPointRevisionedSourceRouteDrivesSelectedHistoryMatrixPostgres(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	ctx := context.Background()
+	type testCase struct {
+		name              string
+		eventName         string
+		sourceRoute       events.RouteIdentity
+		explicitSelector  bool
+		deliveryStatus    string
+		source            func() semanticview.Source
+		wantFrontier      []string
+		wantHistory       []string
+		wantHistoryEvents int
+		wantDynamic       []string
+		wantFrontierCodes []string
+		wantHistoryCodes  []string
+		wantRouteFacts    bool
+	}
+	nonMutating := store.RunForkBlockerSelectedContractRouteAdmissionNonMutating
+	flowHistory := store.RunForkBlockerFlowRouteHistoryUnproven
+	cases := []testCase{
+		{
+			name:             "explicit template fork point without delivery",
+			eventName:        "producer/inst-1/scan.requested",
+			sourceRoute:      events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"},
+			explicitSelector: true,
+			source:           testContractFrontierTemplateConnectSource,
+			wantHistory:      []string{"consumer-node"}, wantHistoryEvents: 1, wantDynamic: []string{"producer/inst-1"},
+			wantHistoryCodes: []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+		{
+			name:        "latest template fork point without delivery",
+			eventName:   "producer/inst-1/scan.requested",
+			sourceRoute: events.RouteIdentity{FlowID: " producer ", FlowInstance: " /producer/inst-1/ "},
+			source:      testContractFrontierTemplateConnectSource,
+			wantHistory: []string{"consumer-node"}, wantHistoryEvents: 1, wantDynamic: []string{"producer/inst-1"},
+			wantHistoryCodes: []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+		{
+			name:             "completed delivery deterministically agrees with fork point",
+			eventName:        "producer/inst-1/scan.requested",
+			sourceRoute:      events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"},
+			explicitSelector: true, deliveryStatus: "completed",
+			source:      testContractFrontierTemplateConnectSource,
+			wantHistory: []string{"consumer-node"}, wantHistoryEvents: 1, wantDynamic: []string{"producer/inst-1"},
+			wantHistoryCodes: []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+		{
+			name:             "pending delivery remains frontier work",
+			eventName:        "producer/inst-1/scan.requested",
+			sourceRoute:      events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"},
+			explicitSelector: true, deliveryStatus: "pending",
+			source:       testContractFrontierTemplateConnectSource,
+			wantFrontier: []string{"consumer-node"}, wantDynamic: []string{"producer/inst-1"},
+			wantFrontierCodes: []string{store.RunForkBlockerContractFrontierExecutionUnsupported},
+			wantHistoryCodes:  []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+		{
+			name:             "static source preserves static connect",
+			eventName:        "producer/scan.requested",
+			sourceRoute:      events.RouteIdentity{FlowID: "producer", FlowInstance: "producer"},
+			explicitSelector: true,
+			source:           func() semanticview.Source { return testContractFrontierConnectSource("static") },
+			wantHistory:      []string{"consumer-node"}, wantHistoryEvents: 1,
+			wantHistoryCodes: []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+		{
+			name:             "root source needs no child route identity",
+			eventName:        "root.ready",
+			sourceRoute:      events.RouteIdentity{EntityID: "root-entity"},
+			explicitSelector: true,
+			source:           testContractFrontierRootConnectSource,
+			wantHistory:      []string{"consumer-node"}, wantHistoryEvents: 1,
+			wantHistoryCodes: []string{nonMutating},
+		},
+		{
+			name:              "template source without route fails closed",
+			eventName:         "producer/inst-1/scan.requested",
+			explicitSelector:  true,
+			source:            testContractFrontierTemplateConnectSource,
+			wantHistoryEvents: 1,
+			wantHistoryCodes:  []string{nonMutating},
+		},
+		{
+			name:              "conflicting template source route fails closed",
+			eventName:         "producer/inst-1/scan.requested",
+			sourceRoute:       events.RouteIdentity{FlowID: "foreign", FlowInstance: "foreign/inst-9"},
+			explicitSelector:  true,
+			source:            testContractFrontierTemplateConnectSource,
+			wantHistoryEvents: 1,
+			wantHistoryCodes:  []string{nonMutating, flowHistory}, wantRouteFacts: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runID := uuid.NewString()
+			eventID := uuid.NewString()
+			at := time.Now().UTC()
+			if _, err := db.ExecContext(ctx, `INSERT INTO runs (run_id, status, started_at) VALUES ($1::uuid, 'running', $2)`, runID, at.Add(-time.Minute)); err != nil {
+				t.Fatalf("seed run: %v", err)
+			}
+			if !tc.explicitSelector {
+				if _, err := db.ExecContext(ctx, `
+					INSERT INTO events (execution_mode, run_id, event_id, event_name, scope, payload, produced_by, produced_by_type, created_at)
+					VALUES ('live', $1::uuid, $2::uuid, 'platform.precursor', 'global', '{}'::jsonb, 'platform', 'platform', $3)
+				`, runID, uuid.NewString(), at.Add(-time.Second)); err != nil {
+					t.Fatalf("seed precursor event: %v", err)
+				}
+				captureRunForkRevision(t, ctx, db, runID)
+			}
+			if _, err := db.ExecContext(ctx, `
+				INSERT INTO events (
+					execution_mode, run_id, event_id, event_name, source_route, scope, payload,
+					produced_by, produced_by_type, created_at
+				)
+				VALUES ('live', $1::uuid, $2::uuid, $3, $4::jsonb, 'flow', '{}'::jsonb, 'producer-node', 'node', $5)
+			`, runID, eventID, tc.eventName, mustJSON(t, tc.sourceRoute), at); err != nil {
+				t.Fatalf("seed fork point event: %v", err)
+			}
+			if tc.deliveryStatus != "" {
+				deliveryID := uuid.NewString()
+				status := "pending"
+				var deliveredAt any
+				if tc.deliveryStatus == "completed" {
+					status = "delivered"
+					deliveredAt = at
+				}
+				if _, err := db.ExecContext(ctx, `
+					INSERT INTO event_deliveries (
+						delivery_id, run_id, event_id, subscriber_type, subscriber_id,
+						status, retry_count, reason_code, delivered_at, created_at
+					) VALUES ($1::uuid, $2::uuid, $3::uuid, 'node', 'source-node', $4, 0, 'matched_node_subscription', $5, $6)
+				`, deliveryID, runID, eventID, status, deliveredAt, at); err != nil {
+					t.Fatalf("seed delivery: %v", err)
+				}
+				if tc.deliveryStatus == "completed" {
+					if _, err := db.ExecContext(ctx, `
+						INSERT INTO event_receipts (event_id, subscriber_type, subscriber_id, outcome, reason_code, side_effects, processed_at)
+						VALUES ($1::uuid, 'node', 'source-node', 'success', 'ok', '{}'::jsonb, $2)
+					`, eventID, at); err != nil {
+						t.Fatalf("seed receipt: %v", err)
+					}
+				}
+			}
+			captureRunForkRevision(t, ctx, db, runID)
+
+			selector := ""
+			if tc.explicitSelector {
+				selector = eventID
+			}
+			plan, err := (&store.PostgresStore{DB: db}).PlanRunFork(ctx, store.RunForkPlanRequest{SourceRunID: runID, At: selector})
+			if err != nil {
+				t.Fatalf("PlanRunFork: %v", err)
+			}
+			if plan.ForkPoint.EventID != eventID || plan.ForkPoint.Input != selector {
+				t.Fatalf("fork point = %#v, want event %s selector %q", plan.ForkPoint, eventID, selector)
+			}
+			if got, want := plan.ForkPoint.SourceRoute, tc.sourceRoute.Normalized(); got != want {
+				t.Fatalf("fork point source route = %#v, want normalized %#v", got, want)
+			}
+
+			source := tc.source()
+			selection := SelectedContractSelection(source, "/tmp/contracts-a")
+			frontier, err := AdmitContractFrontier(ContractFrontierRequest{Plan: plan, Source: source, ContractSelection: selection})
+			if err != nil {
+				t.Fatalf("AdmitContractFrontier: %v", err)
+			}
+			if got := frontierRecipientIDs(frontier); strings.Join(got, "\x00") != strings.Join(tc.wantFrontier, "\x00") {
+				t.Fatalf("frontier recipients = %v, want %v", got, tc.wantFrontier)
+			}
+			if got := blockerCodes(frontier.UnsupportedBlockers); strings.Join(got, "\x00") != strings.Join(tc.wantFrontierCodes, "\x00") {
+				t.Fatalf("frontier blocker codes = %v, want %v", got, tc.wantFrontierCodes)
+			}
+
+			history, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{Plan: plan, Source: source, ContractSelection: selection, FrontierAdmission: frontier})
+			if err != nil {
+				t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+			}
+			if len(history.SelectedRouteEvents) != tc.wantHistoryEvents {
+				t.Fatalf("selected route events = %#v, want %d", history.SelectedRouteEvents, tc.wantHistoryEvents)
+			}
+			if got := historyRecipientIDs(history); strings.Join(got, "\x00") != strings.Join(tc.wantHistory, "\x00") {
+				t.Fatalf("history recipients = %v, want %v", got, tc.wantHistory)
+			}
+			for _, event := range history.SelectedRouteEvents {
+				if event.SourceEventID != eventID || event.Disposition != store.RunForkSelectedContractDispositionEvidenceOnly {
+					t.Fatalf("selected route event = %#v, want fork point evidence-only disposition", event)
+				}
+			}
+			if strings.Join(history.DynamicFlowInstances, "\x00") != strings.Join(tc.wantDynamic, "\x00") {
+				t.Fatalf("dynamic instances = %v, want %v", history.DynamicFlowInstances, tc.wantDynamic)
+			}
+			if got := blockerCodes(history.UnsupportedBlockers); strings.Join(got, "\x00") != strings.Join(tc.wantHistoryCodes, "\x00") {
+				t.Fatalf("history blocker codes = %v, want %v", got, tc.wantHistoryCodes)
+			}
+			if history.SourceRouteFactsPresent != tc.wantRouteFacts {
+				t.Fatalf("source route facts present = %v, want %v", history.SourceRouteFactsPresent, tc.wantRouteFacts)
+			}
+		})
+	}
+}
+
+func captureRunForkRevision(t *testing.T, ctx context.Context, db interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+}, runID string) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin revision capture: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := runforkrevision.Capture(ctx, tx, runID, runforkrevision.AllFamilies()...); err != nil {
+		t.Fatalf("capture revision: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit revision capture: %v", err)
+	}
+}
+
+func frontierRecipientIDs(frontier store.RunForkContractFrontierAdmission) []string {
+	var out []string
+	for _, event := range frontier.FrontierEvents {
+		for _, recipient := range event.DerivedRecipients {
+			out = append(out, recipient.SubscriberID)
+		}
+	}
+	return out
+}
+
+func historyRecipientIDs(history store.RunForkSelectedContractRouteAdmission) []string {
+	var out []string
+	for _, event := range history.SelectedRouteEvents {
+		for _, recipient := range event.DerivedRecipients {
+			out = append(out, recipient.SubscriberID)
+		}
+	}
+	return out
+}
+
+func blockerCodes(blockers []store.RunForkUnsupportedBlocker) []string {
+	out := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		out = append(out, blocker.Code)
+	}
+	return out
 }
 
 func mustJSON(t *testing.T, value any) string {

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -49,7 +49,7 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 	if len(connectIssues) != 0 {
 		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission connect routes: %#v", connectIssues)
 	}
-	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
+	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Source, req.Plan, req.FrontierAdmission))
 	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Source, req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
@@ -107,7 +107,7 @@ type selectedRouteHistoryEvent struct {
 	flowInstance  string
 }
 
-func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
+func selectedRouteHistoryEventEvidence(source semanticview.Source, plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
 	frontierEventIDs := map[string]struct{}{}
 	for _, event := range frontier.FrontierEvents {
 		if sourceEventID := strings.TrimSpace(event.SourceEventID); sourceEventID != "" {
@@ -118,7 +118,11 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 	add := func(sourceEventID, eventName, flowInstance string) {
 		sourceEventID = strings.TrimSpace(sourceEventID)
 		eventName = strings.TrimSpace(eventName)
-		flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
+		effectiveFlowInstances := contractFrontierEffectiveFlowInstances(source, eventName, []string{flowInstance})
+		flowInstance = ""
+		if len(effectiveFlowInstances) > 0 {
+			flowInstance = effectiveFlowInstances[0]
+		}
 		if eventName == "" {
 			return
 		}

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/store"
 )
@@ -44,7 +45,11 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 	if err := installContractFrontierFlowInstanceRoutes(routeTable, req.Source, req.Plan.PendingWork); err != nil {
 		return store.RunForkSelectedContractRouteAdmission{}, err
 	}
-	routeEvents := selectedRouteHistoryEvents(routeTable, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
+	connectPlans, connectIssues := runtimepinrouting.LowerCompositionConnectRoutePlans(req.Source)
+	if len(connectIssues) != 0 {
+		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission connect routes: %#v", connectIssues)
+	}
+	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
 	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Source, req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
@@ -142,13 +147,14 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 	return out
 }
 
-func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
+func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, connectPlans []runtimepinrouting.ConnectRoutePlan, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
 	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
 	for _, event := range events {
+		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, connectPlans)
 		out = append(out, store.RunForkSelectedContractRouteEvent{
 			SourceEventID:     event.sourceEventID,
 			EventName:         event.eventName,
-			DerivedRecipients: contractFrontierRecipients(routeTable.Resolve(event.eventName)),
+			DerivedRecipients: contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned)),
 			Disposition:       store.RunForkSelectedContractDispositionEvidenceOnly,
 		})
 	}

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -50,7 +50,7 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 	if len(connectIssues) != 0 {
 		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission connect routes: %#v", connectIssues)
 	}
-	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
+	routeEvents, incompleteRoutes := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
 	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Source, req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
@@ -60,6 +60,12 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 		blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
 			Code:    store.RunForkBlockerFlowRouteHistoryUnproven,
 			Message: "source route rows are current operational state and remain evidence-only until selected route reconstruction is separately approved",
+		})
+	}
+	if incompleteRoutes {
+		blockers = appendRunForkBlocker(blockers, store.RunForkUnsupportedBlocker{
+			Code:    store.RunForkBlockerSelectedContractDynamicRouteTopologyUnproven,
+			Message: "selected route history has a matched connect receiver that still requires runtime resolution",
 		})
 	}
 	frontierEventCount, frontierSourceEventIDs, frontierFingerprint := store.RunForkContractFrontierEvidenceBinding(req.FrontierAdmission)
@@ -150,18 +156,25 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 	return out
 }
 
-func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, connectPlans []runtimepinrouting.ConnectRoutePlan, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
+func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, connectPlans []runtimepinrouting.ConnectRoutePlan, events []selectedRouteHistoryEvent) ([]store.RunForkSelectedContractRouteEvent, bool) {
 	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
+	incomplete := false
 	for _, event := range events {
-		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, event.sourceRoute, connectPlans)
+		lookups := contractFrontierRouteLookups(event.eventName, event.sourceRoute, connectPlans)
+		eventIncomplete := contractFrontierLookupsRequireRuntimeResolution(lookups)
+		incomplete = incomplete || eventIncomplete
+		disposition := store.RunForkSelectedContractDispositionEvidenceOnly
+		if eventIncomplete {
+			disposition = store.RunForkSelectedContractDispositionFailClosed
+		}
 		out = append(out, store.RunForkSelectedContractRouteEvent{
 			SourceEventID:     event.sourceEventID,
 			EventName:         event.eventName,
-			DerivedRecipients: contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, routeKeys, connectOwned)),
-			Disposition:       store.RunForkSelectedContractDispositionEvidenceOnly,
+			DerivedRecipients: contractFrontierRecipients(resolveContractFrontierRoutes(routeTable, lookups)),
+			Disposition:       disposition,
 		})
 	}
-	return out
+	return out, incomplete
 }
 
 func selectedRouteHistoryDynamicFlowInstances(source semanticview.Source, plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []string {

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -138,7 +138,7 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 		}
 		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName, sourceRoute: sourceRoute}
 	}
-	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName, events.RouteIdentity{})
+	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName, plan.ForkPoint.SourceRoute)
 	for _, item := range plan.PendingWork {
 		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
 			add(item.EventID, item.EventName, item.SourceRoute)
@@ -185,6 +185,7 @@ func selectedRouteHistoryDynamicFlowInstances(source semanticview.Source, plan s
 			seen[value] = struct{}{}
 		}
 	}
+	add(plan.ForkPoint.SourceRoute.Normalized().FlowInstance)
 	for _, item := range plan.PendingWork {
 		add(item.SourceRoute.Normalized().FlowInstance)
 	}

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/events"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -49,7 +50,7 @@ func AdmitSelectedContractRouteHistory(req SelectedContractRouteHistoryRequest) 
 	if len(connectIssues) != 0 {
 		return store.RunForkSelectedContractRouteAdmission{}, fmt.Errorf("derive selected route admission connect routes: %#v", connectIssues)
 	}
-	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Source, req.Plan, req.FrontierAdmission))
+	routeEvents := selectedRouteHistoryEvents(routeTable, connectPlans, selectedRouteHistoryEventEvidence(req.Plan, req.FrontierAdmission))
 	dynamicFlowInstances := selectedRouteHistoryDynamicFlowInstances(req.Source, req.Plan, req.FrontierAdmission)
 	blockers := []store.RunForkUnsupportedBlocker{{
 		Code:    store.RunForkBlockerSelectedContractRouteAdmissionNonMutating,
@@ -104,10 +105,10 @@ func selectedRouteHistoryHasSourceRouteFacts(plan store.RunForkPlan) bool {
 type selectedRouteHistoryEvent struct {
 	sourceEventID string
 	eventName     string
-	flowInstance  string
+	sourceRoute   events.RouteIdentity
 }
 
-func selectedRouteHistoryEventEvidence(source semanticview.Source, plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
+func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
 	frontierEventIDs := map[string]struct{}{}
 	for _, event := range frontier.FrontierEvents {
 		if sourceEventID := strings.TrimSpace(event.SourceEventID); sourceEventID != "" {
@@ -115,14 +116,10 @@ func selectedRouteHistoryEventEvidence(source semanticview.Source, plan store.Ru
 		}
 	}
 	seen := map[string]selectedRouteHistoryEvent{}
-	add := func(sourceEventID, eventName, flowInstance string) {
+	add := func(sourceEventID, eventName string, sourceRoute events.RouteIdentity) {
 		sourceEventID = strings.TrimSpace(sourceEventID)
 		eventName = strings.TrimSpace(eventName)
-		effectiveFlowInstances := contractFrontierEffectiveFlowInstances(source, eventName, []string{flowInstance})
-		flowInstance = ""
-		if len(effectiveFlowInstances) > 0 {
-			flowInstance = effectiveFlowInstances[0]
-		}
+		sourceRoute = sourceRoute.Normalized()
 		if eventName == "" {
 			return
 		}
@@ -133,12 +130,12 @@ func selectedRouteHistoryEventEvidence(source semanticview.Source, plan store.Ru
 		if key == "" {
 			key = eventName
 		}
-		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName, flowInstance: flowInstance}
+		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName, sourceRoute: sourceRoute}
 	}
-	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName, "")
+	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName, events.RouteIdentity{})
 	for _, item := range plan.PendingWork {
 		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
-			add(item.EventID, item.EventName, item.FlowInstance)
+			add(item.EventID, item.EventName, item.SourceRoute)
 		}
 	}
 	keys := make(map[string]struct{}, len(seen))
@@ -156,11 +153,7 @@ func selectedRouteHistoryEventEvidence(source semanticview.Source, plan store.Ru
 func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, connectPlans []runtimepinrouting.ConnectRoutePlan, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
 	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
 	for _, event := range events {
-		flowInstances := []string(nil)
-		if event.flowInstance != "" {
-			flowInstances = []string{event.flowInstance}
-		}
-		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, flowInstances, connectPlans)
+		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, event.sourceRoute, connectPlans)
 		out = append(out, store.RunForkSelectedContractRouteEvent{
 			SourceEventID:     event.sourceEventID,
 			EventName:         event.eventName,
@@ -180,7 +173,7 @@ func selectedRouteHistoryDynamicFlowInstances(source semanticview.Source, plan s
 		}
 	}
 	for _, item := range plan.PendingWork {
-		add(item.FlowInstance)
+		add(item.SourceRoute.Normalized().FlowInstance)
 	}
 	for _, event := range frontier.FrontierEvents {
 		for _, flowInstance := range event.SourceFlowInstances {

--- a/internal/runtime/runforkadmission/selected_route_history.go
+++ b/internal/runtime/runforkadmission/selected_route_history.go
@@ -104,6 +104,7 @@ func selectedRouteHistoryHasSourceRouteFacts(plan store.RunForkPlan) bool {
 type selectedRouteHistoryEvent struct {
 	sourceEventID string
 	eventName     string
+	flowInstance  string
 }
 
 func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.RunForkContractFrontierAdmission) []selectedRouteHistoryEvent {
@@ -114,9 +115,10 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 		}
 	}
 	seen := map[string]selectedRouteHistoryEvent{}
-	add := func(sourceEventID, eventName string) {
+	add := func(sourceEventID, eventName, flowInstance string) {
 		sourceEventID = strings.TrimSpace(sourceEventID)
 		eventName = strings.TrimSpace(eventName)
+		flowInstance = strings.Trim(strings.TrimSpace(flowInstance), "/")
 		if eventName == "" {
 			return
 		}
@@ -127,12 +129,12 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 		if key == "" {
 			key = eventName
 		}
-		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName}
+		seen[key] = selectedRouteHistoryEvent{sourceEventID: sourceEventID, eventName: eventName, flowInstance: flowInstance}
 	}
-	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName)
+	add(plan.ForkPoint.EventID, plan.ForkPoint.EventName, "")
 	for _, item := range plan.PendingWork {
 		if strings.TrimSpace(item.Classification) == store.RunForkPendingClassificationDeliveredCompleted {
-			add(item.EventID, item.EventName)
+			add(item.EventID, item.EventName, item.FlowInstance)
 		}
 	}
 	keys := make(map[string]struct{}, len(seen))
@@ -150,7 +152,11 @@ func selectedRouteHistoryEventEvidence(plan store.RunForkPlan, frontier store.Ru
 func selectedRouteHistoryEvents(routeTable *runtimebus.RouteTable, connectPlans []runtimepinrouting.ConnectRoutePlan, events []selectedRouteHistoryEvent) []store.RunForkSelectedContractRouteEvent {
 	out := make([]store.RunForkSelectedContractRouteEvent, 0, len(events))
 	for _, event := range events {
-		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, connectPlans)
+		flowInstances := []string(nil)
+		if event.flowInstance != "" {
+			flowInstances = []string{event.flowInstance}
+		}
+		routeKeys, connectOwned := contractFrontierRouteKeys(event.eventName, flowInstances, connectPlans)
 		out = append(out, store.RunForkSelectedContractRouteEvent{
 			SourceEventID:     event.sourceEventID,
 			EventName:         event.eventName,

--- a/internal/runtime/runforkadmission/selected_route_history_test.go
+++ b/internal/runtime/runforkadmission/selected_route_history_test.go
@@ -93,6 +93,75 @@ func TestAdmitSelectedContractRouteHistoryConnectMatchesConcreteTemplateSourceEn
 	}
 }
 
+func TestAdmitSelectedContractRouteHistoryConnectInfersTemplateIdentityWhenPersistedIdentityIsAbsent(t *testing.T) {
+	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	source := testContractFrontierTemplateConnectSource()
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(admission.SelectedRouteEvents) != 1 || len(admission.SelectedRouteEvents[0].DerivedRecipients) != 1 || admission.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("selected route events = %#v, want consumer-node through inferred producer identity", admission.SelectedRouteEvents)
+	}
+}
+
+func TestSelectedContractAdmissionsRejectConflictingExplicitTemplateIdentity(t *testing.T) {
+	source := testContractFrontierTemplateConnectSource()
+	frontierPlan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
+	frontierPlan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              frontierPlan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+	if len(frontier.FrontierEvents) != 1 || len(frontier.FrontierEvents[0].DerivedRecipients) != 0 {
+		t.Fatalf("frontier events = %#v, want conflicting explicit identity rejected", frontier.FrontierEvents)
+	}
+	if !hasBlocker(frontier.UnsupportedBlockers, store.RunForkBlockerContractFrontierRouteUnresolved) {
+		t.Fatalf("frontier blockers = %#v, want conflicting explicit identity unresolved", frontier.UnsupportedBlockers)
+	}
+
+	historyPlan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	historyPlan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	historyFrontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              historyPlan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier history: %v", err)
+	}
+	history, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              historyPlan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: historyFrontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(history.SelectedRouteEvents) != 1 || len(history.SelectedRouteEvents[0].DerivedRecipients) != 0 {
+		t.Fatalf("selected route events = %#v, want conflicting explicit identity rejected", history.SelectedRouteEvents)
+	}
+}
+
 func TestAdmitSelectedContractRouteHistoryConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
 	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
 	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"

--- a/internal/runtime/runforkadmission/selected_route_history_test.go
+++ b/internal/runtime/runforkadmission/selected_route_history_test.go
@@ -66,6 +66,60 @@ func TestAdmitSelectedContractRouteHistoryDerivesSelectedRoutesWithoutMutating(t
 	}
 }
 
+func TestAdmitSelectedContractRouteHistoryConnectMatchesConcreteTemplateSourceEndpoint(t *testing.T) {
+	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "producer/inst-1"
+	source := testContractFrontierTemplateConnectSource()
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(admission.SelectedRouteEvents) != 1 || len(admission.SelectedRouteEvents[0].DerivedRecipients) != 1 || admission.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
+		t.Fatalf("selected route events = %#v, want consumer-node through producer connect", admission.SelectedRouteEvents)
+	}
+}
+
+func TestAdmitSelectedContractRouteHistoryConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
+	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
+	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	source := testContractFrontierTemplateConnectSource()
+	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+	})
+	if err != nil {
+		t.Fatalf("AdmitContractFrontier: %v", err)
+	}
+
+	admission, err := AdmitSelectedContractRouteHistory(SelectedContractRouteHistoryRequest{
+		Plan:              plan,
+		Source:            source,
+		ContractSelection: SelectedContractSelection(source, "/tmp/contracts-a"),
+		FrontierAdmission: frontier,
+	})
+	if err != nil {
+		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
+	}
+	if len(admission.SelectedRouteEvents) != 1 || len(admission.SelectedRouteEvents[0].DerivedRecipients) != 0 {
+		t.Fatalf("selected route events = %#v, want unrelated same-leaf template excluded", admission.SelectedRouteEvents)
+	}
+}
+
 func TestAdmitSelectedContractRouteHistoryDoesNotDuplicateFrontierRecipients(t *testing.T) {
 	plan := testRunForkPlan("producer/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
 	historyEventID := uuid.NewString()

--- a/internal/runtime/runforkadmission/selected_route_history_test.go
+++ b/internal/runtime/runforkadmission/selected_route_history_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/store"
 )
 
@@ -68,7 +69,7 @@ func TestAdmitSelectedContractRouteHistoryDerivesSelectedRoutesWithoutMutating(t
 
 func TestAdmitSelectedContractRouteHistoryConnectMatchesConcreteTemplateSourceEndpoint(t *testing.T) {
 	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "producer/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1"}
 	source := testContractFrontierTemplateConnectSource()
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan:              plan,
@@ -93,7 +94,7 @@ func TestAdmitSelectedContractRouteHistoryConnectMatchesConcreteTemplateSourceEn
 	}
 }
 
-func TestAdmitSelectedContractRouteHistoryConnectInfersTemplateIdentityWhenPersistedIdentityIsAbsent(t *testing.T) {
+func TestAdmitSelectedContractRouteHistoryRejectsConcreteTemplateIdentityWhenSourceRouteIsAbsent(t *testing.T) {
 	plan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
 	source := testContractFrontierTemplateConnectSource()
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
@@ -114,15 +115,15 @@ func TestAdmitSelectedContractRouteHistoryConnectInfersTemplateIdentityWhenPersi
 	if err != nil {
 		t.Fatalf("AdmitSelectedContractRouteHistory: %v", err)
 	}
-	if len(admission.SelectedRouteEvents) != 1 || len(admission.SelectedRouteEvents[0].DerivedRecipients) != 1 || admission.SelectedRouteEvents[0].DerivedRecipients[0].SubscriberID != "consumer-node" {
-		t.Fatalf("selected route events = %#v, want consumer-node through inferred producer identity", admission.SelectedRouteEvents)
+	if len(admission.SelectedRouteEvents) != 1 || len(admission.SelectedRouteEvents[0].DerivedRecipients) != 0 {
+		t.Fatalf("selected route events = %#v, want concrete template source without route rejected", admission.SelectedRouteEvents)
 	}
 }
 
 func TestSelectedContractAdmissionsRejectConflictingExplicitTemplateIdentity(t *testing.T) {
 	source := testContractFrontierTemplateConnectSource()
 	frontierPlan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationPending, "node", "source-node")
-	frontierPlan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	frontierPlan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "unrelated", FlowInstance: "unrelated/inst-1"}
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan:              frontierPlan,
 		Source:            source,
@@ -139,7 +140,7 @@ func TestSelectedContractAdmissionsRejectConflictingExplicitTemplateIdentity(t *
 	}
 
 	historyPlan := testRunForkPlan("producer/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
-	historyPlan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	historyPlan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "unrelated", FlowInstance: "unrelated/inst-1"}
 	historyFrontier, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan:              historyPlan,
 		Source:            source,
@@ -164,7 +165,7 @@ func TestSelectedContractAdmissionsRejectConflictingExplicitTemplateIdentity(t *
 
 func TestAdmitSelectedContractRouteHistoryConnectRejectsUnrelatedTemplateSameLeaf(t *testing.T) {
 	plan := testRunForkPlan("unrelated/inst-1/scan.requested", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "unrelated/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "unrelated", FlowInstance: "unrelated/inst-1"}
 	source := testContractFrontierTemplateConnectSource()
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan:              plan,
@@ -240,7 +241,7 @@ func TestAdmitSelectedContractRouteHistoryDoesNotDuplicateFrontierRecipients(t *
 
 func TestAdmitSelectedContractRouteHistoryClassifiesDynamicFlowInstances(t *testing.T) {
 	plan := testRunForkPlan("review/inst-1/task.started", store.RunForkPendingClassificationDeliveredCompleted, "node", "source-node")
-	plan.PendingWork[0].FlowInstance = "review/inst-1"
+	plan.PendingWork[0].SourceRoute = events.RouteIdentity{FlowID: "review", FlowInstance: "review/inst-1"}
 	source := testContractFrontierTemplateSource()
 	frontier, err := AdmitContractFrontier(ContractFrontierRequest{
 		Plan:              plan,

--- a/internal/runtime/runforkexecution/agent_runtime_materialization_test.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization_test.go
@@ -28,12 +28,12 @@ func TestSelectedContractAgentRuntimeWaitsForCurrentRouteSettlementAfterPredeces
 	}
 	oldToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "fork-agent", Generation: 1}
 	newToken := runtimeeffects.LifecycleToken{RuntimeEpoch: 7, AgentID: "fork-agent", Generation: 2}
-	eventBus.ReplaceAgentRoute(oldToken, events.EventType("item.received"))
+	eventBus.ReplaceAgentRoute(oldToken, selectedContractAgentRouteAdmission(t, oldToken.AgentID, "item.received"))
 	oldEvent := eventtest.RuntimeControl("old-work", events.EventType("item.received"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eventBus.Publish(context.Background(), oldEvent); err != nil {
 		t.Fatalf("publish predecessor event: %v", err)
 	}
-	newRoute := eventBus.ReplaceAgentRoute(newToken, events.EventType("item.received"))
+	newRoute := eventBus.ReplaceAgentRoute(newToken, selectedContractAgentRouteAdmission(t, newToken.AgentID, "item.received"))
 	newEvent := eventtest.RuntimeControl("new-work", events.EventType("item.received"), "test", "", []byte(`{}`), 0, "run-1", "", events.EventEnvelope{}, time.Now())
 	if err := eventBus.Publish(context.Background(), newEvent); err != nil {
 		t.Fatalf("publish successor event: %v", err)
@@ -60,6 +60,18 @@ func TestSelectedContractAgentRuntimeWaitsForCurrentRouteSettlementAfterPredeces
 	if err := runtime.WaitForQuiescence(waitCtx, eventBus); err != nil {
 		t.Fatalf("WaitForQuiescence after current route settlement: %v", err)
 	}
+}
+
+func selectedContractAgentRouteAdmission(t *testing.T, agentID string, subscriptions ...string) semanticview.FlowOwnedAgentSubscriptionAdmission {
+	t.Helper()
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       agentID,
+		Subscriptions: subscriptions,
+	})
+	if err != nil {
+		t.Fatalf("admit selected-contract agent route: %v", err)
+	}
+	return admission
 }
 
 type selectedContractSelfReleaseScopeProbe struct {

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -155,7 +155,11 @@ func TestRuntimeShutdown_ClosesAdmissionBeforeManagerDrainAndInboundIngress(t *t
 	testInbound := newTestInboundGateway(t, bus, nil, rt.shutdownAdmissionClosed, inboundStore)
 	rt.InboundGateway = testInbound.InboundGateway
 
-	if err := am.SpawnAgent(runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id}); err != nil {
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		ID:            agent.id,
+		Subscriptions: []string{"test.in"},
+	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	if err := am.Run(managedExecutionTestContext(t, testAuthorActivityContext(context.Background()))); err != nil {
@@ -247,7 +251,11 @@ func TestRuntimeShutdownWithOptions_PropagatesConfiguredGraceToManagerDrain(t *t
 	})
 	rt.Manager = am
 
-	if err := am.SpawnAgent(runtimeactors.AgentConfig{ExecutionMode: "live", ID: agent.id}); err != nil {
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		ID:            agent.id,
+		Subscriptions: []string{"test.in"},
+	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	if err := am.Run(managedExecutionTestContext(t, testAuthorActivityContext(context.Background()))); err != nil {

--- a/internal/runtime/semanticview/agent_subscription_admission.go
+++ b/internal/runtime/semanticview/agent_subscription_admission.go
@@ -1,0 +1,215 @@
+package semanticview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+)
+
+// FlowOwnedAgentSubscriptionRequest is the complete semantic context needed to
+// admit one flow-owned agent's authored or recovered subscriptions.
+type FlowOwnedAgentSubscriptionRequest struct {
+	AgentID       string
+	FlowID        string
+	FlowPath      string
+	PackageKey    string
+	LocalEvents   map[string]struct{}
+	Subscriptions []string
+}
+
+// FlowOwnedAgentSubscriptionAdmission is the only capability that may install
+// a flow-owned agent route. Its fields are private so callers cannot turn raw
+// strings into route authority without running the canonical admission owner.
+type FlowOwnedAgentSubscriptionAdmission struct {
+	agentID                string
+	flowPath               string
+	persistedSubscriptions []string
+	routePatterns          []string
+}
+
+func (a FlowOwnedAgentSubscriptionAdmission) ValidForAgent(agentID string) bool {
+	return a.agentID != "" && a.agentID == strings.TrimSpace(agentID)
+}
+
+func (a FlowOwnedAgentSubscriptionAdmission) AgentID() string {
+	return a.agentID
+}
+
+func (a FlowOwnedAgentSubscriptionAdmission) PersistedSubscriptions() []string {
+	return append([]string(nil), a.persistedSubscriptions...)
+}
+
+func (a FlowOwnedAgentSubscriptionAdmission) RoutePatterns() []string {
+	return append([]string(nil), a.routePatterns...)
+}
+
+func (a FlowOwnedAgentSubscriptionAdmission) FlowPath() string {
+	return a.flowPath
+}
+
+// CarrierOnly preserves the admitted agent identity while installing no
+// subscription route. Typed connect/direct delivery may still target its live
+// channel.
+func (a FlowOwnedAgentSubscriptionAdmission) CarrierOnly() FlowOwnedAgentSubscriptionAdmission {
+	a.routePatterns = nil
+	return a
+}
+
+// AdmitFlowOwnedAgentSubscriptions derives same-scope route identities and
+// consumes the imported-package wildcard/grant owner when a wildcard crosses a
+// package boundary. Qualified exact subscriptions never create boundary edges.
+func AdmitFlowOwnedAgentSubscriptions(source Source, req FlowOwnedAgentSubscriptionRequest) (FlowOwnedAgentSubscriptionAdmission, error) {
+	req.AgentID = strings.TrimSpace(req.AgentID)
+	req.FlowID = strings.TrimSpace(req.FlowID)
+	req.FlowPath = eventidentity.Normalize(req.FlowPath)
+	req.PackageKey = strings.TrimSpace(req.PackageKey)
+	if req.AgentID == "" {
+		return FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf("agent subscription admission requires agent id")
+	}
+
+	localEvents := cloneImportBoundaryEventSet(req.LocalEvents)
+	if source != nil && req.FlowID != "" {
+		if scope, ok := source.FlowScopeByID(req.FlowID); ok {
+			if req.FlowPath == "" {
+				req.FlowPath = eventidentity.Normalize(scope.Path)
+				if req.FlowPath == "" {
+					req.FlowPath = eventidentity.Normalize(source.FlowPath(req.FlowID))
+				}
+			}
+			if req.PackageKey == "" {
+				req.PackageKey = normalizeImportPackageKey(scope.PackageKey)
+			}
+			if len(localEvents) == 0 {
+				localEvents = agentSubscriptionLocalEvents(scope)
+			}
+		}
+	}
+
+	if req.PackageKey != "" {
+		req.PackageKey = normalizeImportPackageKey(req.PackageKey)
+	}
+	imported := source != nil && req.PackageKey != "" && importBoundaryPackageImported(source, req.PackageKey)
+	persisted := make([]string, 0, len(req.Subscriptions))
+	routes := make([]string, 0, len(req.Subscriptions))
+	for _, authored := range req.Subscriptions {
+		authored = eventidentity.Normalize(authored)
+		if authored == "" {
+			continue
+		}
+		if strings.Contains(authored, "*") {
+			if imported {
+				resolution := ResolveImportBoundaryWildcardSubscription(source, req.PackageKey, req.FlowID, req.FlowPath, localEvents, authored)
+				if !resolution.Scoped || len(resolution.Patterns) == 0 {
+					return FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf(
+						"agent %q subscription %q has no imported-package subtree candidate or bind.observe grant; declare a narrow observe grant or use package.yaml connect",
+						req.AgentID,
+						authored,
+					)
+				}
+				persisted = append(persisted, authored)
+				for _, pattern := range resolution.Patterns {
+					routes = append(routes, pattern.EventPattern)
+				}
+				continue
+			}
+			resolved, err := admitNonImportAgentPattern(req.FlowPath, authored)
+			if err != nil {
+				return FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf("agent %q subscription %q: %w", req.AgentID, authored, err)
+			}
+			persisted = append(persisted, resolved)
+			routes = append(routes, resolved)
+			continue
+		}
+
+		resolved, err := admitSameScopeAgentExact(req.FlowPath, authored)
+		if err != nil {
+			return FlowOwnedAgentSubscriptionAdmission{}, fmt.Errorf("agent %q subscription %q: %w", req.AgentID, authored, err)
+		}
+		persisted = append(persisted, resolved)
+		routes = append(routes, resolved)
+	}
+
+	return FlowOwnedAgentSubscriptionAdmission{
+		agentID:                req.AgentID,
+		flowPath:               req.FlowPath,
+		persistedSubscriptions: normalizedAgentSubscriptionValues(persisted),
+		routePatterns:          normalizedAgentSubscriptionValues(routes),
+	}, nil
+}
+
+func agentSubscriptionLocalEvents(scope FlowScope) map[string]struct{} {
+	out := make(map[string]struct{}, len(scope.Events)+len(scope.InputEvents)+len(scope.OutputEvents)+1)
+	for eventType := range scope.Events {
+		if eventType = eventidentity.Normalize(eventType); eventType != "" {
+			out[eventType] = struct{}{}
+		}
+	}
+	for _, values := range [][]string{scope.InputEvents, scope.OutputEvents} {
+		for _, eventType := range values {
+			if eventType = eventidentity.Normalize(eventType); eventType != "" {
+				out[eventType] = struct{}{}
+			}
+		}
+	}
+	if eventType := eventidentity.Normalize(scope.AutoEmitEvent); eventType != "" {
+		out[eventType] = struct{}{}
+	}
+	return out
+}
+
+func admitSameScopeAgentExact(flowPath, raw string) (string, error) {
+	flowPath = eventidentity.Normalize(flowPath)
+	raw = eventidentity.Normalize(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if !strings.Contains(raw, "/") {
+		if flowPath == "" {
+			return raw, nil
+		}
+		return flowPath + "/" + raw, nil
+	}
+	if flowPath == "" || !strings.HasPrefix(raw, flowPath+"/") {
+		return "", fmt.Errorf("qualified exact subscriptions cannot cross a flow boundary; declare package.yaml connect")
+	}
+	local := strings.TrimPrefix(raw, flowPath+"/")
+	if local == "" || strings.Contains(local, "/") {
+		return "", fmt.Errorf("qualified exact subscriptions cannot address a descendant flow; declare package.yaml connect")
+	}
+	return raw, nil
+}
+
+func admitNonImportAgentPattern(flowPath, raw string) (string, error) {
+	flowPath = eventidentity.Normalize(flowPath)
+	raw = eventidentity.Normalize(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if flowPath == "" {
+		return raw, nil
+	}
+	if strings.HasPrefix(raw, flowPath+"/") {
+		return raw, nil
+	}
+	if !strings.Contains(raw, "/") || strings.HasPrefix(raw, "*/") || strings.HasPrefix(raw, "**/") {
+		return flowPath + "/" + raw, nil
+	}
+	return "", fmt.Errorf("qualified wildcard subscriptions cannot cross a flow boundary without typed wildcard/grant authority")
+}
+
+func normalizedAgentSubscriptionValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value = eventidentity.Normalize(value); value != "" {
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/semanticview/agent_subscription_admission_test.go
+++ b/internal/runtime/semanticview/agent_subscription_admission_test.go
@@ -1,0 +1,68 @@
+package semanticview
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAdmitFlowOwnedAgentSubscriptionsCanonicalizesSameScopeExactAndPattern(t *testing.T) {
+	admission, err := AdmitFlowOwnedAgentSubscriptions(nil, FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "reviewer",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*", "review/inst-1/task.done"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	want := []string{"review/inst-1/task.*", "review/inst-1/task.done", "review/inst-1/task.ready"}
+	if got := admission.PersistedSubscriptions(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("persisted subscriptions = %#v, want %#v", got, want)
+	}
+	if got := admission.RoutePatterns(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("route patterns = %#v, want %#v", got, want)
+	}
+}
+
+func TestAdmitFlowOwnedAgentSubscriptionsRejectsForeignExactAndPattern(t *testing.T) {
+	for _, subscription := range []string{"foreign/task.ready", "foreign/**/task.ready"} {
+		t.Run(strings.ReplaceAll(subscription, "/", "_"), func(t *testing.T) {
+			_, err := AdmitFlowOwnedAgentSubscriptions(nil, FlowOwnedAgentSubscriptionRequest{
+				AgentID:       "reviewer",
+				FlowPath:      "review/inst-1",
+				Subscriptions: []string{subscription},
+			})
+			if err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+				t.Fatalf("error = %v, want cross-boundary rejection", err)
+			}
+		})
+	}
+}
+
+func TestAdmitFlowOwnedAgentSubscriptionsPreservesRootExactAndNonImportWildcard(t *testing.T) {
+	admission, err := AdmitFlowOwnedAgentSubscriptions(nil, FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "root-observer",
+		Subscriptions: []string{"task.ready", "**/task.done"},
+	})
+	if err != nil {
+		t.Fatalf("AdmitFlowOwnedAgentSubscriptions: %v", err)
+	}
+	want := []string{"**/task.done", "task.ready"}
+	if got := admission.RoutePatterns(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("route patterns = %#v, want %#v", got, want)
+	}
+}
+
+func TestFlowOwnedAgentSubscriptionAdmissionCarrierOnlyRetainsIdentityWithoutRoutes(t *testing.T) {
+	admission, err := AdmitFlowOwnedAgentSubscriptions(nil, FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "selected-agent",
+		Subscriptions: []string{"task.ready"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	carrier := admission.CarrierOnly()
+	if !carrier.ValidForAgent("selected-agent") || len(carrier.RoutePatterns()) != 0 {
+		t.Fatalf("carrier admission = %#v routes = %#v", carrier, carrier.RoutePatterns())
+	}
+}

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -294,12 +294,6 @@ func (s bundleSource) FlowOutputEventPin(flowID, pinName string) (runtimecontrac
 func (s bundleSource) CompositionConnects() []runtimecontracts.FlowPackageConnect {
 	return s.bundle.CompositionConnects()
 }
-func (s bundleSource) CompositionConnectsTo(flowID, pinName string) []runtimecontracts.FlowPackageConnect {
-	return s.bundle.CompositionConnectsTo(flowID, pinName)
-}
-func (s bundleSource) CompositionConnectsFrom(flowID, pinName string) []runtimecontracts.FlowPackageConnect {
-	return s.bundle.CompositionConnectsFrom(flowID, pinName)
-}
 func (s bundleSource) FlowWritePins(flowID string) []string { return s.bundle.FlowWritePins(flowID) }
 func (s bundleSource) WritePinOwners(pin string) []string   { return s.bundle.WritePinOwners(pin) }
 func (s bundleSource) FlowHasInputEvent(flowID, eventType string) bool {

--- a/internal/runtime/semanticview/composition_connect_test.go
+++ b/internal/runtime/semanticview/composition_connect_test.go
@@ -60,11 +60,11 @@ func TestCompositionConnectFactsExposeTypedPinsAndParentConnect(t *testing.T) {
 	if got, want := connects[0].To, "consumer.work_ready"; got != want {
 		t.Fatalf("connect to = %q, want %q", got, want)
 	}
-	if got, want := source.CompositionConnectsFrom("producer", "work_ready"), connects; len(got) != len(want) || got[0].From != want[0].From {
-		t.Fatalf("CompositionConnectsFrom = %#v, want %#v", got, want)
+	if got := ResolvedCompositionConnectsFrom(source, "producer", "work_ready"); len(got) != 1 || got[0].Connect.From != connects[0].From {
+		t.Fatalf("ResolvedCompositionConnectsFrom = %#v, want %#v", got, connects)
 	}
-	if got, want := source.CompositionConnectsTo("consumer", "work_ready"), connects; len(got) != len(want) || got[0].To != want[0].To {
-		t.Fatalf("CompositionConnectsTo = %#v, want %#v", got, want)
+	if got := ResolvedCompositionConnectsTo(source, "consumer", "work_ready"); len(got) != 1 || got[0].Connect.To != connects[0].To {
+		t.Fatalf("ResolvedCompositionConnectsTo = %#v, want %#v", got, connects)
 	}
 }
 
@@ -100,8 +100,8 @@ func TestCompositionConnectFactsExposeRootProducerEndpoint(t *testing.T) {
 	if !from.Root || from.FlowID != "" || from.Pin != "root_ready" {
 		t.Fatalf("FromRef = %#v, want root root_ready", from)
 	}
-	if got, want := source.CompositionConnectsFrom("", "root_ready"), connects; len(got) != len(want) || got[0].From != want[0].From {
-		t.Fatalf("CompositionConnectsFrom root = %#v, want %#v", got, want)
+	if got := ResolvedCompositionConnectsFrom(source, "", "root_ready"); len(got) != 1 || got[0].Connect.From != connects[0].From {
+		t.Fatalf("ResolvedCompositionConnectsFrom root = %#v, want %#v", got, connects)
 	}
 }
 

--- a/internal/runtime/semanticview/endpoint_census.go
+++ b/internal/runtime/semanticview/endpoint_census.go
@@ -517,9 +517,9 @@ func typedPubSubConsumerIssueSortKey(issue TypedPubSubConsumerIssue) string {
 	return strings.Join([]string{issue.Producer.ID, issue.Consumer.ID, issue.Event.EventKey(), issue.Failure}, "\x00")
 }
 
-// LegacyQualifiedSubscriptions returns runtime-deliverable qualified subscriptions
-// that cross a flow boundary without using pins and connect. They are intentionally
-// excluded from the canonical routing graph.
+// LegacyQualifiedSubscriptions returns retired exact subscriptions that cross
+// a flow boundary instead of using pins and connect. They are validation facts,
+// not executable routing authority.
 func (c AuthoredEventEndpointCensus) LegacyQualifiedSubscriptions() []LegacyQualifiedSubscription {
 	if c.source == nil {
 		return []LegacyQualifiedSubscription{}
@@ -538,25 +538,33 @@ func (c AuthoredEventEndpointCensus) LegacyQualifiedSubscriptions() []LegacyQual
 		if consumer.Pattern || !runtimeDeliveryConsumer(consumer.Kind) {
 			continue
 		}
-		if c.consumerReachedThroughConnectedInput(consumer) {
-			continue
-		}
 		authored := eventidentity.Normalize(consumer.Event.Authored)
 		if !strings.Contains(authored, "/") {
 			continue
 		}
+		consumerPath := eventidentity.Normalize(c.source.FlowPath(consumer.FlowID))
+		canonical := authored
+		if consumerPath != "" && !strings.HasPrefix(authored, consumerPath+"/") {
+			canonical = consumerPath + "/" + authored
+		}
+		if consumerPath != "" && strings.HasPrefix(canonical, consumerPath+"/") {
+			local := strings.TrimPrefix(canonical, consumerPath+"/")
+			if local != "" && !strings.Contains(local, "/") {
+				continue
+			}
+		}
 		for _, flow := range flows {
 			flowID := strings.TrimSpace(flow.ID)
 			flowPath := eventidentity.Normalize(flow.Path)
-			if flowID == "" || flowID == strings.TrimSpace(consumer.FlowID) || flowPath == "" || !strings.HasPrefix(authored, flowPath+"/") {
+			if flowID == "" || flowID == strings.TrimSpace(consumer.FlowID) || flowPath == "" || !strings.HasPrefix(canonical, flowPath+"/") {
 				continue
 			}
-			local := eventidentity.Normalize(strings.TrimPrefix(authored, flowPath+"/"))
+			local := eventidentity.Normalize(strings.TrimPrefix(canonical, flowPath+"/"))
 			if local == "" {
 				continue
 			}
 			proof := ResolveFlowEventProof(c.source, flowID, local)
-			if !proof.HasSchema || eventidentity.Normalize(proof.Canonical) != authored {
+			if !proof.HasSchema || eventidentity.Normalize(proof.Canonical) != canonical {
 				continue
 			}
 			legacy := LegacyQualifiedSubscription{
@@ -572,18 +580,6 @@ func (c AuthoredEventEndpointCensus) LegacyQualifiedSubscriptions() []LegacyQual
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
-}
-
-func (c AuthoredEventEndpointCensus) consumerReachedThroughConnectedInput(consumer AuthoredEventEndpoint) bool {
-	for _, input := range c.inputPins {
-		if strings.TrimSpace(input.FlowID) != strings.TrimSpace(consumer.FlowID) || !declaredInputIdentityMatches(c.source, input, consumer.Event.Authored) {
-			continue
-		}
-		if len(c.source.CompositionConnectsTo(input.FlowID, input.PinName)) > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 func runtimeDeliveryConsumer(kind EventEndpointKind) bool {

--- a/internal/runtime/semanticview/endpoint_census.go
+++ b/internal/runtime/semanticview/endpoint_census.go
@@ -543,39 +543,46 @@ func (c AuthoredEventEndpointCensus) LegacyQualifiedSubscriptions() []LegacyQual
 			continue
 		}
 		consumerPath := eventidentity.Normalize(c.source.FlowPath(consumer.FlowID))
-		canonical := authored
+		candidates := []string{authored}
 		if consumerPath != "" && !strings.HasPrefix(authored, consumerPath+"/") {
-			canonical = consumerPath + "/" + authored
+			candidates = append(candidates, consumerPath+"/"+authored)
 		}
-		if consumerPath != "" && strings.HasPrefix(canonical, consumerPath+"/") {
-			local := strings.TrimPrefix(canonical, consumerPath+"/")
-			if local != "" && !strings.Contains(local, "/") {
-				continue
+		matched := false
+		for _, canonical := range candidates {
+			if consumerPath != "" && strings.HasPrefix(canonical, consumerPath+"/") {
+				local := strings.TrimPrefix(canonical, consumerPath+"/")
+				if local != "" && !strings.Contains(local, "/") {
+					continue
+				}
 			}
-		}
-		for _, flow := range flows {
-			flowID := strings.TrimSpace(flow.ID)
-			flowPath := eventidentity.Normalize(flow.Path)
-			if flowID == "" || flowID == strings.TrimSpace(consumer.FlowID) || flowPath == "" || !strings.HasPrefix(canonical, flowPath+"/") {
-				continue
+			for _, flow := range flows {
+				flowID := strings.TrimSpace(flow.ID)
+				flowPath := eventidentity.Normalize(flow.Path)
+				if flowID == "" || flowID == strings.TrimSpace(consumer.FlowID) || flowPath == "" || !strings.HasPrefix(canonical, flowPath+"/") {
+					continue
+				}
+				local := eventidentity.Normalize(strings.TrimPrefix(canonical, flowPath+"/"))
+				if local == "" {
+					continue
+				}
+				proof := ResolveFlowEventProof(c.source, flowID, local)
+				if !proof.HasSchema || eventidentity.Normalize(proof.Canonical) != canonical {
+					continue
+				}
+				legacy := LegacyQualifiedSubscription{
+					Consumer:       consumer,
+					TargetFlowID:   flowID,
+					TargetFlowPath: flowPath,
+					Event:          proof,
+				}
+				legacy.ID = legacyQualifiedSubscriptionID(legacy)
+				out = append(out, legacy)
+				matched = true
+				break
 			}
-			local := eventidentity.Normalize(strings.TrimPrefix(canonical, flowPath+"/"))
-			if local == "" {
-				continue
+			if matched {
+				break
 			}
-			proof := ResolveFlowEventProof(c.source, flowID, local)
-			if !proof.HasSchema || eventidentity.Normalize(proof.Canonical) != canonical {
-				continue
-			}
-			legacy := LegacyQualifiedSubscription{
-				Consumer:       consumer,
-				TargetFlowID:   flowID,
-				TargetFlowPath: flowPath,
-				Event:          proof,
-			}
-			legacy.ID = legacyQualifiedSubscriptionID(legacy)
-			out = append(out, legacy)
-			break
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })

--- a/internal/runtime/semanticview/endpoint_census_test.go
+++ b/internal/runtime/semanticview/endpoint_census_test.go
@@ -358,27 +358,36 @@ func TestTypedPubSubCrossFlowRelationDeduplicatesProofAndFailsClosedOnAmbiguity(
 	}
 }
 
-func TestLegacyQualifiedSubscriptionsUseDeclaredFlowIdentityAndExactSourceLine(t *testing.T) {
-	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
-	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(
-		repoRoot,
-		filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-child-flow-absolute-path"),
-		runtimecontracts.DefaultPlatformSpecFile(repoRoot),
-	)
-	if err != nil {
-		t.Fatalf("load legacy fixture: %v", err)
+func TestLegacyQualifiedSubscriptionsResolveConsumerRelativeDescendantIdentity(t *testing.T) {
+	grandchild := runtimecontracts.FlowContractView{
+		Paths:  runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild", PackageKey: "flows/child/flows/grandchild"},
+		Path:   "child/grandchild",
+		Events: map[string]runtimecontracts.EventCatalogEntry{"task.done": {}},
 	}
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
+		Path:  "child",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"listener": {ID: "listener", SubscribesTo: []string{"grandchild/task.done"}, EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"grandchild/task.done": {}}},
+		},
+		Children: []runtimecontracts.FlowContractView{grandchild},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{child}}
+	bundle := &runtimecontracts.WorkflowContractBundle{FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+		Root: &root,
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"child":      &root.Children[0],
+			"grandchild": &root.Children[0].Children[0],
+		},
+	}}
 
 	legacy := BuildAuthoredEventEndpointCensus(Wrap(bundle)).LegacyQualifiedSubscriptions()
 	if len(legacy) != 1 {
-		t.Fatalf("legacy subscriptions = %#v, want one direct qualified consumer", legacy)
+		t.Fatalf("retired subscriptions = %#v, want one child-relative qualified consumer", legacy)
 	}
 	got := legacy[0]
-	if got.Consumer.NodeID != "listener" || got.Consumer.Event.Authored != "child/task.done" || got.TargetFlowID != "child" {
-		t.Fatalf("legacy subscription = %#v, want root listener targeting child", got)
-	}
-	if got.Consumer.SourceFile != filepath.Join(repoRoot, "tests", "tier11-flow-composition", "test-child-flow-absolute-path", "nodes.yaml") || got.Consumer.SourceLine != 13 {
-		t.Fatalf("legacy source = %s:%d, want nodes.yaml:13", got.Consumer.SourceFile, got.Consumer.SourceLine)
+	if got.Consumer.NodeID != "listener" || got.Consumer.Event.Authored != "grandchild/task.done" || got.TargetFlowID != "grandchild" || got.Event.Canonical != "child/grandchild/task.done" {
+		t.Fatalf("retired subscription = %#v, want child-relative listener targeting grandchild", got)
 	}
 }
 

--- a/internal/runtime/semanticview/endpoint_census_test.go
+++ b/internal/runtime/semanticview/endpoint_census_test.go
@@ -391,6 +391,38 @@ func TestLegacyQualifiedSubscriptionsResolveConsumerRelativeDescendantIdentity(t
 	}
 }
 
+func TestLegacyQualifiedSubscriptionsPreserveAbsoluteSiblingIdentity(t *testing.T) {
+	producer := runtimecontracts.FlowContractView{
+		Paths:  runtimecontracts.FlowContractPaths{ID: "producer", Flow: "producer", PackageKey: "flows/producer"},
+		Path:   "producer",
+		Events: map[string]runtimecontracts.EventCatalogEntry{"task.done": {}},
+	}
+	consumer := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "consumer", Flow: "consumer", PackageKey: "flows/consumer"},
+		Path:  "consumer",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"listener": {ID: "listener", SubscribesTo: []string{"producer/task.done"}, EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"producer/task.done": {}}},
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{producer, consumer}}
+	bundle := &runtimecontracts.WorkflowContractBundle{FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+		Root: &root,
+		ByID: map[string]*runtimecontracts.FlowContractView{
+			"producer": &root.Children[0],
+			"consumer": &root.Children[1],
+		},
+	}}
+
+	legacy := BuildAuthoredEventEndpointCensus(Wrap(bundle)).LegacyQualifiedSubscriptions()
+	if len(legacy) != 1 {
+		t.Fatalf("retired subscriptions = %#v, want one absolute sibling consumer", legacy)
+	}
+	got := legacy[0]
+	if got.Consumer.NodeID != "listener" || got.Consumer.Event.Authored != "producer/task.done" || got.TargetFlowID != "producer" || got.Event.Canonical != "producer/task.done" {
+		t.Fatalf("retired subscription = %#v, want consumer listener targeting producer", got)
+	}
+}
+
 func TestEndpointCensusReusesBundleYAMLAndPreservesNodeAndAgentSourceLines(t *testing.T) {
 	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	fixture := filepath.Join(repoRoot, "tests", "tier7-composition", "test-agent-emits-to-node")

--- a/internal/runtime/semanticview/flow_input_producer.go
+++ b/internal/runtime/semanticview/flow_input_producer.go
@@ -82,6 +82,11 @@ func ResolveFlowInputProducerWithOptions(source Source, flowID, eventType string
 
 func appendBoundaryIngressEvidence(source Source, flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
 	if flowID == "" && !opts.AllowNonInputEvent {
+		for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
+			if len(source.CompositionConnectsTo(flowID, pin.PinName())) > 0 {
+				return
+			}
+		}
 		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
 			Kind:      runtimecontracts.FlowInputProducerBoundaryExternalIngress,
 			EventType: eventType,
@@ -103,16 +108,6 @@ func appendBoundaryIngressEvidence(source Source, flowID, eventType string, opts
 }
 
 func appendParentConnectEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
-	for _, alias := range ImportBoundaryInputAliases(source, flowID, eventType) {
-		appendEvidence(runtimecontracts.FlowInputProducerEvidence{
-			Kind:      runtimecontracts.FlowInputProducerBoundaryParentConnect,
-			FlowID:    strings.TrimSpace(alias.FlowID),
-			EventType: alias.ParentEvent,
-			Pin:       alias.Pin,
-			Pattern:   alias.EventPattern,
-			Detail:    "import-boundary input bind",
-		})
-	}
 	for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
 		connects := source.CompositionConnectsTo(flowID, pin.PinName())
 		if len(connects) == 0 {

--- a/internal/runtime/semanticview/flow_input_producer.go
+++ b/internal/runtime/semanticview/flow_input_producer.go
@@ -83,7 +83,7 @@ func ResolveFlowInputProducerWithOptions(source Source, flowID, eventType string
 func appendBoundaryIngressEvidence(source Source, flowID, eventType string, opts runtimecontracts.FlowInputProducerResolutionOptions, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
 	if flowID == "" && !opts.AllowNonInputEvent {
 		for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
-			if len(source.CompositionConnectsTo(flowID, pin.PinName())) > 0 {
+			if len(ResolvedCompositionConnectsTo(source, flowID, pin.PinName())) > 0 {
 				return
 			}
 		}
@@ -109,18 +109,17 @@ func appendBoundaryIngressEvidence(source Source, flowID, eventType string, opts
 
 func appendParentConnectEvidence(source Source, flowID, eventType string, appendEvidence func(runtimecontracts.FlowInputProducerEvidence)) {
 	for _, pin := range flowInputPinsForEvent(source, flowID, eventType) {
-		connects := source.CompositionConnectsTo(flowID, pin.PinName())
+		connects := ResolvedCompositionConnectsTo(source, flowID, pin.PinName())
 		if len(connects) == 0 {
 			continue
 		}
 		for _, connect := range connects {
-			ref, _ := connect.FromRef()
 			appendEvidence(runtimecontracts.FlowInputProducerEvidence{
 				Kind:      runtimecontracts.FlowInputProducerBoundaryParentConnect,
-				FlowID:    ref.FlowID,
+				FlowID:    connect.From.FlowID,
 				EventType: eventType,
 				Pin:       pin.PinName(),
-				Detail:    fmt.Sprintf("parent connect from %s", strings.TrimSpace(connect.From)),
+				Detail:    fmt.Sprintf("parent connect from %s", strings.TrimSpace(connect.Connect.From)),
 			})
 		}
 	}

--- a/internal/runtime/semanticview/flow_input_producer_test.go
+++ b/internal/runtime/semanticview/flow_input_producer_test.go
@@ -72,6 +72,50 @@ func TestResolveFlowInputProducer_ExplicitConnectOwnsRootInput(t *testing.T) {
 	}
 }
 
+func TestResolveFlowInputProducer_NestedPackageRootConnectDoesNotSuppressRepositoryRootIngress(t *testing.T) {
+	rootInput := runtimecontracts.FlowInputEventPin{Name: "work_requested", Event: "root.work.requested"}
+	childInput := runtimecontracts.FlowInputEventPin{Name: "work_requested", Event: "child.work.requested"}
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
+		Schema: runtimecontracts.FlowSchemaDocument{Pins: runtimecontracts.FlowPins{Inputs: runtimecontracts.FlowInputPins{
+			Events:    []string{childInput.EventType()},
+			EventPins: []runtimecontracts.FlowInputEventPin{childInput},
+		}}},
+		Path: "child",
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{child}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{Pins: runtimecontracts.FlowPins{Inputs: runtimecontracts.FlowInputPins{
+			Events:    []string{rootInput.EventType()},
+			EventPins: []runtimecontracts.FlowInputEventPin{rootInput},
+		}}},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{"child": &root.Children[0]},
+		},
+		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{"child": child.Schema},
+		Semantics: runtimecontracts.WorkflowSemanticView{CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+			PackageKey: "flows/child",
+			From:       "producer.work_completed",
+			To:         ".work_requested",
+		}}},
+	}
+	source := Wrap(bundle)
+
+	rootResolution := ResolveFlowInputProducer(source, "", rootInput.EventType())
+	if !rootResolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress) {
+		t.Fatalf("root evidence = %#v, want repository-root external ingress", rootResolution.Evidence)
+	}
+	if rootResolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("root evidence = %#v, nested package-root connect must not own the repository-root pin", rootResolution.Evidence)
+	}
+
+	childResolution := ResolveFlowInputProducer(source, "child", childInput.EventType())
+	if !childResolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("child evidence = %#v, want nested package-root connect ownership", childResolution.Evidence)
+	}
+}
+
 func TestResolveFlowInputProducer_ClassifiesParentConnectWithoutRoutePattern(t *testing.T) {
 	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
 		Name:  "work.requested",

--- a/internal/runtime/semanticview/flow_input_producer_test.go
+++ b/internal/runtime/semanticview/flow_input_producer_test.go
@@ -41,6 +41,37 @@ func TestResolveFlowInputProducer_ClassifiesRootBoundaryExternalIngress(t *testi
 	}
 }
 
+func TestResolveFlowInputProducer_ExplicitConnectOwnsRootInput(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{
+			Pins: runtimecontracts.FlowPins{
+				Inputs: runtimecontracts.FlowInputPins{
+					Events: []string{"work.requested"},
+					EventPins: []runtimecontracts.FlowInputEventPin{{
+						Name:  "work_requested",
+						Event: "work.requested",
+					}},
+				},
+			},
+		},
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			CompositionConnects: []runtimecontracts.FlowPackageConnect{{
+				From: "worker.work_completed",
+				To:   ".work_requested",
+			}},
+		},
+	}
+
+	resolution := ResolveFlowInputProducer(Wrap(bundle), "", "work.requested")
+
+	if !resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("evidence = %#v, want parent connect", resolution.Evidence)
+	}
+	if resolution.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryExternalIngress) {
+		t.Fatalf("evidence = %#v, connected root pin must not retain external-ingress authority", resolution.Evidence)
+	}
+}
+
 func TestResolveFlowInputProducer_ClassifiesParentConnectWithoutRoutePattern(t *testing.T) {
 	source := flowInputProducerFixture(runtimecontracts.FlowInputEventPin{
 		Name:  "work.requested",

--- a/internal/runtime/semanticview/import_boundary_aliases_test.go
+++ b/internal/runtime/semanticview/import_boundary_aliases_test.go
@@ -8,16 +8,16 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
-func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
+func TestImportBoundaryPinAliasesDescribeBindingsWithoutCreatingInputProducerAuthority(t *testing.T) {
 	source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{})
 
 	resolution := source.ResolveFlowInputAutoWire("worker", "work.requested")
-	if got, want := resolution.Patterns, []string{"parent.lead_captured"}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want %#v", got, want)
+	if len(resolution.Patterns) != 0 {
+		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want no bind-only route", resolution.Patterns)
 	}
 	proof := runtimecontracts.FlowInputProducerResolution{Evidence: resolution.Evidence}
-	if !proof.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
-		t.Fatalf("ResolveFlowInputAutoWire evidence = %#v, want parent connect", resolution.Evidence)
+	if proof.HasEvidenceKind(runtimecontracts.FlowInputProducerBoundaryParentConnect) {
+		t.Fatalf("ResolveFlowInputAutoWire evidence = %#v, bind must not impersonate parent connect", resolution.Evidence)
 	}
 	if !ImportBoundaryInputAliasRequired(source, "worker", "work.requested") {
 		t.Fatal("expected work.requested to require import-boundary input alias")
@@ -48,14 +48,14 @@ func TestImportBoundaryPinAliasesResolveInputAndOutputBindings(t *testing.T) {
 	}
 }
 
-func TestImportBoundaryInputAliasRequiredDoesNotRawFallbackToSameNameProducer(t *testing.T) {
+func TestImportBoundaryInputAliasDoesNotRouteSameNameProducerWithoutConnect(t *testing.T) {
 	source := loadImportBoundaryAliasFixture(t, importBoundaryAliasFixtureOptions{
 		producerOutput: "work.requested",
 	})
 
 	resolution := source.ResolveFlowInputAutoWire("worker", "work.requested")
-	if got, want := resolution.Patterns, []string{"parent.lead_captured"}; len(got) != len(want) || got[0] != want[0] {
-		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want only explicit bind %#v", got, want)
+	if len(resolution.Patterns) != 0 {
+		t.Fatalf("ResolveFlowInputAutoWire patterns = %#v, want no bind-only or same-name route", resolution.Patterns)
 	}
 }
 

--- a/internal/runtime/semanticview/import_boundary_wildcards.go
+++ b/internal/runtime/semanticview/import_boundary_wildcards.go
@@ -945,7 +945,7 @@ func importBoundaryFlowInputHasExternalProducer(source Source, flowID, eventType
 	if source == nil || strings.TrimSpace(flowID) == "" || eventidentity.Normalize(eventType) == "" {
 		return false
 	}
-	return ImportBoundaryInputAliasRequired(source, flowID, eventType) || len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
+	return len(source.ResolveFlowInputAutoWire(flowID, eventType).Patterns) > 0
 }
 
 func importBoundaryProjectLocalEventSet(scope ProjectScope) map[string]struct{} {

--- a/internal/runtime/semanticview/package_root.go
+++ b/internal/runtime/semanticview/package_root.go
@@ -1,6 +1,18 @@
 package semanticview
 
-import "strings"
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+)
+
+// ResolvedCompositionConnect carries both authored connect evidence and its
+// package-root endpoints resolved to the flows that own them.
+type ResolvedCompositionConnect struct {
+	Connect runtimecontracts.FlowPackageConnect
+	From    runtimecontracts.FlowPackagePinRef
+	To      runtimecontracts.FlowPackagePinRef
+}
 
 // PackageRootFlowID resolves dot-qualified connect endpoints to the flow that
 // owns the package. The repository root has no owning flow.
@@ -31,4 +43,80 @@ func PackageRootFlowID(source Source, packageKey string) (string, bool) {
 		return owner, true
 	}
 	return "", false
+}
+
+func resolveCompositionConnectEndpoints(source Source, connect runtimecontracts.FlowPackageConnect) (ResolvedCompositionConnect, bool) {
+	if source == nil {
+		return ResolvedCompositionConnect{}, false
+	}
+	from, err := connect.FromRef()
+	if err != nil {
+		return ResolvedCompositionConnect{}, false
+	}
+	to, err := connect.ToRef()
+	if err != nil {
+		return ResolvedCompositionConnect{}, false
+	}
+	from, ok := resolveCompositionConnectEndpoint(source, connect.PackageKey, from)
+	if !ok {
+		return ResolvedCompositionConnect{}, false
+	}
+	to, ok = resolveCompositionConnectEndpoint(source, connect.PackageKey, to)
+	if !ok {
+		return ResolvedCompositionConnect{}, false
+	}
+	return ResolvedCompositionConnect{Connect: connect, From: from, To: to}, true
+}
+
+// ResolvedCompositionConnectsTo returns connects whose receiver endpoint owns
+// the requested flow and pin after package-root resolution.
+func ResolvedCompositionConnectsTo(source Source, flowID, pinName string) []ResolvedCompositionConnect {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if source == nil || pinName == "" {
+		return nil
+	}
+	var out []ResolvedCompositionConnect
+	for _, connect := range source.CompositionConnects() {
+		resolved, ok := resolveCompositionConnectEndpoints(source, connect)
+		if !ok || resolved.To.Root != (flowID == "") || strings.TrimSpace(resolved.To.FlowID) != flowID || strings.TrimSpace(resolved.To.Pin) != pinName {
+			continue
+		}
+		out = append(out, resolved)
+	}
+	return out
+}
+
+// ResolvedCompositionConnectsFrom returns connects whose source endpoint owns
+// the requested flow and pin after package-root resolution.
+func ResolvedCompositionConnectsFrom(source Source, flowID, pinName string) []ResolvedCompositionConnect {
+	flowID = strings.TrimSpace(flowID)
+	pinName = strings.TrimSpace(pinName)
+	if source == nil || pinName == "" {
+		return nil
+	}
+	var out []ResolvedCompositionConnect
+	for _, connect := range source.CompositionConnects() {
+		resolved, ok := resolveCompositionConnectEndpoints(source, connect)
+		if !ok || resolved.From.Root != (flowID == "") || strings.TrimSpace(resolved.From.FlowID) != flowID || strings.TrimSpace(resolved.From.Pin) != pinName {
+			continue
+		}
+		out = append(out, resolved)
+	}
+	return out
+}
+
+func resolveCompositionConnectEndpoint(source Source, packageKey string, ref runtimecontracts.FlowPackagePinRef) (runtimecontracts.FlowPackagePinRef, bool) {
+	ref.FlowID = strings.TrimSpace(ref.FlowID)
+	ref.Pin = strings.TrimSpace(ref.Pin)
+	if !ref.Root {
+		return ref, ref.FlowID != "" && ref.Pin != ""
+	}
+	flowID, ok := PackageRootFlowID(source, packageKey)
+	if !ok {
+		return runtimecontracts.FlowPackagePinRef{}, false
+	}
+	ref.FlowID = flowID
+	ref.Root = flowID == ""
+	return ref, ref.Pin != ""
 }

--- a/internal/runtime/semanticview/package_root.go
+++ b/internal/runtime/semanticview/package_root.go
@@ -1,0 +1,34 @@
+package semanticview
+
+import "strings"
+
+// PackageRootFlowID resolves dot-qualified connect endpoints to the flow that
+// owns the package. The repository root has no owning flow.
+func PackageRootFlowID(source Source, packageKey string) (string, bool) {
+	packageKey = normalizeImportPackageKey(packageKey)
+	if packageKey == "." {
+		return "", true
+	}
+	if source == nil || packageKey == "" {
+		return "", false
+	}
+	for _, project := range source.ProjectScopes() {
+		if normalizeImportPackageKey(project.Key) == packageKey {
+			return strings.TrimSpace(project.OwningFlowID), strings.TrimSpace(project.OwningFlowID) != ""
+		}
+	}
+	owner := ""
+	for _, flow := range source.FlowScopes() {
+		if normalizeImportPackageKey(flow.PackageKey) != packageKey || strings.TrimSpace(flow.ID) == "" {
+			continue
+		}
+		if owner != "" && owner != strings.TrimSpace(flow.ID) {
+			return "", false
+		}
+		owner = strings.TrimSpace(flow.ID)
+	}
+	if owner != "" {
+		return owner, true
+	}
+	return "", false
+}

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -40,8 +40,6 @@ type Source interface {
 	FlowInputEventPin(flowID, pinName string) (runtimecontracts.FlowInputEventPin, bool)
 	FlowOutputEventPin(flowID, pinName string) (runtimecontracts.FlowOutputEventPin, bool)
 	CompositionConnects() []runtimecontracts.FlowPackageConnect
-	CompositionConnectsTo(flowID, pinName string) []runtimecontracts.FlowPackageConnect
-	CompositionConnectsFrom(flowID, pinName string) []runtimecontracts.FlowPackageConnect
 	FlowWritePins(flowID string) []string
 	WritePinOwners(pin string) []string
 	FlowHasInputEvent(flowID, eventType string) bool

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -458,6 +458,16 @@ func TestTemplateInstanceAcknowledgedPublishDispatchesRoutedSystemNodeWithoutInt
 			return true, nil
 		},
 	})
+	subscribed := make(chan struct{}, 1)
+	pc.SetTestSubscribeHook(func() { subscribed <- struct{}{} })
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	go pc.Run(runCtx)
+	select {
+	case <-subscribed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow runtime did not subscribe")
+	}
 
 	mailbox := eventtest.RootIngress(
 		"99999999-9999-4999-8999-999999999913",

--- a/internal/runtime/testfixtures/canonicalrouting/composition_connect_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/composition_connect_variants.go
@@ -185,6 +185,106 @@ func CopyCompositionConnectAmbiguity(t testing.TB) string {
 	return writeCompositionConnectAmbiguityFixture(t)
 }
 
+type CompositionConnectReceiverFanoutVariant uint8
+
+const (
+	CompositionConnectReceiverFanoutStatic CompositionConnectReceiverFanoutVariant = iota + 1
+	CompositionConnectReceiverFanoutRuntimeIncomplete
+)
+
+// CopyCompositionConnectReceiverFanout owns the closed root/child receiver
+// policy fixture used by selected-contract routing admission.
+func CopyCompositionConnectReceiverFanout(t testing.TB, variant CompositionConnectReceiverFanoutVariant) string {
+	t.Helper()
+	includeRuntimeReceiver := false
+	switch variant {
+	case CompositionConnectReceiverFanoutStatic:
+	case CompositionConnectReceiverFanoutRuntimeIncomplete:
+		includeRuntimeReceiver = true
+	default:
+		t.Fatalf("unsupported composition-connect receiver fanout variant %d", variant)
+	}
+	root := CopyExample(t, ParentConnect)
+	packageBody := `name: composition-connect-receiver-fanout
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: producer
+    flow: producer
+    mode: static
+  - id: consumer
+    flow: consumer
+    mode: static
+connect:
+  - from: producer.work_ready
+    to: .work_ready
+  - from: producer.work_ready
+    to: consumer.work_ready
+    adapter: work_ready_to_consumer
+`
+	if includeRuntimeReceiver {
+		packageBody = strings.Replace(packageBody, "connect:\n", "  - id: dynamic\n    flow: dynamic\n    mode: template\nconnect:\n", 1)
+		packageBody += "  - from: producer.work_ready\n    to: dynamic.work_ready\n    adapter: work_ready_to_dynamic\n"
+	}
+	writeClosedVariantFile(t, root, "package.yaml", packageBody)
+	writeClosedVariantFile(t, root, "schema.yaml", `name: composition-connect-receiver-fanout
+pins:
+  inputs:
+    events:
+      - name: work_ready
+        event: work.ready
+`)
+	writeClosedVariantFile(t, root, "events.yaml", "work.ready:\n  work_id: string\n")
+	writeClosedVariantFile(t, root, "nodes.yaml", `root-node:
+  id: root-node
+  execution_type: system_node
+  subscribes_to: [work.ready]
+  event_handlers:
+    work.ready: {}
+`)
+	writeClosedVariantFile(t, root, "agents.yaml", `root-agent:
+  id: root-agent
+  model: regular
+  subscriptions: [work.ready]
+`)
+	writeLegacyInstanceFlow(t, root, "consumer", `name: consumer
+mode: static
+pins:
+  inputs:
+    events:
+      - name: work_ready
+        event: consumer.work.ready
+`, "consumer.work.ready:\n  work_id: string\n", "{}\n", `consumer-node:
+  id: consumer-node
+  execution_type: system_node
+  subscribes_to: [consumer.work.ready]
+  event_handlers:
+    consumer.work.ready: {}
+`)
+	if includeRuntimeReceiver {
+		writeLegacyInstanceFlow(t, root, "dynamic", `name: dynamic
+mode: template
+pins:
+  inputs:
+    events:
+      - name: work_ready
+        event: dynamic.work.ready
+        address:
+          by: work_id
+          source: payload.work_id
+          target: _entity.id
+          cardinality: one
+`, "dynamic.work.ready:\n  work_id: string\n", "{}\n", `dynamic-node:
+  id: dynamic-node-{instance_id}
+  execution_type: system_node
+  subscribes_to: [dynamic.work.ready]
+  event_handlers:
+    dynamic.work.ready: {}
+`)
+	}
+	return root
+}
+
 type compositionConnectFixtureOptions struct {
 	connectFrom                    string
 	connectTo                      string

--- a/internal/runtime/testfixtures/canonicalrouting/composition_connect_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/composition_connect_variants.go
@@ -60,7 +60,7 @@ func CopyCompositionConnect(t testing.TB, variant CompositionConnectVariant) str
 	case CompositionConnectMissingReceiverPin:
 		opts.connectTo = "consumer.missing_pin"
 	case CompositionConnectRootReceiver:
-		opts.connectTo = ".deploy_completed"
+		opts.connectTo, opts.omitMap, opts.rootReceiver = ".deploy_completed", true, true
 	case CompositionConnectMissingAdapter:
 		opts.noAdapter = true
 	case CompositionConnectMissingAddressKey:
@@ -213,6 +213,7 @@ type compositionConnectFixtureOptions struct {
 	consumerTemplateInstance       bool
 	consumerTemplateInstanceBy     string
 	consumerTemplateInstanceRegion bool
+	rootReceiver                   bool
 }
 
 type compositionConnectAdapterField struct {
@@ -290,12 +291,26 @@ connect:
     to: `+connectTo+`
 `+adapter+mapBlock+`
 `)
-	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: composition-connect-bootverify\n")
+	rootSchema := "name: composition-connect-bootverify\n"
+	if opts.rootReceiver {
+		rootSchema = `
+name: composition-connect-bootverify
+pins:
+  inputs:
+    events:
+      - name: deploy_completed
+        event: deploy.completed
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
 	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	rootEvents := "{}\n"
 	if opts.producerRequiresOutput {
+		rootEvents = "deploy.completed:\n  vertical_id: string\n"
+	}
+	if opts.rootReceiver {
 		rootEvents = "deploy.completed:\n  vertical_id: string\n"
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), rootEvents)

--- a/internal/runtime/testfixtures/canonicalrouting/import_boundary_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/import_boundary_variants.go
@@ -1,0 +1,213 @@
+package canonicalrouting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type ImportBoundaryAliasVariant uint8
+
+const (
+	ImportBoundaryAliasBindOnly ImportBoundaryAliasVariant = iota + 1
+	ImportBoundaryAliasBindOnlyWildcardOutput
+	ImportBoundaryAliasConnected
+	ImportBoundaryAliasTemplateBindOnly
+)
+
+// CopyImportBoundaryAlias creates a typed specialization of the checked-in
+// parent-connect artifact for import binding and explicit-connect proofs.
+func CopyImportBoundaryAlias(t testing.TB, variant ImportBoundaryAliasVariant) string {
+	t.Helper()
+	root := CopyExample(t, ParentConnect)
+	removeInheritedScenarios(t, root)
+	if err := os.RemoveAll(filepath.Join(root, "flows")); err != nil {
+		t.Fatalf("remove inherited canonical flows: %v", err)
+	}
+
+	parentSubscription := "parent.lead_enriched"
+	connected := false
+	mode := "static"
+	switch variant {
+	case ImportBoundaryAliasBindOnly:
+	case ImportBoundaryAliasBindOnlyWildcardOutput:
+		parentSubscription = "parent.*"
+	case ImportBoundaryAliasConnected:
+		connected = true
+	case ImportBoundaryAliasTemplateBindOnly:
+		mode = "template"
+	default:
+		t.Fatalf("unsupported import-boundary alias variant %d", variant)
+	}
+
+	connect := ""
+	rootSchema := "name: import-boundary-alias\n"
+	if connected {
+		connect = `
+connect:
+  - from: .lead_captured
+    to: worker.work_requested
+  - from: worker.work_completed
+    to: .lead_enriched
+`
+		rootSchema = `
+name: import-boundary-alias
+pins:
+  inputs:
+    events:
+      - name: lead_enriched
+        event: parent.lead_enriched
+  outputs:
+    events:
+      - name: lead_captured
+        event: parent.lead_captured
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: import-boundary-alias
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: `+mode+`
+    bind:
+      inputs:
+        work.requested: parent.lead_captured
+      outputs:
+        work.completed: parent.lead_enriched
+`+connect)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), rootSchema)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+parent.lead_captured: {}
+parent.lead_enriched: {}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+parent-listener:
+  id: parent-listener
+  execution_type: system_node
+  subscribes_to: [`+parentSubscription+`]
+  event_handlers:
+    parent.lead_enriched: {}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "package.yaml"), `
+name: worker
+version: "1.0.0"
+requires:
+  inputs: [work.requested]
+  outputs: [work.completed]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "schema.yaml"), `
+name: worker
+mode: `+mode+`
+pins:
+  inputs:
+    events:
+      - name: work_requested
+        event: work.requested
+  outputs:
+    events:
+      - name: work_completed
+        event: work.completed
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "events.yaml"), "work.completed: {}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "worker", "nodes.yaml"), `
+worker-node:
+  id: worker-node
+  execution_type: system_node
+  subscribes_to: [work.requested]
+  produces: [work.completed]
+  event_handlers:
+    work.requested:
+      emit: work.completed
+`)
+	return root
+}
+
+type ImportBoundaryWildcardVariant uint8
+
+const (
+	ImportBoundaryWildcardDenied ImportBoundaryWildcardVariant = iota + 1
+	ImportBoundaryWildcardObserveGranted
+)
+
+// CopyImportBoundaryWildcard creates the closed imported-package wildcard
+// variants used to prove denied raw matching and typed observe grants.
+func CopyImportBoundaryWildcard(t testing.TB, variant ImportBoundaryWildcardVariant) string {
+	t.Helper()
+	root := CopyExample(t, ParentConnect)
+	removeInheritedScenarios(t, root)
+	if err := os.RemoveAll(filepath.Join(root, "flows")); err != nil {
+		t.Fatalf("remove inherited canonical flows: %v", err)
+	}
+
+	workerBind := ""
+	switch variant {
+	case ImportBoundaryWildcardDenied:
+	case ImportBoundaryWildcardObserveGranted:
+		workerBind = `    bind:
+      observe:
+        - source: producer
+          events: [task.done]
+`
+	default:
+		t.Fatalf("unsupported import-boundary wildcard variant %d", variant)
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: import-boundary-wildcard
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: worker
+    flow: worker
+    mode: static
+`+workerBind+`  - id: producer
+    flow: producer
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: import-boundary-wildcard\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), "{}\n")
+	writeImportBoundaryWildcardFlow(t, root, "worker", true)
+	writeImportBoundaryWildcardFlow(t, root, "producer", false)
+	return root
+}
+
+func writeImportBoundaryWildcardFlow(t testing.TB, root, flowID string, listener bool) {
+	t.Helper()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "package.yaml"), "name: "+flowID+"\nversion: \"1.0.0\"\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "schema.yaml"), `
+name: `+flowID+`
+mode: static
+initial_state: active
+terminal_states: [done]
+states: [active, done]
+pins:
+  outputs:
+    events: [task.done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "policy.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "agents.yaml"), "{}\n")
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "events.yaml"), "task.done: {}\n")
+	nodes := "{}\n"
+	if listener {
+		nodes = `
+worker-listener:
+  id: worker-listener
+  execution_type: system_node
+  subscribes_to: ["**/task.done"]
+  event_handlers:
+    "**/task.done":
+      clear_gates: [sibling_gate]
+`
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", flowID, "nodes.yaml"), nodes)
+}

--- a/internal/runtime/testfixtures/canonicalrouting/legacy_instance_routes.go
+++ b/internal/runtime/testfixtures/canonicalrouting/legacy_instance_routes.go
@@ -24,11 +24,29 @@ const (
 	LegacyInstanceAdapterInvalidTarget
 )
 
+type LegacyInstanceSecondPin uint8
+
+const (
+	LegacyInstanceNoSecondPin LegacyInstanceSecondPin = iota
+	LegacyInstanceSecondPinSameEvent
+	LegacyInstanceSecondPinDistinctEvent
+	LegacyInstanceSecondPinDuplicateEdge
+)
+
+type LegacyInstanceConsumer uint8
+
+const (
+	LegacyInstanceNodeConsumer LegacyInstanceConsumer = iota
+	LegacyInstanceAgentConsumer
+	LegacyInstanceNodeAndAgentConsumer
+)
+
 type LegacyInstanceRouteOptions struct {
-	Missing  LegacyInstancePolicy
-	Conflict LegacyInstancePolicy
-	Adapter  LegacyInstanceAdapter
-	MultiPin bool
+	Missing   LegacyInstancePolicy
+	Conflict  LegacyInstancePolicy
+	Adapter   LegacyInstanceAdapter
+	SecondPin LegacyInstanceSecondPin
+	Consumer  LegacyInstanceConsumer
 }
 
 // CopyLegacyInstanceRoute derives the closed #1738 instance-policy matrix from
@@ -55,9 +73,21 @@ func CopyLegacyInstanceRoute(t testing.TB, opts LegacyInstanceRouteOptions) stri
 	}
 	secondConnect := ""
 	secondPin := ""
-	if opts.MultiPin {
+	secondEventSchema := ""
+	secondHandler := ""
+	if opts.SecondPin == LegacyInstanceSecondPinDuplicateEdge {
+		secondConnect = "  - from: producer.deploy_done\n    to: consumer.deploy_completed\n"
+	} else if opts.SecondPin != LegacyInstanceNoSecondPin {
 		secondConnect = "  - from: producer.deploy_done\n    to: consumer.deploy_audited\n"
-		secondPin = "      - name: deploy_audited\n        event: deploy.done\n"
+		secondEvent := "deploy.done"
+		if opts.SecondPin == LegacyInstanceSecondPinDistinctEvent {
+			secondEvent = "deploy.audited"
+			secondEventSchema = "deploy.audited:\n  " + producerKey + ": string\n"
+			secondHandler = "    " + secondEvent + ": {}\n"
+		} else if opts.SecondPin != LegacyInstanceSecondPinSameEvent {
+			t.Fatalf("unsupported legacy instance second pin %d", opts.SecondPin)
+		}
+		secondPin = "      - name: deploy_audited\n        event: " + secondEvent + "\n"
 	}
 
 	writeClosedVariantFile(t, root, "package.yaml", `name: legacy-instance-route
@@ -96,6 +126,20 @@ pins:
 	if conflict != "" {
 		policy += "  on_conflict: " + conflict + "\n"
 	}
+	consumerNodes := "consumer-node:\n  id: consumer-node-{instance_id}\n  execution_type: system_node\n  event_handlers:\n    deploy.done: {}\n" + secondHandler
+	consumerAgents := "{}\n"
+	if opts.Consumer == LegacyInstanceAgentConsumer || opts.Consumer == LegacyInstanceNodeAndAgentConsumer {
+		subscriptions := "deploy.done"
+		if opts.SecondPin == LegacyInstanceSecondPinDistinctEvent {
+			subscriptions += ", deploy.audited"
+		}
+		if opts.Consumer == LegacyInstanceAgentConsumer {
+			consumerNodes = "{}\n"
+		}
+		consumerAgents = "consumer-agent:\n  id: consumer-agent-{instance_id}\n  model: regular\n  subscriptions: [" + subscriptions + "]\n"
+	} else if opts.Consumer != LegacyInstanceNodeConsumer {
+		t.Fatalf("unsupported legacy instance consumer %d", opts.Consumer)
+	}
 	writeLegacyInstanceFlow(t, root, "consumer", `name: consumer
 mode: template
 instance:
@@ -106,9 +150,10 @@ instance:
       - name: deploy_completed
         event: deploy.done
 `+secondPin,
-		"deploy.done:\n  "+producerKey+": string\n",
+		"deploy.done:\n  "+producerKey+": string\n"+secondEventSchema,
 		"deployment:\n  vertical_id:\n    type: string\n",
-		"consumer-node:\n  id: consumer-node-{instance_id}\n  execution_type: system_node\n  event_handlers:\n    deploy.done: {}\n")
+		consumerNodes)
+	writeClosedVariantFile(t, root, "flows/consumer/agents.yaml", consumerAgents)
 	return root
 }
 

--- a/internal/runtime/testfixtures/canonicalrouting/negative.go
+++ b/internal/runtime/testfixtures/canonicalrouting/negative.go
@@ -5,6 +5,27 @@ import (
 	"testing"
 )
 
+// ApplyCompositionConnectReceiverPinCollisionMutation creates two distinct
+// receiver-local edges that collapse onto one durable event x subscriber row.
+func ApplyCompositionConnectReceiverPinCollisionMutation(t testing.TB, root string) {
+	t.Helper()
+	applyClosedReplacement(t, filepath.Join(root, "package.yaml"),
+		"        target: entity.vertical_id\n",
+		"        target: entity.vertical_id\n  - from: producer.deploy_done\n    to: consumer.deploy_audited\n    adapter: deploy_done_to_audited\n    map:\n      vertical_id:\n        source: payload.vertical_id\n        target: entity.vertical_id\n")
+	applyClosedReplacement(t, filepath.Join(root, "flows", "consumer", "schema.yaml"),
+		"          cardinality: one\n",
+		"          cardinality: one\n      - name: deploy_audited\n        event: deploy.audited\n        address:\n          by: vertical_id\n          source: payload.vertical_id\n          target: entity.vertical_id\n          cardinality: one\n")
+	applyClosedReplacement(t, filepath.Join(root, "flows", "consumer", "events.yaml"),
+		"deploy.completed:\n  vertical_id: string\n",
+		"deploy.completed:\n  vertical_id: string\ndeploy.audited:\n  vertical_id: string\n")
+	applyClosedReplacement(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"),
+		"  subscribes_to: [deploy.completed]\n",
+		"  subscribes_to: [deploy.completed, deploy.audited]\n")
+	applyClosedReplacement(t, filepath.Join(root, "flows", "consumer", "nodes.yaml"),
+		"      advances_to: done\n",
+		"      advances_to: done\n    deploy.audited:\n      create_entity: true\n      advances_to: done\n")
+}
+
 // ApplyRetiredConnectDeliveryOneMutation creates the single deterministic
 // retired spelling accepted by the migration command and rejected by loaders.
 func ApplyRetiredConnectDeliveryOneMutation(t testing.TB, root string) {

--- a/internal/runtime/testfixtures/canonicalrouting/remaining_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/remaining_variants.go
@@ -352,7 +352,6 @@ flows:
   - {id: consumer, flow: consumer, mode: template}
 connect:
   - {from: producer.deploy_done, to: consumer.deploy_completed}
-  - {from: producer.deploy_done, to: consumer.deploy_audited}
 `,
 		"schema.yaml": "name: test\n", "policy.yaml": "{}\n", "tools.yaml": "{}\n", "agents.yaml": "{}\n", "events.yaml": "{}\n", "nodes.yaml": "{}\n",
 		"flows/producer/schema.yaml": `name: producer
@@ -373,7 +372,6 @@ pins:
   inputs:
     events:
       - {name: deploy_completed, event: deploy.done}
-      - {name: deploy_audited, event: deploy.done}
 `,
 		"flows/consumer/policy.yaml": "{}\n", "flows/consumer/agents.yaml": "{}\n", "flows/consumer/events.yaml": "deploy.done:\n  vertical_id: string\n",
 		"flows/consumer/entities.yaml": "deployment:\n  vertical_id:\n    type: string\n",

--- a/internal/runtime/testfixtures/canonicalrouting/resolution_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/resolution_variants.go
@@ -51,6 +51,56 @@ func CopyTemplateSelectOrCreatePilot(t testing.TB) string {
 	return root
 }
 
+// CopyTemplateCreateThenSelectSameEvent proves that one event may create a
+// template instance and then select that request-local instance on a later edge.
+func CopyTemplateCreateThenSelectSameEvent(t testing.TB) string {
+	t.Helper()
+	root := CopyExample(t, TemplateSelectExisting)
+	applyClosedReplacement(t, filepath.Join(root, "package.yaml"),
+		"    to: account.account_setup\n",
+		"    to: account.account_create\n")
+	applyClosedReplacement(t, filepath.Join(root, "flows/account/schema.yaml"),
+		"      - name: account_setup\n",
+		"      - name: account_create\n")
+	applyClosedReplacement(t, filepath.Join(root, "package.yaml"),
+		"  - from: producer.account_ready\n    to: account.account_ready\n",
+		"  - from: producer.account_setup\n    to: account.account_ready\n")
+	writeClosedVariantFile(t, root, "flows/account/nodes.yaml", `account-setup-node:
+  id: account-setup-node-{instance_id}
+  execution_type: system_node
+  subscribes_to: [account.setup]
+  event_handlers:
+    account.setup: {}
+account-ready-node:
+  id: account-ready-node-{instance_id}
+  execution_type: system_node
+  subscribes_to: [account.ready]
+  event_handlers:
+    account.ready: {}
+`)
+	return root
+}
+
+// CopyTemplateSelectAgentOnlyWithUnrelatedNode proves that a connect-selected
+// agent delivery does not imply delivery authority for another node in the flow.
+func CopyTemplateSelectAgentOnlyWithUnrelatedNode(t testing.TB) string {
+	t.Helper()
+	root := CopyExample(t, TemplateSelectExisting)
+	writeClosedVariantFile(t, root, "flows/account/nodes.yaml", `account-setup-node:
+  id: account-setup-node-{instance_id}
+  execution_type: system_node
+  subscribes_to: [account.setup]
+  event_handlers:
+    account.setup: {}
+`)
+	writeClosedVariantFile(t, root, "flows/account/agents.yaml", `account-agent:
+  id: account-agent-{instance_id}
+  model: regular
+  subscriptions: [account.ready]
+`)
+	return root
+}
+
 func applyTemplateSelectOrCreateAccumulation(t testing.TB, root, terminalState string) {
 	t.Helper()
 	producerEvents := filepath.Join(root, "flows", "producer", "events.yaml")

--- a/internal/runtime/testfixtures/canonicalrouting/sealed_package.go
+++ b/internal/runtime/testfixtures/canonicalrouting/sealed_package.go
@@ -25,6 +25,9 @@ func CopySealedParentConnect(t testing.TB, opts SealedParentConnectOptions) stri
 	applyClosedReplacement(t, packageFile,
 		"  - id: consumer\n    flow: consumer\n    mode: static\n",
 		sealedConsumerFlow(opts))
+	applyClosedReplacement(t, packageFile,
+		"connect:\n  - from: producer.work_ready\n    to: consumer.work_ready\n",
+		"connect:\n  - from: .producer_start\n    to: producer.work_requested\n  - from: producer.work_ready\n    to: consumer.work_ready\n  - from: .consumer_start\n    to: consumer.control_start\n")
 	applyClosedReplacement(t, filepath.Join(root, "flows", "producer", "schema.yaml"), "        source: external\n", "")
 	if opts.InvalidConnectReceiver {
 		applyClosedReplacement(t, packageFile, "    to: consumer.work_ready\n", "    to: consumer.missing_work_ready\n")
@@ -51,6 +54,7 @@ func sealedConsumerFlow(opts SealedParentConnectOptions) string {
 
 func addSealedRootDependencies(t testing.TB, root string) {
 	t.Helper()
+	writeClosedVariantFile(t, root, "schema.yaml", "name: routing-parent-connect\npins:\n  inputs:\n    events: [parent.producer_start, parent.consumer_start]\n  outputs:\n    events:\n      - name: producer_start\n        event: parent.producer_start\n      - name: consumer_start\n        event: parent.consumer_start\n")
 	SetOverlayFile(t, root, "policy.yaml", "producer:\n  runtime:\n    profile: producer-bound\nconsumer:\n  runtime:\n    profile: consumer-bound\nruntime:\n  profile: ambient-root\n  ambient: should-not-leak\n")
 	SetOverlayFile(t, root, "events.yaml", "parent.producer_start:\n  work_id: text\nparent.producer_done:\n  work_id: text\nparent.consumer_start:\n  work_id: text\n")
 }

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -177,7 +177,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 			emitted = events.NewChildEventWithLineage(
 				emitted.ID(),
 				emitted.Type(),
-				emitted.SourceAgent(),
+				emitted.Producer(),
 				emitted.TaskID(),
 				emitted.Payload(),
 				emitted.ChainDepth(),

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -130,6 +130,63 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 		time.Now(),
 	)
 	if runtimepinrouting.PinDeclaredOutput(e.workflowSource, flowID, eventType) {
+		spec := runtimecontracts.EmitSpec{Event: eventType}
+		resolvedBeforePreflight := false
+		rootResolution := runtimepinrouting.ResolveEnvelope(runtimepinrouting.ResolutionInput{
+			Source:      e.workflowSource,
+			FlowID:      flowID,
+			EventType:   eventType,
+			Emit:        spec,
+			SourceRoute: sourceRoute,
+			Inbound:     inbound,
+		}, envelope)
+		if rootResolution.Failure == runtimepinrouting.FailureParentRouteIncomplete {
+			parentRoute, allowEntityOnlyParentRoute, err := e.emitParentRouteForActor(ctx, actor, flowID, flowInstance, inbound)
+			if err != nil {
+				wrapped := failures.WrapDetail(
+					"parent_route_lookup_failed",
+					"tool-executor",
+					"handle_emit_tool.parent_route",
+					map[string]any{"event": eventType},
+					err,
+				)
+				e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "parent_route_lookup_failed", "publish", "parent_route", wrapped)
+				return nil, wrapped
+			}
+			rootResolution = runtimepinrouting.ResolveEnvelope(runtimepinrouting.ResolutionInput{
+				Source:                     e.workflowSource,
+				FlowID:                     flowID,
+				EventType:                  eventType,
+				Emit:                       spec,
+				SourceRoute:                sourceRoute,
+				Inbound:                    inbound,
+				ParentRoute:                parentRoute,
+				AllowEntityOnlyParentRoute: allowEntityOnlyParentRoute,
+			}, envelope)
+			if rootResolution.Failure != "" {
+				wrapped := failures.NewTarget(
+					string(rootResolution.Failure),
+					"tool-executor",
+					"handle_emit_tool.pin_target_resolution",
+					map[string]any{"tool": strings.TrimSpace(toolName), "event": eventType},
+				)
+				e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, emitted, "pin_target_resolution_failed", "publish", "pin_target_resolution", wrapped)
+				return nil, wrapped
+			}
+			envelope = rootResolution.Envelope
+			emitted = events.NewChildEventWithLineage(
+				emitted.ID(),
+				emitted.Type(),
+				emitted.SourceAgent(),
+				emitted.TaskID(),
+				emitted.Payload(),
+				emitted.ChainDepth(),
+				emitLineage,
+				envelope,
+				emitted.CreatedAt(),
+			)
+			resolvedBeforePreflight = true
+		}
 		usePublishAuthority := false
 		if planner, ok := e.bus.(publishRecipientPlanner); ok && planner != nil {
 			plan, err := planner.CheckPublishRecipientPlan(ctx, emitted)
@@ -158,8 +215,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 				usePublishAuthority = true
 			}
 		}
-		if !usePublishAuthority {
-			spec := runtimecontracts.EmitSpec{Event: eventType}
+		if !usePublishAuthority && !resolvedBeforePreflight {
 			parentRoute, allowEntityOnlyParentRoute, err := e.emitParentRouteForActor(ctx, actor, flowID, flowInstance, inbound)
 			if err != nil {
 				wrapped := failures.WrapDetail(

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -393,13 +393,16 @@ func flowWithinActorScope(actorFlow, inboundFlow string) bool {
 
 func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eventType string) string {
 	eventType = strings.TrimSpace(eventType)
-	if eventType == "" || strings.Contains(eventType, "/") {
+	if eventType == "" {
 		return eventType
 	}
-	configured := UniqueNonEmpty(actor.EmitEvents)
-	for _, candidate := range configured {
-		if strings.Contains(candidate, "/") && eventidentity.LeafName(candidate) == eventType {
-			return strings.TrimSpace(candidate)
+	if !strings.Contains(eventType, "/") {
+		configured := UniqueNonEmpty(actor.EmitEvents)
+		for _, candidate := range configured {
+			if strings.Contains(candidate, "/") && eventidentity.LeafName(candidate) == eventType {
+				eventType = strings.TrimSpace(candidate)
+				break
+			}
 		}
 	}
 	flowID := strings.TrimSpace(actor.FlowID)
@@ -424,6 +427,17 @@ func (e *Executor) resolveAgentScopedEmitEventType(actor models.AgentConfig, eve
 	localEvents = append(localEvents, scope.OutputEvents...)
 	for candidate := range scope.Events {
 		localEvents = append(localEvents, candidate)
+	}
+	scopePath := eventidentity.Normalize(scope.Path)
+	if strings.EqualFold(strings.TrimSpace(scope.Mode), runtimecontracts.FlowModeTemplate) &&
+		flowPath != scopePath && strings.HasPrefix(eventidentity.Normalize(eventType), scopePath+"/") {
+		local := strings.TrimPrefix(eventidentity.Normalize(eventType), scopePath+"/")
+		for _, candidate := range eventidentity.NormalizeList(localEvents) {
+			if local == candidate {
+				eventType = local
+				break
+			}
+		}
 	}
 	return eventidentity.ExternalizeForFlow(flowPath, localEvents, eventType)
 }

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -1003,6 +1003,111 @@ func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t
 	}
 }
 
+func TestHandleEmitTool_RootReceiverConnectMaterializesParentTargetBeforePreflight(t *testing.T) {
+	source := emitRoutePlanRootReceiverSource()
+	store := newEmitRoutePlanStore()
+	eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("NewEventBusWithOptions: %v", err)
+	}
+	emitRegistry := NewEmitRegistry(source, nil)
+	parentRoute := events.RouteIdentity{EntityID: "root-entity"}
+	actor := models.AgentConfig{
+		ExecutionMode: "live",
+		ID:            "producer-agent",
+		Role:          "producer",
+		FlowID:        "producer",
+		FlowPath:      "producer/inst-1",
+		EntityID:      "producer-entity",
+		EmitEvents:    []string{"producer/deploy.done"},
+	}
+	exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{
+		WorkflowSource: source,
+		EmitRegistry:   emitRegistry,
+		WorkflowInstances: emitWorkflowInstanceLoader{rows: map[string]runtimepipeline.WorkflowInstance{
+			"producer/inst-1": {Metadata: map[string]any{"parent_entity_id": parentRoute.EntityID}},
+		}},
+	})
+	ctx := runtimebus.WithInboundEvent(unmanagedToolTestContext(), eventtest.RootIngress(
+		"evt-parent",
+		events.EventType("producer/deploy.requested"),
+		"runtime",
+		"",
+		nil,
+		0,
+		"run-root-receiver",
+		"",
+		events.EventEnvelope{},
+		time.Now().UTC()))
+
+	out, err := exec.handleEmitTool(ctx, actor, "emit_deploy_done", map[string]any{})
+	if err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	eventID := emitToolResultString(t, out, "event_id")
+	persisted := store.events[eventID]
+	if got := persisted.TargetRoute(); got != parentRoute {
+		t.Fatalf("persisted target route = %#v, want parent route %#v", got, parentRoute)
+	}
+	wantRoute := events.DeliveryRoute{
+		SubscriberType: "node",
+		SubscriberID:   "root-receiver",
+		Target:         parentRoute,
+	}
+	if !emitDeliveryRoutesContain(store.routes[eventID], wantRoute) {
+		t.Fatalf("persisted delivery routes = %#v, want %#v", store.routes[eventID], wantRoute)
+	}
+	if got := store.receipts[eventID]; got != "processed" {
+		t.Fatalf("pipeline receipt = %q, want processed", got)
+	}
+}
+
+func TestHandleEmitTool_RootReceiverConnectRejectsMissingOrIncompleteParentIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rows map[string]runtimepipeline.WorkflowInstance
+	}{
+		{name: "missing", rows: map[string]runtimepipeline.WorkflowInstance{}},
+		{name: "incomplete", rows: map[string]runtimepipeline.WorkflowInstance{
+			"producer/inst-1": {Metadata: map[string]any{
+				"parent_flow_id":       "root",
+				"parent_flow_instance": "root/inst-1",
+			}},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := emitRoutePlanRootReceiverSource()
+			store := newEmitRoutePlanStore()
+			eb, err := runtimebus.NewEventBusWithOptions(store, runtimebus.EventBusOptions{ContractBundle: source})
+			if err != nil {
+				t.Fatalf("NewEventBusWithOptions: %v", err)
+			}
+			actor := models.AgentConfig{
+				ExecutionMode: "live",
+				ID:            "producer-agent",
+				Role:          "producer",
+				FlowID:        "producer",
+				FlowPath:      "producer/inst-1",
+				EntityID:      "producer-entity",
+				EmitEvents:    []string{"producer/deploy.done"},
+			}
+			exec := NewExecutorWithOptions(eb, nil, ExecutorOptions{
+				WorkflowSource:    source,
+				EmitRegistry:      NewEmitRegistry(source, nil),
+				WorkflowInstances: emitWorkflowInstanceLoader{rows: tc.rows},
+			})
+
+			_, err = exec.handleEmitTool(unmanagedToolTestContext(), actor, "emit_deploy_done", map[string]any{})
+			if err == nil || !strings.Contains(err.Error(), "parent_route_incomplete") {
+				t.Fatalf("handleEmitTool error = %v, want parent_route_incomplete", err)
+			}
+			if len(store.events) != 0 || len(store.routes) != 0 {
+				t.Fatalf("persisted events/routes = %d/%d, want 0/0", len(store.events), len(store.routes))
+			}
+		})
+	}
+}
+
 func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthority(t *testing.T) {
 	source := emitRoutePlanSource(nil)
 	store := newEmitRoutePlanStore()
@@ -1431,6 +1536,44 @@ type emitRoutePlanTestFlow struct {
 
 func emitRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) semanticview.Source {
 	return emitRoutePlanSource([]runtimecontracts.FlowPackageConnect{connect})
+}
+
+func emitRoutePlanRootReceiverSource() semanticview.Source {
+	bundle := emitRoutePlanTestBundle([]emitRoutePlanTestFlow{
+		{
+			id:   "producer",
+			mode: "template",
+			outputs: []runtimecontracts.FlowOutputEventPin{{
+				Name:  "deploy_done",
+				Event: "deploy.done",
+			}},
+		},
+	}, []runtimecontracts.FlowPackageConnect{{
+		From: "producer.deploy_done",
+		To:   ".deploy_completed",
+	}})
+	rootHandler := runtimecontracts.SystemNodeEventHandler{}
+	bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{
+		Pins: runtimecontracts.FlowPins{
+			Inputs: runtimecontracts.FlowInputPins{
+				Events: []string{"deploy.done"},
+				EventPins: []runtimecontracts.FlowInputEventPin{{
+					Name:  "deploy_completed",
+					Event: "deploy.done",
+				}},
+			},
+		},
+	}
+	bundle.Nodes = map[string]runtimecontracts.SystemNodeContract{
+		"root-receiver": {
+			ID:            "root-receiver",
+			ExecutionType: "system_node",
+			SubscribesTo:  []string{"deploy.done"},
+			EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{"deploy.done": rootHandler},
+		},
+	}
+	bundle.Semantics.NodeHandlers["root-receiver"] = map[string]runtimecontracts.SystemNodeEventHandler{"deploy.done": rootHandler}
+	return semanticview.Wrap(bundle)
 }
 
 func emitRoutePlanSource(connects []runtimecontracts.FlowPackageConnect) semanticview.Source {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -1046,6 +1046,9 @@ func TestHandleEmitTool_RootReceiverConnectMaterializesParentTargetBeforePreflig
 	}
 	eventID := emitToolResultString(t, out, "event_id")
 	persisted := store.events[eventID]
+	if got, want := string(persisted.Type()), "producer/inst-1/deploy.done"; got != want {
+		t.Fatalf("persisted event type = %q, want concrete template event %q", got, want)
+	}
 	if got := persisted.TargetRoute(); got != parentRoute {
 		t.Fatalf("persisted target route = %#v, want parent route %#v", got, parentRoute)
 	}

--- a/internal/serveapp/run_state_runtime_test.go
+++ b/internal/serveapp/run_state_runtime_test.go
@@ -208,7 +208,12 @@ func TestRunState_KeepsSupportedRunRunningUntilManagerWorkSettles(t *testing.T) 
 		}
 		return testAgent, nil
 	}, pg)
-	if err := am.SpawnAgent(runtimeactors.AgentConfig{ExecutionMode: "live", ID: testAgent.id, Model: "regular"}); err != nil {
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		ID:            testAgent.id,
+		Model:         "regular",
+		Subscriptions: []string{"scan.requested"},
+	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	if err := am.Run(managedRuntimeAdmissionContextForTest(t, runStatusAuthorActivityContext())); err != nil {
@@ -324,7 +329,12 @@ func TestRunState_PreservesRunningTruthWhileManagerWorkIsActive(t *testing.T) {
 		}
 		return testAgent, nil
 	}, pg)
-	if err := am.SpawnAgent(runtimeactors.AgentConfig{ExecutionMode: "live", ID: testAgent.id, Model: "regular"}); err != nil {
+	if err := am.SpawnAgent(runtimeactors.AgentConfig{
+		ExecutionMode: "live",
+		ID:            testAgent.id,
+		Model:         "regular",
+		Subscriptions: []string{"scan.requested"},
+	}); err != nil {
 		t.Fatalf("SpawnAgent: %v", err)
 	}
 	if err := am.Run(managedRuntimeAdmissionContextForTest(t, runStatusAuthorActivityContext())); err != nil {

--- a/internal/serveapp/standing_ingress_supported_surface_test.go
+++ b/internal/serveapp/standing_ingress_supported_surface_test.go
@@ -432,7 +432,11 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if err != nil {
 		t.Fatalf("open SQLite runtime store: %v", err)
 	}
-	defer sqliteStore.Close()
+	defer func() {
+		if sqliteStore != nil {
+			_ = sqliteStore.Close()
+		}
+	}()
 	var runs, instances, entities int
 	var standingRunID string
 	if err := sqliteStore.DB.QueryRow(`
@@ -488,6 +492,10 @@ func TestStandingIngressSupportedSurfaceSQLiteRestartPreservesAuthorityAndReplie
 	if entityEvents == 0 || wrongRunEvents != 0 {
 		t.Fatalf("standing entity event lineage = events:%d wrong_run:%d, want events>0/wrong_run:0", entityEvents, wrongRunEvents)
 	}
+	if err := sqliteStore.Close(); err != nil {
+		t.Fatalf("close SQLite inspection store before restart matrix: %v", err)
+	}
+	sqliteStore = nil
 	requireChangedStandingColdStartMatrix(t, opts, contractsRoot, standingRunID, nil)
 }
 

--- a/internal/store/author_activity_test_context_test.go
+++ b/internal/store/author_activity_test_context_test.go
@@ -57,10 +57,11 @@ func registerTestAuthorActivityCatalogForContext(t *testing.T, target testAuthor
 	eventTypes := []string{
 		"child.event", "child/output.done", "company.scanned", "example.started", "fork.ready",
 		"deadletter.test", "inbound.alert", "inbound.child", "inbound.root", "inbound.test", "item.failed", "item.received",
+		"foreign/task.ready",
 		"github.push.normalized", "inbound.github.push",
 		"human_task.approved", "human_task.expired", "human_task.rejected",
 		"launch.completed", "legacy.filled", "legacy.followup", "legacy.requested", "mailbox.card_superseded", "mailbox.review_requested", "parent.event", "pin.output",
-		"phrase.completed", "review.requested", "scan.completed", "scan.dev", "scan.followup", "scan.requested", "scoring.requested",
+		"phrase.completed", "review.requested", "review/inst-1/task.ready", "scan.completed", "scan.dev", "scan.followup", "scan.requested", "scoring.requested",
 		"subscription.visible", "support_reply.rejected", "support_reply.revision_requested", "system.directive", "system.parent", "system.started", "task.completed",
 		"test.delivery_receipt", "test.delivery_requested", "test.direct_dead_letter", "test.event", "test.started", "test.terminal_admission", "test.terminal_delivery",
 		"test.node_emitted",

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -25,6 +25,7 @@ import (
 	runtimellm "github.com/division-sh/swarm/internal/runtime/llm"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	storerunlifecycle "github.com/division-sh/swarm/internal/store/runlifecycle"
@@ -3491,6 +3492,45 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 	}
 	if _, ok := gotSet[noDeliveryID]; ok {
 		t.Fatalf("did not expect delivery-less event %s in subscribed backlog, got=%v", noDeliveryID, gotSet)
+	}
+}
+
+func TestPendingSubscribedRecoveryUsesAdmittedSameScopeSubscriptionsPostgres(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := &PostgresStore{DB: db}
+	ctx := context.Background()
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "reviewer",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscriptions := make([]events.EventType, 0, len(admission.RoutePatterns()))
+	for _, pattern := range admission.RoutePatterns() {
+		subscriptions = append(subscriptions, events.EventType(pattern))
+	}
+	now := time.Now().UTC()
+	localID, foreignID := uuid.NewString(), uuid.NewString()
+	for _, row := range []struct {
+		id        string
+		eventType events.EventType
+	}{{localID, "review/inst-1/task.ready"}, {foreignID, "foreign/task.ready"}} {
+		if err := pg.AppendEvent(ctx, eventtest.PersistedProjection(row.id, row.eventType, "runtime", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, now)); err != nil {
+			t.Fatalf("AppendEvent(%s): %v", row.eventType, err)
+		}
+		if err := pg.InsertEventDeliveries(ctx, row.id, []string{"reviewer"}); err != nil {
+			t.Fatalf("InsertEventDeliveries(%s): %v", row.eventType, err)
+		}
+	}
+
+	got, err := pg.ListPendingSubscribedEvents(ctx, "reviewer", subscriptions, now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListPendingSubscribedEvents: %v", err)
+	}
+	if len(got) != 1 || got[0].ID() != localID {
+		t.Fatalf("pending events = %#v, want only admitted local event %s", got, localID)
 	}
 }
 

--- a/internal/store/postgres_store_additional_test.go
+++ b/internal/store/postgres_store_additional_test.go
@@ -3497,8 +3497,8 @@ func TestListPendingSubscribedEvents_RespectsDirectDeliveryScope(t *testing.T) {
 
 func TestPendingSubscribedRecoveryUsesAdmittedSameScopeSubscriptionsPostgres(t *testing.T) {
 	_, db, _ := testutil.StartPostgres(t)
-	pg := &PostgresStore{DB: db}
-	ctx := context.Background()
+	pg := newTestPostgresStore(t, db)
+	ctx := testAuthorActivityContext()
 	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
 		AgentID:       "reviewer",
 		FlowPath:      "review/inst-1",

--- a/internal/store/run_fork_materializer_test.go
+++ b/internal/store/run_fork_materializer_test.go
@@ -958,10 +958,10 @@ func TestRunForkActivation_ReplaysSafePendingDeliveryWithForkLocalLineage(t *tes
 	at := time.Unix(1700000850, 0).UTC()
 	seedActivationReadySourceRun(t, db, sourceRunID, entityID, eventID, at)
 	sourceParentID := uuid.NewString()
+	// Route-bearing replay is gated by historical route proof; this fixture isolates direct pending-delivery replay.
 	sourceEnvelope := events.EventEnvelope{
 		EntityID: entityID,
 		Scope:    events.EventScopeEntity,
-		Source:   events.RouteIdentity{FlowID: "source-flow", FlowInstance: "source-flow/instance", EntityID: uuid.NewString()},
 		Target:   events.RouteIdentity{EntityID: entityID},
 	}
 	sourceRoute, _ := json.Marshal(sourceEnvelope.Source)

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -52,14 +52,15 @@ type RunForkPlan struct {
 }
 
 type RunForkPoint struct {
-	Input          string    `json:"input"`
-	EventID        string    `json:"event_id"`
-	EventName      string    `json:"event_name,omitempty"`
-	SourceEventID  string    `json:"source_event_id,omitempty"`
-	ProducedBy     string    `json:"produced_by,omitempty"`
-	ProducedByType string    `json:"produced_by_type,omitempty"`
-	Timestamp      time.Time `json:"timestamp"`
-	Revision       int64     `json:"revision"`
+	Input          string               `json:"input"`
+	EventID        string               `json:"event_id"`
+	EventName      string               `json:"event_name,omitempty"`
+	SourceEventID  string               `json:"source_event_id,omitempty"`
+	ProducedBy     string               `json:"produced_by,omitempty"`
+	ProducedByType string               `json:"produced_by_type,omitempty"`
+	SourceRoute    events.RouteIdentity `json:"source_route,omitempty"`
+	Timestamp      time.Time            `json:"timestamp"`
+	Revision       int64                `json:"revision"`
 }
 
 const (
@@ -221,6 +222,10 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	if err != nil {
 		return RunForkPlan{}, err
 	}
+	forkEvent, err := runForkPointRevisionEvent(snapshot, cursor)
+	if err != nil {
+		return RunForkPlan{}, err
+	}
 	plan.historicalSnapshot = snapshot
 	plan.ForkPoint = RunForkPoint{
 		Input:          at,
@@ -229,6 +234,7 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 		SourceEventID:  cursor.SourceEventID,
 		ProducedBy:     cursor.ProducedBy,
 		ProducedByType: cursor.ProducedByType,
+		SourceRoute:    forkEvent.SourceRoute.Normalized(),
 		Timestamp:      cursor.CreatedAt,
 		Revision:       cursor.Revision,
 	}
@@ -262,6 +268,23 @@ func (s *PostgresStore) PlanRunFork(ctx context.Context, req RunForkPlanRequest)
 	plan.UnsupportedBlockerCount = len(plan.UnsupportedBlockers)
 	plan.ExecutionReady = plan.ReplayResumeAdmission.StateOnlyExecutionReady || plan.ReplayResumeAdmission.DeliveryEventReplayReady
 	return plan, nil
+}
+
+func runForkPointRevisionEvent(snapshot *runForkRevisionSnapshot, cursor runForkEventCursor) (runForkRevisionEvent, error) {
+	if snapshot == nil || snapshot.Revision != cursor.Revision {
+		return runForkRevisionEvent{}, fmt.Errorf("fork point event %s is not backed by fixed revision %d", strings.TrimSpace(cursor.EventID), cursor.Revision)
+	}
+	eventID := strings.TrimSpace(cursor.EventID)
+	for _, event := range snapshot.Events {
+		if strings.TrimSpace(event.EventID) != eventID {
+			continue
+		}
+		if event.FirstRevision != cursor.Revision {
+			return runForkRevisionEvent{}, fmt.Errorf("fork point event %s first revision is %d, want %d", eventID, event.FirstRevision, cursor.Revision)
+		}
+		return event, nil
+	}
+	return runForkRevisionEvent{}, fmt.Errorf("fork point event %s is absent from fixed revision %d", eventID, cursor.Revision)
 }
 
 func loadRunForkSourceSummary(ctx context.Context, q rowQueryer, plan *RunForkPlan) error {

--- a/internal/store/run_fork_planner.go
+++ b/internal/store/run_fork_planner.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/mutationlog"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
@@ -81,22 +82,23 @@ type RunForkEntityState struct {
 }
 
 type RunForkPendingWork struct {
-	EventID         string     `json:"event_id"`
-	EventName       string     `json:"event_name"`
-	FlowInstance    string     `json:"flow_instance,omitempty"`
-	DeliveryID      string     `json:"delivery_id,omitempty"`
-	SubscriberType  string     `json:"subscriber_type,omitempty"`
-	SubscriberID    string     `json:"subscriber_id,omitempty"`
-	Classification  string     `json:"classification"`
-	Status          string     `json:"status,omitempty"`
-	RetryCount      int        `json:"retry_count,omitempty"`
-	ReasonCode      string     `json:"reason_code,omitempty"`
-	ActiveSessionID string     `json:"active_session_id,omitempty"`
-	CreatedAt       time.Time  `json:"created_at"`
-	StartedAt       *time.Time `json:"started_at,omitempty"`
-	DeliveredAt     *time.Time `json:"delivered_at,omitempty"`
-	ReceiptOutcome  string     `json:"receipt_outcome,omitempty"`
-	ReceiptAt       *time.Time `json:"receipt_at,omitempty"`
+	EventID         string               `json:"event_id"`
+	EventName       string               `json:"event_name"`
+	FlowInstance    string               `json:"flow_instance,omitempty"`
+	SourceRoute     events.RouteIdentity `json:"source_route,omitempty"`
+	DeliveryID      string               `json:"delivery_id,omitempty"`
+	SubscriberType  string               `json:"subscriber_type,omitempty"`
+	SubscriberID    string               `json:"subscriber_id,omitempty"`
+	Classification  string               `json:"classification"`
+	Status          string               `json:"status,omitempty"`
+	RetryCount      int                  `json:"retry_count,omitempty"`
+	ReasonCode      string               `json:"reason_code,omitempty"`
+	ActiveSessionID string               `json:"active_session_id,omitempty"`
+	CreatedAt       time.Time            `json:"created_at"`
+	StartedAt       *time.Time           `json:"started_at,omitempty"`
+	DeliveredAt     *time.Time           `json:"delivered_at,omitempty"`
+	ReceiptOutcome  string               `json:"receipt_outcome,omitempty"`
+	ReceiptAt       *time.Time           `json:"receipt_at,omitempty"`
 }
 
 type RunForkUnsupportedBlocker struct {

--- a/internal/store/run_fork_revision_projection.go
+++ b/internal/store/run_fork_revision_projection.go
@@ -41,6 +41,7 @@ func loadRunForkPendingWorkFromRevision(snapshot *runForkRevisionSnapshot) ([]Ru
 			EventID:         strings.TrimSpace(delivery.EventID),
 			EventName:       strings.TrimSpace(event.EventName),
 			FlowInstance:    strings.TrimSpace(event.FlowInstance),
+			SourceRoute:     event.SourceRoute.Normalized(),
 			DeliveryID:      strings.TrimSpace(delivery.DeliveryID),
 			SubscriberType:  strings.TrimSpace(delivery.SubscriberType),
 			SubscriberID:    strings.TrimSpace(delivery.SubscriberID),
@@ -78,6 +79,7 @@ func loadRunForkPendingWorkFromRevision(snapshot *runForkRevisionSnapshot) ([]Ru
 			EventID:        strings.TrimSpace(receipt.EventID),
 			EventName:      strings.TrimSpace(event.EventName),
 			FlowInstance:   strings.TrimSpace(event.FlowInstance),
+			SourceRoute:    event.SourceRoute.Normalized(),
 			SubscriberType: strings.TrimSpace(receipt.SubscriberType),
 			SubscriberID:   strings.TrimSpace(receipt.SubscriberID),
 			ReasonCode:     strings.TrimSpace(receipt.ReasonCode),
@@ -166,9 +168,14 @@ func loadRunForkSourceFactsFromRevision(snapshot *runForkRevisionSnapshot, entit
 			}
 			if flowInstance := strings.TrimSpace(event.FlowInstance); flowInstance != "" {
 				flowSet[flowInstance] = struct{}{}
-				if sourceFlow := runtimeflowidentity.SemanticScope(flowInstance); sourceFlow != "" {
-					sourceFlowSet[sourceFlow] = struct{}{}
-				}
+			}
+			sourceRoute := event.SourceRoute.Normalized()
+			sourceFlow := strings.Trim(strings.TrimSpace(sourceRoute.FlowID), "/")
+			if sourceFlow == "" {
+				sourceFlow = runtimeflowidentity.SemanticScope(sourceRoute.FlowInstance)
+			}
+			if sourceFlow != "" {
+				sourceFlowSet[sourceFlow] = struct{}{}
 			}
 		}
 	}

--- a/internal/store/run_fork_revision_projection_test.go
+++ b/internal/store/run_fork_revision_projection_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
+)
+
+func TestRunForkRevisionProjectionPreservesSourceRouteSeparatelyFromReceiverContext(t *testing.T) {
+	at := time.Unix(1700001000, 0).UTC()
+	snapshot := &runForkRevisionSnapshot{
+		Events: []runForkRevisionEvent{{
+			EventID:      "event-1",
+			EventName:    "producer/inst-1/scan.requested",
+			FlowInstance: "consumer/inst-9",
+			SourceRoute: events.RouteIdentity{
+				FlowID:       " producer ",
+				FlowInstance: "/producer/inst-1/",
+				EntityID:     "source-entity",
+			},
+		}},
+		Deliveries: []runForkRevisionDelivery{{
+			DeliveryID:     "delivery-1",
+			EventID:        "event-1",
+			SubscriberType: "node",
+			SubscriberID:   "source-node",
+			Status:         "pending",
+			CreatedAt:      at,
+		}},
+	}
+
+	pending, err := loadRunForkPendingWorkFromRevision(snapshot)
+	if err != nil {
+		t.Fatalf("loadRunForkPendingWorkFromRevision: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending work = %#v, want one row", pending)
+	}
+	if got, want := pending[0].FlowInstance, "consumer/inst-9"; got != want {
+		t.Fatalf("receiver flow instance = %q, want %q", got, want)
+	}
+	if got, want := pending[0].SourceRoute, (events.RouteIdentity{FlowID: "producer", FlowInstance: "producer/inst-1", EntityID: "source-entity"}); got != want {
+		t.Fatalf("source route = %#v, want %#v", got, want)
+	}
+
+	facts := loadRunForkSourceFactsFromRevision(snapshot, nil)
+	if _, ok := stringSliceSet(facts.FlowInstances)["consumer/inst-9"]; !ok {
+		t.Fatalf("receiver flow instances = %v, want consumer/inst-9", facts.FlowInstances)
+	}
+	if _, ok := stringSliceSet(facts.SourceFlows)["producer"]; !ok {
+		t.Fatalf("source flows = %v, want producer", facts.SourceFlows)
+	}
+	if _, ok := stringSliceSet(facts.SourceFlows)["consumer"]; ok {
+		t.Fatalf("source flows = %v, receiver context must not become source identity", facts.SourceFlows)
+	}
+}
+
+func TestRunForkRevisionProjectionRejectsMalformedSourceRoute(t *testing.T) {
+	snapshot := &runForkRevisionSnapshot{}
+	err := appendRunForkRevisionFact(
+		snapshot,
+		runforkrevision.FamilyEvents,
+		runForkRevisionedFact{FirstRevision: 1, Revision: 1},
+		[]byte(`{"event_id":"event-1","event_name":"producer/scan.requested","source_route":{"flow_instance":17}}`),
+	)
+	if err == nil || !strings.Contains(err.Error(), "decode run fork events revision fact") {
+		t.Fatalf("malformed source route error = %v, want typed revision decode failure", err)
+	}
+}

--- a/internal/store/run_fork_revision_snapshot.go
+++ b/internal/store/run_fork_revision_snapshot.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/division-sh/swarm/internal/events"
 	runforkrevision "github.com/division-sh/swarm/internal/runtime/runforkrevision"
 	"github.com/google/uuid"
 )
@@ -20,22 +21,22 @@ type runForkRevisionedFact struct {
 
 type runForkRevisionEvent struct {
 	runForkRevisionedFact
-	EventID        string          `json:"event_id"`
-	EventName      string          `json:"event_name"`
-	EntityID       string          `json:"entity_id"`
-	FlowInstance   string          `json:"flow_instance"`
-	SourceRoute    json.RawMessage `json:"source_route"`
-	TargetRoute    json.RawMessage `json:"target_route"`
-	TargetSet      json.RawMessage `json:"target_set"`
-	Scope          string          `json:"scope"`
-	Payload        json.RawMessage `json:"payload"`
-	ChainDepth     int             `json:"chain_depth"`
-	ProducedBy     string          `json:"produced_by"`
-	ProducedByType string          `json:"produced_by_type"`
-	HandlerNode    string          `json:"handler_node"`
-	IdempotencyKey string          `json:"idempotency_key"`
-	SourceEventID  string          `json:"source_event_id"`
-	CreatedAt      time.Time       `json:"created_at"`
+	EventID        string               `json:"event_id"`
+	EventName      string               `json:"event_name"`
+	EntityID       string               `json:"entity_id"`
+	FlowInstance   string               `json:"flow_instance"`
+	SourceRoute    events.RouteIdentity `json:"source_route"`
+	TargetRoute    json.RawMessage      `json:"target_route"`
+	TargetSet      json.RawMessage      `json:"target_set"`
+	Scope          string               `json:"scope"`
+	Payload        json.RawMessage      `json:"payload"`
+	ChainDepth     int                  `json:"chain_depth"`
+	ProducedBy     string               `json:"produced_by"`
+	ProducedByType string               `json:"produced_by_type"`
+	HandlerNode    string               `json:"handler_node"`
+	IdempotencyKey string               `json:"idempotency_key"`
+	SourceEventID  string               `json:"source_event_id"`
+	CreatedAt      time.Time            `json:"created_at"`
 }
 
 type runForkRevisionEntityMutation struct {

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1437,6 +1437,44 @@ func TestSQLiteRuntimeStoreImmediateTerminalReceiptPreservesOriginalFailure(t *t
 	}
 }
 
+func TestPendingSubscribedRecoveryUsesAdmittedSameScopeSubscriptionsSQLite(t *testing.T) {
+	ctx := context.Background()
+	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
+	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
+		AgentID:       "reviewer",
+		FlowPath:      "review/inst-1",
+		Subscriptions: []string{"task.ready", "task.*"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscriptions := make([]events.EventType, 0, len(admission.RoutePatterns()))
+	for _, pattern := range admission.RoutePatterns() {
+		subscriptions = append(subscriptions, events.EventType(pattern))
+	}
+	now := time.Now().UTC()
+	localID, foreignID := uuid.NewString(), uuid.NewString()
+	for _, row := range []struct {
+		id        string
+		eventType events.EventType
+	}{{localID, "review/inst-1/task.ready"}, {foreignID, "foreign/task.ready"}} {
+		if err := store.AppendEvent(ctx, eventtest.PersistedProjection(row.id, row.eventType, "runtime", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, now)); err != nil {
+			t.Fatalf("AppendEvent(%s): %v", row.eventType, err)
+		}
+		if err := store.InsertEventDeliveries(ctx, row.id, []string{"reviewer"}); err != nil {
+			t.Fatalf("InsertEventDeliveries(%s): %v", row.eventType, err)
+		}
+	}
+
+	got, err := store.ListPendingSubscribedEvents(ctx, "reviewer", subscriptions, now.Add(-time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListPendingSubscribedEvents: %v", err)
+	}
+	if len(got) != 1 || got[0].ID() != localID {
+		t.Fatalf("pending events = %#v, want only admitted local event %s", got, localID)
+	}
+}
+
 func TestSQLiteRuntimeStoreDirectDeadLetterIsNotRetryExhaustion(t *testing.T) {
 	ctx := testAuthorActivityContext()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)

--- a/internal/store/sqlite_runtime_test.go
+++ b/internal/store/sqlite_runtime_test.go
@@ -1438,7 +1438,7 @@ func TestSQLiteRuntimeStoreImmediateTerminalReceiptPreservesOriginalFailure(t *t
 }
 
 func TestPendingSubscribedRecoveryUsesAdmittedSameScopeSubscriptionsSQLite(t *testing.T) {
-	ctx := context.Background()
+	ctx := testAuthorActivityContext()
 	store := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
 		AgentID:       "reviewer",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -13130,9 +13130,12 @@ run_model:
       read_contract: >-
         PlanRunFork resolves the event UUID to its first revision and reads all eleven families through one read-only
         repeatable-read PostgreSQL snapshot. Every generic and selected planning, readiness, materialization, and
-        historical activation replan consumes that projection. Missing, ambiguous, lineage-invalid, partially deleted,
-        or unrevisioned facts fail closed; old stores are unsupported and must be recreated. SQLite returns typed
-        unsupported for fork mutation and does not emulate this owner.
+        historical activation replan consumes that projection. RunForkPoint carries the exact selected event's
+        normalized revisioned source_route for both explicit event and implicit latest selection. Selected route-history
+        lookup and dynamic flow-instance accounting consume that typed fork-point fact even when no delivery row exists;
+        they MUST NOT recover it from an event name, current route state, receiver flow_instance, or a synthetic delivery.
+        Missing, ambiguous, lineage-invalid, partially deleted, or unrevisioned facts fail closed; old stores are unsupported
+        and must be recreated. SQLite returns typed unsupported for fork mutation and does not emulate this owner.
       route_projection: >-
         Global routing_rules are current unversioned state and are never queried as historical authority. The fixed
         projection emits not_applicable when no route-relevant source fact exists and unknown_unversioned otherwise.
@@ -13289,7 +13292,11 @@ run_model:
     selected_contract_route_admission: 'Selected-contract route/subscription reconstruction admission is a
       non-mutating prerequisite owned by runtime.run_fork.selected_contract_route_admission. It consumes
       runtime.run_fork.contract_frontier_admission for selected frontier work, consumes the fixed planner route state,
-      and consumes selected-source static route derivation through internal/runtime/bus.DeriveRouteTable. A planner
+      consumes the selected RunForkPoint source_route directly for historical event lookup and dynamic instance evidence
+      when the fork-point event has no delivery row, and consumes selected-source static route derivation through
+      internal/runtime/bus.DeriveRouteTable. Completed PendingWork for the same event remains deterministic duplicate
+      evidence and frontier PendingWork remains frontier-owned; neither is required to recover the fork-point source.
+      A planner
       unknown_unversioned state is carried as an unresolved requirement with SourceRouteFactsPresent=true; admission
       does not claim source route history and does not clear flow_route_history_unproven. It MUST NOT read or copy
       current/source routing_rules or flow_instance_routes as historical evidence,

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10111,6 +10111,25 @@ flow_model:
           reply: >
             Receiver `resolution.mode: reply` lowers through typed paired-edge request lineage;
             missing or ambiguous lineage fails closed.
+        receiver_pin_delivery_collision:
+          owner: routing topology over lowered ConnectRoutePlan edges and resolved typed receiver consumers
+          rule: >
+            The durable delivery and receipt model owns exactly one lifecycle row per event x normalized subscriber.
+            Therefore one source event MUST NOT reach the same normalized subscriber and target through more than one
+            distinct receiver input pin or receiver-local event. Verify and boot MUST reject that composition with
+            `connect_receiver_pin_delivery_collision`; duplicate declarations of the same edge remain idempotent, and
+            fan-out to distinct subscribers or distinct targets remains valid.
+          runtime_invariant: >
+            Connect-route materialization MUST compare receiver-local identity before DeliveryRoute or
+            RoutePlanDeliveryIntent normalization can erase it. Distinct receiver-local facts mapping to the same
+            subscriber, target, delivery context, and payload projection MUST fail closed with
+            `delivery_topology_invalid`, persist no delivery row, and execute no handler. Runtime MUST NOT add receiver
+            pin to durable delivery identity, choose the first handler, or reconstruct the missing fact during retry or
+            replay.
+          handler_resolution: >
+            Connected-input workflow handler resolution MUST produce exactly one receiver-local handler candidate.
+            Zero or multiple candidates are explicit failures; execution MUST NOT select the first source-matching
+            input handler.
         implementation_slice_1827_connect_delivery_reply_retirement:
           status: merge_bearing_aggressive_retirement
           canonical_code_owner: internal/runtime/contracts.FlowPackageConnect + internal/runtime/core/pinrouting.ConnectRoutePlan

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -9697,14 +9697,13 @@ flow_model:
           identity_rule: >
             Every endpoint and edge carries authored, local, and canonical event identity plus stable flow/package
             scope. Declared-input and fan-in associations fail closed on zero or multiple matches.
-          legacy_qualified_subscription_rule: >
-            A concrete qualified cross-flow subscription that runtime still honors without a pin/connect route is
-            projected in `legacy_qualified_subscriptions` with disposition `legacy_qualified_subscription`, exact
-            authored file:line evidence, runtime_delivery true, canonical_edge false, migration remediation, and a
-            linked verifier finding. It MUST NOT appear as a canonical edge. Staged/new-model bundles receive a hard
-            invalidity when any root or child flow authors stages; all-legacy bundles receive a semantic-drift warning until E1a retires qualified cross-flow
-            delivery. Wildcard imports and consumers reached through a declared input pin plus connect are not this
-            legacy class.
+          qualified_cross_flow_subscription_retirement: >
+            A concrete qualified subscription that crosses a flow boundary is a hard invalidity and never creates a
+            route, recipient, or topology edge. The authored endpoint census may retain exact file:line evidence only
+            to produce the retirement diagnostic. Inter-flow delivery must use declared output/input pins plus parent
+            connect, while the receiver subscribes to its local event identity. Imported wildcard subscriptions are a
+            distinct typed relation governed by wildcard_subscription_scope; raw exact qualification is never an
+            authorization proof or compatibility path.
           supported_outputs:
           - swarm describe routes
           - swarm describe routes --json
@@ -9876,25 +9875,25 @@ flow_model:
           helper that independently interprets imported package policy or credential handles is non-authoritative. Imported
           package credential use with no declared `requires.credentials` item must resolve as an import-boundary miss, not
           as a raw deployment credential key.
-      pin_alias_delivery:
+      pin_alias_interface_adaptation:
         owner: Runtime import-boundary pin alias resolver over semanticview ProjectScopes and FlowScopes.
         inputs: >
           For an imported package with a declared `requires.inputs` pin, the parent import-site `bind.inputs` value is
-          the canonical producer pattern consumed by flow input auto-wire, boot/verify input pin wiring, RouteTable
-          static/template derivation, EventBus recipient planning/persistence, and workflow-node materialization.
-          The child handler still consumes the package-local input pin name as its localized event. Raw same-name
-          local input fallback is forbidden for declared imported package input pins; same-name fallback remains valid
-          only for authored/local flows or imports that do not declare the input requirement.
+          interface-name adaptation evidence consumed only by an explicit parent connect. Bind alone does not prove a
+          producer, create a RouteTable entry, materialize a workflow-node subscription, or authorize an EventBus
+          recipient. After connect lowering, the child handler consumes the package-local input event identity. Raw
+          same-name local input fallback is forbidden for declared imported package input pins.
         outputs: >
           For an imported package with a declared `requires.outputs` pin, the emitted/persisted event identity remains
-          the child flow output event pattern. Parent-facing subscribers consume the parent import-site `bind.outputs`
-          event name through the same runtime alias resolver. Delivery/readback localized event for the parent consumer
-          is the parent-facing event name; the source event identity, replay scope, target routing metadata, broadcast
-          semantics, correlation, and cardinality are not rewritten by the alias.
+          the child flow output event pattern. The parent import-site `bind.outputs` value adapts that interface name
+          only when an explicit connect consumes it. Bind alone does not create an exact or wildcard RouteTable entry,
+          materialize a parent subscription, or authorize a root recipient. Delivery/readback localization comes from
+          the lowered connect plan; source identity, replay scope, target metadata, correlation, and cardinality are not
+          rewritten by bind.
         fail_closed: >
-          Runtime consumers must use the shared import-boundary alias resolver; local helpers must not independently
-          reinterpret package-local pins, parent event names, or raw same-name fallback for declared imported package
-          pins.
+          Runtime consumers must use the shared import-boundary alias resolver as adaptation evidence inside connect
+          lowering. Local helpers must not independently reinterpret package-local pins, parent event names, or bind
+          values as delivery authority. No pin_bind_input_alias or pin_bind_output_alias route source exists.
       wildcard_subscription_scope:
         owner: Runtime import-boundary wildcard scope/grant resolver over semanticview ProjectScopes, FlowScopes, and
           parent import-site `bind.observe` grants.
@@ -9943,6 +9942,22 @@ flow_model:
           Root and non-imported flow wildcard subscriptions keep their existing wildcard route behavior. Target and
           target_set delivery narrowing still applies after the scoped wildcard candidate is produced; wildcard grants
           do not override delivery target filtering.
+      flow_owned_agent_subscription_admission:
+        owner: semanticview typed exact/pattern admission consumed by AgentManager lifecycle and EventBus agent routes.
+        rule: >
+          Before static, dynamic, ad-hoc, reconfigured, recovered, or pending-query agent state can persist or install a
+          live route, one admission decision resolves its declared flow scope and subscription intent. Same-scope exact
+          and pattern subscriptions become canonical local route identities. Imported cross-boundary patterns consume
+          wildcard_subscription_scope and its typed bind.observe evidence or fail closed. Qualified exact subscriptions
+          cannot cross a flow boundary. Raw EventBus subscription strings and low-level wildcard matching are not route
+          authority.
+        carriers: >
+          An admitted carrier may install no subscription patterns and still receive typed connect/direct delivery by
+          identity. Workflow runtime, system-node, and activity-dispatcher listeners use required typed internal-carrier
+          registration and cannot downgrade to agent-kind subscription routes.
+        recovery: >
+          Startup and pending delivery queries consume the same admitted persisted facts. Invalid exact or pattern
+          authority fails before route mutation or backlog selection; no old-store reader or migration path exists.
       split_runtime_semantics:
         final_e2e_package_proof: >
           Final multi-package marketplace-style runtime proof is tracked by #1455 and guarded by
@@ -10023,10 +10038,11 @@ flow_model:
             `connect` is a list of structured connections. Each entry binds one producer output pin to one receiver
             input pin and optionally names an alias/adapter. `from` uses either
             flow-id plus local pin name or the explicit package-root endpoint form `.{root_output_pin_name}`. `to` uses
-            flow-id plus local input pin name in this slice. Connect refs are not handler keys and not runtime instance paths.
+            flow-id plus local input pin name or the explicit package-root endpoint form
+            `.{root_input_pin_name}`. Connect refs are not handler keys and not runtime instance paths.
           fields:
             from: Required producer reference `{producer_flow_id}.{output_pin_name}` or package-root producer reference `.{root_output_pin_name}`.
-            to: Required receiver reference `{receiver_flow_id}.{input_pin_name}`.
+            to: Required receiver reference `{receiver_flow_id}.{input_pin_name}` or package-root receiver reference `.{root_input_pin_name}`.
             adapter: Optional named payload/event adapter when producer output and receiver input names or payload keys differ.
             map: Optional explicit map from receiver address keys to source/target expressions. Required when inference would be ambiguous or names differ.
           retired_fields:
@@ -10057,9 +10073,8 @@ flow_model:
           package-root endpoint form `.{root_output_pin_name}`.
         producer_output_pin_exists: The `from` pin must exist in the producer schema output event pins; for package-root
           endpoints it must exist in root schema.yaml pins.outputs.events.
-        receiver_flow_exists: The `to` flow must exist in the loaded package registry.
-        receiver_root_unsupported: Root receiver endpoints are not supported by #1508; `to` must name a loaded receiver flow input pin.
-        receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins.
+        receiver_flow_exists: The `to` flow must exist in the loaded package registry unless `to` is the explicit package-root endpoint form `.{root_input_pin_name}`.
+        receiver_input_pin_exists: The `to` pin must exist in the receiver schema input event pins; for package-root endpoints it must exist in root schema.yaml pins.inputs.events.
         event_alias_or_adapter_valid: Differing local event names or payload keys require an explicit alias/adapter or unambiguous bind-derived alias; raw same-name fallback is not valid for declared imported package pins.
         output_carries_address_key: The producer output pin key/carries declaration must prove the top-level payload key used
           by the receiver instance.by route key, receiver address, or explicit connect.map source. Event payload schema and connect.map are validation inputs,
@@ -10202,7 +10217,6 @@ flow_model:
           - connect_pin_ref_invalid
           - producer_flow_missing
           - producer_output_pin_missing
-          - receiver_root_unsupported
           - receiver_flow_missing
           - receiver_input_pin_missing
           - receiver_address_rule_missing
@@ -10699,31 +10713,34 @@ flow_model:
             an explicit root connect consumes that output pin and routes to the
             same loaded receiver flow. Runtime must fail closed before producer
             target/broadcast can repair or override the canonical root connect
-            decision. Root receiver endpoints are not supported in this slice and
-            fail closed as receiver_root_unsupported.
+            decision. Parent connect may symmetrically name a package-root receiver
+            input pin with `to: .{root_input_pin_name}`. Nested package connects
+            resolve that endpoint to the owning package root; top-level connects
+            resolve it to the global root.
           root_endpoint_syntax:
             producer: '`.{root_output_pin_name}` in connect.from names root schema.yaml pins.outputs.events only.'
-            receiver: 'Unsupported in #1508; connect.to must name `{receiver_flow_id}.{input_pin_name}`.'
+            receiver: '`.{root_input_pin_name}` in connect.to names the owning package root schema.yaml pins.inputs.events only.'
           consumes:
           - root schema.yaml pins.outputs.events
           - parent package.yaml connect.from `.{root_output_pin_name}` entries
-          - receiver flow input pin declarations and addressed-input route-plan lowering
+          - receiver flow or owning package-root input pin declarations and addressed-input route-plan lowering
           - root producer authored emit target/broadcast syntax
           produces:
           - typed root ConnectRoutePlan producer endpoints
           - producer_target_common_path_forbidden for root target.flow/match common-path composition where root connect authority applies
           - producer_broadcast_common_path_forbidden for root broadcast:true common-path composition where root connect authority applies
-          - receiver_root_unsupported for attempted root connect receivers
+          - typed root ConnectRoutePlan receiver endpoints
           proof_obligations:
           - semanticview exposes root connect facts through CompositionConnectsFrom("", pin)
           - bootverify accepts root outputs with root connect and no producer target/broadcast
           - bootverify rejects root producer target.flow/match and broadcast:true when root connect authority applies
           - EventBus persists delivery rows and subscribed replay scope from lowered root ConnectRoutePlan authority
+          - strict load, verify, lowering, execution, persistence/replay, and readback accept package-root receivers
+          - nested package root receivers resolve to the owning ancestor package rather than the global root
           - existing loaded flow-scope connect/target/broadcast regressions remain covered
           does_not_close:
           - '#1479 business-field descriptor/index materialization'
           - '#1450 broader package policy/grants/final e2e work'
-          - 'root connect receiver semantics'
           - '#1474 already closed generated agent/node EventBus RoutePlan consumption'
           - '#1479 already closed declared indexed business-field descriptor materialization'
         implementation_slice_1485:
@@ -10823,12 +10840,12 @@ flow_model:
         - live subscription list used to invent missing connect topology
         - producer emit.target used as common parent-composed routing owner
         - select_entity used to repair an in-topology broadcast
-      pin_alias_delivery_composition:
+      pin_alias_interface_adaptation:
         rule: >
           Import-boundary `requires`/`bind` pin aliases from #1452 are lower-level name-adaptation inputs to connect
           lowering. They may rename the parent-facing input/output pin, but they do not rewrite source event identity,
           replay scope, target metadata, receiver resolution, correlation, or cardinality.
-        owner_consumed: platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_delivery
+        owner_consumed: platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_interface_adaptation
       emit_target_escape_hatch:
         role: >
           `emit.target` remains the only producer-authored dynamic routing escape hatch. It is valid for cases where the
@@ -17089,7 +17106,7 @@ static_analyzer:
     supported_surface: cmd/swarm verify
     spec_basis:
     - flow_model.flow_package.composition_routing
-    - flow_model.flow_package.import_boundary.pin_alias_delivery
+    - flow_model.flow_package.import_boundary.pin_alias_interface_adaptation
     - engine.cross_flow_routing
     scope:
       description: Validate parser/model/semantic-view consumption of parent package.yaml connect entries and receiver

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10130,14 +10130,19 @@ flow_model:
             Runtime-resolved connect plans MUST preview every matched plan without lifecycle activation, reply-context
             creation or claim, delivery persistence, or handler execution; it MUST admit the complete transient
             receiver pin/event and durable-delivery-identity set before any of those mutations may begin. Preview route
-            materialization is request-local and cannot install or remove live route-table state. Exact replay of one
-            pin/event/delivery fact is idempotent; a different pin or local event converging on the same durable delivery
-            identity is a hard conflict.
+            materialization is request-local and cannot install or remove live route-table state. A preview-created
+            template instance MUST also become request-local descriptor evidence for every later matched plan, so a later
+            select may consume the same prospective instance exactly as the real pass consumes the newly persisted
+            descriptor. Exact replay of one pin/event/delivery fact is idempotent; a different pin or local event converging
+            on the same durable delivery identity is a hard conflict.
           handler_resolution: >
             Connected-input workflow handler resolution MUST produce exactly one receiver-local handler candidate.
             Zero or multiple candidates are explicit failures propagated through delivery policy and interception;
             stale or replayed invalid delivery routes MUST return the failure without passthrough, receipt settlement,
-            or handler execution. Execution MUST NOT select the first source-matching input handler.
+            or handler execution. These failures apply only when a typed node DeliveryRoute or committed node delivery
+            authority selects that node. Agent-only connect delivery and events without node authority MUST NOT turn an
+            unrelated receiver-flow node into a handler candidate or abort the agent delivery. Execution MUST NOT select
+            the first source-matching input handler.
         implementation_slice_1827_connect_delivery_reply_retirement:
           status: merge_bearing_aggressive_retirement
           canonical_code_owner: internal/runtime/contracts.FlowPackageConnect + internal/runtime/core/pinrouting.ConnectRoutePlan
@@ -10569,9 +10574,11 @@ flow_model:
           - EventBus publish/preflight for select-or-create reuses exactly one existing receiver instance
           - EventBus publish/preflight for select-or-create creates exactly one missing receiver instance through the canonical lifecycle path
           - concurrent same-key select-or-create deliveries converge on one receiver instance or fail closed without duplicate key ownership
+          - one matched event may preview-create a template instance on an earlier plan and select that same request-local descriptor on a later plan without preflight mutation
           - ambiguous select-or-create target failures fail closed with receiver/key/value/remediation detail and no activation
           - same committed select-or-create event replay reuses persisted delivery route/scope and does not reselect or recreate after descriptor drift
           - standalone #1828 `template-select-or-create` conformance fixture verifies and materializes through the canonical select-or-create route plan
+          - an agent-only connect route with an unrelated receiver-flow node delivers to the selected agent without synthesizing node authority or a connected-input handler failure
           - route-plan lowering records fan-in stream metadata, required singleton/window/dedup_by, singular target delivery, and no new target kind
           - bootverify rejects fan-in receiver handler redeclaration of accumulate.dedup_by or accumulate.window
           - EventBus publish/preflight for fan-in stream routes multiple source contributions to the same explicit singleton/coordinator receiver route

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10731,7 +10731,7 @@ flow_model:
           - producer_broadcast_common_path_forbidden for root broadcast:true common-path composition where root connect authority applies
           - typed root ConnectRoutePlan receiver endpoints
           proof_obligations:
-          - semanticview exposes root connect facts through CompositionConnectsFrom("", pin)
+          - semanticview exposes package-aware root connect facts through ResolvedCompositionConnectsFrom, and runtime delivery consumes the same endpoints through lowered ConnectRoutePlan authority
           - bootverify accepts root outputs with root connect and no producer target/broadcast
           - bootverify rejects root producer target.flow/match and broadcast:true when root connect authority applies
           - EventBus persists delivery rows and subscribed replay scope from lowered root ConnectRoutePlan authority

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10743,7 +10743,12 @@ flow_model:
             decision. Parent connect may symmetrically name a package-root receiver
             input pin with `to: .{root_input_pin_name}`. Nested package connects
             resolve that endpoint to the owning package root; top-level connects
-            resolve it to the global root.
+            resolve it to the global root. Runtime source-endpoint matching treats
+            the event envelope `source` route as authoritative. When that route is
+            absent, an event `flow_instance` that identifies semantic child-flow
+            ownership makes a package-root source match ambiguous and MUST fail
+            closed; a UUID root instance remains valid root context. Runtime MUST
+            NOT reconstruct source ownership from the event name or `flow_instance`.
           root_endpoint_syntax:
             producer: '`.{root_output_pin_name}` in connect.from names root schema.yaml pins.outputs.events only.'
             receiver: '`.{root_input_pin_name}` in connect.to names the owning package root schema.yaml pins.inputs.events only.'
@@ -10762,6 +10767,7 @@ flow_model:
           - bootverify accepts root outputs with root connect and no producer target/broadcast
           - bootverify rejects root producer target.flow/match and broadcast:true when root connect authority applies
           - EventBus persists delivery rows and subscribed replay scope from lowered root ConnectRoutePlan authority
+          - package-root source matching rejects absent source-route events carrying semantic child-flow context while retaining UUID root-instance and explicit root-source controls across planning, preflight, publish, connect-issue matching, and workflow connected-input localization
           - strict load, verify, lowering, execution, persistence/replay, and readback accept package-root receivers
           - nested package root receivers resolve to the owning ancestor package rather than the global root
           - existing loaded flow-scope connect/target/broadcast regressions remain covered

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -10120,16 +10120,24 @@ flow_model:
             `connect_receiver_pin_delivery_collision`; duplicate declarations of the same edge remain idempotent, and
             fan-out to distinct subscribers or distinct targets remains valid.
           runtime_invariant: >
-            Connect-route materialization MUST compare receiver-local identity before DeliveryRoute or
-            RoutePlanDeliveryIntent normalization can erase it. Distinct receiver-local facts mapping to the same
-            subscriber, target, delivery context, and payload projection MUST fail closed with
-            `delivery_topology_invalid`, persist no delivery row, and execute no handler. Runtime MUST NOT add receiver
-            pin to durable delivery identity, choose the first handler, or reconstruct the missing fact during retry or
-            replay.
+            Connect-route materialization MUST preserve the normalized receiver input pin and receiver-local event as
+            one transient routing fact, then compare that fact before DeliveryRoute or RoutePlanDeliveryIntent
+            normalization can erase it. Distinct receiver pin/event facts mapping to the same subscriber, target,
+            delivery context, and payload projection MUST fail closed with `delivery_topology_invalid`, persist no
+            delivery row, and execute no handler. Runtime MUST NOT add receiver pin to durable delivery identity,
+            choose the first handler, or reconstruct the missing fact during retry or replay.
+          pre_mutation_admission: >
+            Runtime-resolved connect plans MUST preview every matched plan without lifecycle activation, reply-context
+            creation or claim, delivery persistence, or handler execution; it MUST admit the complete transient
+            receiver pin/event and durable-delivery-identity set before any of those mutations may begin. Preview route
+            materialization is request-local and cannot install or remove live route-table state. Exact replay of one
+            pin/event/delivery fact is idempotent; a different pin or local event converging on the same durable delivery
+            identity is a hard conflict.
           handler_resolution: >
             Connected-input workflow handler resolution MUST produce exactly one receiver-local handler candidate.
-            Zero or multiple candidates are explicit failures; execution MUST NOT select the first source-matching
-            input handler.
+            Zero or multiple candidates are explicit failures propagated through delivery policy and interception;
+            stale or replayed invalid delivery routes MUST return the failure without passthrough, receipt settlement,
+            or handler execution. Execution MUST NOT select the first source-matching input handler.
         implementation_slice_1827_connect_delivery_reply_retirement:
           status: merge_bearing_aggressive_retirement
           canonical_code_owner: internal/runtime/contracts.FlowPackageConnect + internal/runtime/core/pinrouting.ConnectRoutePlan

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/events.yaml
@@ -2,3 +2,4 @@ work.start:
 work.finished:
 child/task.requested:
 child/task.done:
+task.done:

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/nodes.yaml
@@ -9,4 +9,3 @@ child-worker:
       advances_to: finished
       emit:
         event: task.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/flows/child/schema.yaml
@@ -6,4 +6,6 @@ pins:
   inputs:
     events: [task.requested]
   outputs:
-    events: [task.done]
+    events:
+      - name: task_done
+        event: task.done

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/nodes.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/nodes.yaml
@@ -10,10 +10,10 @@ dispatcher:
 listener:
   id: listener
   execution_type: system_node
-  subscribes_to: [child/task.done]
+  subscribes_to: [task.done]
   produces: [work.finished]
   event_handlers:
-    child/task.done:
+    task.done:
       advances_to: done
       emit:
         event: work.finished

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/package.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/package.yaml
@@ -6,3 +6,6 @@ flows:
 - id: child
   flow: child
   mode: static
+connect:
+  - from: child.task_done
+    to: .task_done

--- a/tests/tier11-flow-composition/test-child-flow-absolute-path/schema.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-absolute-path/schema.yaml
@@ -3,6 +3,9 @@ terminal_states: [done]
 states: [waiting, done]
 pins:
   inputs:
-    events: [work.start]
+    events:
+      - work.start
+      - name: task_done
+        event: task.done
   outputs:
     events: [work.finished]

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/events.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/events.yaml
@@ -3,3 +3,4 @@ work.requested:
   task_type: string
 job.done:
 child/work.completed:
+work.completed:

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/nodes.yaml
@@ -9,4 +9,3 @@ child-worker:
       advances_to: completed
       emit:
         event: work.completed
-        broadcast: true

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/flows/child/schema.yaml
@@ -6,4 +6,6 @@ pins:
   inputs:
     events: [work.requested]
   outputs:
-    events: [work.completed]
+    events:
+      - name: work_completed
+        event: work.completed

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/nodes.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/nodes.yaml
@@ -10,10 +10,10 @@ parent-node:
 parent-listener:
   id: parent-listener
   execution_type: system_node
-  subscribes_to: [child/work.completed]
+  subscribes_to: [work.completed]
   produces: [job.done]
   event_handlers:
-    child/work.completed:
+    work.completed:
       advances_to: done
       emit:
         event: job.done

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/package.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/package.yaml
@@ -6,3 +6,6 @@ flows:
 - id: child
   flow: child
   mode: static
+connect:
+  - from: child.work_completed
+    to: .work_completed

--- a/tests/tier11-flow-composition/test-child-flow-pin-wiring/schema.yaml
+++ b/tests/tier11-flow-composition/test-child-flow-pin-wiring/schema.yaml
@@ -3,6 +3,9 @@ terminal_states: [done]
 states: [ready, done]
 pins:
   inputs:
-    events: [job.submit]
+    events:
+      - job.submit
+      - name: work_completed
+        event: work.completed
   outputs:
     events: [job.done]

--- a/tests/tier11-flow-composition/test-data-pin-wiring/events.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/events.yaml
@@ -4,3 +4,4 @@ job.start:
 job.complete:
 processor/process.run:
 processor/process.done:
+process.done:

--- a/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/nodes.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/nodes.yaml
@@ -16,4 +16,3 @@ processor-node:
       advances_to: finished
       emit:
         event: process.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/flows/processor/schema.yaml
@@ -7,5 +7,7 @@ pins:
     events: [process.run]
     reads: [task_config]
   outputs:
-    events: [process.done]
+    events:
+      - name: process_done
+        event: process.done
     writes: [result]

--- a/tests/tier11-flow-composition/test-data-pin-wiring/nodes.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/nodes.yaml
@@ -17,10 +17,10 @@ config-writer:
 result-listener:
   id: result-listener
   execution_type: system_node
-  subscribes_to: [processor/process.done]
+  subscribes_to: [process.done]
   produces: [job.complete]
   event_handlers:
-    processor/process.done:
+    process.done:
       advances_to: done
       emit:
         event: job.complete

--- a/tests/tier11-flow-composition/test-data-pin-wiring/package.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/package.yaml
@@ -6,3 +6,6 @@ flows:
 - id: processor
   flow: processor
   mode: static
+connect:
+  - from: processor.process_done
+    to: .process_done

--- a/tests/tier11-flow-composition/test-data-pin-wiring/schema.yaml
+++ b/tests/tier11-flow-composition/test-data-pin-wiring/schema.yaml
@@ -4,7 +4,10 @@ terminal_states: [done]
 states: [idle, configured, done]
 pins:
   inputs:
-    events: [job.start]
+    events:
+      - job.start
+      - name: process_done
+        event: process.done
   outputs:
     events: [job.complete]
     writes: [task_config]

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/events.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/events.yaml
@@ -2,3 +2,4 @@ validate.requested:
 validate.passed:
 child/validate.start:
 child/validation.done:
+validation.done:

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/nodes.yaml
@@ -13,4 +13,3 @@ validator:
       sets_gate: g_validated
       emit:
         event: validation.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/flows/child/schema.yaml
@@ -11,6 +11,7 @@ pins:
     reads: []
   outputs:
     events:
-      - name: validation.done
+      - name: validation_done
+        event: validation.done
     writes: []
 name: child

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
@@ -2,14 +2,14 @@ router:
   execution_type: system_node
   subscribes_to:
     - validate.requested
-    - child/validation.done
+    - validation.done
   produces:
     - validate.passed
     - child/validate.start
   event_handlers:
     validate.requested:
       emit: child/validate.start
-    child/validation.done:
+    validation.done:
       guard:
         id: check_child_gate
         check: _entity.gates['child/g_validated'] == true

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/package.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/package.yaml
@@ -8,3 +8,6 @@ flows:
   - id: child
     flow: child
     mode: static
+connect:
+  - from: child.validation_done
+    to: .validation_done

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/schema.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/schema.yaml
@@ -8,6 +8,8 @@ pins:
   inputs:
     events:
       - name: validate.requested
+      - name: validation_done
+        event: validation.done
     reads: []
   outputs:
     events:

--- a/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/events.yaml
@@ -2,3 +2,5 @@ pipeline.start:
 pipeline.complete:
 child/step.begin:
 child/grandchild/micro.done:
+step.begin:
+micro.done:

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/events.yaml
@@ -1,2 +1,5 @@
 step.begin:
 grandchild/micro.done:
+micro.start:
+micro.done:
+micro.relayed:

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/nodes.yaml
@@ -5,8 +5,6 @@ grandchild-worker:
   produces: [micro.done]
   event_handlers:
     micro.start:
-      create_entity: true
       advances_to: finished
       emit:
         event: micro.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/schema.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/flows/grandchild/schema.yaml
@@ -4,6 +4,10 @@ terminal_states: [finished]
 states: [ready, finished]
 pins:
   inputs:
-    events: [micro.start]
+    events:
+      - name: micro_start
+        event: micro.start
   outputs:
-    events: [micro.done]
+    events:
+      - name: micro_done
+        event: micro.done

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/nodes.yaml
@@ -1,10 +1,12 @@
 child-relay:
   id: child-relay
   execution_type: system_node
-  subscribes_to: [step.begin]
-  produces: [grandchild/micro.start]
+  subscribes_to: [step.begin, micro.done]
+  produces: [micro.start, micro.relayed]
   event_handlers:
     step.begin:
-      create_entity: true
+      advances_to: delegated
+      emit: micro.start
+    micro.done:
       advances_to: completed
-      emit: grandchild/micro.start
+      emit: micro.relayed

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/package.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/package.yaml
@@ -6,3 +6,9 @@ flows:
 - id: grandchild
   flow: grandchild
   mode: static
+connect:
+  - from: .micro_start
+    to: grandchild.micro_start
+  - from: grandchild.micro_done
+    to: .micro_done
+    adapter: grandchild_micro_done_to_child_micro_done

--- a/tests/tier11-flow-composition/test-nested-three-levels/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/flows/child/schema.yaml
@@ -1,7 +1,17 @@
 name: child
 initial_state: waiting
 terminal_states: [completed]
-states: [waiting, completed]
+states: [waiting, delegated, completed]
 pins:
   inputs:
-    events: [step.begin]
+    events:
+      - name: step_begin
+        event: step.begin
+      - name: micro_done
+        event: micro.done
+  outputs:
+    events:
+      - name: micro_start
+        event: micro.start
+      - name: micro_relayed
+        event: micro.relayed

--- a/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
@@ -2,18 +2,18 @@ root-dispatcher:
   id: root-dispatcher
   execution_type: system_node
   subscribes_to: [pipeline.start]
-  produces: [child/step.begin]
+  produces: [step.begin]
   event_handlers:
     pipeline.start:
-      emit: child/step.begin
+      emit: step.begin
 
 root-collector:
   id: root-collector
   execution_type: system_node
-  subscribes_to: [child/grandchild/micro.done]
+  subscribes_to: [micro.done]
   produces: [pipeline.complete]
   event_handlers:
-    child/grandchild/micro.done:
+    micro.done:
       advances_to: done
       emit:
         event: pipeline.complete

--- a/tests/tier11-flow-composition/test-nested-three-levels/package.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/package.yaml
@@ -6,3 +6,9 @@ flows:
 - id: child
   flow: child
   mode: static
+connect:
+  - from: .step_begin
+    to: child.step_begin
+  - from: child.micro_relayed
+    to: .micro_done
+    adapter: child_micro_relayed_to_root_micro_done

--- a/tests/tier11-flow-composition/test-nested-three-levels/schema.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/schema.yaml
@@ -3,6 +3,12 @@ terminal_states: [done]
 states: [idle, done]
 pins:
   inputs:
-    events: [pipeline.start]
+    events:
+      - pipeline.start
+      - name: micro_done
+        event: micro.done
   outputs:
-    events: [pipeline.complete]
+    events:
+      - pipeline.complete
+      - name: step_begin
+        event: step.begin

--- a/tests/tier11-flow-composition/test-tool-override/events.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/events.yaml
@@ -2,3 +2,4 @@ task.requested:
 task.done:
 child/child.start:
 child/child.done:
+child.done:

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/nodes.yaml
@@ -9,4 +9,3 @@ child-node:
       advances_to: done
       emit:
         event: child.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-tool-override/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/flows/child/schema.yaml
@@ -6,4 +6,6 @@ pins:
   inputs:
     events: [child.start]
   outputs:
-    events: [child.done]
+    events:
+      - name: child_done
+        event: child.done

--- a/tests/tier11-flow-composition/test-tool-override/nodes.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/nodes.yaml
@@ -1,12 +1,12 @@
 root-node:
   id: root-node
   execution_type: system_node
-  subscribes_to: [task.requested, child/child.done]
+  subscribes_to: [task.requested, child.done]
   produces: [task.done, child/child.start]
   event_handlers:
     task.requested:
       emit: child/child.start
-    child/child.done:
+    child.done:
       advances_to: done
       emit:
         event: task.done

--- a/tests/tier11-flow-composition/test-tool-override/package.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/package.yaml
@@ -8,3 +8,6 @@ flows:
 - id: child
   flow: child
   mode: static
+connect:
+  - from: child.child_done
+    to: .child_done

--- a/tests/tier11-flow-composition/test-tool-override/schema.yaml
+++ b/tests/tier11-flow-composition/test-tool-override/schema.yaml
@@ -4,6 +4,9 @@ terminal_states: [done]
 states: [pending, done]
 pins:
   inputs:
-    events: [task.requested]
+    events:
+      - task.requested
+      - name: child_done
+        event: child.done
   outputs:
     events: [task.done]

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/events.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/events.yaml
@@ -2,3 +2,4 @@ work.begin:
 work.finished:
 grandchild/task.start:
 grandchild/task.done:
+task.done:

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/nodes.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/nodes.yaml
@@ -9,4 +9,3 @@ worker:
       advances_to: finished
       emit:
         event: task.done
-        broadcast: true

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/schema.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/flows/grandchild/schema.yaml
@@ -6,4 +6,6 @@ pins:
   inputs:
     events: [task.start]
   outputs:
-    events: [task.done]
+    events:
+      - name: task_done
+        event: task.done

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/nodes.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/nodes.yaml
@@ -11,10 +11,10 @@ relay:
 listener:
   id: listener
   execution_type: system_node
-  subscribes_to: [grandchild/task.done]
+  subscribes_to: [task.done]
   produces: [work.finished]
   event_handlers:
-    grandchild/task.done:
+    task.done:
       advances_to: completed
       emit:
         event: work.finished

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/package.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/package.yaml
@@ -6,3 +6,7 @@ flows:
 - id: grandchild
   flow: grandchild
   mode: static
+connect:
+  - from: grandchild.task_done
+    to: .task_done
+    adapter: grandchild_task_done_to_child_task_done

--- a/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/schema.yaml
+++ b/tests/tier11-flow-composition/test-wildcard-deep-subscription/flows/child/schema.yaml
@@ -4,6 +4,9 @@ terminal_states: [completed]
 states: [waiting, completed]
 pins:
   inputs:
-    events: [work.begin]
+    events:
+      - work.begin
+      - name: task_done
+        event: task.done
   outputs:
     events: [work.finished]

--- a/tests/tier8-boot-verification/test-boot-missing-pin/events.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/events.yaml
@@ -4,3 +4,5 @@ child/task.assigned:
   description: Cross-flow event dispatching a task assignment to the child flow
 child/task.result:
   description: Cross-flow event returning a task result from the child flow
+task.result:
+  description: Receiver-local task result delivered through package connect

--- a/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/nodes.yaml
@@ -12,4 +12,3 @@ worker:
       advances_to: done
       emit:
         event: task.result
-        broadcast: true

--- a/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/flows/child/schema.yaml
@@ -6,4 +6,6 @@ pins:
   inputs:
     events: [task.assigned, task.feedback]
   outputs:
-    events: [task.result]
+    events:
+      - name: task_result
+        event: task.result

--- a/tests/tier8-boot-verification/test-boot-missing-pin/nodes.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/nodes.yaml
@@ -1,12 +1,12 @@
 dispatcher:
   id: dispatcher
   execution_type: system_node
-  subscribes_to: [task.requested, child/task.result]
+  subscribes_to: [task.requested, task.result]
   produces: [task.completed, child/task.assigned]
   event_handlers:
     task.requested:
       emit: child/task.assigned
-    child/task.result:
+    task.result:
       advances_to: done
       emit:
         event: task.completed

--- a/tests/tier8-boot-verification/test-boot-missing-pin/package.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/package.yaml
@@ -8,3 +8,6 @@ flows:
 - id: child
   flow: child
   mode: static
+connect:
+  - from: child.task_result
+    to: .task_result

--- a/tests/tier8-boot-verification/test-boot-missing-pin/schema.yaml
+++ b/tests/tier8-boot-verification/test-boot-missing-pin/schema.yaml
@@ -4,6 +4,9 @@ terminal_states: [done]
 states: [pending, done]
 pins:
   inputs:
-    events: [task.requested]
+    events:
+      - task.requested
+      - name: task_result
+        event: task.result
   outputs:
     events: [task.completed]


### PR DESCRIPTION
## Summary

- make typed flow-owned subscription admission the single authority consumed before agent persistence, lifecycle mutation, live route installation, recovery, and pending selection
- retire qualified cross-flow subscription fallback, both import-bind alias route engines, and all optional raw pipeline carrier fallbacks
- add symmetric package-root `connect.to: .pin` lowering and keep local subscriptions, governed wildcard grants, and internal carriers as non-authoritative consumers
- migrate all eight checked exact-qualified fixtures to explicit connect; remove only the eight connect-colliding broadcast declarations authorized by the lead ruling, leaving the other nine for #2086

## Governing context

Binding spec references:

- `platform-spec.yaml#flow_model.flow_package.import_boundary.qualified_cross_flow_subscription_retirement`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.pin_alias_interface_adaptation`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.wildcard_subscription_scope`
- `platform-spec.yaml#flow_model.flow_package.import_boundary.flow_owned_agent_subscription_admission`
- `platform-spec.yaml#flow_model.flow_package.composition_routing.route_plan_lowering.implementation_slice_1508.root_endpoint_syntax.receiver`

Binding issue context: #1786 comments 4982624635, 4982844118, and 4985696318; #2085 Gate A comment 4985759210; bounded fixture-collateral ruling comment 4987306026. Parent classes remain tracked by #2084, #1827, and #1738.

## Semantic migration

New canonical owners are typed `semanticview` exact/pattern agent admission plus `FlowPackageConnect -> ConnectRoutePlan` for inter-flow edges. The old exact-qualified node/agent fallback, arbitrary live/recovered agent subscription route, `pin_bind_input_alias`, `pin_bind_output_alias`, descendant externalization, and raw pipeline `Subscribe` fallback paths are invalid and removed.

Production paths checked include static and dynamic agent activation, ad-hoc spawn, reconfiguration, startup recovery, ephemeral selected-fork/clone behavior, PostgreSQL and SQLite pending readers, EventBus route installation/planning, workflow/system-node/activity carriers, connect lowering/dispatch, retry/replay, run-fork route evidence, topology, and CLI readback. Migration is complete for the approved #2085 class; no compatibility reader, adapter, migration, or dual authority remains.

## Verification

- focused semantic admission, EventBus, manager lifecycle/recovery, pipeline carrier, bind/connect, root receiver, conformance inventory, canonical fixture, PostgreSQL/SQLite parity, and hostile proofs repeated at `-count=3`
- timing-sensitive `TestMockAgentSupportedSurfaceSQLitePostgres` passed 3 consecutive isolated runs
- `GOCACHE=/private/tmp/swarm-agent-a-go-cache GOTMPDIR=/private/tmp/swarm-agent-a-go-tmp GOFLAGS='-p=1' SWARM_TEST_POSTGRES_DSN='host=127.0.0.1 port=5432 user=youmew dbname=postgres sslmode=disable' PGPASSWORD=postgres go test ./...`

Closes #2085
