### PR TITLE
[agent-c][issue #2013] Render entity reads human-first

### DIFF
--- a/internal/cliapp/cli_identifier_registry_test.go
+++ b/internal/cliapp/cli_identifier_registry_test.go
@@ -325,7 +325,7 @@ func TestCLIIdentifierDisplayColumnsUseFamilyAwareOwner(t *testing.T) {
 		"diagnostics.go\x00SESSION":        cliIdentifierFamilySession,
 		"diagnostics.go\x00EVENT ID":       cliIdentifierFamilyEvent,
 		"entities.go\x00ENTITY_ID":         cliIdentifierFamilyEntity,
-		"entities.go\x00RUN_ID":            cliIdentifierFamilyRun,
+		"entities.go\x00RUN":               cliIdentifierFamilyRun,
 		"entities.go\x00FLOW":              cliIdentifierFamilyFlowInstance,
 		"events.go\x00EVENT ID":            cliIdentifierFamilyEvent,
 		"events.go\x00RUN":                 cliIdentifierFamilyRun,

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -451,23 +451,6 @@ func cliSanitizeOneLineValue(value string) string {
 	return strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
 }
 
-// cliRenderOneLineLabel sanitizes a row label and, when it exceeds the one-line
-// ceiling, retains a distinguishing suffix so two long labels sharing a common
-// prefix never render as identical rows.
-func cliRenderOneLineLabel(value string) string {
-	value = cliSanitizeOneLineValue(value)
-	runes := []rune(value)
-	if len(runes) <= cliOneLineMaxRunes {
-		return value
-	}
-	const retainedSuffixRunes = 12
-	kept := cliOneLineMaxRunes - retainedSuffixRunes - 1
-	if kept < 1 {
-		kept = 1
-	}
-	return string(runes[:kept]) + "…" + string(runes[len(runes)-retainedSuffixRunes:])
-}
-
 func cliReplaceLineBreakingRune(r rune) rune {
 	if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' {
 		return ' '

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -436,7 +436,7 @@ const cliOneLineMaxRunes = 200
 // fixed constant, not terminal-width-dependent, so human output stays
 // deterministic across TTY and piped rendering.
 func cliRenderOneLineValue(value string) string {
-	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	value = cliSanitizeOneLineValue(value)
 	runes := []rune(value)
 	if len(runes) <= cliOneLineMaxRunes {
 		return value
@@ -444,11 +444,18 @@ func cliRenderOneLineValue(value string) string {
 	return string(runes[:cliOneLineMaxRunes]) + "…"
 }
 
+// cliSanitizeOneLineValue preserves the complete value while replacing
+// characters that would break terminal line discipline. Identifier columns
+// consume this helper because truncation belongs to the identifier registry.
+func cliSanitizeOneLineValue(value string) string {
+	return strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+}
+
 // cliRenderOneLineLabel sanitizes a row label and, when it exceeds the one-line
 // ceiling, retains a distinguishing suffix so two long labels sharing a common
 // prefix never render as identical rows.
 func cliRenderOneLineLabel(value string) string {
-	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	value = cliSanitizeOneLineValue(value)
 	runes := []rune(value)
 	if len(runes) <= cliOneLineMaxRunes {
 		return value

--- a/internal/cliapp/cli_output.go
+++ b/internal/cliapp/cli_output.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/division-sh/swarm/internal/userfacing"
@@ -25,6 +27,8 @@ const (
 	cliOutputQuietFlagHelp   = "Render only declared load-bearing value(s)"
 	cliOutputNoColorFlag     = "no-color"
 	cliOutputNoColorFlagHelp = "Disable ANSI color in human-readable output"
+	cliOutputVerboseFlag     = "verbose"
+	cliOutputVerboseFlagHelp = "Render the full record: absolute timestamps, bookkeeping fields, loops, and accumulated state"
 )
 
 type cliOutputOptions struct {
@@ -32,6 +36,7 @@ type cliOutputOptions struct {
 	asYAML  bool
 	quiet   bool
 	noColor bool
+	verbose bool
 }
 
 type cliTextRenderer func(io.Writer)
@@ -182,6 +187,13 @@ func bindCLIOutputFlags(cmd *cobra.Command, opts *cliOutputOptions) {
 
 func bindCLIYAMLOutputFlag(cmd *cobra.Command, opts *cliOutputOptions) {
 	cmd.Flags().BoolVar(&opts.asYAML, cliOutputYAMLFlag, false, cliOutputYAMLFlagHelp)
+}
+
+// bindCLIOutputVerboseFlag binds the shared --verbose flag without sweeping it
+// onto every bindCLIOutputFlags consumer; commands opt into the full record
+// projection explicitly.
+func bindCLIOutputVerboseFlag(cmd *cobra.Command, opts *cliOutputOptions) {
+	cmd.Flags().BoolVar(&opts.verbose, cliOutputVerboseFlag, false, cliOutputVerboseFlagHelp)
 }
 
 func bindCLIOutputFlagSet(fs *flag.FlagSet, opts *cliOutputOptions) {
@@ -380,6 +392,80 @@ func cliDisplayWidth(value string) int {
 		return 0
 	}
 	return utf8.RuneCountInString(value)
+}
+
+// cliRelativeTimeNow is the single owner of "now" for relative-time rendering;
+// tests override it for deterministic output.
+var cliRelativeTimeNow = time.Now
+
+// formatCLIRelativeTime renders an RFC3339 timestamp relative to now
+// ("5m ago"). Timestamps within a minute in the past OR a minute in the
+// future render as "just now" (small clock-skew tolerance); a genuinely future
+// timestamp beyond the skew window falls back to the raw value. Unparseable
+// values also fall back to raw. Machine output must never consume this helper
+// (use the raw absolute value).
+func formatCLIRelativeTime(now time.Time, raw string) string {
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw))
+	if err != nil {
+		return raw
+	}
+	elapsed := now.Sub(at)
+	switch {
+	case elapsed < -time.Minute:
+		return raw
+	case elapsed < time.Minute:
+		return "just now"
+	case elapsed < time.Hour:
+		return fmt.Sprintf("%dm ago", int(elapsed.Minutes()))
+	case elapsed < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(elapsed.Hours()))
+	case elapsed < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(elapsed.Hours()/24))
+	case elapsed < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo ago", int(elapsed.Hours()/(24*30)))
+	default:
+		return fmt.Sprintf("%dy ago", int(elapsed.Hours()/(24*365)))
+	}
+}
+
+const cliOneLineMaxRunes = 200
+
+// cliRenderOneLineValue collapses line-breaking and control characters so a
+// value can never break the CLI's line discipline, then truncates long values
+// at a fixed rune ceiling with a visible truncation marker. The ceiling is a
+// fixed constant, not terminal-width-dependent, so human output stays
+// deterministic across TTY and piped rendering.
+func cliRenderOneLineValue(value string) string {
+	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) <= cliOneLineMaxRunes {
+		return value
+	}
+	return string(runes[:cliOneLineMaxRunes]) + "…"
+}
+
+// cliRenderOneLineLabel sanitizes a row label and, when it exceeds the one-line
+// ceiling, retains a distinguishing suffix so two long labels sharing a common
+// prefix never render as identical rows.
+func cliRenderOneLineLabel(value string) string {
+	value = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) <= cliOneLineMaxRunes {
+		return value
+	}
+	const retainedSuffixRunes = 12
+	kept := cliOneLineMaxRunes - retainedSuffixRunes - 1
+	if kept < 1 {
+		kept = 1
+	}
+	return string(runes[:kept]) + "…" + string(runes[len(runes)-retainedSuffixRunes:])
+}
+
+func cliReplaceLineBreakingRune(r rune) rune {
+	if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' {
+		return ' '
+	}
+	return r
 }
 
 func renderCLIOutput(out, errOut io.Writer, opts cliOutputOptions, value any, text cliTextRenderer, quiet cliQuietRenderer) error {

--- a/internal/cliapp/cli_output_conformance_registry_test.go
+++ b/internal/cliapp/cli_output_conformance_registry_test.go
@@ -60,6 +60,8 @@ var cliOutputSharedOwnerProofs = map[string]cliOutputSharedOwnerProof{
 	"swarm forkchat delete":              {Constructor: "newForkChatDeleteCommand", Runner: "runForkChatDeleteCommand"},
 	"swarm describe":                     {Constructor: "newDescribeCommand", Runner: "runDescribeCommandWithOutput"},
 	"swarm describe routes":              {Constructor: "newDescribeRoutesCommand", Runner: "runDescribeRoutesCommandWithOutput"},
+	"swarm entity list":                  {Constructor: "newEntitiesListCommand", Runner: "runEntitiesListCommand"},
+	"swarm entity view":                  {Constructor: "newEntityViewCommand", Runner: "runEntityViewCommand"},
 }
 
 var cliOutputGrandfatheredNonSharedRows = map[string]string{
@@ -114,8 +116,6 @@ var cliOutputGrandfatheredNonSharedRows = map[string]string{
 	"swarm bundle build":           "split",
 	"swarm forkchat":               "exception",
 	"swarm entity":                 "exception",
-	"swarm entity list":            "split",
-	"swarm entity view":            "split",
 	"swarm entity aggregate":       "split",
 	"swarm logs":                   "split",
 	"swarm incidents":              "split",
@@ -134,6 +134,8 @@ var cliOutputExpectedFactOwners = map[string]string{
 	"swarm agent view":       "/v1/rpc agent.get",
 	"swarm agent diagnose":   "/v1/rpc agent.diagnose",
 	"swarm agent deliveries": "/v1/rpc agent.delivery_lifecycle",
+	"swarm entity list":      "/v1/rpc entity.list",
+	"swarm entity view":      "/v1/rpc entity.get",
 }
 
 var cliOutputSharedDisplayProofs = map[string][]string{
@@ -156,7 +158,7 @@ var cliOutputSharedDisplayProofs = map[string][]string{
 	"writeDiagnosticRunTraceDeliveryDetail":  {"writeCLITable"},
 	"writeDiagnosticRunTraceDeliverySummary": {"writeCLITable"},
 	"writeEntityAggregateResult":             {"writeCLITable"},
-	"writeEntityFullResult":                  {"writeCLIFieldLine"},
+	"writeEntityFullResult":                  {"writeCLILabeledDetail"},
 	"writeEntityListResult":                  {"writeCLITable"},
 	"writeEventDeadLetterLine":               {"writeCLIFieldLine"},
 	"writeEventDetailResult":                 {"writeCLIFieldLine"},

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -537,7 +537,7 @@ func writeEntityListResult(out io.Writer, result entityListResult, opts entityLi
 		row = append(row,
 			entityDash(entityOneLine(entity.EntityType)),
 			entityDash(entityOneLine(entity.CurrentState)),
-			entityShortFlow(entity.FlowInstance),
+			cliSanitizeOneLineValue(entity.FlowInstance),
 			entityTimestampText(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose),
 		)
 		rows = append(rows, row)
@@ -726,25 +726,6 @@ func writeEntityLoopSection(out io.Writer, loops []loopruntime.PublicActivation)
 		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(loop.ID), Value: cliRenderOneLineValue(summary)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
-}
-
-var entityHashSegmentPattern = regexp.MustCompile(`^[0-9a-f]{40,}$`)
-
-const entityHashSegmentMaxRunes = 12
-
-// entityShortFlow truncates ONLY the hash-bearing flow-path segment (e.g. an
-// embedded 64-hex bundle digest); instance-discriminating segments stay intact
-// so two instances differing past a shared prefix still render as distinct,
-// round-trippable cells.
-func entityShortFlow(flow string) string {
-	flow = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(flow))
-	segments := strings.Split(strings.Trim(flow, "/"), "/")
-	for i, segment := range segments {
-		if entityHashSegmentPattern.MatchString(segment) && len(segment) > entityHashSegmentMaxRunes {
-			segments[i] = segment[:entityHashSegmentMaxRunes] + "…"
-		}
-	}
-	return strings.Join(segments, "/")
 }
 
 func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -565,8 +565,8 @@ func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOp
 	entity := result.Entity
 	now := cliRelativeTimeNow()
 	header := []cliLabeledDetailRow{
-		{Label: "run", Value: entityOneLine(entity.RunID)},
-		{Label: "flow", Value: entityOneLine(entity.FlowInstance)},
+		{Label: "run", Value: cliSanitizeOneLineValue(entity.RunID)},
+		{Label: "flow", Value: cliSanitizeOneLineValue(entity.FlowInstance)},
 		{Label: "type", Value: entityDash(entityOneLine(entity.EntityType))},
 		{Label: "state", Value: entityDash(entityOneLine(entity.CurrentState))},
 		{Label: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
@@ -598,9 +598,9 @@ func entityTimestampText(now time.Time, raw string, verbose bool) string {
 	return relative + " (" + raw + ")"
 }
 
-// entityOneLine normalizes an unconstrained summary string (run id, flow,
-// type, state, slug, name) so embedded line-breaking characters cannot break
-// the aligned detail-row or table line discipline.
+// entityOneLine normalizes a truncatable descriptive value so embedded
+// line-breaking characters cannot break the aligned detail-row or table line
+// discipline. Exact identifiers and semantic keys use the full-value sanitizer.
 func entityOneLine(value string) string {
 	return cliRenderOneLineValue(value)
 }
@@ -643,7 +643,7 @@ func entityFieldRows(fields map[string]any, include func(string) bool) []cliLabe
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: entityFieldValue(fields[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: cliSanitizeOneLineValue(key), Value: entityFieldValue(fields[key])})
 	}
 	return rows
 }
@@ -690,7 +690,7 @@ func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
 	sort.Strings(keys)
 	rows := make([]cliLabeledDetailRow, 0, len(keys))
 	for _, key := range keys {
-		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: fmt.Sprintf("%t", gates[key])})
+		rows = append(rows, cliLabeledDetailRow{Label: cliSanitizeOneLineValue(key), Value: fmt.Sprintf("%t", gates[key])})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Gates", Rows: rows})
 }
@@ -723,7 +723,7 @@ func writeEntityLoopSection(out io.Writer, loops []loopruntime.PublicActivation)
 			summary += " · close_reason " + loop.CloseReason
 		}
 		summary += " · stage " + loop.CurrentStage
-		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(loop.ID), Value: cliRenderOneLineValue(summary)})
+		rows = append(rows, cliLabeledDetailRow{Label: cliSanitizeOneLineValue(loop.ID), Value: cliRenderOneLineValue(summary)})
 	}
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
 }

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -8,8 +8,11 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/division-sh/swarm/internal/cli/argcount"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +24,7 @@ const (
 
 type entityListCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 
 	runID        string
 	flow         string
