### PR TITLE
[agent-c][issue #2127] Strengthen decision-route continuation proof

### DIFF
--- a/internal/cliapp/run_command_observer_test.go
+++ b/internal/cliapp/run_command_observer_test.go
@@ -202,6 +202,7 @@ func TestRunCommandTerminalStatusCancelsPendingTraceObserver(t *testing.T) {
 			case "run.start":
 				return map[string]any{"run_id": "run-terminal-pending", "status": "running"}
 			case "run.get":
+				awaitRunCommandTraceRequest(t, requestRead)
 				run := validDiagnosticRunHeader("run-terminal-pending")
 				run["status"] = "completed"
 				run["ended_at"] = "2026-05-13T10:01:00Z"
@@ -244,6 +245,7 @@ func TestRunCommandTerminalFailureCancelsPendingTraceObserver(t *testing.T) {
 			case "run.start":
 				return map[string]any{"run_id": "run-terminal-failure-pending", "status": "running"}
 			case "run.get":
+				awaitRunCommandTraceRequest(t, requestRead)
 				run := validDiagnosticRunHeader("run-terminal-failure-pending")
 				run["status"] = "failed"
 				run["ended_at"] = "2026-05-13T10:01:00Z"

--- a/internal/cliapp/run_command_test.go
+++ b/internal/cliapp/run_command_test.go
@@ -122,6 +122,7 @@ func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *test
 		"serve_api_token_file": tokenFile,
 	}))
 	payloadPath := writeRunCommandPayloadFile(t, map[string]any{"entity_id": "entity-1"})
+	requestRead := make(chan struct{})
 	server, calls, wsRequests := newRunCommandServer(t, runCommandServerOptions{
 		expectedToken: "serve-token",
 		strictAuth:    true,
@@ -132,6 +133,7 @@ func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *test
 			case "run.start":
 				return map[string]any{"run_id": "run-token-file", "status": "running"}
 			case "run.get":
+				awaitRunCommandTraceRequest(t, requestRead)
 				run := validDiagnosticRunHeader("run-token-file")
 				run["status"] = "completed"
 				run["ended_at"] = "2026-05-13T10:01:00Z"
@@ -141,7 +143,8 @@ func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *test
 			}
 			return nil
 		},
-		wsRows: []map[string]any{validRunCommandTraceRow("evt-token-file")},
+		wsRows:        []map[string]any{validRunCommandTraceRow("evt-token-file")},
+		wsRequestRead: requestRead,
 	})
 	defer server.Close()
 
@@ -166,6 +169,15 @@ func TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient(t *test
 	}
 	assertRunCommandMethods(t, calls, []string{"health.check", "health.check", "run.start", "run.get"})
 	assertRunCommandTraceSubscription(t, wsRequests, "run-token-file", true)
+}
+
+func awaitRunCommandTraceRequest(t *testing.T, requestRead <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-requestRead:
+	case <-time.After(5 * time.Second):
+		t.Error("timed out waiting for subscription request read before terminal run.get")
+	}
 }
 
 func TestStartLocalRunServeConsumesContractPathConfigResolver(t *testing.T) {

--- a/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
+++ b/internal/runtime/pipeline/workflow_gate_recovery_external_test.go
@@ -911,12 +911,17 @@ func TestDecisionRouteObligationFairnessAdmitsNewWorkBehindFullDeferredPageOnBot
 				setGateRecoveryRouteAttempt(t, selected, eventID, 1)
 			}
 			newEventID := seedGateRecoveryRouteObligation(t, selected, runID, time.Now().UTC())
