### PR TITLE
fix: make evidence-target flow scoping proof load-bearing (revision of #2189)

### DIFF
--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -1224,46 +1224,73 @@ func TestRun_ReportsRuleRecordEvidenceMissingTargetNamesDeclaredFlowTargets(t *t
 }
 
 func TestRun_RecordEvidenceMissingTargetDoesNotLeakOtherFlowTargets(t *testing.T) {
-	child := runtimecontracts.FlowContractView{
-		Paths: runtimecontracts.FlowContractPaths{ID: "child", Flow: "child", PackageKey: "flows/child"},
-		Path:  "child",
-		Nodes: map[string]runtimecontracts.SystemNodeContract{
-			"child-node": {
-				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"task.completed": {
-						Action:         runtimecontracts.ActionSpec{ID: "record_evidence"},
-						EvidenceTarget: "child_evidence",
-					},
-				},
-			},
-		},
-	}
-	root := runtimecontracts.FlowContractView{
-		Nodes: map[string]runtimecontracts.SystemNodeContract{
-			"root-node": {
-				EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
-					"task.completed": {
-						Action: runtimecontracts.ActionSpec{ID: "record_evidence"},
-					},
-				},
-			},
-		},
-		Children: []runtimecontracts.FlowContractView{child},
-	}
-	bundle := &runtimecontracts.WorkflowContractBundle{
-		FlowTree: runtimecontracts.FlowTree{
-			Root: &root,
-			ByID: map[string]*runtimecontracts.FlowContractView{"child": &root.Children[0]},
-		},
-		Nodes:  root.Nodes,
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{},
-	}
+	bundle := loadFixtureBundleAt(t, repoRootForBootverifyTest(t), writeEvidenceLeakProofFixture(t), runtimecontracts.DefaultPlatformSpecFile(repoRootForBootverifyTest(t)))
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
 	if !reportContains(report.Errors(), "handler_field_compliance", "record_evidence is missing evidence_target; declared evidence targets in flow root: none") {
 		t.Fatalf("expected flow-scoped teaching error without sibling-flow leakage, got %#v", report.Errors())
 	}
+}
+
+// writeEvidenceLeakProofFixture writes a real two-flow bundle: a root node
+// whose record_evidence omits evidence_target and a child-flow node whose
+// record_evidence declares one. The fixture loads through the production
+// loader so nodeSources attribution is real and the flow-scoping filter is
+// load-bearing (deleting it must fail the leak test).
+func writeEvidenceLeakProofFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: evidence-leak-proof
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: child
+    flow: child
+    mode: static
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), `
+name: evidence-leak-proof
+initial_state: collecting
+terminal_states: [done]
+states: [collecting, done]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "events.yaml"), `
+evidence.requested:
+  finding: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+root-node:
+  id: root-node
+  execution_type: system_node
+  subscribes_to: [evidence.requested]
+  event_handlers:
+    evidence.requested:
+      action: record_evidence
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "schema.yaml"), `
+name: child
+mode: static
+states: [ready]
+initial_state: ready
+terminal_states: [ready]
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "events.yaml"), `
+child.evidence:
+  finding: string
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "child", "nodes.yaml"), `
+child-node:
+  id: child-node
+  execution_type: system_node
+  subscribes_to: [child.evidence]
+  event_handlers:
+    child.evidence:
+      action: record_evidence
+      evidence_target: child_evidence
+`)
+	return root
 }
 
 func TestRun_ReportsMailboxWriteMissingMailboxSpec(t *testing.T) {

--- a/internal/runtime/bootverify/workflow_handler_contract_checks.go
+++ b/internal/runtime/bootverify/workflow_handler_contract_checks.go
@@ -3,7 +3,6 @@ package bootverify
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -180,13 +179,12 @@ func handlerActionFinding(nodeID, eventContext, message string) Finding {
 // and the message names the declared evidence targets in the same flow so the
 // author sees what the flow already writes.
 func recordEvidenceMissingTargetMessage(c *checkerContext, nodeID string) string {
-	flowID := nodeFlowID(c.source, nodeID)
-	declared := c.declaredEvidenceTargetsForFlow(flowID)
-	flow := defaultFlowLabel(flowID)
-	if len(declared) == 0 {
-		return fmt.Sprintf("record_evidence is missing evidence_target; declared evidence targets in flow %s: none", flow)
+	declared := c.declaredEvidenceTargetsForFlow(nodeFlowID(c.source, nodeID))
+	targets := "none"
+	if len(declared) > 0 {
+		targets = strings.Join(declared, ", ")
 	}
-	return fmt.Sprintf("record_evidence is missing evidence_target; declared evidence targets in flow %s: %s", flow, strings.Join(declared, ", "))
+	return fmt.Sprintf("record_evidence is missing evidence_target; declared evidence targets in flow %s: %s", defaultFlowLabel(nodeFlowID(c.source, nodeID)), targets)
 }
 
 // declaredEvidenceTargetsForFlow returns the sorted set of evidence_target
@@ -215,12 +213,7 @@ func (c *checkerContext) declaredEvidenceTargetsForFlow(flowID string) []string 
 			}
 		}
 	}