@@ -39,6 +43,7 @@ type entityListCommandOptions struct {
 
 type entityViewCommandOptions struct {
 	apiOptions rootCommandOptions
+	output     cliOutputOptions
 
 	runID    string
 	runIDSet bool
@@ -75,10 +80,11 @@ type entitySummary struct {
 }
 
 type entityFull struct {
-	Entity      entitySummary   `json:"entity"`
-	Fields      map[string]any  `json:"fields"`
-	Gates       map[string]bool `json:"gates"`
-	Accumulated map[string]any  `json:"accumulated"`
+	Entity      entitySummary                  `json:"entity"`
+	Fields      map[string]any                 `json:"fields"`
+	Gates       map[string]bool                `json:"gates"`
+	Accumulated map[string]any                 `json:"accumulated"`
+	Loops       []loopruntime.PublicActivation `json:"loops,omitempty"`
 }
 
 type entityAggregateResult struct {
@@ -138,6 +144,9 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "List entities with filters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := listOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			listOpts.runIDSet = cmd.Flags().Changed("run-id")
 			listOpts.flowSet = cmd.Flags().Changed("flow")
 			listOpts.entityTypeSet = cmd.Flags().Changed("type")
@@ -154,6 +163,8 @@ func newEntitiesListCommand(opts rootCommandOptions) *cobra.Command {
 	cmd.Flags().IntVar(&listOpts.limit, "limit", 0, "Optional page size, 1-500")
 	cmd.Flags().StringVar(&listOpts.cursor, "cursor", "", "Pagination cursor")
 	bindCLIAPIConnectionFlags(cmd, &listOpts.apiOptions)
+	bindCLIOutputFlags(cmd, &listOpts.output)
+	bindCLIOutputVerboseFlag(cmd, &listOpts.output)
 	return cmd
 }
 
@@ -164,6 +175,9 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 		Short: "View one entity's state.",
 		Args:  argcount.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viewOpts.output.validate(); err != nil {
+				return returnCLIValidationError(cmd.ErrOrStderr(), err)
+			}
 			viewOpts.runIDSet = cmd.Flags().Changed("run-id")
 			return runEntityViewCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], viewOpts)
 		},
@@ -171,6 +185,8 @@ func newEntityViewCommand(opts rootCommandOptions) *cobra.Command {
 	argcount.SetDiscoveryHint(cmd, "List entity ids with `swarm entity list`.")
 	cmd.Flags().StringVar(&viewOpts.runID, "run-id", "", "Disambiguate entities reused across runs")
 	bindCLIAPIConnectionFlags(cmd, &viewOpts.apiOptions)
+	bindCLIOutputFlags(cmd, &viewOpts.output)
+	bindCLIOutputVerboseFlag(cmd, &viewOpts.output)
 	return cmd
 }
 
