### PR TITLE
test: pin incompatible-schema boot teaching error at the serve surface

### DIFF
--- a/internal/serveapp/schema_boot_teaching_error_test.go
+++ b/internal/serveapp/schema_boot_teaching_error_test.go
@@ -1,0 +1,95 @@
+package serveapp
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/cliapp"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
+	"github.com/division-sh/swarm/internal/store"
+	"github.com/division-sh/swarm/internal/testutil"
+)
+
+// TestServeBootLegacySchemaRendersTeachingError proves the #995 teaching-error
+// half at the boot surface: state-store initialization against an older
+// schema (legacy timers table missing run_id) fails closed with the typed
+// SchemaCompatibilityError text — both versions, drift evidence, fresh-store
+// remediation — and never surfaces raw driver text.
+func TestServeBootLegacySchemaRendersTeachingError(t *testing.T) {
+	repo := cliapp.RepoRoot()
+	root := canonicalrouting.ExampleRoot(t, canonicalrouting.HarnessInjection)
+	loaded, err := loadServeRuntimeBundle(context.Background(), repo, storeBundle{}, cliapp.CLIContractPlatformSpecPaths{
+		ContractsPath: root, PlatformSpecPath: runtimecontracts.DefaultPlatformSpecFile(repo),
+	}, cliapp.ServeOptions{})
+	if err != nil {
+		t.Fatalf("loadServeRuntimeBundle: %v", err)
+	}
+	loaded.bundleSourceFact = mustServeTestEphemeralBundleSourceFact(loaded.bootIdentity.BundleHash)
+	cfg, err := cliapp.DefaultRuntimeConfig()
+	if err != nil {
+		t.Fatalf("DefaultRuntimeConfig: %v", err)
+	}
+	request := serveRuntimeBundleContextRequest{
+		Ctx:              context.Background(),
+		Loaded:           loaded,
+		Config:           cfg,
+		WorkspaceBackend: cliapp.WorkspaceBackendSelection{Backend: cliapp.WorkspaceBackendNone, NoWorkspace: true, Source: "test"},
+		BootStartedAt:    time.Now().UTC(),
+	}
+
+	t.Run("postgres", func(t *testing.T) {
+		_, pg, cleanup := testutil.StartEmptyPostgres(t)
+		t.Cleanup(cleanup)
+		if _, err := pg.Exec(`CREATE TABLE timers (timer_id TEXT PRIMARY KEY, due_at TIMESTAMPTZ NOT NULL)`); err != nil {
+			t.Fatalf("create legacy timers table: %v", err)
+		}
+		pgStore := &store.PostgresStore{DB: pg}
+		request.Stores = storeBundle{Postgres: pgStore, SQLDB: pg, RuntimeSQLDB: pg, Database: pgStore, SchemaBootstrapper: pgStore}
+
+		_, err := buildServeRuntimeBundleContext(request)
+		assertLegacySchemaTeachingBootError(t, "postgres", err, "create and select a fresh PostgreSQL database")
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "legacy-timers.db")
+		sqliteStore, err := store.NewSQLiteRuntimeStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = sqliteStore.Close() })
+		if _, err := sqliteStore.DB.Exec(`CREATE TABLE timers (timer_id TEXT PRIMARY KEY, due_at TIMESTAMP NOT NULL)`); err != nil {
+			t.Fatalf("create legacy timers table: %v", err)
+		}
+		request.Stores = storeBundle{SQLDB: sqliteStore.DB, RuntimeSQLDB: sqliteStore.DB, Database: sqliteStore, SchemaBootstrapper: sqliteStore}
+
+		_, err = buildServeRuntimeBundleContext(request)
+		assertLegacySchemaTeachingBootError(t, "sqlite", err, "rm -f --")
+	})
+}
+
+func assertLegacySchemaTeachingBootError(t *testing.T, backend string, err error, remediation string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s boot against a legacy timers table succeeded; want fail-closed incompatible-schema error", backend)
+	}
+	for _, want := range []string{
+		"incompatible with Swarm",
+		"platform",
+		"missing column timers.run_id",
+		"stored origin",
+		remediation,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("%s boot error missing %q:\n%v", backend, want, err)
+		}
+	}
+	for _, forbidden := range []string{"pq:", "sql:", "driver:", "Syntax error"} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("%s boot error surfaced raw driver text %q:\n%v", backend, forbidden, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #995 (already closed via disposition comment; this PR ships the proof that was the closing condition).

## Scope (per the 2026-08-09 ruling)

#995's teaching-error half was already shipped by #2003/#2014 (`SchemaCompatibilityError`, verdict-first before any DDL, no bypass via state plans, backend-specific fresh-store remediation). The remaining scope was the **boot-surface proof only**: nothing pinned the guarantee where the user sees it.

## Change

`TestServeBootLegacySchemaRendersTeachingError` (serveapp) drives the serve boot state-store initialization (`buildServeRuntimeBundleContext` → `initializeStateStores` → `BootstrapSchema`) against hand-shaped legacy databases — the probe recipe from the ruling:

- **Postgres** (`StartEmptyPostgres` + legacy `timers` missing `run_id`): boot error contains both versions (`incompatible with Swarm ... / platform ...`), drift evidence (`missing column timers.run_id`), stored-origin line, and the `createdb swarm_fresh` remediation.
- **SQLite** (legacy `timers` in a fresh file): same assertions with the `rm -f -- ... -wal -shm` remediation.
- Both variants assert the **absence** of raw driver text (`pq:`, `sql:`, `driver:`, `Syntax error`).

## Tracker actions (per the ruling)

- #995 **closed** with a disposition comment (teaching half proven; migration path policy-retired pre-1.0 under the fresh-store doctrine).
- Icebox successor **#2187** filed: "Schema migration policy at 1.0 — reopen trigger" (one paragraph, citing #995's history).
- Claim registered in the **#2143** registry: "incompatible-schema boot renders the teaching error" with this test as its proof.

## Verification

`go build`, `go vet` clean; full `serveapp` and `store` suites pass against Postgres.