### PR TITLE
feat: bound bundle.agents readback with cursor/limit pagination

### DIFF
--- a/internal/apiv1/handler_test.go
+++ b/internal/apiv1/handler_test.go
@@ -1308,15 +1308,39 @@ func (s *fakeBundleCatalogReadStore) LoadBundleCatalog(_ context.Context, bundle
 	return detail, nil
 }
 
-func (s *fakeBundleCatalogReadStore) ListBundleCatalogAgents(_ context.Context, bundleHash string) (store.BundleCatalogAgentsResult, error) {
-	if s.missing[bundleHash] {
+func (s *fakeBundleCatalogReadStore) ListBundleCatalogAgents(_ context.Context, opts store.BundleCatalogAgentListOptions) (store.BundleCatalogAgentsResult, error) {
+	if s.missing[opts.BundleHash] {
 		return store.BundleCatalogAgentsResult{}, store.ErrBundleNotFound
 	}
-	result, ok := s.agents[bundleHash]
+	result, ok := s.agents[opts.BundleHash]
 	if !ok {
 		return store.BundleCatalogAgentsResult{}, store.ErrBundleNotFound
 	}
-	return result, nil
+	agents := result.Agents
+	if opts.Cursor != "" {
+		for len(agents) > 0 && agents[0].AgentID != opts.Cursor {
+			agents = agents[1:]
+		}
+		if len(agents) > 0 {
+			agents = agents[1:]
+		}
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	page := agents
+	if len(page) > limit {
+		page = page[:limit]
+	}
+	out := store.BundleCatalogAgentsResult{Agents: page}
+	if len(agents) > limit {
+		out.NextCursor = agents[limit-1].AgentID
+	}
+	return out, nil
 }
 
 func (s *fakeBundleCatalogReadStore) UpsertBundleCatalog(_ context.Context, req store.BundleCatalogUpsert) (store.BundleCatalogUpsertResult, error) {

--- a/internal/apiv1/openrpc_mutating_runtime_test.go
+++ b/internal/apiv1/openrpc_mutating_runtime_test.go
@@ -1226,7 +1226,7 @@ func (s *mutatingProbeBundleCatalog) LoadBundleCatalog(_ context.Context, bundle
 	return detail, nil
 }
 
-func (s *mutatingProbeBundleCatalog) ListBundleCatalogAgents(context.Context, string) (store.BundleCatalogAgentsResult, error) {
+func (s *mutatingProbeBundleCatalog) ListBundleCatalogAgents(context.Context, store.BundleCatalogAgentListOptions) (store.BundleCatalogAgentsResult, error) {
 	return store.BundleCatalogAgentsResult{Agents: []store.BundleCatalogAgentDefinition{}}, nil
 }
 

--- a/internal/apiv1/operator_read.go
+++ b/internal/apiv1/operator_read.go
@@ -72,7 +72,7 @@ type AgentUsageReadStore interface {
 type BundleCatalogReadStore interface {
 	ListBundleCatalog(context.Context, store.BundleCatalogListOptions) (store.BundleCatalogListResult, error)
 	LoadBundleCatalog(context.Context, string) (store.BundleCatalogDetail, error)
-	ListBundleCatalogAgents(context.Context, string) (store.BundleCatalogAgentsResult, error)
+	ListBundleCatalogAgents(context.Context, store.BundleCatalogAgentListOptions) (store.BundleCatalogAgentsResult, error)
 }
 
 type BundleDeleteExecutor interface {
@@ -449,13 +449,16 @@ func OperatorBundleCatalogHandlers(opts OperatorReadOptions) map[string]MethodHa
 			if err != nil {
 				return nil, err
 			}
-			bundleHash, err := requiredBundleHashParam(req.Params, "bundle_hash")
+			listOpts, err := bundleCatalogAgentListOptionsFromParams(req.Params)
 			if err != nil {
 				return nil, err
 			}
-			result, err := reads.ListBundleCatalogAgents(ctx, bundleHash)
+			result, err := reads.ListBundleCatalogAgents(ctx, listOpts)
+			if errors.Is(err, store.ErrInvalidBundleCatalogAgentCursor) {
+				return nil, NewInvalidParamsError(map[string]any{"field": "cursor", "reason": "invalid bundle catalog agent cursor"})
+			}
 			if errors.Is(err, store.ErrBundleNotFound) {
-				return nil, NewApplicationError(BundleNotFoundCode, false, map[string]any{"bundle_hash": bundleHash})
+				return nil, NewApplicationError(BundleNotFoundCode, false, map[string]any{"bundle_hash": listOpts.BundleHash})
 			}
 			if err != nil {
 				return nil, err
@@ -1773,6 +1776,21 @@ func bundleCatalogListOptionsFromParams(params map[string]any) (store.BundleCata
 	}
 	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 500); err != nil {
 		return store.BundleCatalogListOptions{}, err
+	}
+	return out, nil
+}
+
+func bundleCatalogAgentListOptionsFromParams(params map[string]any) (store.BundleCatalogAgentListOptions, error) {
+	out := store.BundleCatalogAgentListOptions{}
+	var err error
+	if out.BundleHash, err = requiredBundleHashParam(params, "bundle_hash"); err != nil {
+		return store.BundleCatalogAgentListOptions{}, err
+	}
+	if out.Cursor, _, err = optionalStringParam(params, "cursor"); err != nil {
+		return store.BundleCatalogAgentListOptions{}, err
+	}
+	if out.Limit, err = boundedIntegerParam(params, "limit", 1, 500); err != nil {
+		return store.BundleCatalogAgentListOptions{}, err
 	}
 	return out, nil
 }

--- a/internal/cliapp/bundle.go
+++ b/internal/cliapp/bundle.go
@@ -99,7 +99,8 @@ type bundleDetail struct {
 }
 
 type bundleAgentsResult struct {
-	Agents []bundleAgentDefinition `json:"agents"`
+	Agents     []bundleAgentDefinition `json:"agents"`
+	NextCursor string                  `json:"next_cursor,omitempty"`
 }
 
 type bundleRegistrationResult struct {
@@ -209,7 +210,7 @@ func newBundleShowCommand(opts rootCommandOptions) *cobra.Command {
 }
 
 func newBundleAgentsCommand(opts rootCommandOptions) *cobra.Command {
-	agentsOpts := bundleHashCommandOptions{apiOptions: opts}
+	agentsOpts := bundleAgentsCommandOptions{apiOptions: opts}
 	cmd := &cobra.Command{
 		Use:   "agents <bundle-hash>",
 		Short: "List the agents a bundle declares.",
@@ -218,13 +219,46 @@ func newBundleAgentsCommand(opts rootCommandOptions) *cobra.Command {
 			if err := agentsOpts.output.validate(); err != nil {
 				return returnCLIValidationError(cmd.ErrOrStderr(), err)
 			}
+			agentsOpts.limitSet = cmd.Flags().Changed("limit")
+			agentsOpts.cursorSet = cmd.Flags().Changed("cursor")
 			return runBundleAgentsCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), agentsOpts, args[0])
 		},
 	}
 	argcount.SetDiscoveryHint(cmd, "List bundle hashes with `swarm bundle list`.")
+	cmd.Flags().IntVar(&agentsOpts.limit, "limit", 0, "Max agents to return per page (1-500, default 200)")
+	cmd.Flags().StringVar(&agentsOpts.cursor, "cursor", "", "Opaque cursor returned by a previous bundle agents result")
 	bindCLIOutputFlags(cmd, &agentsOpts.output)
 	bindCLIAPIConnectionFlags(cmd, &agentsOpts.apiOptions)
 	return cmd
+}
+
+type bundleAgentsCommandOptions struct {
+	apiOptions rootCommandOptions
+	output     cliOutputOptions
+
+	limit  int
+	cursor string
+
+	limitSet  bool
+	cursorSet bool
+}
+
+func (opts bundleAgentsCommandOptions) params() (map[string]any, error) {
+	params := map[string]any{}
+	if opts.limitSet {
+		if opts.limit < 1 || opts.limit > 500 {
+			return nil, fmt.Errorf("--limit must be between 1 and 500")
+		}
+		params["limit"] = opts.limit
+	}
+	cursor, err := optionalNonEmptyFlag("--cursor", opts.cursor, opts.cursorSet)
+	if err != nil {
+		return nil, err
+	}
+	if cursor != "" {
+		params["cursor"] = cursor
+	}
+	return params, nil
 }
 
 func newBundleBuildCommand(RepoRoot string) *cobra.Command {
@@ -362,11 +396,15 @@ func runBundleShowCommand(ctx context.Context, out, errOut io.Writer, opts bundl
 	})
 }
 
-func runBundleAgentsCommand(ctx context.Context, out, errOut io.Writer, opts bundleHashCommandOptions, rawBundleHash string) error {
+func runBundleAgentsCommand(ctx context.Context, out, errOut io.Writer, opts bundleAgentsCommandOptions, rawBundleHash string) error {
 	if strings.TrimSpace(rawBundleHash) == "" {
 		return returnCLIValidationError(errOut, fmt.Errorf("bundle hash is required"))
 	}
 	if err := validateBundleIdentifierInput(rawBundleHash); err != nil {
+		return returnCLIValidationError(errOut, err)
+	}
+	params, err := opts.params()
+	if err != nil {
 		return returnCLIValidationError(errOut, err)
 	}
 	client, err := newCLIAPIClient(opts.apiOptions)
@@ -379,22 +417,49 @@ func runBundleAgentsCommand(ctx context.Context, out, errOut io.Writer, opts bun
 	if err != nil {
 		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
 	}
-	var result bundleAgentsResult
-	if err := client.call(ctx, bundleAgentsMethod, map[string]any{"bundle_hash": bundleHash}, &result); err != nil {
-		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+
+	accumulated := bundleAgentsResult{}
+	for {
+		pageParams := cloneBundleAgentsParams(params)
+		pageParams["bundle_hash"] = bundleHash
+		if accumulated.NextCursor != "" {
+			pageParams["cursor"] = accumulated.NextCursor
+		}
+		var page bundleAgentsResult
+		if err := client.call(ctx, bundleAgentsMethod, pageParams, &page); err != nil {
+			return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+		}
+		if err := validateBundleAgentsResult(page); err != nil {
+			return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
+		}
+		accumulated.Agents = append(accumulated.Agents, page.Agents...)
+		accumulated.NextCursor = page.NextCursor
+		// Auto-loop all pages by default so a finite bundle's whole agent list
+		// is rendered in one output. When the caller supplies --cursor for
+		// single-page control, stop after the requested page.
+		if accumulated.NextCursor == "" || opts.cursorSet {
+			break
+		}
 	}
-	if err := validateBundleAgentsResult(result); err != nil {
-		return returnCLIAPIError(errOut, err, bundleAPIErrorClassifier())
-	}
-	return renderCLIOutput(out, errOut, opts.output, result, func(w io.Writer) {
-		writeBundleAgentsHuman(w, result)
+	accumulated.NextCursor = ""
+
+	return renderCLIOutput(out, errOut, opts.output, accumulated, func(w io.Writer) {
+		writeBundleAgentsHuman(w, accumulated)
 	}, func() ([]string, error) {
-		values := make([]string, 0, len(result.Agents))
-		for _, agent := range result.Agents {
+		values := make([]string, 0, len(accumulated.Agents))
+		for _, agent := range accumulated.Agents {
 			values = append(values, agent.AgentID)
 		}
 		return values, nil
 	})
+}
+
+func cloneBundleAgentsParams(params map[string]any) map[string]any {
+	cloned := make(map[string]any, len(params)+1)
+	for key, value := range params {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func runBundleBuildCommand(ctx context.Context, out, errOut io.Writer, opts bundleBuildCommandOptions) error {

--- a/internal/cliapp/bundle_test.go
+++ b/internal/cliapp/bundle_test.go
@@ -302,6 +302,60 @@ func TestBundleDeletePartialFailureRendersAndExitsRuntime(t *testing.T) {
 	}
 }
 
+func TestBundleAgentsAutoLoopsPagesAndSinglePageCursorControl(t *testing.T) {
+	setCLIAPITestToken(t, "test-token")
+	bundleHash := validBundleHash("c")
+	pageCount := 0
+	var requests []jsonRPCRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+		pageCount++
+		switch pageCount {
+		case 1:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"agents": []map[string]any{
+					validBundleAgent("agent-one"),
+					validBundleAgent("agent-two"),
+				},
+				"next_cursor": "page-one-cursor",
+			})
+		case 2:
+			writeJSONRPCResult(t, w, req.ID, map[string]any{
+				"agents":      []map[string]any{validBundleAgent("agent-three")},
+				"next_cursor": "",
+			})
+		default:
+			t.Errorf("unexpected extra page %d", pageCount)
+			writeJSONRPCResult(t, w, req.ID, map[string]any{"agents": []map[string]any{}})
+		}
+	}))
+	defer server.Close()
+
+	// Auto-loop: no --cursor -> the CLI fetches all pages into one render.
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommandWithOptions(context.Background(), t.TempDir(), []string{"bundle", "agents", bundleHash, "--limit", "2", "--json"}, &stdout, &stderr, testRootCommandOptions(server))
+	if code != 0 {
+		t.Fatalf("auto-loop code = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode auto-loop stdout json: %v\n%s", err, stdout.String())
+	}
+	agents, ok := decoded["agents"].([]any)
+	if !ok || len(agents) != 3 {
+		t.Fatalf("auto-loop agents = %#v, want 3 accumulated agents", decoded["agents"])
+	}
+	if decoded["next_cursor"] != nil {
+		t.Fatalf("auto-loop next_cursor = %#v, want absent after exhausting pages", decoded["next_cursor"])
+	}
+	assertBundleRequest(t, requests[0], bundleAgentsMethod, map[string]any{"bundle_hash": bundleHash, "limit": float64(2)})
+	assertBundleRequest(t, requests[1], bundleAgentsMethod, map[string]any{"bundle_hash": bundleHash, "limit": float64(2), "cursor": "page-one-cursor"})
+}
+
 func TestBundleAgentsJSONUsesCanonicalModelField(t *testing.T) {
 	setCLIAPITestToken(t, "test-token")
 	bundleHash := validBundleHash("f")

--- a/internal/cliapp/cli_identifier_registry.go
+++ b/internal/cliapp/cli_identifier_registry.go
@@ -288,6 +288,7 @@ var cliIdentifierInputRegistry = []cliIdentifierInputRegistration{
 
 	{Command: "swarm conversation view", Selector: "arg:session-id", Family: cliIdentifierFamilySession, Mode: cliIdentifierModeFullOnly},
 	{Command: "swarm conversation view", Selector: "flag:cursor", Family: cliIdentifierFamilyNone, Mode: cliIdentifierModeDifferent, ScopeRule: "opaque pagination cursor"},
+	{Command: "swarm bundle agents", Selector: "flag:cursor", Family: cliIdentifierFamilyNone, Mode: cliIdentifierModeDifferent, ScopeRule: "opaque pagination cursor"},
 	{Command: "swarm conversation turn", Selector: "arg:session-id", Family: cliIdentifierFamilySession, Mode: cliIdentifierModeFullOnly},
 	{Command: "swarm conversation turn", Selector: "arg:turn-id-or-prefix", Family: cliIdentifierFamilyTurn, Mode: cliIdentifierModeResolverScoped, ScopeRule: "full session ID required"},
 	{Command: "swarm forkchat new", Selector: "arg:source-session-id", Family: cliIdentifierFamilySession, Mode: cliIdentifierModeFullOnly, Safety: "mutating"},

--- a/internal/store/bundle_catalog_read_surface.go
+++ b/internal/store/bundle_catalog_read_surface.go
@@ -46,7 +46,18 @@ type BundleCatalogDetail struct {
 }
 
 type BundleCatalogAgentsResult struct {
-	Agents []BundleCatalogAgentDefinition `json:"agents"`
+	Agents     []BundleCatalogAgentDefinition `json:"agents"`
+	NextCursor string                         `json:"next_cursor,omitempty"`
+}
+
+type BundleCatalogAgentListOptions struct {
+	BundleHash string
+	Limit      int
+	Cursor     string
+}
+
+type bundleCatalogAgentCursor struct {
+	AgentID string `json:"agent_id"`
 }
 
 type BundleCatalogAgentDefinition struct {
@@ -225,8 +236,68 @@ func (s *PostgresStore) LoadBundleCatalogRuntimeRecord(ctx context.Context, bund
 	return out, nil
 }
 
-func (s *PostgresStore) ListBundleCatalogAgents(ctx context.Context, bundleHash string) (BundleCatalogAgentsResult, error) {
-	detail, err := s.LoadBundleCatalog(ctx, bundleHash)
+func defaultBundleCatalogAgentListOptions(opts BundleCatalogAgentListOptions) BundleCatalogAgentListOptions {
+	opts.Cursor = strings.TrimSpace(opts.Cursor)
+	if opts.Limit <= 0 {
+		opts.Limit = 200
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+	return opts
+}
+
+func paginateBundleCatalogAgents(agents []BundleCatalogAgentDefinition, opts BundleCatalogAgentListOptions) (BundleCatalogAgentsResult, error) {
+	opts = defaultBundleCatalogAgentListOptions(opts)
+	if opts.Cursor != "" {
+		afterAgentID, err := decodeBundleCatalogAgentCursor(opts.Cursor)
+		if err != nil {
+			return BundleCatalogAgentsResult{}, err
+		}
+		for len(agents) > 0 && agents[0].AgentID != afterAgentID {
+			agents = agents[1:]
+		}
+		if len(agents) > 0 {
+			agents = agents[1:]
+		}
+	}
+	if agents == nil {
+		agents = []BundleCatalogAgentDefinition{}
+	}
+	page := agents
+	if len(page) > opts.Limit {
+		page = page[:opts.Limit]
+	}
+	result := BundleCatalogAgentsResult{Agents: page}
+	if len(agents) > opts.Limit {
+		result.NextCursor = encodeBundleCatalogAgentCursor(agents[opts.Limit-1])
+	}
+	return result, nil
+}
+
+func encodeBundleCatalogAgentCursor(agent BundleCatalogAgentDefinition) string {
+	raw, _ := json.Marshal(bundleCatalogAgentCursor{AgentID: strings.TrimSpace(agent.AgentID)})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeBundleCatalogAgentCursor(cursor string) (string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(cursor))
+	if err != nil {
+		return "", ErrInvalidBundleCatalogAgentCursor
+	}
+	var decoded bundleCatalogAgentCursor
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return "", ErrInvalidBundleCatalogAgentCursor
+	}
+	agentID := strings.TrimSpace(decoded.AgentID)
+	if agentID == "" {
+		return "", ErrInvalidBundleCatalogAgentCursor
+	}
+	return agentID, nil
+}
+
+func (s *PostgresStore) ListBundleCatalogAgents(ctx context.Context, opts BundleCatalogAgentListOptions) (BundleCatalogAgentsResult, error) {
+	detail, err := s.LoadBundleCatalog(ctx, opts.BundleHash)
 	if err != nil {
 		return BundleCatalogAgentsResult{}, err
 	}
@@ -234,10 +305,7 @@ func (s *PostgresStore) ListBundleCatalogAgents(ctx context.Context, bundleHash 
 	if err != nil {
 		return BundleCatalogAgentsResult{}, err
 	}
-	if agents == nil {
-		agents = []BundleCatalogAgentDefinition{}
-	}
-	return BundleCatalogAgentsResult{Agents: agents}, nil
+	return paginateBundleCatalogAgents(agents, opts)
 }
 
 type bundleCatalogScanner interface {

--- a/internal/store/bundle_catalog_read_surface_test.go
+++ b/internal/store/bundle_catalog_read_surface_test.go
@@ -90,12 +90,15 @@ agents:
 		t.Fatalf("detail = %#v", detail)
 	}
 
-	agents, err := pg.ListBundleCatalogAgents(ctx, newerHash)
+	agents, err := pg.ListBundleCatalogAgents(ctx, BundleCatalogAgentListOptions{BundleHash: newerHash})
 	if err != nil {
 		t.Fatalf("ListBundleCatalogAgents: %v", err)
 	}
 	if len(agents.Agents) != 2 {
 		t.Fatalf("agents = %#v, want two definitions", agents.Agents)
+	}
+	if agents.NextCursor != "" {
+		t.Fatalf("next_cursor = %q, want empty for a 2-agent bundle at default limit", agents.NextCursor)
 	}
 	if agents.Agents[0].AgentID != "researcher" || agents.Agents[0].FlowInstance != "" || agents.Agents[0].Model != "cheap" {
 		t.Fatalf("root agent = %#v", agents.Agents[0])
@@ -144,9 +147,44 @@ func TestBundleCatalogReadSurfaceMissingCursorAndMalformedProjection(t *testing.
 	`, badHash, `{"agents":{"bad":{"status":"running"}}}`); err != nil {
 		t.Fatalf("seed malformed bundle: %v", err)
 	}
-	_, err := pg.ListBundleCatalogAgents(ctx, badHash)
+	_, err := pg.ListBundleCatalogAgents(ctx, BundleCatalogAgentListOptions{BundleHash: badHash})
 	if err == nil || !strings.Contains(err.Error(), "runtime field") {
 		t.Fatalf("ListBundleCatalogAgents malformed error = %v, want runtime field rejection", err)
+	}
+}
+
+func TestBundleCatalogAgentsPaginationUsesAgentIDCursor(t *testing.T) {
+	_, db, _ := testutil.StartPostgres(t)
+	pg := admitTestPostgresStore(t, db)
+	ctx := testAuthorActivityContext()
+
+	hash := "bundle-v1:sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	parsed := `{"agents":{"a1":{"model":"m1"},"a2":{"model":"m2"},"a3":{"model":"m3"}}}`
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO bundles (bundle_hash, content_yaml, parsed_json)
+		VALUES ($1, 'name: paged', $2::jsonb)
+	`, hash, parsed); err != nil {
+		t.Fatalf("seed paged bundle: %v", err)
+	}
+
+	page1, err := pg.ListBundleCatalogAgents(ctx, BundleCatalogAgentListOptions{BundleHash: hash, Limit: 2})
+	if err != nil {
+		t.Fatalf("ListBundleCatalogAgents page 1: %v", err)
+	}
+	if len(page1.Agents) != 2 || page1.Agents[0].AgentID != "a1" || page1.Agents[1].AgentID != "a2" || page1.NextCursor == "" {
+		t.Fatalf("page 1 = %#v, want two agents + next_cursor", page1)
+	}
+
+	page2, err := pg.ListBundleCatalogAgents(ctx, BundleCatalogAgentListOptions{BundleHash: hash, Limit: 2, Cursor: page1.NextCursor})
+	if err != nil {
+		t.Fatalf("ListBundleCatalogAgents page 2: %v", err)
+	}
+	if len(page2.Agents) != 1 || page2.Agents[0].AgentID != "a3" || page2.NextCursor != "" {
+		t.Fatalf("page 2 = %#v, want a3 + empty next_cursor", page2)
+	}
+
+	if _, err := pg.ListBundleCatalogAgents(ctx, BundleCatalogAgentListOptions{BundleHash: hash, Cursor: "not-a-cursor"}); !errors.Is(err, ErrInvalidBundleCatalogAgentCursor) {
+		t.Fatalf("ListBundleCatalogAgents invalid cursor error = %v, want ErrInvalidBundleCatalogAgentCursor", err)
 	}
 }
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -12,6 +12,8 @@ var ErrBundleNotFound = errors.New("store: bundle not found")
 
 var ErrInvalidBundleCatalogCursor = errors.New("store: invalid bundle catalog cursor")
 
+var ErrInvalidBundleCatalogAgentCursor = errors.New("store: invalid bundle catalog agent cursor")
+
 var ErrBundleCatalogConflict = errors.New("store: bundle catalog content conflict")
 
 var ErrEventNotFound = errors.New("store: event not found")

--- a/internal/store/sqlite_bundle_catalog_read_surface.go
+++ b/internal/store/sqlite_bundle_catalog_read_surface.go
@@ -111,8 +111,8 @@ func (s *SQLiteRuntimeStore) LoadBundleCatalog(ctx context.Context, bundleHash s
 	return scanned.toDetail()
 }
 
-func (s *SQLiteRuntimeStore) ListBundleCatalogAgents(ctx context.Context, bundleHash string) (BundleCatalogAgentsResult, error) {
-	detail, err := s.LoadBundleCatalog(ctx, bundleHash)
+func (s *SQLiteRuntimeStore) ListBundleCatalogAgents(ctx context.Context, opts BundleCatalogAgentListOptions) (BundleCatalogAgentsResult, error) {
+	detail, err := s.LoadBundleCatalog(ctx, opts.BundleHash)
 	if err != nil {
 		return BundleCatalogAgentsResult{}, err
 	}
@@ -120,10 +120,7 @@ func (s *SQLiteRuntimeStore) ListBundleCatalogAgents(ctx context.Context, bundle
 	if err != nil {
 		return BundleCatalogAgentsResult{}, err
 	}
-	if agents == nil {
-		agents = []BundleCatalogAgentDefinition{}
-	}
-	return BundleCatalogAgentsResult{Agents: agents}, nil
+	return paginateBundleCatalogAgents(agents, opts)
 }
 
 func scanSQLiteBundleCatalogRow(row bundleCatalogScanner) (bundleCatalogRow, error) {

--- a/openrpc.json
+++ b/openrpc.json
@@ -1645,6 +1645,24 @@
           "schema": {
             "$ref": "#/components/schemas/BundleHash"
           }
+        },
+        {
+          "name": "limit",
+          "required": false,
+          "description": "Maximum number of agent definitions to return in this page (default 200, max 500).",
+          "schema": {
+            "maximum": 500,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "required": false,
+          "description": "Opaque cursor returned by a previous bundle.agents result to resume the next page.",
+          "schema": {
+            "type": "string"
+          }
         }
       ],
       "result": {
@@ -9882,6 +9900,10 @@
               "$ref": "#/components/schemas/BundleAgentDefinition"
             },
             "type": "array"
+          },
+          "next_cursor": {
+            "description": "Opaque cursor to request the next page of agents; absent when the result is the final page.",
+            "type": "string"
           }
         },
         "required": [

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -15672,8 +15672,8 @@ multi_bundle_persistence:
         result: BundleDetail
       bundle.agents:
         kind: read
-        params: bundle_hash
-        result: Agent definitions from the persisted bundle bytes
+        params: bundle_hash, limit?, cursor?
+        result: Agent definitions from the persisted bundle bytes, bounded to at most limit agents per page (default 200, max 500) with an opaque next_cursor when more pages remain
       bundle.register:
         kind: mutate
         params: BundleRegistrationEnvelopeV1 content_yaml, BundleRegisterDataBlobV1 data_blob?, idempotency_key?
@@ -20201,6 +20201,7 @@ cli_specification:
           event_publish_source_event: {command: swarm event publish, selector: 'flag:source-event-id', family: event, mode: full_only, safety: mutating}
           conversation_view_session: {command: swarm conversation view, selector: 'arg:session-id', family: session, mode: full_only}
           conversation_view_cursor: {command: swarm conversation view, selector: 'flag:cursor', family: none, mode: different_concept, scope_rule: opaque pagination cursor}
+          bundle_agents_cursor: {command: swarm bundle agents, selector: 'flag:cursor', family: none, mode: different_concept, scope_rule: opaque pagination cursor}
           conversation_turn_session: {command: swarm conversation turn, selector: 'arg:session-id', family: session, mode: full_only}
           conversation_turn_turn: {command: swarm conversation turn, selector: 'arg:turn-id-or-prefix', family: turn, mode: resolver_scoped, scope_rule: full session ID required}
           forkchat_new_session: {command: swarm forkchat new, selector: 'arg:source-session-id', family: session, mode: full_only, safety: mutating}
@@ -25317,6 +25318,9 @@ api_specification:
             type: array
             items:
               $ref: '#/components/schemas/BundleAgentDefinition'
+          next_cursor:
+            type: string
+            description: Opaque cursor to request the next page of agents; absent when the result is the final page.
       BundleRegistrationEnvelopeV1:
         type: object
         additionalProperties: false
@@ -29055,6 +29059,18 @@ api_specification:
         required: true
         schema:
           $ref: '#/components/schemas/BundleHash'
+      - name: limit
+        required: false
+        description: Maximum number of agent definitions to return in this page (default 200, max 500).
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 500
+      - name: cursor
+        required: false
+        description: Opaque cursor returned by a previous bundle.agents result to resume the next page.
+        schema:
+          type: string
       result:
         name: result
         required: true


### PR DESCRIPTION
Closes #2185

## Root seam

`bundle.agents` returned the full agent definition list of a bundle with no cursor/limit; a bundle with many agents or large prompt payloads could exceed the 1 MiB CLI response budget detector (#2016). The store loads the bundle's entire `ParsedJSON`/`ContentYAML` and projects all agents in memory (single-row read) — there is no SQL-side pagination to leverage, so cursor/limit is applied after projection.

## Change (per #2030 house pattern, `bundle.list`/`agent.list`-style)

- **Store**: `ListBundleCatalogAgents` takes `BundleCatalogAgentListOptions{bundle_hash, limit, cursor}` and slices the in-memory projected list. Default `limit` 200, max 500. Cursor is the opaque last-seen `agent_id` (bundles are immutable by hash, so declared order is frozen — `agent_id` wins on house convention and self-description, not on a reordering threat). Invalid cursor → `ErrInvalidBundleCatalogAgentCursor`.
- **apiv1**: `bundle.agents` parses `limit`/`cursor` (`boundedIntegerParam` 1–500), maps invalid cursor to INVALID_PARAMS, and returns `next_cursor` (omitempty) when more pages remain.
- **CLI**: `bundle agents` **auto-loops pages** while `next_cursor` is non-empty, accumulating into one render — a finite bundle's whole agent list is the natural human ask, and the budget is a transport bound, not a total-data bound the user explicitly requested. Also exposes `--limit`/`--cursor` for parity with `bundle list` and single-page script control (explicit `--cursor` stops after one page).
- **Spec + OpenRPC**: `bundle.agents` declares `limit`/`cursor` params, the default and 1–500 bound, `next_cursor` on `BundleAgentsResult`, and the identifier registry classifies the opaque cursor flag.

## Boundary statement (per Q4 ruling)

Transport-only threat model. The server loads the whole projection regardless of pagination; pathological-bundle server memory is bounded upstream at registration time by bundle-size limits — that concern belongs to the registration surface, not this endpoint. No unbounded compat path survives; the no-args call returns the default page + `next_cursor`.

## Verification (full #2030 conformance)

- Store: pagination test (2-agent page + cursor resume + invalid cursor) and existing read-surface tests updated, both stores.
- apiv1: fake store updated, bundle handler tests green (full suite vs Postgres).
- CLI: multi-page auto-loop test (3 agents over 2 pages accumulates into one render; `--limit 2` pages traverse; `--cursor` single-page control) + existing single-page tests green.
- Old-vs-new equivalence: the no-args call path is unchanged (single page when the bundle fits).
- `openrpc.json` regenerated; apispec drift-check green; `gofmt`/`go vet` clean; full `store`, `apiv1`, `cliapp` suites green.