### PR TITLE
fix: hold resource advisory lock around durable intent writes

### DIFF
--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -353,7 +353,7 @@ func (m *Manager) advisoryLockHeld(ctx context.Context, db databaseRowQueryer, k
 		SELECT EXISTS(
 			SELECT 1 FROM pg_locks
 			WHERE locktype='advisory' AND granted
-			  AND ((classid::bigint << 32) | objid::bigint)=$1
+			  AND `+advisoryLockKeyReconstructionSQL+`=$1
 		)`, key).Scan(&held)
 	if err != nil {
 		return false, fmt.Errorf("inspect advisory lock %d: %w", key, err)
@@ -561,10 +561,11 @@ func (m *Manager) reconcileDatabaseCandidate(ctx context.Context, db *sql.DB, ca
 	if !signed {
 		return fmt.Errorf("unprovable postgres test %s %q left untouched: invalid ownership signature", kind, candidate.name)
 	}
-	lockKey := advisoryKey("template:" + candidate.name)
+	intent := resourceIntent{Name: candidate.name, Kind: kind, Identity: identity}
 	if kind == "sandbox" {
-		lockKey = advisoryKey("sandbox:" + identity)
+		intent.LeaseKey = advisoryKey("sandbox:" + identity)
 	}
+	lockKey := resourceLockKey(intent)
 	lockConn, acquired, err := tryAdvisoryLock(ctx, db, lockKey)
 	if err != nil || !acquired {
 		return err
@@ -662,7 +663,8 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 		return err
 	}
 	defer lockConn.Close()
-	lockKey := advisoryKey("template:" + m.templateName)
+	intent := resourceIntent{Name: m.templateName, Kind: "template", Identity: m.templateID}
+	lockKey := resourceLockKey(intent)
 	if err := acquireAdvisoryLock(ctx, lockConn, lockKey, "template "+m.templateName); err != nil {
 		return err
 	}
@@ -704,7 +706,7 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 	if err != sql.ErrNoRows {
 		return fmt.Errorf("inspect postgres template %q: %w", m.templateName, err)
 	}
-	if err := m.putIntent(ctx, resourceIntent{Name: m.templateName, Kind: "template", Identity: m.templateID}); err != nil {
+	if err := m.putIntent(ctx, intent); err != nil {
 		return err
 	}
 	if err := m.withExclusiveDDLAdmission(ctx, adminDB, "create template "+m.templateName, func(conn *sql.Conn) error {
@@ -833,6 +835,19 @@ func tryAdvisoryLock(ctx context.Context, db *sql.DB, key int64) (*sql.Conn, boo
 	return conn, true, nil
 }
 
+// advisoryLockKeyReconstructionSQL reconstructs the 64-bit advisory lock key
+// from pg_locks, whose (classid, objid) pair stores the bigint key split into
+// two 32-bit halves. Single source of truth shared by advisoryLockHeld and
+// advisoryBlockers so the bit reassembly cannot drift between the guard and
+// the diagnostics.
+const advisoryLockKeyReconstructionSQL = `((classid::bigint << 32) | objid::bigint)`
+
+// releaseAdvisoryLock releases a session-scoped advisory lock and closes the
+// connection. It is deliberately idempotent: calling it after the lock was
+// already released (e.g. a defer firing after an earlier explicit release, or
+// after the session already ended) is a harmless no-op. Tests use a deferred
+// release as the leak-safety net and the same idempotent call inline at the
+// point the lock must drop for a later re-acquiring step.
 func releaseAdvisoryLock(conn *sql.Conn, key int64) {
 	if conn == nil {
 		return
@@ -848,7 +863,7 @@ func advisoryBlockers(ctx context.Context, conn *sql.Conn, key int64) string {
 		SELECT a.pid, COALESCE(a.application_name,''), COALESCE(a.state,''), COALESCE(a.datname,''), left(COALESCE(a.query,''), 160)
 		FROM pg_locks l JOIN pg_stat_activity a ON a.pid=l.pid
 		WHERE l.locktype='advisory' AND l.granted
-		  AND ((l.classid::bigint << 32) | l.objid::bigint)=$1
+		  AND `+advisoryLockKeyReconstructionSQL+`=$1
 		ORDER BY a.pid`, key)
 	if err != nil {
 		return "unable to inspect pg_stat_activity/pg_locks: " + err.Error()

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -675,6 +675,9 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 		SELECT COALESCE(shobj_description(d.oid, 'pg_database'), ''), r.rolname
 		FROM pg_database d JOIN pg_roles r ON r.oid=d.datdba
 		WHERE d.datname=$1`, m.templateName).Scan(&comment, &owner)
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("inspect postgres template %q: %w", m.templateName, err)
+	}
 	if err == nil {
 		if owner != m.role {
 			return fmt.Errorf("template database %q owner %q does not match authenticated role %q; left untouched", m.templateName, owner, m.role)
@@ -702,9 +705,6 @@ func (m *Manager) ensureTemplate(ctx context.Context, adminDB *sql.DB) error {
 			}
 			return nil
 		}
-	}
-	if err != sql.ErrNoRows {
-		return fmt.Errorf("inspect postgres template %q: %w", m.templateName, err)
 	}
 	if err := m.putIntent(ctx, intent); err != nil {
 		return err

--- a/internal/testpostgres/manager.go
+++ b/internal/testpostgres/manager.go
@@ -323,15 +323,61 @@ func (m *Manager) validateControlDatabase(ctx context.Context, db databaseRowQue
 	return true, nil
 }
 
+// resourceLockKey derives the advisory lock key that protects a durable
+// resource intent. It must stay in sync with the derivation used by
+// Reconcile's intents loop when taking the lock before reconciling an intent.
+func resourceLockKey(intent resourceIntent) int64 {
+	if intent.Kind == "template" {
+		return advisoryKey("template:" + intent.Name)
+	}
+	return intent.LeaseKey
+}
+
+// advisoryLockHeld reports whether the resource advisory lock is currently
+// granted to ANY session on the cluster.
+//
+// This is deliberately a cluster-wide tripwire, not a held-by-caller gate:
+// the caller's advisory lock typically lives on a dedicated *sql.Conn (the
+// lease connection), while putIntent writes through a pooled control
+// connection, so pg_backend_pid() scoping is not cleanly expressible here.
+// A write performed while another session owns the lock therefore passes
+// undetected; that wrong-holder class is distinct from the lock-free window
+// this guard enforces. It is also check-then-insert, not atomic: the lock may
+// drop between this EXISTS and the INSERT. Both limitations are fine for the
+// guard's purpose — converting intent-ordering bugs from probabilistic CI
+// flakes into deterministic failures — but it must never be treated as a
+// transactional guarantee.
+func (m *Manager) advisoryLockHeld(ctx context.Context, db databaseRowQueryer, key int64) (bool, error) {
+	var held bool
+	err := db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM pg_locks
+			WHERE locktype='advisory' AND granted
+			  AND ((classid::bigint << 32) | objid::bigint)=$1
+		)`, key).Scan(&held)
+	if err != nil {
+		return false, fmt.Errorf("inspect advisory lock %d: %w", key, err)
+	}
+	return held, nil
+}
+
 func (m *Manager) putIntent(ctx context.Context, intent resourceIntent) error {
 	if !m.intentMatchesName(intent) {
 		return fmt.Errorf("refuse invalid postgres test resource intent for %q", intent.Name)
 	}
+	lockKey := resourceLockKey(intent)
 	db, err := m.control.Open()
 	if err != nil {
 		return fmt.Errorf("open postgres test control authority: %w", err)
 	}
 	defer db.Close()
+	held, err := m.advisoryLockHeld(ctx, db, lockKey)
+	if err != nil {
+		return err
+	}
+	if !held {
+		return fmt.Errorf("putIntent requires the resource advisory lock %d for %q; acquire before writing durable intent — see Acquire", lockKey, intent.Name)
+	}
 	_, err = db.ExecContext(ctx, `INSERT INTO `+quoteIdent(intentTableName)+`
 		(resource_name, kind, identity, lease_key, template_name) VALUES ($1,$2,$3,$4,$5)`,
 		intent.Name, intent.Kind, intent.Identity, intent.LeaseKey, intent.Template)
@@ -482,10 +528,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 		if !m.intentMatchesName(intent) {
 			return fmt.Errorf("invalid postgres test resource intent %q left untouched", intent.Name)
 		}
-		lockKey := intent.LeaseKey
-		if intent.Kind == "template" {
-			lockKey = advisoryKey("template:" + intent.Name)
-		}
+		lockKey := resourceLockKey(intent)
 		lockConn, acquired, err := tryAdvisoryLock(ctx, db, lockKey)
 		if err != nil {
 			return err

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -211,6 +211,62 @@ func TestManagerLeavesSignedUnstampedSandboxWithoutIntentUntouched(t *testing.T)
 	assertDatabaseExists(t, manager.admin, name)
 }
 
+func TestManagerPutIntentRequiresResourceAdvisoryLock(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	t.Run("sandbox", func(t *testing.T) {
+		identity := strings.ReplaceAll(uuid.NewString(), "-", "")
+		name := manager.signedResourceName(sandboxNamePrefix, "sandbox", identity)
+		intent := resourceIntent{Name: name, Kind: "sandbox", Identity: identity, LeaseKey: advisoryKey("sandbox:" + identity)}
+		if err := manager.putIntent(ctx, intent); err == nil || !strings.Contains(err.Error(), "requires the resource advisory lock") {
+			t.Fatalf("putIntent without lock error = %v, want teaching blocker", err)
+		}
+		if _, found, err := manager.intent(ctx, name); err != nil || found {
+			t.Fatalf("intent found=%v err=%v, want absent after refused put", found, err)
+		}
+	})
+
+	t.Run("template", func(t *testing.T) {
+		identity := "nolock" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+		name := manager.signedResourceName(templateNamePrefix, "template", identity)
+		intent := resourceIntent{Name: name, Kind: "template", Identity: identity}
+		if err := manager.putIntent(ctx, intent); err == nil || !strings.Contains(err.Error(), "requires the resource advisory lock") {
+			t.Fatalf("putIntent without lock error = %v, want teaching blocker", err)
+		}
+		if _, found, err := manager.intent(ctx, name); err != nil || found {
+			t.Fatalf("intent found=%v err=%v, want absent after refused put", found, err)
+		}
+	})
+
+	t.Run("succeedsWhileLockHeld", func(t *testing.T) {
+		db, err := manager.admin.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		identity := strings.ReplaceAll(uuid.NewString(), "-", "")
+		name := manager.signedResourceName(sandboxNamePrefix, "sandbox", identity)
+		intent := resourceIntent{Name: name, Kind: "sandbox", Identity: identity, LeaseKey: advisoryKey("sandbox:" + identity)}
+		creator, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "teaching "+name); err != nil {
+			t.Fatal(err)
+		}
+		defer releaseAdvisoryLock(creator, resourceLockKey(intent))
+		if err := manager.putIntent(ctx, intent); err != nil {
+			t.Fatalf("putIntent under resource advisory lock = %v, want success", err)
+		}
+		defer manager.deleteIntent(context.Background(), name)
+		if _, found, err := manager.intent(ctx, name); err != nil || !found {
+			t.Fatalf("intent found=%v err=%v, want present", found, err)
+		}
+	})
+}
+
 func TestManagerReclaimsSandboxInterruptedBetweenCreateAndMetadata(t *testing.T) {
 	manager := integrationManager(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -223,12 +279,25 @@ func TestManagerReclaimsSandboxInterruptedBetweenCreateAndMetadata(t *testing.T)
 	identity := strings.ReplaceAll(uuid.NewString(), "-", "")
 	name := manager.signedResourceName(sandboxNamePrefix, "sandbox", identity)
 	intent := resourceIntent{Name: name, Kind: "sandbox", Identity: identity, LeaseKey: advisoryKey("sandbox:" + identity)}
+	// The intent is written under the resource advisory lock, held through
+	// createDatabase, then released before Reconcile — mirroring a manager
+	// session dying between create and metadata, which is exactly the state
+	// this test exercises. Holding the lock through create also prevents a
+	// concurrent Reconcile from retiring the intent mid-create. #2196
+	creator, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "interrupted "+name); err != nil {
+		t.Fatal(err)
+	}
 	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
 	if err := createDatabase(ctx, db, name); err != nil {
 		t.Fatal(err)
 	}
+	releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.Reconcile(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -249,12 +318,24 @@ func TestManagerReclaimsTemplateInterruptedBetweenCreateAndMetadata(t *testing.T
 	defer db.Close()
 	identity := "interrupted" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
 	name := manager.signedResourceName(templateNamePrefix, "template", identity)
-	if err := manager.putIntent(ctx, resourceIntent{Name: name, Kind: "template", Identity: identity}); err != nil {
+	intent := resourceIntent{Name: name, Kind: "template", Identity: identity}
+	// Same interrupted-between-create-and-metadata shape as the sandbox twin:
+	// write the intent under the lock, hold through create, release (session
+	// death), then let Reconcile reclaim. #2196
+	creator, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "interrupted "+name); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
 	if err := createDatabase(ctx, db, name); err != nil {
 		t.Fatal(err)
 	}
+	releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.Reconcile(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -316,18 +397,19 @@ func TestManagerCreateBeforeMetadataCrashHelper(t *testing.T) {
 	}
 	name := manager.signedResourceName(prefix, kind, identity)
 	intent := resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey}
-	if err := manager.putIntent(ctx, intent); err != nil {
-		t.Fatal(err)
-	}
-	lockKey := leaseKey
-	if kind == "template" {
-		lockKey = advisoryKey("template:" + name)
-	}
+	// Mirror production (Acquire/ensureTemplate): the advisory lock is taken
+	// BEFORE the durable intent is written. The process then crashes via
+	// os.Exit, which releases the session-scoped lock — the exact
+	// interrupted-between-create-and-metadata state the parent test reclaims.
+	// #2196
 	lockConn, err := db.Conn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := acquireAdvisoryLock(ctx, lockConn, lockKey, "crash-window "+name); err != nil {
+	if err := acquireAdvisoryLock(ctx, lockConn, resourceLockKey(intent), "crash-window "+name); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(output, []byte(name+"\n"), 0o600); err != nil {
@@ -511,6 +593,17 @@ func TestManagerReconcileRefreshesCreateWindowAfterTakingLease(t *testing.T) {
 	name := manager.signedResourceName(sandboxNamePrefix, "sandbox", identity)
 	leaseKey := advisoryKey("sandbox:" + identity)
 	intent := resourceIntent{Name: name, Kind: "sandbox", Identity: identity, LeaseKey: leaseKey}
+	// The intent is written under the resource advisory lock (mirroring
+	// production Acquire); the lock is released before reconcileDatabaseCandidate,
+	// which takes the lease itself to refresh the stale CREATE-window snapshot.
+	// #2196
+	creator, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "create-window "+name); err != nil {
+		t.Fatal(err)
+	}
 	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
@@ -525,6 +618,7 @@ func TestManagerReconcileRefreshesCreateWindowAfterTakingLease(t *testing.T) {
 	if err := manager.deleteIntent(ctx, name); err != nil {
 		t.Fatal(err)
 	}
+	releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.reconcileDatabaseCandidate(ctx, db, candidate); err != nil {
 		t.Fatalf("stale CREATE-window snapshot produced a false blocker: %v", err)
 	}
@@ -551,6 +645,21 @@ func TestManagerReconcileRefreshesIntentSnapshotAfterTakingLease(t *testing.T) {
 			}
 			name := manager.signedResourceName(prefix, kind, identity)
 			intent := resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey}
+
+			// Mirrors production (Acquire/ensureTemplate): the resource advisory
+			// lock is held from BEFORE the durable intent is written through
+			// createDatabase, so a concurrent manager's Reconcile (shared control
+			// DB + advisory keyspace, see NewManager) can never retire the intent
+			// mid-create and orphan the database. #2196.
+			lockKey := resourceLockKey(intent)
+			creator, err := adminDB.Conn(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := acquireAdvisoryLock(ctx, creator, lockKey, "snapshot-race "+name); err != nil {
+				t.Fatal(err)
+			}
+			defer releaseAdvisoryLock(creator, lockKey)
 			if err := manager.putIntent(ctx, intent); err != nil {
 				t.Fatal(err)
 			}
@@ -578,17 +687,6 @@ func TestManagerReconcileRefreshesIntentSnapshotAfterTakingLease(t *testing.T) {
 				t.Fatal(ctx.Err())
 			}
 
-			lockKey := leaseKey
-			if kind == "template" {
-				lockKey = advisoryKey("template:" + name)
-			}
-			creator, err := adminDB.Conn(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := acquireAdvisoryLock(ctx, creator, lockKey, "snapshot-race "+name); err != nil {
-				t.Fatal(err)
-			}
 			if err := createDatabase(ctx, adminDB, name); err != nil {
 				t.Fatal(err)
 			}
@@ -625,6 +723,21 @@ func TestManagerRetiresFailedCreateIntentOnlyAfterExactAbsence(t *testing.T) {
 				leaseKey = 0
 			}
 			name := manager.signedResourceName(prefix, kind, identity)
+			// Mirrors production (Acquire holds the lease for the resource
+			// lifetime): the advisory lock is acquired BEFORE the durable intent
+			// and held through the whole retained/retired assertions, so a
+			// concurrent manager's Reconcile (shared control DB + advisory
+			// keyspace, see NewManager) can never drop the database or retire
+			// the intent underneath this test. #2196.
+			lockKey := resourceLockKey(resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey})
+			creator, err := db.Conn(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseAdvisoryLock(creator, lockKey)
+			if err := acquireAdvisoryLock(ctx, creator, lockKey, "retain-race "+name); err != nil {
+				t.Fatal(err)
+			}
 			if err := manager.putIntent(ctx, resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -447,6 +447,67 @@ func TestManagerRetainsStampedTemplateFromOlderSchemaDigest(t *testing.T) {
 	assertDatabaseExists(t, manager.admin, name)
 }
 
+func TestManagerRecoversIncompleteTemplateInSingleAcquire(t *testing.T) {
+	manager := integrationManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	db, err := manager.admin.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Crash-state fixture: the template database exists with an empty comment
+	// (create completed, metadata never stamped) and a matching durable intent.
+	// ensureTemplate must drop the incomplete template, delete its intent, and
+	// recreate it in the SAME call — a single Acquire(withTemplate=true) must
+	// succeed without the caller retrying.
+	name := manager.templateName
+	intent := resourceIntent{Name: name, Kind: "template", Identity: manager.templateID}
+	lockKey := resourceLockKey(intent)
+	creator, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := acquireAdvisoryLock(ctx, creator, lockKey, "recover-template "+name); err != nil {
+		t.Fatal(err)
+	}
+	// The template is content-addressed and may already exist (stamped) from a
+	// prior ensureTemplate on this server; clear it so the crash state below is
+	// the only template. Holding the template advisory lock during setup keeps
+	// concurrent managers' ensureTemplate out.
+	if err := dropDatabase(ctx, db, name); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.putIntent(ctx, intent); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.deleteIntent(context.Background(), name)
+	if err := createDatabase(ctx, db, name); err != nil {
+		t.Fatal(err)
+	}
+	defer dropDatabase(context.Background(), db, name)
+	// Release the lock before Acquire: the fixture manager is dead, so its
+	// session-scoped lock is gone — the exact recovery state ensureTemplate
+	// must handle.
+	releaseAdvisoryLock(creator, lockKey)
+
+	sandbox, err := manager.Acquire(ctx, true)
+	if err != nil {
+		t.Fatalf("single Acquire(withTemplate=true) after incomplete template = %v, want successful recovery and recreate", err)
+	}
+	defer sandbox.Release(context.Background())
+
+	var comment string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(shobj_description(d.oid, 'pg_database'), '') FROM pg_database d WHERE d.datname=$1`, name).Scan(&comment); err != nil {
+		t.Fatal(err)
+	}
+	metadata, parseErr := parseResourceMetadata(comment)
+	if parseErr != nil || metadata.Kind != "template" || metadata.Identity != manager.templateID {
+		t.Fatalf("recovered template metadata parseErr=%v metadata=%+v, want stamped template identity", parseErr, metadata)
+	}
+}
+
 func TestManagerDDLAdmissionSharesSandboxWorkAndFencesTemplateMutation(t *testing.T) {
 	manager := integrationManager(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -291,6 +291,7 @@ func TestManagerReclaimsSandboxInterruptedBetweenCreateAndMetadata(t *testing.T)
 	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "interrupted "+name); err != nil {
 		t.Fatal(err)
 	}
+	defer releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +330,7 @@ func TestManagerReclaimsTemplateInterruptedBetweenCreateAndMetadata(t *testing.T
 	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "interrupted "+name); err != nil {
 		t.Fatal(err)
 	}
+	defer releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
@@ -604,6 +606,7 @@ func TestManagerReconcileRefreshesCreateWindowAfterTakingLease(t *testing.T) {
 	if err := acquireAdvisoryLock(ctx, creator, resourceLockKey(intent), "create-window "+name); err != nil {
 		t.Fatal(err)
 	}
+	defer releaseAdvisoryLock(creator, resourceLockKey(intent))
 	if err := manager.putIntent(ctx, intent); err != nil {
 		t.Fatal(err)
 	}
@@ -723,13 +726,14 @@ func TestManagerRetiresFailedCreateIntentOnlyAfterExactAbsence(t *testing.T) {
 				leaseKey = 0
 			}
 			name := manager.signedResourceName(prefix, kind, identity)
+			intent := resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey}
 			// Mirrors production (Acquire holds the lease for the resource
 			// lifetime): the advisory lock is acquired BEFORE the durable intent
 			// and held through the whole retained/retired assertions, so a
 			// concurrent manager's Reconcile (shared control DB + advisory
 			// keyspace, see NewManager) can never drop the database or retire
 			// the intent underneath this test. #2196.
-			lockKey := resourceLockKey(resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey})
+			lockKey := resourceLockKey(intent)
 			creator, err := db.Conn(ctx)
 			if err != nil {
 				t.Fatal(err)
@@ -738,7 +742,7 @@ func TestManagerRetiresFailedCreateIntentOnlyAfterExactAbsence(t *testing.T) {
 			if err := acquireAdvisoryLock(ctx, creator, lockKey, "retain-race "+name); err != nil {
 				t.Fatal(err)
 			}
-			if err := manager.putIntent(ctx, resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey}); err != nil {
+			if err := manager.putIntent(ctx, intent); err != nil {
 				t.Fatal(err)
 			}
 			defer manager.deleteIntent(context.Background(), name)

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -876,17 +876,23 @@ func assertDatabaseAbsent(t *testing.T, connection Connection, name string) {
 
 // waitForAdvisoryLockFree polls until the resource advisory lock is no longer
 // granted by any session. It uses a deadline-poll on the deadline clock (no
-// sleeps) per the deterministic-wait discipline, and reuses the manager's
-// advisory-lock introspection so the poll cannot drift from the guard.
+// sleeps) per the deterministic-wait discipline, reuses the manager's
+// advisory-lock introspection, and derives the key through resourceLockKey so
+// the poll cannot drift from the guard or the reconciler.
 func waitForAdvisoryLockFree(ctx context.Context, manager *Manager, name, kind string) error {
-	lockKey := advisoryKey("template:" + name)
-	if kind == "sandbox" {
-		identity, ok := manager.verifyResourceName(name, sandboxNamePrefix, "sandbox")
-		if !ok {
-			return fmt.Errorf("verify sandbox resource name %q", name)
-		}
-		lockKey = advisoryKey("sandbox:" + identity)
+	prefix := sandboxNamePrefix
+	if kind == "template" {
+		prefix = templateNamePrefix
 	}
+	identity, ok := manager.verifyResourceName(name, prefix, kind)
+	if !ok {
+		return fmt.Errorf("verify %s resource name %q", kind, name)
+	}
+	leaseKey := int64(0)
+	if kind == "sandbox" {
+		leaseKey = advisoryKey("sandbox:" + identity)
+	}
+	lockKey := resourceLockKey(resourceIntent{Name: name, Kind: kind, Identity: identity, LeaseKey: leaseKey})
 	db, err := manager.admin.Open()
 	if err != nil {
 		return err

--- a/internal/testpostgres/manager_integration_test.go
+++ b/internal/testpostgres/manager_integration_test.go
@@ -3,6 +3,7 @@ package testpostgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -362,6 +363,14 @@ func TestManagerReconcilesAbruptCreateBeforeMetadataExit(t *testing.T) {
 			assertDatabaseExists(t, manager.admin, name)
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
+			// The child exited holding the resource advisory lock; the Postgres
+			// backend releases the session-scoped lock asynchronously on socket
+			// EOF. Wait for the lock to be free (bounded deadline-poll, no
+			// sleeps) so Reconcile's single try-lock cannot silently skip the
+			// reclaimed resource. #2196
+			if err := waitForAdvisoryLockFree(ctx, manager, name, kind); err != nil {
+				t.Fatal(err)
+			}
 			if err := manager.Reconcile(ctx); err != nil {
 				t.Fatal(err)
 			}
@@ -862,6 +871,40 @@ func assertDatabaseAbsent(t *testing.T, connection Connection, name string) {
 	}
 	if exists {
 		t.Fatalf("database %q still exists", name)
+	}
+}
+
+// waitForAdvisoryLockFree polls until the resource advisory lock is no longer
+// granted by any session. It uses a deadline-poll on the deadline clock (no
+// sleeps) per the deterministic-wait discipline, and reuses the manager's
+// advisory-lock introspection so the poll cannot drift from the guard.
+func waitForAdvisoryLockFree(ctx context.Context, manager *Manager, name, kind string) error {
+	lockKey := advisoryKey("template:" + name)
+	if kind == "sandbox" {
+		identity, ok := manager.verifyResourceName(name, sandboxNamePrefix, "sandbox")
+		if !ok {
+			return fmt.Errorf("verify sandbox resource name %q", name)
+		}
+		lockKey = advisoryKey("sandbox:" + identity)
+	}
+	db, err := manager.admin.Open()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	for {
+		held, err := manager.advisoryLockHeld(ctx, db, lockKey)
+		if err != nil {
+			return err
+		}
+		if !held {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("resource advisory lock %d for %q never released before context deadline", lockKey, name)
+		case <-time.After(25 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #2196

## Root cause (banked on #2196, lead-approved)

The testpostgres harness writes durable resource intents into a **globally shared** intents table: every proof-unit package runs against one Postgres, and all managers derive the same ownership key, control DB, intents table, and advisory-lock keyspace from `serverID + role`. `NewManager` runs `Reconcile`, so a concurrent manager's `Reconcile` legitimately retires any intent whose DB is absent — while holding the resource's advisory lock. Production (`Acquire`/`ensureTemplate`) acquires that lock **before** `putIntent`; several harness tests did not, leaving a window where the intent sat in the shared table unprotected and absent-DB. A parallel manager then retired the intent, and the test's own `Reconcile` found nothing, orphaning the DB it created — `assertDatabaseAbsent` reports "still exists".

Reproduced empirically (probe + load): a hot concurrent `Reconcile` loop flips `TestManagerReconcileRefreshesIntentSnapshotAfterTakingLease` on iteration 0 pre-fix; 60/60 clean post-fix under the same load. Control (isolated): 15/15 pass.

Classification (#1233): **shared-fixture invariant violation** — new taxonomy pattern, distinct from deadline-margin (#1658) and join-ordering (#2192). Posted on #2196.

## Changes

- **Enforcement (the class-closure move):** `putIntent` now requires the resource advisory lock, failing fast with a teaching error (`acquire before writing durable intent — see Acquire`). The check is a **cluster-wide tripwire** (`advisoryLockHeld` over `pg_locks`), not a held-by-caller gate and not atomic; the comment states both limitations explicitly so it is never mistaken for a transactional guarantee (per lead ruling).
- **Shared key derivation:** `resourceLockKey` used by both `Reconcile`'s intents loop and `putIntent`, so the guard cannot drift from the reconciler.
- **Test fixes (both, per ruling):** `TestManagerReconcileRefreshesIntentSnapshotAfterTakingLease` and `TestManagerRetiresFailedCreateIntentOnlyAfterExactAbsence` now mirror production ordering (lock → putIntent → create → release/hold).
- **Compliance sweep:** the remaining four `putIntent` call sites — reclaims sandbox/template (lock through create, release = session death), the crash helper (reordered to lock-before-putIntent, `os.Exit` releases), and the create-window test (release before `reconcileDatabaseCandidate` re-acquires).
- **Guard test:** `TestManagerPutIntentRequiresResourceAdvisoryLock` covers the teaching error (sandbox + template) and the success path under the lock.

Per the lead ruling, per-test serverID isolation is explicitly rejected (would weaken the shared-keyspace reconciliation realism the tests exist to exercise).

## Verification

- Pre-fix flip evidence (hot concurrent Reconcile → orphaned DB) and post-fix green under the same load.
- `internal/testpostgres`, `internal/store`, `internal/serveapp`, `internal/testutil`, `internal/cliapp` suites all green against Postgres.
- `gofmt`/`go vet` clean.