### PR TITLE
test: derive deadline-test margin from retry budget in runtime mutation test

### DIFF
--- a/internal/store/runtime_mutation_test.go
+++ b/internal/store/runtime_mutation_test.go
@@ -97,7 +97,12 @@ func TestSQLiteRuntimeStore_RunRuntimeMutationStopsRetryOnContextDeadline(t *tes
 		t.Fatalf("acquire sqlite write lock: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(baseCtx, 35*time.Millisecond)
+	// The deadline is derived from the retry budget rather than an arbitrary
+	// wall-time margin: the production retry deadline clamps to the context
+	// deadline (so the deadline always wins structurally), and a budget-derived
+	// value far below the 5s budget but far above the first attempt's busy
+	// cost leaves no starvation window before the first retry attempt (#1658).
+	ctx, cancel := context.WithTimeout(baseCtx, sqliteRuntimeMutationRetryBudget/20)
 	defer cancel()
 	var attempts int32
 	err = store.RunRuntimeMutation(ctx, func(txctx context.Context, tx *sql.Tx) error {


### PR DESCRIPTION
Closes #1658

## Diagnosis (posted on the issue)

The flake was a **production-path classification defect, already fixed in master**: the retry loop's attempt-expired paths returned the retry-budget error whenever `attemptErr != nil` while `ctx.Err()` was momentarily nil (the microsecond window between the attempt-context and outer-context deadline observations under CPU starvation). The baseline `8c4ad335` lacked deadline recovery in those paths; `4382b1948` ("feat: add explicit lifecycle stages") added it — the deadline now always wins structurally (the retry deadline clamps to the context deadline). Verified: `errors.Is(attemptErr, context.DeadlineExceeded)` absent at the baseline, present on HEAD; 150×2 iterations of both deadline tests under `-cpu=1` + concurrent runtime/cliapp suites → 0 failures; a 40-iteration probe → 40/40 deadline wins. No e-escalation needed — nothing outstanding to hand over.

## #1233 classification (the deliverable)

The test **already consumes a real deterministic owner** (post-4382b1948) for its classification assertion. The residual test-health seam was the `attempts > 0` work assertion's ~35ms wall-clock starvation window (a goroutine starved past the deadline before the first loop iteration returns with attempts=0). Pattern used: **margin derived from budget rather than wall-time** — the deadline is now `sqliteRuntimeMutationRetryBudget/20` (250ms): far below the 5s budget (the clamp makes the deadline bind structurally), far above the first attempt's busy cost, closing the pre-first-attempt starvation window to practically zero.

Siblings: `ContextDeadlineCapsDriverBusyTimeout`'s margin is internal to its own busy_timeout semantics; `RetriesBusyAndFlushesPostCommitOnce`'s 2s deadline is a success-path cap, not a race assertion — no sibling change needed (stated on the issue).

## Change

One test-only line (plus the derivation comment): the deadline constant `35*time.Millisecond` → `sqliteRuntimeMutationRetryBudget/20`. No production code touched (store-territory caution).

## Verification

Full `internal/store` suite passes against Postgres; the deadline tests pass `-cpu=1` + concurrent-suite load (100 iterations, exit 0).