@@ -210,8 +226,15 @@ func runEntitiesListCommand(ctx context.Context, out, errOut io.Writer, opts ent
 	if err := validateEntityListResult(result); err != nil {
 		return returnCLIAPIError(errOut, err, entityListAPIErrorClassifier())
 	}
-	writeEntityListResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeEntityListResult(w, result, entityListRenderOptions{verbose: opts.output.verbose, runScoped: opts.runIDSet})
+	}, func() ([]string, error) {
+		ids := make([]string, 0, len(result.Entities))
+		for _, entity := range result.Entities {
+			ids = append(ids, entity.EntityID)
+		}
+		return ids, nil
+	})
 }
 
 func runEntityViewCommand(ctx context.Context, out, errOut io.Writer, entityID string, opts entityViewCommandOptions) error {
@@ -257,8 +280,11 @@ func runEntityViewCommand(ctx context.Context, out, errOut io.Writer, entityID s
 	if err := validateEntityFullResult("entity.get result", result); err != nil {
 		return returnCLIAPIError(errOut, err, entityViewAPIErrorClassifier())
 	}
-	writeEntityFullResult(out, result)
-	return nil
+	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
+		writeEntityFullResult(w, result, entityRenderOptions{verbose: opts.output.verbose})
+	}, func() ([]string, error) {
+		return []string{result.Entity.EntityID}, nil
+	})
 }
 
 func runEntityAggregateCommand(ctx context.Context, out, errOut io.Writer, opts entityAggregateCommandOptions) error {
@@ -481,68 +507,244 @@ func validateEntityAggregateResult(result entityAggregateResult) error {
 	return nil
 }
 
-func writeEntityListResult(out io.Writer, result entityListResult) {
+type entityListRenderOptions struct {
+	verbose   bool
+	runScoped bool
+}
+
+func writeEntityListResult(out io.Writer, result entityListResult, opts entityListRenderOptions) {
 	if out == nil {
 		return
 	}
+	columns := []cliTableColumn{
+		{Header: "ENTITY_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyEntity},
+	}
+	if !opts.runScoped {
+		columns = append(columns, cliTableColumn{Header: "RUN", IdentifierFamily: cliIdentifierFamilyRun})
+	}
+	columns = append(columns,
+		cliTableColumn{Header: "TYPE"},
+		cliTableColumn{Header: "STATE"},
+		cliTableColumn{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
+		cliTableColumn{Header: "UPDATED"},
+	)
 	rows := make([][]string, 0, len(result.Entities))
 	for _, entity := range result.Entities {
-		rows = append(rows, []string{
-			entity.EntityID,
-			entity.RunID,
-			entity.FlowInstance,
-			entity.EntityType,
-			entity.CurrentState,
-			fmt.Sprintf("%d", entity.Revision),
-			entity.UpdatedAt,
-			entityDash(entity.Slug),
-			entityDash(entity.Name),
-		})
+		row := []string{entity.EntityID}
+		if !opts.runScoped {
+			row = append(row, entity.RunID)
+		}
+		row = append(row,
+			entityDash(entityOneLine(entity.EntityType)),
+			entityDash(entityOneLine(entity.CurrentState)),
+			entityShortFlow(entityOneLine(entity.FlowInstance)),
+			entityTimestampText(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose),
+		)
+		rows = append(rows, row)
 	}
 	footers := []string{}
 	if strings.TrimSpace(result.NextCursor) != "" {
 		footers = append(footers, fmt.Sprintf("next_cursor=%s", result.NextCursor))
 	}
 	writeCLITable(out, cliTable{
-		Columns: []cliTableColumn{
-			{Header: "ENTITY_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyEntity},
-			{Header: "RUN_ID", KeyColumn: true, IdentifierFamily: cliIdentifierFamilyRun},
-			{Header: "FLOW", IdentifierFamily: cliIdentifierFamilyFlowInstance},
-			{Header: "TYPE"},
-			{Header: "STATE"},
-			{Header: "REVISION"},
-			{Header: "UPDATED"},
-			{Header: "SLUG"},
-			{Header: "NAME"},
-		},
+		Columns:      columns,
 		Rows:         rows,
 		EmptyMessage: "No entities match the current filters.",
 		FooterLines:  footers,
 	})
 }
 
-func writeEntityFullResult(out io.Writer, result entityFull) {
+type entityRenderOptions struct {
+	verbose bool
+}
+
+func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOptions) {
 	if out == nil {
 		return
 	}
 	entity := result.Entity
-	writeCLITitle(out, fmt.Sprintf("Entity %s", entity.EntityID))
-	writeCLIFieldLine(out,
-		cliDetailField{Key: "run_id", Value: entity.RunID},
-		cliDetailField{Key: "flow", Value: entity.FlowInstance},
-		cliDetailField{Key: "type", Value: entity.EntityType},
-		cliDetailField{Key: "state", Value: entity.CurrentState},
-		cliDetailField{Key: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
-		cliDetailField{Key: "created_at", Value: entity.CreatedAt},
-		cliDetailField{Key: "updated_at", Value: entity.UpdatedAt},
-	)
-	writeCLIFieldLine(out,
-		cliDetailField{Key: "slug", Value: entityDash(entity.Slug)},
-		cliDetailField{Key: "name", Value: entityDash(entity.Name)},
-	)
-	writeCLIFieldLine(out, cliDetailField{Key: "fields", Value: entityCompactJSON(result.Fields)})
-	writeCLIFieldLine(out, cliDetailField{Key: "gates", Value: entityCompactJSON(result.Gates)})
-	writeCLIFieldLine(out, cliDetailField{Key: "accumulated", Value: entityCompactJSON(result.Accumulated)})
+	now := cliRelativeTimeNow()
+	header := []cliLabeledDetailRow{
+		{Label: "run", Value: entityOneLine(entity.RunID)},
+		{Label: "flow", Value: entityOneLine(entity.FlowInstance)},
+		{Label: "type", Value: entityDash(entityOneLine(entity.EntityType))},
+		{Label: "state", Value: entityDash(entityOneLine(entity.CurrentState))},
+		{Label: "revision", Value: fmt.Sprintf("%d", entity.Revision)},
+		{Label: "created", Value: entityTimestampText(now, entity.CreatedAt, opts.verbose)},
+		{Label: "updated", Value: entityTimestampText(now, entity.UpdatedAt, opts.verbose)},
+	}
+	if strings.TrimSpace(entity.Slug) != "" {
+		header = append(header, cliLabeledDetailRow{Label: "slug", Value: entityOneLine(entity.Slug)})
+	}
+	if strings.TrimSpace(entity.Name) != "" {
+		header = append(header, cliLabeledDetailRow{Label: "name", Value: entityOneLine(entity.Name)})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Entity " + entity.EntityID, Rows: header})
+
+	writeEntityFieldSection(out, "Fields", result.Fields, entityContentField, true)
+	writeEntityGatesSection(out, result.Gates)
+	writeEntityAccumulatedSection(out, result.Accumulated, opts.verbose)
+	if opts.verbose {
+		writeEntityLoopSection(out, result.Loops)
+		writeEntityFieldSection(out, "Bookkeeping", result.Fields, entityBookkeepingField, false)
+	}
+}
+
+// entityTimestampText renders a humanized relative time; under --verbose it
+// appends the absolute ISO value so operators can pin the exact moment.
+func entityTimestampText(now time.Time, raw string, verbose bool) string {
+	relative := formatCLIRelativeTime(now, raw)
+	if !verbose {
+		return relative
+	}
+	return relative + " (" + raw + ")"
+}
+
+// entityOneLine normalizes an unconstrained summary string (run id, flow,
+// type, state, slug, name) so embedded line-breaking characters cannot break
+// the aligned detail-row or table line discipline.
+func entityOneLine(value string) string {
+	return cliRenderOneLineValue(value)
+}
+
+// entityContentField reports whether a field key is workflow-declared content
+// (default-visible) rather than platform-injected bookkeeping. The platform key
+// set is owned by runtimecontracts.EntityFieldBookkeepingKeys, adjacent to the
+// injection sites; a platform key forgotten there shows up in default output
+// (fail-visible) instead of silently vanishing.
+func entityContentField(key string) bool {
+	return !runtimecontracts.IsEntityFieldBookkeepingKey(key)
+}
+
+func entityBookkeepingField(key string) bool {
+	return runtimecontracts.IsEntityFieldBookkeepingKey(key)
+}
+
+func writeEntityFieldSection(out io.Writer, title string, fields map[string]any, include func(string) bool, stateEmpty bool) {
+	rows := entityFieldRows(fields, include)
+	if len(rows) == 0 {
+		if stateEmpty {
+			writeCLITitle(out, title+"  none")
+		}
+		return
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: title, Rows: rows})
+}
+
+func entityFieldRows(fields map[string]any, include func(string) bool) []cliLabeledDetailRow {
+	if include == nil {
+		include = func(string) bool { return true }
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if include(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	rows := make([]cliLabeledDetailRow, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: entityFieldValue(fields[key])})
+	}
+	return rows
+}
+
+func entityFieldValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return "none"
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case string:
+		rendered := cliRenderOneLineValue(v)
+		if strings.TrimSpace(rendered) == "" {
+			return "none"
+		}
+		return rendered
+	case map[string]any:
+		if len(v) == 0 {
+			return "none"
+		}
+	case []any:
+		if len(v) == 0 {
+			return "none"
+		}
+	}
+	return cliRenderOneLineValue(entityCompactJSON(value))
+}
+
+// writeEntityGatesSection renders EVERY declared gate with its value in
+// default and --verbose; a false gate is not absence, it is the diagnostic an
+// operator needs. "Gates  none" renders only when the gate map is empty.
+func writeEntityGatesSection(out io.Writer, gates map[string]bool) {
+	if len(gates) == 0 {
+		writeCLITitle(out, "Gates  none")
+		return
+	}
+	keys := make([]string, 0, len(gates))
+	for key := range gates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	rows := make([]cliLabeledDetailRow, 0, len(keys))
+	for _, key := range keys {
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(key), Value: fmt.Sprintf("%t", gates[key])})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Gates", Rows: rows})
+}
+
+// writeEntityAccumulatedSection states accumulated presence in default output
+// (never silence) and renders the full map under --verbose.
+func writeEntityAccumulatedSection(out io.Writer, accumulated map[string]any, verbose bool) {
+	if verbose {
+		writeEntityFieldSection(out, "Accumulated", accumulated, nil, true)
+		return
+	}
+	if len(accumulated) == 0 {
+		writeCLITitle(out, "Accumulated  none")
+		return
+	}
+	writeCLITitle(out, fmt.Sprintf("Accumulated  %d keys (--verbose to expand)", len(accumulated)))
+}
+
+// writeEntityLoopSection renders bounded-loop activations as data under
+// --verbose (strings as-is via loopruntime.PublicActivation; no lifecycle
+// interpretation).
+func writeEntityLoopSection(out io.Writer, loops []loopruntime.PublicActivation) {
+	if len(loops) == 0 {
+		return
+	}
+	rows := make([]cliLabeledDetailRow, 0, len(loops))
+	for _, loop := range loops {
+		summary := fmt.Sprintf("%s · attempt %d/%d · rev %s", loop.Status, loop.Attempt, loop.MaxAttempts, loop.RevisionID)
+		if strings.TrimSpace(loop.CloseReason) != "" {
+			summary += " · close_reason " + loop.CloseReason
+		}
+		summary += " · stage " + loop.CurrentStage
+		rows = append(rows, cliLabeledDetailRow{Label: cliRenderOneLineLabel(loop.ID), Value: cliRenderOneLineValue(summary)})
+	}
+	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Loops", Rows: rows})
+}
+
+var entityHashSegmentPattern = regexp.MustCompile(`^[0-9a-f]{40,}$`)
+
+const entityHashSegmentMaxRunes = 12
+
+// entityShortFlow truncates ONLY the hash-bearing flow-path segment (e.g. an
+// embedded 64-hex bundle digest); instance-discriminating segments stay intact
+// so two instances differing past a shared prefix still render as distinct,
+// round-trippable cells.
+func entityShortFlow(flow string) string {
+	segments := strings.Split(strings.Trim(flow, "/"), "/")
+	for i, segment := range segments {
+		if entityHashSegmentPattern.MatchString(segment) && len(segment) > entityHashSegmentMaxRunes {
+			segments[i] = segment[:entityHashSegmentMaxRunes] + "…"
+		}
+	}
+	return strings.Join(segments, "/")
 }
 
 func writeEntityAggregateResult(out io.Writer, result entityAggregateResult) {

--- a/internal/cliapp/entities.go
+++ b/internal/cliapp/entities.go
@@ -537,7 +537,7 @@ func writeEntityListResult(out io.Writer, result entityListResult, opts entityLi
 		row = append(row,
 			entityDash(entityOneLine(entity.EntityType)),
 			entityDash(entityOneLine(entity.CurrentState)),
-			entityShortFlow(entityOneLine(entity.FlowInstance)),
+			entityShortFlow(entity.FlowInstance),
 			entityTimestampText(cliRelativeTimeNow(), entity.UpdatedAt, opts.verbose),
 		)
 		rows = append(rows, row)
@@ -573,12 +573,10 @@ func writeEntityFullResult(out io.Writer, result entityFull, opts entityRenderOp
 		{Label: "created", Value: entityTimestampText(now, entity.CreatedAt, opts.verbose)},
 		{Label: "updated", Value: entityTimestampText(now, entity.UpdatedAt, opts.verbose)},
 	}
-	if strings.TrimSpace(entity.Slug) != "" {
-		header = append(header, cliLabeledDetailRow{Label: "slug", Value: entityOneLine(entity.Slug)})
-	}
-	if strings.TrimSpace(entity.Name) != "" {
-		header = append(header, cliLabeledDetailRow{Label: "name", Value: entityOneLine(entity.Name)})
-	}
+	header = append(header,
+		cliLabeledDetailRow{Label: "slug", Value: entityDash(entityOneLine(entity.Slug))},
+		cliLabeledDetailRow{Label: "name", Value: entityDash(entityOneLine(entity.Name))},
+	)
 	writeCLILabeledDetail(out, cliLabeledDetail{Title: "Entity " + entity.EntityID, Rows: header})
 
 	writeEntityFieldSection(out, "Fields", result.Fields, entityContentField, true)
@@ -607,11 +605,12 @@ func entityOneLine(value string) string {
 	return cliRenderOneLineValue(value)
 }
 
-// entityContentField reports whether a field key is workflow-declared content
-// (default-visible) rather than platform-injected bookkeeping. The platform key
-// set is owned by runtimecontracts.EntityFieldBookkeepingKeys, adjacent to the
-// injection sites; a platform key forgotten there shows up in default output
-// (fail-visible) instead of silently vanishing.
+// entityContentField is a temporary display classifier for entity.get's
+// undifferentiated fields map. A workflow-authored field whose name collides
+// with a platform bookkeeping key is hidden from default output, but remains
+// available under --verbose and --json. Issue #2242 tracks moving ownership to
+// the API projection so this name-based limitation and classifier can be
+// removed.
 func entityContentField(key string) bool {
 	return !runtimecontracts.IsEntityFieldBookkeepingKey(key)
 }
@@ -738,6 +737,7 @@ const entityHashSegmentMaxRunes = 12
 // so two instances differing past a shared prefix still render as distinct,
 // round-trippable cells.
 func entityShortFlow(flow string) string {
+	flow = strings.Map(cliReplaceLineBreakingRune, strings.TrimSpace(flow))
 	segments := strings.Split(strings.Trim(flow, "/"), "/")
 	for i, segment := range segments {
 		if entityHashSegmentPattern.MatchString(segment) && len(segment) > entityHashSegmentMaxRunes {

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -63,7 +63,7 @@ func TestEntitiesListUsesEntityListV1RPCWithFilters(t *testing.T) {
 	if !reflect.DeepEqual(captured.Params, wantParams) {
 		t.Fatalf("params = %#v, want %#v", captured.Params, wantParams)
 	}
-	for _, want := range []string{"ENTITY_ID", "RUN_ID", "entity-1", "run-1", "flows/review", "vertical", "collecting", "next_cursor=entity-cursor-2"} {
+	for _, want := range []string{"ENTITY_ID", "entity-1", "flows/review", "vertical", "collecting", "next_cursor=entity-cursor-2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -141,7 +141,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("entities list code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"ENTITY_ID", "RUN_ID", entityA, entityB, "vertical", "discovered", "pending"} {
+	for _, want := range []string{"ENTITY_ID", entityA, entityB, "vertical", "discovered", "pending"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entities list stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -156,7 +156,7 @@ func TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("entity view code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	for _, want := range []string{"Entity " + entityA, "type=vertical state=discovered", `fields={"vertical_name":"Healthcare"}`} {
+	for _, want := range []string{"Entity " + entityA, "vertical", "discovered", "vertical_name", "Healthcare"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("entity view stdout missing %q:\n%s", want, stdout.String())
 		}
@@ -208,14 +208,57 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Entity entity-1",
-		"run_id=run-1 flow=flows/review type=vertical state=collecting revision=3",
-		"slug=vertical-1 name=Vertical One",
-		`fields={"score":7}`,
-		`gates={"ready":true}`,
-		`accumulated={"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
+		"run-1",
+		"flows/review",
+		"vertical",
+		"collecting",
+		"score",
+		"ready",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, absent := range []string{"accumulator", `"accumulated"`, `fields={"score":7}`} {
+		if strings.Contains(stdout.String(), absent) {
+			t.Fatalf("stdout should not contain %q:\n%s", absent, stdout.String())
+		}
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestEntityViewJSONIsDataComplete(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEntityFullResult("entity-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{
+		`"entity_id":"entity-1"`,
+		`"run_id":"run-1"`,
+		`"slug":"vertical-1"`,
+		`"name":"Vertical One"`,
+		`"revision":3`,
+		`"created_at":"2026-05-20T01:00:00Z"`,
+		`"updated_at":"2026-05-20T01:05:00Z"`,
+		`"fields":{"score":7}`,
+		`"gates":{"ready":true}`,
+		`"accumulated":{"accumulator":{"count":2},"notes":["a",{"text":"probe"}],"score":3}`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("entity view --json missing %q:\n%s", want, stdout.String())
 		}
 	}
 	if strings.TrimSpace(stderr.String()) != "" {
@@ -451,6 +494,430 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.wantStderr)
 			}
 		})
+	}
+}
+
+func TestEntityViewGatesRenderFalseValuesInDefaultOutput(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["gates"] = map[string]any{"approved": false}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "approved") || !strings.Contains(stdout.String(), "false") {
+		t.Fatalf("Ruling A: a declared false gate must render its name and value in default output:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Gates  none") {
+		t.Fatalf("populated gate map must not render as none:\n%s", stdout.String())
+	}
+}
+
+func TestEntityViewEmptyGatesRenderNone(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["gates"] = map[string]any{}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Gates  none") {
+		t.Fatalf("empty gates map should render as stated none:\n%s", stdout.String())
+	}
+}
+
+func TestEntityViewAccumulatedStatedPresenceAndVerboseExpansion(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Accumulated  3 keys (--verbose to expand)") {
+		t.Fatalf("Ruling B: populated accumulated must be stated in default output:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("verbose code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Accumulated", "accumulator", "notes", "score"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestEntityViewEmptyAccumulatedRendersNone(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["accumulated"] = map[string]any{}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Accumulated  none") {
+		t.Fatalf("empty accumulated should render as stated none:\n%s", stdout.String())
+	}
+}
+
+func TestEntityViewLoopsRenderAsDataUnderVerbose(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		result["loops"] = []map[string]any{
+			{"id": "loop-a", "revision_id": "rev-9", "attempt": 1, "max_attempts": 3, "current_stage": "collecting", "status": "unusual"},
+		}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Loops") {
+		t.Fatalf("default output should not render loops:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("verbose code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Loops", "loop-a", "unusual", "attempt 1/3", "rev-9", "collecting"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestEntityViewVerboseShowsBookkeepingAndAbsoluteTimestamps(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		fields := result["fields"].(map[string]any)
+		fields["bundle_hash"] = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		fields["activation"] = "standing"
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"Bookkeeping", "bundle_hash", "activation", "2026-05-20T01:05:00Z"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("verbose stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("default code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, absent := range []string{"Bookkeeping", "bundle_hash", "activation", "2026-05-20T01:05:00Z"} {
+		if strings.Contains(stdout.String(), absent) {
+			t.Fatalf("default stdout should not contain %q:\n%s", absent, stdout.String())
+		}
+	}
+}
+
+func TestEntityViewStatedEmptyStatesAndTruncationAndControlChars(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		entity := result["entity"].(map[string]any)
+		entity["name"] = "Vertical\nOne"
+		result["fields"] = map[string]any{
+			"chats":               map[string]any{},
+			"empty":               "   ",
+			"long":                strings.Repeat("x", 300),
+			"broken":              "line one\nline two\tand a control \x01 byte",
+			"unicode_separators":  "a\u2028b\u2029c\u0085d",
+			"fan_out_count":       3,
+			"label\nwith_newline": "value",
+		}
+		result["gates"] = map[string]any{}
+		result["accumulated"] = map[string]any{}
+		writeJSONRPCResult(t, w, captured.ID, result)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	chatsLine, emptyLine := "", ""
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.Contains(line, "chats") {
+			chatsLine = line
+		}
+		if strings.Contains(line, "empty") {
+			emptyLine = line
+		}
+	}
+	if !strings.Contains(chatsLine, "none") {
+		t.Fatalf("empty collection value should render as none:\n%s", stdout.String())
+	}
+	if !strings.Contains(emptyLine, "none") {
+		t.Fatalf("empty string field should render as none:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "fan_out_count") {
+		t.Fatalf("platform bookkeeping key leaked into default Fields:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "…") {
+		t.Fatalf("long value missing truncation marker:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nline two") || strings.Contains(stdout.String(), "\x01") {
+		t.Fatalf("control characters leaked into output line discipline:\n%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nOne") {
+		t.Fatalf("embedded newline in entity name broke the header line discipline:\n%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "\nwith_newline") {
+		t.Fatalf("embedded newline in field label broke the detail line discipline:\n%q", stdout.String())
+	}
+	unicodeLine := ""
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if strings.Contains(line, "unicode_separators") {
+			unicodeLine = line
+			break
+		}
+	}
+	if !strings.Contains(unicodeLine, "a b c d") {
+		t.Fatalf("unicode line/paragraph separators not collapsed to spaces:\n%q", stdout.String())
+	}
+}
+
+func TestEntityViewQuietRendersEntityID(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, validEntityFullResult("entity-1"))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "view", "entity-1", "--run-id", "run-1", "--quiet"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "entity-1" {
+		t.Fatalf("quiet stdout = %q, want entity-1", stdout.String())
+	}
+}
+
+func TestEntityListQuietRendersEntityIDs(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities": []map[string]any{validEntitySummary("entity-a"), validEntitySummary("entity-b")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--quiet"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 || lines[0] != "entity-a" || lines[1] != "entity-b" {
+		t.Fatalf("quiet stdout = %q, want entity-a/entity-b lines", stdout.String())
+	}
+}
+
+func TestEntityListUnscopedRetainsRunColumn(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities": []map[string]any{validEntitySummary("entity-1")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"ENTITY_ID", "RUN", "entity-1", "run-1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("unscoped list missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--run-id", "run-1"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("scoped code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), "RUN") {
+		t.Fatalf("run-scoped list should not repeat the RUN column:\n%s", stdout.String())
+	}
+}
+
+func TestEntityListFlowTruncationPreservesDistinguishingSegments(t *testing.T) {
+	sharedHash := strings.Repeat("a", 64)
+	flowA := "ingress/" + sharedHash + "/slot-1"
+	flowB := "ingress/" + sharedHash + "/slot-2"
+	renderedA := entityShortFlow(flowA)
+	renderedB := entityShortFlow(flowB)
+	if renderedA == renderedB {
+		t.Fatalf("instances differing past a shared prefix must render distinct cells:\nA=%s\nB=%s", renderedA, renderedB)
+	}
+	if !strings.Contains(renderedA, "ingress/") || !strings.Contains(renderedA, "slot-1") {
+		t.Fatalf("instance-discriminating segments must stay intact:\n%s", renderedA)
+	}
+	if !strings.Contains(renderedA, "…") || !strings.Contains(renderedB, "…") {
+		t.Fatalf("hash-bearing segment must be truncated:\nA=%s\nB=%s", renderedA, renderedB)
+	}
+}
+
+func TestEntityListVerboseTimestampsAreRelativePlusAbsolute(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var captured jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		writeJSONRPCResult(t, w, captured.ID, map[string]any{
+			"entities": []map[string]any{validEntitySummary("entity-1")},
+		})
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"entity", "list", "--run-id", "run-1", "--verbose"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "2026-05-20T01:05:00Z") {
+		t.Fatalf("verbose list missing absolute timestamp:\n%s", stdout.String())
+	}
+}
+
+func TestEntityOutputModesRejectCollisionBeforeRequest(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		writeJSONRPCResult(t, w, "unexpected", map[string]any{"entities": []any{}})
+	}))
+	defer server.Close()
+
+	for _, args := range [][]string{
+		{"entity", "list", "--json", "--quiet"},
+		{"entity", "view", "entity-1", "--json", "--quiet"},
+	} {
+		calls.Store(0)
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 2 {
+			t.Fatalf("%v code = %d, want 2 stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "mutually exclusive") {
+			t.Fatalf("%v stderr = %q, want collision error", args, stderr.String())
+		}
+		if calls.Load() != 0 {
+			t.Fatalf("%v RPC calls = %d, want 0 (collision must fail before any API call)", args, calls.Load())
+		}
+	}
+}
+
+func TestFormatCLIRelativeTime(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "2026-08-08T11:59:50Z", want: "just now"},
+		{raw: "2026-08-08T11:57:00Z", want: "3m ago"},
+		{raw: "2026-08-08T09:00:00Z", want: "3h ago"},
+		{raw: "2026-08-05T12:00:00Z", want: "3d ago"},
+		{raw: "2026-05-20T01:05:00Z", want: "2mo ago"},
+		{raw: "2020-01-01T00:00:00Z", want: "6y ago"},
+		{raw: "not-a-timestamp", want: "not-a-timestamp"},
+		{raw: "2026-08-08T12:00:30Z", want: "just now"},
+		{raw: "2026-08-09T12:00:00Z", want: "2026-08-09T12:00:00Z"},
+	} {
+		if got := formatCLIRelativeTime(now, tc.raw); got != tc.want {
+			t.Errorf("formatCLIRelativeTime(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -866,11 +866,10 @@ func TestEntityListUnscopedRetainsRunColumn(t *testing.T) {
 	}
 }
 
-func TestEntityListFlowTruncationPreservesDistinguishingSegments(t *testing.T) {
-	sharedHash := strings.Repeat("a", 64)
-	sharedLongPrefix := strings.Repeat("segment-", 30)
-	flowA := "ingress/" + sharedHash + "/" + sharedLongPrefix + "/slot-1"
-	flowB := "ingress/" + sharedHash + "/" + sharedLongPrefix + "/slot-2"
+func TestEntityListFlowIdentifiersRemainExactAndDistinct(t *testing.T) {
+	sharedPrefix := strings.Repeat("a", 63)
+	flowA := "scope/" + sharedPrefix + "1"
+	flowB := "scope/" + sharedPrefix + "2"
 	var stdout bytes.Buffer
 	writeEntityListResult(&stdout, entityListResult{Entities: []entitySummary{
 		{EntityID: "entity-a", RunID: "run-1", FlowInstance: flowA, EntityType: "vertical", CurrentState: "collecting", UpdatedAt: "2026-05-20T01:05:00Z"},
@@ -878,14 +877,34 @@ func TestEntityListFlowTruncationPreservesDistinguishingSegments(t *testing.T) {
 	}}, entityListRenderOptions{runScoped: true})
 
 	rendered := stdout.String()
-	for _, want := range []string{"ingress/", "slot-1", "slot-2", "…"} {
+	for _, want := range []string{flowA, flowB} {
 		if !strings.Contains(rendered, want) {
-			t.Fatalf("rendered flow cells must preserve %q:\n%s", want, rendered)
+			t.Fatalf("rendered flow cells must preserve the exact identifier %q:\n%s", want, rendered)
 		}
+	}
+	if strings.Contains(rendered, "…") {
+		t.Fatalf("flow identifiers must not be abbreviated:\n%s", rendered)
 	}
 	lines := strings.Split(strings.TrimSpace(rendered), "\n")
 	if len(lines) != 3 || lines[1] == lines[2] {
-		t.Fatalf("pathological instances differing after rune 200 must render as distinct rows:\n%s", rendered)
+		t.Fatalf("flow identifiers sharing a long prefix must render as distinct rows:\n%s", rendered)
+	}
+}
+
+func TestEntityListFlowIdentifierSanitizesControlsWithoutTruncation(t *testing.T) {
+	flow := "scope/" + strings.Repeat("b", 64) + "\nterminal\tsegment"
+	want := "scope/" + strings.Repeat("b", 64) + " terminal segment"
+	var stdout bytes.Buffer
+	writeEntityListResult(&stdout, entityListResult{Entities: []entitySummary{
+		{EntityID: "entity-a", RunID: "run-1", FlowInstance: flow, EntityType: "vertical", CurrentState: "collecting", UpdatedAt: "2026-05-20T01:05:00Z"},
+	}}, entityListRenderOptions{runScoped: true})
+
+	rendered := stdout.String()
+	if !strings.Contains(rendered, want) {
+		t.Fatalf("rendered flow must preserve the complete identifier while sanitizing controls; want %q:\n%s", want, rendered)
+	}
+	if strings.Contains(rendered, "\nterminal") || strings.Contains(rendered, "\t") || strings.Contains(rendered, "…") {
+		t.Fatalf("flow identifier leaked controls or was abbreviated:\n%q", rendered)
 	}
 }
 

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -229,6 +229,73 @@ func TestEntityViewUsesEntityGetAndRendersEntityNativeDetail(t *testing.T) {
 	}
 }
 
+func TestEntityViewPreservesExactIdentifiersAndSemanticKeys(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	runID := strings.Repeat("r", 256)
+	rawFlow := "scope/" + strings.Repeat("f", 210) + "\nterminal\tsegment"
+	wantFlow := "scope/" + strings.Repeat("f", 210) + " terminal segment"
+	longKey := func(prefix, discriminator string) string {
+		return strings.Repeat(prefix, 187) + discriminator + strings.Repeat("m", 20) + strings.Repeat("z", 12)
+	}
+	fieldA, fieldB := longKey("f", "a"), longKey("f", "b")
+	gateA, gateB := longKey("g", "a"), longKey("g", "b")
+	accumulatedA, accumulatedB := longKey("a", "a"), longKey("a", "b")
+	loopA, loopB := longKey("l", "a"), longKey("l", "b")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		result := validEntityFullResult("entity-1")
+		entity := result["entity"].(map[string]any)
+		entity["run_id"] = runID
+		entity["flow_instance"] = rawFlow
+		result["fields"] = map[string]any{fieldA: "first", fieldB: "second"}
+		result["gates"] = map[string]any{gateA: false, gateB: true}
+		result["accumulated"] = map[string]any{accumulatedA: 1, accumulatedB: 2}
+		result["loops"] = []map[string]any{
+			{"id": loopA, "revision_id": "rev-a", "attempt": 1, "max_attempts": 2, "current_stage": "collecting", "status": "open"},
+			{"id": loopB, "revision_id": "rev-b", "attempt": 2, "max_attempts": 2, "current_stage": "reviewing", "status": "closed"},
+		}
+		writeJSONRPCResult(t, w, request.ID, result)
+	}))
+	defer server.Close()
+
+	render := func(args ...string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := executeRootCommandWithOptions(context.Background(), t.TempDir(), args, &stdout, &stderr, testRootCommandOptions(server))
+		if code != 0 {
+			t.Fatalf("code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("stderr = %q, want empty", stderr.String())
+		}
+		return stdout.String()
+	}
+
+	defaultOutput := render("entity", "view", "entity-1", "--run-id", "run-1")
+	for _, want := range []string{runID, wantFlow, fieldA, fieldB, gateA, gateB} {
+		if !strings.Contains(defaultOutput, want) {
+			t.Fatalf("default entity view missing exact value %q:\n%s", want, defaultOutput)
+		}
+	}
+	if strings.Contains(defaultOutput, "…") || strings.Contains(defaultOutput, "\t") || strings.Contains(defaultOutput, "\nterminal") {
+		t.Fatalf("default entity view abbreviated an exact fact or leaked controls:\n%q", defaultOutput)
+	}
+
+	verboseOutput := render("entity", "view", "entity-1", "--run-id", "run-1", "--verbose")
+	for _, want := range []string{runID, wantFlow, fieldA, fieldB, gateA, gateB, accumulatedA, accumulatedB, loopA, loopB} {
+		if !strings.Contains(verboseOutput, want) {
+			t.Fatalf("verbose entity view missing exact value %q:\n%s", want, verboseOutput)
+		}
+	}
+	if strings.Contains(verboseOutput, "…") || strings.Contains(verboseOutput, "\t") || strings.Contains(verboseOutput, "\nterminal") {
+		t.Fatalf("verbose entity view abbreviated an exact fact or leaked controls:\n%q", verboseOutput)
+	}
+}
+
 func TestEntityViewJSONIsDataComplete(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	var captured jsonRPCRequest
@@ -477,6 +544,19 @@ func TestEntityCommandsMapRuntimeFailuresAndMalformedResults(t *testing.T) {
 			},
 			wantCode:   3,
 			wantStderr: "fields is required",
+		},
+		{
+			name: "view blank entity type exits three",
+			args: []string{"entity", "view", "entity-1"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				var req jsonRPCRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				result := validEntityFullResult("entity-1")
+				result["entity"].(map[string]any)["entity_type"] = " "
+				writeJSONRPCResult(t, w, req.ID, result)
+			},
+			wantCode:   3,
+			wantStderr: "entity_type is required",
 		},
 		{
 			name: "aggregate unknown rpc exits three",

--- a/internal/cliapp/entities_test.go
+++ b/internal/cliapp/entities_test.go
@@ -266,6 +266,38 @@ func TestEntityViewJSONIsDataComplete(t *testing.T) {
 	}
 }
 
+func TestEntityViewRendersAbsentSlugAndNameAsDash(t *testing.T) {
+	var stdout bytes.Buffer
+	writeEntityFullResult(&stdout, entityFull{
+		Entity: entitySummary{
+			EntityID:     "entity-1",
+			RunID:        "run-1",
+			FlowInstance: "flows/review",
+			EntityType:   "vertical",
+			CurrentState: "collecting",
+			Revision:     1,
+			CreatedAt:    "2026-05-20T01:00:00Z",
+			UpdatedAt:    "2026-05-20T01:05:00Z",
+		},
+		Fields:      map[string]any{},
+		Gates:       map[string]bool{},
+		Accumulated: map[string]any{},
+	}, entityRenderOptions{})
+
+	for _, label := range []string{"slug", "name"} {
+		found := false
+		for _, line := range strings.Split(stdout.String(), "\n") {
+			if reflect.DeepEqual(strings.Fields(line), []string{label, "-"}) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("absent %s must render as a stated dash:\n%s", label, stdout.String())
+		}
+	}
+}
+
 func TestEntityAggregateUsesEntityAggregateDefaultsAndFilters(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	var captured []jsonRPCRequest
@@ -819,6 +851,9 @@ func TestEntityListUnscopedRetainsRunColumn(t *testing.T) {
 			t.Fatalf("unscoped list missing %q:\n%s", want, stdout.String())
 		}
 	}
+	if got, want := strings.Fields(strings.Split(stdout.String(), "\n")[0]), []string{"ENTITY_ID", "RUN", "TYPE", "STATE", "FLOW", "UPDATED"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unscoped columns = %v, want %v:\n%s", got, want, stdout.String())
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -826,25 +861,31 @@ func TestEntityListUnscopedRetainsRunColumn(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("scoped code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
 	}
-	if strings.Contains(stdout.String(), "RUN") {
-		t.Fatalf("run-scoped list should not repeat the RUN column:\n%s", stdout.String())
+	if got, want := strings.Fields(strings.Split(stdout.String(), "\n")[0]), []string{"ENTITY_ID", "TYPE", "STATE", "FLOW", "UPDATED"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("run-scoped columns = %v, want %v:\n%s", got, want, stdout.String())
 	}
 }
 
 func TestEntityListFlowTruncationPreservesDistinguishingSegments(t *testing.T) {
 	sharedHash := strings.Repeat("a", 64)
-	flowA := "ingress/" + sharedHash + "/slot-1"
-	flowB := "ingress/" + sharedHash + "/slot-2"
-	renderedA := entityShortFlow(flowA)
-	renderedB := entityShortFlow(flowB)
-	if renderedA == renderedB {
-		t.Fatalf("instances differing past a shared prefix must render distinct cells:\nA=%s\nB=%s", renderedA, renderedB)
+	sharedLongPrefix := strings.Repeat("segment-", 30)
+	flowA := "ingress/" + sharedHash + "/" + sharedLongPrefix + "/slot-1"
+	flowB := "ingress/" + sharedHash + "/" + sharedLongPrefix + "/slot-2"
+	var stdout bytes.Buffer
+	writeEntityListResult(&stdout, entityListResult{Entities: []entitySummary{
+		{EntityID: "entity-a", RunID: "run-1", FlowInstance: flowA, EntityType: "vertical", CurrentState: "collecting", UpdatedAt: "2026-05-20T01:05:00Z"},
+		{EntityID: "entity-b", RunID: "run-1", FlowInstance: flowB, EntityType: "vertical", CurrentState: "collecting", UpdatedAt: "2026-05-20T01:05:00Z"},
+	}}, entityListRenderOptions{runScoped: true})
+
+	rendered := stdout.String()
+	for _, want := range []string{"ingress/", "slot-1", "slot-2", "…"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered flow cells must preserve %q:\n%s", want, rendered)
+		}
 	}
-	if !strings.Contains(renderedA, "ingress/") || !strings.Contains(renderedA, "slot-1") {
-		t.Fatalf("instance-discriminating segments must stay intact:\n%s", renderedA)
-	}
-	if !strings.Contains(renderedA, "…") || !strings.Contains(renderedB, "…") {
-		t.Fatalf("hash-bearing segment must be truncated:\nA=%s\nB=%s", renderedA, renderedB)
+	lines := strings.Split(strings.TrimSpace(rendered), "\n")
+	if len(lines) != 3 || lines[1] == lines[2] {
+		t.Fatalf("pathological instances differing after rune 200 must render as distinct rows:\n%s", rendered)
 	}
 }
 

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -1,0 +1,49 @@
+package contracts
+
+// EntityFieldBookkeepingKeys enumerates the platform-owned entity field keys
+// that runtime machinery injects into an entity's field surface as
+// bookkeeping, as opposed to workflow-declared content fields.
+//
+// This is a DISPLAY classification only: the CLI uses it to hide bookkeeping
+// below the fold in default human output (shown under --verbose and always in
+// --json). It does NOT reserve or reject these names at contract admission; a
+// workflow-declared field remains content, full stop. The fail-visible design
+// exists precisely so a forgotten platform key SHOWS UP in default output and
+// is caught by eyes rather than names becoming reserved.
+//
+// Ownership test (recorded so every future ambiguous key inherits a rule
+// rather than precedent-by-vibes): if runtime machinery writes the key into
+// the entity field surface as platform bookkeeping, it is BOOKKEEPING; if the
+// key names a workflow-declared field, it is CONTENT.
+//
+// Current platform injection sites:
+//   - activation, bundle_hash, package_key:       internal/runtime/standing_targets.go
+//   - last_data_accumulation_event:               internal/runtime/engine/executor.go
+//   - last_data_accumulation_source:              internal/runtime/engine/helpers.go
+//   - fan_out_count:                              internal/runtime/engine/executor.go
+//   - last_source_event:                          internal/runtime/bus/template_instance_lifecycle.go
+//
+// `last_word` is CONTENT: no runtime machinery writes it; flows declare it.
+//
+// `entity_id` is deliberately NOT listed: no verified field-surface writer
+// exists, and the expression contract permits entity.entity_id when entity_id
+// is declared as business data, so it is a legal declared field and content.
+var EntityFieldBookkeepingKeys = []string{
+	"activation",
+	"bundle_hash",
+	"package_key",
+	"last_data_accumulation_event",
+	"last_data_accumulation_source",
+	"fan_out_count",
+	"last_source_event",
+}
+
+// IsEntityFieldBookkeepingKey reports whether key is in EntityFieldBookkeepingKeys.
+func IsEntityFieldBookkeepingKey(key string) bool {
+	for _, candidate := range EntityFieldBookkeepingKeys {
+		if candidate == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/contracts/entity_field_bookkeeping.go
+++ b/internal/runtime/contracts/entity_field_bookkeeping.go
@@ -6,15 +6,13 @@ package contracts
 //
 // This is a DISPLAY classification only: the CLI uses it to hide bookkeeping
 // below the fold in default human output (shown under --verbose and always in
-// --json). It does NOT reserve or reject these names at contract admission; a
-// workflow-declared field remains content, full stop. The fail-visible design
-// exists precisely so a forgotten platform key SHOWS UP in default output and
-// is caught by eyes rather than names becoming reserved.
+// --json). It does not reserve or reject names at contract admission.
 //
-// Ownership test (recorded so every future ambiguous key inherits a rule
-// rather than precedent-by-vibes): if runtime machinery writes the key into
-// the entity field surface as platform bookkeeping, it is BOOKKEEPING; if the
-// key names a workflow-declared field, it is CONTENT.
+// entity.get currently combines authored fields and platform bookkeeping in
+// one map, so this key-only classifier cannot distinguish an authored collision
+// from a platform value. Such collisions remain available under --verbose and
+// --json but are hidden from the default Fields section. Issue #2242 owns the
+// API-side separation and removal of this temporary classifier.
 //
 // Current platform injection sites:
 //   - activation, bundle_hash, package_key:       internal/runtime/standing_targets.go

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -5311,7 +5311,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if entityListCode != 0 {
 		t.Fatalf("entities list readback code=%d stderr=%s stdout=%s", entityListCode, entityListStderr, entityListStdout)
 	}
-	for _, want := range []string{entityID, runID, "done"} {
+	for _, want := range []string{entityID, "done"} {
 		if !strings.Contains(entityListStdout, want) {
 			t.Fatalf("entities list readback missing %q:\n%s", want, entityListStdout)
 		}
@@ -5320,7 +5320,7 @@ func runServedEventPublishFollowUpProof(t *testing.T, endpoint string, db *sql.D
 	if entityViewCode != 0 {
 		t.Fatalf("entity view readback code=%d stderr=%s stdout=%s", entityViewCode, entityViewStderr, entityViewStdout)
 	}
-	for _, want := range []string{entityID, "state=done", "fields={}"} {
+	for _, want := range []string{entityID, "done", "Fields  none"} {
 		if !strings.Contains(entityViewStdout, want) {
 			t.Fatalf("entity view readback missing %q:\n%s", want, entityViewStdout)
 		}

--- a/internal/userfacing/human_code_projection_cli_test.go
+++ b/internal/userfacing/human_code_projection_cli_test.go
@@ -557,6 +557,10 @@ var cliHumanCodeRawOutputAllowances = map[string]cliHumanCodeRawOutputAllowance{
 		Names:  []string{"mode"},
 		Reason: "flow composition mode is an authoring-view concept, not ConversationMode",
 	},
+	"entities.go\x00writeEntityLoopSection": {
+		Names:  []string{"status"},
+		Reason: "loop activation status is loopruntime.Status rendered as data, a separate loop-lifecycle taxonomy, not a registered run/agent status family",
+	},
 	"local_preflight.go\x00WriteLocalPreflightText": {
 		Names:  []string{"mode"},
 		Reason: "preflight mode is a typed diagnostic rendering input, not a registered conversation mode",

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -25112,7 +25112,7 @@ cli_specification:
         required: false
         api_param: cursor
       output:
-        table: ENTITY_ID / RUN / FLOW / TYPE / STATE / REVISION / UPDATED / SLUG / NAME plus next_cursor when present
+        table: ENTITY_ID / optional RUN (omitted when --run-id scopes the query) / TYPE / STATE / FLOW / UPDATED plus next_cursor when present
         empty: No entities match the filter.
       exit_codes:
         success: 0

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -21949,14 +21949,18 @@ cli_specification:
               exception_rule: group_help
             entities_list:
               command: swarm entity list
-              classification: split
-              owner_issue: '#1913'
-              reason: entity list table/default text consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
+              classification: shared_output
+              fact_owner: /v1/rpc entity.list
+              json_shape: entity.list result object (entities with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; next_cursor)
+              quiet_values:
+              - entity_id, one per returned entity, in API result order
             entity_view:
               command: swarm entity view
-              classification: split
-              owner_issue: '#1913'
-              reason: entity detail shell consumes the shared display renderer; full shared output-mode route-through remains tracked by the active registry split-owner child.
+              classification: shared_output
+              fact_owner: /v1/rpc entity.get
+              json_shape: entity.get result object (entity with entity_id, run_id, flow_instance, entity_type, current_state, revision, created_at, updated_at, slug, name; fields; gates; accumulated; loops when present)
+              quiet_values:
+              - entity_id
             entity_aggregate:
               command: swarm entity aggregate
               classification: split
@@ -25108,7 +25112,7 @@ cli_specification:
         required: false
         api_param: cursor
       output:
-        table: ENTITY_ID / RUN_ID / FLOW / TYPE / STATE / REVISION / UPDATED / SLUG / NAME plus next_cursor when present
+        table: ENTITY_ID / RUN / FLOW / TYPE / STATE / REVISION / UPDATED / SLUG / NAME plus next_cursor when present
         empty: No entities match the filter.
       exit_codes:
         success: 0

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -25114,7 +25114,7 @@ cli_specification:
       output:
         default_text:
           table: ENTITY_ID / optional RUN (omitted when --run-id scopes the query) / TYPE / STATE / FLOW / UPDATED
-          values: Empty TYPE or STATE values render as `-`; FLOW renders the sanitized but otherwise complete flow-instance identifier; UPDATED is relative to the current time.
+          values: TYPE and STATE are required validated facts; blank values are malformed responses. FLOW renders the sanitized but otherwise complete flow-instance identifier; UPDATED is relative to the current time.
           empty: No entities match the current filters.
           pagination: A non-empty next_cursor renders below the table as `next_cursor=<cursor>`.
         verbose: Uses the default table and appends each row's absolute RFC3339 UPDATED value to its relative timestamp.
@@ -25150,7 +25150,7 @@ cli_specification:
       output:
         default_text:
           heading: Entity <entity-id>
-          identity_rows: Labeled run, flow, type, state, revision, created, updated, slug, and name rows; omitted slug/name and empty type/state render as `-`; timestamps are relative.
+          identity_rows: Labeled run, flow, type, state, revision, created, updated, slug, and name rows; omitted slug/name render as `-`; type/state are required validated facts; timestamps are relative.
           sections: Labeled Fields and Gates rows plus an Accumulated presence count; empty sections render explicitly as `none`; every declared false gate remains visible.
           field_projection: Platform bookkeeping fields are omitted from the default Fields section pending the API-owned separation tracked by #2242.
         verbose: Uses the default projection with relative plus absolute RFC3339 timestamps, full accumulated rows, loop activation rows when present, and a separate Bookkeeping section.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -25112,8 +25112,14 @@ cli_specification:
         required: false
         api_param: cursor
       output:
-        table: ENTITY_ID / optional RUN (omitted when --run-id scopes the query) / TYPE / STATE / FLOW / UPDATED plus next_cursor when present
-        empty: No entities match the filter.
+        default_text:
+          table: ENTITY_ID / optional RUN (omitted when --run-id scopes the query) / TYPE / STATE / FLOW / UPDATED
+          values: Empty TYPE or STATE values render as `-`; FLOW renders the sanitized but otherwise complete flow-instance identifier; UPDATED is relative to the current time.
+          empty: No entities match the current filters.
+          pagination: A non-empty next_cursor renders below the table as `next_cursor=<cursor>`.
+        verbose: Uses the default table and appends each row's absolute RFC3339 UPDATED value to its relative timestamp.
+        json: The complete validated entity.list result object, including every returned EntitySummary field and next_cursor when present.
+        quiet: One canonical entity_id per returned entity, in API result order.
       exit_codes:
         success: 0
         cli_validation: 2
@@ -25142,10 +25148,14 @@ cli_specification:
         api_param: run_id
         validation: CLI validates only the OpaqueId envelope and does not assume UUID shape.
       output:
-        heading: Entity <entity-id>
-        summary_line: run_id / flow / type / state / revision / created_at / updated_at
-        optional_line: slug / name with '-' for omitted optional fields
-        structured_lines: compact JSON for server-owned fields, gates, and accumulated maps
+        default_text:
+          heading: Entity <entity-id>
+          identity_rows: Labeled run, flow, type, state, revision, created, updated, slug, and name rows; omitted slug/name and empty type/state render as `-`; timestamps are relative.
+          sections: Labeled Fields and Gates rows plus an Accumulated presence count; empty sections render explicitly as `none`; every declared false gate remains visible.
+          field_projection: Platform bookkeeping fields are omitted from the default Fields section pending the API-owned separation tracked by #2242.
+        verbose: Uses the default projection with relative plus absolute RFC3339 timestamps, full accumulated rows, loop activation rows when present, and a separate Bookkeeping section.
+        json: The complete validated entity.get result object, including entity identity, fields, gates, accumulated data, and loops when present.
+        quiet: The canonical entity_id only.
       exit_codes:
         success: 0
         cli_validation: 2


### PR DESCRIPTION
Closes #2013.

## Governing contract

- `platform-spec.yaml#cli_specification.command_catalog.entities_list`
- `platform-spec.yaml#cli_specification.command_catalog.entity_view`
- Binding issue rulings: https://github.com/division-sh/swarm/issues/2013#issuecomment-5227359351 and https://github.com/division-sh/swarm/issues/2013#issuecomment-5227630476
- Binding recut/review boundary: https://github.com/division-sh/swarm/pull/2205#issuecomment-5229711780
- Takeover pre-audit: https://github.com/division-sh/swarm/issues/2013#issuecomment-5285921974
- Post-implementation proof audit: https://github.com/division-sh/swarm/pull/2205#issuecomment-5286198488

## Change

- Render `swarm entity view` as labeled identity/state rows plus explicit Fields, Gates, and Accumulated sections.
- Render `swarm entity list` as `ENTITY_ID`, conditional `RUN`, `TYPE`, `STATE`, `FLOW`, and `UPDATED`.
- Route list/view through shared `--json`, `--quiet`, `--no-color`, and entity-scoped `--verbose` output ownership.
- Preserve complete structured output while human output uses relative timestamps, one-line sanitation, explicit empty states, and verbose bookkeeping/loop details.
- Preserve complete canonical run and flow-instance identifiers plus field, gate, accumulated, bookkeeping, and loop semantic keys. The shared output owner sanitizes terminal controls, but no local identity or key shortening remains.
- Render absent slug/name as `-` and pin scoped/unscoped column order and all output modes in tests and the authoritative spec.

## Semantic migration

- **Canonical human projection owners:** `writeEntityListResult` and `writeEntityFullResult`, consuming API-owned `entity.list` / `entity.get` facts.
- **Old path now invalid:** inline JSON blobs and command-local lossy flow shortening in default human output.
- **Production consumers checked:** list/view default, verbose, JSON, quiet, validation, malformed response, served SQLite readback, and shared output/identifier conformance.
- **Migration completeness:** complete for the #2013 entity list/view renderer child. Identifier display policy remains #1815, API-side authored/bookkeeping separation remains #2242, and unrelated read surfaces remain #1712. No compatibility or dual output path was added.

## Verification

- `go test ./internal/cliapp ./internal/runtime/contracts`
- entity projection, exact-identity, semantic-key collision, and malformed-result tests repeated 20 times
- `go test ./internal/cliapp -run TestEntityCommandsUseSQLiteEntityReadStoreThroughV1API`
- `go test ./internal/apiv1 -run TestOperatorEntityHandlersServeContractEntityTypesFromSQLite`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go run ./cmd/swarm-openapi-gen --check`
- `go build ./...`
- A local concurrent Postgres-backed whole-suite run passed the changed packages and most broad packages, but unrelated catalog/runtime-persistence packages hit the repository 10-minute timeout while two other whole-suite processes were active; CI is the clean isolated whole-suite proof for this head.
- GitHub Actions isolated matrix: all required checks green at head `12e0da0b8`, including broad-01..04, catalog, runtime, all store shards, Postgres, SQLite, semantic, static, timing, and required-test summary.