### PR TITLE
feat: surface embedded platform-spec digest in swarm version

### DIFF
--- a/internal/cliapp/cli.go
+++ b/internal/cliapp/cli.go
@@ -447,15 +447,16 @@ type versionCommandOptions struct {
 }
 
 type versionOutputResult struct {
-	BinaryVersion   string                       `json:"binary_version"`
-	ModuleVersion   string                       `json:"module_version"`
-	PlatformVersion string                       `json:"platform_version"`
-	Commit          string                       `json:"commit"`
-	Built           string                       `json:"built"`
-	GoVersion       string                       `json:"go_version"`
-	GOOS            string                       `json:"goos"`
-	GOARCH          string                       `json:"goarch"`
-	Server          *diagnosticHealthCheckResult `json:"server,omitempty"`
+	BinaryVersion      string                       `json:"binary_version"`
+	ModuleVersion      string                       `json:"module_version"`
+	PlatformVersion    string                       `json:"platform_version"`
+	PlatformSpecDigest string                       `json:"platform_spec_digest"`
+	Commit             string                       `json:"commit"`
+	Built              string                       `json:"built"`
+	GoVersion          string                       `json:"go_version"`
+	GOOS               string                       `json:"goos"`
+	GOARCH             string                       `json:"goarch"`
+	Server             *diagnosticHealthCheckResult `json:"server,omitempty"`
 }
 
 func newVersionCommand(opts rootCommandOptions) *cobra.Command {
@@ -490,14 +491,15 @@ func runVersionCommand(ctx context.Context, out, errOut io.Writer, opts versionC
 		return err
 	}
 	result := versionOutputResult{
-		BinaryVersion:   metadata.BinaryVersion,
-		ModuleVersion:   metadata.ModuleVersion,
-		PlatformVersion: metadata.PlatformVersion,
-		Commit:          metadata.Commit,
-		Built:           metadata.Built,
-		GoVersion:       metadata.GoVersion,
-		GOOS:            metadata.GOOS,
-		GOARCH:          metadata.GOARCH,
+		BinaryVersion:      metadata.BinaryVersion,
+		ModuleVersion:      metadata.ModuleVersion,
+		PlatformVersion:    metadata.PlatformVersion,
+		PlatformSpecDigest: metadata.PlatformSpecDigest,
+		Commit:             metadata.Commit,
+		Built:              metadata.Built,
+		GoVersion:          metadata.GoVersion,
+		GOOS:               metadata.GOOS,
+		GOARCH:             metadata.GOARCH,
 	}
 	if !opts.server {
 		return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
@@ -527,6 +529,9 @@ func writeLocalVersion(out io.Writer, metadata versionmetadata.Metadata) {
 	fmt.Fprintf(out, "Commit: %s\n", metadata.Commit)
 	fmt.Fprintf(out, "Built: %s\n", metadata.Built)
 	fmt.Fprintf(out, "Go: %s %s/%s\n", metadata.GoVersion, metadata.GOOS, metadata.GOARCH)
+	if digest := strings.TrimSpace(metadata.PlatformSpecDigest); digest != "" {
+		fmt.Fprintf(out, "Platform spec digest: %s\n", digest)
+	}
 }
 
 func writeVersionServerIdentity(out io.Writer, result diagnosticHealthCheckResult) {

--- a/internal/cliapp/cli_output_test.go
+++ b/internal/cliapp/cli_output_test.go
@@ -28,6 +28,7 @@ func TestCLIOutputModesForLocalConsumers(t *testing.T) {
 	if versionJSON["binary_version"] != versionMetadata.BinaryVersion ||
 		versionJSON["module_version"] != versionMetadata.ModuleVersion ||
 		versionJSON["platform_version"] != versionMetadata.PlatformVersion ||
+		versionJSON["platform_spec_digest"] != versionMetadata.PlatformSpecDigest ||
 		versionJSON["commit"] != versionMetadata.Commit {
 		t.Fatalf("version json = %#v, want local metadata", versionJSON)
 	}

--- a/internal/cliapp/main_test.go
+++ b/internal/cliapp/main_test.go
@@ -316,7 +316,7 @@ func TestCLI_VersionPrintsLocalBinaryIdentity(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("version code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Swarm dev", "Commit: unknown", "Built: unknown", "Go:"} {
+	for _, want := range []string{"Swarm dev", "Commit: unknown", "Built: unknown", "Go:", "Platform spec digest: "} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("version output missing %q:\n%s", want, stdout.String())
 		}

--- a/internal/platform/artifacts.go
+++ b/internal/platform/artifacts.go
@@ -37,6 +37,14 @@ func WorkspaceDockerfile() []byte {
 	return rootartifacts.EmbeddedWorkspaceDockerfile()
 }
 
+// PlatformSpecDigest returns the full sha256 hex digest of the embedded
+// platform spec bytes. It is the single source of truth for the binary↔spec
+// version stamp; MaterializePlatformSpecFile derives its content-addressed
+// filename prefix from the same digest so the two spellings cannot diverge.
+func PlatformSpecDigest() string {
+	return embeddedAssetDigest(PlatformSpecYAML())
+}
+
 func MaterializePlatformSpecFile() (string, error) {
 	spec := PlatformSpecYAML()
 	return materializeEmbeddedAsset("platform spec", "platform-spec-", ".yaml", spec)
@@ -47,9 +55,13 @@ func MaterializeWorkspaceDockerfile() (string, error) {
 	return materializeEmbeddedAsset("workspace Dockerfile", "Dockerfile.workspace-", "", dockerfile)
 }
 
-func materializeEmbeddedAsset(label, prefix, suffix string, data []byte) (string, error) {
+func embeddedAssetDigest(data []byte) string {
 	digest := sha256.Sum256(data)
-	name := prefix + hex.EncodeToString(digest[:8]) + suffix
+	return hex.EncodeToString(digest[:])
+}
+
+func materializeEmbeddedAsset(label, prefix, suffix string, data []byte) (string, error) {
+	name := prefix + embeddedAssetDigest(data)[:16] + suffix
 	var attempts []string
 	for _, base := range platformSpecCacheBases() {
 		path, err := materializeEmbeddedAssetFile(base, name, data)

--- a/internal/platform/version_test.go
+++ b/internal/platform/version_test.go
@@ -1,6 +1,11 @@
 package platform
 
-import "testing"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
 
 func TestPlatformVersionFromYAML(t *testing.T) {
 	got, err := PlatformVersionFromYAML([]byte("platform:\n  name: swarm-orchestrator\n  version: 1.6.0\n"))
@@ -15,5 +20,28 @@ func TestPlatformVersionFromYAML(t *testing.T) {
 func TestPlatformVersionFromYAMLRequiresVersion(t *testing.T) {
 	if _, err := PlatformVersionFromYAML([]byte("platform:\n  name: swarm-orchestrator\n")); err == nil {
 		t.Fatal("PlatformVersionFromYAML() error = nil, want missing version error")
+	}
+}
+
+// TestPlatformSpecDigestMatchesMaterializedFilename ensures the version stamp
+// and the content-addressed materialized filename derive from the same digest,
+// so the two spellings of the binary↔spec stamp cannot diverge (#2182).
+func TestPlatformSpecDigestMatchesMaterializedFilename(t *testing.T) {
+	spec := PlatformSpecYAML()
+	if len(spec) == 0 {
+		t.Fatal("embedded platform spec is empty")
+	}
+	digest := sha256.Sum256(spec)
+	want := hex.EncodeToString(digest[:])
+	if got := PlatformSpecDigest(); got != want {
+		t.Fatalf("PlatformSpecDigest() = %q, want %q (sha256 of embedded spec bytes)", got, want)
+	}
+	path, err := MaterializePlatformSpecFile()
+	if err != nil {
+		t.Fatalf("MaterializePlatformSpecFile(): %v", err)
+	}
+	name := path[strings.LastIndex(path, "/")+1:]
+	if !strings.HasPrefix(name, "platform-spec-"+want[:16]) {
+		t.Fatalf("materialized filename %q does not derive its prefix from PlatformSpecDigest %q", name, want)
 	}
 }

--- a/internal/versionmetadata/metadata.go
+++ b/internal/versionmetadata/metadata.go
@@ -13,17 +13,19 @@ const unknownVersionValue = "unknown"
 var (
 	readVersionBuildInfo       = debug.ReadBuildInfo
 	readVersionPlatformVersion = platform.PlatformVersion
+	readVersionPlatformDigest  = platform.PlatformSpecDigest
 )
 
 type Metadata struct {
-	BinaryVersion   string
-	ModuleVersion   string
-	PlatformVersion string
-	Commit          string
-	Built           string
-	GoVersion       string
-	GOOS            string
-	GOARCH          string
+	BinaryVersion      string
+	ModuleVersion      string
+	PlatformVersion    string
+	PlatformSpecDigest string
+	Commit             string
+	Built              string
+	GoVersion          string
+	GOOS               string
+	GOARCH             string
 }
 
 type Injected struct {
@@ -48,14 +50,15 @@ func Resolve(injected Injected) (Metadata, error) {
 	}
 	vcsTime := buildInfoSetting(buildInfo, "vcs.time")
 	return Metadata{
-		BinaryVersion:   resolvedBinaryVersion(injected.Version, moduleVersion),
-		ModuleVersion:   resolvedOptionalVersion(moduleVersion),
-		PlatformVersion: strings.TrimSpace(platformVersion),
-		Commit:          resolvedInjectedOrFallback(injected.Commit, unknownVersionValue, vcsRevision),
-		Built:           resolvedInjectedOrFallback(injected.Date, unknownVersionValue, vcsTime),
-		GoVersion:       goruntime.Version(),
-		GOOS:            goruntime.GOOS,
-		GOARCH:          goruntime.GOARCH,
+		BinaryVersion:      resolvedBinaryVersion(injected.Version, moduleVersion),
+		ModuleVersion:      resolvedOptionalVersion(moduleVersion),
+		PlatformVersion:    strings.TrimSpace(platformVersion),
+		PlatformSpecDigest: readVersionPlatformDigest(),
+		Commit:             resolvedInjectedOrFallback(injected.Commit, unknownVersionValue, vcsRevision),
+		Built:              resolvedInjectedOrFallback(injected.Date, unknownVersionValue, vcsTime),
+		GoVersion:          goruntime.Version(),
+		GOOS:               goruntime.GOOS,
+		GOARCH:             goruntime.GOARCH,
 	}, nil
 }
 

--- a/internal/versionmetadata/metadata_test.go
+++ b/internal/versionmetadata/metadata_test.go
@@ -97,6 +97,7 @@ func withVersionMetadataHooks(t *testing.T, version, commit, date, platformVersi
 	t.Helper()
 	oldBuildInfo := readVersionBuildInfo
 	oldPlatformVersion := readVersionPlatformVersion
+	oldPlatformDigest := readVersionPlatformDigest
 	_ = version
 	_ = commit
 	_ = date
@@ -109,8 +110,12 @@ func withVersionMetadataHooks(t *testing.T, version, commit, date, platformVersi
 	readVersionPlatformVersion = func() (string, error) {
 		return platformVersion, platformErr
 	}
+	readVersionPlatformDigest = func() string {
+		return "platform-spec-digest-test"
+	}
 	t.Cleanup(func() {
 		readVersionBuildInfo = oldBuildInfo
 		readVersionPlatformVersion = oldPlatformVersion
+		readVersionPlatformDigest = oldPlatformDigest
 	})
 }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -20441,8 +20441,8 @@ cli_specification:
             version:
               command: swarm version
               classification: shared_output
-              fact_owner: local binary metadata from injected release metadata, Go build info, and embedded platform-spec version; /v1/rpc health.check when --server is supplied
-              json_shape: local binary metadata object with binary_version, module_version, platform_version, commit, built, go_version, goos, and goarch; with --server includes a server health.check object
+              fact_owner: local binary metadata from injected release metadata, Go build info, and embedded platform-spec version and sha256 digest; /v1/rpc health.check when --server is supplied
+              json_shape: local binary metadata object with binary_version, module_version, platform_version, platform_spec_digest, commit, built, go_version, goos, and goarch; with --server includes a server health.check object
               quiet_values:
               - binary_version
               - server_bundle_hash when --server is supplied
@@ -21746,13 +21746,14 @@ cli_specification:
       implementation_status: implemented
       local_owner: local binary metadata resolver
       server_owner: /v1/rpc health.check
-      behavior: '`swarm version` prints local binary identity and performs no API call. Local binary identity resolves injected release metadata first, Go module/VCS build info second, and deterministic dev/unknown fallbacks last. `swarm version --json` additionally exposes module_version and platform_version as separate fields; platform_version is the embedded root platform-spec.yaml platform.version. `swarm version --server` first queries `/v1/rpc health.check`, then prints the same local binary identity followed by a `Server:` section containing v1 server bundle/runtime identity from health.check.'
+      behavior: '`swarm version` prints local binary identity and performs no API call. Local binary identity resolves injected release metadata first, Go module/VCS build info second, and deterministic dev/unknown fallbacks last. `swarm version --json` additionally exposes module_version, platform_version, and platform_spec_digest as separate fields; platform_version is the embedded root platform-spec.yaml platform.version and platform_spec_digest is the sha256 digest of the embedded spec bytes. `swarm version --server` first queries `/v1/rpc health.check`, then prints the same local binary identity followed by a `Server:` section containing v1 server bundle/runtime identity from health.check.'
       output_contract:
         local:
         - Swarm <binary-version>
         - 'Commit: <binary-commit>'
         - 'Built: <binary-build-date>'
         - 'Go: <go-version> <goos>/<goarch>'
+        - 'Platform spec digest: <platform-spec-sha256-digest>'
         server_flag:
           source: /v1/rpc health.check
           rendering:


### PR DESCRIPTION
Closes #2182

## Two-part disposition (per #2182 analysis + lead ruling)

**Version half — already satisfied, no work.** `swarm version --json` → `platform_version`, derived from the embedded bytes (`versionmetadata` → `platform.PlatformVersion()` → `PlatformSpecYAML()`), asserted in `cli_output_test.go`. Acceptance candidate 2 (derive from embedded, never a user-supplied path) already met.

**Digest half — shipping; evidence gate met.** Two binaries can share a `platform_version` string while carrying different embedded spec bytes, and nothing surfaced that. **Evidence:** the embedded platform version has been `0.7.0` for two months while the platform spec and its generated schema moved underneath it — the stale-binary confusion class is live, not hypothetical. A `platform_spec_digest` in `swarm version` closes it: two binaries' embedded spec bytes are comparable at a glance.

## Change

- `platform.PlatformSpecDigest()` — full sha256 hex of the embedded spec bytes, the single source of truth shared with `MaterializePlatformSpecFile`'s content-addressed filename (`embeddedAssetDigest`), so the version-stamp spelling and the filename spelling cannot diverge.
- `versionmetadata.Metadata.PlatformSpecDigest` — resolved from embedded bytes, behind the existing test-indirection hook.
- `swarm version` surfaces it: `platform_spec_digest` `--json` field + human `Platform spec digest:` line.

One surface only (`swarm version` — the one people already check for version questions); the serve banner stays untouched per the ruling (a second placement is speculative until someone asks).

## Verification

- `internal/platform`, `internal/versionmetadata`, `internal/cliapp` full suites green.
- `TestPlatformSpecDigestMatchesMaterializedFilename` proves the two spellings share one digest.
- `version --json` / text conformance tests updated and green.
- `go vet ./...`, `go build ./...` clean.
- Manual: `swarm version` prints `Platform spec digest: da20269ff1...`.