### PR TITLE
feat: waive boot LLM credentials for fully mocked bundles

### DIFF
--- a/internal/runtime/runtime_claude_startup.go
+++ b/internal/runtime/runtime_claude_startup.go
@@ -42,6 +42,9 @@ func validateClaudeStartupConfig(ctx context.Context, cfg *config.Config, opts R
 	if !hasAgents {
 		return nil
 	}
+	if bundleFullyMocked(source) {
+		return nil
+	}
 	return validateClaudeStartupRequirements(ctx, cfg, opts)
 }
 
@@ -60,6 +63,9 @@ func validateClaudeStartupConfigForActiveAgents(ctx context.Context, cfg *config
 	if !hasAgents {
 		return nil
 	}
+	if bundleFullyMocked(source) {
+		return activeAgentMockConsistencyError(manager)
+	}
 	return validateClaudeStartupRequirements(ctx, cfg, opts)
 }
 
@@ -71,7 +77,10 @@ func validateSelectedBackendCredentialForDeclaredAgents(ctx context.Context, cfg
 	if !hasAgents {
 		return nil
 	}
-	return validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts))
+	if bundleFullyMocked(source) {
+		return nil
+	}
+	return enrichCredentialFailureWithMockCensus(validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts)), cfg, source)
 }
 
 func validateSelectedBackendModelAliasesForDeclaredAgents(cfg *config.Config, source semanticview.Source) error {
@@ -104,7 +113,10 @@ func validateSelectedBackendCredentialForActiveAgents(ctx context.Context, cfg *
 	if !hasAgents {
 		return nil
 	}
-	return validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts))
+	if bundleFullyMocked(source) {
+		return activeAgentMockConsistencyError(manager)
+	}
+	return enrichCredentialFailureWithMockCensus(validateSelectedBackendCredential(ctx, cfg, providerCredentialResolverForRuntimeOptions(opts)), cfg, source)
 }
 
 func validateSelectedBackendCredential(ctx context.Context, cfg *config.Config, credentials llm.ProviderCredentialResolver) error {
@@ -117,6 +129,79 @@ func validateSelectedBackendCredential(ctx context.Context, cfg *config.Config, 
 	}
 	_, err = credentials.Resolve(ctx, profile)
 	return err
+}
+
+// declaredAgentMockCensus is the single owner of the fully-mocked waiver fact:
+// every entry in the effective source agent registry is mock-configured. It
+// reports the mocked/total counts and the sorted unmocked agent ids.
+func declaredAgentMockCensus(source semanticview.Source) (mocked, total int, unmocked []string) {
+	if source == nil {
+		return 0, 0, nil
+	}
+	entries := source.AgentEntries()
+	total = len(entries)
+	for id, agent := range entries {
+		if agent.Mock.Configured() {
+			mocked++
+		} else {
+			unmocked = append(unmocked, strings.TrimSpace(id))
+		}
+	}
+	sort.Strings(unmocked)
+	return mocked, total, unmocked
+}
+
+// bundleFullyMocked reports whether every declared model agent in the bundle
+// carries a configured mock performance. A fully-mocked bundle can never
+// launch a provider turn, so boot provider-backend startup obligations are
+// waived for it (zero-credential testing affordance; production validity is
+// unchanged and mock mode still fails closed on real external surfaces).
+func bundleFullyMocked(source semanticview.Source) bool {
+	mocked, total, _ := declaredAgentMockCensus(source)
+	return total > 0 && mocked == total
+}
+
+// activeAgentMockConsistencyError enforces the waiver invariant at the
+// active-agents site: recovered and cloned agents are bundle-derived, so a
+// fully-mocked source must never observe a non-mock-configured active agent.
+// A divergence is corruption, not a case to handle; fail closed loudly rather
+// than silently falling back to credential gating.
+func activeAgentMockConsistencyError(manager *runtimemanager.AgentManager) error {
+	if manager == nil {
+		return nil
+	}
+	unmocked := make([]string, 0)
+	for _, agentCfg := range manager.ListAgentConfigs() {
+		if !agentCfg.Mock.Configured() {
+			unmocked = append(unmocked, strings.TrimSpace(agentCfg.ID))
+		}
+	}
+	sort.Strings(unmocked)
+	if len(unmocked) == 0 {
+		return nil
+	}
+	return fmt.Errorf("mock waiver invariant violation: bundle agents are fully mocked but active agents %s are not mock-configured", strings.Join(unmocked, ", "))
+}
+
+// enrichCredentialFailureWithMockCensus keeps the existing typed
+// provider_credential_missing failure and extends its message with the mock
+// census and unmocked agent names when the resolve fails with unmocked agents
+// present. Fully-mocked bundles never reach here (waived earlier).
+func enrichCredentialFailureWithMockCensus(err error, cfg *config.Config, source semanticview.Source) error {
+	if err == nil {
+		return nil
+	}
+	mocked, total, unmocked := declaredAgentMockCensus(source)
+	if len(unmocked) == 0 {
+		return err
+	}
+	envVar := ""
+	if cfg != nil {
+		if profile, profileErr := cfg.LLMBackendProfile(); profileErr == nil {
+			envVar = strings.TrimSpace(profile.Credential.EnvVar)
+		}
+	}
+	return fmt.Errorf("%w (%d of %d declared agents are mocked; unmocked: %s — mock them or provide %s)", err, mocked, total, strings.Join(unmocked, ", "), envVar)
 }
 
 func validateClaudeStartupRequirements(ctx context.Context, cfg *config.Config, opts RuntimeOptions) error {
@@ -167,6 +252,9 @@ func validateClaudeManagedAgentWorkspaces(ctx context.Context, cfg *config.Confi
 	}
 	if !hasAgents {
 		return nil
+	}
+	if bundleFullyMocked(source) {
+		return activeAgentMockConsistencyError(manager)
 	}
 	if workspaces == nil {
 		return fmt.Errorf("workspace lifecycle is required for claude cli runtime")
@@ -243,6 +331,9 @@ func ValidateManagedProviderPreflight(ctx context.Context, cfg *config.Config, s
 	}
 	if !hasAgents {
 		return nil, nil
+	}
+	if bundleFullyMocked(source) {
+		return nil, activeAgentMockConsistencyError(manager)
 	}
 	if err := authority.validate(); err != nil {
 		return nil, err

--- a/internal/runtime/runtime_mock_boot_waiver_boot_test.go
+++ b/internal/runtime/runtime_mock_boot_waiver_boot_test.go
@@ -1,0 +1,106 @@
+package runtime_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/config"
+	swarmruntime "github.com/division-sh/swarm/internal/runtime"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/worklifetime"
+	"github.com/division-sh/swarm/internal/runtime/mockperformance"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
+	"github.com/division-sh/swarm/internal/store/storetest"
+)
+
+func TestNewRuntime_FullyMockedBundleBootsWithoutCredential(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	processOwner := worklifetime.NewProcess()
+	t.Cleanup(processOwner.Retire)
+	store := storetest.StartSQLiteRuntimeStore(t)
+	rt, err := swarmruntime.NewRuntime(testAuthorActivityContext(context.Background()), swarmruntime.RuntimeDeps{
+		Config:                   cfg,
+		EffectsStore:             store,
+		CompletionStore:          store,
+		CompletionHeartbeatStore: store,
+		LiveSessionAcquirer:      store,
+		Options: swarmruntime.RuntimeOptions{
+			SelfCheck:         false,
+			WorkflowModule:    newRuntimeTestWorkflowModule(t, fullyMockedBootAgentMemorySource(t)),
+			BundleSourceFact:  authorActivityTestBundleSourceFact,
+			RuntimeInstanceID: authorActivityTestRuntimeInstanceID,
+			ProcessWorkOwner:  processOwner,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Shutdown() })
+}
+
+func TestNewRuntime_FullyMockedBundleBootsClaudeCLIWithoutCLIBinary(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "claude_cli"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	processOwner := worklifetime.NewProcess()
+	t.Cleanup(processOwner.Retire)
+	store := storetest.StartSQLiteRuntimeStore(t)
+	rt, err := swarmruntime.NewRuntime(testAuthorActivityContext(context.Background()), swarmruntime.RuntimeDeps{
+		Config:                   cfg,
+		EffectsStore:             store,
+		CompletionStore:          store,
+		CompletionHeartbeatStore: store,
+		LiveSessionAcquirer:      store,
+		Options: swarmruntime.RuntimeOptions{
+			SelfCheck:         false,
+			WorkflowModule:    newRuntimeTestWorkflowModule(t, fullyMockedBootAgentMemorySource(t)),
+			BundleSourceFact:  authorActivityTestBundleSourceFact,
+			RuntimeInstanceID: authorActivityTestRuntimeInstanceID,
+			ProcessWorkOwner:  processOwner,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime with claude_cli backend: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Shutdown() })
+}
+
+func fullyMockedBootAgentMemorySource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := canonicalrouting.CopyRuntimeAgentMemory(t, canonicalrouting.RuntimeAgentMemoryPackageBacked)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	ids := make([]string, 0, len(bundle.Agents))
+	for id := range bundle.Agents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	if len(ids) == 0 {
+		t.Fatal("agent memory fixture unexpectedly declares zero agents")
+	}
+	for id, entry := range bundle.Agents {
+		entry.Mock = mockperformance.Performance{
+			Kind:   "python",
+			Module: "mocks/" + id + ".py",
+			Source: []byte("def handle(input):\n    return {}\n"),
+			Digest: "sha256:" + strings.Repeat("a", 64),
+		}
+		bundle.Agents[id] = entry
+	}
+	return semanticview.Wrap(bundle)
+}

--- a/internal/runtime/runtime_mock_boot_waiver_test.go
+++ b/internal/runtime/runtime_mock_boot_waiver_test.go
@@ -1,0 +1,164 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/config"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	"github.com/division-sh/swarm/internal/runtime/mockperformance"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
+)
+
+func TestValidateSelectedBackendCredentialForDeclaredAgents_WaivesFullyMockedBundle(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	err := validateSelectedBackendCredentialForDeclaredAgents(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{
+		ProviderCredentials: testProviderCredentialStore(t, "ANTHROPIC_API_KEY", ""),
+	}, fullyMockedRuntimeAgentMemorySource(t))
+	if err != nil {
+		t.Fatalf("fully-mocked bundle must waive the boot credential requirement, got %v", err)
+	}
+}
+
+func TestValidateSelectedBackendCredentialForDeclaredAgents_NamesUnmockedAgents(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	err := validateSelectedBackendCredentialForDeclaredAgents(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{
+		ProviderCredentials: testProviderCredentialStore(t, "ANTHROPIC_API_KEY", ""),
+	}, partiallyMockedRuntimeAgentMemorySource(t, 1))
+	if err == nil {
+		t.Fatal("partially-mocked bundle must still require the credential")
+	}
+	failure, ok := runtimefailures.As(err)
+	if !ok || failure.Failure.Class != runtimefailures.ClassAuthenticationNeeded || failure.Failure.Detail.Code != "provider_credential_missing" {
+		t.Fatalf("error = %v, want typed provider_credential_missing preserved", err)
+	}
+	for _, want := range []string{"declared agents are mocked", "ANTHROPIC_API_KEY"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestValidateSelectedBackendCredentialForDeclaredAgents_UnmockedAgentWithCredentialPasses(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	err := validateSelectedBackendCredentialForDeclaredAgents(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{
+		ProviderCredentials: testProviderCredentialStore(t, "ANTHROPIC_API_KEY", "sk-test"),
+	}, partiallyMockedRuntimeAgentMemorySource(t, 1))
+	if err != nil {
+		t.Fatalf("unmocked agent with credential present must pass, got %v", err)
+	}
+}
+
+func TestValidateSelectedBackendCredentialForActiveAgents_MockWaiverInvariant(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	manager := runtimemanager.NewAgentManager(nil, nil)
+	if err := manager.SpawnAgent(runtimeactors.AgentConfig{
+		ExecutionMode: "live", ID: "recovered-agent", Role: "recovered",
+		Model: "regular", Config: json.RawMessage(`{"system_prompt":"Recovered agent"}`),
+	}); err != nil {
+		t.Fatalf("SpawnAgent: %v", err)
+	}
+
+	err := validateSelectedBackendCredentialForActiveAgents(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{}, fullyMockedRuntimeAgentMemorySource(t), manager)
+	if err == nil || !strings.Contains(err.Error(), "mock waiver invariant violation") || !strings.Contains(err.Error(), "recovered-agent") {
+		t.Fatalf("error = %v, want mock waiver invariant violation naming the active agent", err)
+	}
+}
+
+func TestValidateSelectedBackendCredentialForActiveAgents_MockWaiverAcceptsNoDivergentActiveAgents(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "anthropic"
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	manager := runtimemanager.NewAgentManager(nil, nil)
+
+	err := validateSelectedBackendCredentialForActiveAgents(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{}, fullyMockedRuntimeAgentMemorySource(t), manager)
+	if err != nil {
+		t.Fatalf("fully-mocked source with bundle-derived active agents must waive, got %v", err)
+	}
+}
+
+func TestValidateClaudeStartupConfig_WaivesFullyMockedBundle(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Backend = "claude_cli"
+	t.Setenv("SWARM_CLAUDE_USE_MCP", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_CONTAINER_URL", "")
+	t.Setenv("SWARM_TOOL_GATEWAY_TOKEN", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	err := validateClaudeStartupConfig(testAuthorActivityContext(context.Background()), cfg, RuntimeOptions{}, fullyMockedRuntimeAgentMemorySource(t))
+	if err != nil {
+		t.Fatalf("fully-mocked bundle must waive the claude startup chain, got %v", err)
+	}
+}
+
+func fullyMockedRuntimeAgentMemorySource(t *testing.T) semanticview.Source {
+	t.Helper()
+	return mockAgentMemorySource(t, 0)
+}
+
+func partiallyMockedRuntimeAgentMemorySource(t *testing.T, unmockedCount int) semanticview.Source {
+	t.Helper()
+	return mockAgentMemorySource(t, unmockedCount)
+}
+
+// mockAgentMemorySource loads the package-backed agent memory fixture and
+// configures a mock performance on every declared agent except the first
+// (sorted) unmockedCount entries, which stay live so the partial-mock paths
+// are exercised against real fixture agent ids.
+func mockAgentMemorySource(t *testing.T, unmockedCount int) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := canonicalrouting.CopyRuntimeAgentMemory(t, canonicalrouting.RuntimeAgentMemoryPackageBacked)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	sortedIDs := make([]string, 0, len(bundle.Agents))
+	for id := range bundle.Agents {
+		sortedIDs = append(sortedIDs, id)
+	}
+	sort.Strings(sortedIDs)
+	if len(sortedIDs) == 0 {
+		t.Fatal("agent memory fixture unexpectedly declares zero agents")
+	}
+	if unmockedCount > len(sortedIDs) {
+		unmockedCount = len(sortedIDs)
+	}
+	unmocked := map[string]struct{}{}
+	for _, id := range sortedIDs[:unmockedCount] {
+		unmocked[id] = struct{}{}
+	}
+	for id, entry := range bundle.Agents {
+		if _, skip := unmocked[id]; skip {
+			continue
+		}
+		entry.Mock = mockperformance.Performance{
+			Kind:   "python",
+			Module: "mocks/" + id + ".py",
+			Source: []byte("def handle(input):\n    return {}\n"),
+			Digest: "sha256:" + strings.Repeat("a", 64),
+		}
+		bundle.Agents[id] = entry
+	}
+	return semanticview.Wrap(bundle)
+}


### PR DESCRIPTION
Closes #2172

## Problem

A bundle whose agents are all mocked still refused to boot without a live LLM credential (e.g. `ANTHROPIC_API_KEY`), forcing the dummy-key workaround. Zero-credential testing (the E3 wedge) was unreachable.

## Design rulings (review, 2026-08-07)

- **Q1 — one predicate owner**: the waiver fact ("this bundle is fully mocked") is owned by ONE predicate — every entry in `source.AgentEntries()` is `Mock.Configured()` — consumed by both boot sites. At the active-agents site the predicate is verified, never re-derived: if the source is fully mocked but any active agent config is not mock-configured, that is an invariant violation → fail closed loudly naming the agent (recovered/ephemeral agents are bundle-derived; divergence is corruption, not a case to handle).
- **Q2 — waiver covers the WHOLE backend startup chain**: with zero unmocked agents no provider turn can ever occur, so all provider-backend startup obligations are waived, backend-agnostic — credential resolve, Claude CLI probe, tool-gateway binding, MCP bridge, workspaces, managed-provider preflight. Mock mode still fails closed on any attempt to reach real external surfaces (#2075). Load-bearing for #2168: the golden bundle boots with `claude_cli` config and no CLI binary in CI.
- **Q3 — enrich the EXISTING typed failure; no new code**: `provider_credential_missing` is unchanged and its message gains the mock census — "N of M declared agents are mocked; unmocked: x, y — mock them or provide <env var>" — with sorted unmocked agent names.
- **Q4 — runtime-level proof here**: `NewRuntime` succeeds with a fully-mocked bundle and empty credential env/store (anthropic + claude_cli-with-no-CLI variants); unit tests at both validate sites; the negative enriches the typed failure. The serve-level zero-credential E2E is #2168's proof obligation (claim registered there).

## Implementation

- `declaredAgentMockCensus` / `bundleFullyMocked` — the single waiver predicate owner (effective source agent registry).
- `activeAgentMockConsistencyError` — the active-site invariant check.
- `enrichCredentialFailureWithMockCensus` — keeps the typed failure, adds census + env var context.
- Waivers at: `validateSelectedBackendCredentialForDeclaredAgents`, `validateSelectedBackendCredentialForActiveAgents`, `validateClaudeStartupConfig`, `validateClaudeStartupConfigForActiveAgents`, `validateClaudeManagedAgentWorkspaces`, `ValidateManagedProviderPreflight`.

## Tests (8 new)

- Fully-mocked bundle waives at the declared site (empty store, no env).
- Partially-mocked bundle fails with the typed `provider_credential_missing` + census naming unmocked agents + env var.
- Unmocked agents + credential present → passes (live behavior unchanged).
- Active site: invariant violation names the divergent active agent; bundle-derived active set waives.
- Claude chain: fully-mocked bundle waives with no CLI env/gateway.
- Boot: `NewRuntime` succeeds with fully-mocked bundle, empty credentials, anthropic backend; and with `claude_cli` backend + no CLI binary (SQLite runtime store).

## Verification

`go build`, `go vet` clean; full `internal/runtime` and `internal/runtime/llm` suites pass against Postgres. DSN-less failures are the pre-existing gated baseline.