### PR TITLE
fix: materialize agent mock modules into bundle identity

### DIFF
--- a/internal/apiv1/operator_bundle_register.go
+++ b/internal/apiv1/operator_bundle_register.go
@@ -196,9 +196,6 @@ func bundleRegistrationDataBlobParam(params map[string]any) ([]bundleRegistratio
 		if err != nil {
 			return nil, err
 		}
-		if err := validateBundleRegistrationDataPath(path, field+".path"); err != nil {
-			return nil, err
-		}
 		folded := asciiFoldBundleRegistrationPath(path)
 		if existing, exists := seen[folded]; exists {
 			if existing == path {
@@ -367,22 +364,10 @@ func cleanBundleRegistrationPath(raw, field string) (string, error) {
 	return raw, nil
 }
 
-func validateBundleRegistrationDataPath(path, field string) error {
-	segments := strings.Split(path, "/")
-	if !bundleRegistrationDataPathIsFlowData(segments) {
-		return NewInvalidParamsError(map[string]any{"field": field, "reason": "data_blob entries must be under a flow data directory (.../flows/<flow>/data/...)"})
-	}
-	return nil
-}
-
-func bundleRegistrationDataPathIsFlowData(segments []string) bool {
-	for i := 0; i+3 < len(segments); i++ {
-		if segments[i] == "flows" && segments[i+1] != "" && segments[i+2] == "data" {
-			return true
-		}
-	}
-	return false
-}
+// Data blob entries are admitted structurally by cleanBundleRegistrationPath;
+// bundle membership is gated by verifyBundleRegistrationInputsConsumed against
+// the canonical bundle_hash owner, which covers every raw input including flow
+// data directories, policy modules, and declared agent mock modules.
 
 func asciiFoldBundleRegistrationPath(path string) string {
 	buf := []byte(path)

--- a/internal/apiv1/operator_bundle_register_test.go
+++ b/internal/apiv1/operator_bundle_register_test.go
@@ -8,6 +8,96 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 )
 
+func TestBundleRegistrationAcceptsDeclaredMockModuleDataEntry(t *testing.T) {
+	repo := repoRoot(t)
+	contentYAML := `
+api_version: swarm.bundle.register.v1
+files:
+  - path: package.yaml
+    text: |
+      name: mocked-agent-registration
+      version: "1.0.0"
+      platform_version: ">=0.7.0 <0.8.0"
+      flows: []
+  - path: agents.yaml
+    text: |
+      assistant:
+        id: assistant
+        role: helper
+        model: regular
+        mock:
+          kind: python
+          module: mocks/assistant.py
+`
+	mockSource := []byte("def handle(input):\n    return {\"text\": \"hello from mock\"}\n")
+	projection, err := buildBundleRegistrationProjection(bundleRegistrationParams{
+		ContentYAML: contentYAML,
+		DataBlob: []bundleRegistrationDataEntry{
+			{Path: "mocks/assistant.py", Data: mockSource},
+		},
+	}, bundleRegistrationRuntimeContext{
+		RepoRoot:         repo,
+		PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	})
+	if err != nil {
+		t.Fatalf("buildBundleRegistrationProjection: %v", err)
+	}
+	files, ok := projection.ParsedJSON["files"].([]map[string]any)
+	if !ok {
+		t.Fatalf("parsed_json files = %T, want []map[string]any", projection.ParsedJSON["files"])
+	}
+	consumed := false
+	for _, file := range files {
+		if file["label"] == "bundle/mocks/assistant.py" {
+			consumed = true
+		}
+	}
+	if !consumed {
+		t.Fatalf("projection files = %#v, want bundle/mocks/assistant.py consumed input", projection.ParsedJSON["files"])
+	}
+	if len(projection.DataBlob) == 0 {
+		t.Fatal("projection.DataBlob is empty, want declared mock module data")
+	}
+}
+
+func TestBundleRegistrationRejectsUndeclaredMockModuleDataEntry(t *testing.T) {
+	repo := repoRoot(t)
+	contentYAML := `
+api_version: swarm.bundle.register.v1
+files:
+  - path: package.yaml
+    text: |
+      name: mocked-agent-registration
+      version: "1.0.0"
+      platform_version: ">=0.7.0 <0.8.0"
+      flows: []
+`
+	_, err := buildBundleRegistrationProjection(bundleRegistrationParams{
+		ContentYAML: contentYAML,
+		DataBlob: []bundleRegistrationDataEntry{
+			{Path: "mocks/undeclared.py", Data: []byte("def handle(input):\n    return {}\n")},
+		},
+	}, bundleRegistrationRuntimeContext{
+		RepoRoot:         repo,
+		PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	})
+	if err == nil {
+		t.Fatal("buildBundleRegistrationProjection succeeded, want undeclared mock module rejected")
+	}
+	var invalid *InvalidParamsError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("error = %T %v, want InvalidParamsError", err, err)
+	}
+	details, ok := invalid.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details = %T, want map", invalid.Details)
+	}
+	reason, _ := details["reason"].(string)
+	if !strings.Contains(reason, "not consumed by canonical bundle_hash owner") {
+		t.Fatalf("reason = %q, want not-consumed rejection", reason)
+	}
+}
+
 func TestBundleRegistrationProjectionReturnsStructuredLoaderDiagnostic(t *testing.T) {
 	repo := repoRoot(t)
 	contentYAML := `

--- a/internal/runtime/contracts/bundle_build_test.go
+++ b/internal/runtime/contracts/bundle_build_test.go
@@ -322,6 +322,130 @@ func TestBuildBundleMaterializationFailsClosedForPythonSyntax(t *testing.T) {
 	}
 }
 
+func TestBuildBundleMaterializationMaterializesAgentMockModules(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	platform := DefaultPlatformSpecFile(repo)
+
+	report, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       filepath.Join(t.TempDir(), "build"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization: %v", err)
+	}
+	materialized, err := os.ReadFile(filepath.Join(report.OutputPath, "mocks", "assistant.py"))
+	if err != nil {
+		t.Fatalf("materialized mock module missing: %v", err)
+	}
+	if string(materialized) != mockAssistantSource {
+		t.Fatalf("materialized mock module = %q, want %q", materialized, mockAssistantSource)
+	}
+	var manifest BundleBuildManifest
+	if err := json.Unmarshal([]byte(readBundleBuildFile(t, report.OutputPath, "build-manifest.json")), &manifest); err != nil {
+		t.Fatalf("decode build manifest: %v", err)
+	}
+	found := false
+	for _, input := range manifest.Inputs {
+		if input.Label == "bundle/mocks/assistant.py" {
+			found = true
+			if input.Policy != "raw_data" || input.SizeBytes != int64(len(mockAssistantSource)) {
+				t.Fatalf("mock build input = %#v, want raw_data policy with exact size", input)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("manifest inputs = %#v, want bundle/mocks/assistant.py", manifest.Inputs)
+	}
+	reloaded, err := LoadWorkflowContractBundleWithOverrides(repo, report.OutputPath, platform)
+	if err != nil {
+		t.Fatalf("reload materialized bundle: %v", err)
+	}
+	reloadedHash, err := BundleHash(reloaded)
+	if err != nil {
+		t.Fatalf("reload bundle hash: %v", err)
+	}
+	if reloadedHash != report.BundleHash {
+		t.Fatalf("reloaded hash = %s, want %s", reloadedHash, report.BundleHash)
+	}
+
+	outB := filepath.Join(t.TempDir(), "build-b")
+	reportB, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       outB,
+	})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if reportB.BundleHash != report.BundleHash {
+		t.Fatalf("rebuild hash = %s, want %s", reportB.BundleHash, report.BundleHash)
+	}
+	if gotA, gotB := materializedHashedFileBytes(t, report.OutputPath), materializedHashedFileBytes(t, reportB.OutputPath); !reflect.DeepEqual(gotA, gotB) {
+		t.Fatalf("materialized hashed files drifted:\nA=%#v\nB=%#v", gotA, gotB)
+	}
+}
+
+func TestBuildBundleMaterializationChangesHashWhenMockBytesChange(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	platform := DefaultPlatformSpecFile(repo)
+
+	reportA, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       filepath.Join(t.TempDir(), "build-a"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization A: %v", err)
+	}
+	writeBundleHashText(t, filepath.Join(root, "mocks", "assistant.py"), strings.Replace(mockAssistantSource, "hello from mock", "hello from moxk", 1))
+	reportB, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       filepath.Join(t.TempDir(), "build-b"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization B: %v", err)
+	}
+	if reportB.BundleHash == reportA.BundleHash {
+		t.Fatalf("mock byte change produced identical bundle hash %s; content silently replaced under unchanged identity", reportA.BundleHash)
+	}
+}
+
+func TestBuildBundleMaterializationDetectsTamperedMaterializedMock(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	platform := DefaultPlatformSpecFile(repo)
+
+	report, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: platform,
+		OutputRoot:       filepath.Join(t.TempDir(), "build"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization: %v", err)
+	}
+	writeBundleHashText(t, filepath.Join(report.OutputPath, "mocks", "assistant.py"), strings.Replace(mockAssistantSource, "hello from mock", "hello from moxk", 1))
+	reloaded, err := LoadWorkflowContractBundleWithOverrides(repo, report.OutputPath, platform)
+	if err != nil {
+		t.Fatalf("reload tampered materialized bundle: %v", err)
+	}
+	tamperedHash, err := BundleHash(reloaded)
+	if err != nil {
+		t.Fatalf("hash tampered materialized bundle: %v", err)
+	}
+	if tamperedHash == report.BundleHash {
+		t.Fatalf("tampered mock module retained bundle hash %s; identity no longer covers execution behavior", report.BundleHash)
+	}
+}
+
 func writeBundleBuildContractsDir(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -345,6 +469,30 @@ terminal_states: [ready]
 	writeBundleHashBytes(t, filepath.Join(root, "modules", "structured_renderer.wasm"), raw)
 	writeBundleHashText(t, filepath.Join(root, "src", "structured_renderer.rs"), "fn compute() {}\n")
 	writeBundleHashText(t, filepath.Join(root, "flows", "render", "policy.yaml"), bundleBuildPolicyYAML(t, root, bundleBuildSourceHash(t, root)))
+	return root
+}
+
+const mockAssistantSource = `def handle(input):
+    return {"text": "hello from mock"}
+`
+
+func writeMockedAgentContractsDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBundleHashText(t, filepath.Join(root, "package.yaml"), `name: mocked-agent-bundle
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows: []
+`)
+	writeBundleHashText(t, filepath.Join(root, "agents.yaml"), `assistant:
+  id: assistant
+  role: helper
+  model: regular
+  mock:
+    kind: python
+    module: mocks/assistant.py
+`)
+	writeBundleHashText(t, filepath.Join(root, "mocks", "assistant.py"), mockAssistantSource)
 	return root
 }
 

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -166,6 +166,9 @@ func bundleHashEntries(bundle *WorkflowContractBundle) ([]bundleHashEntry, error
 	if err := builder.addPolicyModuleFiles(bundle); err != nil {
 		return nil, err
 	}
+	if err := builder.addAgentMockModuleFiles(bundle); err != nil {
+		return nil, err
+	}
 
 	sort.Slice(builder.entries, func(i, j int) bool {
 		return builder.entries[i].Label < builder.entries[j].Label
@@ -216,6 +219,31 @@ func (b *bundleHashEntryBuilder) addPolicyModuleFiles(bundle *WorkflowContractBu
 			if err := b.addOptionalBundleFile(path, bundleHashRaw); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// addAgentMockModuleFiles captures every declared agent mock module as a raw
+// bundle hash input. Mock modules are behavior-bearing authored content: in
+// mock execution mode the module is the agent's behavior, so the bundle
+// identity must cover its exact bytes, not just the path string authored in
+// agents.yaml.
+func (b *bundleHashEntryBuilder) addAgentMockModuleFiles(bundle *WorkflowContractBundle) error {
+	if bundle == nil {
+		return nil
+	}
+	for _, agent := range bundle.ScopedAgentEntries() {
+		if !agent.Mock.Configured() {
+			continue
+		}
+		sourcePath := strings.TrimSpace(agent.Mock.SourcePath)
+		if sourcePath == "" {
+			return fmt.Errorf("agent %s mock module is configured but has no source path", strings.TrimSpace(agent.ID))
+		}
+		path := filepath.Join(b.contractsRoot, filepath.FromSlash(sourcePath))
+		if err := b.addOptionalBundleFile(path, bundleHashRaw); err != nil {
+			return fmt.Errorf("agent %s mock module: %w", strings.TrimSpace(agent.ID), err)
 		}
 	}
 	return nil

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -94,6 +94,40 @@ func TestBundleHashV1AcceptsCurrentPlatformSpec(t *testing.T) {
 	}
 }
 
+func TestBundleHashV1IncludesAgentMockModuleBytes(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	platform := DefaultPlatformSpecFile(repo)
+	load := func() *WorkflowContractBundle {
+		t.Helper()
+		bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, platform)
+		if err != nil {
+			t.Fatalf("load mocked agent bundle: %v", err)
+		}
+		return bundle
+	}
+	before, err := BundleHash(load())
+	if err != nil {
+		t.Fatalf("BundleHash before: %v", err)
+	}
+	writeBundleHashText(t, filepath.Join(root, "mocks", "assistant.py"), strings.Replace(mockAssistantSource, "hello from mock", "hello from moxk", 1))
+	after, err := BundleHash(load())
+	if err != nil {
+		t.Fatalf("BundleHash after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("BundleHash did not change after mock module byte change: %s", before)
+	}
+
+	unchanged, err := BundleHash(load())
+	if err != nil {
+		t.Fatalf("BundleHash unchanged fixture: %v", err)
+	}
+	if unchanged != after {
+		t.Fatalf("identical mock bytes produced different hashes: %s vs %s", unchanged, after)
+	}
+}
+
 func TestBundleHashV1IncludesPolicyModuleBytes(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/bundle_registration_upload.go
+++ b/internal/runtime/contracts/bundle_registration_upload.go
@@ -55,6 +55,7 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 	if err != nil {
 		return BundleRegistrationUpload{}, err
 	}
+	mockModulePaths := declaredAgentMockModulePaths(bundle)
 	files := make([]bundleRegistrationUploadFile, 0, len(entries))
 	var dataEntries []BundleRegisterDataEntryV1
 	for _, entry := range entries {
@@ -71,7 +72,7 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 		}
 		switch entry.Policy {
 		case bundleHashRaw:
-			if err := validateBundleRegistrationUploadDataPath(rel); err != nil {
+			if err := validateBundleRegistrationUploadDataPath(rel, mockModulePaths); err != nil {
 				return BundleRegistrationUpload{}, err
 			}
 			dataEntries = append(dataEntries, BundleRegisterDataEntryV1{
@@ -137,12 +138,34 @@ func encodeBundleRegistrationEnvelopeYAML(files []bundleRegistrationUploadFile) 
 	return builder.String(), nil
 }
 
-func validateBundleRegistrationUploadDataPath(path string) error {
-	segments := strings.Split(path, "/")
-	if !bundleRegistrationUploadDataPathIsFlowData(segments) {
-		return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under a flow data directory (.../flows/<flow>/data/...)", path)
+// declaredAgentMockModulePaths returns the contracts-root-relative slash paths
+// of every agent mock module declared by the bundle. These are admissible raw
+// data blob entries alongside flow data directories.
+func declaredAgentMockModulePaths(bundle *WorkflowContractBundle) map[string]struct{} {
+	paths := map[string]struct{}{}
+	if bundle == nil {
+		return paths
 	}
-	return nil
+	for _, agent := range bundle.ScopedAgentEntries() {
+		if !agent.Mock.Configured() {
+			continue
+		}
+		if sourcePath := strings.TrimSpace(agent.Mock.SourcePath); sourcePath != "" {
+			paths[sourcePath] = struct{}{}
+		}
+	}
+	return paths
+}
+
+func validateBundleRegistrationUploadDataPath(path string, mockModulePaths map[string]struct{}) error {
+	segments := strings.Split(path, "/")
+	if bundleRegistrationUploadDataPathIsFlowData(segments) {
+		return nil
+	}
+	if _, declared := mockModulePaths[path]; declared {
+		return nil
+	}
+	return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under a flow data directory (.../flows/<flow>/data/...) or a declared agent mock module path", path)
 }
 
 func bundleRegistrationUploadDataPathIsFlowData(segments []string) bool {

--- a/internal/runtime/contracts/bundle_registration_upload_test.go
+++ b/internal/runtime/contracts/bundle_registration_upload_test.go
@@ -69,6 +69,39 @@ func TestBuildBundleRegistrationDirectoryUploadPackagesTextAndData(t *testing.T)
 	}
 }
 
+func TestBuildBundleRegistrationDirectoryUploadCarriesDeclaredMockModules(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+
+	upload, err := BuildBundleRegistrationDirectoryUpload(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload: %v", err)
+	}
+	if upload.DataBlob == nil {
+		t.Fatal("DataBlob = nil, want declared mock module entry")
+	}
+	var paths []string
+	for _, entry := range upload.DataBlob.Entries {
+		paths = append(paths, entry.Path)
+	}
+	if !reflect.DeepEqual(paths, []string{"mocks/assistant.py"}) {
+		t.Fatalf("data entries = %#v, want mocks/assistant.py only", paths)
+	}
+	want := base64.StdEncoding.EncodeToString([]byte(mockAssistantSource))
+	if got := upload.DataBlob.Entries[0].DataBase64; got != want {
+		t.Fatalf("mock data_base64 = %q, want exact declared module bytes", got)
+	}
+	var envelope bundleRegistrationEnvelopeUploadV1
+	if err := yaml.Unmarshal([]byte(upload.ContentYAML), &envelope); err != nil {
+		t.Fatalf("unmarshal content_yaml: %v\n%s", err, upload.ContentYAML)
+	}
+	for _, file := range envelope.Files {
+		if file.Path == "mocks/assistant.py" {
+			t.Fatal("mock module must be carried as a data blob entry, not a text envelope file")
+		}
+	}
+}
+
 func TestBuildBundleRegistrationDirectoryUploadFailsClosed(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	for _, tc := range []struct {


### PR DESCRIPTION
Closes #2170

## Problem

`swarm bundle build` on a bundle whose agent declares `mock: {kind: python, module: mocks/assistant.py}` did not materialize `mocks/` into the built bundle, and `bundle register --contracts` could not carry the module either — so a bundle with a mocked agent could not be built or registered at all, and the `swarm test` server loop was unreachable for mocked flows.

Root cause: the compile-time capture in `materializeAgentMockPerformances` stores exact bytes + sha256 in the in-memory descriptor, but the mock module was invisible to the packaging/identity layer:

- `bundleHashEntries` never included mock module files — only the `module:` path string in `agents.yaml` was hashed.
- `bundle build` materializes only hash entries and policy module sources, so `mocks/assistant.py` was never copied; the final re-load of the output failed on the missing file.
- `bundle register --contracts` packages only hash entries; the data blob path policy admitted only flow-data directories.

## Design ruling (identity integrity)

Mock modules are behavior-bearing authored content — in mock execution mode the module **is** the agent's behavior. They are the same content class as prompt/intent files, which are byte-hashed in `bundleHashEntries`, and they fall under the #1788 invariant: bundle hash/build/register/catalog include exact referenced local bytes and reject path attacks.

Path-only hashing would mean two bundles with identical identity execute differently depending on ambient file content, and re-registering a changed mock would silently replace execution behavior under an unchanged bundle identity. The fix therefore treats mock modules as ordinary raw bundle hash inputs — uniform machinery, no special-casing:

- `bundleHashEntries` now captures every declared agent mock module as `bundle/mocks/assistant.py` (raw policy) from the effective agent registry.
- `bundle build` materializes them through the generic input path; the materialized-hash equality check now also detects mock drift.
- `bundle register --contracts` carries them in the data blob; the client uploader admits declared mock module paths alongside flow-data directories.
- The server-side flow-data-only data blob pre-check is removed; bundle membership is gated by the existing `verifyBundleRegistrationInputsConsumed` check against the canonical `bundle_hash` owner — which covers every raw input including flow data, policy modules, and declared mock modules. No mock-specific exemption in the consumed-inputs check.

## Tests

- `TestBuildBundleMaterializationMaterializesAgentMockModules` — mock module materialized with exact bytes; manifest input `bundle/mocks/assistant.py`; reload hash equality; reproducible rebuild.
- `TestBuildBundleMaterializationChangesHashWhenMockBytesChange` — changed mock bytes produce a different bundle hash (no silent same-hash content replacement).
- `TestBuildBundleMaterializationDetectsTamperedMaterializedMock` — tampered mock in a materialized bundle is detected on reload.
- `TestBundleHashV1IncludesAgentMockModuleBytes` — hash covers mock bytes; stable for identical bytes.
- `TestBuildBundleRegistrationDirectoryUploadCarriesDeclaredMockModules` — declared mock carried as a data blob entry, not an envelope text file.
- `TestBundleRegistrationAcceptsDeclaredMockModuleDataEntry` / `TestBundleRegistrationRejectsUndeclaredMockModuleDataEntry` — server admission: declared mock accepted and consumed; undeclared mock path rejected by the consumed-inputs gate.

## Verification

- `go build ./...`, `go vet` clean.
- Full suites pass: `internal/runtime/contracts`, `internal/cliapp`, `internal/runtime/llm`.
- `internal/apiv1` / `internal/store` / `internal/serveapp` failures are pre-existing `SWARM_TEST_POSTGRES_DSN`-gated parity tests; failure counts are identical with and without this change.

Note: bundles with wasm/python **policy** modules remain un-registerable via `--contracts` (pre-existing, same content class) — left out of scope; worth a follow-up.