### PR TITLE
fix: require record_evidence evidence_target with declared-target teaching error

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1151,8 +1151,118 @@ func TestRun_ReportsRecordEvidenceMissingEvidenceTarget(t *testing.T) {
 
 	report := Run(context.Background(), source, Options{})
 
-	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target") {
+	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target; declared evidence targets in flow root: none") {
 		t.Fatalf("expected handler_field_compliance error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsRecordEvidenceMissingTargetNamesDeclaredFlowTargetsSorted(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.completed": {
+						Action: runtimecontracts.ActionSpec{ID: "record_evidence"},
+					},
+				},
+			},
+			"node-b": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.approved": {
+						Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+						EvidenceTarget: "zeta_evidence",
+					},
+				},
+			},
+			"node-c": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.rejected": {
+						Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+						EvidenceTarget: "alpha_evidence",
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target; declared evidence targets in flow root: alpha_evidence, zeta_evidence") {
+		t.Fatalf("expected sorted declared-targets teaching error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_ReportsRuleRecordEvidenceMissingTargetNamesDeclaredFlowTargets(t *testing.T) {
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"node-a": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.completed": {
+						Rules: []runtimecontracts.HandlerRuleEntry{{
+							ID:     "approve",
+							Action: runtimecontracts.ActionSpec{ID: "record_evidence"},
+						}},
+					},
+				},
+			},
+			"node-b": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.approved": {
+						Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+						EvidenceTarget: "build_evidence",
+					},
+				},
+			},
+		},
+	})
+
+	report := Run(context.Background(), source, Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target; declared evidence targets in flow root: build_evidence") {
+		t.Fatalf("expected rule-branch teaching error, got %#v", report.Errors())
+	}
+}
+
+func TestRun_RecordEvidenceMissingTargetDoesNotLeakOtherFlowTargets(t *testing.T) {
+	child := runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
+		Path:  "child",
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"child-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.completed": {
+						Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
+						EvidenceTarget: "child_evidence",
+					},
+				},
+			},
+		},
+	}
+	root := runtimecontracts.FlowContractView{
+		Nodes: map[string]runtimecontracts.SystemNodeContract{
+			"root-node": {
+				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+					"task.completed": {
+						Action: runtimecontracts.ActionSpec{ID: "record_evidence"},
+					},
+				},
+			},
+		},
+		Children: []runtimecontracts.FlowContractView{child},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{"child": &root.Children[0]},
+		},
+		Nodes:  root.Nodes,
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{},
+	}
+
+	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+
+	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target; declared evidence targets in flow root: none") {
+		t.Fatalf("expected flow-scoped teaching error without sibling-flow leakage, got %#v", report.Errors())
 	}
 }
 

--- a/internal/runtime/bootverify/workflow_handler_contract_checks.go
+++ b/internal/runtime/bootverify/workflow_handler_contract_checks.go
@@ -105,7 +105,8 @@ func handlerRuleContext(prefix string, idx int, id string) string {
 	return fmt.Sprintf("%s[%d]", prefix, idx)
 }
 
