### PR TITLE
feat: render entity view/list human-first with shared output modes (#2013)

### DIFF
--- a/internal/cliapp/cli_identifier_registry_test.go
+++ b/internal/cliapp/cli_identifier_registry_test.go
@@ -325,7 +325,6 @@ func TestCLIIdentifierDisplayColumnsUseFamilyAwareOwner(t *testing.T) {
 		"diagnostics.go\x00SESSION":        cliIdentifierFamilySession,
 		"diagnostics.go\x00EVENT ID":       cliIdentifierFamilyEvent,
 		"entities.go\x00ENTITY_ID":         cliIdentifierFamilyEntity,
-		"entities.go\x00RUN_ID":            cliIdentifierFamilyRun,
 		"entities.go\x00FLOW":              cliIdentifierFamilyFlowInstance,
 		"events.go\x00EVENT ID":            cliIdentifierFamilyEvent,
 		"events.go\x00RUN":                 cliIdentifierFamilyRun,

--- a/internal/cliapp/cli_identifier_registry_test.go
+++ b/internal/cliapp/cli_identifier_registry_test.go
@@ -325,6 +325,7 @@ func TestCLIIdentifierDisplayColumnsUseFamilyAwareOwner(t *testing.T) {
 		"diagnostics.go\x00SESSION":        cliIdentifierFamilySession,
 		"diagnostics.go\x00EVENT ID":       cliIdentifierFamilyEvent,
 		"entities.go\x00ENTITY_ID":         cliIdentifierFamilyEntity,
+		"entities.go\x00RUN_ID":            cliIdentifierFamilyRun,
 		"entities.go\x00FLOW":              cliIdentifierFamilyFlowInstance,
 		"events.go\x00EVENT ID":            cliIdentifierFamilyEvent,
 		"events.go\x00RUN":                 cliIdentifierFamilyRun,

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -438,6 +438,23 @@ func cliReplaceLineBreakingRune(r rune) rune {
 	return r
 }
 
+// cliRenderOneLineLabel sanitizes a row label and, when it exceeds the one-line
+// ceiling, retains a distinguishing suffix so two long labels sharing a common
+// prefix never render as identical rows.
+func cliRenderOneLineLabel(value string) string {
+	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) <= cliOneLineMaxRunes {
+		return value
+	}
+	const retainedSuffixRunes = 12
+	kept := cliOneLineMaxRunes - retainedSuffixRunes - 1
+	if kept < 1 {
+		kept = 1
+	}
+	return string(runes[:kept]) + "…" + string(runes[len(runes)-retainedSuffixRunes:])
+}
+
 func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {
 	if err := opts.validate(); err != nil {
 		return returnCLIValidationError(errOut, err)

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/division-sh/swarm/internal/userfacing"
@@ -431,7 +432,7 @@ func cliRenderOneLineValue(value string) string {
 }
 
 func cliReplaceLineBreakingRune(r rune) rune {
-	if r < 0x20 {
+	if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' {
 		return ' '
 	}
 	return r

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/division-sh/swarm/internal/userfacing"
@@ -22,12 +23,15 @@ const (
 	cliOutputQuietFlagHelp   = "Render only declared load-bearing value(s)"
 	cliOutputNoColorFlag     = "no-color"
 	cliOutputNoColorFlagHelp = "Disable ANSI color in human-readable output"
+	cliOutputVerboseFlag     = "verbose"
+	cliOutputVerboseFlagHelp = "Render the full record: absolute timestamps, bookkeeping fields, and accumulated state"
 )
 
 type cliOutputOptions struct {
 	asJSON  bool
 	quiet   bool
 	noColor bool
+	verbose bool
 }
 
 type cliTextRenderer func(io.Writer)
@@ -174,6 +178,13 @@ func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
 	cmd.Flags().BoolVar(&opts.asJSON, cliOutputJSONFlag, false, cliOutputJSONFlagHelp)
 	cmd.Flags().BoolVar(&opts.quiet, cliOutputQuietFlag, false, cliOutputQuietFlagHelp)
 	cmd.Flags().BoolVar(&opts.noColor, cliOutputNoColorFlag, false, cliOutputNoColorFlagHelp)
+}
+
+// bindCLIOutputVerboseFlag binds the shared --verbose flag without sweeping it
+// onto every bindCLIOutputFlags consumer; commands opt into the full record
+// projection explicitly.
+func bindCLIOutputVerboseFlag(cmd *cobra.Command, opts *cliOutputOptions) {
+	cmd.Flags().BoolVar(&opts.verbose, cliOutputVerboseFlag, false, cliOutputVerboseFlagHelp)
 }
 
 func bindCLIOutputFlagSet(fs *flag.FlagSet, opts *cliOutputOptions) {
@@ -369,6 +380,61 @@ func cliDisplayWidth(value string) int {
 		return 0
 	}
 	return utf8.RuneCountInString(value)
+}
+
+// cliRelativeTimeNow is the single owner of "now" for relative-time rendering;
+// tests override it for deterministic output.
+var cliRelativeTimeNow = time.Now
+
+// formatCLIRelativeTime renders an RFC3339 timestamp relative to now
+// ("5m ago"). Unparseable or future timestamps fall back to the raw value;
+// machine output must never consume this helper (use the raw absolute value).
+func formatCLIRelativeTime(now time.Time, raw string) string {
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil {
+		return raw
+	}
+	elapsed := now.Sub(at)
+	if elapsed < 0 {
+		return raw
+	}
+	switch {
+	case elapsed < time.Minute:
+		return "just now"
+	case elapsed < time.Hour:
+		return fmt.Sprintf("%dm ago", int(elapsed.Minutes()))
+	case elapsed < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(elapsed.Hours()))
+	case elapsed < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(elapsed.Hours()/24))
+	case elapsed < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo ago", int(elapsed.Hours()/(24*30)))
+	default:
+		return fmt.Sprintf("%dy ago", int(elapsed.Hours()/(24*365)))
+	}
+}
+
+const cliOneLineMaxRunes = 200
+
+// cliRenderOneLineValue collapses line-breaking and control characters so a
+// value can never break the CLI's line discipline, then truncates long values
+// at a fixed rune ceiling with a visible truncation marker. The ceiling is a
+// fixed constant, not terminal-width-dependent, so human output stays
+// deterministic across TTY and piped rendering.
+func cliRenderOneLineValue(value string) string {
+	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) <= cliOneLineMaxRunes {
+		return value
+	}
+	return string(runes[:cliOneLineMaxRunes]) + "…"
+}
+
+func cliReplaceLineBreakingRune(r rune) rune {
+	if r < 0x20 {
+		return ' '
+	}
+	return r
 }
 
 func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {

--- a/internal/cliapp/cli_output_conformance_registry_test.go
+++ b/internal/cliapp/cli_output_conformance_registry_test.go
@@ -60,6 +60,8 @@ var cliOutputSharedOwnerProofs = map[string]cliOutputSharedOwnerProof{
 	"swarm forkchat delete":              {Constructor: "newForkChatDeleteCommand", Runner: "runForkChatDeleteCommand"},
 	"swarm describe":                     {Constructor: "newDescribeCommand", Runner: "runDescribeCommandWithOutput"},
 	"swarm describe routes":              {Constructor: "newDescribeRoutesCommand", Runner: "runDescribeRoutesCommandWithOutput"},
+	"swarm entity list":                  {Constructor: "newEntitiesListCommand", Runner: "runEntitiesListCommand"},
+	"swarm entity view":                  {Constructor: "newEntityViewCommand", Runner: "runEntityViewCommand"},
 }
 
 var cliOutputGrandfatheredNonSharedRows = map[string]string{
@@ -113,8 +115,6 @@ var cliOutputGrandfatheredNonSharedRows = map[string]string{
 	"swarm bundle build":           "split",
 	"swarm forkchat":               "exception",
 	"swarm entity":                 "exception",
-	"swarm entity list":            "split",
-	"swarm entity view":            "split",
 	"swarm entity aggregate":       "split",
 	"swarm logs":                   "split",
 	"swarm incidents":              "split",
@@ -133,6 +133,8 @@ var cliOutputExpectedFactOwners = map[string]string{
 	"swarm agent view":       "/v1/rpc agent.get",
 	"swarm agent diagnose":   "/v1/rpc agent.diagnose",
 	"swarm agent deliveries": "/v1/rpc agent.delivery_lifecycle",
+	"swarm entity list":      "/v1/rpc entity.list",
+	"swarm entity view":      "/v1/rpc entity.get",
 }
 
 var cliOutputSharedDisplayProofs = map[string][]string{
@@ -155,7 +157,7 @@ var cliOutputSharedDisplayProofs = map[string][]string{
 	"writeDiagnosticRunTraceDeliveryDetail":  {"writeCLITable"},
 	"writeDiagnosticRunTraceDeliverySummary": {"writeCLITable"},
 	"writeEntityAggregateResult":             {"writeCLITable"},
-	"writeEntityFullResult":                  {"writeCLIFieldLine"},
+	"writeEntityFullResult":                  {"writeCLILabeledDetail"},
 	"writeEntityListResult":                  {"writeCLITable"},
 	"writeEventDeadLetterLine":               {"writeCLIFieldLine"},
 	"writeEventDetailResult":                 {"writeCLIFieldLine"},

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -123,6 +123,32 @@ type entityLoopActivation struct {
 	CurrentStage string `json:"current_stage"`
 	Status       string `json:"status"`
 	CloseReason  string `json:"close_reason,omitempty"`
+
+	closeReasonPresent bool
+}
+
+// UnmarshalJSON preserves whether close_reason was present (even as null) so a
+// schema-invalid open loop carrying a present close reason fails closed instead
+// of being normalized into an omitted property by --json.
+func (l *entityLoopActivation) UnmarshalJSON(data []byte) error {
+	type entityLoopActivationAlias entityLoopActivation
+	var shadow struct {
+		entityLoopActivationAlias
+		CloseReason json.RawMessage `json:"close_reason"`
+	}
+	if err := json.Unmarshal(data, &shadow); err != nil {
+		return err
+	}
+	*l = entityLoopActivation(shadow.entityLoopActivationAlias)
+	if len(shadow.CloseReason) > 0 {
+		l.closeReasonPresent = true
+		if !bytes.Equal(bytes.TrimSpace(shadow.CloseReason), []byte("null")) {
+			if err := json.Unmarshal(shadow.CloseReason, &l.CloseReason); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 type entityAggregateResult struct {
@@ -525,10 +551,11 @@ func validateEntityLoopActivation(prefix string, loop entityLoopActivation) erro
 	default:
 		return fmt.Errorf("malformed %s: status %q is invalid", prefix, loop.Status)
 	}
-	if loop.Status == "open" && loop.CloseReason != "" {
-		return fmt.Errorf("malformed %s: open loop cannot have close reason %q", prefix, loop.CloseReason)
-	}
-	if loop.Status == "closed" {
+	if loop.Status == "open" {
+		if loop.closeReasonPresent {
+			return fmt.Errorf("malformed %s: open loop cannot have a close reason", prefix)
+		}
+	} else {
 		switch loop.CloseReason {
 		case "completed", "escaped":
 		default:

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -468,6 +468,39 @@ func validateEntityFullResult(prefix string, result entityFull) error {
 	if result.Accumulated == nil {
 		return fmt.Errorf("malformed %s: accumulated is required", prefix)
 	}
+	for i, loop := range result.Loops {
+		if err := validateEntityLoopActivation(fmt.Sprintf("%s.loops[%d]", prefix, i), loop); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEntityLoopActivation mirrors loopruntime.Activation.Validate at the
+// CLI boundary so a malformed loop activation from a non-store server is
+// rejected instead of being rewritten into a schema-invalid --json result or
+// displayed with misleading zero values under --verbose.
+func validateEntityLoopActivation(prefix string, loop entityLoopActivation) error {
+	if strings.TrimSpace(loop.ID) == "" || strings.TrimSpace(loop.RevisionID) == "" {
+		return fmt.Errorf("malformed %s: loop activation identity is incomplete", prefix)
+	}
+	if loop.Attempt <= 0 || loop.MaxAttempts <= 0 || loop.Attempt > loop.MaxAttempts {
+		return fmt.Errorf("malformed %s: attempt bounds are invalid: attempt=%d max=%d", prefix, loop.Attempt, loop.MaxAttempts)
+	}
+	if strings.TrimSpace(loop.CurrentStage) == "" {
+		return fmt.Errorf("malformed %s: current stage is required", prefix)
+	}
+	switch loop.Status {
+	case "open", "closed":
+	default:
+		return fmt.Errorf("malformed %s: status %q is invalid", prefix, loop.Status)
+	}
+	if loop.Status == "open" && loop.CloseReason != "" {
+		return fmt.Errorf("malformed %s: open loop cannot have close reason %q", prefix, loop.CloseReason)
+	}
+	if loop.Status == "closed" && strings.TrimSpace(loop.CloseReason) == "" {
+		return fmt.Errorf("malformed %s: closed loop requires a close reason", prefix)
+	}
 	return nil
 }
 
@@ -616,7 +649,7 @@ func writeEntityLoopSection(out io.Writer, loops []entityLoopActivation) {
 		if strings.TrimSpace(loop.CloseReason) != "" {
 			summary += " · " + loop.CloseReason
 		}
-		rows = append(rows, cliLabeledDetailRow{Label: loop.ID, Value: cliRenderOneLineValue(summary)})
+		rows = append(rows, cliLabeledDetailRow{Label: loop.ID, Value: cliRenderOneLineValue(summary + " · rev " + loop.RevisionID)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -596,9 +596,29 @@ func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOp
 	writeEntityFieldSection(out, "Fields", result.Fields, entityContentField, true)
 	writeEntityGatesSection(out, result.Gates)
 	if opts.verbose {
+		writeEntityLoopSection(out, result.Loops)
 		writeEntityFieldSection(out, "Bookkeeping", result.Fields, entityBookkeepingField, false)
 		writeEntityFieldSection(out, "Accumulated", result.Accumulated, nil, true)
 	}
+}
+
+// writeEntityLoopSection renders bounded-loop activations under --verbose. The
+// store removes the reserved loop bucket from Accumulated and exposes it solely
+// through Loops, so the full-record flag must render it or loop state would be
+// unreachable except via --json.
+func writeEntityLoopSection(out io.Writer, loops []entityLoopActivation) {
+	if len(loops) == 0 {
+		return
+	}
+	rows := make([]cliLabeledDetailRow, 0, len(loops))
+	for _, loop := range loops {
+		summary := fmt.Sprintf("%s · %s · attempt %d/%d", loop.CurrentStage, loop.Status, loop.Attempt, loop.MaxAttempts)
+		if strings.TrimSpace(loop.CloseReason) != "" {
+			summary += " · " + loop.CloseReason
+		}
+		rows = append(rows, cliLabeledDetailRow{Label: loop.ID, Value: cliRenderOneLineValue(summary)})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }
 
 func entityListTimestamp(now time.Time, raw string, verbose bool) string {

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -670,7 +670,7 @@ func writeEntityLoopSection(out io.Writer, loops []entityLoopActivation) {
 		if strings.TrimSpace(loop.CloseReason) != "" {
 			summary += " · " + loop.CloseReason
 		}
-		rows = append(rows, cliLabeledDetailRow{Label: loop.ID, Value: cliRenderOneLineValue(summary + " · rev " + loop.RevisionID)})
+		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(loop.ID), Value: cliRenderOneLineValue(summary + " · rev " + loop.RevisionID)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }
@@ -734,7 +734,7 @@ func entityFieldRows(fields map[string]any, include func(string) bool) []cliLabe
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: key, Value: entityFieldValue(fields[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(key), Value: entityFieldValue(fields[key])})
 	}
 	return rows
 }
@@ -778,7 +778,7 @@ func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: key, Value: fmt.Sprintf("%t", gates[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(key), Value: fmt.Sprintf("%t", gates[key])})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Gates", Rows: rows})
 }

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -574,21 +574,38 @@ func writeEntityListResult(out io.Writer, result entityListResult, opts entityLi
 		cliTableColumn{Header: "TYPE"},
 		cliTableColumn{Header: "STATE"},
 		cliTableColumn{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
-		cliTableColumn{Header: "UPDATED"},
 	)
+	if opts.verbose {
+		columns = append(columns,
+			cliTableColumn{Header: "REVISION"},
+			cliTableColumn{Header: "CREATED"},
+		)
+	}
+	columns = append(columns, cliTableColumn{Header: "UPDATED"})
+	if opts.verbose {
+		columns = append(columns,
+			cliTableColumn{Header: "SLUG"},
+			cliTableColumn{Header: "NAME"},
+		)
+	}
 	rows := make([][]string, 0, len(result.Entities))
 	for _, entity := range result.Entities {
-		updated := entityListTimestamp(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose)
 		row := []string{entity.EntityID}
 		if !opts.runScoped {
 			row = append(row, entity.RunID)
 		}
 		row = append(row,
-			entityDash(entity.EntityType),
-			entityDash(entity.CurrentState),
-			entityShortFlow(entity.FlowInstance),
-			updated,
+			entityDash(entityOneLine(entity.EntityType)),
+			entityDash(entityOneLine(entity.CurrentState)),
+			entityShortFlow(entityOneLine(entity.FlowInstance)),
 		)
+		if opts.verbose {
+			row = append(row, fmt.Sprintf("%d", entity.Revision), entity.CreatedAt)
+		}
+		row = append(row, entityListTimestamp(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose))
+		if opts.verbose {
+			row = append(row, entityDash(entityOneLine(entity.Slug)), entityDash(entityOneLine(entity.Name)))
+		}
 		rows = append(rows, row)
 	}
 	footers := []string{}
@@ -750,17 +767,13 @@ func entityFieldValue(value any) string {
 }
 
 func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
-	keys := make([]string, 0, len(gates))
-	anyTrue := false
-	for key, value := range gates {
-		keys = append(keys, key)
-		if value {
-			anyTrue = true
-		}
-	}
-	if len(keys) == 0 || !anyTrue {
+	if len(gates) == 0 {
 		writeCLITitle(out, "Gates  none")
 		return
+	}
+	keys := make([]string, 0, len(gates))
+	for key := range gates {
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -79,10 +79,23 @@ type entitySummary struct {
 }
 
 type entityFull struct {
-	Entity      entitySummary   `json:"entity"`
-	Fields      map[string]any  `json:"fields"`
-	Gates       map[string]bool `json:"gates"`
-	Accumulated map[string]any  `json:"accumulated"`
+	Entity      entitySummary          `json:"entity"`
+	Fields      map[string]any         `json:"fields"`
+	Gates       map[string]bool        `json:"gates"`
+	Accumulated map[string]any         `json:"accumulated"`
+	Loops       []entityLoopActivation `json:"loops,omitempty"`
+}
+
+// entityLoopActivation mirrors loopruntime.PublicActivation so the --json path
+// round-trips the canonical entity.get result without dropping loop state.
+type entityLoopActivation struct {
+	ID           string `json:"id"`
+	RevisionID   string `json:"revision_id"`
+	Attempt      int    `json:"attempt"`
+	MaxAttempts  int    `json:"max_attempts"`
+	CurrentStage string `json:"current_stage"`
+	Status       string `json:"status"`
+	CloseReason  string `json:"close_reason,omitempty"`
 }
 
 type entityAggregateResult struct {
@@ -142,6 +155,9 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "List entities with filters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := listOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			listOpts.runIDSet = cmd.Flags().Changed("run-id")
 			listOpts.flowSet = cmd.Flags().Changed("flow")
 			listOpts.entityTypeSet = cmd.Flags().Changed("type")
@@ -170,6 +186,9 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one entity's state.",
 		Args:  argcount.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viewOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			viewOpts.runIDSet = cmd.Flags().Changed("run-id")
 			return runEntityViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], viewOpts)
 		},
@@ -219,7 +238,7 @@ func runEntitiesListCommand(ctx context.Context, out, errOut io.Writer, opts ent
 		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
 	}
 	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
-		writeEntityListResult(w, result, opts.output.verbose)
+		writeEntityListResult(w, result, entityListRenderOptions{verbose: opts.output.verbose, runScoped: opts.runIDSet})
 	}, func() ([]string, error) {
 		ids := make([]string, 0, len(result.Entities))
 		for _, entity := range result.Entities {
@@ -499,33 +518,48 @@ func validateEntityAggregateResult(result entityAggregateResult) error {
 	return nil
 }
 
-func writeEntityListResult(out io.Writer, result entityListResult, verbose bool) {
+type entityListRenderOptions struct {
+	verbose   bool
+	runScoped bool
+}
+
+func writeEntityListResult(out io.Writer, result entityListResult, opts entityListRenderOptions) {
 	if out == nil {
 		return
 	}
+	columns := []cliTableColumn{
+		{Header: "ENTITY_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyEntity},
+	}
+	if !opts.runScoped {
+		columns = append(columns, cliTableColumn{Header: "RUN_ID", IdentifierFamily: cliIdentifierFamilyRun})
+	}
+	columns = append(columns,
+		cliTableColumn{Header: "TYPE"},
+		cliTableColumn{Header: "STATE"},
+		cliTableColumn{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
+		cliTableColumn{Header: "UPDATED"},
+	)
 	rows := make([][]string, 0, len(result.Entities))
 	for _, entity := range result.Entities {
-		updated := entityListTimestamp(cliRelativeTimeNow(), entity.UpdatedAt, verbose)
-		rows = append(rows, []string{
-			entity.EntityID,
+		updated := entityListTimestamp(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose)
+		row := []string{entity.EntityID}
+		if !opts.runScoped {
+			row = append(row, entity.RunID)
+		}
+		row = append(row,
 			entityDash(entity.EntityType),
 			entityDash(entity.CurrentState),
 			entityShortFlow(entity.FlowInstance),
 			updated,
-		})
+		)
+		rows = append(rows, row)
 	}
 	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
 		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
 	writeCLITable(out, cliTable{
-		Columns: []cliTableColumn{
-			{Header: "ENTITY_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyEntity},
-			{Header: "TYPE"},
-			{Header: "STATE"},
-			{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
-			{Header: "UPDATED"},
-		},
+		Columns:      columns,
 		Rows:         rows,
 		EmptyMessage: "No entities match the current filters.",
 		FooterLines:  footers,
@@ -634,7 +668,11 @@ func entityFieldValue(value any) string {
 		}
 		return "false"
 	case string:
-		return cliRenderOneLineValue(v)
+		rendered := cliRenderOneLineValue(v)
+		if strings.TrimSpace(rendered) == "" {
+			return "none"
+		}
+		return rendered
 	case map[string]any:
 		if len(v) == 0 {
 			return "none"

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -66,6 +66,21 @@ type entityListResult struct {
 	NextCursor string          `json:"next_cursor,omitempty"`
 }
 
+// UnmarshalJSON rejects unknown properties (entity.list result and rows are
+// additionalProperties: false) so --json cannot silently drop a malformed
+// member.
+func (r *entityListResult) UnmarshalJSON(data []byte) error {
+	type entityListResultAlias entityListResult
+	var shadow entityListResultAlias
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&shadow); err != nil {
+		return err
+	}
+	*r = entityListResult(shadow)
+	return nil
+}
+
 type entitySummary struct {
 	EntityID     string `json:"entity_id"`
 	RunID        string `json:"run_id"`
@@ -80,28 +95,33 @@ type entitySummary struct {
 }
 
 type entityFull struct {
-	Entity      entitySummary          `json:"entity"`
-	Fields      map[string]any         `json:"fields"`
-	Gates       map[string]bool        `json:"gates"`
-	Accumulated map[string]any         `json:"accumulated"`
-	Loops       []entityLoopActivation `json:"loops,omitempty"`
-	loopsNull   bool
+	Entity       entitySummary          `json:"entity"`
+	Fields       map[string]any         `json:"fields"`
+	Gates        map[string]bool        `json:"gates"`
+	Accumulated  map[string]any         `json:"accumulated"`
+	Loops        []entityLoopActivation `json:"loops,omitempty"`
+	loopsPresent bool
+	loopsNull    bool
 }
 
-// UnmarshalJSON preserves whether the loops property was present and rejects
-// null so a schema-invalid server response cannot be normalized into an
-// omitted property by --json.
+// UnmarshalJSON rejects unknown properties (EntityFull and EntitySummary are
+// additionalProperties: false) and preserves whether loops was present, so a
+// schema-invalid response (extra member, or loops: null) fails closed instead
+// of --json normalizing it away.
 func (f *entityFull) UnmarshalJSON(data []byte) error {
 	type entityFullAlias entityFull
 	var shadow struct {
 		entityFullAlias
 		Loops json.RawMessage `json:"loops"`
 	}
-	if err := json.Unmarshal(data, &shadow); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&shadow); err != nil {
 		return err
 	}
 	*f = entityFull(shadow.entityFullAlias)
 	if len(shadow.Loops) > 0 {
+		f.loopsPresent = true
 		if bytes.Equal(bytes.TrimSpace(shadow.Loops), []byte("null")) {
 			f.loopsNull = true
 			return nil
@@ -111,6 +131,25 @@ func (f *entityFull) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+// MarshalJSON retains an explicitly present loops property (including an empty
+// array) instead of letting omitempty drop it, while still omitting the key
+// when the server omitted it.
+func (f entityFull) MarshalJSON() ([]byte, error) {
+	type entityFullAlias entityFull
+	var loops json.RawMessage
+	if f.loopsPresent {
+		encoded, err := json.Marshal(f.Loops)
+		if err != nil {
+			return nil, err
+		}
+		loops = encoded
+	}
+	return json.Marshal(struct {
+		entityFullAlias
+		Loops json.RawMessage `json:"loops,omitempty"`
+	}{entityFullAlias: entityFullAlias(f), Loops: loops})
 }
 
 // entityLoopActivation mirrors loopruntime.PublicActivation so the --json path

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -499,7 +499,7 @@ func validateEntityLoopActivation(prefix string, loop entityLoopActivation) erro
 		return fmt.Errorf("malformed %s: open loop cannot have close reason %q", prefix, loop.CloseReason)
 	}
 	if loop.Status == "closed" {
-		switch strings.TrimSpace(loop.CloseReason) {
+		switch loop.CloseReason {
 		case "completed", "escaped":
 		default:
 			return fmt.Errorf("malformed %s: close reason %q is invalid; must be completed or escaped", prefix, loop.CloseReason)
@@ -614,19 +614,19 @@ func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOp
 	entity := result.Entity
 	now := cliRelativeTimeNow()
 	header := []cliLabeledDetailRow{
-		{Label: "run", Value: entity.RunID},
-		{Label: "flow", Value: entity.FlowInstance},
-		{Label: "type", Value: entityDash(entity.EntityType)},
-		{Label: "state", Value: entityDash(entity.CurrentState)},
+		{Label: "run", Value: entityOneLine(entity.RunID)},
+		{Label: "flow", Value: entityOneLine(entity.FlowInstance)},
+		{Label: "type", Value: entityDash(entityOneLine(entity.EntityType))},
+		{Label: "state", Value: entityDash(entityOneLine(entity.CurrentState))},
 		{Label: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
 		{Label: "created", Value: entityTimestampText(now, entity.CreatedAt, opts.verbose)},
 		{Label: "updated", Value: entityTimestampText(now, entity.UpdatedAt, opts.verbose)},
 	}
 	if strings.TrimSpace(entity.Slug) != "" {
-		header = append(header, cliLabeledDetailRow{Label: "slug", Value: entity.Slug})
+		header = append(header, cliLabeledDetailRow{Label: "slug", Value: entityOneLine(entity.Slug)})
 	}
 	if strings.TrimSpace(entity.Name) != "" {
-		header = append(header, cliLabeledDetailRow{Label: "name", Value: entity.Name})
+		header = append(header, cliLabeledDetailRow{Label: "name", Value: entityOneLine(entity.Name)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Entity " + entity.EntityID, Rows: header})
 
@@ -663,6 +663,13 @@ func entityListTimestamp(now time.Time, raw string, verbose bool) string {
 		return raw
 	}
 	return formatCLIRelativeTime(now, raw)
+}
+
+// entityOneLine normalizes an unconstrained summary string (run id, flow,
+// type, state, slug, name) so embedded line-breaking characters cannot break
+// the aligned detail-row line discipline.
+func entityOneLine(value string) string {
+	return cliRenderOneLineValue(value)
 }
 
 func entityTimestampText(now time.Time, raw string, verbose bool) string {

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -8,8 +8,10 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/division-sh/swarm/internal/cli/argcount"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +23,7 @@ const (
 
 type entityListCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 
 	runID        string
 	flow         string
@@ -39,6 +42,7 @@ type entityListCommandOptions struct {
 
 type entityViewCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 
 	runID    string
 	runIDSet bool
@@ -154,6 +158,8 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
 	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
+	bindCLIOutputFlags(cmd, &listOpts.output)
+	bindCLIOutputVerboseFlag(cmd, &listOpts.output)
 	return cmd
 }
 
@@ -171,6 +177,8 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 	argcount.SetDiscoveryHint(cmd, "List entity ids with `swarm entity list`.")
 	cmd.Flags().StringVar(&viewOpts.runID, "run-id", "", "Disambiguate entities reused across runs")
 	bindCLIAPIConnectionFlags(cmd, &viewOpts.apiOptions)
+	bindCLIOutputFlags(cmd, &viewOpts.output)
+	bindCLIOutputVerboseFlag(cmd, &viewOpts.output)
 	return cmd
 }
 
@@ -210,8 +218,15 @@ func runEntitiesListCommand(ctx context.Context, out, errOut io.Writer, opts ent
 	if err := validateEntityListResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
 	}
-	writeEntityListResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeEntityListResult(w, result, opts.output.verbose)
+	}, func() ([]string, error) {
+		ids := make([]string, 0, len(result.Entities))
+		for _, entity := range result.Entities {
+			ids = append(ids, entity.EntityID)
+		}
+		return ids, nil
+	})
 }
 
 func runEntityViewCommand(ctx context.Context, out, errOut io.Writer, entityID string, opts entityViewCommandOptions) error {
@@ -257,8 +272,11 @@ func runEntityViewCommand(ctx context.Context, out, errOut io.Writer, entityID s
 	if err := validateEntityFullResult("entity.get result", result); err != nil {
 		return returnCLIAPIError(errOut, err, entityViewAPIErrorClassifier())
 	}
-	writeEntityFullResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeEntityFullResult(w, result, entityRenderOptions{verbose: opts.output.verbose})
+	}, func() ([]string, error) {
+		return []string{result.Entity.EntityID}, nil
+	})
 }
 
 func runEntityAggregateCommand(ctx context.Context, out, errOut io.Writer, opts entityAggregateCommandOptions) error {
@@ -481,22 +499,19 @@ func validateEntityAggregateResult(result entityAggregateResult) error {
 	return nil
 }
 
-func writeEntityListResult(out io.Writer, result entityListResult) {
+func writeEntityListResult(out io.Writer, result entityListResult, verbose bool) {
 	if out == nil {
 		return
 	}
 	rows := make([][]string, 0, len(result.Entities))
 	for _, entity := range result.Entities {
+		updated := entityListTimestamp(cliRelativeTimeNow(), entity.UpdatedAt, verbose)
 		rows = append(rows, []string{
 			entity.EntityID,
-			entity.RunID,
-			entity.FlowInstance,
-			entity.EntityType,
-			entity.CurrentState,
-			fmt.Sprintf("%d", entity.Revision),
-			entity.UpdatedAt,
-			entityDash(entity.Slug),
-			entityDash(entity.Name),
+			entityDash(entity.EntityType),
+			entityDash(entity.CurrentState),
+			entityShortFlow(entity.FlowInstance),
+			updated,
 		})
 	}
 	footers := []string{}
@@ -506,14 +521,10 @@ func writeEntityListResult(out io.Writer, result entityListResult) {
 	writeCLITable(out, cliTable{
 		Columns: []cliTableColumn{
 			{Header: "ENTITY_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyEntity},
-			{Header: "RUN_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyRun},
-			{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
 			{Header: "TYPE"},
 			{Header: "STATE"},
-			{Header: "REVISION"},
+			{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
 			{Header: "UPDATED"},
-			{Header: "SLUG"},
-			{Header: "NAME"},
 		},
 		Rows:         rows,
 		EmptyMessage: "No entities match the current filters.",
@@ -521,28 +532,157 @@ func writeEntityListResult(out io.Writer, result entityListResult) {
 	})
 }
 
-func writeEntityFullResult(out io.Writer, result entityFull) {
+type entityRenderOptions struct {
+	verbose bool
+}
+
+func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOptions) {
 	if out == nil {
 		return
 	}
 	entity := result.Entity
-	writeCLITitle(out, fmt.Sprintf("Entity %s", entity.EntityID))
-	writeCLIFieldLine(out,
-		cliDetailField{Key: "run_id", Value: entity.RunID},
-		cliDetailField{Key: "flow", Value: entity.FlowInstance},
-		cliDetailField{Key: "type", Value: entity.EntityType},
-		cliDetailField{Key: "state", Value: entity.CurrentState},
-		cliDetailField{Key: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
-		cliDetailField{Key: "created_at", Value: entity.CreatedAt},
-		cliDetailField{Key: "updated_at", Value: entity.UpdatedAt},
-	)
-	writeCLIFieldLine(out,
-		cliDetailField{Key: "slug", Value: entityDash(entity.Slug)},
-		cliDetailField{Key: "name", Value: entityDash(entity.Name)},
-	)
-	writeCLIFieldLine(out, cliDetailField{Key: "fields", Value: entityCompactJSON(result.Fields)})
-	writeCLIFieldLine(out, cliDetailField{Key: "gates", Value: entityCompactJSON(result.Gates)})
-	writeCLIFieldLine(out, cliDetailField{Key: "accumulated", Value: entityCompactJSON(result.Accumulated)})
+	now := cliRelativeTimeNow()
+	header := []cliLabeledDetailRow{
+		{Label: "run", Value: entity.RunID},
+		{Label: "flow", Value: entity.FlowInstance},
+		{Label: "type", Value: entityDash(entity.EntityType)},
+		{Label: "state", Value: entityDash(entity.CurrentState)},
+		{Label: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
+		{Label: "created", Value: entityTimestampText(now, entity.CreatedAt, opts.verbose)},
+		{Label: "updated", Value: entityTimestampText(now, entity.UpdatedAt, opts.verbose)},
+	}
+	if strings.TrimSpace(entity.Slug) != "" {
+		header = append(header, cliLabeledDetailRow{Label: "slug", Value: entity.Slug})
+	}
+	if strings.TrimSpace(entity.Name) != "" {
+		header = append(header, cliLabeledDetailRow{Label: "name", Value: entity.Name})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Entity " + entity.EntityID, Rows: header})
+
+	writeEntityFieldSection(out, "Fields", result.Fields, entityContentField, true)
+	writeEntityGatesSection(out, result.Gates)
+	if opts.verbose {
+		writeEntityFieldSection(out, "Bookkeeping", result.Fields, entityBookkeepingField, false)
+		writeEntityFieldSection(out, "Accumulated", result.Accumulated, nil, true)
+	}
+}
+
+func entityListTimestamp(now time.Time, raw string, verbose bool) string {
+	if verbose {
+		return raw
+	}
+	return formatCLIRelativeTime(now, raw)
+}
+
+func entityTimestampText(now time.Time, raw string, verbose bool) string {
+	relative := formatCLIRelativeTime(now, raw)
+	if !verbose {
+		return relative
+	}
+	return relative + " (" + raw + ")"
+}
+
+// entityContentField reports whether a field key is workflow-declared content
+// (default-visible) rather than platform-injected bookkeeping. The platform key
+// set is owned by runtimecontracts.EntityFieldBookkeepingKeys, adjacent to the
+// injection sites; a platform key forgotten there shows up in default output
+// (fail-visible) instead of silently vanishing.
+func entityContentField(key string) bool {
+	return !runtimecontracts.IsEntityFieldBookkeepingKey(key)
+}
+
+func entityBookkeepingField(key string) bool {
+	return runtimecontracts.IsEntityFieldBookkeepingKey(key)
+}
+
+func writeEntityFieldSection(out io.Writer, title string, fields map[string]any, include func(string) bool, stateEmpty bool) {
+	rows := entityFieldRows(fields, include)
+	if len(rows) == 0 {
+		if stateEmpty {
+			writeCLITitle(out, title+"  none")
+		}
+		return
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: title, Rows: rows})
+}
+
+func entityFieldRows(fields map[string]any, include func(string) bool) []cliLabeledDetailRow {
+	if include == nil {
+		include = func(string) bool { return true }
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if include(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	rows := make([]cliLabeledDetailRow, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, cliLabeledDetailRow{Label: key, Value: entityFieldValue(fields[key])})
+	}
+	return rows
+}
+
+func entityFieldValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "none"
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case string:
+		return cliRenderOneLineValue(v)
+	case map[string]any:
+		if len(v) == 0 {
+			return "none"
+		}
+	case []any:
+		if len(v) == 0 {
+			return "none"
+		}
+	}
+	return cliRenderOneLineValue(entityCompactJSON(value))
+}
+
+func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
+	keys := make([]string, 0, len(gates))
+	anyTrue := false
+	for key, value := range gates {
+		keys = append(keys, key)
+		if value {
+			anyTrue = true
+		}
+	}
+	if len(keys) == 0 || !anyTrue {
+		writeCLITitle(out, "Gates  none")
+		return
+	}
+	sort.Strings(keys)
+	rows := make([]cliLabeledDetailRow, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, cliLabeledDetailRow{Label: key, Value: fmt.Sprintf("%t", gates[key])})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Gates", Rows: rows})
+}
+
+const entityFlowSegmentMaxRunes = 16
+
+// entityShortFlow truncates long flow-path segments (e.g. an embedded bundle
+// hash) while preserving the flow structure, so the FLOW column stays
+// scannable. The full flow instance remains available via entity view and
+// --json.
+func entityShortFlow(flow string) string {
+	segments := strings.Split(strings.Trim(flow, "/"), "/")
+	for i, segment := range segments {
+		runes := []rune(segment)
+		if len(runes) > entityFlowSegmentMaxRunes {
+			segments[i] = string(runes[:entityFlowSegmentMaxRunes]) + "…"
+		}
+	}
+	return strings.Join(segments, "/")
 }
 
 func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -498,8 +498,12 @@ func validateEntityLoopActivation(prefix string, loop entityLoopActivation) erro
 	if loop.Status == "open" && loop.CloseReason != "" {
 		return fmt.Errorf("malformed %s: open loop cannot have close reason %q", prefix, loop.CloseReason)
 	}
-	if loop.Status == "closed" && strings.TrimSpace(loop.CloseReason) == "" {
-		return fmt.Errorf("malformed %s: closed loop requires a close reason", prefix)
+	if loop.Status == "closed" {
+		switch strings.TrimSpace(loop.CloseReason) {
+		case "completed", "escaped":
+		default:
+			return fmt.Errorf("malformed %s: close reason %q is invalid; must be completed or escaped", prefix, loop.CloseReason)
+		}
 	}
 	return nil
 }

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -129,14 +129,17 @@ type entityLoopActivation struct {
 
 // UnmarshalJSON preserves whether close_reason was present (even as null) so a
 // schema-invalid open loop carrying a present close reason fails closed instead
-// of being normalized into an omitted property by --json.
+// of being normalized into an omitted property by --json, and rejects unknown
+// properties since BoundedLoopActivation is additionalProperties: false.
 func (l *entityLoopActivation) UnmarshalJSON(data []byte) error {
 	type entityLoopActivationAlias entityLoopActivation
 	var shadow struct {
 		entityLoopActivationAlias
 		CloseReason json.RawMessage `json:"close_reason"`
 	}
-	if err := json.Unmarshal(data, &shadow); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&shadow); err != nil {
 		return err
 	}
 	*l = entityLoopActivation(shadow.entityLoopActivationAlias)
@@ -728,7 +731,7 @@ func writeEntityLoopSection(out io.Writer, loops []entityLoopActivation) {
 			summary += " · " + loop.CloseReason
 		}
 		summary += " · " + loop.CurrentStage
-		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(loop.ID), Value: cliRenderOneLineValue(summary)})
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(loop.ID), Value: cliRenderOneLineValue(summary)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }
@@ -792,7 +795,7 @@ func entityFieldRows(fields map[string]any, include func(string) bool) []cliLabe
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(key), Value: entityFieldValue(fields[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: entityFieldValue(fields[key])})
 	}
 	return rows
 }
@@ -836,7 +839,7 @@ func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(key), Value: fmt.Sprintf("%t", gates[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: fmt.Sprintf("%t", gates[key])})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Gates", Rows: rows})
 }

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -84,6 +85,32 @@ type entityFull struct {
 	Gates       map[string]bool        `json:"gates"`
 	Accumulated map[string]any         `json:"accumulated"`
 	Loops       []entityLoopActivation `json:"loops,omitempty"`
+	loopsNull   bool
+}
+
+// UnmarshalJSON preserves whether the loops property was present and rejects
+// null so a schema-invalid server response cannot be normalized into an
+// omitted property by --json.
+func (f *entityFull) UnmarshalJSON(data []byte) error {
+	type entityFullAlias entityFull
+	var shadow struct {
+		entityFullAlias
+		Loops json.RawMessage `json:"loops"`
+	}
+	if err := json.Unmarshal(data, &shadow); err != nil {
+		return err
+	}
+	*f = entityFull(shadow.entityFullAlias)
+	if len(shadow.Loops) > 0 {
+		if bytes.Equal(bytes.TrimSpace(shadow.Loops), []byte("null")) {
+			f.loopsNull = true
+			return nil
+		}
+		if err := json.Unmarshal(shadow.Loops, &f.Loops); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // entityLoopActivation mirrors loopruntime.PublicActivation so the --json path
@@ -468,6 +495,9 @@ func validateEntityFullResult(prefix string, result entityFull) error {
 	if result.Accumulated == nil {
 		return fmt.Errorf("malformed %s: accumulated is required", prefix)
 	}
+	if result.loopsNull {
+		return fmt.Errorf("malformed %s: loops must be an array, got null", prefix)
+	}
 	for i, loop := range result.Loops {
 		if err := validateEntityLoopActivation(fmt.Sprintf("%s.loops[%d]", prefix, i), loop); err != nil {
 			return err
@@ -666,11 +696,12 @@ func writeEntityLoopSection(out io.Writer, loops []entityLoopActivation) {
 	}
 	rows := make([]cliLabeledDetailRow, 0, len(loops))
 	for _, loop := range loops {
-		summary := fmt.Sprintf("%s · %s · attempt %d/%d", loop.CurrentStage, loop.Status, loop.Attempt, loop.MaxAttempts)
+		summary := fmt.Sprintf("%s · attempt %d/%d · rev %s", loop.Status, loop.Attempt, loop.MaxAttempts, loop.RevisionID)
 		if strings.TrimSpace(loop.CloseReason) != "" {
 			summary += " · " + loop.CloseReason
 		}
-		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(loop.ID), Value: cliRenderOneLineValue(summary + " · rev " + loop.RevisionID)})
+		summary += " · " + loop.CurrentStage
+		rows = append(rows, cliLabeledDetailRow{Label: entityOneLine(loop.ID), Value: cliRenderOneLineValue(summary)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -537,6 +537,9 @@ func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *te
 		fields["bundle_hash"] = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		fields["package_key"] = "."
 		fields["activation"] = "standing"
+		result["loops"] = []map[string]any{
+			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "active"},
+		}
 		writeJSONRPCResult(t, w, captured.ID, result)
 	}))
 	defer server.Close()
@@ -546,7 +549,7 @@ func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *te
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Bookkeeping", "bundle_hash", "package_key", "activation", "Accumulated", "accumulator"} {
+	for _, want := range []string{"Bookkeeping", "bundle_hash", "package_key", "activation", "Accumulated", "accumulator", "Loops", "loop-a", "attempt 1/3"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -564,7 +567,7 @@ func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *te
 	if code != 0 {
 		t.Fatalf("default code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, absent := range []string{"Bookkeeping", "bundle_hash", "Accumulated", "accumulator", "2026-05-20T01:05:00Z"} {
+	for _, absent := range []string{"Bookkeeping", "bundle_hash", "Accumulated", "accumulator", "Loops", "loop-a", "2026-05-20T01:05:00Z"} {
 		if strings.Contains(stdout.String(), absent) {
 			t.Fatalf("default stdout should not contain %q:\n%s", absent, stdout.String())
 		}

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -533,6 +533,21 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "loops must be an array",
 		},
 		{
+			name: "view open loop with present close reason exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = []map[string]any{
+					{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "open", "close_reason": nil},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "open loop cannot have a close reason",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -505,6 +505,21 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "close reason",
 		},
 		{
+			name: "view whitespace-padded loop close reason exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = []map[string]any{
+					{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "closed", "close_reason": " completed "},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "close reason",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -612,6 +627,8 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 			t.Errorf("decode request: %v", err)
 		}
 		result := validEntityFullResult("entity-1")
+		entity := result["entity"].(map[string]any)
+		entity["name"] = "Vertical\nOne"
 		result["fields"] = map[string]any{
 			"chats":                         map[string]any{},
 			"empty":                         "   ",
@@ -659,6 +676,9 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "\nline two") || strings.Contains(stdout.String(), "\x01") {
 		t.Fatalf("control characters leaked into output line discipline:\n%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nOne") {
+		t.Fatalf("embedded newline in entity name broke the header line discipline:\n%q", stdout.String())
 	}
 	unicodeLine := ""
 	for _, line := range strings.Split(stdout.String(), "\n") {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -271,7 +271,7 @@ func TestEntityViewJSONPreservesLoopActivations(t *testing.T) {
 		}
 		result := validEntityFullResult("entity-1")
 		result["loops"] = []map[string]any{
-			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "active"},
+			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "open"},
 		}
 		writeJSONRPCResult(t, w, captured.ID, result)
 	}))
@@ -283,7 +283,7 @@ func TestEntityViewJSONPreservesLoopActivations(t *testing.T) {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
 	for _, want := range []string{
-		`"loops":[{"id":"loop-a","revision_id":"rev-9","attempt":1,"max_attempts":3,"current_stage":"collecting","status":"active"}]`,
+		`"loops":[{"id":"loop-a","revision_id":"rev-9","attempt":1,"max_attempts":3,"current_stage":"collecting","status":"open"}]`,
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entity view --json missing %q:\n%s", want, stdout.String())
@@ -475,6 +475,21 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "fields is required",
 		},
 		{
+			name: "view malformed loop activation exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = []map[string]any{
+					{"id": "loop-a", "revision_id": "rev-9", "attempt": 0, "max_attempts": 0, "current_stage": "collecting", "status": "open"},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "attempt bounds are invalid",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -538,7 +553,7 @@ func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *te
 		fields["package_key"] = "."
 		fields["activation"] = "standing"
 		result["loops"] = []map[string]any{
-			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "active"},
+			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "open"},
 		}
 		writeJSONRPCResult(t, w, captured.ID, result)
 	}))
@@ -549,7 +564,7 @@ func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *te
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Bookkeeping", "bundle_hash", "package_key", "activation", "Accumulated", "accumulator", "Loops", "loop-a", "attempt 1/3"} {
+	for _, want := range []string{"Bookkeeping", "bundle_hash", "package_key", "activation", "Accumulated", "accumulator", "Loops", "loop-a", "attempt 1/3", "rev-9"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -548,6 +548,21 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "open loop cannot have a close reason",
 		},
 		{
+			name: "view loop activation with unknown property exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = []map[string]any{
+					{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "open", "bogus": "extra"},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "unknown field",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -916,6 +931,21 @@ func TestEntityListJSONPreservesFullMachineShape(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entity list --json missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestCLIRenderOneLineLabelKeepsDistinguishingSuffix(t *testing.T) {
+	shared := strings.Repeat("x", 190)
+	a := cliRenderOneLineLabel(shared + "alpha")
+	b := cliRenderOneLineLabel(shared + "beta")
+	if a == b {
+		t.Fatalf("labels sharing a long prefix must stay distinguishable:\nA=%s\nB=%s", a, b)
+	}
+	if !strings.Contains(a, "alpha") || !strings.Contains(b, "beta") {
+		t.Fatalf("truncated labels should retain their distinguishing suffix:\nA=%s\nB=%s", a, b)
+	}
+	if strings.Contains(a, "\n") || strings.Contains(a, "\u2028") {
+		t.Fatalf("label sanitization leaked a line-breaking character:\n%q", a)
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -563,6 +563,30 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "unknown field",
 		},
 		{
+			name: "list unknown member exits three",
+			args: []string{"entity", "list"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				writeJSONRPCResult(t, w, req.ID, map[string]any{"entities": []any{}, "bogus": 1})
+			},
+			wantCode:   3,
+			wantStderr: "unknown field",
+		},
+		{
+			name: "view unknown member exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["bogus"] = 1
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "unknown field",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -838,6 +862,29 @@ func TestEntityListQuietRendersEntityIDs(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
 	if len(lines) != 2 || lines[0] != "entity-a" || lines[1] != "entity-b" {
 		t.Fatalf("quiet stdout = %q, want entity-a/entity-b lines", stdout.String())
+	}
+}
+
+func TestEntityViewJSONPreservesExplicitEmptyLoops(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["loops"] = []any{}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"loops":[]`) {
+		t.Fatalf("explicitly present empty loops array was dropped by --json:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -580,11 +580,13 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 		}
 		result := validEntityFullResult("entity-1")
 		result["fields"] = map[string]any{
-			"chats":         map[string]any{},
-			"empty":         "   ",
-			"long":          strings.Repeat("x", 300),
-			"broken":        "line one\nline two\tand a control \x01 byte",
-			"fan_out_count": 3,
+			"chats":                         map[string]any{},
+			"empty":                         "   ",
+			"long":                          strings.Repeat("x", 300),
+			"broken":                        "line one\nline two\tand a control \x01 byte",
+			"unicode_separators":            "a\u2028b\u2029c\u0085d",
+			"fan_out_count":                 3,
+			"last_data_accumulation_source": "scan.completed",
 		}
 		result["gates"] = map[string]any{"blocked": false, "paused": false}
 		writeJSONRPCResult(t, w, captured.ID, result)
@@ -615,14 +617,27 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 	if !strings.Contains(emptyLine, "none") {
 		t.Fatalf("empty string field should render as none:\n%s", stdout.String())
 	}
-	if strings.Contains(stdout.String(), "fan_out_count") {
-		t.Fatalf("platform bookkeeping key fan_out_count leaked into default Fields:\n%s", stdout.String())
+	if strings.Contains(stdout.String(), "fan_out_count") || strings.Contains(stdout.String(), "last_data_accumulation_source") {
+		t.Fatalf("platform bookkeeping keys leaked into default Fields:\n%s", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "…") {
 		t.Fatalf("long value missing truncation marker:\n%s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "\nline two") || strings.Contains(stdout.String(), "\x01") {
 		t.Fatalf("control characters leaked into output line discipline:\n%q", stdout.String())
+	}
+	unicodeLine := ""
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.Contains(line, "unicode_separators") {
+			unicodeLine = line
+			break
+		}
+	}
+	if !strings.Contains(unicodeLine, "a b c d") {
+		t.Fatalf("unicode line/paragraph separators not collapsed to spaces:\n%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\u2028") || strings.Contains(stdout.String(), "\u2029") || strings.Contains(stdout.String(), "\u0085") {
+		t.Fatalf("unicode line/paragraph separators leaked into output:\n%q", stdout.String())
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -649,8 +649,8 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Gates  none") {
-		t.Fatalf("all-false gates should render as stated none:\n%s", stdout.String())
+	if !strings.Contains(stdout.String(), "blocked") || !strings.Contains(stdout.String(), "false") || !strings.Contains(stdout.String(), "paused") {
+		t.Fatalf("populated all-false gates should render their names and values, not collapse to none:\n%s", stdout.String())
 	}
 	chatsLine := ""
 	emptyLine := ""
@@ -713,6 +713,60 @@ func TestEntityViewQuietRendersEntityID(t *testing.T) {
 	}
 	if strings.TrimSpace(stdout.String()) != "entity-1" {
 		t.Fatalf("quiet stdout = %q, want entity-1", stdout.String())
+	}
+}
+
+func TestEntityViewEmptyGatesRenderNone(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["gates"] = map[string]any{}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Gates  none") {
+		t.Fatalf("empty gates map should render as stated none:\n%s", stdout.String())
+	}
+}
+
+func TestEntityListVerboseShowsFullSummaryColumns(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		entity := validEntitySummary("entity-1")
+		entity["current_state"] = "collecting\nmore"
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{"entities": []map[string]any{entity}})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"REVISION", "CREATED", "SLUG", "NAME", "vertical-1", "Vertical One"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("verbose list missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "\nmore") {
+		t.Fatalf("control character in list cell broke the table line discipline:\n%q", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -262,6 +262,38 @@ func TestEntityViewJSONPreservesFullMachineShape(t *testing.T) {
 	}
 }
 
+func TestEntityViewJSONPreservesLoopActivations(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["loops"] = []map[string]any{
+			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "active"},
+		}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		`"loops":[{"id":"loop-a","revision_id":"rev-9","attempt":1,"max_attempts":3,"current_stage":"collecting","status":"active"}]`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity view --json missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	var captured []jsonRPCRequest
@@ -548,9 +580,11 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 		}
 		result := validEntityFullResult("entity-1")
 		result["fields"] = map[string]any{
-			"chats":  map[string]any{},
-			"long":   strings.Repeat("x", 300),
-			"broken": "line one\nline two\tand a control \x01 byte",
+			"chats":         map[string]any{},
+			"empty":         "   ",
+			"long":          strings.Repeat("x", 300),
+			"broken":        "line one\nline two\tand a control \x01 byte",
+			"fan_out_count": 3,
 		}
 		result["gates"] = map[string]any{"blocked": false, "paused": false}
 		writeJSONRPCResult(t, w, captured.ID, result)
@@ -566,14 +600,23 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 		t.Fatalf("all-false gates should render as stated none:\n%s", stdout.String())
 	}
 	chatsLine := ""
+	emptyLine := ""
 	for _, line := range strings.Split(stdout.String(), "\n") {
 		if strings.Contains(line, "chats") {
 			chatsLine = line
-			break
+		}
+		if strings.Contains(line, "empty") {
+			emptyLine = line
 		}
 	}
 	if !strings.Contains(chatsLine, "none") {
 		t.Fatalf("empty collection value should render as none:\n%s", stdout.String())
+	}
+	if !strings.Contains(emptyLine, "none") {
+		t.Fatalf("empty string field should render as none:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "fan_out_count") {
+		t.Fatalf("platform bookkeeping key fan_out_count leaked into default Fields:\n%s", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "…") {
 		t.Fatalf("long value missing truncation marker:\n%s", stdout.String())
@@ -625,6 +668,69 @@ func TestEntityListQuietRendersEntityIDs(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
 	if len(lines) != 2 || lines[0] != "entity-a" || lines[1] != "entity-b" {
 		t.Fatalf("quiet stdout = %q, want entity-a/entity-b lines", stdout.String())
+	}
+}
+
+func TestEntityListUnscopedRetainsRunIdentityColumn(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities": []map[string]any{validEntitySummary("entity-1")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"ENTITY_ID", "RUN_ID", "entity-1", "run-1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("unscoped list missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("scoped code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "RUN_ID") {
+		t.Fatalf("run-scoped list should not repeat the RUN_ID column:\n%s", stdout.String())
+	}
+}
+
+func TestEntityOutputModesRejectCollisionBeforeRequest(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"entities": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"entity", "list", "--json", "--quiet"},
+		{"entity", "view", "entity-1", "--json", "--quiet"},
+	} {
+		calls.Store(0)
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 2 {
+			t.Fatalf("%v code = %d, want 2 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "mutually exclusive") {
+			t.Fatalf("%v stderr = %q, want collision error", args, stderr.String())
+		}
+		if calls.Load() != 0 {
+			t.Fatalf("%v RPC calls = %d, want 0 (collision must fail before any API call)", args, calls.Load())
+		}
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -490,6 +490,21 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "attempt bounds are invalid",
 		},
 		{
+			name: "view unsupported loop close reason exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = []map[string]any{
+					{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "closed", "close_reason": "timed_out"},
+				}
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "close reason",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
@@ -605,6 +620,7 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 			"unicode_separators":            "a\u2028b\u2029c\u0085d",
 			"fan_out_count":                 3,
 			"last_data_accumulation_source": "scan.completed",
+			"last_source_event":             "event-9",
 		}
 		result["gates"] = map[string]any{"blocked": false, "paused": false}
 		writeJSONRPCResult(t, w, captured.ID, result)
@@ -635,7 +651,7 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 	if !strings.Contains(emptyLine, "none") {
 		t.Fatalf("empty string field should render as none:\n%s", stdout.String())
 	}
-	if strings.Contains(stdout.String(), "fan_out_count") || strings.Contains(stdout.String(), "last_data_accumulation_source") {
+	if strings.Contains(stdout.String(), "fan_out_count") || strings.Contains(stdout.String(), "last_data_accumulation_source") || strings.Contains(stdout.String(), "last_source_event") {
 		t.Fatalf("platform bookkeeping keys leaked into default Fields:\n%s", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "…") {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -520,6 +520,19 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			wantStderr: "close reason",
 		},
 		{
+			name: "view null loop collection exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["loops"] = nil
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "loops must be an array",
+		},
+		{
 			name: "aggregate unknown rpc exits three",
 			args: []string{"entity", "aggregate"},
 			handler: func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -638,6 +638,7 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 			"fan_out_count":                 3,
 			"last_data_accumulation_source": "scan.completed",
 			"last_source_event":             "event-9",
+			"label\nwith_newline":           "value",
 		}
 		result["gates"] = map[string]any{"blocked": false, "paused": false}
 		writeJSONRPCResult(t, w, captured.ID, result)
@@ -679,6 +680,9 @@ func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "\nOne") {
 		t.Fatalf("embedded newline in entity name broke the header line discipline:\n%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nwith_newline") {
+		t.Fatalf("embedded newline in field label broke the detail line discipline:\n%q", stdout.String())
 	}
 	unicodeLine := ""
 	for _, line := range strings.Split(stdout.String(), "\n") {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -63,7 +63,7 @@ func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"ENTITY_ID", "RUN_ID", "entity-1", "run-1", "flows/review", "vertical", "collecting", "next_cursor=entity-cursor-2"} {
+	for _, want := range []string{"ENTITY_ID", "entity-1", "flows/review", "vertical", "collecting", "next_cursor=entity-cursor-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -143,7 +143,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("entities list code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"ENTITY_ID", "RUN_ID", entityA, entityB, "vertical", "discovered", "pending"} {
+	for _, want := range []string{"ENTITY_ID", entityA, entityB, "vertical", "discovered", "pending"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entities list stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -158,7 +158,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("entity view code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Entity " + entityA, "type=vertical state=discovered", `fields={"vertical_name":"Healthcare"}`} {
+	for _, want := range []string{"Entity " + entityA, "vertical", "discovered", "vertical_name", "Healthcare"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entity view stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -210,14 +210,51 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Entity entity-1",
-		"run_id=run-1 flow=flows/review type=vertical state=collecting revision=3",
-		"slug=vertical-1 name=Vertical One",
-		`fields={"score":7}`,
-		`gates={"ready":true}`,
-		`accumulated={"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
+		"run-1",
+		"flows/review",
+		"vertical",
+		"collecting",
+		"score",
+		"ready",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, absent := range []string{"accumulator", `"accumulated"`, `fields={"score":7}`} {
+		if strings.Contains(stdout.String(), absent) {
+			t.Fatalf("stdout should not contain %q:\n%s", absent, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEntityViewJSONPreservesFullMachineShape(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEntityFullResult("entity-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		`"entity_id":"entity-1"`,
+		`"fields":{"score":7}`,
+		`"gates":{"ready":true}`,
+		`"accumulated":{"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity view --json missing %q:\n%s", want, stdout.String())
 		}
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
@@ -453,6 +490,192 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
 			}
 		})
+	}
+}
+
+func TestEntityViewVerboseShowsBookkeepingAccumulatedAndAbsoluteTimestamps(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		fields := result["fields"].(map[string]any)
+		fields["bundle_hash"] = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		fields["package_key"] = "."
+		fields["activation"] = "standing"
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Bookkeeping", "bundle_hash", "package_key", "activation", "Accumulated", "accumulator"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if !strings.Contains(stdout.String(), "2026-05-20T01:05:00Z") {
+		t.Fatalf("verbose stdout missing absolute timestamp:\n%s", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("default code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, absent := range []string{"Bookkeeping", "bundle_hash", "Accumulated", "accumulator", "2026-05-20T01:05:00Z"} {
+		if strings.Contains(stdout.String(), absent) {
+			t.Fatalf("default stdout should not contain %q:\n%s", absent, stdout.String())
+		}
+	}
+}
+
+func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["fields"] = map[string]any{
+			"chats":  map[string]any{},
+			"long":   strings.Repeat("x", 300),
+			"broken": "line one\nline two\tand a control \x01 byte",
+		}
+		result["gates"] = map[string]any{"blocked": false, "paused": false}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Gates  none") {
+		t.Fatalf("all-false gates should render as stated none:\n%s", stdout.String())
+	}
+	chatsLine := ""
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.Contains(line, "chats") {
+			chatsLine = line
+			break
+		}
+	}
+	if !strings.Contains(chatsLine, "none") {
+		t.Fatalf("empty collection value should render as none:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "…") {
+		t.Fatalf("long value missing truncation marker:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nline two") || strings.Contains(stdout.String(), "\x01") {
+		t.Fatalf("control characters leaked into output line discipline:\n%q", stdout.String())
+	}
+}
+
+func TestEntityViewQuietRendersEntityID(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEntityFullResult("entity-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--quiet"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "entity-1" {
+		t.Fatalf("quiet stdout = %q, want entity-1", stdout.String())
+	}
+}
+
+func TestEntityListQuietRendersEntityIDs(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities": []map[string]any{validEntitySummary("entity-a"), validEntitySummary("entity-b")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--quiet"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 || lines[0] != "entity-a" || lines[1] != "entity-b" {
+		t.Fatalf("quiet stdout = %q, want entity-a/entity-b lines", stdout.String())
+	}
+}
+
+func TestEntityListJSONPreservesFullMachineShape(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities":    []map[string]any{validEntitySummary("entity-1")},
+			"next_cursor": "entity-cursor-2",
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		`"entity_id":"entity-1"`,
+		`"run_id":"run-1"`,
+		`"next_cursor":"entity-cursor-2"`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity list --json missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestFormatCLIRelativeTime(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "2026-08-08T11:59:50Z", want: "just now"},
+		{raw: "2026-08-08T11:57:00Z", want: "3m ago"},
+		{raw: "2026-08-08T09:00:00Z", want: "3h ago"},
+		{raw: "2026-08-05T12:00:00Z", want: "3d ago"},
+		{raw: "2026-05-20T01:05:00Z", want: "2mo ago"},
+		{raw: "2020-01-01T00:00:00Z", want: "6y ago"},
+		{raw: "not-a-timestamp", want: "not-a-timestamp"},
+		{raw: "2026-08-09T12:00:00Z", want: "2026-08-09T12:00:00Z"},
+	} {
+		if got := formatCLIRelativeTime(now, tc.raw); got != tc.want {
+			t.Errorf("formatCLIRelativeTime(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
 	}
 }
 

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -12,9 +12,10 @@ package contracts
 // names a workflow-declared field, it is CONTENT and stays default-visible.
 //
 // Current platform injection sites:
-//   - activation, bundle_hash, package_key: internal/runtime/standing_targets.go
-//   - last_data_accumulation_event:        internal/runtime/engine/executor.go
-//   - fan_out_count:                       internal/runtime/engine/executor.go
+//   - activation, bundle_hash, package_key:      internal/runtime/standing_targets.go
+//   - last_data_accumulation_event:              internal/runtime/engine/executor.go
+//   - last_data_accumulation_source:             internal/runtime/engine/helpers.go
+//   - fan_out_count:                             internal/runtime/engine/executor.go
 //
 // `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
 // This list must stay adjacent to the injection sites; a platform-injected key
@@ -26,6 +27,7 @@ var EntityFieldBookkeepingKeys = []string{
 	"package_key",
 	"entity_id",
 	"last_data_accumulation_event",
+	"last_data_accumulation_source",
 	"fan_out_count",
 }
 

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -14,6 +14,7 @@ package contracts
 // Current platform injection sites:
 //   - activation, bundle_hash, package_key: internal/runtime/standing_targets.go
 //   - last_data_accumulation_event:        internal/runtime/engine/executor.go
+//   - fan_out_count:                       internal/runtime/engine/executor.go
 //
 // `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
 // This list must stay adjacent to the injection sites; a platform-injected key
@@ -25,6 +26,7 @@ var EntityFieldBookkeepingKeys = []string{
 	"package_key",
 	"entity_id",
 	"last_data_accumulation_event",
+	"fan_out_count",
 }
 
 // IsEntityFieldBookkeepingKey reports whether key is in EntityFieldBookkeepingKeys.

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -22,6 +22,11 @@ package contracts
 // (workflow_contract_yaml_wave1.go), so a field present under one of these
 // keys is always platform-injected bookkeeping, never workflow content.
 //
+// `entity_id` is deliberately NOT bookkeeping: the expression contract permits
+// `entity.entity_id` when `entity_id` is declared as business data
+// (platform-spec entity read model), and no runtime injection site writes it
+// into the field surface, so declaring it must remain legal and content-visible.
+//
 // `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
 // This list must stay adjacent to the injection sites; a platform-injected key
 // forgotten here SHOWS UP in default output and is caught by eyes (fail-visible),
@@ -30,7 +35,6 @@ var EntityFieldBookkeepingKeys = []string{
 	"activation",
 	"bundle_hash",
 	"package_key",
-	"entity_id",
 	"last_data_accumulation_event",
 	"last_data_accumulation_source",
 	"fan_out_count",

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -16,6 +16,11 @@ package contracts
 //   - last_data_accumulation_event:              internal/runtime/engine/executor.go
 //   - last_data_accumulation_source:             internal/runtime/engine/helpers.go
 //   - fan_out_count:                             internal/runtime/engine/executor.go
+//   - last_source_event:                         internal/runtime/bus/template_instance_lifecycle.go
+//
+// Entity field declaration validation rejects these names as reserved
+// (workflow_contract_yaml_wave1.go), so a field present under one of these
+// keys is always platform-injected bookkeeping, never workflow content.
 //
 // `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
 // This list must stay adjacent to the injection sites; a platform-injected key
@@ -29,6 +34,7 @@ var EntityFieldBookkeepingKeys = []string{
 	"last_data_accumulation_event",
 	"last_data_accumulation_source",
 	"fan_out_count",
+	"last_source_event",
 }
 
 // IsEntityFieldBookkeepingKey reports whether key is in EntityFieldBookkeepingKeys.

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -1,0 +1,38 @@
+package contracts
+
+// EntityFieldBookkeepingKeys enumerates the platform-owned entity field keys
+// that runtime machinery injects into an entity's field surface as
+// bookkeeping, as opposed to workflow-declared content fields.
+//
+// Ownership test (recorded so every future ambiguous key inherits a rule
+// rather than precedent-by-vibes): if runtime machinery writes the key into
+// the entity field surface as part of platform bookkeeping (bundle provenance,
+// activation identity, engine accumulation metadata), the key is BOOKKEEPING
+// and is hidden from default human output (shown under --verbose). If the key
+// names a workflow-declared field, it is CONTENT and stays default-visible.
+//
+// Current platform injection sites:
+//   - activation, bundle_hash, package_key: internal/runtime/standing_targets.go
+//   - last_data_accumulation_event:        internal/runtime/engine/executor.go
+//
+// `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
+// This list must stay adjacent to the injection sites; a platform-injected key
+// forgotten here SHOWS UP in default output and is caught by eyes (fail-visible),
+// rather than content silently vanishing.
+var EntityFieldBookkeepingKeys = []string{
+	"activation",
+	"bundle_hash",
+	"package_key",
+	"entity_id",
+	"last_data_accumulation_event",
+}
+
+// IsEntityFieldBookkeepingKey reports whether key is in EntityFieldBookkeepingKeys.
+func IsEntityFieldBookkeepingKey(key string) bool {
+	for _, candidate := range EntityFieldBookkeepingKeys {
+		if candidate == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -4062,3 +4062,14 @@ func TestEntityContractDecode_RejectsReservedBookkeepingFieldNames(t *testing.T)
 		})
 	}
 }
+
+func TestEntityContractDecode_AllowsDeclaredEntityIDBusinessField(t *testing.T) {
+	var contract EntityContract
+	err := yaml.Unmarshal([]byte("entity_id: {type: text}\n"), &contract)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal error = %v, want entity_id accepted as declared business data", err)
+	}
+	if _, ok := contract.Fields["entity_id"]; !ok {
+		t.Fatalf("declared entity_id field not retained: %#v", contract.Fields)
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_test.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_test.go
@@ -4050,3 +4050,15 @@ func TestEnumTypeDeclValidate_SharedInvariantNondeterministicFree(t *testing.T) 
 		t.Fatalf("multi-enum validation error = %v, want sorted deterministic first error naming zebra", err)
 	}
 }
+
+func TestEntityContractDecode_RejectsReservedBookkeepingFieldNames(t *testing.T) {
+	for _, name := range EntityFieldBookkeepingKeys {
+		t.Run(name, func(t *testing.T) {
+			var contract EntityContract
+			err := yaml.Unmarshal([]byte(name+": {type: text}\n"), &contract)
+			if err == nil || !strings.Contains(err.Error(), "RESERVED") || !strings.Contains(err.Error(), name) {
+				t.Fatalf("yaml.Unmarshal error = %v, want RESERVED rejection of %q", err, name)
+			}
+		})
+	}
+}

--- a/internal/runtime/contracts/workflow_contract_yaml_wave1.go
+++ b/internal/runtime/contracts/workflow_contract_yaml_wave1.go
@@ -1044,6 +1044,9 @@ func (e *EntityContract) UnmarshalYAML(node *yaml.Node) error {
 		if key == "state_field" {
 			return fmt.Errorf("RETIRED: entity field %q is retired; state authority is implicit from schema.yaml", key)
 		}
+		if IsEntityFieldBookkeepingKey(key) {
+			return fmt.Errorf("RESERVED: entity field %q is reserved for platform-injected bookkeeping and cannot be declared as workflow content", key)
+		}
 		var field EntityFieldDecl
 		if err := value.Decode(&field); err != nil {
 			return err

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -5282,7 +5282,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if entityListCode != 0 {
 		t.Fatalf("entities list readback code=%d stderr=%s stdout=%s", entityListCode, entityListStderr, entityListStdout)
 	}
-	for _, want := range []string{entityID, runID, "done"} {
+	for _, want := range []string{entityID, "done"} {
 		if !strings.Contains(entityListStdout, want) {
 			t.Fatalf("entities list readback missing %q:\n%s", want, entityListStdout)
 		}
@@ -5291,7 +5291,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if entityViewCode != 0 {
 		t.Fatalf("entity view readback code=%d stderr=%s stdout=%s", entityViewCode, entityViewStderr, entityViewStdout)
 	}
-	for _, want := range []string{entityID, "state=done", "fields={}"} {
+	for _, want := range []string{entityID, "done", "Fields  none"} {
 		if !strings.Contains(entityViewStdout, want) {
 			t.Fatalf("entity view readback missing %q:\n%s", want, entityViewStdout)
 		}

--- a/internal/userfacing/human_code_projection_cli_test.go
+++ b/internal/userfacing/human_code_projection_cli_test.go
@@ -557,6 +557,10 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Names:  []string{"mode"},
 		Reason: "flow composition mode is an authoring-view concept, not ConversationMode",
 	},
+	"entities.go\x00writeEntityLoopSection": {
+		Names:  []string{"status"},
+		Reason: "loop activation status is loopruntime.Status, a separate loop-lifecycle taxonomy, not a registered run/agent status family",
+	},
 	"local_preflight.go\x00WriteLocalPreflightText": {
 		Names:  []string{"mode"},
 		Reason: "preflight mode is a typed diagnostic rendering input, not a registered conversation mode",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -23906,8 +23906,11 @@ cli_specification:
         required: false
         api_param: cursor
       output:
-        table: ENTITY_ID / RUN_ID / FLOW / TYPE / STATE / REVISION / UPDATED / SLUG / NAME plus next_cursor when present
-        empty: No entities match the filter.
+        table: >
+          ENTITY_ID / [RUN_ID when not scoped by --run-id] / TYPE / STATE / FLOW / UPDATED by default;
+          --verbose adds REVISION / CREATED / SLUG / NAME with absolute ISO timestamps. FLOW long
+          segments (embedded bundle hash) are truncated; UPDATED is humanized relative. plus next_cursor when present
+        empty: No entities match the current filters.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -23937,9 +23940,16 @@ cli_specification:
         validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
       output:
         heading: Entity <entity-id>
-        summary_line: run_id / flow / type / state / revision / created_at / updated_at
-        optional_line: slug / name with '-' for omitted optional fields
-        structured_lines: compact JSON for server-owned fields, gates, and accumulated maps
+        detail_rows: aligned labeled rows for run / flow / type / state / revision / created / updated / slug / name
+        timestamps: humanized relative by default; absolute ISO under --verbose
+        fields_section: >
+          workflow-declared content fields as aligned one-line rows (fixed 200-rune ceiling with
+          ellipsis marker; empty collections and empty strings stated as none). Platform-injected
+          bookkeeping keys are hidden from default output and shown under --verbose in a Bookkeeping section.
+        gates_section: gate name/value rows; an empty gate map states Gates none
+        verbose_sections: absolute timestamps, plus Loops (id / status / attempt / revision / stage),
+          Bookkeeping, and Accumulated sections
+        json: raw entity.get result object, including loops when present (see output_conformance_registry json_shape)
       exit_codes:
         success: 0
         cli_validation: 2

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -20850,7 +20850,7 @@ cli_specification:
               command: swarm entity view
               classification: shared_output
               fact_owner: /v1/rpc entity.get
-              json_shape: entity.get result object (entity with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; fields; gates; accumulated)
+              json_shape: entity.get result object (entity with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; fields; gates; accumulated; loops when present)
               quiet_values:
               - entity_id
             entity_aggregate:

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -20841,14 +20841,18 @@ cli_specification:
               exception_rule: group_help
             entities_list:
               command: swarm entity list
-              classification: split
-              owner_issue: '#1913'
-              reason: entity list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
+              classification: shared_output
+              fact_owner: /v1/rpc entity.list
+              json_shape: entity.list result object (entities with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; next_cursor)
+              quiet_values:
+              - entity_id, one per returned entity, in API result order
             entity_view:
               command: swarm entity view
-              classification: split
-              owner_issue: '#1913'
-              reason: entity detail shell consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
+              classification: shared_output
+              fact_owner: /v1/rpc entity.get
+              json_shape: entity.get result object (entity with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; fields; gates; accumulated)
+              quiet_values:
+              - entity_id
             entity_aggregate:
               command: swarm entity aggregate
               classification: split


### PR DESCRIPTION
Closes #2013

## What changed

`entity view` and `entity list` now consume the shared output-mode owner (`--json`, `--quiet`, `--no-color`, plus a new shared `--verbose`) via `bindCLIOutputFlags`/`renderCLIOutput`. The default human path is a readable record instead of raw JSON blobs + full-width IDs:

- **view**: aligned k/v header (run/flow/type/state/revision/slug/name) with humanized relative timestamps; `Fields` section renders content fields one-line with a truncation marker and stated empty states (`none`); `Gates` section (or `Gates  none` for zero/all-false); `--verbose` adds absolute timestamps, the platform-injected `Bookkeeping` section, and `Accumulated`.
- **list**: columns trimmed to identity+state+stage+updated (`ENTITY_ID, TYPE, STATE, FLOW, UPDATED`), FLOW long segments (embedded bundle hash) truncated, UPDATED humanized. `--verbose` swaps UPDATED to absolute ISO.
- **`--json`** is byte-compatible with the API result shape (machine consumers keep the full `entity.get`/`entity.list` object verbatim); the completeness assertions that used to pin the human raw-JSON blobs moved there.
- **`--quiet`**: view → `entity_id`; list → one `entity_id` per line.

## #1233 / bookkeeping census

The platform-injected key set lives in **`runtimecontracts.EntityFieldBookkeepingKeys`** (adjacent to the injection sites `standing_targets.go`, `engine/executor.go`) with the ownership test recorded in the comment: platform machinery writes it → bookkeeping (hidden below the fold, shown under `--verbose`); workflow-declared field → content. `last_word` classified CONTENT by that test. Fail-visible: a forgotten platform key shows up in default output rather than content silently vanishing. The CLI consumes the export; it does not enumerate keys.

## Registry

Both commands graduate `split (#1913)` → `shared_output` in `platform-spec.yaml` (fact_owner, json_shape, quiet_values) with matching shared-owner proofs; `writeEntityFullResult` conformance proof moves `writeCLIFieldLine` → `writeCLILabeledDetail`.

## Input-space census (standing amendment)

- empty list → `No entities match the current filters.` (existing) — retained
- nil/absent maps → validation rejects; empty maps → stated `none`
- huge field values → fixed 200-rune one-line ceiling + `…` marker (fixed constant, not terminal-width-dependent, so TTY/piped output is deterministic — the terminal-width census item is deliberately answered with a fixed ceiling)
- newline/control chars → collapsed to spaces; cannot break line discipline
- zero-gate and all-gates-false → `Gates  none`
- covered by `TestEntityViewStatedEmptyStatesAndTruncationAndControlChars` + `TestEntityViewVerbose…` + `TestEntityListJSONPreservesFullMachineShape` + `TestEntityViewJSONPreservesFullMachineShape`

## Verification

- `go test ./internal/cliapp/` and `./internal/runtime/contracts/` green
- served CLI readback tests (SQLite + Postgres) green
- `go build ./...` clean

## Deferred

Short-ID display remains `#1815` (registry projection); this issue is layout/humanization only.