### PR TITLE
feat: make enum defaults explicit instead of order-dependent

### DIFF
--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -85,7 +85,7 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 			h.Join.Remaining = runtimecontracts.JoinRemainingIgnore
 		}, wantError: "no matching overload"},
 		{name: "custom completion preserves enum result", mutate: func(h *runtimecontracts.SystemNodeEventHandler, bundle *runtimecontracts.WorkflowContractBundle) {
-			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Enums: map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}}}}
+			bundle.RootTypes = runtimecontracts.TypeCatalogDocument{Enums: map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}, Default: "accept"}}}
 			event := bundle.Events["item.completed"]
 			event.Payload.Properties["result"] = runtimecontracts.EventFieldSpec{Type: "Decision"}
 			bundle.Events["item.completed"] = event

--- a/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
+++ b/internal/runtime/bootverify/workflow_node_state_schema_checks_test.go
@@ -89,7 +89,7 @@ func TestRun_AllowsDeclaredNodeStateNamedType(t *testing.T) {
 func TestRun_AllowsDeclaredNodeStateScalarAndEnumRefs(t *testing.T) {
 	bundle := nodeStateSchemaTypingBundle()
 	bundle.RootTypes.Scalars["ScoreID"] = runtimecontracts.ScalarTypeDecl{Base: "text"}
-	bundle.RootTypes.Enums["ScoreStatus"] = runtimecontracts.EnumTypeDecl{Values: []string{"ready", "done"}}
+	bundle.RootTypes.Enums["ScoreStatus"] = runtimecontracts.EnumTypeDecl{Values: []string{"ready", "done"}, Default: "ready"}
 	bundle.Nodes["scoring-node"] = runtimecontracts.SystemNodeContract{
 		ID:         "scoring-node",
 		StateTable: "scoring_state",

--- a/internal/runtime/bootverify/workflow_stage_gate_input_types_test.go
+++ b/internal/runtime/bootverify/workflow_stage_gate_input_types_test.go
@@ -159,7 +159,7 @@ func TestStageGateLiteralEmitConsumesExactResolvedEventFieldSchema(t *testing.T)
 		{name: "uuid format", field: runtimecontracts.EventFieldSpec{Type: "uuid"}, valid: "17e1d38a-ed95-49e7-a5e9-6421e15aa503", invalid: "card-1", wantDetail: "must be uuid"},
 		{
 			name: "enum", field: runtimecontracts.EventFieldSpec{Type: "ReviewMode"}, valid: "fast", invalid: "slow", wantDetail: "enum",
-			rootTypes: runtimecontracts.TypeCatalogDocument{Enums: map[string]runtimecontracts.EnumTypeDecl{"ReviewMode": {Values: []string{"fast", "deep"}}}},
+			rootTypes: runtimecontracts.TypeCatalogDocument{Enums: map[string]runtimecontracts.EnumTypeDecl{"ReviewMode": {Values: []string{"fast", "deep"}, Default: "fast"}}},
 		},
 		{
 			name: "pattern", field: runtimecontracts.EventFieldSpec{Type: "text", Refinements: runtimecontracts.SchemaRefinements{Pattern: "^[a-z]+$"}},

--- a/internal/runtime/contracts/schema_registry_test.go
+++ b/internal/runtime/contracts/schema_registry_test.go
@@ -346,7 +346,7 @@ func TestEventSchemaRegistryFromBundle_PreservesWave1TypeMeaning(t *testing.T) {
 		flowTypes: map[string]TypeCatalogDocument{
 			"review": {
 				Enums: map[string]EnumTypeDecl{
-					"Mode": {Values: []string{"fast", "deep"}},
+					"Mode": {Values: []string{"fast", "deep"}, Default: "fast"},
 				},
 			},
 		},
@@ -432,7 +432,7 @@ func TestEventSchemaForFlowEvent_UsesDeclaringFlowTypeCatalogForOverride(t *test
 	bundle := &WorkflowContractBundle{
 		RootTypes: TypeCatalogDocument{
 			Enums: map[string]EnumTypeDecl{
-				"Priority": {Values: []string{"low"}},
+				"Priority": {Values: []string{"low"}, Default: "low"},
 			},
 		},
 		FlowTree: FlowTree{
@@ -444,7 +444,7 @@ func TestEventSchemaForFlowEvent_UsesDeclaringFlowTypeCatalogForOverride(t *test
 		flowTypes: map[string]TypeCatalogDocument{
 			"review": {
 				Enums: map[string]EnumTypeDecl{
-					"Priority": {Values: []string{"urgent"}},
+					"Priority": {Values: []string{"urgent"}, Default: "urgent"},
 				},
 			},
 		},

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -1186,6 +1187,26 @@ type ScalarTypeDecl struct {
 type EnumTypeDecl struct {
 	Values  []string `yaml:"values"`
 	Default string   `yaml:"default"`
+}
+
+// Validate enforces the explicit-default enum invariant: every enum declares
+// its members and an explicit default member (#1532). It is the shared
+// invariant owner called from the catalog decode loop and the runtime default
+// guard, so the loader verdict and the runtime verdict can never diverge.
+// Each defect has a distinct message naming the offending value or the
+// declared members as appropriate.
+func (e EnumTypeDecl) Validate(name string) error {
+	name = strings.TrimSpace(name)
+	if len(e.Values) == 0 {
+		return fmt.Errorf("enum %s is declared without values; declare the mapping form {values: [...], default: <member>}", name)
+	}
+	if strings.TrimSpace(e.Default) == "" {
+		return fmt.Errorf("enum %s has no declared default; add default: %s to preserve current behavior", name, e.Values[0])
+	}
+	if !slices.Contains(e.Values, strings.TrimSpace(e.Default)) {
+		return fmt.Errorf("enum %s default %q is not a declared member; declared members: %s", name, e.Default, strings.Join(e.Values, ", "))
+	}
+	return nil
 }
 
 type NamedTypeDecl struct {

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1184,7 +1184,8 @@ type ScalarTypeDecl struct {
 }
 
 type EnumTypeDecl struct {
-	Values []string `yaml:"-"`
+	Values  []string `yaml:"values"`
+	Default string   `yaml:"default"`
 }
 
 type NamedTypeDecl struct {

--- a/internal/runtime/contracts/workflow_contract_wave1_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_wave1_accessors.go
@@ -704,7 +704,7 @@ func cloneTypeCatalogDocument(in TypeCatalogDocument) TypeCatalogDocument {
 	if len(in.Enums) > 0 {
 		out.Enums = make(map[string]EnumTypeDecl, len(in.Enums))
 		for key, value := range in.Enums {
-			out.Enums[key] = EnumTypeDecl{Values: append([]string{}, value.Values...)}
+			out.Enums[key] = EnumTypeDecl{Values: append([]string{}, value.Values...), Default: value.Default}
 		}
 	}
 	if len(in.Types) > 0 {

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -4026,3 +4026,27 @@ func TestTypeCatalogDecode_RejectsNullEnumEntry(t *testing.T) {
 		t.Fatalf("null enum entry error = %v, want load-time teaching rejection", err)
 	}
 }
+
+func TestTypeCatalogDecode_RejectsEmptyEnumKey(t *testing.T) {
+	var catalog TypeCatalogDocument
+	err := yaml.Unmarshal([]byte("enums:\n  \"\":\n    values: [low]\n    default: low\n"), &catalog)
+	if err == nil || !strings.Contains(err.Error(), "empty name") {
+		t.Fatalf("empty enum key error = %v, want empty-name rejection", err)
+	}
+}
+
+func TestTypeCatalogDecode_RejectsWhitespacePaddedEnumKey(t *testing.T) {
+	var catalog TypeCatalogDocument
+	err := yaml.Unmarshal([]byte("enums:\n  \" Mode\":\n    values: [low]\n    default: low\n"), &catalog)
+	if err == nil || !strings.Contains(err.Error(), "surrounding whitespace") {
+		t.Fatalf("whitespace-padded enum key error = %v, want whitespace rejection", err)
+	}
+}
+
+func TestEnumTypeDeclValidate_SharedInvariantNondeterministicFree(t *testing.T) {
+	var catalog TypeCatalogDocument
+	err := yaml.Unmarshal([]byte("enums:\n  zebra:\n  alpha:\n    values: [low]\n    default: low\n"), &catalog)
+	if err == nil || !strings.Contains(err.Error(), "enum zebra is declared without values") {
+		t.Fatalf("multi-enum validation error = %v, want sorted deterministic first error naming zebra", err)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -3999,3 +3999,30 @@ func TestEnumTypeDeclDecode_AcceptsCanonicalMappingForm(t *testing.T) {
 		t.Fatalf("decoded enum = %#v", decl)
 	}
 }
+
+func TestEnumTypeDeclDecode_EmptyScalarShorthandRequiresMappingForm(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte(`""`), &decl)
+	if err == nil || !strings.Contains(err.Error(), "requires the mapping form") {
+		t.Fatalf("empty scalar shorthand error = %v, want mapping-form guidance", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_NonScalarDefaultGetsAuthorMessage(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte("values: [low, high]\ndefault: [low]\n"), &decl)
+	if err == nil || !strings.Contains(err.Error(), "default must be a scalar member") {
+		t.Fatalf("non-scalar default error = %v, want author-facing scalar-member message", err)
+	}
+	if strings.Contains(err.Error(), "kind") {
+		t.Fatalf("non-scalar default leaked an internal yaml kind: %v", err)
+	}
+}
+
+func TestTypeCatalogDecode_RejectsNullEnumEntry(t *testing.T) {
+	var catalog TypeCatalogDocument
+	err := yaml.Unmarshal([]byte("enums:\n  Mode:\n"), &catalog)
+	if err == nil || !strings.Contains(err.Error(), `enum Mode is declared without values`) {
+		t.Fatalf("null enum entry error = %v, want load-time teaching rejection", err)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -3930,3 +3930,37 @@ emit:
 		t.Fatalf("yaml.Unmarshal error = %v, want nested retired target diagnostic", err)
 	}
 }
+
+func TestEnumTypeDeclDecode_RetiresSequenceFormWithTeachingCodemod(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte(`[low, medium, high]`), &decl)
+	if err == nil || !strings.Contains(err.Error(), "retired sequence form") || !strings.Contains(err.Error(), "default: low") {
+		t.Fatalf("sequence form error = %v, want teaching codemod naming default: low", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_RequiresDefault(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte("values: [low, medium, high]\n"), &decl)
+	if err == nil || !strings.Contains(err.Error(), "requires default") || !strings.Contains(err.Error(), "default: low") {
+		t.Fatalf("missing default error = %v, want teaching codemod naming default: low", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_RejectsNonMemberDefaultNamingMembers(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte("values: [low, medium, high]\ndefault: urgent\n"), &decl)
+	if err == nil || !strings.Contains(err.Error(), `default "urgent" is not a declared member`) || !strings.Contains(err.Error(), "low, medium, high") {
+		t.Fatalf("non-member default error = %v, want error naming the declared members", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_AcceptsCanonicalMappingForm(t *testing.T) {
+	var decl EnumTypeDecl
+	if err := yaml.Unmarshal([]byte("values: [low, medium, high]\ndefault: medium\n"), &decl); err != nil {
+		t.Fatalf("canonical mapping form rejected: %v", err)
+	}
+	if !reflect.DeepEqual(decl.Values, []string{"low", "medium", "high"}) || decl.Default != "medium" {
+		t.Fatalf("decoded enum = %#v", decl)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -3934,8 +3934,43 @@ emit:
 func TestEnumTypeDeclDecode_RetiresSequenceFormWithTeachingCodemod(t *testing.T) {
 	var decl EnumTypeDecl
 	err := yaml.Unmarshal([]byte(`[low, medium, high]`), &decl)
-	if err == nil || !strings.Contains(err.Error(), "retired sequence form") || !strings.Contains(err.Error(), "default: low") {
+	if err == nil || !strings.Contains(err.Error(), "RETIRED: enum declaration uses the sequence form") || !strings.Contains(err.Error(), "default: low") {
 		t.Fatalf("sequence form error = %v, want teaching codemod naming default: low", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_RetiresScalarShorthandWithTeachingCodemod(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte(`fast`), &decl)
+	if err == nil || !strings.Contains(err.Error(), "RETIRED: enum declaration uses the scalar shorthand") || !strings.Contains(err.Error(), "default: fast") {
+		t.Fatalf("scalar shorthand error = %v, want teaching codemod naming default: fast", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_RejectsDuplicateKeys(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte("values: [low, high]\ndefault: low\ndefault: high\n"), &decl)
+	if err == nil || !strings.Contains(err.Error(), `repeats key "default"`) {
+		t.Fatalf("duplicate key error = %v, want duplicate-key rejection", err)
+	}
+}
+
+func TestEnumTypeDeclDecode_UnknownFieldListsValidOptions(t *testing.T) {
+	var decl EnumTypeDecl
+	err := yaml.Unmarshal([]byte("values: [low, high]\ndefualt: low\n"), &decl)
+	if err == nil {
+		t.Fatal("unknown enum field accepted")
+	}
+	diagnostic, ok := AsLoaderDiagnostic(err)
+	if !ok {
+		t.Fatalf("unknown field error = %T %v, want LoaderDiagnostic", err, err)
+	}
+	if diagnostic.Code != "contract_loader.undefined_field" || !strings.Contains(diagnostic.Problem, "defualt") {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	options := strings.Join(diagnostic.ValidOptions, ",")
+	if !strings.Contains(options, "values") || !strings.Contains(options, "default") {
+		t.Fatalf("valid options = %v, want values and default", diagnostic.ValidOptions)
 	}
 }
 

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -814,15 +814,71 @@ func (e *EnumTypeDecl) UnmarshalYAML(node *yaml.Node) error {
 	if e == nil {
 		return nil
 	}
-	values, err := decodeStringListNode(node)
+	values, defaultValue, err := decodeEnumDeclaration(node)
 	if err != nil {
 		return err
 	}
-	if len(values) == 0 {
-		return fmt.Errorf("enum declaration requires at least one value")
-	}
 	e.Values = values
+	e.Default = defaultValue
 	return nil
+}
+
+// decodeEnumDeclaration parses the canonical enum mapping form
+// (`{values: [...], default: <member>}`). The retired sequence form is
+// rejected with a teaching error carrying the behavior-preserving codemod:
+// enum defaults are explicit, never implied by member order (#1532).
+func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, "", fmt.Errorf("enum declaration requires the mapping form {values: [...], default: <member>}")
+	}
+	if node.Kind == yaml.SequenceNode {
+		values, err := decodeStringListNode(node)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(values) == 0 {
+			return nil, "", fmt.Errorf("enum declaration requires at least one value")
+		}
+		return nil, "", fmt.Errorf("enum declaration uses the retired sequence form; convert to the mapping form and add default: %s to preserve behavior (e.g. {values: [...], default: %s})", values[0], values[0])
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, "", fmt.Errorf("enum declaration must be a mapping {values: [...], default: <member>}")
+	}
+	var values []string
+	var defaultValue string
+	seen := map[string]bool{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := strings.TrimSpace(node.Content[i].Value)
+		value := node.Content[i+1]
+		switch key {
+		case "values":
+			decoded, err := decodeStringListNode(value)
+			if err != nil {
+				return nil, "", fmt.Errorf("enum declaration values: %w", err)
+			}
+			values = decoded
+		case "default":
+			if value.Kind != yaml.ScalarNode {
+				return nil, "", fmt.Errorf("enum declaration default must be a scalar member")
+			}
+			defaultValue = strings.TrimSpace(value.Value)
+		default:
+			return nil, "", fmt.Errorf("enum declaration has unknown field %q; the canonical form is {values: [...], default: <member>}", key)
+		}
+		seen[key] = true
+	}
+	if len(values) == 0 {
+		return nil, "", fmt.Errorf("enum declaration requires values with at least one member")
+	}
+	if strings.TrimSpace(defaultValue) == "" {
+		return nil, "", fmt.Errorf("enum declaration requires default; add default: %s to preserve current behavior", values[0])
+	}
+	for _, member := range values {
+		if strings.TrimSpace(member) == defaultValue {
+			return values, defaultValue, nil
+		}
+	}
+	return nil, "", fmt.Errorf("enum declaration default %q is not a declared member; declared members: %s", defaultValue, strings.Join(values, ", "))
 }
 
 func (n *NamedTypeDecl) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -789,6 +789,15 @@ func (d *TypeCatalogDocument) UnmarshalYAML(node *yaml.Node) error {
 			return NewUndefinedFieldDiagnostic("type catalog", key, typeCatalogFieldOptions)
 		}
 	}
+	for name, decl := range doc.Enums {
+		name = strings.TrimSpace(name)
+		if len(decl.Values) == 0 {
+			return fmt.Errorf("enum %s is declared without values; declare the mapping form {values: [...], default: <member>}", name)
+		}
+		if strings.TrimSpace(decl.Default) == "" {
+			return fmt.Errorf("enum %s has no declared default; add default: %s to preserve current behavior", name, decl.Values[0])
+		}
+	}
 	*d = doc
 	return nil
 }
@@ -844,10 +853,7 @@ func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
 		return nil, "", fmt.Errorf("RETIRED: enum declaration uses the sequence form; convert to the mapping form and add default: %s to preserve behavior (e.g. {values: [...], default: %s})", values[0], values[0])
 	}
 	if node.Kind == yaml.ScalarNode {
-		member, err := decodeScalarStringNode(node)
-		if err != nil {
-			return nil, "", err
-		}
+		member, _ := decodeScalarStringNode(node)
 		if member == "" {
 			return nil, "", fmt.Errorf("enum declaration requires the mapping form {values: [...], default: <member>}")
 		}
@@ -874,10 +880,10 @@ func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
 			}
 			values = decoded
 		case "default":
-			decoded, err := decodeScalarStringNode(value)
-			if err != nil {
-				return nil, "", fmt.Errorf("enum declaration default: %w", err)
+			if value.Kind != yaml.ScalarNode {
+				return nil, "", fmt.Errorf("enum declaration default must be a scalar member")
 			}
+			decoded, _ := decodeScalarStringNode(value)
 			defaultValue = decoded
 		default:
 			return nil, "", NewUndefinedFieldDiagnostic("enum declaration", key, enumDeclarationFields)

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -789,13 +790,21 @@ func (d *TypeCatalogDocument) UnmarshalYAML(node *yaml.Node) error {
 			return NewUndefinedFieldDiagnostic("type catalog", key, typeCatalogFieldOptions)
 		}
 	}
-	for name, decl := range doc.Enums {
-		name = strings.TrimSpace(name)
-		if len(decl.Values) == 0 {
-			return fmt.Errorf("enum %s is declared without values; declare the mapping form {values: [...], default: <member>}", name)
+	enumNames := make([]string, 0, len(doc.Enums))
+	for name := range doc.Enums {
+		enumNames = append(enumNames, name)
+	}
+	sort.Strings(enumNames)
+	for _, name := range enumNames {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("type catalog declares an enum with an empty name")
 		}
-		if strings.TrimSpace(decl.Default) == "" {
-			return fmt.Errorf("enum %s has no declared default; add default: %s to preserve current behavior", name, decl.Values[0])
+		if trimmed != name {
+			return fmt.Errorf("type catalog enum name %q must not have surrounding whitespace", name)
+		}
+		if err := doc.Enums[name].Validate(trimmed); err != nil {
+			return err
 		}
 	}
 	*d = doc

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -824,9 +825,10 @@ func (e *EnumTypeDecl) UnmarshalYAML(node *yaml.Node) error {
 }
 
 // decodeEnumDeclaration parses the canonical enum mapping form
-// (`{values: [...], default: <member>}`). The retired sequence form is
-// rejected with a teaching error carrying the behavior-preserving codemod:
-// enum defaults are explicit, never implied by member order (#1532).
+// (`{values: [...], default: <member>}`). The retired sequence form and the
+// scalar shorthand are rejected with teaching errors carrying the
+// behavior-preserving codemod: enum defaults are explicit, never implied by
+// member order (#1532).
 func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, "", fmt.Errorf("enum declaration requires the mapping form {values: [...], default: <member>}")
@@ -839,17 +841,31 @@ func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
 		if len(values) == 0 {
 			return nil, "", fmt.Errorf("enum declaration requires at least one value")
 		}
-		return nil, "", fmt.Errorf("enum declaration uses the retired sequence form; convert to the mapping form and add default: %s to preserve behavior (e.g. {values: [...], default: %s})", values[0], values[0])
+		return nil, "", fmt.Errorf("RETIRED: enum declaration uses the sequence form; convert to the mapping form and add default: %s to preserve behavior (e.g. {values: [...], default: %s})", values[0], values[0])
+	}
+	if node.Kind == yaml.ScalarNode {
+		member, err := decodeScalarStringNode(node)
+		if err != nil {
+			return nil, "", err
+		}
+		if member == "" {
+			return nil, "", fmt.Errorf("enum declaration requires the mapping form {values: [...], default: <member>}")
+		}
+		return nil, "", fmt.Errorf("RETIRED: enum declaration uses the scalar shorthand; convert to the mapping form and add default: %s to preserve behavior (e.g. {values: [%s], default: %s})", member, member, member)
 	}
 	if node.Kind != yaml.MappingNode {
 		return nil, "", fmt.Errorf("enum declaration must be a mapping {values: [...], default: <member>}")
 	}
 	var values []string
 	var defaultValue string
-	seen := map[string]bool{}
+	seen := map[string]struct{}{}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := strings.TrimSpace(node.Content[i].Value)
 		value := node.Content[i+1]
+		if _, duplicate := seen[key]; duplicate {
+			return nil, "", fmt.Errorf("enum declaration repeats key %q; each of values and default may appear once", key)
+		}
+		seen[key] = struct{}{}
 		switch key {
 		case "values":
 			decoded, err := decodeStringListNode(value)
@@ -858,27 +874,30 @@ func decodeEnumDeclaration(node *yaml.Node) ([]string, string, error) {
 			}
 			values = decoded
 		case "default":
-			if value.Kind != yaml.ScalarNode {
-				return nil, "", fmt.Errorf("enum declaration default must be a scalar member")
+			decoded, err := decodeScalarStringNode(value)
+			if err != nil {
+				return nil, "", fmt.Errorf("enum declaration default: %w", err)
 			}
-			defaultValue = strings.TrimSpace(value.Value)
+			defaultValue = decoded
 		default:
-			return nil, "", fmt.Errorf("enum declaration has unknown field %q; the canonical form is {values: [...], default: <member>}", key)
+			return nil, "", NewUndefinedFieldDiagnostic("enum declaration", key, enumDeclarationFields)
 		}
-		seen[key] = true
 	}
 	if len(values) == 0 {
 		return nil, "", fmt.Errorf("enum declaration requires values with at least one member")
 	}
-	if strings.TrimSpace(defaultValue) == "" {
+	if defaultValue == "" {
 		return nil, "", fmt.Errorf("enum declaration requires default; add default: %s to preserve current behavior", values[0])
 	}
-	for _, member := range values {
-		if strings.TrimSpace(member) == defaultValue {
-			return values, defaultValue, nil
-		}
+	if slices.Contains(values, defaultValue) {
+		return values, defaultValue, nil
 	}
 	return nil, "", fmt.Errorf("enum declaration default %q is not a declared member; declared members: %s", defaultValue, strings.Join(values, ", "))
+}
+
+var enumDeclarationFields = map[string]struct{}{
+	"values":  {},
+	"default": {},
 }
 
 func (n *NamedTypeDecl) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/runtime/engine/context_builder.go
+++ b/internal/runtime/engine/context_builder.go
@@ -28,9 +28,12 @@ type ContextBuilderInput struct {
 	Payload map[string]any
 }
 
-func BuildBaseContext(input ContextBuilderInput) BaseContext {
+func BuildBaseContext(input ContextBuilderInput) (BaseContext, error) {
 	base := values.NewContext()
-	materializedMetadata := entityruntime.MaterializeMetadataForFlow(input.Source, input.FlowID, input.State.StateCarrier.Metadata)
+	materializedMetadata, err := entityruntime.MaterializeMetadataForFlow(input.Source, input.FlowID, input.State.StateCarrier.Metadata)
+	if err != nil {
+		return BaseContext{}, err
+	}
 	materializedState := input.State
 	materializedState.StateCarrier.Metadata = materializedMetadata
 	base.Entity = values.Wrap(materializedState.EntityContext())
@@ -43,7 +46,7 @@ func BuildBaseContext(input ContextBuilderInput) BaseContext {
 	if input.Source != nil {
 		base.Policy = values.Wrap(policyDocumentToMap(input.Source.ResolvedPolicyForFlow(input.FlowID)))
 	}
-	return base
+	return base, nil
 }
 
 func contextFlowInstance(state StateSnapshot, evt events.Event, fallbackFlowID string) string {

--- a/internal/runtime/engine/context_builder_test.go
+++ b/internal/runtime/engine/context_builder_test.go
@@ -1,10 +1,13 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
 func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
@@ -20,7 +23,10 @@ func TestBuildBaseContext_CopiesPayloadMetadataAndPolicy(t *testing.T) {
 		Payload: map[string]any{"p": "x"},
 	}
 
-	base := BuildBaseContext(input)
+	base, err := BuildBaseContext(input)
+	if err != nil {
+		t.Fatalf("BuildBaseContext: %v", err)
+	}
 
 	if got := base.PlatformEntity.Raw()["id"]; got != "entity-1" {
 		t.Fatalf("_entity.id = %#v", got)
@@ -60,7 +66,10 @@ func TestBuildBaseContext_UsesConcreteFlowInstanceForPlatformEntity(t *testing.T
 		},
 	}
 
-	base := BuildBaseContext(input)
+	base, err := BuildBaseContext(input)
+	if err != nil {
+		t.Fatalf("BuildBaseContext: %v", err)
+	}
 
 	if got := base.PlatformEntity.Raw()["flow_instance"]; got != "child/inst-1" {
 		t.Fatalf("_entity.flow_instance = %#v, want concrete flow path", got)
@@ -157,5 +166,34 @@ func TestStateMutationAndResultBucketHelpers(t *testing.T) {
 	result.SetComputed("score", 9)
 	if got := result.ComputedBucket().Int("score"); got != 9 {
 		t.Fatalf("computed bucket score = %d", got)
+	}
+}
+
+func TestBuildBaseContext_PropagatesEntityMaterializationFailure(t *testing.T) {
+	input := ContextBuilderInput{
+		Source: semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+			RootEntities: runtimecontracts.EntityContractsDocument{
+				"ticket": {
+					Fields: map[string]runtimecontracts.EntityFieldDecl{
+						"status": {Type: "order_status"},
+					},
+				},
+			},
+			RootTypes: runtimecontracts.TypeCatalogDocument{
+				Enums: map[string]runtimecontracts.EnumTypeDecl{
+					"order_status": {Values: []string{"draft", "open"}, Default: ""},
+				},
+			},
+		}),
+		State: StateSnapshot{
+			EntityID:     "entity-1",
+			CurrentState: "researching",
+			StateCarrier: NewStateCarrier(nil, map[string]bool{}, nil),
+		},
+		Payload: map[string]any{},
+	}
+	_, err := BuildBaseContext(input)
+	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared member default") {
+		t.Fatalf("BuildBaseContext error = %v, want propagated enum-default invariant violation", err)
 	}
 }

--- a/internal/runtime/engine/context_builder_test.go
+++ b/internal/runtime/engine/context_builder_test.go
@@ -193,7 +193,7 @@ func TestBuildBaseContext_PropagatesEntityMaterializationFailure(t *testing.T) {
 		Payload: map[string]any{},
 	}
 	_, err := BuildBaseContext(input)
-	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared member default") {
+	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared default") {
 		t.Fatalf("BuildBaseContext error = %v, want propagated enum-default invariant violation", err)
 	}
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -523,7 +523,11 @@ func (e *Executor) Execute(ctx context.Context, req ExecutionRequest) (Execution
 		return e.deps.TxRunner.Run(lockCtx, func(tx Tx) error {
 			actionIntents := []EmitIntent{}
 			txCtx := WithActionEmitIntentCollector(tx.Context(), &actionIntents)
-			frame := e.newExecutionFrame(contextTx{Tx: tx, ctx: txCtx}, req)
+			frame, err := e.newExecutionFrame(contextTx{Tx: tx, ctx: txCtx}, req)
+			if err != nil {
+				SetExecutionFailure(&result, err, "runtime.engine", "base_context")
+				return err
+			}
 			if err := e.runSteps(&frame); err != nil {
 				result = frame.result
 				var moduleErr *computemodule.Error
@@ -606,7 +610,7 @@ func (e *Executor) loadState(ctx context.Context, req ExecutionRequest) (StateSn
 	return state, nil
 }
 
-func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame {
+func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) (executionFrame, error) {
 	state := req.State
 	if state.StateCarrier.Metadata == nil {
 		state.StateCarrier.Metadata = map[string]any{}
@@ -618,13 +622,16 @@ func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame
 	if len(payload) == 0 {
 		payload = map[string]any{}
 	}
-	base := BuildBaseContext(ContextBuilderInput{
+	base, err := BuildBaseContext(ContextBuilderInput{
 		Source:  e.deps.Source,
 		FlowID:  req.FlowID.String(),
 		State:   state,
 		Event:   req.Event,
 		Payload: payload,
 	})
+	if err != nil {
+		return executionFrame{}, err
+	}
 	req.State = state
 	currentState := strings.TrimSpace(state.CurrentState)
 	return executionFrame{
@@ -648,7 +655,7 @@ func (e *Executor) newExecutionFrame(tx Tx, req ExecutionRequest) executionFrame
 			NextState:    currentState,
 			Computed:     map[string]any{},
 		},
-	}
+	}, nil
 }
 
 func (e *Executor) runSteps(frame *executionFrame) error {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -616,13 +616,16 @@ func TestExecutorTimerReconciliationRequiresExactEventAuthority(t *testing.T) {
 			ID: "waiting.timeout", Stage: "waiting", StageOwned: true, Event: "timer.timeout", Delay: "1h",
 		}}},
 	}), WorkflowLifecycle: owner}}
-	frame := executor.newExecutionFrame(stubTx{ctx: context.Background()}, ExecutionRequest{
+	frame, err := executor.newExecutionFrame(stubTx{ctx: context.Background()}, ExecutionRequest{
 		EntityID: "entity-1",
 		Event: eventtest.RunCreatingRootIngress(
 			"event-1", "work.received", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, time.Time{},
 		),
 		State: StateSnapshot{CurrentState: "waiting"},
 	})
+	if err != nil {
+		t.Fatalf("newExecutionFrame: %v", err)
+	}
 	if _, _, err := executor.buildWorkflowLifecycleEffect(&frame); err == nil || !strings.Contains(err.Error(), "exact event identity") {
 		t.Fatalf("buildWorkflowLifecycleEffect error = %v, want exact-authority refusal", err)
 	}
@@ -636,13 +639,16 @@ func TestExecutorTimerReconciliationCarriesOnlyActualTransitionTarget(t *testing
 		}}},
 	}), WorkflowLifecycle: owner}}
 	createdAt := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
-	frame := executor.newExecutionFrame(stubTx{ctx: context.Background()}, ExecutionRequest{
+	frame, err := executor.newExecutionFrame(stubTx{ctx: context.Background()}, ExecutionRequest{
 		EntityID: "entity-1",
 		Event: eventtest.RunCreatingRootIngress(
 			"event-1", "work.noted", "", "", json.RawMessage(`{}`), 0, "", "", events.EventEnvelope{}, createdAt,
 		),
 		State: StateSnapshot{CurrentState: "waiting"},
 	})
+	if err != nil {
+		t.Fatalf("newExecutionFrame: %v", err)
+	}
 
 	effect, ok, err := executor.buildWorkflowLifecycleEffect(&frame)
 	if err != nil {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -353,10 +354,10 @@ func Materialize(contract Contract, provided map[string]any) (map[string]any, er
 	return out, nil
 }
 
-func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metadata map[string]any) map[string]any {
+func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metadata map[string]any) (map[string]any, error) {
 	contract, ok := ResolveForFlow(source, flowID)
 	if !ok {
-		return cloneMap(metadata)
+		return cloneMap(metadata), nil
 	}
 	input := map[string]any{}
 	for name := range contract.Entity.Fields {
@@ -366,7 +367,7 @@ func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metad
 	}
 	materialized, err := Materialize(contract, input)
 	if err != nil {
-		return cloneMap(metadata)
+		return nil, err
 	}
 	out := cloneMap(metadata)
 	if out == nil {
@@ -375,7 +376,7 @@ func MaterializeMetadataForFlow(source semanticview.Source, flowID string, metad
 	for key, value := range materialized {
 		out[key] = value
 	}
-	return out
+	return out, nil
 }
 
 func NormalizeFieldValue(contract Contract, fieldName string, value any) (any, error) {
@@ -549,8 +550,8 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 		return []any{}, nil
 	case isEnumType(contract, typeRef):
 		enum := contract.Types.Enums[typeName(contract, typeRef)]
-		if strings.TrimSpace(enum.Default) == "" {
-			return "", fmt.Errorf("enum %s has no declared default; every enum must declare default: <member>", typeName(contract, typeRef))
+		if strings.TrimSpace(enum.Default) == "" || !slices.Contains(enum.Values, strings.TrimSpace(enum.Default)) {
+			return "", fmt.Errorf("enum %s has no declared member default; every enum must declare default: <member>", typeName(contract, typeRef))
 		}
 		return strings.TrimSpace(enum.Default), nil
 	case isNamedType(contract, typeRef):

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -549,9 +548,10 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 	case isJSONArrayType(contract, typeRef):
 		return []any{}, nil
 	case isEnumType(contract, typeRef):
-		enum := contract.Types.Enums[typeName(contract, typeRef)]
-		if strings.TrimSpace(enum.Default) == "" || !slices.Contains(enum.Values, strings.TrimSpace(enum.Default)) {
-			return "", fmt.Errorf("enum %s has no declared member default; every enum must declare default: <member>", typeName(contract, typeRef))
+		enumName := typeName(contract, typeRef)
+		enum := contract.Types.Enums[enumName]
+		if err := enum.Validate(enumName); err != nil {
+			return "", err
 		}
 		return strings.TrimSpace(enum.Default), nil
 	case isNamedType(contract, typeRef):

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -549,6 +549,9 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 		return []any{}, nil
 	case isEnumType(contract, typeRef):
 		enum := contract.Types.Enums[typeName(contract, typeRef)]
+		if strings.TrimSpace(enum.Default) == "" {
+			return "", fmt.Errorf("enum %s has no declared default; every enum must declare default: <member>", typeName(contract, typeRef))
+		}
 		return strings.TrimSpace(enum.Default), nil
 	case isNamedType(contract, typeRef):
 		named := contract.Types.Types[typeName(contract, typeRef)]

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -549,10 +549,7 @@ func defaultValue(contract Contract, typeRef string, explicit any) (any, error) 
 		return []any{}, nil
 	case isEnumType(contract, typeRef):
 		enum := contract.Types.Enums[typeName(contract, typeRef)]
-		if len(enum.Values) == 0 {
-			return "", nil
-		}
-		return strings.TrimSpace(enum.Values[0]), nil
+		return strings.TrimSpace(enum.Default), nil
 	case isNamedType(contract, typeRef):
 		named := contract.Types.Types[typeName(contract, typeRef)]
 		out := make(map[string]any, len(named.Fields))

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -331,3 +331,37 @@ func TestContainedOperationTarget_RejectsSetOrMergeIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestEnumDefaultIsOrderInert(t *testing.T) {
+	build := func(values []string) Contract {
+		return Contract{
+			Entity: runtimecontracts.EntityContract{
+				Fields: map[string]runtimecontracts.EntityFieldDecl{
+					"status": {Type: "order_status"},
+				},
+			},
+			Types: runtimecontracts.TypeCatalogDocument{
+				Enums: map[string]runtimecontracts.EnumTypeDecl{
+					"order_status": {Values: values, Default: "draft"},
+				},
+			},
+		}
+	}
+	original := build([]string{"archived", "draft", "published"})
+	permuted := build([]string{"published", "archived", "draft"})
+
+	got, err := defaultValue(original, "order_status", nil)
+	if err != nil {
+		t.Fatalf("defaultValue original: %v", err)
+	}
+	gotPermuted, err := defaultValue(permuted, "order_status", nil)
+	if err != nil {
+		t.Fatalf("defaultValue permuted: %v", err)
+	}
+	if got != "draft" || gotPermuted != "draft" {
+		t.Fatalf("defaults = %q and %q, want the declared default draft regardless of member order", got, gotPermuted)
+	}
+	if got != gotPermuted {
+		t.Fatalf("member order changed the default: %q vs %q", got, gotPermuted)
+	}
+}

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -365,3 +365,22 @@ func TestEnumDefaultIsOrderInert(t *testing.T) {
 		t.Fatalf("member order changed the default: %q vs %q", got, gotPermuted)
 	}
 }
+
+func TestEnumDefaultMissingFailsFast(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"status": {Type: "order_status"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Enums: map[string]runtimecontracts.EnumTypeDecl{
+				"order_status": {Values: []string{"archived", "draft", "published"}},
+			},
+		},
+	}
+	_, err := defaultValue(contract, "order_status", nil)
+	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared default") {
+		t.Fatalf("missing enum default error = %v, want fail-fast invariant violation", err)
+	}
+}

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -380,8 +380,8 @@ func TestEnumDefaultMissingFailsFast(t *testing.T) {
 		},
 	}
 	_, err := defaultValue(contract, "order_status", nil)
-	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared member default") {
-		t.Fatalf("missing enum default error = %v, want fail-fast invariant violation", err)
+	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared default") || !strings.Contains(err.Error(), "default: archived") {
+		t.Fatalf("missing enum default error = %v, want fail-fast invariant violation with codemod", err)
 	}
 }
 
@@ -399,7 +399,7 @@ func TestEnumDefaultNonMemberFailsFast(t *testing.T) {
 		},
 	}
 	_, err := defaultValue(contract, "order_status", nil)
-	if err == nil || !strings.Contains(err.Error(), "no declared member default") {
-		t.Fatalf("non-member enum default error = %v, want fail-fast invariant violation", err)
+	if err == nil || !strings.Contains(err.Error(), `default "urgent" is not a declared member`) || !strings.Contains(err.Error(), "archived, draft") {
+		t.Fatalf("non-member enum default error = %v, want fail-fast invariant violation naming value and members", err)
 	}
 }

--- a/internal/runtime/entityruntime/contracts_test.go
+++ b/internal/runtime/entityruntime/contracts_test.go
@@ -380,7 +380,26 @@ func TestEnumDefaultMissingFailsFast(t *testing.T) {
 		},
 	}
 	_, err := defaultValue(contract, "order_status", nil)
-	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared default") {
+	if err == nil || !strings.Contains(err.Error(), "order_status") || !strings.Contains(err.Error(), "no declared member default") {
 		t.Fatalf("missing enum default error = %v, want fail-fast invariant violation", err)
+	}
+}
+
+func TestEnumDefaultNonMemberFailsFast(t *testing.T) {
+	contract := Contract{
+		Entity: runtimecontracts.EntityContract{
+			Fields: map[string]runtimecontracts.EntityFieldDecl{
+				"status": {Type: "order_status"},
+			},
+		},
+		Types: runtimecontracts.TypeCatalogDocument{
+			Enums: map[string]runtimecontracts.EnumTypeDecl{
+				"order_status": {Values: []string{"archived", "draft"}, Default: "urgent"},
+			},
+		},
+	}
+	_, err := defaultValue(contract, "order_status", nil)
+	if err == nil || !strings.Contains(err.Error(), "no declared member default") {
+		t.Fatalf("non-member enum default error = %v, want fail-fast invariant violation", err)
 	}
 }

--- a/internal/runtime/pipeline/engine_adapter_test.go
+++ b/internal/runtime/pipeline/engine_adapter_test.go
@@ -2964,7 +2964,7 @@ func TestValidatePipelineEmitPayload_RejectsEnumViolationOnActionSurface(t *test
 		"package.yaml":             "name: action-emit-enum\nversion: 1.0.0\ndescription: Action emit enum proof.\nplatform_version: \">=0.7.0 <0.8.0\"\nflows:\n- id: child\n  flow: child\n  mode: static\n",
 		"schema.yaml":              "initial_state: idle\nterminal_states: [done]\nstates: [idle, done]\npins:\n  inputs:\n    events: [parent.trigger]\n  outputs:\n    events: [parent.result]\n",
 		"events.yaml":              "parent.trigger:\n  entity_id: string\nparent.result:\n  entity_id: string\n",
-		"types.yaml":               "enums:\n  Mode: [fast, deep]\n",
+		"types.yaml":               "enums:\n  Mode:\n    values: [fast, deep]\n    default: fast\n",
 		"flows/child/package.yaml": "name: child\nversion: 1.0.0\ndescription: child flow\nplatform_version: \">=0.7.0 <0.8.0\"\nflows: []\n",
 		"flows/child/schema.yaml":  "name: child\ninitial_state: waiting\nterminal_states: [processed]\nstates: [waiting, processed]\npins:\n  inputs:\n    events: [child.start]\n  outputs:\n    events: [child.internal]\n",
 		"flows/child/events.yaml":  "child.start:\n  entity_id: string\nchild.internal:\n  mode: Mode\n  required: [mode]\n",

--- a/internal/runtime/tools/delivery_contracts_test.go
+++ b/internal/runtime/tools/delivery_contracts_test.go
@@ -25,7 +25,9 @@ types:
     region: text
     score_band: score_band
 enums:
-  score_band: [low, medium, high]
+  score_band:
+    values: [low, medium, high]
+    default: low
 `, `
 review_subject:
   status: text

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -333,7 +333,7 @@ func TestGenerateEmitToolsForActor_GeneratedSchemaIsClosedRequiredAndRejectsUnde
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{
 			Enums: map[string]runtimecontracts.EnumTypeDecl{
-				"SignalStrength": {Values: []string{"weak", "strong"}},
+				"SignalStrength": {Values: []string{"weak", "strong"}, Default: "weak"},
 			},
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"DiscoveryContext": {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -1407,8 +1407,8 @@ func TestHandleEmitTool_ResolvesDuplicateLeafScopedSchemasThroughActor(t *testin
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{
 			Enums: map[string]runtimecontracts.EnumTypeDecl{
-				"ReviewPriority":     {Values: []string{"urgent"}},
-				"ValidationPriority": {Values: []string{"low"}},
+				"ReviewPriority":     {Values: []string{"urgent"}, Default: "urgent"},
+				"ValidationPriority": {Values: []string{"low"}, Default: "low"},
 			},
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"ReviewRequest": {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -1314,7 +1314,7 @@ func TestHandleEmitTool_AllowsValidWave1EventPayloadTypes(t *testing.T) {
 				"Label":   {Base: "text"},
 			},
 			Enums: map[string]runtimecontracts.EnumTypeDecl{
-				"Mode": {Values: []string{"fast", "deep"}},
+				"Mode": {Values: []string{"fast", "deep"}, Default: "fast"},
 			},
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"ScanDetails": {

--- a/internal/runtime/workflowexpr/data_expression_test.go
+++ b/internal/runtime/workflowexpr/data_expression_test.go
@@ -116,7 +116,7 @@ func TestJoinExpressionTypeCheckingMatchesRuntimeContext(t *testing.T) {
 func TestJoinExpressionTypeCheckingPreservesCatalogTypes(t *testing.T) {
 	catalog := runtimecontracts.TypeCatalogDocument{
 		Scalars: map[string]runtimecontracts.ScalarTypeDecl{"Score": {Base: "integer"}},
-		Enums:   map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}}},
+		Enums:   map[string]runtimecontracts.EnumTypeDecl{"Decision": {Values: []string{"accept", "reject"}, Default: "accept"}},
 		Types: map[string]runtimecontracts.NamedTypeDecl{
 			"JoinResult": {Fields: map[string]runtimecontracts.TypeFieldSpec{
 				"value": {Type: "text"},

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1861,7 +1861,11 @@ type_system:
     - timestamp
     - uuid
     named_types: Composite types with declared inner fields.
-    enums: Closed named sets of values.
+    enums: |
+      Closed named sets of values. Each enum declares its members and an explicit default member: the canonical
+      mapping form is `enums: {name: {values: [...], default: <member>}}`. Enum defaults are explicit, never implied
+      by member order; the retired sequence form and omitted/non-member defaults are contract-load errors rejected
+      with teaching guidance (#1532).
     lists: Ordered collections of a declared element type.
   schema_refinements:
     description: |
@@ -1961,7 +1965,7 @@ type_system:
       boolean: 'false'
       list: '[]'
       named_type: empty instance with each field at its own default
-      enum: first declared value unless initial overrides it
+      enum: the enum's declared default member unless initial overrides it
       timestamp: 'null'
       uuid: 'null'
 entity_contracts:


### PR DESCRIPTION
Closes #1532

## Change (per the 2026-08-10 rulings)

Enum defaults are now **explicit** (`default: <member>`); order-dependence is retired. The one canonical form is `enums: {name: {values: [...], default: <member>}}`.

- **Loader** (`EnumTypeDecl.UnmarshalYAML`): the retired sequence form is rejected with the teaching codemod ("convert to the mapping form and add default: <current first member> to preserve behavior"); `default:` is always required (locally checkable — no action-at-a-distance validity from distant field declarations); a non-member default is rejected naming the declared members. No dual-form shim; no `description:` rider (no consumer).
- **Runtime**: the one first-member default consumer (`entityruntime/contracts.go:555`) now reads the declared `Default`.
- **Corpus migrated same-PR** (behavior-preserving: every site's `default:` names its current first member): 12 Go `EnumTypeDecl` constructions + 2 inline-YAML fixture sites (`delivery_contracts_test.go`, `engine_adapter_test.go`).

## Discriminating tests (beyond the negatives)

- **Order-inertness** (`TestEnumDefaultIsOrderInert`): permuted `values` order with `default:` held fixed → entity-field defaulting byte-identical. Member order is now semantically inert, proven, pinned.
- **Membership** (`TestEnumTypeDeclDecode_RejectsNonMemberDefaultNamingMembers`): non-member `default:` → teaching error naming the declared members.
- **Loader negatives**: sequence form → codemod teaching error; missing `default:` → codemod naming the current first member; canonical mapping form accepted.

## Ruled surfaces (frozen/unchanged)

- **Connector-response inhabitation (spec:8461)**: NOT touched — S2's first-authored-literal enum selection is under the #2101/E3 explicit freeze ("any change to S2's frozen enum-selection behavior must be explicitly gated"); generated values participate in recorded expectations, so selection stability is replay stability. This PR is forbidden to touch it.
- `initial:` still overrides the enum default per field; the JSON-schema enum projection stays default-free (JSON-schema semantics).

## Census-to-zero (the #2114 closure pattern, miniature)

Post-PR production reads of enum-member-position-as-default: **zero**. `grep 'Values\[0\]'` across non-test Go leaves only `timestampValues[0]` in `providertriggers.go` — a timestamp-array extraction, not an enum default. The `entityruntime` first-member read is gone.

## Verification

`go build`, `go vet`, gofmt clean; full `runtime`, `contracts`, `bootverify`, `tools`, `workflowexpr`, `entityruntime`, `pipeline`, `apispec`, `cliapp` suites pass against Postgres.