+			setGateRecoveryRouteAttempt(t, selected, newEventID, 2)
 			bus, err := newScopedTestEventBus(t, selected.events, runtimebus.EventBusOptions{Interceptors: []runtimebus.EventInterceptor{gateRecoveryFairnessInterceptor{deferred: deferred}}})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if _, err := bus.SweepPipelineObligations(ctx, 200); err != nil {
+			result, err := bus.SweepPipelineObligations(ctx, 202)
+			if err != nil {
 				t.Fatal(err)
+			}
+			if result.Settled != 201 || result.Examined != 201 || !result.Exhausted || result.Blocked {
+				t.Fatalf("deferred-prefix sweep = %#v", result)
 			}
 			assertGateRecoveryProcessedReceipt(t, selected, newEventID)
 			if got := gateRecoveryPipelineReceiptCount(t, selected, firstGateRecoveryEventID(deferred)); got != 0 {


### PR DESCRIPTION
## Summary

- order the later eligible decision route after the complete 200-route deferred prefix under the canonical attempt ordering
- give the sweep one extra owner step to establish explicit exhaustion
- assert the exact typed `SweepResult` in addition to the later route's durable platform/pipeline receipt
- synchronize all three terminal-status fixtures with the server-observed trace-subscription request, closing #2201 without changing production behavior

No runtime, persistence, API, compatibility, migration, or platform-spec behavior changes.

Closes #2127
Closes #2201

## Governing contract

Binding `platform-spec.yaml` section: `durable_pipeline_processing_obligation_authority`, specifically:

- `scan_contract.scan_blockage`
- `scan_contract.scan_result`
- `PPO-SEL-001`
- `PPO-REL-001`
- `PPO-CUR-001`
- `PPO-DCR-001`

The canonical semantic owner remains `internal/runtime/pipelineobligation.Store`; the EventBus typed sweeper remains its sole production cursor interpreter. The #2201 repair changes only CLI test-fixture synchronization.

## Proof

Final rebased-head supported-surface proof:

```text
go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/pipeline \
  -run 'TestDecisionRouteObligation(FairnessAdmitsNewWorkBehindFullDeferredPage|QuarantinesPoisonAndContinues)OnBothStores' \
  -count=3 -timeout=300s
ok github.com/division-sh/swarm/internal/runtime/pipeline 41.047s

go test ./internal/cliapp \
  -run '^(TestRunCommandLocalForegroundUsesServeAPITokenFileForEmbeddedClient|TestRunCommandTerminal(Status|Failure)CancelsPendingTraceObserver)$' \
  -count=100 -timeout=300s
ok github.com/division-sh/swarm/internal/cliapp 3.401s

go test ./internal/cliapp -count=1 -timeout=300s
ok github.com/division-sh/swarm/internal/cliapp 22.307s
```

Disposable mutation proof: forcing the first returned decision-route `ScanBatch` to report `Exhausted=true` made both manifestations fail on both stores:

```text
fairness/sqlite:   SweepResult{Settled:1, Examined:1, Exhausted:true, Blocked:false}
fairness/postgres: SweepResult{Settled:1, Examined:1, Exhausted:true, Blocked:false}
poison/sqlite:     settled 1, want 2
poison/postgres:   settled 1, want 2
```

The mutation was removed before commit. Required final-head CI run `31284310361` is green, including `broad-03`, `runtime-full`, `store-full`, the timing budget, and the required summary.

The earlier complete PostgreSQL-enabled repository run passed all #2127, runtime, bus, pipeline, store, serve, and parity packages. Its CLI trace-subscription failure is closed by #2201's three-fixture repair. The remaining local release-E2E macOS `/private/var/...` versus `/var/...` fake-Docker comparison reproduces identically on clean `origin/master` and is outside this PR.

## Migration

No semantic migration. The invalid paths removed are the false-positive decision-route fixture ordering and terminal-status test fixtures that asserted a subscription without waiting for the server-observed request. No old runtime producer, reader, writer, compatibility path, selected-store behavior, or production observer barrier survives or changes because none was introduced.

## Coordination

The branch is rebased onto current `origin/master` commit `e07ed7f2c`. PR #2166 remains open; it relocates selected-store mechanics behind private adapters but preserves the `pipelineobligation.Store` contract, canonical ordering, and #2127 test body.