-func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {	actionID := strings.TrimSpace(action.ID)
+func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {
+	actionID := strings.TrimSpace(action.ID)
 	if actionID == "" {
 		return nil
 	}

--- a/internal/runtime/bootverify/workflow_handler_contract_checks.go
+++ b/internal/runtime/bootverify/workflow_handler_contract_checks.go
@@ -3,6 +3,7 @@ package bootverify
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -104,8 +105,7 @@ func handlerRuleContext(prefix string, idx int, id string) string {
 	return fmt.Sprintf("%s[%d]", prefix, idx)
 }
 
-func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {
-	actionID := strings.TrimSpace(action.ID)
+func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, evidenceTarget string, action runtimecontracts.ActionSpec) []Finding {	actionID := strings.TrimSpace(action.ID)
 	if actionID == "" {
 		return nil
 	}
@@ -126,7 +126,7 @@ func (c *checkerContext) validateWorkflowActionSpec(nodeID, eventContext, eviden
 		}
 	case "record_evidence":
 		if strings.TrimSpace(evidenceTarget) == "" {
-			findings = append(findings, handlerActionFinding(nodeID, eventContext, "record_evidence is missing evidence_target"))
+			findings = append(findings, handlerActionFinding(nodeID, eventContext, recordEvidenceMissingTargetMessage(c, nodeID)))
 		}
 	case "mailbox_write":
 		if action.Mailbox == nil {
@@ -172,6 +172,54 @@ func handlerActionFinding(nodeID, eventContext, message string) Finding {
 		Message:  fmt.Sprintf("node %s handler %s %s", nodeID, eventContext, message),
 		Location: nodeID,
 	}
+}
+
+// recordEvidenceMissingTargetMessage is the teaching error for an omitted
+// record_evidence.evidence_target: evidence_target is required (no default),
+// and the message names the declared evidence targets in the same flow so the
+// author sees what the flow already writes.
+func recordEvidenceMissingTargetMessage(c *checkerContext, nodeID string) string {
+	flowID := nodeFlowID(c.source, nodeID)
+	declared := c.declaredEvidenceTargetsForFlow(flowID)
+	flow := defaultFlowLabel(flowID)
+	if len(declared) == 0 {
+		return fmt.Sprintf("record_evidence is missing evidence_target; declared evidence targets in flow %s: none", flow)
+	}
+	return fmt.Sprintf("record_evidence is missing evidence_target; declared evidence targets in flow %s: %s", flow, strings.Join(declared, ", "))
+}
+
+// declaredEvidenceTargetsForFlow returns the sorted set of evidence_target
+// values declared by record_evidence actions (handler-level or rule-level) in
+// the given flow. Rules share their handler's evidence_target.
+func (c *checkerContext) declaredEvidenceTargetsForFlow(flowID string) []string {
+	declared := map[string]struct{}{}
+	for nodeID, node := range c.source.NodeEntries() {
+		if nodeFlowID(c.source, nodeID) != flowID {
+			continue
+		}
+		for _, handler := range node.EventHandlers {
+			target := strings.TrimSpace(handler.EvidenceTarget)
+			if target == "" {
+				continue
+			}
+			if normalizeWorkflowBuiltinActionID(strings.TrimSpace(handler.Action.ID)) == "record_evidence" {
+				declared[target] = struct{}{}
+				continue
+			}
+			for _, rule := range handler.Rules {
+				if normalizeWorkflowBuiltinActionID(strings.TrimSpace(rule.Action.ID)) == "record_evidence" {
+					declared[target] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(declared))
+	for target := range declared {
+		out = append(out, target)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func supportedWorkflowRuntimeExecutorIDs(source semanticview.Source) map[string]struct{} {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -3931,8 +3931,10 @@ handler_specification:
         its node declared.'
       limitation: 'All-or-nothing. Selective gate clearing (clear_gates: [gate_a]) is a potential v1.3 feature.'
     evidence_target:
-      description: Specifies which accumulator key the evidence is appended to when action is record_evidence. If omitted,
-        defaults to the node ID. Explicit declaration is recommended for clarity.
+      description: Specifies which accumulator key the evidence is appended to when action is record_evidence. Required
+        when the handler action (or a selected handler.rules branch action) is record_evidence; there is no default.
+        Omitted evidence_target is a contract error rejected by boot verification with a teaching error naming the field
+        and the declared evidence targets in the same flow.
       type: string
       example: build_evidence
   expression_context:
@@ -7921,7 +7923,9 @@ tool_model:
         They are listed separately from the tool catalog because agents cannot call them directly.
       actions:
         create_flow_instance: Create a new dynamic flow instance from a template.
-        record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler.
+        record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler; there is no
+          default — omitted evidence_target is a contract error rejected by boot verification with a teaching error naming
+          the field and the declared evidence targets in the same flow.
         mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler-without-rules
           or selected handler.rules branch action only.
         artifact_repo_commit: Deterministically commit allowlisted service-owned artifact files to a local git repository,


### PR DESCRIPTION
Closes #1432

## Problem

The spec contradicted itself: `action_fields.evidence_target` said omitted `evidence_target` "defaults to the node ID", while `handler_actions.record_evidence` required the field — and boot verification always enforced the required interpretation (the "default" behavior never existed; the runtime never defaults either). This was spec-drift correction plus message enrichment, not a behavior change.

## Design rulings (review, 2026-08-09)

- `evidence_target` is REQUIRED, no default (canonical form only, no compatibility default) — same doctrine as payload-field guessing and #1788 bare scalars.
- The teaching error names the field and the **declared evidence targets in the same flow** (sorted; `none` when a flow's first evidence writer omits it). Evidence buckets are free-form keys (verified), so flow-sibling declarations are the only meaningful in-scope set — the teaching value is the misspelled/forgotten-target case.
- The runtime's defensive message stays bare: it is a post-verify invariant safety net, not the teaching surface; verify is the teaching boundary.

## Change

- **Spec**: `action_fields.evidence_target` and `handler_actions.record_evidence` now agree verbatim — required, no default, verify rejects omission with a teaching error naming the field and the declared targets in the same flow.
- **Verify**: `validateWorkflowActionSpec`'s single finding (shared by handler-level and handler.rules branch paths) now renders `record_evidence is missing evidence_target; declared evidence targets in flow <flow>: <sorted list | none>`, with targets collected from sibling handlers/rules in the same flow (`declaredEvidenceTargetsForFlow`, sorted for determinism).

## Tests (4 bootverify)

- `TestRun_ReportsRecordEvidenceMissingEvidenceTarget` — `none` form (flow's first evidence writer gets a truthful empty answer).
- `TestRun_ReportsRecordEvidenceMissingTargetNamesDeclaredFlowTargetsSorted` — two out-of-order target-declaring handlers → sorted `alpha_evidence, zeta_evidence`.
- `TestRun_ReportsRuleRecordEvidenceMissingTargetNamesDeclaredFlowTargets` — rule-branch `record_evidence` with the handler omitting the target → names the flow's declared target.
- `TestRun_RecordEvidenceMissingTargetDoesNotLeakOtherFlowTargets` — a sibling flow's declared target does not leak into the root flow's teaching error (flow scoping).

## Verification

`go build`, `go vet` clean; full `bootverify`, `contracts`, `apispec`, `cliapp` suites pass; `pipeline` full pass against Postgres (DSN-less failures are the pre-existing baseline).