-	out := make([]string, 0, len(declared))
-	for target := range declared {
-		out = append(out, target)
-	}
-	sort.Strings(out)
-	return out
+	return sortedSetKeys(declared)
 }
 
 func supportedWorkflowRuntimeExecutorIDs(source semanticview.Source) map[string]struct{} {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -7923,9 +7923,9 @@ tool_model:
         They are listed separately from the tool catalog because agents cannot call them directly.
       actions:
         create_flow_instance: Create a new dynamic flow instance from a template.
-        record_evidence: Append payload to entity accumulator. Requires evidence_target field on the handler; there is no
-          default — omitted evidence_target is a contract error rejected by boot verification with a teaching error naming
-          the field and the declared evidence targets in the same flow.
+        record_evidence: Append payload to entity accumulator. Required when the handler action (or a selected handler.rules
+          branch action) is record_evidence; there is no default. Omitted evidence_target is a contract error rejected by
+          boot verification with a teaching error naming the field and the declared evidence targets in the same flow.
         mailbox_write: Deterministically materialize authored mailbox request events into public.mailbox. Handler-without-rules
           or selected handler.rules branch action only.
         artifact_repo_commit: Deterministically commit allowlisted service-owned artifact files to a local git repository,


### PR DESCRIPTION
Revision of #2189 per the review-lead follow-up (PR-2118 cycle-6 lesson: a proof that can't fail proves nothing).

## 1. The leak test was vacuous — now load-bearing (mutation-verified)

The `DoesNotLeakOtherFlowTargets` fixture populated `bundle.Nodes`, so `NodeEntries()` never surfaced the child-flow node — deleting the flow-scoping filter left all tests green. The revision replaces the hand-built bundle with a **real two-flow fixture loaded through the production loader** (`writeEvidenceLeakProofFixture` + `loadFixtureBundleAt`), so `nodeSources` attribution is real and the filter is exercised. Mutation-verified: deleting the filter now **fails the test** with exactly the expected leak (`declared evidence targets in flow root: child_evidence`).

## 2. Spec sites verbatim

Both sites now carry the identical full clause including the rule-branch case: "Required when the handler action (or a selected handler.rules branch action) is record_evidence; there is no default. Omitted evidence_target is a contract error rejected by boot verification with a teaching error naming the field and the declared evidence targets in the same flow." — `action_fields.evidence_target` and `handler_actions.record_evidence` agree verbatim.

## 3. Flattened-bundle census

Census result: **no production load path yields multi-flow Nodes without `nodeSources` entries.** `mergeNodeContracts` (workflow_contract_merging.go) flattens every node (project + flow) into `bundle.Nodes` WITH a `nodeSources` entry carrying the FlowID attribution, so `NodeContractSource` always resolves flow attribution for loaded bundles. The unattributable pattern (flow nodes without `nodeSources`, `nodeFlowID` returning "") is **fixture-only** (hand-built bundles bypassing the loader). No fail-closed posture is required for the collector.

## 4. Cleanups

- `recordEvidenceMissingTargetMessage`: single `Sprintf` with a `targets` list variable (kills the two-branch divergence risk the exact-string tests would otherwise entrench).
- `declaredEvidenceTargetsForFlow`: returns the existing package helper `sortedSetKeys(declared)` instead of the manual sort.

## Verification

Mutation check (filter deletion → test fails with the exact leak) documented above; `go build`, `go vet`, gofmt clean; full `bootverify`, `contracts`, `apispec`, `cliapp` suites pass; `pipeline` full pass against Postgres.