### PR TITLE
fix: count stage gate context reads as entity reader coverage (V7)

### DIFF
--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -167,6 +167,7 @@ func (c *checkerContext) entityReaderCoverage() []Finding {
 	c.entityReaderCoverageLoaded = true
 
 	readers := wave1EntityReaderCoverageByFlow(c.source)
+	wave1MergeEntityReaderCoverage(readers, wave1GateReaderCoverageByFlow(c.source))
 	for _, contract := range wave1DeclaredEntityContracts(c.source) {
 		for fieldName, fieldDecl := range contract.Contract.Fields {
 			fieldName = strings.TrimSpace(fieldName)
@@ -498,6 +499,45 @@ func wave1ScopedAgentRecords(bundle *runtimecontracts.WorkflowContractBundle) []
 		}
 	}
 	return out
+}
+
+// wave1GateReaderCoverageByFlow counts the entity-field references of every
+// gate-evaluated expression (stage gate `context:` values) as reader coverage,
+// through the same expression-reference owner used by handler reads.
+func wave1GateReaderCoverageByFlow(source semanticview.Source) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	for _, plan := range source.WorkflowGates() {
+		flowID := strings.TrimSpace(plan.FlowID)
+		for _, expression := range plan.Context {
+			expr := expressionReference{
+				Kind:       "gate context",
+				Expression: stageGateExpressionText(expression),
+				Phase:      runtimepipeline.WorkflowEntityFieldLifecycleGate,
+			}
+			if strings.TrimSpace(expr.Expression) == "" {
+				continue
+			}
+			for _, ref := range wave1ResolvedExpressionRefs(source, flowID, "", "", expr) {
+				ownerFlowID := strings.TrimSpace(ref.OwnerFlowID)
+				if out[ownerFlowID] == nil {
+					out[ownerFlowID] = map[string]struct{}{}
+				}
+				out[ownerFlowID][ref.Field] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func wave1MergeEntityReaderCoverage(into, extra map[string]map[string]struct{}) {
+	for flowID, fields := range extra {
+		if into[flowID] == nil {
+			into[flowID] = map[string]struct{}{}
+		}
+		for field := range fields {
+			into[flowID][field] = struct{}{}
+		}
+	}
 }
 
 func wave1EntityReaderCoverageByFlow(source semanticview.Source) map[string]map[string]struct{} {

--- a/internal/runtime/bootverify/workflow_entity_reader_coverage_checks_test.go
+++ b/internal/runtime/bootverify/workflow_entity_reader_coverage_checks_test.go
@@ -54,6 +54,48 @@ func TestRun_UnusedReaderReasonDoesNotSatisfyEntityWriterCoverage(t *testing.T) 
 	}
 }
 
+func TestRun_GateContextCountsAsEntityReaderCoverage(t *testing.T) {
+	bundle := entityReaderCoverageBundle(runtimecontracts.EntityFieldDecl{
+		Type:    "text",
+		Initial: "",
+	})
+	bundle.Semantics.Gates = []runtimecontracts.WorkflowGatePlan{{
+		FlowID:   "",
+		Stage:    "review",
+		Decision: "review_gate",
+		Context: map[string]runtimecontracts.ExpressionValue{
+			"resolution": {Kind: runtimecontracts.ExpressionKindCEL, CEL: "entity.resolution"},
+		},
+	}}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if reportContains(report.LintEvidence(), "entity_reader_coverage", "resolution") {
+		t.Fatalf("expected gate context read to count as reader coverage, got %#v", report.LintEvidence())
+	}
+}
+
+func TestRun_GateContextLiteralDoesNotCountAsEntityReaderCoverage(t *testing.T) {
+	bundle := entityReaderCoverageBundle(runtimecontracts.EntityFieldDecl{
+		Type:    "text",
+		Initial: "",
+	})
+	bundle.Semantics.Gates = []runtimecontracts.WorkflowGatePlan{{
+		FlowID:   "",
+		Stage:    "review",
+		Decision: "review_gate",
+		Context: map[string]runtimecontracts.ExpressionValue{
+			"note": {Literal: "no entity reference here"},
+		},
+	}}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.LintEvidence(), "entity_reader_coverage", "flow root entity_type ticket declares field resolution with no detected internal reader coverage") {
+		t.Fatalf("expected reader coverage lint when the gate context is not an entity reference, got %#v", report.LintEvidence())
+	}
+}
+
 func entityReaderCoverageBundle(field runtimecontracts.EntityFieldDecl) *runtimecontracts.WorkflowContractBundle {
 	return &runtimecontracts.WorkflowContractBundle{
 		RootEntities: runtimecontracts.EntityContractsDocument{

--- a/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_entity_field_lifecycle.go
@@ -13,6 +13,7 @@ type WorkflowEntityFieldLifecyclePhase string
 const (
 	WorkflowEntityFieldLifecycleGuard            WorkflowEntityFieldLifecyclePhase = "guard"
 	WorkflowEntityFieldLifecycleGuardEscalation  WorkflowEntityFieldLifecyclePhase = "guard_escalation_fields"
+	WorkflowEntityFieldLifecycleGate             WorkflowEntityFieldLifecyclePhase = "gate"
 	WorkflowEntityFieldLifecycleAccumulate       WorkflowEntityFieldLifecyclePhase = "accumulate"
 	WorkflowEntityFieldLifecycleFilter           WorkflowEntityFieldLifecyclePhase = "filter"
 	WorkflowEntityFieldLifecycleGroupBy          WorkflowEntityFieldLifecyclePhase = "group_by"


### PR DESCRIPTION
Closes #2173 (final PR of the T8a+T8b → T5 → V7 set).

## Problem

Fields read only by a stage gate's `context:` still emitted `entity_reader_coverage` INFO noise: reader coverage was collected exclusively from node event handlers (`wave1EntityReaderCoverageByFlow` iterates `source.NodeEventHandlers`), while gate context expressions (`WorkflowGatePlan.Context` — CEL/ref values evaluated against the entity for the decision card) were validated but never counted as reads.

## Change (per review ruling: reuse the one expression-reference owner)

- `wave1GateReaderCoverageByFlow` — a gates pass alongside `wave1EntityReaderCoverageByFlow` that feeds every gate-evaluated expression (`context:` values) through the **existing shared collector** (`wave1ResolvedExpressionRefs` → `workflowexpr.EntityReferences`), with the gate's flow scope. No parallel regex, no invented broader semantics.
- Merged into `entityReaderCoverage()`; literal context values are naturally inert because `EntityReferences` strips string literals (a literal cannot fabricate a read).
- New `WorkflowEntityFieldLifecycleGate` phase constant for the gate read metadata (switch-based phase handling has safe defaults; no lifecycle semantics changed).

## Tests

- `TestRun_GateContextCountsAsEntityReaderCoverage` — gate `context: {resolution: entity.resolution}` suppresses the `entity_reader_coverage` lint (the lint shrinking is the point).
- `TestRun_GateContextLiteralDoesNotCountAsEntityReaderCoverage` — a literal context value leaves the lint in place.
- Existing reader/writer coverage tests unchanged and green; no pinned expectations in the suite shrank beyond the intended behavior.

## Verification

`go build`, `go vet` clean. Full `bootverify`, `contracts`, `cliapp` suites pass; full `pipeline` suite passes against Postgres. `pipeline` failures without a DSN are the pre-existing DSN-gated baseline (count identical with and without this change: 183).