### PR TITLE
fix: register wasm and python policy modules via bundle --contracts

### DIFF
--- a/internal/apiv1/operator_bundle_register_test.go
+++ b/internal/apiv1/operator_bundle_register_test.go
@@ -1,7 +1,11 @@
 package apiv1
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -96,6 +100,167 @@ files:
 	if !strings.Contains(reason, "not consumed by canonical bundle_hash owner") {
 		t.Fatalf("reason = %q, want not-consumed rejection", reason)
 	}
+}
+
+func TestBundleRegistrationAcceptsPolicyModuleDataEntries(t *testing.T) {
+	repo := repoRoot(t)
+	wasmRaw, err := os.ReadFile(filepath.Join("..", "runtime", "computemodule", "testdata", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pythonSource := []byte("def handle(input):\n    return {\"content\": \"\", \"format\": \"yaml\", \"line_count\": 0}\n")
+	contentYAML := policyModuleRegistrationEnvelopeYAML(t, wasmRaw, pythonSource)
+	projection, err := buildBundleRegistrationProjection(bundleRegistrationParams{
+		ContentYAML: contentYAML,
+		DataBlob: []bundleRegistrationDataEntry{
+			{Path: "modules/structured_renderer.wasm", Data: wasmRaw},
+			{Path: "modules/python_renderer.py", Data: pythonSource},
+		},
+	}, bundleRegistrationRuntimeContext{
+		RepoRoot:         repo,
+		PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	})
+	if err != nil {
+		t.Fatalf("buildBundleRegistrationProjection: %v", err)
+	}
+	files, ok := projection.ParsedJSON["files"].([]map[string]any)
+	if !ok {
+		t.Fatalf("parsed_json files = %T, want []map[string]any", projection.ParsedJSON["files"])
+	}
+	consumed := map[string]bool{}
+	for _, file := range files {
+		consumed[file["label"].(string)] = true
+	}
+	for _, label := range []string{"bundle/modules/structured_renderer.wasm", "bundle/modules/python_renderer.py"} {
+		if !consumed[label] {
+			t.Fatalf("projection files = %#v, want consumed input %s", projection.ParsedJSON["files"], label)
+		}
+	}
+}
+
+func TestBundleRegistrationRejectsUndeclaredPolicyModuleDataEntry(t *testing.T) {
+	repo := repoRoot(t)
+	wasmRaw, err := os.ReadFile(filepath.Join("..", "runtime", "computemodule", "testdata", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentYAML := policyModuleRegistrationEnvelopeYAML(t, wasmRaw, nil)
+	_, err = buildBundleRegistrationProjection(bundleRegistrationParams{
+		ContentYAML: contentYAML,
+		DataBlob: []bundleRegistrationDataEntry{
+			{Path: "modules/structured_renderer.wasm", Data: wasmRaw},
+			{Path: "modules/undeclared.wasm", Data: wasmRaw},
+		},
+	}, bundleRegistrationRuntimeContext{
+		RepoRoot:         repo,
+		PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	})
+	if err == nil {
+		t.Fatal("buildBundleRegistrationProjection succeeded, want undeclared module rejected")
+	}
+	var invalid *InvalidParamsError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("error = %T %v, want InvalidParamsError", err, err)
+	}
+	details, ok := invalid.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details = %T, want map", invalid.Details)
+	}
+	reason, _ := details["reason"].(string)
+	if !strings.Contains(reason, "not consumed by canonical bundle_hash owner") {
+		t.Fatalf("reason = %q, want not-consumed rejection", reason)
+	}
+}
+
+func policyModuleRegistrationEnvelopeYAML(t *testing.T, wasmRaw, pythonSource []byte) string {
+	t.Helper()
+	wasmDigest := "sha256:" + hex.EncodeToString(sha256Sum(wasmRaw))
+	policy := "modules:\n" +
+		"  structured_renderer:\n" +
+		"    path: modules/structured_renderer.wasm\n" +
+		"    abi: core-json-v1\n" +
+		"    entry: compute\n" +
+		"    digest: " + wasmDigest + "\n" +
+		"    limits:\n" +
+		"      gas: 5000000\n" +
+		"      memory_pages: 17\n" +
+		"      output_bytes: 1024\n" +
+		"    input_schema:\n" +
+		"      type: object\n" +
+		"      additionalProperties: false\n" +
+		"      required: [component, owner, language, files]\n" +
+		"      properties:\n" +
+		"        component: {type: string}\n" +
+		"        owner: {type: string}\n" +
+		"        language: {type: string}\n" +
+		"        files: {type: array, items: {type: string}}\n" +
+		"    output_schema:\n" +
+		"      type: object\n" +
+		"      additionalProperties: false\n" +
+		"      required: [content, format, line_count]\n" +
+		"      properties:\n" +
+		"        content: {type: string}\n" +
+		"        format: {type: string}\n" +
+		"        line_count: {type: integer}\n"
+	if len(pythonSource) > 0 {
+		pythonDigest := "sha256:" + hex.EncodeToString(sha256Sum(pythonSource))
+		policy += "  python_renderer:\n" +
+			"    path: modules/python_renderer.py\n" +
+			"    kind: python\n" +
+			"    abi: python-json-v1\n" +
+			"    entry: handle\n" +
+			"    digest: " + pythonDigest + "\n" +
+			"    limits:\n" +
+			"      gas: 2500000000\n" +
+			"      memory_pages: 8192\n" +
+			"      output_bytes: 4096\n" +
+			"    input_schema:\n" +
+			"      type: object\n" +
+			"      additionalProperties: false\n" +
+			"      required: [component, owner, language, files]\n" +
+			"      properties:\n" +
+			"        component: {type: string}\n" +
+			"        owner: {type: string}\n" +
+			"        language: {type: string}\n" +
+			"        files: {type: array, items: {type: string}}\n" +
+			"    output_schema:\n" +
+			"      type: object\n" +
+			"      additionalProperties: false\n" +
+			"      required: [content, format, line_count]\n" +
+			"      properties:\n" +
+			"        content: {type: string}\n" +
+			"        format: {type: string}\n" +
+			"        line_count: {type: integer}\n"
+	}
+	return "api_version: swarm.bundle.register.v1\n" +
+		"files:\n" +
+		"  - path: package.yaml\n" +
+		"    text: |\n" +
+		"      name: policy-module-registration\n" +
+		"      version: \"1.0.0\"\n" +
+		"      platform_version: \">=0.7.0 <0.8.0\"\n" +
+		"      flows:\n" +
+		"        - id: render\n" +
+		"          flow: render\n" +
+		"  - path: flows/render/schema.yaml\n" +
+		"    text: |\n" +
+		"      name: render\n" +
+		"      mode: static\n" +
+		"      states: [ready]\n" +
+		"      initial_state: ready\n" +
+		"      terminal_states: [ready]\n" +
+		"  - path: flows/render/policy.yaml\n" +
+		"    text: |\n" + yamlBlockQuote(policy)
+}
+
+func sha256Sum(raw []byte) []byte {
+	sum := sha256.Sum256(raw)
+	return sum[:]
+}
+
+func yamlBlockQuote(text string) string {
+	text = strings.TrimSuffix(text, "\n")
+	return "      " + strings.ReplaceAll(text, "\n", "\n      ") + "\n"
 }
 
 func TestBundleRegistrationProjectionReturnsStructuredLoaderDiagnostic(t *testing.T) {

--- a/internal/runtime/contracts/bundle_registration_upload.go
+++ b/internal/runtime/contracts/bundle_registration_upload.go
@@ -55,7 +55,6 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 	if err != nil {
 		return BundleRegistrationUpload{}, err
 	}
-	mockModulePaths := declaredAgentMockModulePaths(bundle)
 	files := make([]bundleRegistrationUploadFile, 0, len(entries))
 	var dataEntries []BundleRegisterDataEntryV1
 	for _, entry := range entries {
@@ -72,9 +71,6 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 		}
 		switch entry.Policy {
 		case bundleHashRaw:
-			if err := validateBundleRegistrationUploadDataPath(rel, mockModulePaths); err != nil {
-				return BundleRegistrationUpload{}, err
-			}
 			dataEntries = append(dataEntries, BundleRegisterDataEntryV1{
 				Path:       rel,
 				DataBase64: base64.StdEncoding.EncodeToString(raw),
@@ -138,41 +134,6 @@ func encodeBundleRegistrationEnvelopeYAML(files []bundleRegistrationUploadFile) 
 	return builder.String(), nil
 }
 
-// declaredAgentMockModulePaths returns the contracts-root-relative slash paths
-// of every agent mock module declared by the bundle. These are admissible raw
-// data blob entries alongside flow data directories.
-func declaredAgentMockModulePaths(bundle *WorkflowContractBundle) map[string]struct{} {
-	paths := map[string]struct{}{}
-	if bundle == nil {
-		return paths
-	}
-	for _, agent := range bundle.ScopedAgentEntries() {
-		if !agent.Mock.Configured() {
-			continue
-		}
-		if sourcePath := strings.TrimSpace(agent.Mock.SourcePath); sourcePath != "" {
-			paths[sourcePath] = struct{}{}
-		}
-	}
-	return paths
-}
-
-func validateBundleRegistrationUploadDataPath(path string, mockModulePaths map[string]struct{}) error {
-	segments := strings.Split(path, "/")
-	if bundleRegistrationUploadDataPathIsFlowData(segments) {
-		return nil
-	}
-	if _, declared := mockModulePaths[path]; declared {
-		return nil
-	}
-	return fmt.Errorf("raw data input %s cannot be represented in BundleRegisterDataBlobV1; data entries must be under a flow data directory (.../flows/<flow>/data/...) or a declared agent mock module path", path)
-}
-
-func bundleRegistrationUploadDataPathIsFlowData(segments []string) bool {
-	for i := 0; i+3 < len(segments); i++ {
-		if segments[i] == "flows" && segments[i+1] != "" && segments[i+2] == "data" {
-			return true
-		}
-	}
-	return false
-}
+// Bundle membership of raw data entries is owned exclusively by the canonical
+// bundle_hash entry list (this packager) and the server-side consumed-inputs
+// gate; no additional client-side path shape whitelist is maintained.

--- a/internal/runtime/contracts/bundle_registration_upload_test.go
+++ b/internal/runtime/contracts/bundle_registration_upload_test.go
@@ -1,7 +1,9 @@
 package contracts
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -99,6 +101,92 @@ func TestBuildBundleRegistrationDirectoryUploadCarriesDeclaredMockModules(t *tes
 		if file.Path == "mocks/assistant.py" {
 			t.Fatal("mock module must be carried as a data blob entry, not a text envelope file")
 		}
+	}
+}
+
+func TestBuildBundleRegistrationDirectoryUploadCarriesPolicyModules(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writePolicyModuleContractsDir(t)
+
+	upload, err := BuildBundleRegistrationDirectoryUpload(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload: %v", err)
+	}
+	if upload.DataBlob == nil {
+		t.Fatal("DataBlob = nil, want policy module entries")
+	}
+	wasmRaw, err := os.ReadFile(filepath.Join(root, "modules", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pythonRaw := []byte(pythonRendererSource())
+	want := []BundleRegisterDataEntryV1{
+		{Path: "modules/python_renderer.py", DataBase64: base64.StdEncoding.EncodeToString(pythonRaw)},
+		{Path: "modules/structured_renderer.wasm", DataBase64: base64.StdEncoding.EncodeToString(wasmRaw)},
+	}
+	if !reflect.DeepEqual(upload.DataBlob.Entries, want) {
+		t.Fatalf("data entries = %#v, want %#v", upload.DataBlob.Entries, want)
+	}
+}
+
+func TestPolicyModuleRegistrationRuntimeSourceReloadRoundTrip(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writePolicyModuleContractsDir(t)
+	platform := DefaultPlatformSpecFile(repo)
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, platform)
+	if err != nil {
+		t.Fatalf("load policy module bundle: %v", err)
+	}
+	bundleHash, err := BundleHash(bundle)
+	if err != nil {
+		t.Fatalf("BundleHash: %v", err)
+	}
+	projection, err := BuildBundleCatalogProjectionWithOptions(bundle, BundleCatalogProjectionOptions{Source: "test"})
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	source, err := LoadBundleCatalogRuntimeSource(repo, BundleCatalogRuntimeLoadRequest{
+		BundleHash:              bundleHash,
+		ContentYAML:             projection.ContentYAML,
+		DataBlob:                projection.DataBlob,
+		RunningPlatformSpecPath: platform,
+	})
+	if err != nil {
+		t.Fatalf("LoadBundleCatalogRuntimeSource: %v", err)
+	}
+	defer source.Cleanup()
+	reloadedHash, err := BundleHash(source.Bundle)
+	if err != nil {
+		t.Fatalf("reloaded bundle hash: %v", err)
+	}
+	if reloadedHash != bundleHash {
+		t.Fatalf("reloaded hash = %s, want %s", reloadedHash, bundleHash)
+	}
+	for _, rel := range []string{"modules/structured_renderer.wasm", "modules/python_renderer.py"} {
+		info, err := os.Stat(filepath.Join(source.ContractsRoot, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("reconstructed root missing %s: %v", rel, err)
+		}
+		if !info.Mode().IsRegular() {
+			t.Fatalf("reconstructed %s is not a regular file", rel)
+		}
+	}
+
+	mutated := append([]byte(nil), wasmPolicyModuleBytes(t)...)
+	mutated[len(mutated)-1] ^= 0xff
+	writeBundleHashBytes(t, filepath.Join(root, "modules", "structured_renderer.wasm"), mutated)
+	writeBundleHashText(t, filepath.Join(root, "flows", "render", "policy.yaml"), combinedPolicyModuleYAML(t, root, mutated, []byte(pythonRendererSource())))
+	drifted, err := LoadWorkflowContractBundleWithOverrides(repo, root, platform)
+	if err != nil {
+		t.Fatalf("load drifted policy module bundle: %v", err)
+	}
+	driftedHash, err := BundleHash(drifted)
+	if err != nil {
+		t.Fatalf("drifted bundle hash: %v", err)
+	}
+	if driftedHash == bundleHash {
+		t.Fatalf("policy module byte change produced identical bundle hash %s; content replaced under unchanged identity", bundleHash)
 	}
 }
 
@@ -204,4 +292,103 @@ states:
 	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "data", "payload.bin"), []byte{0x01, 0x02, 0x03})
 	writeBundleHashBytes(t, filepath.Join(root, "flows", "alpha", "flows", "gamma", "data", "nested.bin"), []byte{0x09})
 	writeBundleHashBytes(t, filepath.Join(root, "packages", "foo", "flows", "beta", "data", "child.bin"), []byte{0x04, 0x05})
+}
+
+func wasmPolicyModuleBytes(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "computemodule", "testdata", "structured_renderer.wasm"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func writePolicyModuleContractsDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBundleHashText(t, filepath.Join(root, "package.yaml"), `name: policy-module-bundle
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: render
+    flow: render
+`)
+	writeBundleHashText(t, filepath.Join(root, "flows", "render", "schema.yaml"), `name: render
+mode: static
+states: [ready]
+initial_state: ready
+terminal_states: [ready]
+`)
+	writeBundleHashBytes(t, filepath.Join(root, "modules", "structured_renderer.wasm"), wasmPolicyModuleBytes(t))
+	writeBundleHashBytes(t, filepath.Join(root, "modules", "python_renderer.py"), []byte(pythonRendererSource()))
+	writeBundleHashText(t, filepath.Join(root, "flows", "render", "policy.yaml"), combinedPolicyModuleYAML(t, root, wasmPolicyModuleBytes(t), []byte(pythonRendererSource())))
+	return root
+}
+
+func combinedPolicyModuleYAML(t *testing.T, root string, wasmBytes, pythonBytes []byte) string {
+	t.Helper()
+	wasmSum := sha256.Sum256(wasmBytes)
+	pythonSum := sha256.Sum256(pythonBytes)
+	srcRaw, err := os.ReadFile(filepath.Join(root, "src", "structured_renderer.rs"))
+	if err != nil {
+		srcRaw = []byte("fn compute() {}\n")
+	}
+	srcSum := sha256.Sum256(srcRaw)
+	return `modules:
+  structured_renderer:
+    path: modules/structured_renderer.wasm
+    abi: core-json-v1
+    entry: compute
+    digest: sha256:` + hex.EncodeToString(wasmSum[:]) + `
+    source_path: src/structured_renderer.rs
+    source_hash: sha256:` + hex.EncodeToString(srcSum[:]) + `
+    limits:
+      gas: 5000000
+      memory_pages: 17
+      output_bytes: 1024
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [component, owner, language, files]
+      properties:
+        component: {type: string}
+        owner: {type: string}
+        language: {type: string}
+        files: {type: array, items: {type: string}}
+    output_schema:
+      type: object
+      additionalProperties: false
+      required: [content, format, line_count]
+      properties:
+        content: {type: string}
+        format: {type: string}
+        line_count: {type: integer}
+  python_renderer:
+    path: modules/python_renderer.py
+    kind: python
+    abi: python-json-v1
+    entry: handle
+    digest: sha256:` + hex.EncodeToString(pythonSum[:]) + `
+    limits:
+      gas: 2500000000
+      memory_pages: 8192
+      output_bytes: 4096
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [component, owner, language, files]
+      properties:
+        component: {type: string}
+        owner: {type: string}
+        language: {type: string}
+        files: {type: array, items: {type: string}}
+    output_schema:
+      type: object
+      additionalProperties: false
+      required: [content, format, line_count]
+      properties:
+        content: {type: string}
+        format: {type: string}
+        line_count: {type: integer}
+`
 }


### PR DESCRIPTION
Closes #2175

## Problem

`bundle register --contracts` on a bundle declaring wasm/python policy modules failed client-side: the uploader's data-path whitelist admitted only flow-data directories and (post-#2174) declared agent mock module paths — policy module files (`modules/*.wasm`, `modules/*.py`) were rejected even though they are already canonical bundle-hash inputs (`addPolicyModuleFiles`).

## Design rulings (review, 2026-08-07)

- **Q1 — uniform admission**: the client-side path shape whitelist was a redundant second interpreter of "what belongs in a bundle" — the same validator class #2174 already deleted server-side. It could only ever reject legitimate entries and would grow a branch per future raw content class. Deleted entirely; membership is owned by the canonical hash-entry list (this packager) and the server-side consumed-inputs gate. Structural safety remains where it lives (`cleanBundleRegistrationPath` server-side, hash-label containment client-side).
- **Q2 — wasm `source_path` out of scope**: filed as #2176 (bundle inputs vs. provenance-only design question).
- **Q3 — proof level**: registration + `LoadBundleCatalogRuntimeSource` reload + hash match + module present. Served compute-module execution through a registered bundle is registered as **unproven** on #2143 (engine-level coverage exists in `handler_engine_transaction_test`; a served E2E belongs to the conformance corpus, #2168 family).
- **Q4 — both ABIs, no new fixtures**: reuses the in-tree `structured_renderer.wasm` fixture and the existing inline `pythonRendererSource()` (proven by `TestBuildBundleMaterializationMaterializesPythonModuleIdentity`).

## Tests

- `TestBuildBundleRegistrationDirectoryUploadCarriesPolicyModules` — wasm + python module paths carried in the data blob with exact bytes.
- `TestPolicyModuleRegistrationRuntimeSourceReloadRoundTrip` — full cycle: upload → hash → projection → `LoadBundleCatalogRuntimeSource` reload with hash match, both modules present in the reconstructed root, and byte-drift assertion (mutated wasm bytes + updated digest → different bundle hash).
- `TestBundleRegistrationAcceptsPolicyModuleDataEntries` — registration succeeds; both module labels consumed by the canonical hash owner.
- `TestBundleRegistrationRejectsUndeclaredPolicyModuleDataEntry` — extra undeclared module path rejected by the consumed-inputs gate (declared module present so the gate — not the load — is what rejects).
- Byte-drift at the hash level remains covered by `TestBundleHashV1IncludesPolicyModuleBytes`.

## Verification

- `go build`, `go vet` clean; full `internal/runtime/contracts` and `internal/cliapp` suites pass.
- `internal/apiv1` (73) / `internal/store` (460) failures are pre-existing `SWARM_TEST_POSTGRES_DSN`-gated parity tests; counts unchanged.

## Follow-ups (executed)

- #2176: wasm policy `source_path` files as bundle inputs vs. provenance-only.
- #2143 claim registry: served compute-module execution through a registered bundle — unproven.