### PR TITLE
Fix platform entity ownership classification

### DIFF
--- a/internal/apiv1/operator_event_publish_test.go
+++ b/internal/apiv1/operator_event_publish_test.go
@@ -2207,7 +2207,7 @@ func eventPublishTargetRouteTestBundle() *runtimecontracts.WorkflowContractBundl
 		SubscribesTo:  []string{targetEvent},
 		EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
 			targetEvent: {
-				Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+				Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 			},
 		},
 	}

--- a/internal/runtime/bus/delivery_planner_test.go
+++ b/internal/runtime/bus/delivery_planner_test.go
@@ -55,7 +55,7 @@ func testSelectedOwnerPolicy(owners ...ActiveTargetDescriptor) deliveryRecipient
 
 func existingOwnerHandlerFixture() runtimecontracts.SystemNodeEventHandler {
 	return runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{
-		ID: "selected_owner", Check: "has(entity.id) || !has(entity.id)",
+		ID: "selected_owner", Check: `_entity.id != ""`,
 	}}
 }
 

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -3501,7 +3501,7 @@ func TestEventBusPublish_MixedEmptyAndTargetedNodeRoutesExecuteAndSettle(t *test
 func mixedNodeRouteWorkflowModule(t *testing.T) (runtimepipeline.WorkflowModule, *runtimecontracts.WorkflowContractBundle) {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{
-		ID: "selected_owner", Check: "has(entity.id) || !has(entity.id)",
+		ID: "selected_owner", Check: `_entity.id != ""`,
 	}}
 	child := runtimecontracts.FlowContractView{
 		Path:  "child",

--- a/internal/runtime/bus/eventbus_target_routes_test.go
+++ b/internal/runtime/bus/eventbus_target_routes_test.go
@@ -2573,7 +2573,7 @@ version: 1.0.0
     opco.spinup_requested:
       guard:
         id: selected_owner
-        check: "has(entity.id) || !has(entity.id)"
+        check: '_entity.id != ""'
 `,
 	}
 }

--- a/internal/runtime/github_app_issue_comment_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_comment_supported_surface_test.go
@@ -351,7 +351,7 @@ func githubAppIssueCommentSource(t *testing.T, baseURL, flowInstance string) sem
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
 		Guard: &runtimecontracts.GuardSpec{
-			Check:  `(has(entity.id) || !has(entity.id)) && payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
+			Check:  `_entity.id != "" && payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
 			OnFail: "discard",
 		},
 		Activity: runtimecontracts.ActivitySpec{

--- a/internal/runtime/github_app_issue_workflow_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_workflow_supported_surface_test.go
@@ -457,7 +457,7 @@ func githubAppIssueWorkflowSource(t *testing.T, baseURL, flowInstance string) se
 	t.Helper()
 	commentHandler := runtimecontracts.SystemNodeEventHandler{
 		Guard: &runtimecontracts.GuardSpec{
-			Check:  `(has(entity.id) || !has(entity.id)) && payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
+			Check:  `_entity.id != "" && payload.payload.comment.user.type != "Bot" && payload.payload.sender.type != "Bot"`,
 			OnFail: "discard",
 		},
 		Activity: runtimecontracts.ActivitySpec{
@@ -474,7 +474,7 @@ func githubAppIssueWorkflowSource(t *testing.T, baseURL, flowInstance string) se
 	}
 	createIssueHandler := runtimecontracts.SystemNodeEventHandler{
 		Guard: &runtimecontracts.GuardSpec{
-			Check:  `(has(entity.id) || !has(entity.id)) && payload.payload.action == "opened"`,
+			Check:  `_entity.id != "" && payload.payload.action == "opened"`,
 			OnFail: "discard",
 		},
 		Activity: runtimecontracts.ActivitySpec{
@@ -491,7 +491,7 @@ func githubAppIssueWorkflowSource(t *testing.T, baseURL, flowInstance string) se
 	}
 	addLabelsHandler := runtimecontracts.SystemNodeEventHandler{
 		Guard: &runtimecontracts.GuardSpec{
-			Check:  `(has(entity.id) || !has(entity.id)) && payload.payload.action == "opened"`,
+			Check:  `_entity.id != "" && payload.payload.action == "opened"`,
 			OnFail: "discard",
 		},
 		Activity: runtimecontracts.ActivitySpec{

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -344,7 +344,7 @@ func microsoftGraphClientCredentialsRecord(baseURL, accessToken string, expiresA
 func microsoftGraphConnectorSource(t *testing.T, baseURL, flowInstance string) semanticview.Source {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
-		Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "microsoft_graph_send_mail",
 			Tool: "microsoft_graph.send_mail",

--- a/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
@@ -334,7 +334,7 @@ func (f *fakeNotionManagedConnectorServer) providerHTTPRequestCount() int {
 func notionManagedConnectorSource(t *testing.T, baseURL, flowInstance string) semanticview.Source {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
-		Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "notion_append_block_children",
 			Tool: "notion.append_block_children",

--- a/internal/runtime/pipeline/delivery_target_ownership.go
+++ b/internal/runtime/pipeline/delivery_target_ownership.go
@@ -810,7 +810,18 @@ func typedPathReferencesEntity(raw string, path paths.Path) bool {
 }
 
 func expressionReferencesEntity(expression string) bool {
-	return workflowexpr.ExpressionReferencesEntity(strings.TrimSpace(expression))
+	expression = strings.TrimSpace(expression)
+	if workflowexpr.ExpressionReferencesEntity(expression) {
+		return true
+	}
+	for _, ref := range workflowexpr.PlatformEntityReferences(expression) {
+		head, _, _ := strings.Cut(strings.TrimSpace(ref), ".")
+		switch head {
+		case "id", "current_state", "gates":
+			return true
+		}
+	}
+	return false
 }
 
 func pathReferencesEntity(path string) bool {

--- a/internal/runtime/pipeline/delivery_target_ownership_test.go
+++ b/internal/runtime/pipeline/delivery_target_ownership_test.go
@@ -392,6 +392,9 @@ func TestHandlerEntityClassifierRejectsEntitylessOwnershipAcrossNestedOperators(
 		{name: "loop lifecycle", handler: runtimecontracts.SystemNodeEventHandler{Loop: &runtimecontracts.LoopOperationSpec{Admit: "revision"}}},
 		{name: "activity input", handler: runtimecontracts.SystemNodeEventHandler{Activity: runtimecontracts.ActivitySpec{Input: map[string]runtimecontracts.ExpressionValue{"state": runtimecontracts.RefExpression("entity.status")}}}},
 		{name: "guard escalation", handler: runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{OnFailSpec: runtimecontracts.GuardFailureSpec{Action: runtimecontracts.GuardFailureActionEscalate, Escalation: runtimecontracts.EmitSpec{Event: "guard.failed", From: "entity"}}}}},
+		{name: "platform entity identity", handler: runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`}}},
+		{name: "platform entity state", handler: runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{Check: `_entity.current_state == "active"`}}},
+		{name: "platform entity gate", handler: runtimecontracts.SystemNodeEventHandler{Guard: &runtimecontracts.GuardSpec{Check: `_entity.gates.ready`}}},
 		{name: "nested rule fan out", handler: runtimecontracts.SystemNodeEventHandler{Rules: []runtimecontracts.HandlerRuleEntry{{FanOut: &runtimecontracts.FanOutSpec{ItemsFrom: "entity.items"}}}}},
 		{name: "nested rule activity", handler: runtimecontracts.SystemNodeEventHandler{OnComplete: []runtimecontracts.HandlerRuleEntry{{Activity: runtimecontracts.ActivitySpec{Input: map[string]runtimecontracts.ExpressionValue{"owner": runtimecontracts.CELExpression("entity.owner")}}}}}},
 	}
@@ -406,6 +409,11 @@ func TestHandlerEntityClassifierRejectsEntitylessOwnershipAcrossNestedOperators(
 		FanOut: &runtimecontracts.FanOutSpec{ItemsFrom: "payload.items", Emit: runtimecontracts.EmitSpec{Event: "work.item", From: "payload"}},
 	}) != handlerEntitylessSafe {
 		t.Fatal("payload-only fan out classified as entity-scoped")
+	}
+	if handlerExecutionEntityRequirement(nil, "review", runtimecontracts.SystemNodeEventHandler{
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.flow_instance == "review/one"`},
+	}) != handlerEntitylessSafe {
+		t.Fatal("flow-instance-only platform metadata classified as entity-scoped")
 	}
 }
 
@@ -438,6 +446,10 @@ func TestHandlerExecutionEntityRequirementOwnsDurableBehaviorCapabilities(t *tes
 		}, want: handlerExistingEntityRequired},
 		{name: "explicit creation may materialize", handler: runtimecontracts.SystemNodeEventHandler{
 			CreateEntity: true,
+		}, want: handlerMaterializingEntity},
+		{name: "creation dominates platform entity identity", handler: runtimecontracts.SystemNodeEventHandler{
+			CreateEntity: true,
+			Guard:        &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 		}, want: handlerMaterializingEntity},
 		{name: "payload-only fanout is entityless safe", handler: runtimecontracts.SystemNodeEventHandler{
 			FanOut: &runtimecontracts.FanOutSpec{ItemsFrom: "payload.items", Emit: runtimecontracts.EmitSpec{Event: "work.item", From: "payload"}},

--- a/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
@@ -340,7 +340,7 @@ func publishTelegramMessageToSlack(t *testing.T, backend slackManagedConnectorBa
 func slackManagedConnectorSource(t *testing.T, baseURL, flowInstance string) semanticview.Source {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
-		Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "slack_post_message",
 			Tool: "slack.post_message",

--- a/internal/runtime/telegram_connector_supported_surface_test.go
+++ b/internal/runtime/telegram_connector_supported_surface_test.go
@@ -283,7 +283,7 @@ const telegramConnectorSupportedSurfaceNodeID = "telegram-responder"
 func telegramConnectorSupportedSurfaceSource(t *testing.T, baseURL, flowInstance string) semanticview.Source {
 	t.Helper()
 	handler := runtimecontracts.SystemNodeEventHandler{
-		Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 		Activity: runtimecontracts.ActivitySpec{
 			ID:   "telegram_send_message",
 			Tool: "telegram.send_message",

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -1702,7 +1702,7 @@ func emitRoutePlanRootReceiverSource() semanticview.Source {
 		To:   ".deploy_completed",
 	}})
 	rootHandler := runtimecontracts.SystemNodeEventHandler{
-		Guard: &runtimecontracts.GuardSpec{Check: "has(entity.id) || !has(entity.id)"},
+		Guard: &runtimecontracts.GuardSpec{Check: `_entity.id != ""`},
 	}
 	bundle.RootSchema = &runtimecontracts.FlowSchemaDocument{
 		Pins: runtimecontracts.FlowPins{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -1299,7 +1299,9 @@ contract_formats:
             approval lifecycle, persistent clears, evidence recording, accumulation, joins, and nested rule sites rather than
             inferring ownership only from authored entity references. Selected entity evidence for an otherwise entityless
             handler is contradictory and fails before mutation; only an admitted structural current-delivery owner may supply
-            shared existing ownership. An admitted materializing owner may satisfy a later select handler in the same plan.
+            shared existing ownership. References to persisted platform entity identity, state, or gates are existing-entity
+            requirements; flow-instance platform metadata alone remains route metadata and does not invent entity ownership.
+            An admitted materializing owner may satisfy a later select handler in the same plan.
             Handler-derived materialization MUST agree with the canonical future identity. Routing, stamped validation,
             and pipeline execution consume that same requirement owner, and pipeline consumes the persisted target variant
             directly; source-event identity, path text, descriptors, singleton fan-in, and missing-row fallback cannot repair

--- a/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
+++ b/tests/tier11-flow-composition/test-gates-in-child-flow/nodes.yaml
@@ -9,7 +9,7 @@ router:
     validate.requested:
       guard:
         id: selected_owner
-        check: "has(entity.id) || !has(entity.id)"
+        check: '_entity.id != ""'
       emit: child/validate.start
     validation.done:
       guard:

--- a/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
+++ b/tests/tier11-flow-composition/test-nested-three-levels/nodes.yaml
@@ -7,7 +7,7 @@ root-dispatcher:
     pipeline.start:
       guard:
         id: selected_owner
-        check: "has(entity.id) || !has(entity.id)"
+        check: '_entity.id != ""'
       emit: step.begin
 
 root-collector:


### PR DESCRIPTION
## Summary

Follow-up to #2216.

- remove all 15 tautological `has(entity.id) || !has(entity.id)` fixture guards
- classify persisted platform entity references (`_entity.id`, `_entity.current_state`, and `_entity.gates`) as existing-entity execution requirements in the canonical delivery-target owner
- keep `_entity.flow_instance` entityless-safe because it is route metadata rather than persisted entity evidence
- replace the affected fixtures with the truthful precondition `_entity.id != ""`
- update the authoritative platform specification and classifier coverage

## Root cause

The fixtures needed to declare real existing-entity execution semantics after #2216, but used a logically unconditional business-entity expression to trigger the classifier. The underlying classifier also ignored persisted platform entity metadata, forcing that workaround.

## Behavior

Handlers that read persisted platform identity, state, or gates now require an existing entity before delivery. Flow-instance-only platform metadata does not acquire entity ownership. Materializing handlers continue to take precedence.

## Validation

- focused classifier and ownership tests
- complete EventBus, operator API, tool emission, and supported connector matrix
- tier-11 composition and pipeline proofs
- `go run ./cmd/swarm-test-postgres -- go test -p 1 ./...`
- `git diff --check`
- repo-wide tautology search returns no matches