### PR TITLE
[agent-a][issue #2169] Canonicalize declared agent names

### DIFF
--- a/examples/routing/notify-all-children/flows/account/agents.yaml
+++ b/examples/routing/notify-all-children/flows/account/agents.yaml
@@ -1,5 +1,4 @@
 account-worker:
-  id: account-worker
   type: generic
   role: account_worker
   intent: prompts/account-worker.md

--- a/internal/cliapp/main_test.go
+++ b/internal/cliapp/main_test.go
@@ -4748,6 +4748,7 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 					"agent-1": {ID: "agent-1", Tools: []string{"missing_tool"}},
 				}
+				addTestAgentOwners(bundle)
 				return bundle
 			}(),
 			wantErr: false,
@@ -4759,6 +4760,7 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 					"agent-1": {ID: "agent-1", Tools: []string{"schedule"}, Permissions: []string{"schedule"}},
 				}
+				addTestAgentOwners(bundle)
 				return bundle
 			}(),
 			wantErr: false,
@@ -4770,6 +4772,7 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
 				}
+				addTestAgentOwners(bundle)
 				return bundle
 			}(),
 			errContains: "'missing.event' emitted but no schema in events.yaml",
@@ -4824,6 +4827,24 @@ func TestVerifyBundle_AgreesWithRuntimeValidationOnTouchedToolAndEventClasses(t 
 				}
 			}
 		})
+	}
+}
+
+func addTestAgentOwners(bundle *runtimecontracts.WorkflowContractBundle) {
+	if bundle == nil {
+		return
+	}
+	if bundle.URIRegistry.Agents == nil {
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
+	}
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	for localID := range bundle.Agents {
+		uri := "swarm-test://root/agents/" + localID
+		ref := runtimecontracts.ContractURIRef{Kind: "agent", LocalID: localID, Full: uri}
+		bundle.URIRegistry.Agents[localID] = ref
+		bundle.URIRegistry.ByURI[uri] = ref
 	}
 }
 

--- a/internal/cliapp/workspace_backend.go
+++ b/internal/cliapp/workspace_backend.go
@@ -263,7 +263,14 @@ func classifyWorkspaceBackendRequirement(cfg *config.Config, source semanticview
 	reasons := []WorkspaceCapabilityReason{{Kind: WorkspaceReasonLifecycle}}
 	for _, declaration := range entries {
 		entry := declaration.Entry
-		label := workspaceBackendAgentLabel(declaration.Label(localIDCounts[declaration.LocalID] > 1), entry.ID, entry.Role)
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			return "", nil, err
+		}
+		label := plan.AgentID
+		if localIDCounts[declaration.LocalID] > 1 {
+			label += " (" + declaration.Label(true) + ")"
+		}
 		selection, err := llmselection.ResolveAgentExecutionSelection(llmselection.AgentExecutionSelectionInput{
 			ConfiguredDefault: profile,
 			MockConfigured:    entry.Mock.Configured(),

--- a/internal/cliapp/workspace_backend_decision_test.go
+++ b/internal/cliapp/workspace_backend_decision_test.go
@@ -128,7 +128,7 @@ func TestWorkspaceBackendDecisionCapabilityMatrix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			decision, err := DecideWorkspaceBackend(tt.preference, tt.cfg, semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Agents: tt.agents}))
+			decision, err := DecideWorkspaceBackend(tt.preference, tt.cfg, workspaceBackendTestSource(tt.agents))
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("DecideWorkspaceBackend error = %v, want containing %q", err, tt.wantErr)
@@ -183,9 +183,7 @@ func TestWorkspaceBackendHostRemediationUsesTypedExecReasons(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			preference := WorkspaceBackendSelection{Backend: workspace.BackendHost, Source: "--workspace-backend", PreferenceExplicit: true, AllowExecOnHost: true}
-			decision, err := DecideWorkspaceBackend(preference, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-				Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": tt.agent},
-			}))
+			decision, err := DecideWorkspaceBackend(preference, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), workspaceBackendTestSource(map[string]runtimecontracts.AgentRegistryEntry{"worker": tt.agent}))
 			if err == nil {
 				t.Fatal("DecideWorkspaceBackend unexpectedly accepted claude_cli host execution")
 			}
@@ -216,11 +214,9 @@ func TestWorkspaceBackendHostRemediationUsesTypedExecReasons(t *testing.T) {
 func TestWorkspaceBackendClaudeCLIUsesEffectivePerAgentMockSelection(t *testing.T) {
 	mocked := testWorkspaceBackendMockPerformance()
 	t.Run("fully mocked bundle keeps ordinary host workspace lifecycle", func(t *testing.T) {
-		decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-			Agents: map[string]runtimecontracts.AgentRegistryEntry{
-				"alpha": {ID: "alpha", Mock: mocked},
-				"beta":  {ID: "beta", Mock: mocked},
-			},
+		decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), workspaceBackendTestSource(map[string]runtimecontracts.AgentRegistryEntry{
+			"alpha": {ID: "alpha", Mock: mocked},
+			"beta":  {ID: "beta", Mock: mocked},
 		}))
 		if err != nil {
 			t.Fatalf("DecideWorkspaceBackend: %v", err)
@@ -238,11 +234,9 @@ func TestWorkspaceBackendClaudeCLIUsesEffectivePerAgentMockSelection(t *testing.
 
 	t.Run("mixed bundle refuses host and names only unmocked Claude agent", func(t *testing.T) {
 		preference := WorkspaceBackendSelection{Backend: workspace.BackendHost, Source: "workspace.backend", PreferenceExplicit: true}
-		decision, err := DecideWorkspaceBackend(preference, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-			Agents: map[string]runtimecontracts.AgentRegistryEntry{
-				"mocked-worker": {ID: "mocked-worker", Mock: mocked},
-				"live-worker":   {ID: "live-worker"},
-			},
+		decision, err := DecideWorkspaceBackend(preference, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), workspaceBackendTestSource(map[string]runtimecontracts.AgentRegistryEntry{
+			"mocked-worker": {ID: "mocked-worker", Mock: mocked},
+			"live-worker":   {ID: "live-worker"},
 		}))
 		if err == nil {
 			t.Fatal("DecideWorkspaceBackend unexpectedly admitted mixed claude_cli bundle on host")
@@ -265,10 +259,8 @@ func TestWorkspaceBackendClaudeCLIUsesEffectivePerAgentMockSelection(t *testing.
 	})
 
 	t.Run("mock does not waive independently declared native execution", func(t *testing.T) {
-		decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-			Agents: map[string]runtimecontracts.AgentRegistryEntry{
-				"worker": {ID: "worker", Mock: mocked, NativeTools: map[string]any{"bash": true}},
-			},
+		decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendClaudeCLI), workspaceBackendTestSource(map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": {ID: "worker", Mock: mocked, NativeTools: map[string]any{"bash": true}},
 		}))
 		if err != nil {
 			t.Fatalf("DecideWorkspaceBackend: %v", err)
@@ -404,7 +396,7 @@ func TestWorkspaceBackendReasonsPreserveEveryAgentCapabilityAcrossAggregateClass
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses), semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{Agents: tt.agents}))
+			decision, err := DecideWorkspaceBackend(WorkspaceBackendSelection{}, testWorkspaceBackendConfig(llmselection.BackendOpenAIResponses), workspaceBackendTestSource(tt.agents))
 			if err != nil {
 				t.Fatalf("DecideWorkspaceBackend: %v", err)
 			}
@@ -425,6 +417,12 @@ func TestWorkspaceBackendReasonsPreserveEveryAgentCapabilityAcrossAggregateClass
 			}
 		})
 	}
+}
+
+func workspaceBackendTestSource(agents map[string]runtimecontracts.AgentRegistryEntry) semanticview.Source {
+	bundle := &runtimecontracts.WorkflowContractBundle{Agents: agents}
+	addTestAgentOwners(bundle)
+	return semanticview.Wrap(bundle)
 }
 
 func TestConfiguredWorkspaceLifecycleForBackendNoWorkspace(t *testing.T) {

--- a/internal/providerconnectors/packs.go
+++ b/internal/providerconnectors/packs.go
@@ -535,14 +535,6 @@ func (s connectorPackSource) ProjectScopes() []semanticview.ProjectScope {
 	return out
 }
 
-func (s connectorPackSource) ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
-	if tool, ok := s.Source.ToolEntryForAgent(agentID, toolID); ok {
-		return tool, true
-	}
-	tool, ok := s.importedTools[strings.TrimSpace(toolID)]
-	return tool, ok
-}
-
 func (s connectorPackSource) ResolvedEventCatalog() map[string]runtimecontracts.EventCatalogEntry {
 	out := cloneConnectorEventCatalog(s.Source.ResolvedEventCatalog())
 	for eventType, entry := range s.generatedActivityEventEntries() {

--- a/internal/providerconnectors/providerconnectors.go
+++ b/internal/providerconnectors/providerconnectors.go
@@ -207,21 +207,27 @@ func validateProviderConnectorAgentExposure(source semanticview.Source) []error 
 	if source == nil {
 		return nil
 	}
-	agents := source.AgentEntries()
-	agentIDs := make([]string, 0, len(agents))
-	for agentID := range agents {
-		agentIDs = append(agentIDs, strings.TrimSpace(agentID))
-	}
-	sort.Strings(agentIDs)
 	var errs []error
-	for _, agentID := range agentIDs {
-		entry := agents[agentID]
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		agentID := strings.TrimSpace(declaration.LocalID)
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			agentID = plan.AgentID
+		}
+		projection, ok := semanticview.ScopedAgentContractProjection(source, declaration)
+		if !ok {
+			errs = append(errs, fmt.Errorf("agent %q has no exact contract projection", agentID))
+			continue
+		}
+		entry := declaration.Entry
 		for _, toolID := range entry.ConfiguredTools() {
 			toolID = strings.TrimSpace(toolID)
 			if toolID == "" {
 				continue
 			}
-			tool, ok := source.ToolEntryForAgent(agentID, toolID)
+			tool, ok := projection.ToolEntry(toolID)
 			if !ok || !isProviderConnector(tool) {
 				continue
 			}

--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -144,6 +144,48 @@ func TestValidateSourceRejectsAgentExposureOfProviderConnector(t *testing.T) {
 	}
 }
 
+func TestValidateSourceRejectsScopedDuplicateAgentExposureOfProviderConnector(t *testing.T) {
+	connector := telegramConnectorTool("https://api.telegram.org")
+	alpha := runtimecontracts.FlowContractView{
+		Path:  "alpha",
+		Paths: runtimecontracts.FlowContractPaths{ID: "alpha", Flow: "alpha"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"sender": {ID: "alpha-sender", Tools: []string{"telegram.send_message"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{"telegram.send_message": connector},
+	}
+	beta := runtimecontracts.FlowContractView{
+		Path:  "beta",
+		Paths: runtimecontracts.FlowContractPaths{ID: "beta", Flow: "beta"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"sender": {ID: "beta-sender", Tools: []string{"telegram.send_message"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{"telegram.send_message": connector},
+	}
+	refs := map[string]runtimecontracts.ContractURIRef{
+		"alpha/sender": {Kind: "agent", FlowID: "alpha", LocalID: "sender", Full: "test://alpha/sender"},
+		"beta/sender":  {Kind: "agent", FlowID: "beta", LocalID: "sender", Full: "test://beta/sender"},
+	}
+	byURI := map[string]runtimecontracts.ContractURIRef{}
+	for _, ref := range refs {
+		byURI[ref.Full] = ref
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{alpha, beta}},
+			ByID: map[string]*runtimecontracts.FlowContractView{"alpha": &alpha, "beta": &beta},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{Agents: refs, ByURI: byURI},
+	})
+
+	joined := joinErrors(ValidateSource(source))
+	for _, agentID := range []string{"alpha-sender", "beta-sender"} {
+		if !strings.Contains(joined, `agent "`+agentID+`" must not expose provider connector tool "telegram.send_message" directly`) {
+			t.Fatalf("ValidateSource errors = %q, want scoped exposure rejection for %s", joined, agentID)
+		}
+	}
+}
+
 func TestSurfacesReportManagedCredentialRequirementsWithoutSecretValues(t *testing.T) {
 	ctx := context.Background()
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{

--- a/internal/releasee2e/docker_helper_test.go
+++ b/internal/releasee2e/docker_helper_test.go
@@ -28,7 +28,7 @@ const (
 	releaseE2EWorkspaceImage   = "swarm-workspace:latest"
 	releaseE2ENetwork          = "mas_default"
 	releaseE2EAgentWorkdir     = "/workspace"
-	releaseE2EAgentFingerprint = "ef1581e2042b4a9932ec6994425466b32b6e05c225780b02d46be87a535524f7"
+	releaseE2EAgentFingerprint = "1f16a79924a40cd1e6e42105063bd4b8d5e3332769c777508831bb193986d791"
 	releaseE2EAgentContainer   = "swarm-agent-" + releaseE2EAgentFingerprint
 	releaseE2EAgentVolume      = "workspaces_agent_" + releaseE2EAgentFingerprint
 	releaseE2EOrphanKill       = `if command -v pkill >/dev/null 2>&1; then
@@ -528,7 +528,7 @@ func validateReleaseDockerLabels(create releaseDockerCreate, kind, resetEligible
 	if create.name == releaseE2EAgentContainer {
 		wantIdentityLabels := map[string]string{
 			"dev.swarm.agent_id":                 "release-worker",
-			"dev.swarm.agent_name_owner":         "claude-cli-release-lifecycle://worker/release-worker",
+			"dev.swarm.agent_name_owner":         "claude-cli-release-lifecycle://flows/worker/release-worker",
 			"dev.swarm.agent_name_source":        "declared",
 			"dev.swarm.agent_route_presence":     "present",
 			"dev.swarm.agent_flow_scope_key":     "worker",

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -26,7 +26,7 @@ import (
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	llm "github.com/division-sh/swarm/internal/runtime/llm"
-	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
@@ -708,7 +708,7 @@ func newFactoryDirectiveAgent(t *testing.T, cfg models.AgentConfig, modelRuntime
 	t.Helper()
 	cfg = withTestResolvedIntent(t, cfg, "You coordinate workflow launch.")
 
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 	authority := runtimeauthority.NewSourceProvider(source)
 	emitRegistry := runtimetools.NewEmitRegistry(source, authority)
 	bus := &directiveFactoryPublishBus{}

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -307,13 +307,25 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 	if !ok || bundle == nil {
 		return View{}, fmt.Errorf("authoring view requires a workflow contract bundle source")
 	}
+	agentNames, err := authoringAgentNames(source)
+	if err != nil {
+		return View{}, err
+	}
+	root, err := buildRoot(bundle, agentNames)
+	if err != nil {
+		return View{}, err
+	}
+	flows, err := buildFlows(source, bundle, agentNames)
+	if err != nil {
+		return View{}, err
+	}
 	view := View{
 		WorkflowName:    bundle.WorkflowName(),
 		WorkflowVersion: bundle.WorkflowVersion(),
 		ContractsRoot:   strings.TrimSpace(bundle.Paths.ContractsRoot),
 		SourceAuthority: "projection_only_existing_contract_owners",
-		Root:            buildRoot(bundle),
-		Flows:           buildFlows(source, bundle),
+		Root:            root,
+		Flows:           flows,
 		ApprovalPoints:  buildApprovalPoints(bundle),
 		RoutingTopology: BuildRoutingTopologyWithReport(source, bundle, opts.BootReport),
 		Diagnostics:     buildDiagnostics(bundle, opts.BootReport),
@@ -335,6 +347,30 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		view.StageGraphs = buildStageGraphs(source, bundle)
 	}
 	return view, nil
+}
+
+type authoringAgentNameKey struct {
+	scopeKind string
+	scopeID   string
+	localID   string
+}
+
+func authoringAgentNames(source semanticview.Source) (map[authoringAgentNameKey]string, error) {
+	plans, err := semanticview.AgentNamePlans(source)
+	if err != nil {
+		return nil, fmt.Errorf("authoring agent names: %w", err)
+	}
+	out := make(map[authoringAgentNameKey]string, len(plans))
+	for _, plan := range plans {
+		scopeKind := plan.ScopeKind
+		scopeID := plan.ScopeID
+		if strings.TrimSpace(scopeKind) == "" {
+			scopeKind = "project"
+			scopeID = "."
+		}
+		out[authoringAgentNameKey{scopeKind: scopeKind, scopeID: scopeID, localID: plan.LocalID}] = plan.AgentID
+	}
+	return out, nil
 }
 
 func buildApprovalPoints(bundle *runtimecontracts.WorkflowContractBundle) []ApprovalPointView {
@@ -389,8 +425,12 @@ func BuildRoutingTopologyWithReport(source semanticview.Source, bundle *runtimec
 	return routingtopology.WithIssues(topology, issues...)
 }
 
-func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
-	rootAgents, rootAgentsFile := rootAgentViewEntries(bundle)
+func buildRoot(bundle *runtimecontracts.WorkflowContractBundle, agentNames map[authoringAgentNameKey]string) (RootView, error) {
+	rootAgents, rootAgentsFile, rootScopeID := rootAgentViewEntries(bundle)
+	agents, err := agentViews(rootAgents, rootAgentsFile, "project", rootScopeID, agentNames)
+	if err != nil {
+		return RootView{}, err
+	}
 	out := RootView{
 		SourceFiles: RootSourceFiles{
 			Schema:   strings.TrimSpace(bundle.Paths.RootSchemaFile),
@@ -398,7 +438,7 @@ func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
 			Package:  strings.TrimSpace(bundle.Paths.ProjectPackageFile),
 			Agents:   strings.TrimSpace(bundle.Paths.ProjectAgentsFile),
 		},
-		Agents: agentViews(rootAgents, rootAgentsFile),
+		Agents: agents,
 	}
 	if bundle.RootSchema != nil {
 		out.RequiredAgents = requiredAgentsView(*bundle.RootSchema, bundle.RootRequiredAgentFacts(), bundle.Paths.RootSchemaFile, bundle.Paths.ProjectAgentsFile)
@@ -408,18 +448,18 @@ func buildRoot(bundle *runtimecontracts.WorkflowContractBundle) RootView {
 		declared = strings.TrimSpace(bundle.RootSchema.Entity)
 	}
 	if declared == "" && len(bundle.RootEntities) == 0 {
-		return out
+		return out, nil
 	}
 	primary, err := bundle.ResolveRootPrimaryEntity()
 	if err != nil {
 		out.PrimaryEntityError = err.Error()
-		return out
+		return out, nil
 	}
 	out.PrimaryEntity = primaryEntityView(primary, bundle.Paths.RootEntitiesFile)
-	return out
+	return out, nil
 }
 
-func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) []FlowView {
+func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle, agentNames map[authoringAgentNameKey]string) ([]FlowView, error) {
 	opsByFlow := containedOperationsByFlow(source, bundle)
 	refsByFlow := packageFlowRefsByID(bundle)
 	views := bundle.FlowViews()
@@ -427,12 +467,16 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 	for _, flow := range views {
 		flowID := strings.TrimSpace(flow.Paths.ID)
 		schema := flow.Schema
+		agents, err := agentViews(flow.Agents, flow.Paths.AgentsFile, "flow", flowID, agentNames)
+		if err != nil {
+			return nil, err
+		}
 		item := FlowView{
 			ID:          flowID,
 			Path:        strings.Trim(strings.TrimSpace(flow.Path), "/"),
 			Mode:        strings.TrimSpace(schema.Mode),
 			SourceFiles: flowSourceFiles(bundle, flow),
-			Agents:      agentViews(flow.Agents, flow.Paths.AgentsFile),
+			Agents:      agents,
 			RequiredAgents: requiredAgentsView(
 				schema,
 				bundle.FlowRequiredAgentFacts(flowID),
@@ -482,7 +526,7 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 		item.ContainedOperations = opsByFlow[flowID]
 		out = append(out, item)
 	}
-	return out
+	return out, nil
 }
 
 func standingIngressProviderView(provider runtimecontracts.ProjectFlowIngressProvider) StandingIngressProviderView {
@@ -880,26 +924,26 @@ func authoringStringSet(values []string) map[string]struct{} {
 	return out
 }
 
-func rootAgentViewEntries(bundle *runtimecontracts.WorkflowContractBundle) (map[string]runtimecontracts.AgentRegistryEntry, string) {
+func rootAgentViewEntries(bundle *runtimecontracts.WorkflowContractBundle) (map[string]runtimecontracts.AgentRegistryEntry, string, string) {
 	if bundle == nil {
-		return nil, ""
+		return nil, "", ""
 	}
 	for _, view := range bundle.ProjectViews() {
 		if strings.TrimSpace(view.Paths.ParentKey) == "" && view.Paths.Depth == 0 {
-			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile)
+			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile), strings.TrimSpace(view.Paths.Key)
 		}
 	}
 	for _, view := range bundle.ProjectViews() {
 		if strings.TrimSpace(view.Paths.ParentKey) == "" {
-			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile)
+			return view.Agents, strings.TrimSpace(view.Paths.ProjectAgentsFile), strings.TrimSpace(view.Paths.Key)
 		}
 	}
-	return bundle.AgentEntries(), strings.TrimSpace(bundle.Paths.ProjectAgentsFile)
+	return bundle.AgentEntries(), strings.TrimSpace(bundle.Paths.ProjectAgentsFile), "."
 }
 
-func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFile string) []AgentView {
+func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFile, scopeKind, scopeID string, names map[authoringAgentNameKey]string) ([]AgentView, error) {
 	if len(entries) == 0 {
-		return nil
+		return nil, nil
 	}
 	ids := make([]string, 0, len(entries))
 	for id := range entries {
@@ -911,6 +955,10 @@ func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFi
 	out := make([]AgentView, 0, len(ids))
 	for _, id := range ids {
 		entry := runtimecontracts.EffectiveAgentRegistryEntry(id, entries[id])
+		publicName := strings.TrimSpace(names[authoringAgentNameKey{scopeKind: strings.TrimSpace(scopeKind), scopeID: strings.TrimSpace(scopeID), localID: id}])
+		if publicName == "" {
+			return nil, fmt.Errorf("authoring agent %s %s/%s has no canonical declared-name plan", strings.TrimSpace(scopeKind), strings.TrimSpace(scopeID), id)
+		}
 		fields := map[string]AgentFieldView{}
 		addAgentField(fields, entry, "type", entry.Type)
 		addAgentField(fields, entry, "model", entry.Model)
@@ -920,12 +968,12 @@ func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFi
 		addAgentField(fields, entry, "workspace_class", entry.WorkspaceClass)
 		addAgentField(fields, entry, "manager_fallback", entry.ManagerFallback)
 		out = append(out, AgentView{
-			ID:         id,
+			ID:         publicName,
 			SourceFile: strings.TrimSpace(sourceFile),
 			Fields:     fields,
 		})
 	}
-	return out
+	return out, nil
 }
 
 func addAgentField(fields map[string]AgentFieldView, entry runtimecontracts.AgentRegistryEntry, name string, value any) {

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -293,6 +293,7 @@ func TestBuildShowsRequiredAgentProvenance(t *testing.T) {
 			},
 		},
 	}
+	addAuthoringViewAgentOwners(bundle)
 	view := mustBuild(t, semanticview.Wrap(bundle), nil)
 
 	if view.Root.RequiredAgents.Source != runtimecontracts.RequiredAgentSourceInferred ||
@@ -622,6 +623,7 @@ func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
 			},
 		},
 	}
+	addAuthoringViewAgentOwners(bundle)
 
 	view := mustBuild(t, semanticview.Wrap(bundle), nil)
 
@@ -642,6 +644,34 @@ func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
 	assertDefaultedAgentField(t, flowAgent, "memory_source", agentmemory.SourcePlatformDefault)
 	assertDefaultedAgentField(t, flowAgent, "max_turns_per_task", runtimecontracts.DefaultAgentMaxTurnsPerTask)
 	assertDefaultedAgentField(t, flowAgent, "workspace_class", "")
+}
+
+func TestBuildRendersEffectivePublicAgentNameInsteadOfLocalCoordinate(t *testing.T) {
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker", Model: "regular"},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				"local-worker": {Kind: "agent", LocalID: "local-worker", Full: "swarm-test://local-worker"},
+			},
+		},
+	}
+	view := mustBuild(t, semanticview.Wrap(bundle), nil)
+	if len(view.Root.Agents) != 1 || view.Root.Agents[0].ID != "public-worker" {
+		t.Fatalf("root agents = %#v, want effective public-worker readback", view.Root.Agents)
+	}
+}
+
+func addAuthoringViewAgentOwners(bundle *runtimecontracts.WorkflowContractBundle) {
+	bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{
+		"root-agent": {
+			Kind: "agent", LocalID: "root-agent", Full: "swarm-test://root-agent",
+		},
+		"analysis/analyzer": {
+			Kind: "agent", FlowID: "analysis", LocalID: "analyzer", Path: "analysis", Full: "swarm-test://analysis/analyzer",
+		},
+	}
 }
 
 func assertDefaultedAgentField(t testing.TB, agent AgentView, field string, want any) {

--- a/internal/runtime/authority/source_provider.go
+++ b/internal/runtime/authority/source_provider.go
@@ -119,10 +119,15 @@ func sourceRoles(source semanticview.Source) []string {
 	if source == nil {
 		return nil
 	}
-	roles := make([]string, 0, len(source.AgentEntries()))
-	seen := make(map[string]struct{}, len(source.AgentEntries()))
-	for key, entry := range source.AgentEntries() {
-		role := canonicalRole(firstNonEmpty(entry.Role, key))
+	declarations := semanticview.AgentDeclarations(source)
+	roles := make([]string, 0, len(declarations))
+	seen := make(map[string]struct{}, len(declarations))
+	for _, declaration := range declarations {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			continue
+		}
+		role := canonicalRole(plan.EffectiveRole(declaration.Entry))
 		if role == "" {
 			continue
 		}

--- a/internal/runtime/authority/source_provider_test.go
+++ b/internal/runtime/authority/source_provider_test.go
@@ -21,7 +21,7 @@ func TestNewSourceProvider_UsesDeclaredAgentEmitEventsOnly(t *testing.T) {
 		},
 	}
 
-	provider := NewSourceProvider(semanticview.Wrap(bundle))
+	provider := NewSourceProvider(authorityTestSource(bundle))
 	got := provider.ProducerEventsForRole("worker")
 	if len(got) != 1 || got[0] != "work.completed" {
 		t.Fatalf("ProducerEventsForRole(worker) = %#v, want [work.completed]", got)
@@ -45,7 +45,7 @@ func TestNewSourceProvider_UsesDeclaredRoleForProducerEvents(t *testing.T) {
 		},
 	}
 
-	provider := NewSourceProvider(semanticview.Wrap(bundle))
+	provider := NewSourceProvider(authorityTestSource(bundle))
 	got := provider.ProducerEventsForRole("reviewer")
 	if len(got) != 1 || got[0] != "review.completed" {
 		t.Fatalf("ProducerEventsForRole(reviewer) = %#v, want [review.completed]", got)
@@ -53,6 +53,40 @@ func TestNewSourceProvider_UsesDeclaredRoleForProducerEvents(t *testing.T) {
 	if got := provider.ProducerEventsForRole("agent-instance-1"); len(got) != 0 {
 		t.Fatalf("ProducerEventsForRole(agent-instance-1) = %#v, want nil/empty", got)
 	}
+}
+
+func TestNewSourceProvider_UsesEffectiveDeclaredNameForMailboxRole(t *testing.T) {
+	provider := NewSourceProvider(authorityTestSource(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker"},
+		},
+	}))
+
+	if err := provider.AuthorizeMailboxSend(models.AgentConfig{Role: "public-worker"}); err != nil {
+		t.Fatalf("effective declared name mailbox authority: %v", err)
+	}
+	if err := provider.AuthorizeMailboxSend(models.AgentConfig{Role: "local-worker"}); err == nil {
+		t.Fatal("local declaration coordinate retained mailbox authority")
+	}
+}
+
+func authorityTestSource(bundle *runtimecontracts.WorkflowContractBundle) semanticview.Source {
+	if bundle == nil {
+		return nil
+	}
+	if bundle.URIRegistry.Agents == nil {
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
+	}
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	for localID := range bundle.Agents {
+		uri := "swarm-test://root/agents/" + localID
+		ref := runtimecontracts.ContractURIRef{Kind: "agent", LocalID: localID, Full: uri}
+		bundle.URIRegistry.Agents[localID] = ref
+		bundle.URIRegistry.ByURI[uri] = ref
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func TestNewSourceProvider_UsesEffectiveSystemNodeProduces(t *testing.T) {
@@ -74,7 +108,7 @@ func TestNewSourceProvider_UsesEffectiveSystemNodeProduces(t *testing.T) {
 }
 
 func TestNewSourceProvider_AuthorityMatrix(t *testing.T) {
-	provider := NewSourceProvider(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	provider := NewSourceProvider(authorityTestSource(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"control-plane": {ID: "control-plane", Role: "control-plane"},
 			"reviewer":      {ID: "reviewer", Role: "reviewer", ManagerFallback: "control-plane"},
@@ -130,7 +164,7 @@ func TestNewSourceProvider_AuthorityMatrix(t *testing.T) {
 }
 
 func TestMessageSelfAuthorityRequiresExactConcreteIdentity(t *testing.T) {
-	provider := NewSourceProvider(semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	provider := NewSourceProvider(authorityTestSource(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"worker": {ID: "worker", Role: "worker"},
 		},

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -206,6 +206,7 @@ type checkerContext struct {
 }
 
 var bootCheckRegistry = []Check{
+	{ID: "declared_agent_name_valid", Severity: SeverityHardInvalidity, Run: checkDeclaredAgentNameValid},
 	{ID: "event_metadata_authority", Severity: SeverityHardInvalidity, Run: checkEventMetadataAuthority},
 	{ID: "event_chain_integrity", Severity: "warning", Run: checkEventChainIntegrity},
 	{ID: semanticview.TypedPubSubFailureAuthorizationAmbiguous, Severity: SeverityHardInvalidity, Run: checkTypedPubSubAuthorization},
@@ -284,6 +285,22 @@ var bootCheckRegistry = []Check{
 	{ID: "select_entity_validation", Severity: "error", Run: checkSelectEntityValidation},
 	{ID: "flow_boundary_create_entity_validation", Severity: "error", Run: checkFlowBoundaryCreateEntityValidation},
 	{ID: "flow_data_access_validation", Severity: "error", Run: checkFlowDataAccessValidation},
+}
+
+func checkDeclaredAgentNameValid(c *checkerContext) []Finding {
+	if c == nil || c.source == nil {
+		return nil
+	}
+	if _, err := semanticview.AgentNamePlans(c.source); err != nil {
+		return []Finding{{
+			CheckID:     "declared_agent_name_valid",
+			Severity:    SeverityHardInvalidity,
+			Message:     err.Error(),
+			Location:    "agents",
+			Remediation: stableHardInvalidityRemediation["declared_agent_name_valid"],
+		}}
+	}
+	return nil
 }
 
 var supplementalChecks = []Check{
@@ -1547,38 +1564,32 @@ func mergedAgentPermissionWarnings(source semanticview.Source) []permissionWarni
 	if source == nil {
 		return nil
 	}
-	agents := source.AgentEntries()
-	ids := make([]string, 0, len(agents))
-	for agentID := range agents {
-		agentID = strings.TrimSpace(agentID)
-		if agentID != "" {
-			ids = append(ids, agentID)
+	declarations := semanticview.AgentDeclarations(source)
+	out := make([]permissionWarning, 0, len(declarations))
+	for _, declaration := range declarations {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			out = append(out, permissionWarning{Message: err.Error()})
+			continue
 		}
-	}
-	sort.Strings(ids)
-	out := make([]permissionWarning, 0, len(ids))
-	for _, agentID := range ids {
-		agent := agents[agentID]
-		flowID := ""
-		if sourceInfo, ok := source.AgentContractSource(agentID); ok {
-			flowID = strings.TrimSpace(sourceInfo.FlowID)
-		}
-		scopeLabel := validationFlowLabel(flowID)
-		policy := source.ResolvedPolicyForFlow(flowID)
-		out = append(out, agentPermissionWarningsLocal(source, scopeLabel, agentID, agent, policy)...)
+		scopeLabel := validationFlowLabel(plan.OwnerFlowID)
+		policy := source.ResolvedPolicyForFlow(plan.OwnerFlowID)
+		out = append(out, agentPermissionWarningsLocal(source, scopeLabel, plan.AgentID, declaration, policy)...)
 	}
 	return out
 }
 
-func agentPermissionWarningsLocal(source semanticview.Source, scopeLabel, agentID string, agent runtimecontracts.AgentRegistryEntry, policy runtimecontracts.PolicyDocument) []permissionWarning {
+func agentPermissionWarningsLocal(source semanticview.Source, scopeLabel, agentID string, declaration semanticview.AgentDeclaration, policy runtimecontracts.PolicyDocument) []permissionWarning {
 	if source == nil {
 		return nil
 	}
+	agent := declaration.Entry
 	perms, err := resolvedAgentPermissionsLocal(agent, policy)
 	if err != nil {
 		return []permissionWarning{{Message: fmt.Sprintf("%s/%s permissions resolution failed: %v", strings.TrimSpace(scopeLabel), strings.TrimSpace(agentID), err)}}
 	}
 	permSet := stringSet(perms)
+	projection, projected := semanticview.ScopedAgentContractProjection(source, declaration)
 	tools := agent.ConfiguredTools()
 	out := make([]permissionWarning, 0, len(tools))
 	for _, toolID := range tools {
@@ -1586,7 +1597,10 @@ func agentPermissionWarningsLocal(source semanticview.Source, scopeLabel, agentI
 		if toolID == "" {
 			continue
 		}
-		entry, _ := source.ToolEntryForAgent(agentID, toolID)
+		if !projected {
+			continue
+		}
+		entry, _ := projection.ToolEntry(toolID)
 		required := entry.Permission().String()
 		if required == "" {
 			continue

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -66,8 +66,8 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 78 {
-		t.Fatalf("bootCheckRegistry count = %d, want 78", got)
+	if got := len(bootCheckRegistry); got != 79 {
+		t.Fatalf("bootCheckRegistry count = %d, want 79", got)
 	}
 }
 

--- a/internal/runtime/bootverify/report.go
+++ b/internal/runtime/bootverify/report.go
@@ -49,6 +49,7 @@ var stableHardInvalidityRemediation = map[string]string{
 	"contained_state_operation_compliance":    "Fix contained state operations so they target declared contained-state fields through supported syntax.",
 	"credential_key_exists":                   "Configure the required credential or fix access to the credential store used by verifier credential checks.",
 	"data_accumulation_expression_validation": "Fix the data_accumulation expression so it references declared fields and uses supported CEL syntax.",
+	"declared_agent_name_valid":               "Give every agent declaration one scoped URI owner and one non-empty literal public name, or remove the invalid declaration.",
 	"dialect_compliance":                      "Replace the unsupported contract dialect form with the promoted platform-spec shape or remove it.",
 	"emit_field_expression_validation":        "Fix the emit field expression so it references declared fields and uses supported CEL syntax.",
 	"entity_write_target_compliance":          "Update the entity write target to a declared writable entity field or remove the invalid write.",

--- a/internal/runtime/bootverify/report_test.go
+++ b/internal/runtime/bootverify/report_test.go
@@ -20,6 +20,7 @@ import (
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/requiredagentsparentconnect"
 	"gopkg.in/yaml.v3"
@@ -147,7 +148,7 @@ func TestRun_DoesNotWarnForBuiltinRuntimeToolReference(t *testing.T) {
 	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 		"agent-1": {ID: "agent-1", Tools: []string{"schedule"}, Permissions: []string{"schedule"}},
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 
 	report := Run(context.Background(), source, Options{})
 
@@ -156,6 +157,58 @@ func TestRun_DoesNotWarnForBuiltinRuntimeToolReference(t *testing.T) {
 	}
 	if reportContains(report.Warnings(), "tool_resolution", "schedule") {
 		t.Fatalf("unexpected tool_resolution warning for builtin runtime tool, got %#v", report.Warnings())
+	}
+}
+
+func TestScopedLiteralAgentToolResolutionMatchesRuntimeAndPermissionOwner(t *testing.T) {
+	tool := func(description, permission string) runtimecontracts.ToolSchemaEntry {
+		return runtimecontracts.MustToolSchemaEntry(
+			runtimecontracts.WithToolDescription(description),
+			runtimecontracts.WithToolPermission(permission),
+			runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerPlatformBuiltin),
+			runtimecontracts.WithToolSchemas(
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+			),
+		)
+	}
+	alpha := runtimecontracts.FlowContractView{
+		Path:  "alpha",
+		Paths: runtimecontracts.FlowContractPaths{ID: "alpha", Flow: "alpha"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker", Tools: []string{"shared-tool"}, Permissions: []string{"alpha-permission"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("alpha tool", "alpha-permission")},
+	}
+	beta := runtimecontracts.FlowContractView{
+		Path:  "beta",
+		Paths: runtimecontracts.FlowContractPaths{ID: "beta", Flow: "beta"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker", Tools: []string{"shared-tool"}, Permissions: []string{"beta-permission"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("beta tool", "beta-permission")},
+	}
+	refs := map[string]runtimecontracts.ContractURIRef{
+		"alpha/local-worker": {Kind: "agent", FlowID: "alpha", LocalID: "local-worker", Full: "test://alpha/local-worker"},
+		"beta/local-worker":  {Kind: "agent", FlowID: "beta", LocalID: "local-worker", Full: "test://beta/local-worker"},
+	}
+	byURI := map[string]runtimecontracts.ContractURIRef{}
+	for _, ref := range refs {
+		byURI[ref.Full] = ref
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{alpha, beta}},
+			ByID: map[string]*runtimecontracts.FlowContractView{"alpha": &alpha, "beta": &beta},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{Agents: refs, ByURI: byURI},
+	})
+	checker := newCheckerContext(context.Background(), source, Options{})
+	if findings := checker.toolResolution(); len(findings) != 0 {
+		t.Fatalf("scoped tool resolution findings = %#v", findings)
+	}
+	if warnings := mergedAgentPermissionWarnings(source); len(warnings) != 0 {
+		t.Fatalf("scoped permission warnings = %#v", warnings)
 	}
 }
 
@@ -234,7 +287,7 @@ func TestRun_FailsClosedForMissingDiscoveredMCPTool(t *testing.T) {
 	}))
 	defer server.Close()
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				Tools: []string{"infra.missing"},
@@ -298,7 +351,7 @@ func TestRun_FailsClosedForMissingContractMCPTool(t *testing.T) {
 	}))
 	defer server.Close()
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {Tools: []string{"infra.missing"}},
 		},
@@ -362,7 +415,7 @@ func TestRun_FailsClosedForRequiredMCPToolWhenDiscoveryFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {Tools: []string{"infra.ping"}},
 		},
@@ -395,7 +448,7 @@ func TestRun_FailsClosedForPrefixOnlyRequiredMCPToolWhenDiscoveryDisabled(t *tes
 	}))
 	defer server.Close()
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {Tools: []string{"infra.ping"}},
 		},
@@ -526,7 +579,7 @@ func TestRun_SkipsMCPServerReachableWhenReachabilityCheckDisabled(t *testing.T) 
 }
 
 func TestRun_MapsPlatformToolUsageHintCoverageToBootCheck(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Tools: map[string]runtimecontracts.ToolSchemaEntry{
 			"custom_platform_tool": runtimecontracts.MustToolSchemaEntry(runtimecontracts.WithToolHandler(runtimecontracts.MustToolHandlerKind("platform_builtin")), runtimecontracts.WithToolSchemas(runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject), runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject))),
 		},
@@ -540,7 +593,7 @@ func TestRun_MapsPlatformToolUsageHintCoverageToBootCheck(t *testing.T) {
 }
 
 func TestRun_MapsGeneratedToolSchemaClosureToBootCheck(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := semanticviewtest.WrapRootAgents(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {ID: "agent-1", Role: "agent", EmitEvents: []string{"ready.event"}},
 		},
@@ -3533,6 +3586,7 @@ func TestRun_MapsReservedPlatformNamespaceInAgentEmitEventsToNamedCheck(t *testi
 	agent := bundle.Agents["intake-agent"]
 	agent.EmitEvents = []string{"platform.forbidden"}
 	bundle.Agents["intake-agent"] = agent
+	addBootverifyAgentOwner(bundle, "", "", "intake-agent")
 	source := semanticview.Wrap(bundle)
 
 	report := Run(context.Background(), source, Options{})
@@ -4435,6 +4489,7 @@ func TestRun_RejectsHarnessInputWithInternalOrPlatformProducer(t *testing.T) {
 		bundle := loadTier8FixtureBundle(t, "test-boot-missing-pin")
 		markFlowInputPinSource(t, bundle, "child", "task.feedback", "harness")
 		bundle.Agents["lifecycle-coordinator"] = runtimecontracts.AgentRegistryEntry{ID: "lifecycle-coordinator", EmitEvents: []string{"task.feedback"}}
+		addBootverifyAgentOwner(bundle, "", "", "lifecycle-coordinator")
 		report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 		if !reportContains(report.Errors(), "input_pin_wiring", "source: harness and another accepted producer source") ||
 			!reportContains(report.Errors(), "input_pin_wiring", "internal") {
@@ -4523,6 +4578,7 @@ func TestRun_DoesNotErrorForRootAgentEmitInputProducerPath(t *testing.T) {
 		ID:         "lifecycle-coordinator",
 		EmitEvents: []string{"task.feedback"},
 	}
+	addBootverifyAgentOwner(bundle, "", "", "lifecycle-coordinator")
 
 	report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 
@@ -4734,6 +4790,7 @@ func TestRun_RejectsExactQualifiedNodeAndAgentSubscriptions(t *testing.T) {
 						bundle.FlowTree.Root.Nodes["listener"] = listener
 					case "agent":
 						bundle.Agents["retired-agent"] = runtimecontracts.AgentRegistryEntry{ID: "retired-agent", Subscriptions: []string{authored}}
+						addBootverifyAgentOwner(bundle, "", "", "retired-agent")
 					}
 
 					report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
@@ -4824,6 +4881,9 @@ func TestRun_ExactSubscriptionAdmissionPreservesOnlySameScopeAgentException(t *t
 				Root: &root,
 				ByID: map[string]*runtimecontracts.FlowContractView{"child": &root.Children[0]},
 			}}
+			if tc.kind == "agent" {
+				addBootverifyAgentOwner(bundle, "child", "child", "observer")
+			}
 
 			report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
 			gotInvalid := reportContains(report.HardInvalidities(), "legacy_qualified_subscription", tc.authored)
@@ -4832,6 +4892,32 @@ func TestRun_ExactSubscriptionAdmissionPreservesOnlySameScopeAgentException(t *t
 			}
 		})
 	}
+}
+
+func addBootverifyAgentOwner(bundle *runtimecontracts.WorkflowContractBundle, flowID, path, localID string) {
+	if bundle == nil {
+		return
+	}
+	if bundle.URIRegistry.Agents == nil {
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
+	}
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	absolute := strings.Trim(strings.TrimSpace(path), "/")
+	if absolute != "" {
+		absolute += "/"
+	}
+	absolute += strings.TrimSpace(localID)
+	uri := "swarm-test://" + absolute
+	ref := runtimecontracts.ContractURIRef{Kind: "agent", FlowID: strings.TrimSpace(flowID), LocalID: strings.TrimSpace(localID), Path: strings.Trim(strings.TrimSpace(path), "/"), Absolute: absolute, Full: uri}
+	key := strings.TrimSpace(localID)
+	if strings.TrimSpace(flowID) != "" {
+		key = strings.TrimSpace(flowID) + "/" + key
+	}
+	bundle.URIRegistry.Agents[key] = ref
+	bundle.URIRegistry.ByURI[absolute] = ref
+	bundle.URIRegistry.ByURI[uri] = ref
 }
 
 func TestRun_ReportsExpressionFieldReferenceWarning(t *testing.T) {
@@ -6550,8 +6636,8 @@ func TestRun_ReportsMissingRuntimeExecutorForOwnedRuntimeEvent(t *testing.T) {
 }
 
 func TestBootCheckRegistry_HasSpecCheckCount(t *testing.T) {
-	if got := len(bootCheckRegistry); got != 78 {
-		t.Fatalf("bootCheckRegistry count = %d, want 78", got)
+	if got := len(bootCheckRegistry); got != 79 {
+		t.Fatalf("bootCheckRegistry count = %d, want 79", got)
 	}
 	if got := len(supplementalChecks); got != 3 {
 		t.Fatalf("supplementalChecks count = %d, want 3", got)

--- a/internal/runtime/bootverify/runtime_tool_surface_checks.go
+++ b/internal/runtime/bootverify/runtime_tool_surface_checks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
@@ -27,18 +28,25 @@ func (c *checkerContext) toolResolution() []Finding {
 	// Boot tool warnings must consume the same runtime inventory truth that the
 	// generic runtime ships, then layer MCP discovery on top of it.
 	runtimeToolNames := c.runtimeAvailableToolNames()
-	for agentID, agent := range c.source.AgentEntries() {
-		agentID = strings.TrimSpace(agentID)
+	for _, declaration := range semanticview.AgentDeclarations(c.source) {
+		plan, err := semanticview.ScopedAgentNamePlan(c.source, declaration)
+		if err != nil {
+			continue
+		}
+		projection, projected := semanticview.ScopedAgentContractProjection(c.source, declaration)
+		agent := declaration.Entry
 		for _, toolID := range agent.ConfiguredTools() {
 			toolID = strings.TrimSpace(toolID)
 			if toolID == "" {
 				continue
 			}
-			if runtimetools.IsAgentRequiredMCPToolReference(c.source, agentID, toolID) {
+			if runtimetools.IsAgentRequiredMCPToolReference(c.source, declaration, toolID) {
 				continue
 			}
-			if _, ok := c.source.ToolEntryForAgent(agentID, toolID); ok {
-				continue
+			if projected {
+				if _, ok := projection.ToolEntry(toolID); ok {
+					continue
+				}
 			}
 			if runtimetools.MCPToolDiscovered(toolID, discoveredTools) {
 				continue
@@ -49,8 +57,8 @@ func (c *checkerContext) toolResolution() []Finding {
 			c.toolFindings = append(c.toolFindings, Finding{
 				CheckID:  "tool_resolution",
 				Severity: "warning",
-				Message:  fmt.Sprintf("agent %s references missing tool %s", agentID, toolID),
-				Location: agentID,
+				Message:  fmt.Sprintf("agent %s references missing tool %s", plan.AgentID, toolID),
+				Location: plan.AgentID,
 			})
 		}
 	}

--- a/internal/runtime/bootverify/workflow_event_metadata_authority_checks.go
+++ b/internal/runtime/bootverify/workflow_event_metadata_authority_checks.go
@@ -107,11 +107,13 @@ func eventMetadataInternalActorNames(source semanticview.Source) eventMetadataNa
 			names.add(id, fmt.Sprintf("system node %s", id))
 		}
 	}
-	for agentKey, agent := range source.AgentEntries() {
-		agentKey = strings.TrimSpace(agentKey)
-		names.add(agentKey, fmt.Sprintf("agent %s", agentKey))
-		names.add(agent.ID, fmt.Sprintf("agent %s", strings.TrimSpace(agent.ID)))
-		names.add(agent.Role, fmt.Sprintf("agent role %s", strings.TrimSpace(agent.Role)))
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			continue
+		}
+		names.add(plan.AgentID, fmt.Sprintf("agent %s", plan.AgentID))
+		names.add(declaration.Entry.Role, fmt.Sprintf("agent role %s", strings.TrimSpace(declaration.Entry.Role)))
 	}
 	for _, required := range source.RequiredAgents() {
 		names.add(required.Role, fmt.Sprintf("required agent role %s", strings.TrimSpace(required.Role)))
@@ -245,7 +247,7 @@ func eventMetadataAddEndpointRole(source semanticview.Source, names eventMetadat
 		if endpoint.Direction == semanticview.EventEndpointProducer {
 			role = "emit_events"
 		}
-		eventMetadataAddAgentRole(names, endpoint.AgentID, source.AgentEntries()[endpoint.AgentID], role)
+		eventMetadataAddAgentRole(names, endpoint.AgentID, endpoint.Role, role)
 	case semanticview.EventEndpointRequiredAgentRole:
 		role := "subscribes_to"
 		if endpoint.Direction == semanticview.EventEndpointProducer {
@@ -280,15 +282,14 @@ func eventMetadataAddNodeRole(names eventMetadataNameIndex, nodeKey string, node
 	}
 }
 
-func eventMetadataAddAgentRole(names eventMetadataNameIndex, agentKey string, agent runtimecontracts.AgentRegistryEntry, role string) {
+func eventMetadataAddAgentRole(names eventMetadataNameIndex, agentKey, agentRole, role string) {
 	agentKey = strings.TrimSpace(agentKey)
 	role = strings.TrimSpace(role)
 	if role == "" {
 		role = "topology"
 	}
 	names.add(agentKey, fmt.Sprintf("agent %s %s", agentKey, role))
-	names.add(agent.ID, fmt.Sprintf("agent %s %s", strings.TrimSpace(agent.ID), role))
-	names.add(agent.Role, fmt.Sprintf("agent role %s %s", strings.TrimSpace(agent.Role), role))
+	names.add(agentRole, fmt.Sprintf("agent role %s %s", strings.TrimSpace(agentRole), role))
 }
 
 func eventMetadataAddFlowRole(names eventMetadataNameIndex, flowID, pinName, role string) {

--- a/internal/runtime/bootverify/workflow_timer_checks.go
+++ b/internal/runtime/bootverify/workflow_timer_checks.go
@@ -498,8 +498,12 @@ func participantExistsLocal(source semanticview.Source, participant string) bool
 	if _, ok := source.NodeEntries()[participant]; ok {
 		return true
 	}
-	for _, agent := range source.AgentEntries() {
-		if strings.TrimSpace(agent.ID) == participant || strings.TrimSpace(agent.Role) == participant {
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			continue
+		}
+		if plan.AgentID == participant || strings.TrimSpace(declaration.Entry.Role) == participant {
 			return true
 		}
 	}

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -137,12 +137,12 @@ type routeFlowTemplate struct {
 }
 
 type routeSubscriberTemplate struct {
-	IDTemplate     string
-	Kind           subscriberKind
-	RawPatterns    []string
-	AgentNameOwner string
-	HandlerFlowID  string
-	HandlerNodeID  string
+	IDTemplate    string
+	Kind          subscriberKind
+	RawPatterns   []string
+	AgentNamePlan semanticview.AgentNamePlan
+	HandlerFlowID string
+	HandlerNodeID string
 }
 
 type subscriberKind uint8
@@ -203,11 +203,18 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	if source == nil {
 		return rt, nil
 	}
+	if _, err := semanticview.AgentNamePlans(source); err != nil {
+		return nil, fmt.Errorf("compile declared agent names: %w", err)
+	}
 	if err := validateTypedPubSubAuthorizations(source); err != nil {
 		return nil, err
 	}
 
 	for _, scope := range semanticview.ProjectScopes(source) {
+		agentNamePlans, err := routeProjectAgentNamePlans(source, scope)
+		if err != nil {
+			return nil, err
+		}
 		localEvents := routeProjectLocalEventSet(scope)
 		agentFlowID := strings.TrimSpace(scope.OwningFlowID)
 		agentPath := ""
@@ -233,7 +240,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 			handlerFlowID = strings.TrimSpace(source.WorkflowName())
 		}
 		rt.addAuthoredEventPathsLocked(basePath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, agentFlowID, inputEvents, basePath, agentPath, localEvents, scope.Agents); err != nil {
+		if err := rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, agentFlowID, inputEvents, basePath, agentPath, localEvents, scope.Agents, agentNamePlans); err != nil {
 			return nil, err
 		}
 		if err := rt.addNodePatternsLocked(source, scope.Key, owningFlowID, agentFlowID, handlerFlowID, inputEvents, basePath, localEvents, scope.Nodes); err != nil {
@@ -242,6 +249,10 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	}
 
 	for _, scope := range semanticview.FlowScopes(source) {
+		agentNamePlans, err := routeFlowAgentNamePlans(source, scope)
+		if err != nil {
+			return nil, err
+		}
 		flowPath := routeFlowPath(source, scope.ID)
 		localEvents := routeFlowLocalEventSet(source, scope)
 		if strings.EqualFold(scope.Mode, "template") || routeFlowStanding(source, scope.ID) {
@@ -262,7 +273,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 			rt.authoredScopes[flowPath] = struct{}{}
 		}
 		rt.addAuthoredEventPathsLocked(flowPath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, scope.PackageKey, scope.ID, scope.ID, scope.InputEvents, flowPath, flowPath, localEvents, scope.Agents); err != nil {
+		if err := rt.addAgentPatternsLocked(source, scope.PackageKey, scope.ID, scope.ID, scope.InputEvents, flowPath, flowPath, localEvents, scope.Agents, agentNamePlans); err != nil {
 			return nil, err
 		}
 		if err := rt.addNodePatternsLocked(source, scope.PackageKey, scope.ID, scope.ID, scope.ID, scope.InputEvents, flowPath, localEvents, scope.Nodes); err != nil {
@@ -451,7 +462,17 @@ func (rt *RouteTable) addFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 	rt.materializeTemplateSourceObserversLocked(templateScope, instancePath)
 	vars := flowInstanceRouteMaterializationVars(req, templateDef.FlowID)
 	for _, subscriberTemplate := range templateDef.Subscribers {
-		recipient, err := subscriberRecipient(subscriberTemplate.Kind, routeRenderTemplate(subscriberTemplate.IDTemplate, vars))
+		subscriberID := routeRenderTemplate(subscriberTemplate.IDTemplate, vars)
+		var name agentidentity.Name
+		var err error
+		if subscriberTemplate.Kind == subscriberAgent {
+			name, err = subscriberTemplate.AgentNamePlan.Materialize()
+			if err != nil {
+				return fmt.Errorf("materialize route subscriber agent name: %w", err)
+			}
+			subscriberID = name.AgentID
+		}
+		recipient, err := subscriberRecipient(subscriberTemplate.Kind, subscriberID)
 		if err != nil {
 			return fmt.Errorf("materialize route subscriber: %w", err)
 		}
@@ -460,10 +481,6 @@ func (rt *RouteTable) addFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 			handlerFlowID: subscriberTemplate.HandlerFlowID, handlerNodeID: subscriberTemplate.HandlerNodeID,
 		}
 		if subscriber.Recipient.IsAgent() {
-			name, err := agentidentity.DeclaredName(subscriber.Recipient.ID(), subscriberTemplate.AgentNameOwner)
-			if err != nil {
-				return fmt.Errorf("materialize route subscriber agent identity: %w", err)
-			}
 			agentRoute, err := identity.AgentIdentityRoute()
 			if err != nil {
 				return fmt.Errorf("materialize route subscriber flow identity: %w", err)
@@ -1004,6 +1021,30 @@ func routeCanonicalPathsOverlap(left, right string) bool {
 	return left == right || strings.HasPrefix(left, right+"/") || strings.HasPrefix(right, left+"/")
 }
 
+func routeProjectAgentNamePlans(source semanticview.Source, scope semanticview.ProjectScope) (map[string]semanticview.AgentNamePlan, error) {
+	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
+	for _, key := range sortedStringKeys(scope.Agents) {
+		plan, err := semanticview.ProjectAgentNamePlan(source, scope, key)
+		if err != nil {
+			return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, key, err)
+		}
+		plans[key] = plan
+	}
+	return plans, nil
+}
+
+func routeFlowAgentNamePlans(source semanticview.Source, scope semanticview.FlowScope) (map[string]semanticview.AgentNamePlan, error) {
+	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
+	for _, key := range sortedStringKeys(scope.Agents) {
+		plan, err := semanticview.FlowAgentNamePlan(source, scope, key)
+		if err != nil {
+			return nil, fmt.Errorf("flow scope %q agent %s declaration name: %w", scope.ID, key, err)
+		}
+		plans[key] = plan
+	}
+	return plans, nil
+}
+
 func (rt *RouteTable) addAgentPatternsLocked(
 	source semanticview.Source,
 	packageKey, routingFlowID, agentFlowID string,
@@ -1011,20 +1052,21 @@ func (rt *RouteTable) addAgentPatternsLocked(
 	basePath, agentPath string,
 	localEvents map[string]struct{},
 	agents map[string]runtimecontracts.AgentRegistryEntry,
+	agentNamePlans map[string]semanticview.AgentNamePlan,
 ) error {
 	for _, key := range sortedStringKeys(agents) {
 		entry := agents[key]
-		subscriber := Subscriber{
-			Recipient: events.MustAgentDeliveryRecipient(strings.TrimSpace(entry.ID)),
-			Path:      strings.Trim(strings.TrimSpace(agentPath), "/"),
-		}
-		owner, ok := semanticview.AgentDeclarationOwner(source, agentFlowID, key)
+		namePlan, ok := agentNamePlans[key]
 		if !ok {
-			return fmt.Errorf("route subscriber agent %s missing scoped declaration owner", key)
+			return fmt.Errorf("route subscriber agent %s has no exact scoped declaration name", key)
 		}
-		name, err := agentidentity.DeclaredName(subscriber.Recipient.ID(), owner)
+		name, err := namePlan.Materialize()
 		if err != nil {
 			return fmt.Errorf("route subscriber agent %s declaration identity: %w", key, err)
+		}
+		subscriber := Subscriber{
+			Recipient: events.MustAgentDeliveryRecipient(name.AgentID),
+			Path:      strings.Trim(strings.TrimSpace(agentPath), "/"),
 		}
 		route := agentidentity.RootRoute()
 		if subscriber.Path != "" {
@@ -1387,15 +1429,20 @@ func routeSubscriberTemplates(source semanticview.Source, scope semanticview.Flo
 				return nil, fmt.Errorf("route subscriber agent %s: %s", key, admission.Message())
 			}
 		}
-		owner, ok := semanticview.AgentDeclarationOwner(source, scope.ID, key)
-		if !ok {
-			return nil, fmt.Errorf("route subscriber template agent %s missing scoped declaration owner", key)
+		namePlan, err := semanticview.FlowAgentNamePlan(source, scope, key)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"flow %q agent subscriber %q subscriptions %q has no valid declared name: %w; remediation: omit id to use the declaration key or author one non-empty literal id",
+				scope.ID,
+				key,
+				strings.Join(patterns, ","),
+				err,
+			)
 		}
 		out = append(out, routeSubscriberTemplate{
-			IDTemplate:     strings.TrimSpace(entry.ID),
-			Kind:           subscriberAgent,
-			RawPatterns:    append([]string{}, patterns...),
-			AgentNameOwner: owner,
+			Kind:          subscriberAgent,
+			RawPatterns:   append([]string{}, patterns...),
+			AgentNamePlan: namePlan,
 		})
 	}
 	for _, key := range sortedStringKeys(scope.Nodes) {

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -146,7 +146,7 @@ func TestEventBusTemplateAgentSameScopeExactAdmissionRendersConcreteInstanceRout
 		t.Fatalf("AddFlowInstanceRoute: %v", err)
 	}
 	got := rt.Resolve(identity.InstancePath + "/opco.product_initialization_requested")
-	if len(got) != 1 || got[0].Recipient.ID() != "ceo-"+identity.InstanceID || got[0].AgentIdentity.FlowInstance() != identity.InstancePath {
+	if len(got) != 1 || got[0].Recipient.ID() != "ceo" || got[0].AgentIdentity.FlowInstance() != identity.InstancePath {
 		t.Fatalf("resolved subscribers = %#v, want concrete same-scope agent route", got)
 	}
 }
@@ -375,7 +375,7 @@ func TestEventBusStageFlowInstanceRouteKeepsPublicationManifestInvisibleUntilRea
 		t.Fatalf("Publish after readiness: %v", err)
 	}
 	got := store.deliveries[after.ID()]
-	if len(got) != 1 || got[0] != "ceo-11111111-1111-4111-8111-111111111111" {
+	if len(got) != 1 || got[0] != "ceo" {
 		t.Fatalf("post-readiness delivery recipients = %#v, want exact instantiated agent", got)
 	}
 }
@@ -739,8 +739,8 @@ func TestEventBusFlowInstanceRoutePersistsAndDeliversRenderedActivationConfigSub
 	if !ok {
 		t.Fatalf("persisted routes = %#v, want operating instance route", store.routes)
 	}
-	if route.SubscriberID != "ceo-11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("persisted subscriber_id = %q, want rendered ceo id", route.SubscriberID)
+	if route.SubscriberID != "ceo" {
+		t.Fatalf("persisted subscriber_id = %q, want stable declared ceo name", route.SubscriberID)
 	}
 
 	agentIdentity, admission := routeMaterializationAgentRoute(t, source, identity)
@@ -761,8 +761,8 @@ func TestEventBusFlowInstanceRoutePersistsAndDeliversRenderedActivationConfigSub
 		t.Fatalf("Publish: %v", err)
 	}
 	got := store.deliveries[evt.ID()]
-	if len(got) != 1 || got[0] != "ceo-11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("delivery recipients = %#v, want rendered ceo id", got)
+	if len(got) != 1 || got[0] != "ceo" {
+		t.Fatalf("delivery recipients = %#v, want stable declared ceo name", got)
 	}
 }
 
@@ -849,7 +849,7 @@ func TestRouteTableConcreteTemplateInstanceNodeSubscriberResolvesBeforeDeliveryP
 	}
 }
 
-func TestRouteTableFlowInstanceRouteRendersSubscriberWithActivationConfigVars(t *testing.T) {
+func TestRouteTableFlowInstanceRouteKeepsAgentNameStableAcrossActivationConfig(t *testing.T) {
 	rt, err := runtimebus.DeriveRouteTable(semanticview.Wrap(routeMaterializationConfigVarBundle()))
 	if err != nil {
 		t.Fatalf("DeriveRouteTable: %v", err)
@@ -868,8 +868,8 @@ func TestRouteTableFlowInstanceRouteRendersSubscriberWithActivationConfigVars(t 
 	if len(got) != 1 {
 		t.Fatalf("resolved subscribers = %#v, want one ceo route", got)
 	}
-	if got[0].Recipient.ID() != "ceo-11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("resolved subscriber id = %q, want rendered ceo id", got[0].Recipient.ID())
+	if got[0].Recipient.ID() != "ceo" {
+		t.Fatalf("resolved subscriber id = %q, want stable declared ceo name", got[0].Recipient.ID())
 	}
 	if got[0].AgentIdentity.AgentID() != got[0].Recipient.ID() || got[0].AgentIdentity.FlowInstance() != identity.InstancePath {
 		t.Fatalf("resolved subscriber identity = %#v, want exact first instance", got[0].AgentIdentity)
@@ -890,8 +890,51 @@ func TestRouteTableFlowInstanceRouteRendersSubscriberWithActivationConfigVars(t 
 		t.Fatalf("resolved sibling subscriber = %#v, want same slug with distinct concrete identity from %#v", sibling, got[0])
 	}
 	routes := rt.MaterializedRoutes(identity)
-	if len(routes) != 1 || routes[0].SubscriberID != "ceo-11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("materialized routes = %#v, want rendered ceo subscriber", routes)
+	if len(routes) != 1 || routes[0].SubscriberID != "ceo" {
+		t.Fatalf("materialized routes = %#v, want stable declared ceo subscriber", routes)
+	}
+}
+
+func TestRouteTableExplicitAgentNameChangesPublicNameNotScopedCoordinate(t *testing.T) {
+	bundle := routeMaterializationConfigVarBundle()
+	flow := bundle.FlowTree.ByID["operating"]
+	entry := flow.Agents["ceo"]
+	entry.ID = "executive"
+	flow.Agents["ceo"] = entry
+	source := semanticview.Wrap(bundle)
+
+	scope, ok := source.FlowScopeByID("operating")
+	if !ok {
+		t.Fatal("operating flow scope not found")
+	}
+	plan, err := semanticview.FlowAgentNamePlan(source, scope, "ceo")
+	if err != nil {
+		t.Fatalf("AgentNamePlanFor: %v", err)
+	}
+	if plan.LocalID != "ceo" || plan.AgentID != "executive" {
+		t.Fatalf("agent name plan = %#v, want local coordinate ceo and public name executive", plan)
+	}
+	routes, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	identities := []runtimeflowidentity.Route{
+		runtimeflowidentity.DeriveRoute("operating", "11111111-1111-4111-8111-111111111111"),
+		runtimeflowidentity.DeriveRoute("operating", "22222222-2222-4222-8222-222222222222"),
+	}
+	var concrete []agentidentity.Identity
+	for _, identity := range identities {
+		if err := routes.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: identity}); err != nil {
+			t.Fatalf("AddFlowInstanceRoute(%s): %v", identity.InstancePath, err)
+		}
+		got := routes.Resolve(identity.InstancePath + "/opco.product_initialization_requested")
+		if len(got) != 1 || got[0].Recipient.ID() != "executive" || got[0].AgentIdentity.FlowInstance() != identity.InstancePath {
+			t.Fatalf("resolved %s = %#v, want executive on exact instance", identity.InstancePath, got)
+		}
+		concrete = append(concrete, got[0].AgentIdentity)
+	}
+	if concrete[0] == concrete[1] {
+		t.Fatalf("sibling concrete identities collapsed: %#v", concrete)
 	}
 }
 
@@ -939,7 +982,6 @@ func routeMaterializationConfigVarBundle() *runtimecontracts.WorkflowContractBun
 		},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"ceo": {
-				ID:            "ceo-{vertical_id}",
 				Type:          "generic",
 				Role:          "ceo",
 				Subscriptions: []string{"opco.product_initialization_requested"},
@@ -983,14 +1025,17 @@ func routeMaterializationAgentRoute(
 	route runtimeflowidentity.Route,
 ) (agentidentity.Identity, semanticview.FlowOwnedAgentSubscriptionAdmission) {
 	t.Helper()
-	const agentID = "ceo-11111111-1111-4111-8111-111111111111"
-	owner, ok := semanticview.AgentDeclarationOwner(source, "operating", "ceo")
+	scope, ok := source.FlowScopeByID("operating")
 	if !ok {
-		t.Fatal("resolve operating/ceo declaration owner")
+		t.Fatal("operating flow scope not found")
 	}
-	name, err := agentidentity.DeclaredName(agentID, owner)
+	plan, err := semanticview.FlowAgentNamePlan(source, scope, "ceo")
 	if err != nil {
-		t.Fatalf("build rendered agent name: %v", err)
+		t.Fatalf("resolve operating/ceo declared name: %v", err)
+	}
+	name, err := plan.Materialize()
+	if err != nil {
+		t.Fatalf("materialize operating/ceo declared name: %v", err)
 	}
 	identityRoute, err := route.AgentIdentityRoute()
 	if err != nil {
@@ -1001,7 +1046,7 @@ func routeMaterializationAgentRoute(
 		t.Fatalf("build rendered agent identity: %v", err)
 	}
 	admission, err := semanticview.AdmitFlowOwnedAgentSubscriptions(nil, semanticview.FlowOwnedAgentSubscriptionRequest{
-		AgentID:  agentID,
+		AgentID:  plan.AgentID,
 		FlowID:   "operating",
 		FlowPath: route.InstancePath,
 	})

--- a/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
+++ b/internal/runtime/conformance/notify_all_children_runtime_conformance_test.go
@@ -970,109 +970,118 @@ func TestDynamicFlowTerminalizationAndRouteReplacementRollbackTogetherOnBothBack
 }
 
 func TestHandleEmitTool_TemplateAgentEmissionReachesSameInstanceNodeAndTerminalizesEntity(t *testing.T) {
-	for _, tc := range []struct {
-		name  string
-		setup func(*testing.T) (notifyAllChildrenStore, *sql.DB)
+	for _, nameCase := range []struct {
+		name    string
+		agentID string
+		opts    notifyallchildren.Options
 	}{
-		{
-			name: "postgres",
-			setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
-				_, db, cleanup := testutil.StartPostgres(t)
-				t.Cleanup(cleanup)
-				return storetest.AdmitPostgresRuntimeStore(t, db), db
-			},
-		},
-		{
-			name: "sqlite",
-			setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
-				backend := storetest.StartSQLiteRuntimeStore(t)
-				return backend, storetest.DatabaseForTest(backend)
-			},
-		},
+		{name: "omitted_id", agentID: "account-worker"},
+		{name: "literal_override", agentID: "account-handler", opts: notifyallchildren.Options{ExplicitAgentName: true}},
 	} {
-		for _, cardinality := range []int{1, 2, 3} {
-			t.Run(fmt.Sprintf("%s/n=%d", tc.name, cardinality), func(t *testing.T) {
-				ctx := testAuthorActivityContext(context.Background())
-				backend, db := tc.setup(t)
-				runID := uuid.NewString()
-				ctx = runtimecorrelation.WithRunID(ctx, runID)
-				source := notifyallchildren.LoadSource(t, notifyallchildren.Options{})
-				gate := newNotifyAllChildrenAgentGate()
-				runtime := newNotifyAllChildrenRuntime(
-					t,
-					backend,
-					db,
-					source,
-					time.Now,
-					notifyAllChildrenRuntimeOptions{realMockAgents: true, agentGate: gate},
-				)
-				t.Cleanup(func() {
-					if t.Failed() {
-						t.Logf("notify-all-children runtime diagnostics: %#v", runtime.diagnostics.snapshot())
+		for _, tc := range []struct {
+			name  string
+			setup func(*testing.T) (notifyAllChildrenStore, *sql.DB)
+		}{
+			{
+				name: "postgres",
+				setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
+					_, db, cleanup := testutil.StartPostgres(t)
+					t.Cleanup(cleanup)
+					return storetest.AdmitPostgresRuntimeStore(t, db), db
+				},
+			},
+			{
+				name: "sqlite",
+				setup: func(t *testing.T) (notifyAllChildrenStore, *sql.DB) {
+					backend := storetest.StartSQLiteRuntimeStore(t)
+					return backend, storetest.DatabaseForTest(backend)
+				},
+			},
+		} {
+			for _, cardinality := range []int{1, 2, 3} {
+				t.Run(fmt.Sprintf("%s/%s/n=%d", nameCase.name, tc.name, cardinality), func(t *testing.T) {
+					ctx := testAuthorActivityContext(context.Background())
+					backend, db := tc.setup(t)
+					runID := uuid.NewString()
+					ctx = runtimecorrelation.WithRunID(ctx, runID)
+					source := notifyallchildren.LoadSource(t, nameCase.opts)
+					gate := newNotifyAllChildrenAgentGate()
+					runtime := newNotifyAllChildrenRuntime(
+						t,
+						backend,
+						db,
+						source,
+						time.Now,
+						notifyAllChildrenRuntimeOptions{realMockAgents: true, agentGate: gate},
+					)
+					t.Cleanup(func() {
+						if t.Failed() {
+							t.Logf("notify-all-children runtime diagnostics: %#v", runtime.diagnostics.snapshot())
+						}
+					})
+					if err := runtime.manager.Run(managedConformanceExecutionContext(t, ctx, "notify-all-children-fixed-slug")); err != nil {
+						t.Fatalf("run manager: %v", err)
+					}
+
+					publishNotifyAllChildrenRunCreatingEvent(t, ctx, runtime.bus, source, runID, "portfolio.opened", map[string]any{
+						"portfolio_id": "portfolio-main",
+					})
+					accountIDs := make([]string, 0, cardinality)
+					for i := 0; i < cardinality; i++ {
+						accountIDs = append(accountIDs, fmt.Sprintf("acct-%d", i+1))
+					}
+					publishNotifyAllChildrenEvent(t, ctx, runtime.bus, source, runID, "portfolio.accounts.register.requested", map[string]any{
+						"portfolio_id": "portfolio-main",
+						"account_ids":  accountIDs,
+					})
+
+					descriptors := notifyAllChildrenAccountDescriptors(t, ctx, backend)
+					if len(descriptors) != cardinality {
+						t.Fatalf("active account descriptors = %#v, want %d", descriptors, cardinality)
+					}
+					assertNotifyAllChildrenConcreteAgentSet(t, ctx, backend, descriptors, nameCase.agentID)
+
+					blocked := descriptors[accountIDs[len(accountIDs)-1]].FlowInstance
+					gate.block(blocked)
+					publishNotifyAllChildrenEventAsync(t, ctx, runtime.bus, source, runID, "portfolio.notify.requested", map[string]any{
+						"portfolio_id": "portfolio-main",
+						"command":      "notify-every-account",
+					})
+					gate.waitStarted(t, blocked)
+
+					for _, accountID := range accountIDs[:len(accountIDs)-1] {
+						waitNotifyAllChildrenEntityState(t, ctx, backend, db, descriptors[accountID].FlowInstance, "completed")
+					}
+					if got := loadNotifyAllChildrenEntityState(t, ctx, backend, db, blocked); got != "active" {
+						t.Fatalf("blocked sibling status = %q, want active while another instance is terminal", got)
+					}
+					if _, err := runtime.manager.ResolveAgentConfig(nameCase.agentID, blocked); err != nil {
+						t.Fatalf("blocked sibling agent disappeared after another instance terminated: %v", err)
+					}
+					waitNotifyAllChildrenAgentDeliveryStatus(t, ctx, backend, db, runID, nameCase.agentID, blocked, "in_progress")
+
+					gate.release(blocked)
+					waitNotifyAllChildrenBus(t, runtime.bus)
+					for _, accountID := range accountIDs {
+						instancePath := descriptors[accountID].FlowInstance
+						waitNotifyAllChildrenEntityState(t, ctx, backend, db, instancePath, "completed")
+						waitNotifyAllChildrenAgentDeliveryStatus(t, ctx, backend, db, runID, nameCase.agentID, instancePath, "delivered")
+						assertNotifyAllChildrenAgentEmissionSettledToSameInstanceNode(t, ctx, db, tc.name, runID, nameCase.agentID, instancePath)
+						waitNotifyAllChildrenAgentAbsent(t, runtime.manager, nameCase.agentID, instancePath)
+					}
+					assertNotifyAllChildrenCompletedTurns(t, ctx, backend, db, runID, nameCase.agentID, cardinality)
+					if active, err := backend.LoadAgents(ctx); err != nil {
+						t.Fatalf("LoadAgents after independent terminalization: %v", err)
+					} else if len(active) != 0 {
+						t.Fatalf("active agents after independent terminalization = %#v, want none", active)
 					}
 				})
-				if err := runtime.manager.Run(managedConformanceExecutionContext(t, ctx, "notify-all-children-fixed-slug")); err != nil {
-					t.Fatalf("run manager: %v", err)
-				}
-
-				publishNotifyAllChildrenRunCreatingEvent(t, ctx, runtime.bus, source, runID, "portfolio.opened", map[string]any{
-					"portfolio_id": "portfolio-main",
-				})
-				accountIDs := make([]string, 0, cardinality)
-				for i := 0; i < cardinality; i++ {
-					accountIDs = append(accountIDs, fmt.Sprintf("acct-%d", i+1))
-				}
-				publishNotifyAllChildrenEvent(t, ctx, runtime.bus, source, runID, "portfolio.accounts.register.requested", map[string]any{
-					"portfolio_id": "portfolio-main",
-					"account_ids":  accountIDs,
-				})
-
-				descriptors := notifyAllChildrenAccountDescriptors(t, ctx, backend)
-				if len(descriptors) != cardinality {
-					t.Fatalf("active account descriptors = %#v, want %d", descriptors, cardinality)
-				}
-				assertNotifyAllChildrenConcreteAgentSet(t, ctx, backend, descriptors)
-
-				blocked := descriptors[accountIDs[len(accountIDs)-1]].FlowInstance
-				gate.block(blocked)
-				publishNotifyAllChildrenEventAsync(t, ctx, runtime.bus, source, runID, "portfolio.notify.requested", map[string]any{
-					"portfolio_id": "portfolio-main",
-					"command":      "notify-every-account",
-				})
-				gate.waitStarted(t, blocked)
-
-				for _, accountID := range accountIDs[:len(accountIDs)-1] {
-					waitNotifyAllChildrenEntityState(t, ctx, backend, db, descriptors[accountID].FlowInstance, "completed")
-				}
-				if got := loadNotifyAllChildrenEntityState(t, ctx, backend, db, blocked); got != "active" {
-					t.Fatalf("blocked sibling status = %q, want active while another instance is terminal", got)
-				}
-				if _, err := runtime.manager.ResolveAgentConfig("account-worker", blocked); err != nil {
-					t.Fatalf("blocked sibling agent disappeared after another instance terminated: %v", err)
-				}
-				waitNotifyAllChildrenAgentDeliveryStatus(t, ctx, backend, db, runID, blocked, "in_progress")
-
-				gate.release(blocked)
-				waitNotifyAllChildrenBus(t, runtime.bus)
-				for _, accountID := range accountIDs {
-					instancePath := descriptors[accountID].FlowInstance
-					waitNotifyAllChildrenEntityState(t, ctx, backend, db, instancePath, "completed")
-					waitNotifyAllChildrenAgentDeliveryStatus(t, ctx, backend, db, runID, instancePath, "delivered")
-					assertNotifyAllChildrenAgentEmissionSettledToSameInstanceNode(t, ctx, db, tc.name, runID, instancePath)
-					waitNotifyAllChildrenAgentAbsent(t, runtime.manager, instancePath)
-				}
-				assertNotifyAllChildrenCompletedTurns(t, ctx, backend, db, runID, cardinality)
-				if active, err := backend.LoadAgents(ctx); err != nil {
-					t.Fatalf("LoadAgents after independent terminalization: %v", err)
-				} else if len(active) != 0 {
-					t.Fatalf("active agents after independent terminalization = %#v, want none", active)
-				}
-			})
+			}
 		}
 	}
 }
 
-func assertNotifyAllChildrenAgentEmissionSettledToSameInstanceNode(t testing.TB, ctx context.Context, db *sql.DB, backend, runID, flowInstance string) {
+func assertNotifyAllChildrenAgentEmissionSettledToSameInstanceNode(t testing.TB, ctx context.Context, db *sql.DB, backend, runID, agentID, flowInstance string) {
 	t.Helper()
 	query := `
 		SELECT COUNT(*)
@@ -1080,16 +1089,17 @@ func assertNotifyAllChildrenAgentEmissionSettledToSameInstanceNode(t testing.TB,
 		JOIN event_deliveries d ON d.event_id = e.event_id
 		WHERE e.run_id = ?
 		  AND e.produced_by_type = 'agent'
-		  AND e.produced_by = 'account-worker'
+		  AND e.produced_by = ?
 		  AND e.flow_instance = ?
 		  AND d.subscriber_type = 'node'
 		  AND d.subscriber_id = 'account-node'
 		  AND d.status = 'delivered'
 		  AND e.route_settlement IS NOT NULL`
-	args := []any{runID, flowInstance}
+	args := []any{runID, agentID, flowInstance}
 	if backend == "postgres" {
 		query = strings.Replace(query, "e.run_id = ?", "e.run_id = $1::uuid", 1)
-		query = strings.Replace(query, "e.flow_instance = ?", "e.flow_instance = $2", 1)
+		query = strings.Replace(query, "e.produced_by = ?", "e.produced_by = $2", 1)
+		query = strings.Replace(query, "e.flow_instance = ?", "e.flow_instance = $3", 1)
 	}
 	var count int
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
@@ -1592,6 +1602,7 @@ func assertNotifyAllChildrenConcreteAgentSet(
 	ctx context.Context,
 	selected notifyAllChildrenStore,
 	descriptors map[string]runtimebus.ActiveFlowInstanceDescriptor,
+	agentID string,
 ) {
 	t.Helper()
 	agents, err := selected.LoadAgents(ctx)
@@ -1604,15 +1615,15 @@ func assertNotifyAllChildrenConcreteAgentSet(
 	}
 	var matched int
 	for _, agent := range agents {
-		if agent.Config.ID != "account-worker" {
+		if agent.Config.ID != agentID {
 			continue
 		}
 		identity, err := agent.Config.ConcreteIdentity()
 		if err != nil {
-			t.Fatalf("account-worker concrete identity: %v", err)
+			t.Fatalf("%s concrete identity: %v", agentID, err)
 		}
 		if _, ok := remaining[identity.FlowInstance()]; !ok {
-			t.Fatalf("account-worker has unexpected concrete route %#v", identity)
+			t.Fatalf("%s has unexpected concrete route %#v", agentID, identity)
 		}
 		delete(remaining, identity.FlowInstance())
 		matched++
@@ -1699,6 +1710,7 @@ func waitNotifyAllChildrenAgentDeliveryStatus(
 	backend notifyAllChildrenStore,
 	db *sql.DB,
 	runID string,
+	agentID string,
 	flowInstance string,
 	want string,
 ) {
@@ -1708,8 +1720,8 @@ func waitNotifyAllChildrenAgentDeliveryStatus(
 		FROM event_deliveries
 		WHERE run_id = $1::uuid
 		  AND subscriber_type = 'agent'
-		  AND subscriber_id = 'account-worker'
-		  AND agent_flow_instance_path = $2
+		  AND subscriber_id = $2
+		  AND agent_flow_instance_path = $3
 		ORDER BY created_at DESC, delivery_id DESC
 		LIMIT 1
 	`
@@ -1719,7 +1731,7 @@ func waitNotifyAllChildrenAgentDeliveryStatus(
 			FROM event_deliveries
 			WHERE run_id = ?
 			  AND subscriber_type = 'agent'
-			  AND subscriber_id = 'account-worker'
+			  AND subscriber_id = ?
 			  AND agent_flow_instance_path = ?
 			ORDER BY created_at DESC, delivery_id DESC
 			LIMIT 1
@@ -1731,14 +1743,15 @@ func waitNotifyAllChildrenAgentDeliveryStatus(
 		lastErr error
 	)
 	for time.Now().Before(deadline) {
-		lastErr = db.QueryRowContext(ctx, query, runID, flowInstance).Scan(&got)
+		lastErr = db.QueryRowContext(ctx, query, runID, agentID, flowInstance).Scan(&got)
 		if lastErr == nil && strings.TrimSpace(got) == want {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf(
-		"account-worker delivery at %s = %q err=%v, want %q",
+		"%s delivery at %s = %q err=%v, want %q",
+		agentID,
 		flowInstance,
 		strings.TrimSpace(got),
 		lastErr,
@@ -1752,28 +1765,30 @@ func assertNotifyAllChildrenCompletedTurns(
 	backend notifyAllChildrenStore,
 	db *sql.DB,
 	runID string,
+	agentID string,
 	wantInstances int,
 ) {
 	t.Helper()
 	query := `
 		SELECT COUNT(*), COUNT(DISTINCT flow_instance)
 		FROM agent_turns
-		WHERE run_id = $1::uuid AND agent_id = 'account-worker' AND failure IS NULL
+		WHERE run_id = $1::uuid AND agent_id = $2 AND failure IS NULL
 	`
 	if _, ok := backend.(*store.SQLiteRuntimeStore); ok {
 		query = `
 			SELECT COUNT(*), COUNT(DISTINCT flow_instance)
 			FROM agent_turns
-			WHERE run_id = ? AND agent_id = 'account-worker' AND failure IS NULL
+			WHERE run_id = ? AND agent_id = ? AND failure IS NULL
 		`
 	}
 	var turns, instances int
-	if err := db.QueryRowContext(ctx, query, runID).Scan(&turns, &instances); err != nil {
-		t.Fatalf("count completed account-worker turns: %v", err)
+	if err := db.QueryRowContext(ctx, query, runID, agentID).Scan(&turns, &instances); err != nil {
+		t.Fatalf("count completed %s turns: %v", agentID, err)
 	}
 	if turns < wantInstances || instances != wantInstances {
 		t.Fatalf(
-			"completed account-worker turns=%d distinct instances=%d, want at least %d turns across %d instances",
+			"completed %s turns=%d distinct instances=%d, want at least %d turns across %d instances",
+			agentID,
 			turns,
 			instances,
 			wantInstances,
@@ -1785,13 +1800,14 @@ func assertNotifyAllChildrenCompletedTurns(
 func waitNotifyAllChildrenAgentAbsent(
 	t testing.TB,
 	manager *runtimemanager.AgentManager,
+	agentID string,
 	flowInstance string,
 ) {
 	t.Helper()
 	deadline := time.Now().Add(15 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		_, lastErr = manager.ResolveAgentConfig("account-worker", flowInstance)
+		_, lastErr = manager.ResolveAgentConfig(agentID, flowInstance)
 		if lastErr != nil {
 			return
 		}

--- a/internal/runtime/context_manager.go
+++ b/internal/runtime/context_manager.go
@@ -461,7 +461,11 @@ func (m *RuntimeContextManager) register(contextDef BundleContext, activateOccur
 	if _, exists := m.contexts[contextDef.BundleHash()]; exists {
 		return fmt.Errorf("duplicate runtime context bundle_hash %s", contextDef.BundleHash())
 	}
-	if collision, ok := m.duplicateLoadedAgentSlugLocked(contextDef); ok {
+	collision, duplicateAgent, err := m.duplicateLoadedAgentSlugLocked(contextDef)
+	if err != nil {
+		return fmt.Errorf("resolve runtime context declared agent names: %w", err)
+	}
+	if duplicateAgent {
 		return fmt.Errorf(
 			"duplicate runtime context agent_id %q across loaded BundleContexts: existing %s; incoming %s",
 			collision.agentID,
@@ -724,10 +728,13 @@ func (m *RuntimeContextManager) duplicateLoadedIngressAliasLocked(incoming Bundl
 	return BundleContext{}, BundleContext{}, "", false
 }
 
-func (m *RuntimeContextManager) duplicateLoadedAgentSlugLocked(incoming BundleContext) (runtimeContextAgentSlugCollision, bool) {
-	incomingIDs := runtimeContextAgentIDs(incoming.Source)
+func (m *RuntimeContextManager) duplicateLoadedAgentSlugLocked(incoming BundleContext) (runtimeContextAgentSlugCollision, bool, error) {
+	incomingIDs, err := runtimeContextAgentIDs(incoming.Source)
+	if err != nil {
+		return runtimeContextAgentSlugCollision{}, false, err
+	}
 	if len(incomingIDs) == 0 {
-		return runtimeContextAgentSlugCollision{}, false
+		return runtimeContextAgentSlugCollision{}, false, nil
 	}
 	incomingSet := make(map[string]struct{}, len(incomingIDs))
 	for _, agentID := range incomingIDs {
@@ -738,7 +745,11 @@ func (m *RuntimeContextManager) duplicateLoadedAgentSlugLocked(incoming BundleCo
 		if !runtimeContextEntryLoaded(entry) {
 			continue
 		}
-		for _, existingAgentID := range runtimeContextAgentIDs(entry.context.Source) {
+		existingAgentIDs, err := runtimeContextAgentIDs(entry.context.Source)
+		if err != nil {
+			return runtimeContextAgentSlugCollision{}, false, err
+		}
+		for _, existingAgentID := range existingAgentIDs {
 			if _, ok := incomingSet[existingAgentID]; !ok {
 				continue
 			}
@@ -746,10 +757,10 @@ func (m *RuntimeContextManager) duplicateLoadedAgentSlugLocked(incoming BundleCo
 				agentID:  existingAgentID,
 				existing: *entry.context,
 				incoming: incoming,
-			}, true
+			}, true, nil
 		}
 	}
-	return runtimeContextAgentSlugCollision{}, false
+	return runtimeContextAgentSlugCollision{}, false, nil
 }
 
 func runtimeContextEntryLoaded(entry *runtimeContextEntry) bool {
@@ -763,24 +774,20 @@ func runtimeContextEntryLoaded(entry *runtimeContextEntry) bool {
 	return state == RuntimeContextStateLoaded
 }
 
-func runtimeContextAgentIDs(source semanticview.Source) []string {
+func runtimeContextAgentIDs(source semanticview.Source) ([]string, error) {
 	if source == nil {
-		return nil
+		return nil, nil
 	}
-	entries := source.AgentEntries()
-	ids := make([]string, 0, len(entries))
-	for key, entry := range entries {
-		agentID := strings.TrimSpace(entry.ID)
-		if agentID == "" {
-			agentID = strings.TrimSpace(key)
-		}
-		if agentID == "" {
-			continue
-		}
-		ids = append(ids, agentID)
+	plans, err := semanticview.AgentNamePlans(source)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(plans))
+	for _, plan := range plans {
+		ids = append(ids, plan.AgentID)
 	}
 	sort.Strings(ids)
-	return ids
+	return ids, nil
 }
 
 func runtimeContextBundleLabel(contextDef BundleContext) string {
@@ -1684,7 +1691,11 @@ func (m *RuntimeContextManager) prepareReplacementPublicationLocked(existingHash
 			return nil, fmt.Errorf("replacement runtime context bundle_hash %s is already registered", contextDef.BundleHash())
 		}
 	}
-	if collision, ok := m.duplicateLoadedAgentSlugLockedExcluding(contextDef, existingHash); ok {
+	collision, duplicateAgent, err := m.duplicateLoadedAgentSlugLockedExcluding(contextDef, existingHash)
+	if err != nil {
+		return nil, fmt.Errorf("resolve replacement declared agent names: %w", err)
+	}
+	if duplicateAgent {
 		return nil, fmt.Errorf("duplicate runtime context agent_id %q across loaded BundleContexts: existing %s; incoming %s", collision.agentID, runtimeContextBundleLabel(collision.existing), runtimeContextBundleLabel(collision.incoming))
 	}
 	if existing, incoming, alias, ok := m.duplicateLoadedIngressAliasLockedExcluding(contextDef, existingHash); ok {
@@ -1980,7 +1991,11 @@ func (m *RuntimeContextManager) validateReplacementLocked(existingHash string, c
 			return fmt.Errorf("replacement runtime context bundle_hash %s is already registered", contextDef.BundleHash())
 		}
 	}
-	if collision, ok := m.duplicateLoadedAgentSlugLockedExcluding(contextDef, existingHash); ok {
+	collision, duplicateAgent, err := m.duplicateLoadedAgentSlugLockedExcluding(contextDef, existingHash)
+	if err != nil {
+		return fmt.Errorf("resolve replacement declared agent names: %w", err)
+	}
+	if duplicateAgent {
 		return fmt.Errorf("duplicate runtime context agent_id %q across loaded BundleContexts: existing %s; incoming %s", collision.agentID, runtimeContextBundleLabel(collision.existing), runtimeContextBundleLabel(collision.incoming))
 	}
 	if existing, incoming, alias, ok := m.duplicateLoadedIngressAliasLockedExcluding(contextDef, existingHash); ok {
@@ -1989,9 +2004,13 @@ func (m *RuntimeContextManager) validateReplacementLocked(existingHash string, c
 	return nil
 }
 
-func (m *RuntimeContextManager) duplicateLoadedAgentSlugLockedExcluding(incoming BundleContext, excludedHash string) (runtimeContextAgentSlugCollision, bool) {
+func (m *RuntimeContextManager) duplicateLoadedAgentSlugLockedExcluding(incoming BundleContext, excludedHash string) (runtimeContextAgentSlugCollision, bool, error) {
 	incomingSet := map[string]struct{}{}
-	for _, agentID := range runtimeContextAgentIDs(incoming.Source) {
+	incomingIDs, err := runtimeContextAgentIDs(incoming.Source)
+	if err != nil {
+		return runtimeContextAgentSlugCollision{}, false, err
+	}
+	for _, agentID := range incomingIDs {
 		incomingSet[agentID] = struct{}{}
 	}
 	for _, bundleHash := range m.order {
@@ -2002,13 +2021,17 @@ func (m *RuntimeContextManager) duplicateLoadedAgentSlugLockedExcluding(incoming
 		if !runtimeContextEntryLoaded(entry) {
 			continue
 		}
-		for _, agentID := range runtimeContextAgentIDs(entry.context.Source) {
+		existingAgentIDs, err := runtimeContextAgentIDs(entry.context.Source)
+		if err != nil {
+			return runtimeContextAgentSlugCollision{}, false, err
+		}
+		for _, agentID := range existingAgentIDs {
 			if _, ok := incomingSet[agentID]; ok {
-				return runtimeContextAgentSlugCollision{agentID: agentID, existing: *entry.context, incoming: incoming}, true
+				return runtimeContextAgentSlugCollision{agentID: agentID, existing: *entry.context, incoming: incoming}, true, nil
 			}
 		}
 	}
-	return runtimeContextAgentSlugCollision{}, false
+	return runtimeContextAgentSlugCollision{}, false, nil
 }
 
 func (m *RuntimeContextManager) duplicateLoadedIngressAliasLockedExcluding(incoming BundleContext, excludedHash string) (BundleContext, BundleContext, string, bool) {

--- a/internal/runtime/context_manager_test.go
+++ b/internal/runtime/context_manager_test.go
@@ -11,7 +11,7 @@ import (
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/runbundle"
-	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 )
 
 const (
@@ -430,7 +430,7 @@ func testBundleContextWithAgentEntries(t *testing.T, bundleHash, eventName strin
 		},
 		Agents: agents,
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 	workOwner := runtimeTestOccurrence(t, bundleHash)
 	bus, err := newRuntimeTestEventBusWithOptions(t, nil, runtimebus.EventBusOptions{
 		WorkOwner:        workOwner,

--- a/internal/runtime/contracts/bundle_catalog_projection.go
+++ b/internal/runtime/contracts/bundle_catalog_projection.go
@@ -93,6 +93,10 @@ func BuildBundleCatalogProjectionWithOptions(bundle *WorkflowContractBundle, opt
 	if err != nil {
 		return BundleCatalogProjection{}, err
 	}
+	agents, err := bundleCatalogAgentsJSON(bundle)
+	if err != nil {
+		return BundleCatalogProjection{}, err
+	}
 	parsed := map[string]any{
 		"projection_version": bundleCatalogProjectionVersion,
 		"package":            bundleCatalogPackageJSON(bundle.Package),
@@ -101,7 +105,7 @@ func BuildBundleCatalogProjectionWithOptions(bundle *WorkflowContractBundle, opt
 			"version": strings.TrimSpace(bundle.Semantics.Version),
 		},
 		"files":  bundleCatalogFilesJSON(files),
-		"agents": bundleCatalogAgentsJSON(bundle),
+		"agents": agents,
 	}
 	metadata := map[string]any{
 		"projection_version": bundleCatalogProjectionVersion,
@@ -256,13 +260,17 @@ func packageExtraJSON(extra map[string]string) map[string]string {
 	return out
 }
 
-func bundleCatalogAgentsJSON(bundle *WorkflowContractBundle) []any {
+func bundleCatalogAgentsJSON(bundle *WorkflowContractBundle) ([]any, error) {
 	records := bundleAgentRecords(bundle)
 	out := make([]any, 0, len(records))
 	for _, record := range records {
 		entry := record.Entry
+		agentID, err := DeclaredAgentID(record.LogicalID, entry)
+		if err != nil {
+			return nil, fmt.Errorf("project bundle catalog agent %q: %w", record.LogicalID, err)
+		}
 		def := map[string]any{
-			"agent_id": record.LogicalID,
+			"agent_id": agentID,
 		}
 		addStringField(def, "role", entry.Role)
 		addStringField(def, "type", firstNonEmpty(entry.Type, entry.NodeType))
@@ -280,7 +288,7 @@ func bundleCatalogAgentsJSON(bundle *WorkflowContractBundle) []any {
 		addStringListField(def, "tools", entry.ConfiguredTools())
 		out = append(out, def)
 	}
-	return out
+	return out, nil
 }
 
 func addStringField(values map[string]any, key, value string) {

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -283,16 +283,20 @@ func (b *bundleHashEntryBuilder) addAgentMockModuleFiles(bundle *WorkflowContrac
 	}
 	for _, record := range bundleAgentRecords(bundle) {
 		agent := record.Entry
+		agentID, err := DeclaredAgentID(record.LogicalID, agent)
+		if err != nil {
+			return err
+		}
 		if !agent.Mock.Configured() {
 			continue
 		}
 		sourcePath := strings.TrimSpace(agent.Mock.SourcePath)
 		if sourcePath == "" {
-			return fmt.Errorf("agent %s mock module is configured but has no source path", strings.TrimSpace(agent.ID))
+			return fmt.Errorf("agent %s mock module is configured but has no source path", agentID)
 		}
 		path := filepath.Join(b.contractsRoot, filepath.FromSlash(sourcePath))
 		if err := b.addOptionalBundleFile(path, bundleHashRaw); err != nil {
-			return fmt.Errorf("agent %s mock module: %w", strings.TrimSpace(agent.ID), err)
+			return fmt.Errorf("agent %s mock module: %w", agentID, err)
 		}
 	}
 	return nil

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -776,7 +776,7 @@ func bundleHashTestBundleWithIntent(t *testing.T, root, platform, coordinate str
 	return bundle
 }
 
-func TestBundleCatalogAgentProjectionPreservesScopedDuplicateLogicalIDs(t *testing.T) {
+func TestBundleCatalogAgentProjectionRendersEffectiveNamesForScopedDuplicateCoordinates(t *testing.T) {
 	rootIntent, err := runtimeagentintent.Resolve(runtimeagentintent.SourceInline, "inline", "agents.yaml#agents.worker.intent", "root intent")
 	if err != nil {
 		t.Fatal(err)
@@ -787,7 +787,7 @@ func TestBundleCatalogAgentProjectionPreservesScopedDuplicateLogicalIDs(t *testi
 	}
 	flow := FlowContractView{
 		Paths:  FlowContractPaths{ID: "review", Flow: "review", AgentsFile: "/contracts/flows/review/agents.yaml"},
-		Agents: map[string]AgentRegistryEntry{"worker": {ID: "worker", ResolvedIntent: flowIntent}},
+		Agents: map[string]AgentRegistryEntry{"worker": {ID: "review-worker", ResolvedIntent: flowIntent}},
 	}
 	bundle := &WorkflowContractBundle{
 		projectContracts: map[string]ProjectContractView{
@@ -799,14 +799,17 @@ func TestBundleCatalogAgentProjectionPreservesScopedDuplicateLogicalIDs(t *testi
 		FlowTree: FlowTree{Root: &flow, ByID: map[string]*FlowContractView{"review": &flow}},
 	}
 
-	projected := bundleCatalogAgentsJSON(bundle)
+	projected, err := bundleCatalogAgentsJSON(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(projected) != 2 {
 		t.Fatalf("catalog agents = %#v, want both scoped worker declarations", projected)
 	}
 	first := projected[0].(map[string]any)
 	second := projected[1].(map[string]any)
-	if first["agent_id"] != "worker" || second["agent_id"] != "worker" {
-		t.Fatalf("catalog agent ids = %#v, want duplicate logical ids preserved", projected)
+	if first["agent_id"] != "worker" || second["agent_id"] != "review-worker" {
+		t.Fatalf("catalog agent ids = %#v, want scoped effective names worker and review-worker", projected)
 	}
 	seen := map[string]string{}
 	for _, raw := range projected {

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -235,23 +235,6 @@ func (b *WorkflowContractBundle) ToolEntries() map[string]ToolSchemaEntry {
 	}
 	return cloneToolSchemaEntryMap(b.Tools)
 }
-func (b *WorkflowContractBundle) ToolEntryForAgent(agentID, toolID string) (ToolSchemaEntry, bool) {
-	agentID = strings.TrimSpace(agentID)
-	toolID = strings.TrimSpace(toolID)
-	if b == nil || agentID == "" || toolID == "" {
-		return ToolSchemaEntry{}, false
-	}
-	source, ok := b.AgentContractSource(agentID)
-	if !ok {
-		entry, ok := b.Tools[toolID]
-		return entry, ok
-	}
-	if entry, ok := b.scopedTools[contractScopeKey(source, toolID)]; ok {
-		return entry, true
-	}
-	entry, ok := b.Tools[toolID]
-	return entry, ok
-}
 func (b *WorkflowContractBundle) AuthoredEventEntries() map[string]EventCatalogEntry {
 	if b == nil {
 		return nil
@@ -741,6 +724,14 @@ func (b *WorkflowContractBundle) AgentContractSource(agentID string) (ContractIt
 		return ContractItemSource{}, false
 	}
 	source, ok := b.agentSources[strings.TrimSpace(agentID)]
+	return source, ok
+}
+
+func (b *WorkflowContractBundle) ScopedAgentContractSource(scope ContractItemSource, agentID string) (ContractItemSource, bool) {
+	if b == nil {
+		return ContractItemSource{}, false
+	}
+	source, ok := b.scopedAgentSources[contractScopeKey(scope, strings.TrimSpace(agentID))]
 	return source, ok
 }
 func (b *WorkflowContractBundle) ResolveNodeEventReference(nodeID, eventType string) string {

--- a/internal/runtime/contracts/workflow_contract_effective.go
+++ b/internal/runtime/contracts/workflow_contract_effective.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -79,6 +80,34 @@ func EffectiveAgentRegistryEntry(logicalID string, entry AgentRegistryEntry) Age
 	}
 
 	return effective
+}
+
+// DeclaredAgentID derives the public agent name from one authored declaration.
+// Scoped ownership is added by semanticview before the name becomes runtime identity.
+func DeclaredAgentID(logicalID string, entry AgentRegistryEntry) (string, error) {
+	logicalID = strings.TrimSpace(logicalID)
+	if logicalID == "" {
+		return "", fmt.Errorf("agent declaration map key is required")
+	}
+	authoredID := entry.AuthoredFields["id"]
+	agentID := strings.TrimSpace(entry.ID)
+	if authoredID && agentID == "" {
+		return "", fmt.Errorf(
+			"agent %q id is authored but empty; omit id to use the map key, or author a non-empty literal id",
+			logicalID,
+		)
+	}
+	if strings.ContainsAny(agentID, "{}") {
+		return "", fmt.Errorf(
+			"agent %q id %q contains interpolation; move the discriminator to instance.by because agent identity is declaration x instance route",
+			logicalID,
+			agentID,
+		)
+	}
+	if agentID == "" {
+		return logicalID, nil
+	}
+	return agentID, nil
 }
 
 func (e AgentRegistryEntry) EffectiveSourceForField(field string) string {

--- a/internal/runtime/contracts/workflow_contract_tree.go
+++ b/internal/runtime/contracts/workflow_contract_tree.go
@@ -106,7 +106,9 @@ func normalizeAgentRegistryEntries(entries map[string]AgentRegistryEntry, source
 		return map[string]AgentRegistryEntry{}, nil
 	}
 	out := make(map[string]AgentRegistryEntry, len(entries))
-	for key, entry := range entries {
+	effectiveOwners := make(map[string]string, len(entries))
+	for _, key := range sortedContractKeys(entries) {
+		entry := entries[key]
 		trimmedKey := strings.TrimSpace(key)
 		if trimmedKey == "" {
 			continue
@@ -115,13 +117,20 @@ func normalizeAgentRegistryEntries(entries map[string]AgentRegistryEntry, source
 			return nil, err
 		}
 		effective := EffectiveAgentRegistryEntry(trimmedKey, entry)
-		if strings.Contains(strings.TrimSpace(effective.ID), "{instance_id}") {
+		effectiveID, err := DeclaredAgentID(trimmedKey, effective)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", strings.TrimSpace(sourceFile), err)
+		}
+		if previous, exists := effectiveOwners[effectiveID]; exists {
 			return nil, fmt.Errorf(
-				"%s agent %q: agent IDs are declaration identities and cannot interpolate {instance_id}; remove the interpolation because the runtime carries flow-instance identity separately",
+				"%s agents %q and %q derive the same effective agent id %q; use distinct declaration map keys or literal id overrides",
 				strings.TrimSpace(sourceFile),
+				previous,
 				trimmedKey,
+				effectiveID,
 			)
 		}
+		effectiveOwners[effectiveID] = trimmedKey
 		out[trimmedKey] = effective
 	}
 	return out, nil
@@ -183,7 +192,7 @@ func buildFlowTree(bundle *WorkflowContractBundle, flowViewsByID map[string]Flow
 			func(view *FlowContractView, path string) { view.Path = path },
 			func(view *FlowContractView, uri string) { view.URI = uri },
 			func(view *FlowContractView) string { return strings.TrimSpace(view.Paths.ID) },
-			func(view *FlowContractView) string { return strings.Trim(strings.TrimSpace(view.Path), "/") },
+			flowTreeDeclarationPath,
 			func(view *FlowContractView) map[string]SystemNodeContract { return view.Nodes },
 			func(view *FlowContractView) map[string]AgentRegistryEntry { return view.Agents },
 			func(view *FlowContractView) map[string]EventCatalogEntry { return view.Events },
@@ -264,7 +273,7 @@ func buildFlowTree(bundle *WorkflowContractBundle, flowViewsByID map[string]Flow
 		func(view *FlowContractView, path string) { view.Path = path },
 		func(view *FlowContractView, uri string) { view.URI = uri },
 		func(view *FlowContractView) string { return strings.TrimSpace(view.Paths.ID) },
-		func(view *FlowContractView) string { return strings.Trim(strings.TrimSpace(view.Path), "/") },
+		flowTreeDeclarationPath,
 		nodeEntries,
 		func(view *FlowContractView) map[string]AgentRegistryEntry { return view.Agents },
 		eventEntries,
@@ -287,6 +296,24 @@ func buildFlowTree(bundle *WorkflowContractBundle, flowViewsByID map[string]Flow
 	bundle.URIRegistry = registry
 	return nil
 }
+
+func flowTreeDeclarationPath(view *FlowContractView) string {
+	if view == nil {
+		return ""
+	}
+	packageKey := strings.Trim(strings.TrimSpace(view.Paths.PackageKey), "/")
+	if strings.TrimSpace(view.Paths.ID) == "" && packageKey != "" && packageKey != "." {
+		return packageKey
+	}
+	if path := strings.Trim(strings.TrimSpace(view.Path), "/"); path != "" {
+		return path
+	}
+	if packageKey == "." {
+		return ""
+	}
+	return packageKey
+}
+
 func materializeFlowTree(node *flowmodel.BuildNode[FlowContractView]) FlowContractView {
 	return flowmodel.Materialize(
 		node,

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -138,21 +138,90 @@ func TestBuildFlowTreeRootOnlyPackageIndexesAgentIdentityWithoutCopyingCatalogs(
 	}
 }
 
-func TestAgentDeclarationRejectsInstanceIDInterpolation(t *testing.T) {
-	_, err := normalizeAgentRegistryEntries(map[string]AgentRegistryEntry{
-		"account-worker": {ID: "account-worker-{instance_id}"},
-	}, "flows/account/agents.yaml")
-	if err == nil {
-		t.Fatal("agent declaration accepted retired {instance_id} interpolation")
+func TestAgentDeclarationRejectsArbitraryIDInterpolation(t *testing.T) {
+	for _, id := range []string{"account-worker-{instance_id}", "account-worker-{unknown_business_key}"} {
+		t.Run(id, func(t *testing.T) {
+			_, err := normalizeAgentRegistryEntries(map[string]AgentRegistryEntry{
+				"account-worker": {ID: id},
+			}, "flows/account/agents.yaml")
+			if err == nil {
+				t.Fatalf("agent declaration accepted retired interpolation %q", id)
+			}
+			for _, want := range []string{
+				"flows/account/agents.yaml",
+				`agent "account-worker"`,
+				"contains interpolation",
+				"move the discriminator to instance.by",
+				"declaration x instance route",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want teaching fragment %q", err, want)
+				}
+			}
+		})
 	}
-	for _, want := range []string{
-		"flows/account/agents.yaml",
-		`agent "account-worker"`,
-		"agent IDs are declaration identities",
-		"runtime carries flow-instance identity separately",
+}
+
+func TestAgentDeclarationIDPresenceMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		field   string
+		wantErr bool
+	}{
+		{name: "omitted"},
+		{name: "quoted empty", field: `  id: ""`, wantErr: true},
+		{name: "whitespace", field: `  id: "   "`, wantErr: true},
+		{name: "null", field: "  id: null", wantErr: true},
+		{name: "bare", field: "  id:", wantErr: true},
+		{name: "tilde", field: "  id: ~", wantErr: true},
+		{name: "literal override", field: "  id: public-worker"},
 	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error = %q, want teaching fragment %q", err, want)
+		t.Run(tc.name, func(t *testing.T) {
+			source := "worker:\n  role: worker\n"
+			if tc.field != "" {
+				source = "worker:\n" + tc.field + "\n  role: worker\n"
+			}
+			var entries map[string]AgentRegistryEntry
+			if err := yaml.Unmarshal([]byte(source), &entries); err != nil {
+				t.Fatal(err)
+			}
+			normalized, err := normalizeAgentRegistryEntries(entries, "agents.yaml")
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "id is authored but empty") {
+					t.Fatalf("normalize error = %v, want authored-empty rejection", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := DeclaredAgentID("worker", normalized["worker"])
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "worker"
+			if tc.name == "literal override" {
+				want = "public-worker"
+			}
+			if got != want {
+				t.Fatalf("effective id = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestAgentDeclarationRejectsDuplicateEffectiveNames(t *testing.T) {
+	for _, source := range []string{
+		"worker:\n  role: worker\nalias:\n  id: worker\n  role: alias\n",
+		"first:\n  id: shared\n  role: first\nsecond:\n  id: shared\n  role: second\n",
+	} {
+		var entries map[string]AgentRegistryEntry
+		if err := yaml.Unmarshal([]byte(source), &entries); err != nil {
+			t.Fatal(err)
+		}
+		_, err := normalizeAgentRegistryEntries(entries, "agents.yaml")
+		if err == nil || !strings.Contains(err.Error(), "derive the same effective agent id") {
+			t.Fatalf("normalize error = %v, want duplicate effective-name rejection", err)
 		}
 	}
 }

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -1873,8 +1873,8 @@ func staticConnectReceiverDeliveryRoute(source semanticview.Source, endpoint sem
 			Handler: MustConnectReceiverHandler(flowID, nodeID),
 		}, true
 	case semanticview.EventEndpointAgent:
-		logicalID := strings.TrimSpace(endpoint.AgentID)
-		agentID, owner, ok := staticConnectReceiverAgent(source, endpoint.FlowID, logicalID)
+		logicalID := strings.TrimSpace(endpoint.AgentLocalID)
+		agentID, owner, ok := staticConnectReceiverAgent(source, endpoint, logicalID)
 		if !ok {
 			return ConnectDeliveryRoute{}, false
 		}
@@ -1903,20 +1903,30 @@ func staticConnectReceiverDeliveryRoute(source semanticview.Source, endpoint sem
 	}
 }
 
-func staticConnectReceiverAgent(source semanticview.Source, flowID, logicalID string) (string, string, bool) {
-	owner, ok := semanticview.AgentDeclarationOwner(source, flowID, logicalID)
-	if !ok {
-		return "", "", false
-	}
-	agentID := logicalID
-	if scope, found := source.FlowScopeByID(strings.TrimSpace(flowID)); found {
-		if entry, exists := scope.Agents[logicalID]; exists && strings.TrimSpace(entry.ID) != "" {
-			agentID = strings.TrimSpace(entry.ID)
+func staticConnectReceiverAgent(source semanticview.Source, endpoint semanticview.AuthoredEventEndpoint, logicalID string) (string, string, bool) {
+	packageKey := strings.TrimSpace(endpoint.PackageKey)
+	if packageKey != "" {
+		for _, scope := range source.ProjectScopes() {
+			if strings.TrimSpace(scope.Key) != packageKey {
+				continue
+			}
+			namePlan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
+			if err == nil {
+				return namePlan.AgentID, namePlan.OwnerURI, true
+			}
+			break
 		}
-	} else if entry, exists := source.AgentEntries()[logicalID]; exists && strings.TrimSpace(entry.ID) != "" {
-		agentID = strings.TrimSpace(entry.ID)
 	}
-	return agentID, owner, agentID != ""
+	flowID := strings.TrimSpace(endpoint.FlowID)
+	if flowID != "" {
+		if scope, ok := source.FlowScopeByID(flowID); ok {
+			namePlan, err := semanticview.FlowAgentNamePlan(source, scope, logicalID)
+			if err == nil {
+				return namePlan.AgentID, namePlan.OwnerURI, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 func (g CompiledConnectGraph) MatchingPlans(evt events.Event) []ConnectRoutePlan {

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -41,6 +41,76 @@ func TestConnectSourceEndpointMatchesEventUsesImmutableSourceAcrossTargetProject
 	}
 }
 
+func TestStaticConnectReceiverAgentPreservesExactProjectScopeAndLocalCoordinate(t *testing.T) {
+	omittedOwner := "test://connect/packages/first/worker"
+	literalOwner := "test://connect/packages/second/worker"
+	omittedEntry := runtimecontracts.AgentRegistryEntry{}
+	literalEntry := runtimecontracts.AgentRegistryEntry{
+		ID:             "public-worker",
+		AuthoredFields: map[string]bool{"id": true},
+	}
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+			omittedOwner: {Kind: "agent", LocalID: "worker", Full: omittedOwner},
+			literalOwner: {Kind: "agent", LocalID: "worker", Full: literalOwner},
+		}},
+	})
+	source := staticConnectAgentScopeSource{
+		Source: base,
+		projects: []semanticview.ProjectScope{
+			{
+				Key: "packages/first", OwningFlowID: "support",
+				Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": omittedEntry},
+				AgentURIs: map[string]string{"worker": omittedOwner},
+			},
+			{
+				Key: "packages/second", OwningFlowID: "support",
+				Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": literalEntry},
+				AgentURIs: map[string]string{"worker": literalOwner},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		packageKey string
+		publicID   string
+		owner      string
+	}{
+		{name: "omitted id", packageKey: "packages/first", publicID: "worker", owner: omittedOwner},
+		{name: "literal override", packageKey: "packages/second", publicID: "public-worker", owner: literalOwner},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint := semanticview.AuthoredEventEndpoint{
+				Kind:         semanticview.EventEndpointAgent,
+				PackageKey:   tc.packageKey,
+				FlowID:       "support",
+				AgentLocalID: "worker",
+				AgentID:      tc.publicID,
+			}
+			route, ok := staticConnectReceiverDeliveryRoute(source, endpoint, events.RouteIdentity{})
+			if !ok {
+				t.Fatal("static connect receiver route was omitted")
+			}
+			if got := route.Recipient.ID(); got != tc.publicID {
+				t.Fatalf("recipient id = %q, want %q", got, tc.publicID)
+			}
+			if got := route.AgentIdentity.Name.Owner; got != tc.owner {
+				t.Fatalf("identity owner = %q, want %q", got, tc.owner)
+			}
+		})
+	}
+}
+
+type staticConnectAgentScopeSource struct {
+	semanticview.Source
+	projects []semanticview.ProjectScope
+}
+
+func (s staticConnectAgentScopeSource) ProjectScopes() []semanticview.ProjectScope {
+	return append([]semanticview.ProjectScope(nil), s.projects...)
+}
+
 func TestConnectReceiverPinAdmissionOwnsRuntimeCollisionIdentity(t *testing.T) {
 	source := newConnectRoutePlanEndpoint(ConnectEndpointRoleProducer, false, "producer", "producer", runtimecontracts.FlowModeStatic, "work_ready", "work.ready", "producer/work.ready", "", nil)
 	plan := func(pin, event string) ConnectRoutePlan {

--- a/internal/runtime/entityruntime/contracts.go
+++ b/internal/runtime/entityruntime/contracts.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesharedjson "github.com/division-sh/swarm/internal/runtime/sharedjson"
@@ -39,22 +40,21 @@ type WriteTarget struct {
 	Nested    bool
 }
 
-func ResolveForActor(source semanticview.Source, actorID string) (Contract, bool) {
-	actorID = strings.TrimSpace(actorID)
-	if source == nil || actorID == "" {
+func ResolveForActor(source semanticview.Source, actor models.AgentConfig) (Contract, bool) {
+	if source == nil || strings.TrimSpace(actor.ID) == "" {
 		return Contract{}, false
 	}
-	contractSource, ok := source.AgentContractSource(actorID)
+	projection, ok := semanticview.ResolveAgentContractProjection(source, actor)
 	if !ok {
 		return Contract{}, false
 	}
-	return ResolveForFlow(source, contractSource.FlowID)
+	return ResolveForFlow(source, projection.OwnerFlowID)
 }
 
-func ResolveForReadTarget(source semanticview.Source, actorID, target string) (Contract, bool, error) {
+func ResolveForReadTarget(source semanticview.Source, actor models.AgentConfig, target string) (Contract, bool, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		contract, ok := ResolveForActor(source, actorID)
+		contract, ok := ResolveForActor(source, actor)
 		return contract, ok, nil
 	}
 	if source == nil {

--- a/internal/runtime/flowdata/flowdata.go
+++ b/internal/runtime/flowdata/flowdata.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -184,33 +183,21 @@ func resolveAgentFlowDataDeclaration(source semanticview.Source, actor models.Ag
 	if source == nil {
 		return agentFlowDataDeclaration{}, false
 	}
-	actorID := strings.TrimSpace(actor.ID)
-	if actorID == "" {
+	declaration, ok := semanticview.ResolveAgentDeclaration(source, actor)
+	if !ok || strings.TrimSpace(declaration.OwnerFlowID) == "" {
 		return agentFlowDataDeclaration{}, false
 	}
-	var matches []agentFlowDataDeclaration
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" {
-			continue
-		}
-		for _, logicalID := range sortedAgentIDs(scope.Agents) {
-			entry := scope.Agents[logicalID]
-			if !agentIdentityMatches(logicalID, entry.ID, actorID) {
-				continue
-			}
-			matches = append(matches, agentFlowDataDeclaration{
-				LogicalID: strings.TrimSpace(logicalID),
-				Entry:     entry,
-				FlowID:    flowID,
-				Scope:     scope,
-			})
-		}
-	}
-	if len(matches) != 1 {
+	flowID := strings.TrimSpace(declaration.OwnerFlowID)
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
 		return agentFlowDataDeclaration{}, false
 	}
-	return matches[0], true
+	return agentFlowDataDeclaration{
+		LogicalID: strings.TrimSpace(declaration.LocalID),
+		Entry:     declaration.Entry,
+		FlowID:    flowID,
+		Scope:     scope,
+	}, true
 }
 
 func resolveUnderDataRoot(dataDir, filename string) (string, error) {
@@ -300,55 +287,3 @@ func scopedLabel(scopeLabel, localID string) string {
 func FlowDataAccessFromEntry(entry runtimecontracts.AgentRegistryEntry) []string {
 	return NormalizeAccessList(entry.FlowDataAccess)
 }
-
-func sortedAgentIDs(agents map[string]runtimecontracts.AgentRegistryEntry) []string {
-	ids := make([]string, 0, len(agents))
-	for id := range agents {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
-	sort.Strings(ids)
-	return ids
-}
-
-func agentIdentityMatches(logicalID, declaredID, actorID string) bool {
-	logicalID = strings.TrimSpace(logicalID)
-	declaredID = strings.TrimSpace(declaredID)
-	actorID = strings.TrimSpace(actorID)
-	if actorID == "" {
-		return false
-	}
-	if logicalID != "" && logicalID == actorID {
-		return true
-	}
-	if declaredID == "" {
-		return false
-	}
-	if declaredID == actorID {
-		return true
-	}
-	matched, err := regexp.MatchString(flowDataTemplateMatchPattern(declaredID), actorID)
-	return err == nil && matched
-}
-
-func flowDataTemplateMatchPattern(template string) string {
-	matches := flowDataTemplateFieldPattern.FindAllStringIndex(template, -1)
-	if len(matches) == 0 {
-		return "^" + regexp.QuoteMeta(template) + "$"
-	}
-	var builder strings.Builder
-	builder.WriteString("^")
-	last := 0
-	for _, match := range matches {
-		builder.WriteString(regexp.QuoteMeta(template[last:match[0]]))
-		builder.WriteString(".+")
-		last = match[1]
-	}
-	builder.WriteString(regexp.QuoteMeta(template[last:]))
-	builder.WriteString("$")
-	return builder.String()
-}
-
-var flowDataTemplateFieldPattern = regexp.MustCompile(`\{[^{}]+\}`)

--- a/internal/runtime/flowmodel/model_test.go
+++ b/internal/runtime/flowmodel/model_test.go
@@ -551,6 +551,45 @@ func TestPopulateScopedURIs_RegistersKindsByFlowScope(t *testing.T) {
 	}
 }
 
+func TestPopulateScopedURIs_SeparatesProjectScopedDeclarationsWithTheSameLocalID(t *testing.T) {
+	type projectNode struct {
+		Path      string
+		Agents    map[string]struct{}
+		AgentURIs map[string]string
+	}
+	registry := &URIRegistry{
+		Agents: map[string]URIRef{},
+		ByURI:  map[string]URIRef{},
+	}
+	register := func(path string) projectNode {
+		node := projectNode{Path: path, Agents: map[string]struct{}{"worker": {}}}
+		PopulateScopedURIs(
+			&node,
+			registry,
+			func(*projectNode) string { return "" },
+			func(node *projectNode) string { return node.Path },
+			func(*projectNode) map[string]struct{} { return nil },
+			func(node *projectNode) map[string]struct{} { return node.Agents },
+			func(*projectNode) map[string]struct{} { return nil },
+			func(*projectNode) *map[string]string { return nil },
+			func(node *projectNode) *map[string]string { return &node.AgentURIs },
+			func(*projectNode) *map[string]string { return nil },
+		)
+		return node
+	}
+
+	left := register("packages/left")
+	right := register("packages/right")
+	if left.AgentURIs["worker"] == right.AgentURIs["worker"] {
+		t.Fatalf("project declaration URIs collapsed: left=%q right=%q", left.AgentURIs["worker"], right.AgentURIs["worker"])
+	}
+	for _, key := range []string{"packages/left/worker", "packages/right/worker"} {
+		if _, ok := registry.Agents[key]; !ok {
+			t.Fatalf("agent registry missing project-scoped coordinate %q: %#v", key, registry.Agents)
+		}
+	}
+}
+
 func TestIndexAndPopulateScopedURIs_AssignsTreeAndScopedURIs(t *testing.T) {
 	type scopedTreeNode struct {
 		ID        string

--- a/internal/runtime/flowmodel/query.go
+++ b/internal/runtime/flowmodel/query.go
@@ -292,13 +292,17 @@ func RegisterURI(registry *URIRegistry, target *map[string]string, kind, flowID,
 		Absolute: AbsoluteURI(flowPath, localID),
 		Full:     FullURI(registry, AbsoluteURI(flowPath, localID)),
 	}
+	registryKey := RegistryKey(ref.FlowID, ref.LocalID)
+	if ref.FlowID == "" && strings.Trim(strings.TrimSpace(ref.Path), "/") != "" {
+		registryKey = ref.Absolute
+	}
 	switch ref.Kind {
 	case "node":
-		registry.Nodes[RegistryKey(ref.FlowID, ref.LocalID)] = ref
+		registry.Nodes[registryKey] = ref
 	case "agent":
-		registry.Agents[RegistryKey(ref.FlowID, ref.LocalID)] = ref
+		registry.Agents[registryKey] = ref
 	case "event":
-		registry.Events[RegistryKey(ref.FlowID, ref.LocalID)] = ref
+		registry.Events[registryKey] = ref
 	}
 	registry.ByURI[ref.Absolute] = ref
 	registry.ByURI[ref.Full] = ref

--- a/internal/runtime/manager/agent_manager_llm_backend_test.go
+++ b/internal/runtime/manager/agent_manager_llm_backend_test.go
@@ -135,7 +135,29 @@ func TestResolveAgentModelMockRetainsAndRequiresCapturedArtifact(t *testing.T) {
 
 func TestAuthoredMockStaticAndInstantiatedAgentsSpawnPersistRecoverMock(t *testing.T) {
 	artifact := capturedMockAlternative()
+	staticFlow := runtimecontracts.FlowContractView{
+		Path:  "static-support",
+		Paths: runtimecontracts.FlowContractPaths{ID: "static-support", Flow: "static-support"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"static-worker": managerTestAgentEntry("static-worker", runtimecontracts.AgentRegistryEntry{ID: "static-worker"}),
+		},
+	}
+	templateFlow := runtimecontracts.FlowContractView{
+		Path:  "template-support",
+		Paths: runtimecontracts.FlowContractPaths{ID: "template-support", Flow: "template-support"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"worker": managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "template-worker"}),
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{staticFlow, templateFlow}}
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"static-support":   &root.Children[0],
+				"template-support": &root.Children[1],
+			},
+		},
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"static-support/static-worker": {
@@ -149,13 +171,13 @@ func TestAuthoredMockStaticAndInstantiatedAgentsSpawnPersistRecoverMock(t *testi
 			},
 		},
 	})
-	staticCfg, err := buildStaticFlowAgentConfig(source, "static-support", "static-support", "static-worker", managerTestAgentEntry("static-worker", runtimecontracts.AgentRegistryEntry{
+	staticCfg, err := buildStaticFlowAgentConfig(source, managerTestFlowAgentNamePlan(t, source, "static-support", "static-worker"), "static-support", "static-support", "static-worker", managerTestAgentEntry("static-worker", runtimecontracts.AgentRegistryEntry{
 		ID: "static-worker", Role: "worker", Model: "regular", MemoryPlan: agentmemory.PlatformDefault(), Mock: artifact,
 	}), nil)
 	if err != nil {
 		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
 	}
-	instantiatedCfg, err := buildFlowAgentConfig(source, "template-support", "inst-1", "entity-1", "template-support/inst-1", "worker", managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{
+	instantiatedCfg, err := buildFlowAgentConfig(source, managerTestFlowAgentNamePlan(t, source, "template-support", "worker"), "template-support", "inst-1", "entity-1", "template-support/inst-1", "worker", managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{
 		ID: "template-worker", Role: "worker", Model: "regular", MemoryPlan: agentmemory.PlatformDefault(), Mock: artifact,
 	}), map[string]string{"instance_id": "inst-1"}, nil, nil)
 	if err != nil {

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -372,7 +372,11 @@ func (am *AgentManager) flowInstanceAgentRecords(req runtimepipeline.FlowInstanc
 	records := make([]PersistedAgent, 0, len(agentKeys))
 	for _, key := range agentKeys {
 		entry := scope.Agents[key]
-		cfg, err := buildFlowAgentConfig(req.ContractBundle, instance.TemplateID, instance.InstanceID, instance.EntityID, instance.InstancePath, key, entry, vars, localEvents, req.Config)
+		namePlan, err := semanticview.FlowAgentNamePlan(req.ContractBundle, scope, key)
+		if err != nil {
+			return nil, fmt.Errorf("flow agent %s declared name: %w", key, err)
+		}
+		cfg, err := buildFlowAgentConfig(req.ContractBundle, namePlan, instance.TemplateID, instance.InstanceID, instance.EntityID, instance.InstancePath, key, entry, vars, localEvents, req.Config)
 		if err != nil {
 			return nil, err
 		}
@@ -607,15 +611,25 @@ func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedA
 	records := []PersistedAgent{}
 	for _, scope := range source.ProjectScopes() {
 		projectAgents := make(map[string]runtimecontracts.AgentRegistryEntry, len(scope.Agents))
+		projectNamePlans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
 		packageFlowAgents := map[string]staticAgentFlowGroup{}
 		for logicalID, entry := range scope.Agents {
+			namePlan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
+			if err != nil {
+				return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, logicalID, err)
+			}
 			proof := semanticview.ResolveAgentMemoryProof(source, semanticview.AgentMemoryLocator{
 				AgentID:         logicalID,
 				ProjectScopeKey: scope.Key,
 			})
 			if strings.TrimSpace(proof.OwningFlowID) != "" {
-				if flowScopeContainsStaticAgent(source, proof.OwningFlowID, logicalID, entry) {
-					continue
+				if flowScope, ok := source.FlowScopeByID(proof.OwningFlowID); ok {
+					if _, represented := flowScope.Agents[logicalID]; represented {
+						flowPlan, flowPlanErr := semanticview.FlowAgentNamePlan(source, flowScope, logicalID)
+						if flowPlanErr == nil && flowPlan.OwnerURI == namePlan.OwnerURI {
+							continue
+						}
+					}
 				}
 				groupKey := staticAgentFlowGroupKey(proof.OwningFlowID, proof.FlowPath)
 				group := packageFlowAgents[groupKey]
@@ -624,13 +638,18 @@ func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedA
 				if group.Agents == nil {
 					group.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
 				}
+				if group.NamePlans == nil {
+					group.NamePlans = map[string]semanticview.AgentNamePlan{}
+				}
 				group.Agents[strings.TrimSpace(logicalID)] = entry
+				group.NamePlans[strings.TrimSpace(logicalID)] = namePlan
 				packageFlowAgents[groupKey] = group
 				continue
 			}
 			projectAgents[strings.TrimSpace(logicalID)] = entry
+			projectNamePlans[strings.TrimSpace(logicalID)] = namePlan
 		}
-		scopeRecords, err := staticAgentsForScope(source, "", "", projectAgents)
+		scopeRecords, err := staticAgentsForScope(source, "", "", projectAgents, projectNamePlans)
 		if err != nil {
 			return nil, err
 		}
@@ -642,7 +661,7 @@ func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedA
 		sort.Strings(groupKeys)
 		for _, key := range groupKeys {
 			group := packageFlowAgents[key]
-			scopeRecords, err := staticAgentsForScope(source, group.FlowID, group.FlowPath, group.Agents)
+			scopeRecords, err := staticAgentsForScope(source, group.FlowID, group.FlowPath, group.Agents, group.NamePlans)
 			if err != nil {
 				return nil, err
 			}
@@ -660,7 +679,11 @@ func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedA
 		proof := semanticview.ResolveAgentMemoryProof(source, semanticview.AgentMemoryLocator{
 			FlowID: flowID,
 		})
-		scopeRecords, err := staticAgentsForScope(source, proof.OwningFlowID, proof.FlowPath, scope.Agents)
+		namePlans, err := flowAgentNamePlans(source, scope)
+		if err != nil {
+			return nil, err
+		}
+		scopeRecords, err := staticAgentsForScope(source, proof.OwningFlowID, proof.FlowPath, scope.Agents, namePlans)
 		if err != nil {
 			return nil, err
 		}
@@ -678,7 +701,15 @@ func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) (
 	standingFlows := standingActivatedFlowIDs(source)
 	records := []PersistedAgent{}
 	if rootScope, ok := runtimerequiredagents.RootScope(source); ok {
-		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", rootScope.Agents, rootScope.Required)
+		projectScope, found := rootAgentProjectScope(source)
+		if !found && len(rootScope.Required) > 0 {
+			return nil, fmt.Errorf("root required agents have no exact project declaration scope")
+		}
+		namePlans, err := projectAgentNamePlans(source, projectScope)
+		if err != nil {
+			return nil, err
+		}
+		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", rootScope.Agents, namePlans, rootScope.Required)
 		if err != nil {
 			return nil, err
 		}
@@ -692,7 +723,11 @@ func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) (
 		if _, standing := standingFlows[flowID]; standing {
 			continue
 		}
-		scopeRecords, err := staticRequiredAgentsForScope(source, flowID, strings.Trim(scope.Path, "/"), scope.Agents, source.FlowRequiredAgents(flowID))
+		namePlans, err := flowAgentNamePlans(source, scope)
+		if err != nil {
+			return nil, err
+		}
+		scopeRecords, err := staticRequiredAgentsForScope(source, flowID, strings.Trim(scope.Path, "/"), scope.Agents, namePlans, source.FlowRequiredAgents(flowID))
 		if err != nil {
 			return nil, err
 		}
@@ -719,38 +754,52 @@ func standingActivatedFlowIDs(source semanticview.Source) map[string]struct{} {
 }
 
 type staticAgentFlowGroup struct {
-	FlowID   string
-	FlowPath string
-	Agents   map[string]runtimecontracts.AgentRegistryEntry
+	FlowID    string
+	FlowPath  string
+	Agents    map[string]runtimecontracts.AgentRegistryEntry
+	NamePlans map[string]semanticview.AgentNamePlan
 }
 
 func staticAgentFlowGroupKey(flowID, flowPath string) string {
 	return strings.TrimSpace(flowID) + "\x00" + strings.Trim(strings.TrimSpace(flowPath), "/")
 }
 
-func flowScopeContainsStaticAgent(source semanticview.Source, flowID, logicalID string, entry runtimecontracts.AgentRegistryEntry) bool {
-	flowID = strings.TrimSpace(flowID)
-	logicalID = strings.TrimSpace(logicalID)
-	if source == nil || flowID == "" || logicalID == "" {
-		return false
+func projectAgentNamePlans(source semanticview.Source, scope semanticview.ProjectScope) (map[string]semanticview.AgentNamePlan, error) {
+	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
+	for logicalID := range scope.Agents {
+		plan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
+		if err != nil {
+			return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, logicalID, err)
+		}
+		plans[strings.TrimSpace(logicalID)] = plan
 	}
-	scope, ok := source.FlowScopeByID(flowID)
-	if !ok {
-		return false
+	return plans, nil
+}
+
+func flowAgentNamePlans(source semanticview.Source, scope semanticview.FlowScope) (map[string]semanticview.AgentNamePlan, error) {
+	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
+	for logicalID := range scope.Agents {
+		plan, err := semanticview.FlowAgentNamePlan(source, scope, logicalID)
+		if err != nil {
+			return nil, fmt.Errorf("flow scope %q agent %s declaration name: %w", scope.ID, logicalID, err)
+		}
+		plans[strings.TrimSpace(logicalID)] = plan
 	}
-	if scopedEntry, ok := scope.Agents[logicalID]; ok {
-		return scopedEntry.ID == entry.ID
-	}
-	entryID := strings.TrimSpace(entry.ID)
-	if entryID == "" {
-		return false
-	}
-	for scopedLogicalID, scopedEntry := range scope.Agents {
-		if strings.TrimSpace(scopedLogicalID) == logicalID || strings.TrimSpace(scopedEntry.ID) == entryID {
-			return true
+	return plans, nil
+}
+
+func rootAgentProjectScope(source semanticview.Source) (semanticview.ProjectScope, bool) {
+	for _, scope := range source.ProjectScopes() {
+		if strings.TrimSpace(scope.OwningFlowID) == "" && scope.Depth == 0 {
+			return scope, true
 		}
 	}
-	return false
+	for _, scope := range source.ProjectScopes() {
+		if strings.TrimSpace(scope.OwningFlowID) == "" {
+			return scope, true
+		}
+	}
+	return semanticview.ProjectScope{}, false
 }
 
 func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
@@ -916,6 +965,7 @@ func (am *AgentManager) logTerminalFlowInstanceSideEffectFailure(plan terminalFl
 
 func buildFlowAgentConfig(
 	source semanticview.Source,
+	namePlan semanticview.AgentNamePlan,
 	templateID string,
 	instanceID string,
 	entityID string,
@@ -926,18 +976,11 @@ func buildFlowAgentConfig(
 	localEvents map[string]struct{},
 	config map[string]any,
 ) (models.AgentConfig, error) {
-	agentID := strings.TrimSpace(renderFlowTemplate(strings.TrimSpace(entry.ID), vars))
-	if agentID == "" {
-		return models.AgentConfig{}, fmt.Errorf("flow agent %s resolved empty id", key)
-	}
-	declarationOwner, ok := semanticview.AgentDeclarationOwner(source, templateID, key)
-	if !ok {
-		return models.AgentConfig{}, fmt.Errorf("flow agent %s missing scoped declaration owner", key)
-	}
-	name, err := runtimeagentidentity.DeclaredName(agentID, declarationOwner)
+	name, err := namePlan.Materialize()
 	if err != nil {
 		return models.AgentConfig{}, fmt.Errorf("flow agent %s declaration identity: %w", key, err)
 	}
+	agentID := name.AgentID
 	route, err := runtimeflowidentity.StoredRoute("", "", flowPath).AgentIdentityRoute()
 	if err != nil {
 		return models.AgentConfig{}, fmt.Errorf("flow agent %s route identity: %w", key, err)
@@ -1005,7 +1048,7 @@ func buildFlowAgentConfig(
 		ID:              agentID,
 		Identity:        identity,
 		Type:            strings.TrimSpace(entry.Type),
-		Role:            strings.TrimSpace(entry.Role),
+		Role:            namePlan.EffectiveRole(entry),
 		FlowID:          templateID,
 		Model:           strings.TrimSpace(entry.Model),
 		LLMBackend:      "",
@@ -1035,26 +1078,12 @@ func buildFlowAgentConfig(
 	return cfg, nil
 }
 
-func (am *AgentManager) ensureStaticRequiredAgentsForScope(
-	ctx context.Context,
-	source semanticview.Source,
-	flowID string,
-	flowPath string,
-	agents map[string]runtimecontracts.AgentRegistryEntry,
-	required []runtimecontracts.FlowRequiredAgent,
-) error {
-	records, err := staticRequiredAgentsForScope(source, flowID, flowPath, agents, required)
-	if err != nil {
-		return err
-	}
-	return am.spawnStaticAgentRecords(ctx, records)
-}
-
 func staticRequiredAgentsForScope(
 	source semanticview.Source,
 	flowID string,
 	flowPath string,
 	agents map[string]runtimecontracts.AgentRegistryEntry,
+	namePlans map[string]semanticview.AgentNamePlan,
 	required []runtimecontracts.FlowRequiredAgent,
 ) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
@@ -1069,7 +1098,11 @@ func staticRequiredAgentsForScope(
 		if !ok {
 			return nil, fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
 		}
-		cfg, err := buildStaticFlowAgentConfig(source, flowID, flowPath, logicalID, entry, localEvents)
+		namePlan, exists := namePlans[logicalID]
+		if !exists {
+			return nil, fmt.Errorf("required agent %q in scope %q has no exact scoped declaration name", logicalID, flowID)
+		}
+		cfg, err := buildStaticFlowAgentConfig(source, namePlan, flowID, flowPath, logicalID, entry, localEvents)
 		if err != nil {
 			return nil, err
 		}
@@ -1083,25 +1116,12 @@ func staticRequiredAgentsForScope(
 	return records, nil
 }
 
-func (am *AgentManager) ensureStaticAgentsForScope(
-	ctx context.Context,
-	source semanticview.Source,
-	flowID string,
-	flowPath string,
-	agents map[string]runtimecontracts.AgentRegistryEntry,
-) error {
-	records, err := staticAgentsForScope(source, flowID, flowPath, agents)
-	if err != nil {
-		return err
-	}
-	return am.spawnStaticAgentRecords(ctx, records)
-}
-
 func staticAgentsForScope(
 	source semanticview.Source,
 	flowID string,
 	flowPath string,
 	agents map[string]runtimecontracts.AgentRegistryEntry,
+	namePlans map[string]semanticview.AgentNamePlan,
 ) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
 	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
@@ -1120,7 +1140,11 @@ func staticAgentsForScope(
 	records := make([]PersistedAgent, 0, len(logicalIDs))
 	for _, logicalID := range logicalIDs {
 		entry := agents[logicalID]
-		cfg, err := buildStaticFlowAgentConfig(source, flowID, flowPath, logicalID, entry, localEvents)
+		namePlan, exists := namePlans[logicalID]
+		if !exists {
+			return nil, fmt.Errorf("static agent %q in scope %q has no exact scoped declaration name", logicalID, flowID)
+		}
+		cfg, err := buildStaticFlowAgentConfig(source, namePlan, flowID, flowPath, logicalID, entry, localEvents)
 		if err != nil {
 			return nil, err
 		}
@@ -1136,6 +1160,7 @@ func staticAgentsForScope(
 
 func buildStaticFlowAgentConfig(
 	source semanticview.Source,
+	namePlan semanticview.AgentNamePlan,
 	flowID string,
 	flowPath string,
 	logicalID string,
@@ -1146,21 +1171,11 @@ func buildStaticFlowAgentConfig(
 		"flow_id":   strings.TrimSpace(flowID),
 		"flow_path": strings.Trim(strings.TrimSpace(flowPath), "/"),
 	}
-	agentID := strings.TrimSpace(renderFlowTemplate(strings.TrimSpace(entry.ID), vars))
-	if agentID == "" {
-		agentID = strings.TrimSpace(logicalID)
-	}
-	if agentID == "" {
-		return models.AgentConfig{}, fmt.Errorf("static flow agent %s resolved empty id", logicalID)
-	}
-	declarationOwner, ok := semanticview.AgentDeclarationOwner(source, flowID, logicalID)
-	if !ok {
-		return models.AgentConfig{}, fmt.Errorf("static flow agent %s missing scoped declaration owner", logicalID)
-	}
-	name, err := runtimeagentidentity.DeclaredName(agentID, declarationOwner)
+	name, err := namePlan.Materialize()
 	if err != nil {
 		return models.AgentConfig{}, fmt.Errorf("static flow agent %s declaration identity: %w", logicalID, err)
 	}
+	agentID := name.AgentID
 	route := runtimeagentidentity.RootRoute()
 	if flowPath != "" {
 		route, err = runtimeflowidentity.StoredRoute("", "", flowPath).AgentIdentityRoute()
@@ -1197,15 +1212,11 @@ func buildStaticFlowAgentConfig(
 	if err != nil {
 		return models.AgentConfig{}, fmt.Errorf("static flow agent %s permissions: %w", logicalID, err)
 	}
-	role := strings.TrimSpace(entry.Role)
-	if role == "" {
-		role = strings.TrimSpace(logicalID)
-	}
 	cfg := models.AgentConfig{
 		ID:              agentID,
 		Identity:        identity,
 		Type:            strings.TrimSpace(entry.Type),
-		Role:            role,
+		Role:            namePlan.EffectiveRole(entry),
 		FlowID:          flowID,
 		Model:           strings.TrimSpace(entry.Model),
 		LLMBackend:      "",

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/agentmemory"
+	runtimeauthority "github.com/division-sh/swarm/internal/runtime/authority"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -2863,7 +2864,7 @@ func TestActivateFlowInstancePassesActivationConfigToRouteMaterialization(t *tes
 	}
 }
 
-func TestActivateFlowInstanceUsesSameBuiltinsForAgentAndRouteMaterialization(t *testing.T) {
+func TestActivateFlowInstanceRejectsAgentNameInterpolationBeforeMutation(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(t, bus, &flowActivationTestInstanceStore{})
 	bundle := testFlowBundle("")
@@ -2882,27 +2883,12 @@ func TestActivateFlowInstanceUsesSameBuiltinsForAgentAndRouteMaterialization(t *
 		"instance_id":        "wrong-config-instance",
 		"template_id":        "wrong-config-template",
 	}
-	if err := activateFlowInstanceForTest(am, testAuthorActivityContext(context.Background()), req); err != nil {
-		t.Fatalf("ActivateFlowInstance: %v", err)
+	err := activateFlowInstanceForTest(am, testAuthorActivityContext(context.Background()), req)
+	if err == nil || !strings.Contains(err.Error(), "contains interpolation") || !strings.Contains(err.Error(), "instance.by") {
+		t.Fatalf("ActivateFlowInstance error = %v, want agent-name interpolation teaching error", err)
 	}
-	if _, ok := testAgentConfig(t, am, "reviewer-review/inst-1", ""); !ok {
-		t.Fatalf("expected flow agent rendered with built-in flow_instance_path, configs=%#v", am.ListAgentConfigs())
-	}
-	if len(bus.addedRouteRequests) != 1 {
-		t.Fatalf("route materialization requests = %#v, want one", bus.addedRouteRequests)
-	}
-	vars := bus.addedRouteRequests[0].ActivationVariables
-	if got := vars["flow_instance_path"]; got != "review/inst-1" {
-		t.Fatalf("route activation variable flow_instance_path = %q, want review/inst-1", got)
-	}
-	if got := vars["flow_scope_key"]; got != "review" {
-		t.Fatalf("route activation variable flow_scope_key = %q, want review", got)
-	}
-	if got := vars["instance_id"]; got != "inst-1" {
-		t.Fatalf("route activation variable instance_id = %q, want inst-1", got)
-	}
-	if got := vars["template_id"]; got != "review" {
-		t.Fatalf("route activation variable template_id = %q, want review", got)
+	if len(bus.addedRouteRequests) != 0 || len(am.ListAgentConfigs()) != 0 {
+		t.Fatalf("rejected interpolation mutated activation: routes=%#v agents=%#v", bus.addedRouteRequests, am.ListAgentConfigs())
 	}
 }
 
@@ -3646,8 +3632,10 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 }
 
 func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t *testing.T) {
+	source := semanticview.Wrap(testNestedFlowBundle())
 	cfg, err := buildFlowAgentConfig(
-		semanticview.Wrap(testNestedFlowBundle()),
+		source,
+		managerTestFlowAgentNamePlan(t, source, "grandchild", "worker"),
 		"grandchild",
 		"inst-1",
 		"ent-1",
@@ -3668,6 +3656,47 @@ func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t 
 	}
 	if len(cfg.Subscriptions) != 1 || cfg.Subscriptions[0] != "child/grandchild/inst-1/micro.started" {
 		t.Fatalf("subscriptions = %#v, want [child/grandchild/inst-1/micro.started]", cfg.Subscriptions)
+	}
+}
+
+func TestStaticAndTemplateAgentMaterializationDefaultRoleToEffectiveName(t *testing.T) {
+	bundle := testFlowBundle("")
+	review := bundle.FlowTree.ByID["review"]
+	entry := review.Agents["reviewer"]
+	entry.ID = "public-reviewer"
+	entry.Role = ""
+	review.Agents["reviewer"] = entry
+	bundle.FlowTree.Root.Children[0] = *review
+	source := semanticview.Wrap(bundle)
+	namePlan := managerTestFlowAgentNamePlan(t, source, "review", "reviewer")
+
+	staticCfg, err := buildStaticFlowAgentConfig(source, namePlan, "review", "review", "reviewer", entry, staticFlowLocalEventSet(review.Agents))
+	if err != nil {
+		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
+	}
+	templateCfg, err := buildFlowAgentConfig(
+		source,
+		namePlan,
+		"review",
+		"inst-1",
+		"ent-1",
+		"review/inst-1",
+		"reviewer",
+		entry,
+		nil,
+		staticFlowLocalEventSet(review.Agents),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildFlowAgentConfig: %v", err)
+	}
+	for _, cfg := range []models.AgentConfig{staticCfg, templateCfg} {
+		if cfg.ID != "public-reviewer" || cfg.Role != "public-reviewer" {
+			t.Fatalf("materialized actor = id %q role %q, want effective public role", cfg.ID, cfg.Role)
+		}
+		if err := runtimeauthority.NewSourceProvider(source).AuthorizeMailboxSend(cfg); err != nil {
+			t.Fatalf("materialized actor mailbox authority: %v", err)
+		}
 	}
 }
 
@@ -3725,6 +3754,72 @@ func TestStandingActivatedFlowAgentsAreOwnedOnlyByFlowInstanceActivation(t *test
 	}
 }
 
+func TestStaticAgentMaterializationKeepsDistinctProjectAndFlowDeclarationsWithSharedLocalID(t *testing.T) {
+	projectOwner := "test://agent-name/packages/support-extension/worker"
+	flowOwner := "test://agent-name/flows/support/worker"
+	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+		projectOwner: {Kind: "agent", LocalID: "worker", Full: projectOwner},
+		flowOwner:    {Kind: "agent", FlowID: "support", LocalID: "worker", Full: flowOwner},
+	}}})
+	projectEntry := managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "project-worker", Role: "project-worker"})
+	flowEntry := managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "flow-worker", Role: "flow-worker"})
+	source := managerScopedAgentSource{
+		Source: base,
+		projects: []semanticview.ProjectScope{{
+			Key: "packages/support-extension", OwningFlowID: "support",
+			Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": projectEntry},
+			AgentURIs: map[string]string{"worker": projectOwner},
+		}},
+		flows: []semanticview.FlowScope{{
+			ID: "support", Path: "support", PackageKey: "flows/support", Mode: "static",
+			Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": flowEntry},
+			AgentURIs: map[string]string{"worker": flowOwner},
+		}},
+	}
+
+	records, err := StaticAgentMaterializationRecords(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, record := range records {
+		got[record.Config.ID] = record.Config.Identity.Name.Owner
+	}
+	if len(got) != 2 || got["project-worker"] != projectOwner || got["flow-worker"] != flowOwner {
+		t.Fatalf("materialized owners = %#v, want both exact declarations", got)
+	}
+}
+
+type managerScopedAgentSource struct {
+	semanticview.Source
+	projects []semanticview.ProjectScope
+	flows    []semanticview.FlowScope
+}
+
+func (s managerScopedAgentSource) ProjectScopes() []semanticview.ProjectScope {
+	return append([]semanticview.ProjectScope(nil), s.projects...)
+}
+
+func (s managerScopedAgentSource) FlowScopes() []semanticview.FlowScope {
+	return append([]semanticview.FlowScope(nil), s.flows...)
+}
+
+func (s managerScopedAgentSource) FlowScopeByID(flowID string) (semanticview.FlowScope, bool) {
+	for _, scope := range s.flows {
+		if strings.TrimSpace(scope.ID) == strings.TrimSpace(flowID) {
+			return scope, true
+		}
+	}
+	return semanticview.FlowScope{}, false
+}
+
+func (s managerScopedAgentSource) FlowPath(flowID string) string {
+	if scope, ok := s.FlowScopeByID(flowID); ok {
+		return scope.Path
+	}
+	return ""
+}
+
 func TestEnsureStaticFlowRequiredAgentsInfersFromOmittedRequiredAgents(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	store := &flowActivationTestStore{}
@@ -3760,7 +3855,7 @@ func TestStaticRequiredAgentsForScopeRejectsRoleFallbackWithoutMapKey(t *testing
 			Subscriptions: []string{"analysis.requested"},
 			EmitEvents:    []string{"analysis.done"},
 		},
-	}, []runtimecontracts.FlowRequiredAgent{{
+	}, nil, []runtimecontracts.FlowRequiredAgent{{
 		Role:         "worker",
 		SubscribesTo: []string{"analysis.requested"},
 		Emits:        []string{"analysis.done"},
@@ -3774,7 +3869,7 @@ func TestStaticRequiredAgentsForScopeRejectsRoleFallbackWithoutMapKey(t *testing
 func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newFlowActivationManager(t, bus, &flowActivationTestInstanceStore{})
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"test-agent": {
@@ -3791,7 +3886,8 @@ func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.
 				"ops-flow": "ops-flow",
 			},
 		},
-	})
+	}
+	source := semanticview.Wrap(bundle)
 
 	rootAgents := map[string]runtimecontracts.AgentRegistryEntry{
 		"test-agent": managerTestAgentEntry("test-agent", runtimecontracts.AgentRegistryEntry{
@@ -3802,7 +3898,13 @@ func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.
 			EmitEvents:    []string{"task.completed"},
 		}),
 	}
-	if err := am.ensureStaticAgentsForScope(testAuthorActivityContext(context.Background()), source, "", "", rootAgents); err != nil {
+	bundle.Agents = rootAgents
+	rootPlan := managerTestAgentNamePlan(t, source, "", "test-agent")
+	rootRecords, err := staticAgentsForScope(source, "", "", rootAgents, map[string]semanticview.AgentNamePlan{"test-agent": rootPlan})
+	if err != nil {
+		t.Fatalf("staticAgentsForScope(root): %v", err)
+	}
+	if err := am.spawnStaticAgentRecords(testAuthorActivityContext(context.Background()), rootRecords); err != nil {
 		t.Fatalf("ensureStaticAgentsForScope(root): %v", err)
 	}
 	flowAgents := map[string]runtimecontracts.AgentRegistryEntry{
@@ -3814,7 +3916,21 @@ func TestEnsureStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.
 			EmitEvents:    []string{"work.completed"},
 		}),
 	}
-	if err := am.ensureStaticAgentsForScope(testAuthorActivityContext(context.Background()), source, "ops-flow", "ops-flow", flowAgents); err != nil {
+	flow := &runtimecontracts.FlowContractView{
+		Paths:  runtimecontracts.FlowContractPaths{ID: "ops-flow"},
+		Path:   "ops-flow",
+		Agents: flowAgents,
+	}
+	bundle.FlowTree = runtimecontracts.FlowTree{
+		Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{*flow}},
+		ByID: map[string]*runtimecontracts.FlowContractView{"ops-flow": flow},
+	}
+	flowPlan := managerTestFlowAgentNamePlan(t, source, "ops-flow", "operator")
+	flowRecords, err := staticAgentsForScope(source, "ops-flow", "ops-flow", flowAgents, map[string]semanticview.AgentNamePlan{"operator": flowPlan})
+	if err != nil {
+		t.Fatalf("staticAgentsForScope(flow): %v", err)
+	}
+	if err := am.spawnStaticAgentRecords(testAuthorActivityContext(context.Background()), flowRecords); err != nil {
 		t.Fatalf("ensureStaticAgentsForScope(flow): %v", err)
 	}
 
@@ -3857,8 +3973,8 @@ func TestEnsureStaticAgents_PackageBackedFlowOwnedAgentsCarryCanonicalFlowPath(t
 	if captured[0].FlowID != "support" {
 		t.Fatalf("FlowID = %q, want support", captured[0].FlowID)
 	}
-	if captured[0].ID != "backend-{vertical_id}" {
-		t.Fatalf("ID = %q, want backend-{vertical_id}", captured[0].ID)
+	if captured[0].ID != "backend" {
+		t.Fatalf("ID = %q, want backend", captured[0].ID)
 	}
 	if len(store.upserts) != 1 || store.upserts[0].Config.FlowPath != "support" {
 		t.Fatalf("persisted agents = %#v, want support flow path", store.upserts)
@@ -3887,8 +4003,8 @@ func TestEnsureStaticAgents_SoleParentFlowPackageAgentsStartWithOwningFlowPath(t
 	if captured[0].FlowID != "support" {
 		t.Fatalf("FlowID = %q, want support", captured[0].FlowID)
 	}
-	if captured[0].ID != "backend-{vertical_id}" {
-		t.Fatalf("ID = %q, want backend-{vertical_id}", captured[0].ID)
+	if captured[0].ID != "backend" {
+		t.Fatalf("ID = %q, want backend", captured[0].ID)
 	}
 }
 
@@ -3947,7 +4063,6 @@ support/item.created:
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 backend:
-  id: backend-{vertical_id}
   type: generic
   role: backend
   intent: {inline: "Handle backend work for this flow instance."}
@@ -4011,7 +4126,6 @@ flows: []
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "agents.yaml"), `
 backend:
-  id: backend-{vertical_id}
   type: generic
   role: backend
   intent: {inline: "Handle backend work for this flow instance."}
@@ -4038,9 +4152,46 @@ func writeFlowActivationFixtureFile(t *testing.T, path, contents string) {
 	}
 }
 
+func managerTestFlowAgentNamePlan(t *testing.T, source semanticview.Source, flowID, logicalID string) semanticview.AgentNamePlan {
+	t.Helper()
+	scope, ok := source.FlowScopeByID(flowID)
+	if !ok {
+		t.Fatalf("flow scope %q not found", flowID)
+	}
+	plan, err := semanticview.FlowAgentNamePlan(source, scope, logicalID)
+	if err != nil {
+		t.Fatalf("flow scope %q agent %q name plan: %v", flowID, logicalID, err)
+	}
+	return plan
+}
+
+func managerTestAgentNamePlan(t *testing.T, source semanticview.Source, ownerFlowID, logicalID string) semanticview.AgentNamePlan {
+	t.Helper()
+	var matched semanticview.AgentNamePlan
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		if strings.TrimSpace(declaration.LocalID) != strings.TrimSpace(logicalID) || strings.TrimSpace(declaration.OwnerFlowID) != strings.TrimSpace(ownerFlowID) {
+			continue
+		}
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			t.Fatalf("agent %q name plan: %v", logicalID, err)
+		}
+		if matched.LocalID != "" {
+			t.Fatalf("agent %q resolved multiple test name plans", logicalID)
+		}
+		matched = plan
+	}
+	if matched.LocalID == "" {
+		t.Fatalf("agent %q name plan not found", logicalID)
+	}
+	return matched
+}
+
 func TestBuildFlowAgentConfig_PassesContractToolsAndEmitEvents(t *testing.T) {
+	source := semanticview.Wrap(testFlowBundle(""))
 	cfg, err := buildFlowAgentConfig(
-		semanticview.Wrap(testFlowBundle("")),
+		source,
+		managerTestFlowAgentNamePlan(t, source, "review", "reviewer"),
 		"review",
 		"inst-1",
 		"ent-1",
@@ -4077,8 +4228,10 @@ func TestBuildFlowAgentConfig_PassesContractToolsAndEmitEvents(t *testing.T) {
 }
 
 func TestBuildFlowAgentConfigRejectsPayloadDerivedNestedSystemPromptBeforeMaterialization(t *testing.T) {
+	source := semanticview.Wrap(testFlowBundle(""))
 	_, err := buildFlowAgentConfig(
-		semanticview.Wrap(testFlowBundle("")),
+		source,
+		managerTestFlowAgentNamePlan(t, source, "review", "reviewer"),
 		"review",
 		"inst-1",
 		"ent-1",
@@ -4103,10 +4256,11 @@ func TestStaticAndDynamicFlowAgentConfigRejectForeignExactAndPattern(t *testing.
 	for _, subscription := range []string{"foreign/task.ready", "foreign/**/task.ready"} {
 		t.Run(strings.ReplaceAll(subscription, "/", "_"), func(t *testing.T) {
 			entry := managerTestAgentEntry("reviewer", runtimecontracts.AgentRegistryEntry{ID: "reviewer", Type: "generic", Subscriptions: []string{subscription}})
-			if _, err := buildStaticFlowAgentConfig(source, "review", "review", "reviewer", entry, map[string]struct{}{"task.started": {}}); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+			namePlan := managerTestFlowAgentNamePlan(t, source, "review", "reviewer")
+			if _, err := buildStaticFlowAgentConfig(source, namePlan, "review", "review", "reviewer", entry, map[string]struct{}{"task.started": {}}); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
 				t.Fatalf("buildStaticFlowAgentConfig error = %v, want admission rejection", err)
 			}
-			if _, err := buildFlowAgentConfig(source, "review", "inst-1", "ent-1", "review/inst-1", "reviewer", entry, nil, map[string]struct{}{"task.started": {}}, nil); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
+			if _, err := buildFlowAgentConfig(source, namePlan, "review", "inst-1", "ent-1", "review/inst-1", "reviewer", entry, nil, map[string]struct{}{"task.started": {}}, nil); err == nil || !strings.Contains(err.Error(), "cannot cross a flow boundary") {
 				t.Fatalf("buildFlowAgentConfig error = %v, want admission rejection", err)
 			}
 		})
@@ -4117,6 +4271,7 @@ func TestBuildFlowAgentConfigRebasesAdmittedSameScopeExactToConcreteInstance(t *
 	source := semanticview.Wrap(testFlowBundle(""))
 	cfg, err := buildFlowAgentConfig(
 		source,
+		managerTestFlowAgentNamePlan(t, source, "review", "reviewer"),
 		"review",
 		"inst-1",
 		"ent-1",
@@ -4147,7 +4302,7 @@ func TestStaticAndTemplateAgentMaterializationConsumeEffectivePlatformDefaults(t
 		t.Fatal("static_support flow scope missing")
 	}
 	staticEntry := staticScope.Agents["worker"]
-	staticCfg, err := buildStaticFlowAgentConfig(source, "static_support", "static_support", "worker", staticEntry, staticFlowLocalEventSet(staticScope.Agents))
+	staticCfg, err := buildStaticFlowAgentConfig(source, managerTestFlowAgentNamePlan(t, source, "static_support", "worker"), "static_support", "static_support", "worker", staticEntry, staticFlowLocalEventSet(staticScope.Agents))
 	if err != nil {
 		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
 	}
@@ -4160,6 +4315,7 @@ func TestStaticAndTemplateAgentMaterializationConsumeEffectivePlatformDefaults(t
 	templateEntry := templateScope.Agents["worker"]
 	templateCfg, err := buildFlowAgentConfig(
 		source,
+		managerTestFlowAgentNamePlan(t, source, "template_support", "worker"),
 		"template_support",
 		"inst-1",
 		"entity-1",

--- a/internal/runtime/manager/semantic_source_test.go
+++ b/internal/runtime/manager/semantic_source_test.go
@@ -9,14 +9,20 @@ import (
 )
 
 func TestDefaultManagerAgentID_UsesInjectedSemanticSource(t *testing.T) {
+	const owner = "test://manager/flows/ops/agents/worker"
 	flow := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "ops", Flow: "ops"},
 		Path:  "ops",
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"worker": {Role: "worker", ManagerFallback: "control-injected"},
 		},
+		AgentURIs: map[string]string{"worker": owner},
 	}
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{owner: {Kind: "agent", FlowID: "ops", LocalID: "worker", Full: owner}},
+			ByURI:  map[string]runtimecontracts.ContractURIRef{owner: {Kind: "agent", FlowID: "ops", LocalID: "worker", Full: owner}},
+		},
 		FlowTree: runtimecontracts.FlowTree{
 			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}},
 			ByID: map[string]*runtimecontracts.FlowContractView{
@@ -26,7 +32,7 @@ func TestDefaultManagerAgentID_UsesInjectedSemanticSource(t *testing.T) {
 	})
 	am := newTestAgentManagerWithOptions(t, nil, nil, AgentManagerOptions{SemanticSource: source})
 
-	got := am.defaultManagerAgentID(runtimeactors.AgentConfig{ExecutionMode: "live", ID: "worker-1", Role: "worker"})
+	got := am.defaultManagerAgentID(runtimeactors.AgentConfig{ExecutionMode: "live", ID: "worker-1", Role: "worker", FlowID: "ops"})
 	if got != "control-injected" {
 		t.Fatalf("defaultManagerAgentID = %q, want control-injected", got)
 	}

--- a/internal/runtime/node_delivery_startup_recovery_test.go
+++ b/internal/runtime/node_delivery_startup_recovery_test.go
@@ -35,6 +35,7 @@ import (
 	runtimepipelineobligation "github.com/division-sh/swarm/internal/runtime/pipelineobligation"
 	runtimerunlifecycle "github.com/division-sh/swarm/internal/runtime/runlifecycle"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	"github.com/division-sh/swarm/internal/store/storetest"
 	"github.com/division-sh/swarm/internal/testutil"
 )
@@ -192,9 +193,6 @@ func TestRuntimeStartHydratesPersistedAgentsBeforeRecoveringNodeDeliveriesParity
 				workflowPersistence = runtimepipeline.NewWorkflowPersistence(selected)
 			}
 			bundle := loadEntitylessStartupRecoveryBundle(t)
-			source := semanticview.Wrap(bundle)
-			module := newRuntimeTestWorkflowModule(t, source)
-
 			const agentID = "startup-order-agent"
 			agentConfig := runtimeTestAgentConfig(t, runtimeactors.AgentConfig{
 				ID: agentID, Type: "test", Role: "observer", FlowID: "global", Model: "regular",
@@ -204,6 +202,8 @@ func TestRuntimeStartHydratesPersistedAgentsBeforeRecoveringNodeDeliveriesParity
 				ID: agentID, Type: "test", Role: "observer", Model: "regular",
 				ResolvedIntent: agentConfig.Intent, Subscriptions: []string{"task.completed"},
 			}
+			source := semanticviewtest.WrapRootAgents(bundle)
+			module := newRuntimeTestWorkflowModule(t, source)
 
 			eventID := eventtest.UUID("startup-order-node-event-" + backend.name)
 			entityID := eventtest.UUID("startup-order-node-entity-" + backend.name)

--- a/internal/runtime/runtime_agent_memory_startup_test.go
+++ b/internal/runtime/runtime_agent_memory_startup_test.go
@@ -41,7 +41,7 @@ func assertRuntimeStartCarriesMemoryIdentity(t *testing.T, source semanticview.S
 		t.Fatalf("Start: %v", err)
 	}
 
-	cfg, err := rt.Manager.ResolveAgentConfig("backend-{vertical_id}", "support")
+	cfg, err := rt.Manager.ResolveAgentConfig("backend", "support")
 	if err != nil {
 		t.Fatalf("resolve package-backed static flow agent config: %v", err)
 	}

--- a/internal/runtime/semanticview/agent_contract_projection.go
+++ b/internal/runtime/semanticview/agent_contract_projection.go
@@ -1,0 +1,105 @@
+package semanticview
+
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+)
+
+// AgentContractProjection keeps declaration scope attached to contract and
+// tool lookup. Public agent names are not declaration coordinates.
+type AgentContractProjection struct {
+	Declaration    AgentDeclaration
+	ContractSource runtimecontracts.ContractItemSource
+	OwnerFlowID    string
+	scopedTools    map[string]runtimecontracts.ToolSchemaEntry
+	globalTools    map[string]runtimecontracts.ToolSchemaEntry
+}
+
+func ResolveAgentContractProjection(source Source, actor models.AgentConfig) (AgentContractProjection, bool) {
+	declaration, ok := ResolveAgentDeclaration(source, actor)
+	if !ok {
+		return AgentContractProjection{}, false
+	}
+	return ScopedAgentContractProjection(source, declaration)
+}
+
+func ScopedAgentContractProjection(source Source, declaration AgentDeclaration) (AgentContractProjection, bool) {
+	if source == nil || strings.TrimSpace(declaration.LocalID) == "" {
+		return AgentContractProjection{}, false
+	}
+	projection := AgentContractProjection{
+		Declaration: declaration,
+		OwnerFlowID: strings.TrimSpace(declaration.OwnerFlowID),
+		globalTools: source.ToolEntries(),
+	}
+	switch strings.TrimSpace(declaration.ScopeKind) {
+	case "flow":
+		for _, scope := range source.FlowScopes() {
+			if strings.TrimSpace(scope.ID) != strings.TrimSpace(declaration.ScopeID) {
+				continue
+			}
+			if _, exists := scope.Agents[strings.TrimSpace(declaration.LocalID)]; !exists {
+				return AgentContractProjection{}, false
+			}
+			projection.ContractSource = runtimecontracts.ContractItemSource{
+				PackageKey: strings.TrimSpace(scope.PackageKey),
+				FlowID:     strings.TrimSpace(scope.ID),
+				Layer:      "flow",
+			}
+			projection.ContractSource = exactAgentContractSource(source, projection.ContractSource, declaration.LocalID)
+			projection.scopedTools = scope.Tools
+			return projection, true
+		}
+	case "project":
+		for _, scope := range source.ProjectScopes() {
+			if strings.TrimSpace(scope.Key) != strings.TrimSpace(declaration.ScopeID) {
+				continue
+			}
+			if _, exists := scope.Agents[strings.TrimSpace(declaration.LocalID)]; !exists {
+				return AgentContractProjection{}, false
+			}
+			projection.ContractSource = runtimecontracts.ContractItemSource{
+				PackageKey: strings.TrimSpace(scope.Key),
+				Layer:      "project",
+			}
+			projection.ContractSource = exactAgentContractSource(source, projection.ContractSource, declaration.LocalID)
+			projection.scopedTools = scope.Tools
+			return projection, true
+		}
+	default:
+		if _, exists := source.AgentEntries()[strings.TrimSpace(declaration.LocalID)]; !exists {
+			return AgentContractProjection{}, false
+		}
+		projection.ContractSource = runtimecontracts.ContractItemSource{Layer: "project"}
+		if bundle, ok := Bundle(source); ok {
+			if contractSource, exists := bundle.AgentContractSource(declaration.LocalID); exists {
+				projection.ContractSource = contractSource
+			}
+		}
+		return projection, true
+	}
+	return AgentContractProjection{}, false
+}
+
+func exactAgentContractSource(source Source, scope runtimecontracts.ContractItemSource, localID string) runtimecontracts.ContractItemSource {
+	if bundle, ok := Bundle(source); ok {
+		if contractSource, exists := bundle.ScopedAgentContractSource(scope, localID); exists {
+			return contractSource
+		}
+	}
+	return scope
+}
+
+func (p AgentContractProjection) ToolEntry(toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
+	toolID = strings.TrimSpace(toolID)
+	if toolID == "" {
+		return runtimecontracts.ToolSchemaEntry{}, false
+	}
+	if entry, ok := p.scopedTools[toolID]; ok {
+		return entry, true
+	}
+	entry, ok := p.globalTools[toolID]
+	return entry, ok
+}

--- a/internal/runtime/semanticview/agent_memory_proof.go
+++ b/internal/runtime/semanticview/agent_memory_proof.go
@@ -29,11 +29,13 @@ func ResolveAgentMemoryProof(source Source, locator AgentMemoryLocator) AgentMem
 		return proof
 	}
 
-	if proof.AgentID != "" {
-		if contractSource, ok := source.AgentContractSource(proof.AgentID); ok {
-			proof.ContractSource = contractSource
+	if declaration, ok := agentMemoryDeclaration(source, locator); ok {
+		projection, projected := ScopedAgentContractProjection(source, declaration)
+		if projected {
+			proof.ContractSource = projection.ContractSource
+			proof.OwningFlowID = projection.OwnerFlowID
 			if proof.ProjectScopeKey == "" {
-				proof.ProjectScopeKey = strings.TrimSpace(contractSource.PackageKey)
+				proof.ProjectScopeKey = strings.TrimSpace(projection.ContractSource.PackageKey)
 			}
 		}
 	}
@@ -62,6 +64,30 @@ func ResolveAgentMemoryProof(source Source, locator AgentMemoryLocator) AgentMem
 
 	proof.FlowPath = strings.Trim(strings.TrimSpace(source.FlowPath(proof.OwningFlowID)), "/")
 	return proof
+}
+
+func agentMemoryDeclaration(source Source, locator AgentMemoryLocator) (AgentDeclaration, bool) {
+	agentID := strings.TrimSpace(locator.AgentID)
+	projectScopeKey := strings.TrimSpace(locator.ProjectScopeKey)
+	flowID := strings.TrimSpace(locator.FlowID)
+	var matched AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		if projectScopeKey != "" && strings.TrimSpace(declaration.ScopeID) != projectScopeKey {
+			continue
+		}
+		if flowID != "" && !agentDeclarationMatchesFlow(declaration, flowID) {
+			continue
+		}
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err != nil || (agentID != declaration.LocalID && agentID != plan.AgentID) {
+			continue
+		}
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return AgentDeclaration{}, false
+		}
+		matched = declaration
+	}
+	return matched, strings.TrimSpace(matched.LocalID) != ""
 }
 
 func projectScopeByKey(source Source, key string) (ProjectScope, bool) {

--- a/internal/runtime/semanticview/agent_name_ownership_guard_test.go
+++ b/internal/runtime/semanticview/agent_name_ownership_guard_test.go
@@ -1,0 +1,297 @@
+package semanticview_test
+
+import (
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type agentNameOwnershipFinding struct {
+	Path      string
+	Enclosing string
+	Kind      string
+}
+
+func (f agentNameOwnershipFinding) key() string {
+	return strings.Join([]string{f.Path, f.Enclosing, f.Kind}, "::")
+}
+
+func TestDeclaredAgentNameOwnershipBoundary(t *testing.T) {
+	root := agentNameGuardRepoRoot(t)
+	findings := loadAgentNameOwnershipFindings(t, root, nil)
+	if len(findings) != 0 {
+		keys := make([]string, len(findings))
+		for i, finding := range findings {
+			keys[i] = finding.key()
+		}
+		t.Fatalf("declared-agent-name ownership bypasses remain:\n%s", strings.Join(keys, "\n"))
+	}
+}
+
+func TestDeclaredAgentNameOwnershipBoundaryRejectsHostileBypasses(t *testing.T) {
+	root := agentNameGuardRepoRoot(t)
+	path := filepath.Join(root, "internal", "runtime", "semanticview", "agent_name_guard_hostile.go")
+	overlay := map[string][]byte{path: []byte(`package semanticview
+
+import runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+
+func hostileRawAgentID(entry runtimecontracts.AgentRegistryEntry) string {
+	return entry.ID
+}
+
+func hostileMapKeyAgentID(source Source) []string {
+	var out []string
+	for key := range source.AgentEntries() {
+		out = append(out, key)
+	}
+	return out
+}
+
+func hostileScopedMapKeyAgentID(view runtimecontracts.FlowContractView) []string {
+	var out []string
+	for key := range view.Agents {
+		out = append(out, key)
+	}
+	return out
+}
+
+func hostileLegacyContractLookup(bundle *runtimecontracts.WorkflowContractBundle, actorID string) {
+	bundle.AgentContractSource(actorID)
+	bundle.ScopedAgentContractSource(runtimecontracts.ContractItemSource{FlowID: "hostile"}, actorID)
+}
+`)}
+	findings := loadAgentNameOwnershipFindings(t, root, overlay)
+	want := map[string]bool{"raw_agent_registry_id": false, "unclassified_agent_entries": false, "unclassified_agent_map_range": false, "legacy_agent_contract_lookup": false}
+	for _, finding := range findings {
+		if _, ok := want[finding.Kind]; ok && strings.Contains(finding.Enclosing, "hostile") {
+			want[finding.Kind] = true
+		}
+	}
+	for kind, found := range want {
+		if !found {
+			t.Fatalf("hostile ownership guard did not detect %s: %#v", kind, findings)
+		}
+	}
+}
+
+func loadAgentNameOwnershipFindings(t *testing.T, root string, overlay map[string][]byte) []agentNameOwnershipFinding {
+	t.Helper()
+	cfg := &packages.Config{
+		Dir: root,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports,
+		Tests:   false,
+		Overlay: overlay,
+	}
+	patterns := []string{
+		"./internal/cliapp",
+		"./internal/providerconnectors",
+		"./internal/serveapp",
+		"./internal/runtime/...",
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		t.Fatalf("load declared-agent-name ownership packages: %v", err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		t.Fatal("load declared-agent-name ownership packages reported type errors")
+	}
+	var findings []agentNameOwnershipFinding
+	for _, pkg := range pkgs {
+		for index, file := range pkg.Syntax {
+			if index >= len(pkg.CompiledGoFiles) || strings.HasSuffix(pkg.CompiledGoFiles[index], "_test.go") {
+				continue
+			}
+			rel, err := filepath.Rel(root, pkg.CompiledGoFiles[index])
+			if err != nil {
+				t.Fatal(err)
+			}
+			findings = append(findings, collectAgentNameOwnershipFindings(filepath.ToSlash(rel), file, pkg.TypesInfo)...)
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool { return findings[i].key() < findings[j].key() })
+	return findings
+}
+
+func collectAgentNameOwnershipFindings(path string, file *ast.File, info *types.Info) []agentNameOwnershipFinding {
+	var findings []agentNameOwnershipFinding
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		enclosing := agentNameGuardFunctionName(function)
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			if statement, ok := node.(*ast.RangeStmt); ok && agentNameGuardIsAgentMapRange(statement, info) && !agentNameGuardAgentMapRangeAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "unclassified_agent_map_range"})
+			}
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if agentNameGuardIsRawID(selector, info) && !agentNameGuardRawIDAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "raw_agent_registry_id"})
+			}
+			if agentNameGuardIsAgentEntriesCall(selector, info) && !agentNameGuardAgentEntriesAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "unclassified_agent_entries"})
+			}
+			if agentNameGuardIsLegacyContractLookup(selector, info) && !agentNameGuardLegacyContractLookupAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "legacy_agent_contract_lookup"})
+			}
+			return true
+		})
+	}
+	return findings
+}
+
+func agentNameGuardIsLegacyContractLookup(selector *ast.SelectorExpr, info *types.Info) bool {
+	if selector == nil || selector.Sel == nil || info == nil {
+		return false
+	}
+	if selector.Sel.Name != "AgentContractSource" && selector.Sel.Name != "ScopedAgentContractSource" {
+		return false
+	}
+	function, ok := info.Uses[selector.Sel].(*types.Func)
+	return ok && function.Pkg() != nil && function.Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/contracts"
+}
+
+func agentNameGuardLegacyContractLookupAllowed(path, enclosing string) bool {
+	if path != "internal/runtime/semanticview/agent_contract_projection.go" {
+		return false
+	}
+	return enclosing == "ScopedAgentContractProjection" || enclosing == "exactAgentContractSource"
+}
+
+func agentNameGuardIsAgentMapRange(statement *ast.RangeStmt, info *types.Info) bool {
+	if statement == nil || statement.X == nil || info == nil {
+		return false
+	}
+	typ := info.TypeOf(statement.X)
+	named, ok := typ.(*types.Named)
+	if ok {
+		typ = named.Underlying()
+	}
+	mapping, ok := typ.(*types.Map)
+	if !ok {
+		return false
+	}
+	key, ok := mapping.Key().Underlying().(*types.Basic)
+	if !ok || key.Kind() != types.String {
+		return false
+	}
+	element := mapping.Elem()
+	if pointer, ok := element.(*types.Pointer); ok {
+		element = pointer.Elem()
+	}
+	entry, ok := element.(*types.Named)
+	return ok && entry.Obj() != nil && entry.Obj().Pkg() != nil &&
+		entry.Obj().Name() == "AgentRegistryEntry" &&
+		entry.Obj().Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/contracts"
+}
+
+func agentNameGuardIsRawID(selector *ast.SelectorExpr, info *types.Info) bool {
+	if selector == nil || selector.Sel == nil || selector.Sel.Name != "ID" || info == nil {
+		return false
+	}
+	typ := info.TypeOf(selector.X)
+	if pointer, ok := typ.(*types.Pointer); ok {
+		typ = pointer.Elem()
+	}
+	named, ok := typ.(*types.Named)
+	if !ok || named.Obj() == nil || named.Obj().Pkg() == nil {
+		return false
+	}
+	return named.Obj().Name() == "AgentRegistryEntry" && named.Obj().Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/contracts"
+}
+
+func agentNameGuardIsAgentEntriesCall(selector *ast.SelectorExpr, info *types.Info) bool {
+	if selector == nil || selector.Sel == nil || selector.Sel.Name != "AgentEntries" || info == nil {
+		return false
+	}
+	function, ok := info.Uses[selector.Sel].(*types.Func)
+	return ok && function.Pkg() != nil && function.Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/semanticview"
+}
+
+func agentNameGuardRawIDAllowed(path, enclosing string) bool {
+	return path == "internal/runtime/contracts/workflow_contract_effective.go" && enclosing == "DeclaredAgentID"
+}
+
+func agentNameGuardAgentEntriesAllowed(path, enclosing string) bool {
+	allowed := map[string]struct{}{
+		"internal/runtime/requiredagents/fulfillment.go::RootScope":                                 {},
+		"internal/runtime/runtime.go::(*Runtime).publishBootCompleted":                              {},
+		"internal/runtime/semanticview/agent_declarations.go::AgentDeclarations":                    {},
+		"internal/runtime/semanticview/agent_contract_projection.go::ScopedAgentContractProjection": {},
+		"internal/runtime/tools/emit_runtime.go::NewEmitRegistry":                                   {},
+		"internal/serveapp/main.go::serveBootRegistryDetail":                                        {},
+		"internal/serveapp/main.go::serveLifecycleSourceCounts":                                     {},
+	}
+	_, ok := allowed[path+"::"+enclosing]
+	return ok
+}
+
+func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
+	// These exact functions use the map key only as an authored declaration
+	// coordinate, or ignore it while inspecting non-identity entry fields. Any
+	// new range over the wire map must be classified here or consume a name plan.
+	allowed := map[string]struct{}{
+		"internal/runtime/authoringview/view.go::agentViews":                                                     {},
+		"internal/runtime/bootverify/checks.go::(*checkerContext).invalidFieldDetection":                         {},
+		"internal/runtime/bootverify/checks.go::intentFindingsForScope":                                          {},
+		"internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go::wave1ScopedAgentRecords":       {},
+		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
+		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaReferences":                     {},
+		"internal/runtime/contracts/mock_performance_loading.go::materializeAgentMockPerformances":               {},
+		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":               {},
+		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                           {},
+		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                      {},
+		"internal/runtime/flowdata/flowdata.go::ValidateSource":                                                  {},
+		"internal/runtime/flowdata/flowdata.go::sortedAgentLocalIDs":                                             {},
+		"internal/runtime/manager/flow_activation.go::(*AgentManager).flowInstanceAgentRecords":                  {},
+		"internal/runtime/manager/flow_activation.go::StaticAgentMaterializationRecords":                         {},
+		"internal/runtime/manager/flow_activation.go::flowAgentNamePlans":                                        {},
+		"internal/runtime/manager/flow_activation.go::projectAgentNamePlans":                                     {},
+		"internal/runtime/manager/flow_activation.go::staticAgentsForScope":                                      {},
+		"internal/runtime/manager/flow_activation.go::staticFlowLocalEventSet":                                   {},
+		"internal/runtime/semanticview/agent_declarations.go::AgentDeclarations":                                 {},
+		"internal/runtime/semanticview/bundle_source.go::projectAgentURIs":                                       {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":    {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions": {},
+		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                            {},
+		"internal/runtime/tools/emit_runtime.go::NewEmitRegistry":                                                {},
+	}
+	_, ok := allowed[path+"::"+enclosing]
+	return ok
+}
+
+func agentNameGuardFunctionName(function *ast.FuncDecl) string {
+	if function.Recv == nil || len(function.Recv.List) == 0 {
+		return function.Name.Name
+	}
+	receiver := function.Recv.List[0].Type
+	switch typed := receiver.(type) {
+	case *ast.Ident:
+		return "(" + typed.Name + ")." + function.Name.Name
+	case *ast.StarExpr:
+		if name, ok := typed.X.(*ast.Ident); ok {
+			return "(*" + name.Name + ")." + function.Name.Name
+		}
+	}
+	return function.Name.Name
+}
+
+func agentNameGuardRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/runtime/semanticview/agent_name_plan.go
+++ b/internal/runtime/semanticview/agent_name_plan.go
@@ -1,0 +1,184 @@
+package semanticview
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+)
+
+// AgentNamePlan binds one scoped declaration coordinate to its effective
+// public name. The declaration URI remains map-key based; an authored id only
+// changes the public name.
+type AgentNamePlan struct {
+	ScopeKind   string
+	ScopeID     string
+	OwnerFlowID string
+	LocalID     string
+	OwnerURI    string
+	AgentID     string
+}
+
+func (p AgentNamePlan) Normalize() AgentNamePlan {
+	p.ScopeKind = strings.TrimSpace(p.ScopeKind)
+	p.ScopeID = strings.TrimSpace(p.ScopeID)
+	p.OwnerFlowID = strings.TrimSpace(p.OwnerFlowID)
+	p.LocalID = strings.TrimSpace(p.LocalID)
+	p.OwnerURI = strings.TrimSpace(p.OwnerURI)
+	p.AgentID = strings.TrimSpace(p.AgentID)
+	return p
+}
+
+func (p AgentNamePlan) Validate() error {
+	p = p.Normalize()
+	if p.LocalID == "" {
+		return fmt.Errorf("agent declaration local id is required")
+	}
+	if p.OwnerURI == "" {
+		return fmt.Errorf("agent declaration %q is missing its scoped owner URI", p.LocalID)
+	}
+	if p.AgentID == "" {
+		return fmt.Errorf("agent declaration %q has no effective public name", p.LocalID)
+	}
+	return nil
+}
+
+func (p AgentNamePlan) Materialize() (agentidentity.Name, error) {
+	p = p.Normalize()
+	if err := p.Validate(); err != nil {
+		return agentidentity.Name{}, err
+	}
+	return agentidentity.DeclaredName(p.AgentID, p.OwnerURI)
+}
+
+// EffectiveRole keeps declaration-derived actor and authority projections on
+// one role. Required-agent socket identity remains the scoped local map key.
+func (p AgentNamePlan) EffectiveRole(entry runtimecontracts.AgentRegistryEntry) string {
+	if role := strings.TrimSpace(entry.Role); role != "" {
+		return role
+	}
+	return strings.TrimSpace(p.AgentID)
+}
+
+func (d AgentDeclaration) NamePlan() (AgentNamePlan, error) {
+	agentID, err := runtimecontracts.DeclaredAgentID(d.LocalID, d.Entry)
+	if err != nil {
+		return AgentNamePlan{}, err
+	}
+	plan := AgentNamePlan{
+		ScopeKind:   d.ScopeKind,
+		ScopeID:     d.ScopeID,
+		OwnerFlowID: d.OwnerFlowID,
+		LocalID:     d.LocalID,
+		OwnerURI:    d.OwnerURI,
+		AgentID:     agentID,
+	}.Normalize()
+	if err := plan.Validate(); err != nil {
+		return AgentNamePlan{}, err
+	}
+	return plan, nil
+}
+
+func ScopedAgentNamePlan(source Source, declaration AgentDeclaration) (AgentNamePlan, error) {
+	owner, ok := ScopedAgentDeclarationOwner(source, declaration)
+	if !ok {
+		return AgentNamePlan{}, fmt.Errorf("agent declaration %q is missing a unique scoped owner", strings.TrimSpace(declaration.LocalID))
+	}
+	declaration.OwnerURI = owner
+	return declaration.NamePlan()
+}
+
+func ProjectAgentNamePlan(source Source, scope ProjectScope, localID string) (AgentNamePlan, error) {
+	return agentNamePlanForScope(source, "project", scope.Key, scope.OwningFlowID, scope.AgentURIs[localID], localID)
+}
+
+func FlowAgentNamePlan(source Source, scope FlowScope, localID string) (AgentNamePlan, error) {
+	return agentNamePlanForScope(source, "flow", scope.ID, scope.ID, scope.AgentURIs[localID], localID)
+}
+
+func agentNamePlanForScope(source Source, scopeKind, scopeID, ownerFlowID, ownerURI, localID string) (AgentNamePlan, error) {
+	if source == nil {
+		return AgentNamePlan{}, fmt.Errorf("semantic source is required")
+	}
+	scopeKind = strings.TrimSpace(scopeKind)
+	scopeID = strings.TrimSpace(scopeID)
+	ownerFlowID = strings.TrimSpace(ownerFlowID)
+	ownerURI = strings.TrimSpace(ownerURI)
+	localID = strings.TrimSpace(localID)
+	if localID == "" {
+		return AgentNamePlan{}, fmt.Errorf("agent declaration local id is required")
+	}
+	ownerMatches := []AgentDeclaration{}
+	exact := []AgentDeclaration{}
+	projected := []AgentDeclaration{}
+	available := []string{}
+	for _, declaration := range AgentDeclarations(source) {
+		if strings.TrimSpace(declaration.LocalID) != localID {
+			continue
+		}
+		available = append(available, declaration.Label(true))
+		if ownerURI != "" && strings.TrimSpace(declaration.OwnerURI) == ownerURI {
+			ownerMatches = append(ownerMatches, declaration)
+		}
+		if strings.TrimSpace(declaration.ScopeKind) == scopeKind &&
+			strings.TrimSpace(declaration.ScopeID) == scopeID &&
+			strings.TrimSpace(declaration.OwnerFlowID) == ownerFlowID {
+			exact = append(exact, declaration)
+			continue
+		}
+		if scopeKind == "flow" && strings.TrimSpace(declaration.ScopeKind) == "project" &&
+			strings.TrimSpace(declaration.OwnerFlowID) == ownerFlowID {
+			projected = append(projected, declaration)
+		}
+	}
+	if len(ownerMatches) > 1 {
+		return AgentNamePlan{}, fmt.Errorf("agent declaration %q at owner %q resolved to multiple declarations", localID, ownerURI)
+	}
+	if len(ownerMatches) == 1 {
+		return ScopedAgentNamePlan(source, ownerMatches[0])
+	}
+	if len(exact) > 1 {
+		return AgentNamePlan{}, fmt.Errorf("agent declaration %q in %s scope %q resolved to multiple exact declarations", localID, scopeKind, scopeID)
+	}
+	if len(exact) == 1 {
+		return ScopedAgentNamePlan(source, exact[0])
+	}
+	// Package-backed flow declarations canonicalize to their project scope.
+	// The flow projection may consume that owner only when it is unique.
+	if scopeKind == "flow" && len(projected) == 1 {
+		return ScopedAgentNamePlan(source, projected[0])
+	}
+	return AgentNamePlan{}, fmt.Errorf("agent declaration %q in %s scope %q is not canonical; candidates: %s", localID, scopeKind, scopeID, strings.Join(available, ", "))
+}
+
+func AgentNamePlans(source Source) ([]AgentNamePlan, error) {
+	declarations := AgentDeclarations(source)
+	plans := make([]AgentNamePlan, 0, len(declarations))
+	owners := make(map[string]AgentNamePlan, len(declarations))
+	for _, declaration := range declarations {
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			return nil, err
+		}
+		scopeKey := strings.Join([]string{plan.ScopeKind, plan.ScopeID, plan.OwnerFlowID, plan.AgentID}, "\x00")
+		if previous, exists := owners[scopeKey]; exists && previous.LocalID != plan.LocalID {
+			return nil, fmt.Errorf(
+				"agent declarations %q and %q in scope %q derive the same effective public name %q",
+				previous.LocalID,
+				plan.LocalID,
+				plan.ScopeID,
+				plan.AgentID,
+			)
+		}
+		owners[scopeKey] = plan
+		plans = append(plans, plan)
+	}
+	sort.Slice(plans, func(i, j int) bool {
+		left := strings.Join([]string{plans[i].ScopeKind, plans[i].ScopeID, plans[i].OwnerFlowID, plans[i].LocalID}, "\x00")
+		right := strings.Join([]string{plans[j].ScopeKind, plans[j].ScopeID, plans[j].OwnerFlowID, plans[j].LocalID}, "\x00")
+		return left < right
+	})
+	return plans, nil
+}

--- a/internal/runtime/semanticview/agent_name_plan_test.go
+++ b/internal/runtime/semanticview/agent_name_plan_test.go
@@ -1,0 +1,367 @@
+package semanticview
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+)
+
+func TestAgentNamePlansPreserveScopedCoordinateAndEffectivePublicName(t *testing.T) {
+	source := agentNamePlanNestedSource(false)
+	plans, err := AgentNamePlans(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %#v, want two nested declarations", plans)
+	}
+	byFlow := map[string]AgentNamePlan{}
+	for _, plan := range plans {
+		byFlow[plan.OwnerFlowID] = plan
+	}
+	if got := byFlow["parent"]; got.LocalID != "worker" || got.AgentID != "worker" || got.OwnerURI != "test://agent-name/parent/worker" {
+		t.Fatalf("parent plan = %#v", got)
+	}
+	if got := byFlow["child"]; got.LocalID != "worker" || got.AgentID != "public-worker" || got.OwnerURI != "test://agent-name/child/worker" {
+		t.Fatalf("child plan = %#v", got)
+	}
+	parent, err := byFlow["parent"].Materialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := byFlow["child"].Materialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parent.Owner == child.Owner || parent.AgentID == child.AgentID {
+		t.Fatalf("materialized names = parent %#v child %#v, want distinct owner and effective name", parent, child)
+	}
+}
+
+func TestAgentNamePlansRejectMissingOwnerAndSameScopeCollision(t *testing.T) {
+	missingOwner := agentNamePlanNestedSource(false)
+	bundle, _ := Bundle(missingOwner)
+	bundle.URIRegistry = runtimecontracts.ContractURIRegistry{}
+	if _, err := AgentNamePlans(missingOwner); err == nil || !strings.Contains(err.Error(), "missing a unique scoped owner") {
+		t.Fatalf("missing-owner error = %v", err)
+	}
+
+	collision := agentNamePlanNestedSource(true)
+	if _, err := AgentNamePlans(collision); err == nil || !strings.Contains(err.Error(), "derive the same effective public name") {
+		t.Fatalf("collision error = %v", err)
+	}
+}
+
+func TestResolveAgentRegistryEntryUsesEffectiveNameWithoutLocalAlias(t *testing.T) {
+	source := agentNamePlanNestedSource(false)
+	localID, _, ok := ResolveAgentRegistryEntry(source, models.AgentConfig{ID: "public-worker", FlowID: "child"})
+	if !ok || localID != "worker" {
+		t.Fatalf("effective-name lookup = local %q ok %v, want child worker declaration", localID, ok)
+	}
+	if _, _, ok := ResolveAgentRegistryEntry(source, models.AgentConfig{ID: "worker", FlowID: "child"}); ok {
+		t.Fatal("explicitly overridden child declaration retained its local map key as a public-name alias")
+	}
+}
+
+func TestResolveAgentRegistryEntryPreservesScopeForSharedEffectiveName(t *testing.T) {
+	source := agentNamePlanNestedSource(false)
+	bundle, _ := Bundle(source)
+	child := bundle.FlowTree.ByID["child"]
+	entry := child.Agents["worker"]
+	entry.ID = ""
+	child.Agents["worker"] = entry
+
+	localID, got, ok := ResolveAgentRegistryEntry(source, models.AgentConfig{ID: "worker", FlowID: "child"})
+	if !ok || localID != "worker" || got.Role != "child-worker" {
+		t.Fatalf("child lookup = local %q entry %#v ok %v, want child-scoped worker", localID, got, ok)
+	}
+	localID, got, ok = ResolveAgentRegistryEntry(source, models.AgentConfig{ID: "worker", FlowID: "parent"})
+	if !ok || localID != "worker" || got.Role != "parent-worker" {
+		t.Fatalf("parent lookup = local %q entry %#v ok %v, want parent-scoped worker", localID, got, ok)
+	}
+	if _, _, ok := ResolveAgentRegistryEntry(source, models.AgentConfig{ID: "worker"}); ok {
+		t.Fatal("scope-free lookup accepted a public name owned by two declarations")
+	}
+}
+
+func TestAgentContractProjectionPreservesScopedToolForLiteralPublicName(t *testing.T) {
+	source := agentNamePlanNestedSource(false)
+	child, ok := ResolveAgentContractProjection(source, models.AgentConfig{ID: "public-worker", FlowID: "child"})
+	if !ok || child.OwnerFlowID != "child" || child.ContractSource.FlowID != "child" {
+		t.Fatalf("child projection = %#v ok %v", child, ok)
+	}
+	tool, ok := child.ToolEntry("shared-tool")
+	if !ok || tool.Description() != "child scoped tool" {
+		t.Fatalf("child scoped tool = %#v ok %v", tool, ok)
+	}
+	parent, ok := ResolveAgentContractProjection(source, models.AgentConfig{ID: "worker", FlowID: "parent"})
+	if !ok {
+		t.Fatal("parent projection did not resolve")
+	}
+	tool, ok = parent.ToolEntry("shared-tool")
+	if !ok || tool.Description() != "parent scoped tool" {
+		t.Fatalf("parent scoped tool = %#v ok %v", tool, ok)
+	}
+}
+
+func TestProjectAgentNamePlanPreservesExactScopeForSharedFlowAndLocalID(t *testing.T) {
+	firstOwner := "test://agent-name/packages/first/worker"
+	secondOwner := "test://agent-name/packages/second/worker"
+	refs := map[string]runtimecontracts.ContractURIRef{
+		firstOwner:  {Kind: "agent", LocalID: "worker", Full: firstOwner},
+		secondOwner: {Kind: "agent", LocalID: "worker", Full: secondOwner},
+	}
+	source := agentNameProjectScopeSource{
+		Source: Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: refs}}),
+		projects: []ProjectScope{
+			{Key: "packages/first", OwningFlowID: "support", Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": {ID: "first-worker"}}, AgentURIs: map[string]string{"worker": firstOwner}},
+			{Key: "packages/second", OwningFlowID: "support", Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": {ID: "second-worker"}}, AgentURIs: map[string]string{"worker": secondOwner}},
+		},
+	}
+
+	first, err := ProjectAgentNamePlan(source, source.projects[0], "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ProjectAgentNamePlan(source, source.projects[1], "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ScopeID != "packages/first" || first.AgentID != "first-worker" || first.OwnerURI != firstOwner {
+		t.Fatalf("first plan = %#v", first)
+	}
+	if second.ScopeID != "packages/second" || second.AgentID != "second-worker" || second.OwnerURI != secondOwner {
+		t.Fatalf("second plan = %#v", second)
+	}
+}
+
+func TestResolveAgentDeclarationUsesConcreteOwnerForSameFlowProjectScopes(t *testing.T) {
+	firstOwner := "test://agent-name/packages/first/worker"
+	secondOwner := "test://agent-name/packages/second/worker"
+	refs := map[string]runtimecontracts.ContractURIRef{
+		firstOwner:  {Kind: "agent", LocalID: "worker", Full: firstOwner},
+		secondOwner: {Kind: "agent", LocalID: "worker", Full: secondOwner},
+	}
+	tool := func(description string) runtimecontracts.ToolSchemaEntry {
+		return runtimecontracts.MustToolSchemaEntry(
+			runtimecontracts.WithToolDescription(description),
+			runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerPlatformBuiltin),
+			runtimecontracts.WithToolSchemas(
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+			),
+		)
+	}
+	source := agentNameProjectScopeSource{
+		Source: Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: refs}}),
+		projects: []ProjectScope{
+			{
+				Key: "packages/first", OwningFlowID: "support",
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{
+					"worker": {
+						Role:           "first-role",
+						Permissions:    []string{"first-permission"},
+						Criteria:       []string{"first-criterion"},
+						FlowDataAccess: []string{"first.json"},
+						EntityWrites: map[string]runtimecontracts.AgentEntityWriteDecl{
+							"case": {Save: runtimecontracts.AgentEntityWriteRule{Fields: []string{"first-field"}}},
+						},
+					},
+				},
+				AgentURIs: map[string]string{"worker": firstOwner},
+				Tools:     map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("first scoped tool")},
+			},
+			{
+				Key: "packages/second", OwningFlowID: "support",
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{
+					"worker": {
+						Role:           "second-role",
+						Permissions:    []string{"second-permission"},
+						Criteria:       []string{"second-criterion"},
+						FlowDataAccess: []string{"second.json"},
+						EntityWrites: map[string]runtimecontracts.AgentEntityWriteDecl{
+							"case": {Save: runtimecontracts.AgentEntityWriteRule{Fields: []string{"second-field"}}},
+						},
+					},
+				},
+				AgentURIs: map[string]string{"worker": secondOwner},
+				Tools:     map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("second scoped tool")},
+			},
+		},
+	}
+
+	prefixes := []string{"first", "second"}
+	toolDescriptions := []string{"first scoped tool", "second scoped tool"}
+	for index, scope := range source.projects {
+		plan, err := ProjectAgentNamePlan(source, scope, "worker")
+		if err != nil {
+			t.Fatal(err)
+		}
+		name, err := plan.Materialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+		actor := models.AgentConfig{ID: "worker", FlowID: "support"}
+		actor.Identity.Name = name
+		declaration, ok := ResolveAgentDeclaration(source, actor)
+		prefix := prefixes[index]
+		if !ok || declaration.ScopeID != scope.Key || declaration.Entry.Role != prefix+"-role" ||
+			!slices.Equal(declaration.Entry.Permissions, []string{prefix + "-permission"}) ||
+			!slices.Equal(declaration.Entry.Criteria, []string{prefix + "-criterion"}) ||
+			!slices.Equal(declaration.Entry.FlowDataAccess, []string{prefix + ".json"}) ||
+			!slices.Equal(declaration.Entry.EntityWrites["case"].Save.Fields, []string{prefix + "-field"}) {
+			t.Fatalf("scope %q declaration = %#v ok %v", scope.Key, declaration, ok)
+		}
+		projection, ok := ResolveAgentContractProjection(source, actor)
+		if !ok || projection.Declaration.ScopeID != scope.Key {
+			t.Fatalf("scope %q projection = %#v ok %v", scope.Key, projection, ok)
+		}
+		entry, ok := projection.ToolEntry("shared-tool")
+		if !ok || entry.Description() != toolDescriptions[index] {
+			t.Fatalf("scope %q tool = %#v ok %v", scope.Key, entry, ok)
+		}
+	}
+
+	firstPlan, err := ProjectAgentNamePlan(source, source.projects[0], "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstName, err := firstPlan.Materialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongID := models.AgentConfig{ID: "other", FlowID: "support"}
+	wrongID.Identity.Name = firstName
+	if _, ok := ResolveAgentDeclaration(source, wrongID); ok {
+		t.Fatal("declared identity with a mismatched public ID fell back to another declaration")
+	}
+	wrongFlow := models.AgentConfig{ID: "worker", FlowID: "other"}
+	wrongFlow.Identity.Name = firstName
+	if _, ok := ResolveAgentDeclaration(source, wrongFlow); ok {
+		t.Fatal("declared identity with a mismatched owner flow bypassed scope validation")
+	}
+	scopeKeyFlow := models.AgentConfig{ID: "worker", FlowID: source.projects[0].Key}
+	scopeKeyFlow.Identity.Name = firstName
+	if _, ok := ResolveAgentDeclaration(source, scopeKeyFlow); ok {
+		t.Fatal("project scope key was accepted as the declaration owner flow")
+	}
+	if _, _, ok := ResolveAgentRegistryEntry(source, scopeKeyFlow); ok {
+		t.Fatal("project scope key inherited a declaration registry entry across flows")
+	}
+	if _, ok := ResolveAgentContractProjection(source, scopeKeyFlow); ok {
+		t.Fatal("project scope key inherited a declaration contract across flows")
+	}
+	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{ID: "worker", FlowID: source.projects[0].Key}); ok {
+		t.Fatal("project scope key cross-bound the ID-only declaration lookup")
+	}
+	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{Role: "first-role", FlowID: source.projects[0].Key}); ok {
+		t.Fatal("project scope key cross-bound the role-only declaration lookup")
+	}
+	firstName.Owner = "test://agent-name/packages/missing/worker"
+	unknownOwner := models.AgentConfig{ID: "worker", FlowID: "support"}
+	unknownOwner.Identity.Name = firstName
+	if _, ok := ResolveAgentDeclaration(source, unknownOwner); ok {
+		t.Fatal("unknown declared owner disambiguated otherwise ambiguous flow/name selection")
+	}
+	source.projects = source.projects[:1]
+	if _, ok := ResolveAgentDeclaration(source, unknownOwner); ok {
+		t.Fatal("unknown declared owner fell back to the unique public ID")
+	}
+	if _, _, ok := ResolveAgentRegistryEntry(source, unknownOwner); ok {
+		t.Fatal("unknown declared owner inherited the unique registry entry")
+	}
+	if _, ok := ResolveAgentContractProjection(source, unknownOwner); ok {
+		t.Fatal("unknown declared owner inherited the unique scoped contract")
+	}
+	entry := source.projects[0].Agents["worker"]
+	entry.ID = "public-worker"
+	entry.Role = ""
+	source.projects[0].Agents["worker"] = entry
+	if !retiredLocalAgentAlias(source, "support", "worker") {
+		t.Fatal("literal public name did not retire its local alias in the owner flow")
+	}
+	if retiredLocalAgentAlias(source, source.projects[0].Key, "worker") {
+		t.Fatal("project scope key was treated as the owner flow while retiring a local alias")
+	}
+	runtimeRoleActor := models.AgentConfig{ID: "runtime-worker", Role: "public-worker", FlowID: "support"}
+	declaration, ok := ResolveAgentDeclaration(source, runtimeRoleActor)
+	if !ok || declaration.ScopeID != source.projects[0].Key {
+		t.Fatalf("effective-role fallback = %#v ok %v, want exact project declaration", declaration, ok)
+	}
+	if _, ok := ResolveAgentContractProjection(source, runtimeRoleActor); !ok {
+		t.Fatal("effective-role fallback withheld the declaration contract")
+	}
+	runtimeRoleActor.FlowID = source.projects[0].Key
+	if _, ok := ResolveAgentDeclaration(source, runtimeRoleActor); ok {
+		t.Fatal("project scope key cross-bound the effective-role fallback")
+	}
+}
+
+type agentNameProjectScopeSource struct {
+	Source
+	projects []ProjectScope
+}
+
+func (s agentNameProjectScopeSource) ProjectScopes() []ProjectScope {
+	return append([]ProjectScope(nil), s.projects...)
+}
+
+func agentNamePlanNestedSource(collision bool) Source {
+	tool := func(description string) runtimecontracts.ToolSchemaEntry {
+		return runtimecontracts.MustToolSchemaEntry(
+			runtimecontracts.WithToolDescription(description),
+			runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerPlatformBuiltin),
+			runtimecontracts.WithToolSchemas(
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+			),
+		)
+	}
+	parentAgents := map[string]runtimecontracts.AgentRegistryEntry{
+		"worker": {Role: "parent-worker"},
+	}
+	childAgents := map[string]runtimecontracts.AgentRegistryEntry{
+		"worker": {ID: "public-worker", Role: "child-worker"},
+	}
+	if collision {
+		childAgents["alias"] = runtimecontracts.AgentRegistryEntry{ID: "public-worker", Role: "alias"}
+	}
+	child := runtimecontracts.FlowContractView{
+		Path: "parent/child",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: "child", Flow: "child",
+		},
+		Agents: childAgents,
+		Tools:  map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("child scoped tool")},
+	}
+	parent := runtimecontracts.FlowContractView{
+		Path: "parent",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: "parent", Flow: "parent",
+		},
+		Agents:   parentAgents,
+		Tools:    map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("parent scoped tool")},
+		Children: []runtimecontracts.FlowContractView{child},
+	}
+	refs := map[string]runtimecontracts.ContractURIRef{
+		"parent/worker": {Kind: "agent", FlowID: "parent", LocalID: "worker", Full: "test://agent-name/parent/worker"},
+		"child/worker":  {Kind: "agent", FlowID: "child", LocalID: "worker", Full: "test://agent-name/child/worker"},
+	}
+	if collision {
+		refs["child/alias"] = runtimecontracts.ContractURIRef{Kind: "agent", FlowID: "child", LocalID: "alias", Full: "test://agent-name/child/alias"}
+	}
+	byURI := map[string]runtimecontracts.ContractURIRef{}
+	for _, ref := range refs {
+		byURI[ref.Full] = ref
+	}
+	return Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{parent}},
+			ByID: map[string]*runtimecontracts.FlowContractView{"parent": &parent, "child": &child},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{Agents: refs, ByURI: byURI},
+	})
+}

--- a/internal/runtime/semanticview/agents.go
+++ b/internal/runtime/semanticview/agents.go
@@ -1,48 +1,87 @@
 package semanticview
 
 import (
-	"regexp"
-	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
 )
 
-type agentRecord struct {
-	logicalID string
-	entry     runtimecontracts.AgentRegistryEntry
-	flowID    string
-}
-
 func ResolveAgentRegistryEntry(source Source, cfg models.AgentConfig) (string, runtimecontracts.AgentRegistryEntry, bool) {
-	if source == nil {
+	declaration, ok := ResolveAgentDeclaration(source, cfg)
+	if !ok {
 		return "", runtimecontracts.AgentRegistryEntry{}, false
 	}
-	if matched := resolveAgentRegistryByID(source, strings.TrimSpace(cfg.ID)); matched != "" {
-		for _, record := range agentRecords(source) {
-			if strings.TrimSpace(record.logicalID) == matched {
-				return matched, record.entry, true
-			}
+	return strings.TrimSpace(declaration.LocalID), declaration.Entry, true
+}
+
+// ResolveAgentDeclaration returns the exact scoped declaration owned by a
+// runtime actor. Effective public names are only unique within a scope, so the
+// scope must remain attached throughout selection.
+func ResolveAgentDeclaration(source Source, cfg models.AgentConfig) (AgentDeclaration, bool) {
+	if source == nil {
+		return AgentDeclaration{}, false
+	}
+	agentID := strings.TrimSpace(cfg.ID)
+	flowID := strings.TrimSpace(cfg.FlowID)
+	name := cfg.Identity.Name.Normalize()
+	if name.Source == agentidentity.NameSourceDeclared {
+		if err := name.Validate(); err != nil || (agentID != "" && agentID != name.AgentID) {
+			return AgentDeclaration{}, false
 		}
-		return "", runtimecontracts.AgentRegistryEntry{}, false
+		if declaration, ok := resolveAgentDeclarationByName(source, flowID, name.AgentID, name.Owner); ok {
+			return declaration, true
+		}
+		return AgentDeclaration{}, false
+	}
+	if declaration, ok := resolveAgentDeclarationByID(source, flowID, agentID); ok {
+		return declaration, true
+	}
+	if agentID != "" && retiredLocalAgentAlias(source, flowID, agentID) {
+		return AgentDeclaration{}, false
 	}
 
 	role := canonicalLookupValue(cfg.Role)
 	if role == "" {
-		return "", runtimecontracts.AgentRegistryEntry{}, false
+		return AgentDeclaration{}, false
 	}
-	flowID := canonicalLookupValue(cfg.FlowID)
-	for _, record := range agentRecords(source) {
-		if canonicalLookupValue(record.entry.Role) != role {
+	var matched AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err != nil || canonicalLookupValue(plan.EffectiveRole(declaration.Entry)) != role {
 			continue
 		}
-		if flowID != "" && canonicalLookupValue(record.flowID) != flowID {
+		if !agentDeclarationMatchesFlow(declaration, flowID) {
 			continue
 		}
-		return strings.TrimSpace(record.logicalID), record.entry, true
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return AgentDeclaration{}, false
+		}
+		matched = declaration
 	}
-	return "", runtimecontracts.AgentRegistryEntry{}, false
+	if strings.TrimSpace(matched.LocalID) == "" {
+		return AgentDeclaration{}, false
+	}
+	return matched, true
+}
+
+func retiredLocalAgentAlias(source Source, flowID, candidate string) bool {
+	flowID = strings.TrimSpace(flowID)
+	candidate = strings.TrimSpace(candidate)
+	for _, declaration := range AgentDeclarations(source) {
+		if strings.TrimSpace(declaration.LocalID) != candidate {
+			continue
+		}
+		if flowID != "" && strings.TrimSpace(declaration.OwnerFlowID) != flowID {
+			continue
+		}
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err == nil && plan.AgentID != candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func AgentDeclarationOwner(source Source, flowID, logicalID string) (string, bool) {
@@ -56,9 +95,6 @@ func ScopedAgentDeclarationOwner(source Source, declaration AgentDeclaration) (s
 			strings.TrimSpace(candidate.ScopeID) != strings.TrimSpace(declaration.ScopeID) ||
 			strings.TrimSpace(candidate.LocalID) != strings.TrimSpace(declaration.LocalID) {
 			continue
-		}
-		if strings.TrimSpace(candidate.ScopeKind) != "" && strings.TrimSpace(candidate.OwnerURI) == "" {
-			return "", false
 		}
 		ownerURI := strings.TrimSpace(candidate.OwnerURI)
 		for _, other := range declarations {
@@ -166,75 +202,65 @@ func projectAgentRefOwnedByFlow(source Source, ref runtimecontracts.ContractURIR
 	return matchingRefs == 1
 }
 
-func resolveAgentRegistryByID(source Source, agentID string) string {
+func resolveAgentDeclarationByName(source Source, flowID, agentID, ownerURI string) (AgentDeclaration, bool) {
+	flowID = strings.TrimSpace(flowID)
+	agentID = strings.TrimSpace(agentID)
+	ownerURI = strings.TrimSpace(ownerURI)
+	if source == nil || agentID == "" || ownerURI == "" {
+		return AgentDeclaration{}, false
+	}
+	var matched AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		if !agentDeclarationMatchesFlow(declaration, flowID) {
+			continue
+		}
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err != nil || plan.AgentID != agentID || plan.OwnerURI != ownerURI {
+			continue
+		}
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return AgentDeclaration{}, false
+		}
+		matched = declaration
+	}
+	if strings.TrimSpace(matched.LocalID) == "" {
+		return AgentDeclaration{}, false
+	}
+	return matched, true
+}
+
+func resolveAgentDeclarationByID(source Source, flowID, agentID string) (AgentDeclaration, bool) {
+	flowID = strings.TrimSpace(flowID)
 	agentID = strings.TrimSpace(agentID)
 	if source == nil || agentID == "" {
-		return ""
+		return AgentDeclaration{}, false
 	}
-	for _, record := range agentRecords(source) {
-		if strings.TrimSpace(record.logicalID) == agentID || registryIDMatches(record.entry.ID, agentID) {
-			return strings.TrimSpace(record.logicalID)
+	var matched AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		if !agentDeclarationMatchesFlow(declaration, flowID) {
+			continue
 		}
+		plan, err := ScopedAgentNamePlan(source, declaration)
+		if err != nil || plan.AgentID != agentID {
+			continue
+		}
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return AgentDeclaration{}, false
+		}
+		matched = declaration
 	}
-	return ""
+	if strings.TrimSpace(matched.LocalID) == "" {
+		return AgentDeclaration{}, false
+	}
+	return matched, true
 }
 
-func agentRecords(source Source) []agentRecord {
-	if source == nil {
-		return nil
-	}
-	projectScopes := source.ProjectScopes()
-	flowScopes := source.FlowScopes()
-	records := make([]agentRecord, 0, len(projectScopes)+len(flowScopes))
-	for _, scope := range projectScopes {
-		for _, logicalID := range sortedKeys(scope.Agents) {
-			records = append(records, agentRecord{
-				logicalID: logicalID,
-				entry:     scope.Agents[logicalID],
-			})
-		}
-	}
-	for _, scope := range flowScopes {
-		for _, logicalID := range sortedKeys(scope.Agents) {
-			records = append(records, agentRecord{
-				logicalID: logicalID,
-				entry:     scope.Agents[logicalID],
-				flowID:    strings.TrimSpace(scope.ID),
-			})
-		}
-	}
-	return records
-}
-
-func registryIDMatches(template, candidate string) bool {
-	template = strings.TrimSpace(template)
-	candidate = strings.TrimSpace(candidate)
-	if template == "" || candidate == "" {
-		return false
-	}
-	if template == candidate {
+func agentDeclarationMatchesFlow(declaration AgentDeclaration, flowID string) bool {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
 		return true
 	}
-	matched, err := regexp.MatchString(templateMatchPattern(template), candidate)
-	return err == nil && matched
-}
-
-func templateMatchPattern(template string) string {
-	matches := promptTemplateFieldPattern.FindAllStringIndex(template, -1)
-	if len(matches) == 0 {
-		return "^" + regexp.QuoteMeta(template) + "$"
-	}
-	var builder strings.Builder
-	builder.WriteString("^")
-	last := 0
-	for _, match := range matches {
-		builder.WriteString(regexp.QuoteMeta(template[last:match[0]]))
-		builder.WriteString(".+")
-		last = match[1]
-	}
-	builder.WriteString(regexp.QuoteMeta(template[last:]))
-	builder.WriteString("$")
-	return builder.String()
+	return strings.TrimSpace(declaration.OwnerFlowID) == flowID
 }
 
 func canonicalLookupValue(value string) string {
@@ -242,23 +268,3 @@ func canonicalLookupValue(value string) string {
 	value = strings.ReplaceAll(value, "_", "-")
 	return value
 }
-
-func sortedKeys[V any](m map[string]V) []string {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		key = strings.TrimSpace(key)
-		if key != "" {
-			keys = append(keys, key)
-		}
-	}
-	if len(keys) == 0 {
-		return nil
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-var promptTemplateFieldPattern = regexp.MustCompile(`\{[^{}]+\}`)

--- a/internal/runtime/semanticview/agents_test.go
+++ b/internal/runtime/semanticview/agents_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestResolveAgentRegistryEntryRoleFallbackUsesFlowID(t *testing.T) {
+	const owner = "test://semanticview/flows/support/agents/flow-responder"
 	flow := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{
 			ID:   "support",
@@ -20,8 +21,13 @@ func TestResolveAgentRegistryEntryRoleFallbackUsesFlowID(t *testing.T) {
 				Role: "responder",
 			},
 		},
+		AgentURIs: map[string]string{"flow-responder": owner},
 	}
 	bundle := &runtimecontracts.WorkflowContractBundle{
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{owner: {Kind: "agent", FlowID: "support", LocalID: "flow-responder", Full: owner}},
+			ByURI:  map[string]runtimecontracts.ContractURIRef{owner: {Kind: "agent", FlowID: "support", LocalID: "flow-responder", Full: owner}},
+		},
 		FlowTree: runtimecontracts.FlowTree{
 			Root: &flow,
 			ByID: map[string]*runtimecontracts.FlowContractView{

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -410,9 +410,6 @@ func (s bundleSource) RuntimeEventOwners(eventType string) []string {
 func (s bundleSource) NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool) {
 	return s.bundle.NodeContractSource(nodeID)
 }
-func (s bundleSource) AgentContractSource(agentID string) (runtimecontracts.ContractItemSource, bool) {
-	return s.bundle.AgentContractSource(agentID)
-}
 func (s bundleSource) ResolveNodeEventReference(nodeID, eventType string) string {
 	return s.bundle.ResolveNodeEventReference(nodeID, eventType)
 }
@@ -446,9 +443,6 @@ func (s bundleSource) EventEntry(eventType string) (runtimecontracts.EventCatalo
 }
 func (s bundleSource) ToolEntries() map[string]runtimecontracts.ToolSchemaEntry {
 	return s.bundle.ToolEntries()
-}
-func (s bundleSource) ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
-	return s.bundle.ToolEntryForAgent(agentID, toolID)
 }
 func (s bundleSource) AuthoredResolvedEventCatalog() map[string]runtimecontracts.EventCatalogEntry {
 	return s.bundle.AuthoredResolvedEventCatalog()

--- a/internal/runtime/semanticview/endpoint_census.go
+++ b/internal/runtime/semanticview/endpoint_census.go
@@ -47,6 +47,7 @@ type AuthoredEventEndpoint struct {
 	Pattern        bool                                     `json:"pattern,omitempty"`
 	NodeID         string                                   `json:"node_id,omitempty"`
 	HandlerEvent   string                                   `json:"handler_event,omitempty"`
+	AgentLocalID   string                                   `json:"agent_local_id,omitempty"`
 	AgentID        string                                   `json:"agent_id,omitempty"`
 	Role           string                                   `json:"role,omitempty"`
 	TimerID        string                                   `json:"timer_id,omitempty"`
@@ -791,48 +792,30 @@ func (b *endpointCensusBuilder) addNodeEndpoints() {
 }
 
 func (b *endpointCensusBuilder) addAgentEndpoints() {
-	represented := map[string]struct{}{}
-	projectScopes := sortedAuthoredProjectScopes(b.source.ProjectScopes())
-	for _, scope := range projectScopes {
-		if authoredEmitSiteSkipsProjectScope(scope) {
+	for _, declaration := range AgentDeclarations(b.source) {
+		projection, ok := ScopedAgentContractProjection(b.source, declaration)
+		if !ok {
 			continue
 		}
-		b.addAgentScope(scope.OwningFlowID, scope.Key, "", scope.Agents, represented)
-	}
-	flowScopes := sortedAuthoredFlowScopes(b.source.FlowScopes())
-	preferredFlowScopeKeys := authoredPreferredFlowScopeKeys(projectScopes, flowScopes)
-	for _, scope := range flowScopes {
-		scopeKey := authoredEmitSiteFlowScopeKey(scope)
-		if preferred := preferredFlowScopeKeys[strings.TrimSpace(scope.ID)]; preferred != "" && scopeKey != preferred {
+		plan, err := ScopedAgentNamePlan(b.source, declaration)
+		if err != nil {
 			continue
 		}
-		b.addAgentScope(scope.ID, scopeKey, scope.Path, scope.Agents, represented)
-	}
-	for _, agentID := range sortedMapKeys(b.source.AgentEntries()) {
-		if _, ok := represented[agentID]; ok {
-			continue
+		flowPath := ""
+		if projection.OwnerFlowID != "" {
+			flowPath = strings.Trim(strings.TrimSpace(b.source.FlowPath(projection.OwnerFlowID)), "/")
 		}
-		agent := b.source.AgentEntries()[agentID]
-		contractSource, _ := b.source.AgentContractSource(agentID)
-		b.addAgent(agentID, agent, contractSource.FlowID, contractSource.PackageKey, "", contractSource.File)
+		b.addAgent(plan, declaration.Entry, projection.ContractSource.PackageKey, flowPath, projection.ContractSource.File)
 	}
 }
 
-func (b *endpointCensusBuilder) addAgentScope(flowID, packageKey, flowPath string, agents map[string]runtimecontracts.AgentRegistryEntry, represented map[string]struct{}) {
-	for _, agentID := range sortedMapKeys(agents) {
-		represented[agentID] = struct{}{}
-		contractSource, _ := b.source.AgentContractSource(agentID)
-		sourceFile := strings.TrimSpace(contractSource.File)
-		b.addAgent(agentID, agents[agentID], flowID, packageKey, flowPath, sourceFile)
-	}
-}
-
-func (b *endpointCensusBuilder) addAgent(agentID string, agent runtimecontracts.AgentRegistryEntry, flowID, packageKey, flowPath, sourceFile string) {
-	flowID = strings.TrimSpace(flowID)
+func (b *endpointCensusBuilder) addAgent(plan AgentNamePlan, agent runtimecontracts.AgentRegistryEntry, packageKey, flowPath, sourceFile string) {
+	flowID := strings.TrimSpace(plan.OwnerFlowID)
 	role := strings.TrimSpace(agent.Role)
 	for _, eventType := range normalizedSortedStrings(agent.EmitEvents) {
 		endpoint := b.endpoint(EventEndpointProducer, EventEndpointAgent, flowID, eventType)
-		endpoint.AgentID = agentID
+		endpoint.AgentLocalID = plan.LocalID
+		endpoint.AgentID = plan.AgentID
 		endpoint.Role = role
 		endpoint.PackageKey = strings.TrimSpace(packageKey)
 		endpoint.FlowPath = strings.TrimSpace(flowPath)
@@ -842,7 +825,8 @@ func (b *endpointCensusBuilder) addAgent(agentID string, agent runtimecontracts.
 	}
 	for _, eventType := range normalizedSortedStrings(agent.Subscriptions) {
 		endpoint := b.endpoint(EventEndpointConsumer, EventEndpointAgent, flowID, eventType)
-		endpoint.AgentID = agentID
+		endpoint.AgentLocalID = plan.LocalID
+		endpoint.AgentID = plan.AgentID
 		endpoint.Role = role
 		endpoint.PackageKey = strings.TrimSpace(packageKey)
 		endpoint.FlowPath = strings.TrimSpace(flowPath)
@@ -1036,7 +1020,7 @@ func (b *endpointCensusBuilder) endpointSourceLine(endpoint AuthoredEventEndpoin
 		if endpoint.Direction == EventEndpointProducer {
 			field = "emit_events"
 		}
-		return yamlActorEventLine(root, endpoint.AgentID, []string{field}, eventType)
+		return yamlActorEventLine(root, endpoint.AgentLocalID, []string{field}, eventType)
 	default:
 		return 0
 	}
@@ -1179,7 +1163,7 @@ func endpointSubscriptionAdmission(source Source, endpoint AuthoredEventEndpoint
 		consumerID = endpoint.NodeID
 	case EventEndpointAgent:
 		consumerKind = AuthoredSubscriptionConsumerAgent
-		consumerID = endpoint.AgentID
+		consumerID = endpoint.AgentLocalID
 	case EventEndpointTimer:
 		consumerKind = AuthoredSubscriptionConsumerTimer
 		consumerID = endpoint.TimerID

--- a/internal/runtime/semanticview/endpoint_census_test.go
+++ b/internal/runtime/semanticview/endpoint_census_test.go
@@ -120,6 +120,14 @@ func TestAuthoredEventEndpointCensusEnumeratesEveryProducerConsumerFamily(t *tes
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"analyst": {ID: "analyst", Role: "analyst", Subscriptions: []string{"analysis.requested"}, EmitEvents: []string{"analysis.completed"}},
 		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				"analyst": {Kind: "agent", LocalID: "analyst", Full: "test://endpoint-census/analyst"},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				"test://endpoint-census/analyst": {Kind: "agent", LocalID: "analyst", Full: "test://endpoint-census/analyst"},
+			},
+		},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"external.received": {Swarm: runtimecontracts.EventSwarmMetadata{Source: "external", Consumer: []string{"external"}}},
 		},

--- a/internal/runtime/semanticview/helpers.go
+++ b/internal/runtime/semanticview/helpers.go
@@ -190,27 +190,6 @@ func policyOwnerPackageKey(packageKey string) string {
 	return "package:" + packageKey
 }
 
-func FindAgentEntry(source Source, agentID, role string) (runtimecontracts.AgentRegistryEntry, bool) {
-	if source == nil {
-		return runtimecontracts.AgentRegistryEntry{}, false
-	}
-	agentID = strings.TrimSpace(agentID)
-	role = strings.TrimSpace(role)
-	if agentID != "" {
-		if entry, ok := source.AgentEntries()[agentID]; ok {
-			return entry, true
-		}
-	}
-	if role != "" {
-		for _, entry := range source.AgentEntries() {
-			if strings.EqualFold(strings.TrimSpace(entry.Role), role) || strings.EqualFold(strings.TrimSpace(entry.ID), role) {
-				return entry, true
-			}
-		}
-	}
-	return runtimecontracts.AgentRegistryEntry{}, false
-}
-
 func splitPolicyKey(key string) (string, string) {
 	key = strings.TrimSpace(key)
 	if idx := strings.IndexByte(key, '.'); idx >= 0 {

--- a/internal/runtime/semanticview/import_boundary_dependencies.go
+++ b/internal/runtime/semanticview/import_boundary_dependencies.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 )
 
 const (
@@ -73,8 +74,8 @@ func CredentialStoreKeyForActorFlow(source Source, actorID, flowID, key string) 
 	if flowID != "" {
 		return CredentialStoreKeyForFlow(source, flowID, key)
 	}
-	if agentSource, ok := source.AgentContractSource(actorID); ok {
-		return CredentialStoreKeyForFlow(source, agentSource.FlowID, key)
+	if projection, ok := ResolveAgentContractProjection(source, models.AgentConfig{ID: actorID, FlowID: flowID}); ok {
+		return CredentialStoreKeyForFlow(source, projection.OwnerFlowID, key)
 	}
 	return strings.TrimSpace(key), false
 }

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -200,7 +200,6 @@ states:
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 backend:
-  id: backend-{vertical_id}
   intent: {inline: "Exercise package-backed memory proof."}
   model: regular
   memory: true
@@ -263,7 +262,6 @@ states:
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
 	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 backend:
-  id: backend-{flow_id}
   intent: {inline: "Exercise flow-scoped memory proof."}
   model: regular
   memory: true

--- a/internal/runtime/semanticview/source.go
+++ b/internal/runtime/semanticview/source.go
@@ -57,7 +57,6 @@ type Source interface {
 	DerivedHandlerTransitions() []runtimecontracts.HandlerTransitionSemantic
 	RuntimeEventOwners(eventType string) []string
 	NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool)
-	AgentContractSource(agentID string) (runtimecontracts.ContractItemSource, bool)
 	ResolveNodeEventReference(nodeID, eventType string) string
 	NodeRuntimeSubscriptions(nodeID string) []string
 	NodeHandlerSubscriptions(nodeID string) []string
@@ -69,6 +68,5 @@ type Source interface {
 	EventEntries() map[string]runtimecontracts.EventCatalogEntry
 	EventEntry(eventType string) (runtimecontracts.EventCatalogEntry, bool)
 	ToolEntries() map[string]runtimecontracts.ToolSchemaEntry
-	ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool)
 	AuthoredResolvedEventCatalog() map[string]runtimecontracts.EventCatalogEntry
 }

--- a/internal/runtime/semanticview/tool_overlay.go
+++ b/internal/runtime/semanticview/tool_overlay.go
@@ -20,14 +20,6 @@ func (s toolOverlaySource) ToolEntries() map[string]runtimecontracts.ToolSchemaE
 	return out
 }
 
-func (s toolOverlaySource) ToolEntryForAgent(agentID, toolID string) (runtimecontracts.ToolSchemaEntry, bool) {
-	if tool, ok := s.Source.ToolEntryForAgent(agentID, toolID); ok {
-		return tool, true
-	}
-	tool, ok := s.tools[strings.TrimSpace(toolID)]
-	return tool, ok
-}
-
 // WithRuntimeTools adds platform-compiled tools without mutating the authored
 // bundle or granting authors a second declaration path.
 func WithRuntimeTools(source Source, tools map[string]runtimecontracts.ToolSchemaEntry) (Source, error) {

--- a/internal/runtime/semanticviewtest/source.go
+++ b/internal/runtime/semanticviewtest/source.go
@@ -1,0 +1,34 @@
+package semanticviewtest
+
+import (
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+// WrapRootAgents gives direct in-memory root declarations the owner facts that
+// the contract loader normally supplies. It is for tests that intentionally
+// bypass loading, not a runtime identity fallback.
+func WrapRootAgents(bundle *runtimecontracts.WorkflowContractBundle) semanticview.Source {
+	if bundle == nil {
+		return nil
+	}
+	if bundle.URIRegistry.Agents == nil {
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
+	}
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	for rawLocalID := range bundle.Agents {
+		localID := strings.TrimSpace(rawLocalID)
+		if localID == "" {
+			continue
+		}
+		uri := "swarm-test://root/agents/" + localID
+		ref := runtimecontracts.ContractURIRef{Kind: "agent", LocalID: localID, Full: uri}
+		bundle.URIRegistry.Agents[localID] = ref
+		bundle.URIRegistry.ByURI[uri] = ref
+	}
+	return semanticview.Wrap(bundle)
+}

--- a/internal/runtime/template_instance_delivery_test.go
+++ b/internal/runtime/template_instance_delivery_test.go
@@ -331,7 +331,7 @@ func TestTemplateInstanceActivationConfigSubscriberPersistsRenderedRouteAndDeliv
 		WHERE event_name = 'operating/11111111-1111-4111-8111-111111111111/opco.product_initialization_requested'
 	`, nil)
 
-	renderedAgentID := "ceo-product-1"
+	renderedAgentID := "ceo"
 	waitRuntimeDBCount(t, ctx, db, `
 		SELECT COUNT(*) FROM routing_rules
 		WHERE flow_instance = 'operating/11111111-1111-4111-8111-111111111111'
@@ -865,7 +865,6 @@ auto_emit_on_create:
   product_id: string
 `,
 		"flows/operating/agents.yaml": `ceo:
-  id: ceo-{product_id}
   type: generic
   role: ceo
   intent: {inline: "Initialize the product for this operating instance."}

--- a/internal/runtime/testfixtures/canonicalrouting/closure_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/closure_variants.go
@@ -32,7 +32,7 @@ func CopyRuntimeAgentMemory(t testing.TB, variant RuntimeAgentMemoryVariant) str
 	writeClosedVariantFile(t, root, "flows/support/schema.yaml", "name: support\ninitial_state: waiting\nstates:\n  - waiting\n")
 	writeClosedVariantFile(t, root, "flows/support/policy.yaml", "{}\n")
 	writeClosedVariantFile(t, root, "flows/support/events.yaml", "support/item.created:\n  entity_id: string\n")
-	agentBody := "backend:\n  id: backend-{vertical_id}\n  type: generic\n  role: backend\n  intent: prompts/backend.md\n  model: regular\n  memory: true\n  subscriptions:\n    - support/item.created\n  emit_events:\n    - support/item.created\n"
+	agentBody := "backend:\n  type: generic\n  role: backend\n  intent: prompts/backend.md\n  model: regular\n  memory: true\n  subscriptions:\n    - support/item.created\n  emit_events:\n    - support/item.created\n"
 	if variant == RuntimeAgentMemoryPackageBacked {
 		writeClosedVariantFile(t, root, "flows/support/package.yaml", "name: support\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\nflows: []\n")
 		writeClosedVariantFile(t, root, "flows/support/prompts/backend.md", "Handle support events.\n")

--- a/internal/runtime/testfixtures/notifyallchildren/fixture.go
+++ b/internal/runtime/testfixtures/notifyallchildren/fixture.go
@@ -20,7 +20,6 @@ const (
 	ChildFlowID            = "account"
 	ChildInputPin          = "account_notify_requested"
 	canonicalAccountAgents = `account-worker:
-  id: account-worker
   type: generic
   role: account_worker
   intent: prompts/account-worker.md
@@ -45,6 +44,7 @@ type Options struct {
 	ProducerBroadcast           bool
 	ObjectMembership            bool
 	UndeclaredPayloadMembership bool
+	ExplicitAgentName           bool
 	AgentTopologyRevision       int
 	AutoEmitOnCreate            bool
 	AutoEmitEventRevision       int
@@ -233,6 +233,9 @@ retired:
 `)
 	default:
 		t.Fatalf("unsupported agent topology revision %d", opts.AgentTopologyRevision)
+	}
+	if opts.ExplicitAgentName {
+		replaceFile(t, accountAgents, "account-worker:\n", "account-worker:\n  id: account-handler\n")
 	}
 	return root
 }

--- a/internal/runtime/tools/agent_name_test.go
+++ b/internal/runtime/tools/agent_name_test.go
@@ -1,0 +1,11 @@
+package tools
+
+import (
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
+)
+
+func wrapRootAgentBundle(bundle *runtimecontracts.WorkflowContractBundle) semanticview.Source {
+	return semanticviewtest.WrapRootAgents(bundle)
+}

--- a/internal/runtime/tools/authorizer_permission_test.go
+++ b/internal/runtime/tools/authorizer_permission_test.go
@@ -84,7 +84,7 @@ func TestToolAuthorizer_PermissionGatedTools(t *testing.T) {
 }
 
 func TestResolveAgentPermissions_ExpandsBundleAndDedupes(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
 			"permission_bundles": {
 				Value: map[string]any{
@@ -116,7 +116,7 @@ func TestResolveAgentPermissions_ExpandsBundleAndDedupes(t *testing.T) {
 func TestValidateAgentPermissions_ReportsToolPermissionMismatch(t *testing.T) {
 	platform := runtimecontracts.PlatformSpecDocument{}
 	platform.PermissionsModel.Permissions = append([]string(nil), defaultPlatformPermissions...)
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Platform: platform,
 		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
 			"permission_bundles": {
@@ -155,7 +155,7 @@ func TestValidateAgentPermissions_ReportsToolPermissionMismatch(t *testing.T) {
 }
 
 func TestValidateAgentPermissions_AcceptsToolDefinedExtensionPermission(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"researcher": {
 				ID:          "researcher",

--- a/internal/runtime/tools/criteria_citation.go
+++ b/internal/runtime/tools/criteria_citation.go
@@ -78,42 +78,14 @@ func criteriaRefsForActor(source semanticview.Source, actor models.AgentConfig) 
 }
 
 func criteriaAgentContractDeclaration(source semanticview.Source, actor models.AgentConfig) (runtimecontracts.AgentRegistryEntry, string, bool) {
-	actorID := strings.TrimSpace(actor.ID)
-	if source == nil || actorID == "" {
+	if source == nil {
 		return runtimecontracts.AgentRegistryEntry{}, "", false
 	}
-	type match struct {
-		entry  runtimecontracts.AgentRegistryEntry
-		flowID string
-	}
-	matches := []match{}
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" {
-			continue
-		}
-		for _, logicalID := range sortedAgentIDs(scope.Agents) {
-			entry := scope.Agents[logicalID]
-			if !criteriaAgentIdentityMatches(logicalID, entry.ID, actorID) {
-				continue
-			}
-			matches = append(matches, match{entry: entry, flowID: flowID})
-		}
-	}
-	if len(matches) != 1 {
+	declaration, ok := semanticview.ResolveAgentDeclaration(source, actor)
+	if !ok || strings.TrimSpace(declaration.OwnerFlowID) == "" {
 		return runtimecontracts.AgentRegistryEntry{}, "", false
 	}
-	return matches[0].entry, matches[0].flowID, true
-}
-
-func criteriaAgentIdentityMatches(logicalID, declaredID, actorID string) bool {
-	logicalID = strings.TrimSpace(logicalID)
-	declaredID = strings.TrimSpace(declaredID)
-	actorID = strings.TrimSpace(actorID)
-	if actorID == "" {
-		return false
-	}
-	return logicalID == actorID || declaredID == actorID
+	return declaration.Entry, strings.TrimSpace(declaration.OwnerFlowID), true
 }
 
 func criteriaCitationIDs(value any) ([]string, error) {

--- a/internal/runtime/tools/emit_runtime.go
+++ b/internal/runtime/tools/emit_runtime.go
@@ -208,7 +208,9 @@ func ValidateGeneratedEmitToolSchemasForSource(source semanticview.Source) []err
 	}
 	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
 	var errs []error
-	for _, actor := range providerSchemaValidationActors(source) {
+	actors, actorErrs := providerSchemaValidationActors(source)
+	errs = append(errs, actorErrs...)
+	for _, actor := range actors {
 		validatedTools := map[string]struct{}{}
 		for _, tool := range registry.GenerateEmitToolsForActor(actor, nil) {
 			validatedTools[tool.Name] = struct{}{}
@@ -238,11 +240,12 @@ func ValidateGeneratedEmitToolSchemasForSource(source semanticview.Source) []err
 	return errs
 }
 
-func providerSchemaValidationActors(source semanticview.Source) []models.AgentConfig {
+func providerSchemaValidationActors(source semanticview.Source) ([]models.AgentConfig, []error) {
 	if source == nil {
-		return nil
+		return nil, nil
 	}
 	var actors []models.AgentConfig
+	var errs []error
 	seen := map[string]struct{}{}
 	appendActor := func(actor models.AgentConfig) {
 		key := strings.Join([]string{
@@ -260,56 +263,18 @@ func providerSchemaValidationActors(source semanticview.Source) []models.AgentCo
 		seen[key] = struct{}{}
 		actors = append(actors, actor)
 	}
-	for _, scope := range source.ProjectScopes() {
-		for _, id := range sortedEmitSchemaAgentIDs(scope.Agents) {
-			entry := scope.Agents[id]
-			proof := semanticview.ResolveAgentMemoryProof(source, semanticview.AgentMemoryLocator{
-				AgentID:         id,
-				ProjectScopeKey: scope.Key,
-			})
-			appendActor(models.AgentConfig{
-				ID:              strings.TrimSpace(id),
-				Type:            strings.TrimSpace(entry.Type),
-				Role:            strings.TrimSpace(entry.Role),
-				FlowID:          strings.TrimSpace(proof.OwningFlowID),
-				Model:           strings.TrimSpace(entry.Model),
-				Memory:          entry.MemoryPlan,
-				MaxTurnsPerTask: entry.MaxTurnsPerTask,
-				Subscriptions:   UniqueNonEmpty(entry.Subscriptions),
-				EmitEvents:      UniqueNonEmpty(entry.EmitEvents),
-				Criteria:        UniqueNonEmpty(entry.Criteria),
-				Tools:           UniqueNonEmpty(entry.ConfiguredTools()),
-				Permissions:     UniqueNonEmpty(entry.Permissions),
-				FlowPath:        strings.Trim(strings.TrimSpace(proof.FlowPath), "/"),
-			})
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			errs = append(errs, err)
+			continue
 		}
-	}
-	for _, scope := range source.FlowScopes() {
-		for _, id := range sortedEmitSchemaAgentIDs(scope.Agents) {
-			entry := scope.Agents[id]
-			appendActor(models.AgentConfig{
-				ID:              strings.TrimSpace(id),
-				Type:            strings.TrimSpace(entry.Type),
-				Role:            strings.TrimSpace(entry.Role),
-				FlowID:          strings.TrimSpace(scope.ID),
-				Model:           strings.TrimSpace(entry.Model),
-				Memory:          entry.MemoryPlan,
-				MaxTurnsPerTask: entry.MaxTurnsPerTask,
-				Subscriptions:   UniqueNonEmpty(entry.Subscriptions),
-				EmitEvents:      UniqueNonEmpty(entry.EmitEvents),
-				Criteria:        UniqueNonEmpty(entry.Criteria),
-				Tools:           UniqueNonEmpty(entry.ConfiguredTools()),
-				Permissions:     UniqueNonEmpty(entry.Permissions),
-				FlowPath:        strings.Trim(strings.TrimSpace(scope.Path), "/"),
-			})
-		}
-	}
-	for _, id := range sortedEmitSchemaAgentIDs(source.AgentEntries()) {
-		entry := source.AgentEntries()[id]
+		entry := declaration.Entry
 		appendActor(models.AgentConfig{
-			ID:              strings.TrimSpace(id),
+			ID:              plan.AgentID,
 			Type:            strings.TrimSpace(entry.Type),
-			Role:            strings.TrimSpace(entry.Role),
+			Role:            plan.EffectiveRole(entry),
+			FlowID:          plan.OwnerFlowID,
 			Model:           strings.TrimSpace(entry.Model),
 			Memory:          entry.MemoryPlan,
 			MaxTurnsPerTask: entry.MaxTurnsPerTask,
@@ -318,21 +283,10 @@ func providerSchemaValidationActors(source semanticview.Source) []models.AgentCo
 			Criteria:        UniqueNonEmpty(entry.Criteria),
 			Tools:           UniqueNonEmpty(entry.ConfiguredTools()),
 			Permissions:     UniqueNonEmpty(entry.Permissions),
+			FlowPath:        strings.Trim(strings.TrimSpace(source.FlowPath(plan.OwnerFlowID)), "/"),
 		})
 	}
-	return actors
-}
-
-func sortedEmitSchemaAgentIDs(agents map[string]runtimecontracts.AgentRegistryEntry) []string {
-	ids := make([]string, 0, len(agents))
-	for id := range agents {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
-	sort.Strings(ids)
-	return ids
+	return actors, errs
 }
 
 func (r *EmitRegistry) EventSchemaSnapshot() map[string]EmitSchema {

--- a/internal/runtime/tools/emit_test.go
+++ b/internal/runtime/tools/emit_test.go
@@ -26,7 +26,7 @@ func TestEmitToolName_LocalizesScopedEventTypes(t *testing.T) {
 }
 
 func TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"campaign-coordinator": {
 				ID:         "campaign-coordinator",
@@ -83,8 +83,36 @@ func TestGenerateEmitToolsForActor_FallsBackToRoleWhenConfigIsSilent(t *testing.
 	t.Fatalf("expected role-scoped emit tool in %#v", tools)
 }
 
+func TestDeclarationDerivedActorRolesUseEffectivePublicName(t *testing.T) {
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker"},
+		},
+	})
+	declarations := semanticview.AgentDeclarations(source)
+	if len(declarations) != 1 {
+		t.Fatalf("declarations = %#v, want one", declarations)
+	}
+	plan, err := semanticview.ScopedAgentNamePlan(source, declarations[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	actors, errs := providerSchemaValidationActors(source)
+	if len(errs) != 0 || len(actors) != 1 || actors[0].Role != "public-worker" {
+		t.Fatalf("provider actors = %#v errors = %v, want effective public role", actors, errs)
+	}
+	entries, errs := scopedAgentEntries(source)
+	if len(errs) != 0 || len(entries) != 1 || entries[0].role != "public-worker" {
+		t.Fatalf("permission actors = %#v errors = %v, want effective public role", entries, errs)
+	}
+	nativeActor := nativeToolAgentConfig(plan.AgentID, plan.EffectiveRole(declarations[0].Entry), declarations[0].Entry)
+	if nativeActor.Role != "public-worker" {
+		t.Fatalf("native-tool actor role = %q, want public-worker", nativeActor.Role)
+	}
+}
+
 func TestEmitRegistry_KeepsRuntimeSourcesIsolated(t *testing.T) {
-	sourceA := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	sourceA := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"coordinator": {
 				ID:         "coordinator",
@@ -102,7 +130,7 @@ func TestEmitRegistry_KeepsRuntimeSourcesIsolated(t *testing.T) {
 			},
 		},
 	})
-	sourceB := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	sourceB := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"coordinator": {
 				ID:         "coordinator",
@@ -272,7 +300,7 @@ func TestGenerateEmitToolsForActor_ResolvesInstanceScopedFlowEmitEventsThroughOw
 }
 
 func TestGenerateEmitToolsForActor_ProviderSchemaNormalizesPrecisionRefs(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{
 			Types: map[string]runtimecontracts.NamedTypeDecl{
 				"RequiredCapabilities": {
@@ -330,7 +358,7 @@ func TestGenerateEmitToolsForActor_ProviderSchemaNormalizesPrecisionRefs(t *test
 }
 
 func TestGenerateEmitToolsForActor_GeneratedSchemaIsClosedRequiredAndRejectsUndeclaredPayload(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		RootTypes: runtimecontracts.TypeCatalogDocument{
 			Enums: map[string]runtimecontracts.EnumTypeDecl{
 				"SignalStrength": {Values: []string{"weak", "strong"}, Default: "weak"},
@@ -445,7 +473,7 @@ func generatedSchemaClosureErrorStrings(errs []error) []string {
 }
 
 func TestValidateGeneratedEmitToolSchemasForSourceRejectsUnloweredContractRefs(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"market-research-agent": {
 				ID:         "market-research-agent",

--- a/internal/runtime/tools/entity_read_authorization.go
+++ b/internal/runtime/tools/entity_read_authorization.go
@@ -14,21 +14,20 @@ func actorOwnedReadTargetContracts(source semanticview.Source, actor *models.Age
 	if actor == nil {
 		return contracts
 	}
-	actorID := strings.TrimSpace(actor.ID)
-	if actorID == "" {
+	if strings.TrimSpace(actor.ID) == "" {
 		return nil
 	}
 	out := make([]entityruntime.Contract, 0, len(contracts))
 	for _, contract := range contracts {
-		if entityReadContractOwnedByActor(source, actorID, contract) {
+		if entityReadContractOwnedByActor(source, *actor, contract) {
 			out = append(out, contract)
 		}
 	}
 	return out
 }
 
-func entityReadContractOwnedByActor(source semanticview.Source, actorID string, target entityruntime.Contract) bool {
-	actor, ok := entityruntime.ResolveForActor(source, actorID)
+func entityReadContractOwnedByActor(source semanticview.Source, actorConfig models.AgentConfig, target entityruntime.Contract) bool {
+	actor, ok := entityruntime.ResolveForActor(source, actorConfig)
 	if !ok {
 		return false
 	}
@@ -43,21 +42,21 @@ func entityReadContractOwnedByActor(source semanticview.Source, actorID string, 
 	return entityFlowOwnedBy(actorRoot, targetRoot)
 }
 
-func entityReadRowOwnedByActor(source semanticview.Source, actorID string, row map[string]any) bool {
+func entityReadRowOwnedByActor(source semanticview.Source, actor models.AgentConfig, row map[string]any) bool {
 	contract, ok := entityruntime.ResolveForEntityRow(source, row)
 	if !ok {
 		return false
 	}
-	return entityReadContractOwnedByActor(source, actorID, contract)
+	return entityReadContractOwnedByActor(source, actor, contract)
 }
 
-func filterEntityReadRowsForActor(source semanticview.Source, actorID string, rows []map[string]any) []map[string]any {
+func filterEntityReadRowsForActor(source semanticview.Source, actor models.AgentConfig, rows []map[string]any) []map[string]any {
 	if len(rows) == 0 {
 		return rows
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
-		if entityReadRowOwnedByActor(source, actorID, row) {
+		if entityReadRowOwnedByActor(source, actor, row) {
 			out = append(out, row)
 		}
 	}
@@ -65,7 +64,7 @@ func filterEntityReadRowsForActor(source semanticview.Source, actorID string, ro
 }
 
 func enforceEntityReadOwnership(source semanticview.Source, actor models.AgentConfig, entityID string, row map[string]any, operation string) error {
-	if entityReadRowOwnedByActor(source, actor.ID, row) {
+	if entityReadRowOwnedByActor(source, actor, row) {
 		return nil
 	}
 	return failures.NewDetail(

--- a/internal/runtime/tools/entity_schema.go
+++ b/internal/runtime/tools/entity_schema.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -13,30 +14,30 @@ type entityToolSchema struct {
 	Contract entityruntime.Contract
 }
 
-func entityToolSchemaForActor(source semanticview.Source, actorID string) (entityToolSchema, error) {
+func entityToolSchemaForActor(source semanticview.Source, actor models.AgentConfig) (entityToolSchema, error) {
 	if source == nil {
 		return entityToolSchema{}, fmt.Errorf("workflow source is not configured")
 	}
-	contract, ok := entityruntime.ResolveForActor(source, actorID)
+	contract, ok := entityruntime.ResolveForActor(source, actor)
 	if !ok {
-		return entityToolSchema{}, fmt.Errorf("flow-owned entity contract is not available for actor %s", strings.TrimSpace(actorID))
+		return entityToolSchema{}, fmt.Errorf("flow-owned entity contract is not available for actor %s", strings.TrimSpace(actor.ID))
 	}
 	return entityToolSchema{Defined: true, Contract: contract}, nil
 }
 
-func entityToolSchemaForReadTarget(source semanticview.Source, actorID string, payload map[string]any) (entityToolSchema, error) {
+func entityToolSchemaForReadTarget(source semanticview.Source, actor models.AgentConfig, payload map[string]any) (entityToolSchema, error) {
 	if source == nil {
 		return entityToolSchema{}, fmt.Errorf("workflow source is not configured")
 	}
 	target := strings.TrimSpace(asString(payload["entity_type"]))
-	contract, ok, err := entityruntime.ResolveForReadTarget(source, actorID, target)
+	contract, ok, err := entityruntime.ResolveForReadTarget(source, actor, target)
 	if err != nil {
 		return entityToolSchema{}, err
 	}
 	if !ok {
-		return entityToolSchema{}, fmt.Errorf("flow-owned entity contract is not available for actor %s", strings.TrimSpace(actorID))
+		return entityToolSchema{}, fmt.Errorf("flow-owned entity contract is not available for actor %s", strings.TrimSpace(actor.ID))
 	}
-	if !entityReadContractOwnedByActor(source, actorID, contract) {
+	if !entityReadContractOwnedByActor(source, actor, contract) {
 		targetLabel := target
 		if targetLabel == "" {
 			targetLabel = entityruntime.CanonicalReadTargetName(contract)

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -332,8 +332,8 @@ func emitActorFlowID(source semanticview.Source, actor models.AgentConfig, flowI
 	if source == nil {
 		return ""
 	}
-	if agentSource, ok := source.AgentContractSource(actor.ID); ok {
-		if flowID := strings.TrimSpace(agentSource.FlowID); flowID != "" {
+	if projection, ok := semanticview.ResolveAgentContractProjection(source, actor); ok {
+		if flowID := strings.TrimSpace(projection.OwnerFlowID); flowID != "" {
 			return flowID
 		}
 	}

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -321,6 +321,18 @@ func TestHandleEmitTool_ValidatesCriteriaCitationsBeforePublish(t *testing.T) {
 	}
 }
 
+func TestHandleEmitTool_CriteriaCitationsSelectActorScopeForSharedEffectiveName(t *testing.T) {
+	exec, bus, actor := criteriaCitationEmitTestExecutor(t)
+	if _, err := exec.handleEmitTool(toolEventTestContext(actor), actor, "emit_cto_spec_vetoed", map[string]any{
+		"cite": "FX-HARD-01",
+	}); err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want 1", bus.count)
+	}
+}
+
 func criteriaCitationEmitTestExecutor(t testing.TB) (*Executor, *publishBusCapture, models.AgentConfig) {
 	return criteriaCitationEmitTestExecutorWithAgent(t, runtimecontracts.AgentRegistryEntry{
 		ID:         "cto-agent",
@@ -381,12 +393,31 @@ func criteriaCitationEmitTestExecutorWithAgent(t testing.TB, agent runtimecontra
 			},
 		},
 	}
-	root := &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	otherFlow := runtimecontracts.FlowContractView{
+		Paths:  runtimecontracts.FlowContractPaths{ID: "other-validation", Flow: "other-validation"},
+		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeStatic},
+		Path:   "other-validation",
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"cto-agent": {Role: "other-cto", Criteria: []string{"other_criteria"}},
+		},
+	}
+	root := &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow, otherFlow}}
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: root,
 			ByID: map[string]*runtimecontracts.FlowContractView{
-				"validation": &root.Children[0],
+				"validation":       &root.Children[0],
+				"other-validation": &root.Children[1],
+			},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				"validation/cto-agent":       {Kind: "agent", FlowID: "validation", LocalID: "cto-agent", Path: "validation", Full: "swarm-test://validation/cto-agent"},
+				"other-validation/cto-agent": {Kind: "agent", FlowID: "other-validation", LocalID: "cto-agent", Path: "other-validation", Full: "swarm-test://other-validation/cto-agent"},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				"swarm-test://validation/cto-agent":       {Kind: "agent", FlowID: "validation", LocalID: "cto-agent", Path: "validation", Full: "swarm-test://validation/cto-agent"},
+				"swarm-test://other-validation/cto-agent": {Kind: "agent", FlowID: "other-validation", LocalID: "cto-agent", Path: "other-validation", Full: "swarm-test://other-validation/cto-agent"},
 			},
 		},
 	}

--- a/internal/runtime/tools/executor_entity_query.go
+++ b/internal/runtime/tools/executor_entity_query.go
@@ -22,7 +22,7 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
+	schema, err := entityToolSchemaForReadTarget(source, actor, payload)
 	if err != nil {
 		return nil, failures.WrapDetail("invalid_tool_input", "tool-executor", "exec_search_entities.schema", entityReadTargetFailureAttributes(payload), err)
 	}
@@ -67,7 +67,7 @@ func (e *Executor) execSearchEntities(ctx context.Context, actor models.AgentCon
 	if err != nil {
 		return nil, failures.Wrap(failures.ClassInternalFailure, "entity_materialization_failed", "tool-executor", "exec_search_entities.materialize", nil, err)
 	}
-	rows = filterEntityReadRowsForActor(source, actor.ID, rows)
+	rows = filterEntityReadRowsForActor(source, actor, rows)
 	total := len(rows)
 	if offset >= len(rows) {
 		rows = []map[string]any{}
@@ -89,7 +89,7 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
+	schema, err := entityToolSchemaForReadTarget(source, actor, payload)
 	if err != nil {
 		return nil, failures.WrapDetail("invalid_tool_input", "tool-executor", "exec_query_entities.schema", entityReadTargetFailureAttributes(payload), err)
 	}
@@ -106,7 +106,7 @@ func (e *Executor) execQueryEntities(ctx context.Context, actor models.AgentConf
 	if err != nil {
 		return nil, failures.Wrap(failures.ClassInternalFailure, "entity_materialization_failed", "tool-executor", "exec_query_entities.materialize", nil, err)
 	}
-	rows = filterEntityReadRowsForActor(source, actor.ID, rows)
+	rows = filterEntityReadRowsForActor(source, actor, rows)
 	filterExpression := strings.TrimSpace(asString(payload["filter"]))
 	filtered, err := filterEntityStateRowsCEL(filterExpression, rows, schema)
 	if err != nil {
@@ -137,7 +137,7 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 	if err != nil {
 		return nil, err
 	}
-	schema, err := entityToolSchemaForReadTarget(source, actor.ID, payload)
+	schema, err := entityToolSchemaForReadTarget(source, actor, payload)
 	if err != nil {
 		return nil, failures.WrapDetail("invalid_tool_input", "tool-executor", "exec_query_metrics.schema", entityReadTargetFailureAttributes(payload), err)
 	}
@@ -173,7 +173,7 @@ func (e *Executor) execQueryMetrics(ctx context.Context, actor models.AgentConfi
 	if err != nil {
 		return nil, failures.Wrap(failures.ClassInternalFailure, "entity_materialization_failed", "tool-executor", "exec_query_metrics.materialize", nil, err)
 	}
-	rows = filterEntityReadRowsForActor(source, actor.ID, rows)
+	rows = filterEntityReadRowsForActor(source, actor, rows)
 	filterExpression := strings.TrimSpace(asString(payload["filter"]))
 	filtered, err := filterEntityStateRowsCEL(filterExpression, rows, schema)
 	if err != nil {

--- a/internal/runtime/tools/executor_entity_write.go
+++ b/internal/runtime/tools/executor_entity_write.go
@@ -126,7 +126,7 @@ func entityJSONPathSegments(path string) ([]string, error) {
 }
 
 func enforceEntityWriteOwnership(ctx context.Context, store EntityPersistence, source semanticview.Source, actor models.AgentConfig, entityID string, logger runtimeToolLogSink) error {
-	flowRoot := actorFlowOwnershipRoot(source, actor.ID)
+	flowRoot := actorFlowOwnershipRoot(source, actor)
 	if flowRoot == "" || store == nil {
 		return nil
 	}
@@ -178,16 +178,15 @@ func enforceEntityWriteOwnership(ctx context.Context, store EntityPersistence, s
 	return denial
 }
 
-func actorFlowOwnershipRoot(source semanticview.Source, actorID string) string {
-	actorID = strings.TrimSpace(actorID)
-	if source == nil || actorID == "" {
+func actorFlowOwnershipRoot(source semanticview.Source, actor models.AgentConfig) string {
+	if source == nil || strings.TrimSpace(actor.ID) == "" {
 		return ""
 	}
-	contractSource, ok := source.AgentContractSource(actorID)
+	projection, ok := semanticview.ResolveAgentContractProjection(source, actor)
 	if !ok {
 		return ""
 	}
-	flowID := strings.TrimSpace(contractSource.FlowID)
+	flowID := strings.TrimSpace(projection.OwnerFlowID)
 	if flowID == "" {
 		return ""
 	}
@@ -215,7 +214,7 @@ func (e *Executor) execCreateEntity(ctx context.Context, actor models.AgentConfi
 	if flowInstance == "" {
 		return nil, failures.NewDetail("invalid_tool_input", "tool-executor", "exec_create_entity.flow_instance", map[string]any{"field": "flow_instance"})
 	}
-	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	contract, ok := entityruntime.ResolveForActor(source, actor)
 	if !ok {
 		contract, ok = entityruntime.ResolveForFlowInstance(source, flowInstance)
 	}

--- a/internal/runtime/tools/executor_flow_data_test.go
+++ b/internal/runtime/tools/executor_flow_data_test.go
@@ -8,7 +8,9 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/entityruntime"
 	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	"github.com/division-sh/swarm/internal/runtime/flowdata"
 	"github.com/division-sh/swarm/internal/runtime/llm"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -135,7 +137,7 @@ func TestExecutorReadFlowDataIgnoresMutableActorFlowDataAccess(t *testing.T) {
 	requireToolFailure(t, err, runtimefailures.ClassSchemaInvalid, "invalid_tool_input")
 }
 
-func TestExecutorReadFlowDataUsesContractOwnedFlowRoot(t *testing.T) {
+func TestExecutorReadFlowDataSelectsActorScopeForSharedEffectiveName(t *testing.T) {
 	source, root := loadFlowDataToolSource(t)
 	if err := os.MkdirAll(filepath.Join(root, "flows", "other", "data"), 0o755); err != nil {
 		t.Fatalf("mkdir other data: %v", err)
@@ -156,8 +158,29 @@ func TestExecutorReadFlowDataUsesContractOwnedFlowRoot(t *testing.T) {
 	if !ok {
 		t.Fatalf("result type = %T, want map[string]any", out)
 	}
-	if got := strings.TrimSpace(asString(result["content"])); got != "blocked: true" {
-		t.Fatalf("content = %q, want support-flow contract-owned data root", got)
+	if got := strings.TrimSpace(asString(result["content"])); got != "blocked: other-flow" {
+		t.Fatalf("content = %q, want other-flow contract-owned data root", got)
+	}
+}
+
+func TestPackageBackedAgentConsumersUseOwningFlowInsteadOfStorageScopeKind(t *testing.T) {
+	source, _ := loadFlowDataToolSource(t)
+	actor := flowDataActor()
+	declaration, ok := semanticview.ResolveAgentDeclaration(source, actor)
+	if !ok || declaration.ScopeKind != "project" || declaration.OwnerFlowID != "support" {
+		t.Fatalf("package-backed declaration = %#v ok %v", declaration, ok)
+	}
+	filenames := flowdata.AllowedFilenames(source, actor)
+	if len(filenames) != 1 || filenames[0] != "exclusions.yaml" {
+		t.Fatalf("flow-data filenames = %#v", filenames)
+	}
+	entry, flowID, ok := criteriaAgentContractDeclaration(source, actor)
+	if !ok || flowID != "support" || entry.Role != "factory_cto" {
+		t.Fatalf("criteria declaration = entry %#v flow %q ok %v", entry, flowID, ok)
+	}
+	entity, ok := entityruntime.ResolveForActor(source, actor)
+	if !ok || entity.FlowID != "support" || entity.EntityType != "support_state" {
+		t.Fatalf("entity contract = %#v ok %v", entity, ok)
 	}
 }
 
@@ -202,7 +225,7 @@ func TestExecutorReadFlowDataRequiresWorkflowSource(t *testing.T) {
 func flowDataActor() models.AgentConfig {
 	return models.AgentConfig{
 		ExecutionMode:  "live",
-		ID:             "factory-cto",
+		ID:             "public-factory-cto",
 		Role:           "factory_cto",
 		FlowID:         "support",
 		FlowPath:       "support",
@@ -235,18 +258,28 @@ flows:
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "events.yaml"), "{}\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), "name: support\nmode: static\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "entities.yaml"), "support_state:\n  support_id: string\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
 factory-cto:
-  id: factory-cto
+  id: public-factory-cto
   role: factory_cto
   intent: {inline: "Read only the flow data declared by this contract."}
 `+toolFlowDataAccessYAML(access))
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "support", "data", "exclusions.yaml"), "blocked: true\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "package.yaml"), "name: other\nversion: \"1.0.0\"\nflows: []\n")
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "schema.yaml"), "name: other\nmode: static\n")
-	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "agents.yaml"), "{}\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "entities.yaml"), "other_state:\n  other_id: string\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "agents.yaml"), `
+factory-cto:
+  id: public-factory-cto
+  role: other_factory_cto
+  intent: {inline: "Read only the other flow data declared by this contract."}
+`+toolFlowDataAccessYAML(access))
 	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "events.yaml"), "{}\n")
+	writeToolFlowDataFixtureFile(t, filepath.Join(root, "flows", "other", "data", "exclusions.yaml"), "blocked: other-flow\n")
 
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))

--- a/internal/runtime/tools/generated_schema_closure.go
+++ b/internal/runtime/tools/generated_schema_closure.go
@@ -21,8 +21,7 @@ func ValidateGeneratedToolSchemaClosureForSource(source semanticview.Source) []e
 		return nil
 	}
 	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
-	actors := providerSchemaValidationActors(source)
-	var errs []error
+	actors, errs := providerSchemaValidationActors(source)
 	for _, actor := range actors {
 		errs = append(errs, validateGeneratedRoleScopedEntitySchemasForActor(source, actor)...)
 		for _, tool := range registry.GenerateEmitToolsForActor(actor, nil) {

--- a/internal/runtime/tools/mcp_availability.go
+++ b/internal/runtime/tools/mcp_availability.go
@@ -20,18 +20,26 @@ func RequiredMCPToolAvailabilityFindings(source semanticview.Source, discovered 
 		return nil
 	}
 	findings := make([]RequiredMCPToolAvailabilityFinding, 0)
-	for agentID, agent := range source.AgentEntries() {
-		agentID = strings.TrimSpace(agentID)
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			continue
+		}
+		projection, ok := semanticview.ScopedAgentContractProjection(source, declaration)
+		if !ok {
+			continue
+		}
+		agent := declaration.Entry
 		for _, toolName := range agent.ConfiguredTools() {
 			toolName = strings.TrimSpace(toolName)
-			if toolName == "" || !IsAgentRequiredMCPToolReference(source, agentID, toolName) {
+			if toolName == "" || !isAgentRequiredMCPToolReference(source, projection, toolName) {
 				continue
 			}
 			if MCPToolDiscovered(toolName, discovered) {
 				continue
 			}
 			findings = append(findings, RequiredMCPToolAvailabilityFinding{
-				AgentID:  agentID,
+				AgentID:  plan.AgentID,
 				ToolName: toolName,
 				Reason:   "no exact discovered MCP catalog entry exists for required agent tool",
 			})
@@ -46,7 +54,15 @@ func RequiredMCPToolAvailabilityFindings(source semanticview.Source, discovered 
 	return findings
 }
 
-func IsAgentRequiredMCPToolReference(source semanticview.Source, agentID, toolName string) bool {
+func IsAgentRequiredMCPToolReference(source semanticview.Source, declaration semanticview.AgentDeclaration, toolName string) bool {
+	projection, ok := semanticview.ScopedAgentContractProjection(source, declaration)
+	if !ok {
+		return false
+	}
+	return isAgentRequiredMCPToolReference(source, projection, toolName)
+}
+
+func isAgentRequiredMCPToolReference(source semanticview.Source, projection semanticview.AgentContractProjection, toolName string) bool {
 	if source == nil {
 		return false
 	}
@@ -54,7 +70,7 @@ func IsAgentRequiredMCPToolReference(source semanticview.Source, agentID, toolNa
 	if toolName == "" {
 		return false
 	}
-	if entry, ok := source.ToolEntryForAgent(strings.TrimSpace(agentID), toolName); ok {
+	if entry, ok := projection.ToolEntry(toolName); ok {
 		return toolEntryRequiresMCPDiscovery(entry)
 	}
 	prefix, _, ok := strings.Cut(toolName, ".")

--- a/internal/runtime/tools/native_tools_admission.go
+++ b/internal/runtime/tools/native_tools_admission.go
@@ -214,11 +214,11 @@ func validateWebSearchCredential(ctx context.Context, source semanticview.Source
 	return nil
 }
 
-func nativeToolAgentConfig(agentID string, entry runtimecontracts.AgentRegistryEntry) models.AgentConfig {
+func nativeToolAgentConfig(agentID, role string, entry runtimecontracts.AgentRegistryEntry) models.AgentConfig {
 	cfg := models.AgentConfig{
-		ID:              coalesce(strings.TrimSpace(entry.ID), strings.TrimSpace(agentID)),
+		ID:              strings.TrimSpace(agentID),
 		Type:            strings.TrimSpace(entry.Type),
-		Role:            strings.TrimSpace(entry.Role),
+		Role:            strings.TrimSpace(role),
 		Model:           strings.TrimSpace(entry.Model),
 		Memory:          entry.MemoryPlan,
 		Mock:            entry.Mock,

--- a/internal/runtime/tools/native_tools_validation.go
+++ b/internal/runtime/tools/native_tools_validation.go
@@ -26,9 +26,17 @@ func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Sourc
 		localIDCounts[declaration.LocalID]++
 	}
 	for _, declaration := range declarations {
-		agentID := declaration.Label(localIDCounts[declaration.LocalID] > 1)
+		namePlan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			failures = append(failures, err.Error())
+			continue
+		}
+		agentID := namePlan.AgentID
+		if localIDCounts[declaration.LocalID] > 1 {
+			agentID += " (" + declaration.Label(true) + ")"
+		}
 		entry := declaration.Entry
-		actor := nativeToolAgentConfig(declaration.LocalID, entry)
+		actor := nativeToolAgentConfig(namePlan.AgentID, namePlan.EffectiveRole(entry), entry)
 		if !actor.NativeTools.Any() {
 			continue
 		}
@@ -45,12 +53,8 @@ func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Sourc
 			continue
 		}
 		actor = resolved.Actor
-		if owner, ok := semanticview.ScopedAgentDeclarationOwner(source, declaration); ok {
-			name, err := runtimeagentidentity.DeclaredName(actor.ID, owner)
-			if err != nil {
-				failures = append(failures, err.Error())
-				continue
-			}
+		name, err := namePlan.Materialize()
+		if err == nil {
 			route := runtimeagentidentity.RootRoute()
 			flowID := strings.TrimSpace(declaration.OwnerFlowID)
 			flowPath := ""
@@ -74,8 +78,8 @@ func ValidateNativeToolBootConfig(ctx context.Context, source semanticview.Sourc
 			actor.FlowID = flowID
 			actor.FlowPath = flowPath
 			actor.NormalizeRuntimeDescriptor()
-		} else if strings.TrimSpace(declaration.ScopeKind) != "" {
-			failures = append(failures, fmt.Sprintf("agent %s has no unique scoped declaration owner", strings.TrimSpace(agentID)))
+		} else {
+			failures = append(failures, err.Error())
 			continue
 		}
 		if err := ValidateNativeToolAgentAdmission(ctx, actor, NativeToolAdmissionOptions{

--- a/internal/runtime/tools/native_tools_validation_test.go
+++ b/internal/runtime/tools/native_tools_validation_test.go
@@ -103,7 +103,7 @@ func TestExecutorNativeToolAdmissionUsesActorSelectedProviderContract(t *testing
 }
 
 func TestValidateNativeToolBootConfig_FailsClosedWhenRuntimeLacksNativeCapability(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				ID: "agent-1",
@@ -121,7 +121,7 @@ func TestValidateNativeToolBootConfig_FailsClosedWhenRuntimeLacksNativeCapabilit
 }
 
 func TestValidateNativeToolBootConfig_CLINativeWebSearchDoesNotRequireFallbackProviderPolicy(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				ID: "agent-1",
@@ -145,7 +145,7 @@ func TestValidateNativeToolBootConfig_CLINativeWebSearchDoesNotRequireFallbackPr
 }
 
 func TestValidateNativeToolBootConfig_NonCLIRuntimeRequiresWebSearchFallbackCredential(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				ID: "agent-1",
@@ -192,7 +192,7 @@ func TestValidateNativeToolBootConfig_NonCLIRuntimeRequiresWebSearchFallbackCred
 }
 
 func TestValidateNativeToolBootConfig_ExactlyMockedAgentSkipsLiveNativeAdmission(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				ID: "agent-1",
@@ -246,7 +246,7 @@ func TestValidateNativeToolBootConfig_ExactlyMockedAgentSkipsLiveNativeAdmission
 }
 
 func TestValidateNativeToolBootConfig_FallbackFileIORequiresWorkspaceExecutionTarget(t *testing.T) {
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-1": {
 				ID: "agent-1",
@@ -294,28 +294,20 @@ func TestValidateNativeToolBootConfigCensusesScopedAgentsHiddenByAmbiguousAlias(
 	}
 }
 
-func TestValidateNativeToolBootConfigRejectsCollapsedProjectOwnersAndResolvesFlowOwners(t *testing.T) {
+func TestValidateNativeToolBootConfigResolvesDistinctProjectAndFlowOwners(t *testing.T) {
 	source := scopedNativeToolAgentFixture(t)
-	_, err := ValidateNativeToolBootConfig(
+	warnings, err := ValidateNativeToolBootConfig(
 		unmanagedToolTestContext(),
 		source,
 		nil,
 		nativeCapabilityRuntimeSet(t, nativeCapabilityRuntimeStub{}),
 		relayWorkspaceResolverStub{target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()}},
 	)
-	if err == nil {
-		t.Fatal("ValidateNativeToolBootConfig unexpectedly admitted declarations with one shared runtime owner")
+	if err != nil {
+		t.Fatalf("ValidateNativeToolBootConfig: %v", err)
 	}
-	for _, project := range []string{"project-a", "project-b"} {
-		want := "project packages/" + project + " agent shared-worker has no unique scoped declaration owner"
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("ValidateNativeToolBootConfig error = %v, want %q", err, want)
-		}
-	}
-	for _, flowID := range []string{"flow-a", "flow-b"} {
-		if strings.Contains(err.Error(), "flow "+flowID+" agent shared-worker") {
-			t.Fatalf("ValidateNativeToolBootConfig error = %v, flow owner %s should resolve exactly", err, flowID)
-		}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", warnings)
 	}
 }
 
@@ -355,33 +347,30 @@ func TestValidateNativeToolBootConfigUsesScopedFlowRouteForWorkspaceAdmission(t 
 	}
 }
 
-func TestValidateNativeToolBootConfigRejectsProjectOwnersCollapsedWithinOneFlow(t *testing.T) {
+func TestValidateNativeToolBootConfigResolvesProjectOwnersWithinOneFlow(t *testing.T) {
 	source := sameFlowScopedNativeToolAgentFixture(t)
 	declarations := semanticview.AgentDeclarations(source)
 	if len(declarations) != 2 {
 		t.Fatalf("declarations = %#v, want two scoped project agents", declarations)
 	}
 	for _, declaration := range declarations {
-		if owner, ok := semanticview.ScopedAgentDeclarationOwner(source, declaration); ok {
-			t.Fatalf("declaration %#v unexpectedly resolved shared owner %q", declaration, owner)
+		if owner, ok := semanticview.ScopedAgentDeclarationOwner(source, declaration); !ok || strings.TrimSpace(owner) == "" {
+			t.Fatalf("declaration %#v did not resolve an exact owner", declaration)
 		}
 	}
 
-	_, err := ValidateNativeToolBootConfig(
+	warnings, err := ValidateNativeToolBootConfig(
 		unmanagedToolTestContext(),
 		source,
 		nil,
 		nativeCapabilityRuntimeSet(t, nativeCapabilityRuntimeStub{}),
 		relayWorkspaceResolverStub{target: &workspace.Target{Backend: workspace.BackendHost, Workdir: t.TempDir()}},
 	)
-	if err == nil {
-		t.Fatal("ValidateNativeToolBootConfig unexpectedly admitted collapsed same-flow owners")
+	if err != nil {
+		t.Fatalf("ValidateNativeToolBootConfig: %v", err)
 	}
-	for _, project := range []string{"project-a", "project-b"} {
-		want := "project flows/operating/packages/" + project + " agent shared-worker has no unique scoped declaration owner"
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("ValidateNativeToolBootConfig error = %v, want %q", err, want)
-		}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", warnings)
 	}
 }
 

--- a/internal/runtime/tools/permissions.go
+++ b/internal/runtime/tools/permissions.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -49,9 +48,9 @@ func ResolveAgentPermissions(source semanticview.Source, flowID string, entry ru
 }
 
 func ValidateAgentPermissions(source semanticview.Source) (int, []error) {
-	agents := scopedAgentEntries(source)
+	agents, errs := scopedAgentEntries(source)
 	known := knownPermissionNames(source)
-	errs := ValidateRetiredDynamicAgentToolReferences(source)
+	errs = append(errs, ValidateRetiredDynamicAgentToolReferences(source)...)
 	for _, agent := range agents {
 		policy := agent.policy
 		if len(policy.Values) == 0 && source != nil {
@@ -64,7 +63,7 @@ func ValidateAgentPermissions(source semanticview.Source) (int, []error) {
 		}
 		cfg := models.AgentConfig{
 			ID:          agent.id,
-			Role:        strings.TrimSpace(agent.entry.Role),
+			Role:        agent.role,
 			Permissions: perms,
 		}
 		for _, perm := range perms {
@@ -96,44 +95,33 @@ func ValidateAgentPermissions(source semanticview.Source) (int, []error) {
 
 type scopedAgentEntry struct {
 	id     string
+	role   string
 	flowID string
 	entry  runtimecontracts.AgentRegistryEntry
 	policy runtimecontracts.PolicyDocument
 }
 
-func scopedAgentEntries(source semanticview.Source) []scopedAgentEntry {
+func scopedAgentEntries(source semanticview.Source) ([]scopedAgentEntry, []error) {
 	if source == nil {
-		return nil
+		return nil, nil
 	}
 	entries := make([]scopedAgentEntry, 0)
-	for _, id := range sortedAgentIDs(source.AgentEntries()) {
-		flowID := ""
-		if sourceInfo, ok := source.AgentContractSource(id); ok {
-			flowID = strings.TrimSpace(sourceInfo.FlowID)
+	var errs []error
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			errs = append(errs, err)
+			continue
 		}
 		entries = append(entries, scopedAgentEntry{
-			id:     id,
-			flowID: flowID,
-			entry:  source.AgentEntries()[id],
-			policy: source.ResolvedPolicyForFlow(flowID),
+			id:     plan.AgentID,
+			role:   plan.EffectiveRole(declaration.Entry),
+			flowID: plan.OwnerFlowID,
+			entry:  declaration.Entry,
+			policy: source.ResolvedPolicyForFlow(plan.OwnerFlowID),
 		})
 	}
-	return entries
-}
-
-func sortedAgentIDs(entries map[string]runtimecontracts.AgentRegistryEntry) []string {
-	if len(entries) == 0 {
-		return nil
-	}
-	ids := make([]string, 0, len(entries))
-	for id := range entries {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
-	sort.Strings(ids)
-	return ids
+	return entries, errs
 }
 
 func resolveAgentPermissionsFromPolicy(entry runtimecontracts.AgentRegistryEntry, policy runtimecontracts.PolicyDocument) ([]string, error) {

--- a/internal/runtime/tools/platform_builtin_catalog.go
+++ b/internal/runtime/tools/platform_builtin_catalog.go
@@ -176,7 +176,7 @@ func resolveEntityToolContract(source semanticview.Source, actor *models.AgentCo
 		return entityruntime.Contract{}, false
 	}
 	if actor != nil {
-		if contract, ok := entityruntime.ResolveForActor(source, actor.ID); ok {
+		if contract, ok := entityruntime.ResolveForActor(source, *actor); ok {
 			return contract, true
 		}
 	}

--- a/internal/runtime/tools/registry.go
+++ b/internal/runtime/tools/registry.go
@@ -299,8 +299,12 @@ func executionToolsForActor(source semanticview.Source, actor models.AgentConfig
 		}
 	}
 	if source != nil && strings.TrimSpace(actor.ID) != "" {
+		projection, projected := semanticview.ResolveAgentContractProjection(source, actor)
 		for name := range candidates {
-			entry, ok := source.ToolEntryForAgent(strings.TrimSpace(actor.ID), strings.TrimSpace(name))
+			if !projected {
+				continue
+			}
+			entry, ok := projection.ToolEntry(name)
 			if !ok {
 				continue
 			}

--- a/internal/runtime/tools/retired_dynamic_agent_tools.go
+++ b/internal/runtime/tools/retired_dynamic_agent_tools.go
@@ -39,21 +39,18 @@ func ValidateRetiredDynamicAgentToolReferences(source semanticview.Source) []err
 	}
 	type authoredScope struct {
 		label  string
-		agents map[string]runtimecontracts.AgentRegistryEntry
 		tools  map[string]runtimecontracts.ToolSchemaEntry
 		policy runtimecontracts.PolicyDocument
 	}
 
 	scopes := []authoredScope{{
 		label:  "root",
-		agents: source.AgentEntries(),
 		tools:  source.ToolEntries(),
 		policy: source.ResolvedPolicyForFlow(""),
 	}}
 	for _, project := range semanticview.ProjectScopes(source) {
 		scopes = append(scopes, authoredScope{
 			label:  "project " + strings.TrimSpace(project.Key),
-			agents: project.Agents,
 			tools:  project.Tools,
 			policy: project.Policy,
 		})
@@ -61,7 +58,6 @@ func ValidateRetiredDynamicAgentToolReferences(source semanticview.Source) []err
 	for _, flow := range semanticview.FlowScopes(source) {
 		scopes = append(scopes, authoredScope{
 			label:  "flow " + strings.TrimSpace(flow.ID),
-			agents: flow.Agents,
 			tools:  flow.Tools,
 			policy: flow.Policy,
 		})
@@ -83,16 +79,19 @@ func ValidateRetiredDynamicAgentToolReferences(source semanticview.Source) []err
 		errs = append(errs, retiredDynamicAgentToolError(name, location))
 	}
 
-	for _, scope := range scopes {
-		for _, agentID := range sortedAgentIDs(scope.agents) {
-			agent := scope.agents[agentID]
-			for _, name := range agent.ConfiguredTools() {
-				add(name, fmt.Sprintf("%s agent %s tools", scope.label, agentID))
-			}
-			for _, name := range agent.Permissions {
-				add(name, fmt.Sprintf("%s agent %s permissions", scope.label, agentID))
-			}
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		label := declaration.Label(true)
+		if strings.TrimSpace(declaration.ScopeKind) == "" {
+			label = "root agent " + strings.TrimSpace(declaration.LocalID)
 		}
+		for _, name := range declaration.Entry.ConfiguredTools() {
+			add(name, label+" tools")
+		}
+		for _, name := range declaration.Entry.Permissions {
+			add(name, label+" permissions")
+		}
+	}
+	for _, scope := range scopes {
 		for name := range scope.tools {
 			add(name, scope.label+" tool entry")
 		}

--- a/internal/runtime/tools/role_scoped_entity_tools.go
+++ b/internal/runtime/tools/role_scoped_entity_tools.go
@@ -60,7 +60,7 @@ func actorHasEntityContract(source semanticview.Source, actor models.AgentConfig
 	if source == nil || strings.TrimSpace(actor.ID) == "" {
 		return false
 	}
-	_, ok := entityruntime.ResolveForActor(source, actor.ID)
+	_, ok := entityruntime.ResolveForActor(source, actor)
 	return ok
 }
 
@@ -315,7 +315,7 @@ func roleScopedToolNamePart(raw string) string {
 }
 
 func roleScopedEntityToolSpecForActor(source semanticview.Source, actor models.AgentConfig, toolName string) (roleScopedEntityToolSpec, entityruntime.Contract, bool) {
-	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	contract, ok := entityruntime.ResolveForActor(source, actor)
 	if !ok {
 		return roleScopedEntityToolSpec{}, entityruntime.Contract{}, false
 	}
@@ -331,7 +331,7 @@ func (e *Executor) RoleScopedEntityToolNamesForActor(actor models.AgentConfig) m
 	e.mu.RLock()
 	source := e.workflowSource
 	e.mu.RUnlock()
-	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	contract, ok := entityruntime.ResolveForActor(source, actor)
 	if !ok {
 		return nil
 	}
@@ -360,7 +360,7 @@ func roleScopedEntityToolsEligibleForCurrentTurn(ctx context.Context, store Enti
 	if store == nil || source == nil {
 		return false
 	}
-	contract, ok := entityruntime.ResolveForActor(source, actor.ID)
+	contract, ok := entityruntime.ResolveForActor(source, actor)
 	if !ok {
 		return false
 	}

--- a/internal/runtime/tools/tool_model_test.go
+++ b/internal/runtime/tools/tool_model_test.go
@@ -102,6 +102,76 @@ func TestAdmittedToolMutationCannotChangeDefinitionAuthorizationRateOrDispatch(t
 	}
 }
 
+func TestExecutionToolsForActorUsesScopedDeclarationWithLiteralPublicName(t *testing.T) {
+	tool := func(description string) runtimecontracts.ToolSchemaEntry {
+		return runtimecontracts.MustToolSchemaEntry(
+			runtimecontracts.WithToolDescription(description),
+			runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerPlatformBuiltin),
+			runtimecontracts.WithToolSchemas(
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
+			),
+		)
+	}
+	alpha := runtimecontracts.FlowContractView{
+		Path:  "alpha",
+		Paths: runtimecontracts.FlowContractPaths{ID: "alpha", Flow: "alpha"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "alpha-worker", Tools: []string{"shared-tool", "infra.ping"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"shared-tool": tool("alpha scoped tool"),
+			"infra.ping": runtimecontracts.MustToolSchemaEntry(
+				runtimecontracts.WithToolHandler(runtimecontracts.MustToolHandlerKind("mcp")),
+				runtimecontracts.WithToolSchemas(runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject), runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject)),
+			),
+		},
+	}
+	beta := runtimecontracts.FlowContractView{
+		Path:  "beta",
+		Paths: runtimecontracts.FlowContractPaths{ID: "beta", Flow: "beta"},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"local-worker": {ID: "public-worker", Tools: []string{"shared-tool", "infra.ping"}},
+		},
+		Tools: map[string]runtimecontracts.ToolSchemaEntry{
+			"shared-tool": tool("beta scoped tool"),
+			"infra.ping": runtimecontracts.MustToolSchemaEntry(
+				runtimecontracts.WithToolHandler(runtimecontracts.MustToolHandlerKind("mcp")),
+				runtimecontracts.WithToolSchemas(runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject), runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject)),
+			),
+		},
+	}
+	refs := map[string]runtimecontracts.ContractURIRef{
+		"alpha/local-worker": {Kind: "agent", FlowID: "alpha", LocalID: "local-worker", Full: "test://alpha/local-worker"},
+		"beta/local-worker":  {Kind: "agent", FlowID: "beta", LocalID: "local-worker", Full: "test://beta/local-worker"},
+	}
+	byURI := map[string]runtimecontracts.ContractURIRef{}
+	for _, ref := range refs {
+		byURI[ref.Full] = ref
+	}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{alpha, beta}},
+			ByID: map[string]*runtimecontracts.FlowContractView{"alpha": &alpha, "beta": &beta},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{Agents: refs, ByURI: byURI},
+	})
+	entries, err := executionToolsForActor(source, models.AgentConfig{
+		ID: "public-worker", FlowID: "beta", Tools: []string{"shared-tool"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := entries["shared-tool"]
+	if !ok || entry.Description() != "beta scoped tool" {
+		t.Fatalf("runtime scoped tool = %#v ok %v", entry, ok)
+	}
+	findings := RequiredMCPToolAvailabilityFindings(source, nil)
+	if len(findings) != 2 || findings[0].AgentID != "alpha-worker" || findings[1].AgentID != "public-worker" {
+		t.Fatalf("scoped required MCP findings = %#v", findings)
+	}
+}
+
 func TestDirectAndDurableHTTPExecutionConsumeSameAdmittedToolSemantics(t *testing.T) {
 	entry := runtimecontracts.MustToolSchemaEntry(
 		runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerHTTP),

--- a/internal/runtime/tools/usage.go
+++ b/internal/runtime/tools/usage.go
@@ -127,7 +127,11 @@ func validateEmitToolUsageHintCoverage(source semanticview.Source) []UsageHintFi
 	}
 	registry := NewEmitRegistry(source, runtimeauthority.NewSourceProvider(source))
 	findings := make([]UsageHintFinding, 0)
-	for _, actor := range providerSchemaValidationActors(source) {
+	actors, actorErrs := providerSchemaValidationActors(source)
+	for _, err := range actorErrs {
+		findings = append(findings, UsageHintFinding{ToolName: "generated emit tools", Severity: "error", Message: err.Error()})
+	}
+	for _, actor := range actors {
 		for _, def := range registry.GenerateEmitToolsForActor(actor, nil) {
 			usage := strings.TrimSpace(def.Usage)
 			if usage == "" {

--- a/internal/runtime/tools/usage_test.go
+++ b/internal/runtime/tools/usage_test.go
@@ -55,7 +55,7 @@ func TestValidateUsageHintCoverage_RejectsGeneratedEmitHintMentioningCEL(t *test
 	emitToolUsageHint = "Use CEL"
 	t.Cleanup(func() { emitToolUsageHint = original })
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent": {
 				ID:         "agent",
@@ -87,7 +87,7 @@ func TestValidateUsageHintCoverage_CoversRoleDerivedEmitTools(t *testing.T) {
 	emitToolUsageHint = "Use CEL"
 	t.Cleanup(func() { emitToolUsageHint = original })
 
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	source := wrapRootAgentBundle(&runtimecontracts.WorkflowContractBundle{
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"agent-instance-1": {
 				ID:   "agent-instance-1",

--- a/internal/runtime/workflow_validation_test.go
+++ b/internal/runtime/workflow_validation_test.go
@@ -13,6 +13,7 @@ import (
 	llmselection "github.com/division-sh/swarm/internal/runtime/llm/selection"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 )
 
@@ -224,7 +225,7 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 					"agent-1": {ID: "agent-1", Tools: []string{"missing_tool"}},
 				}
-				return semanticview.Wrap(bundle)
+				return semanticviewtest.WrapRootAgents(bundle)
 			}(),
 			wantErr: false,
 		},
@@ -235,7 +236,7 @@ func TestEnsureWorkflowBootWiring_RejectsTouchedValidationDriftThroughSharedPath
 				bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 					"agent-1": {ID: "agent-1", EmitEvents: []string{"missing.event"}},
 				}
-				return semanticview.Wrap(bundle)
+				return semanticviewtest.WrapRootAgents(bundle)
 			}(),
 			errContains: "'missing.event' emitted but no schema in events.yaml",
 			wantErr:     true,
@@ -956,7 +957,7 @@ func TestValidateWorkflowContractSurface_AllowsExplicitEventSchemas(t *testing.T
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 
 	result, err := ValidateWorkflowContractSurface(testAuthorActivityContext(context.Background()), source, DefaultWorkflowContractValidationOptions(nil, executionposture.Live))
 	if err != nil {
@@ -987,7 +988,7 @@ func TestValidateWorkflowContractSurfaceRejectsInvalidGeneratedEmitToolSchema(t 
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 
 	result, err := ValidateWorkflowContractSurface(testAuthorActivityContext(context.Background()), source, DefaultWorkflowContractValidationOptions(nil, executionposture.Live))
 	if err == nil || !strings.Contains(err.Error(), "generated_tool_schema_closure") {
@@ -1028,7 +1029,7 @@ func TestValidateWorkflowContractSurfaceAllowsPrecisionQualifiedGeneratedEmitToo
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 
 	result, err := ValidateWorkflowContractSurface(testAuthorActivityContext(context.Background()), source, DefaultWorkflowContractValidationOptions(nil, executionposture.Live))
 	if err != nil {

--- a/internal/runtime/workspace/manager_test.go
+++ b/internal/runtime/workspace/manager_test.go
@@ -438,6 +438,7 @@ func (s workspaceLookupStub) ListRuntimeWorkspaceContainers(context.Context, str
 }
 
 func TestResolveWorkspace_UsesInjectedSemanticSourceForRoleLookup(t *testing.T) {
+	const owner = "test://workspace/ops/worker"
 	dataDir := t.TempDir()
 	contractsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(contractsDir, "package.yaml"), []byte("name: test\n"), 0o644); err != nil {
@@ -452,6 +453,14 @@ func TestResolveWorkspace_UsesInjectedSemanticSourceForRoleLookup(t *testing.T) 
 	manager.SetConfig(cfg)
 
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				owner: {Kind: "agent", FlowID: "ops", LocalID: "worker", Full: owner},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				owner: {Kind: "agent", FlowID: "ops", LocalID: "worker", Full: owner},
+			},
+		},
 		Policy: runtimecontracts.PolicyDocument{Values: map[string]runtimecontracts.PolicyValue{
 			"workspace_classes": {
 				Value: map[string]any{
@@ -460,15 +469,16 @@ func TestResolveWorkspace_UsesInjectedSemanticSourceForRoleLookup(t *testing.T) 
 			},
 		}},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"worker": {Role: "worker", WorkspaceClass: "shared_flow"},
+			"worker": {ID: "worker-1", Role: "worker", WorkspaceClass: "shared_flow"},
 		},
 		FlowTree: runtimecontracts.FlowTree{
 			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{{
 				Paths: runtimecontracts.FlowContractPaths{ID: "ops", Flow: "ops"},
 				Path:  "ops",
 				Agents: map[string]runtimecontracts.AgentRegistryEntry{
-					"worker": {Role: "worker", WorkspaceClass: "shared_flow"},
+					"worker": {ID: "worker-1", Role: "worker", WorkspaceClass: "shared_flow"},
 				},
+				AgentURIs: map[string]string{"worker": owner},
 			}}},
 			ByID: map[string]*runtimecontracts.FlowContractView{},
 		},
@@ -491,7 +501,7 @@ func TestResolveWorkspace_UsesInjectedSemanticSourceForRoleLookup(t *testing.T) 
 	target, err := manager.ResolveWorkspace(context.Background(), models.AgentConfig{
 		ExecutionMode: "live",
 		ID:            "worker-1",
-		Identity:      runtimeagentidentitytest.Declared(t, "worker-1", "test/agents.yaml", "ops", "instance-1", "ops/instance-1"),
+		Identity:      runtimeagentidentitytest.Declared(t, "worker-1", owner, "ops", "instance-1", "ops/instance-1"),
 		Role:          "worker",
 		FlowPath:      "ops/instance-1",
 	})

--- a/internal/serveapp/builder_project_supervisor_test.go
+++ b/internal/serveapp/builder_project_supervisor_test.go
@@ -40,6 +40,7 @@ import (
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/runtime/triggergeneration"
@@ -2353,7 +2354,7 @@ func TestRuntimeProjectSupervisorOpenProjectExecutesExplicitHostRefusal(t *testi
 	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
 		"worker": {ID: "worker"},
 	}
-	source := semanticview.Wrap(bundle)
+	source := semanticviewtest.WrapRootAgents(bundle)
 	module := stubWorkflowModule{source: source}
 	cfg := testWorkspaceBackendConfig(llmselection.BackendClaudeCLI)
 	supervisor := newRuntimeProjectSupervisor(

--- a/internal/serveapp/builtin_tool_parity_invariants_test.go
+++ b/internal/serveapp/builtin_tool_parity_invariants_test.go
@@ -12,6 +12,7 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/executionposture"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 )
 
@@ -48,7 +49,7 @@ func TestBuiltinToolParityInvariant_SupportedSurfacesShareRuntimeToolTruth_V2(t 
 					Permissions: tc.permissions,
 				},
 			}
-			source := semanticview.Wrap(bundle)
+			source := semanticviewtest.WrapRootAgents(bundle)
 
 			directReport := runtimebootverify.Run(context.Background(), source, runtimebootverify.Options{})
 			assertToolResolutionWarning(t, directReport.Warnings(), tc.configuredTool, tc.wantToolResolution)

--- a/internal/store/testdata/persistence_authority_findings.tsv
+++ b/internal/store/testdata/persistence_authority_findings.tsv
@@ -2060,7 +2060,6 @@ typed-process-local	interface-method	typed	internal/runtime/runtime_claude_start
 typed-process-local	interface-method	typed	internal/runtime/runtime_claude_startup.go	claudeStartupToolSource	method:ToolDefinitionsForActor	func(github.com/division-sh/swarm/internal/runtime/core/actors.AgentConfig) []github.com/division-sh/swarm/internal/runtime/llm.ToolDefinition
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:ActionInstructionByID	func(id string) (github.com/division-sh/swarm/internal/runtime/core/registry.ActionInstruction, bool)
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:ActionInstructions	func() []github.com/division-sh/swarm/internal/runtime/core/registry.ActionInstruction
-typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:AgentContractSource	func(agentID string) (github.com/division-sh/swarm/internal/runtime/contracts.ContractItemSource, bool)
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:AgentEntries	func() map[string]github.com/division-sh/swarm/internal/runtime/contracts.AgentRegistryEntry
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:AuthoredEventEntries	func() map[string]github.com/division-sh/swarm/internal/runtime/contracts.EventCatalogEntry
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:AuthoredResolvedEventCatalog	func() map[string]github.com/division-sh/swarm/internal/runtime/contracts.EventCatalogEntry
@@ -2108,7 +2107,6 @@ typed-process-local	interface-method	typed	internal/runtime/semanticview/source.
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:RuntimeEventOwners	func(eventType string) []string
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:SemanticCapabilities	func() github.com/division-sh/swarm/internal/runtime/semanticview.Capabilities
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:ToolEntries	func() map[string]github.com/division-sh/swarm/internal/runtime/contracts.ToolSchemaEntry
-typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:ToolEntryForAgent	func(agentID string, toolID string) (github.com/division-sh/swarm/internal/runtime/contracts.ToolSchemaEntry, bool)
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:WorkflowEntitySchema	func() github.com/division-sh/swarm/internal/runtime/contracts.EntitySchema
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:WorkflowGateForStage	func(flowID string, stage string) (github.com/division-sh/swarm/internal/runtime/contracts.WorkflowGatePlan, bool)
 typed-process-local	interface-method	typed	internal/runtime/semanticview/source.go	Source	method:WorkflowGates	func() []github.com/division-sh/swarm/internal/runtime/contracts.WorkflowGatePlan

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -301,11 +301,14 @@ contract_formats:
     flow_namespace: Non-authorable. Derived from the flow path relative to root. A flow at flows/intake/ gets namespace "intake".
       Root flow gets empty namespace. Public schema.yaml namespace override fields, including namespace, namespace_prefix,
       and namespace_rule, are not accepted.
-    agent_id: 'Optional. If omitted, the YAML map key IS the agent ID. agents.yaml uses map keys as canonical identifiers:
-      {"classifier-agent": {model: regular, ...}} means agent_id = "classifier-agent". Explicit id field overrides the
-      map key if present, but this is discouraged. Under agent_identity_model.current_supported_posture this authored
-      slug is also the current public/runtime agent_id and must be unique across live loaded/boot-pinned bundles until
-      the #977 UUID-internal migration is separately promoted and implemented.'
+    agent_id: 'Optional presence-aware literal public name. If omitted, the YAML map key derives agent_id:
+      {"classifier-agent": {model: regular, ...}} means agent_id = "classifier-agent". If id is present, it MUST be
+      a non-empty literal; empty, whitespace, null, bare, tilde, and any interpolation form hard-fail loading. Business
+      discriminators belong in instance.by because concrete identity is declaration x flow route. The declaration map
+      key remains the scoped URI/lookup coordinate even when a literal id overrides the public name. Effective public
+      names MUST be unique within one declaration scope. Under agent_identity_model.current_supported_posture this
+      effective name is the public/runtime agent_id and must be unique across live loaded/boot-pinned bundles until the
+      #977 UUID-internal migration is separately promoted and implemented.'
     agent_emit_events: Optional. If omitted, defaults to empty list []. An agent that only observes (subscribes but never
       emits) may omit emit_events entirely.
   file_layout:
@@ -4568,7 +4571,9 @@ engine:
     process:
     - 1. For each flow in the flat list (from walker), construct its instance path.
     - '2. For each node in flow''s nodes.yaml: register with URI {root}://{instance_path}/{node_id}'
-    - '3. For each agent in flow''s agents.yaml: register with URI {root}://{instance_path}/{agent_id}'
+    - '3. For each agent in flow''s agents.yaml: register its declaration with URI {root}://{instance_path}/{agent_local_id},
+      where agent_local_id is the YAML map key. A literal id override changes only the effective public agent_id and never
+      the declaration URI segment.'
     - '4. For each event in flow''s events.yaml: register with URI {root}://{instance_path}/{event_name}'
     - '5. For each tool in flow''s tools.yaml: register as shared (tools are not URI-scoped)'
     - '6. For each policy key in flow''s policy.yaml: register scoped to flow instance'
@@ -15830,9 +15835,21 @@ agent_identity_model:
     workspace, recovery, or control identity.
   concepts:
     agent_name:
-      source: agents.yaml map key or explicit id field after contract loading
+      source: One presence-aware scoped AgentDeclaration plan derives a non-empty literal effective name from the agents.yaml
+        map key or an explicitly present literal id field, then materializes one declared agentidentity.Name with the
+        declaration owner URI.
       current_public_name: agent_id
-      role: Human-authored or runtime-created operator-facing name with explicit provenance and owner.
+      declaration_coordinate: The YAML map key and scoped owner URI remain the authoring/lookup coordinate; an explicit
+        id never rewrites the URI.
+      invalid_authored_forms: [empty, whitespace_only, null, bare, tilde, interpolation]
+      collision_rule: Two declarations in one scope MUST NOT derive the same effective public name.
+      role: Human-authored or runtime-created operator-facing name with explicit provenance and owner. Runtime, routing,
+        activation, verification, diagnostics, catalog, tool, authority, timer, and lookup consumers MUST consume the
+        typed plan/materialized name rather than reconstructing from wire ID or map keys.
+      runtime_role_projection: 'A declaration-derived runtime actor role is the explicit agents.yaml role when present;
+        otherwise it is the declaration effective public agent_id. Static activation, template activation, authority,
+        emit-schema, native-tool, and permission projections MUST consume this same value. This does not change
+        required_agents fulfillment: required-agent sockets remain bound to the scoped agents.yaml map key.'
     concrete_live_identity:
       source: agent name provenance plus explicit present-or-root route
       role: Durable composite primary key, runtime map key, EventBus target key, delivery/session/timer/workspace owner,


### PR DESCRIPTION
## Summary

- introduce one presence-aware scoped declared-agent-name plan that preserves the map-key/URI declaration coordinate while materializing one validated public `agentidentity.Name`
- migrate routing, activation, static connect, lookup, collision admission, authority, timer, tool/MCP/permission, catalog, diagnostics, workspace, and bundle/hash consumers to that owner
- reject authored-empty IDs, arbitrary identity interpolation, malformed ownership, and same-scope effective-name collisions; remove retired alias/template interpreters and redundant fixture IDs
- reconcile `platform-spec.yaml` and add a compiler-resolved boundary guard plus SQLite/PostgreSQL N=1/2/3 execution proof for omitted IDs and literal overrides

## Governing Context

Exact governing references:

- `platform-spec.yaml#contract_formats.common_keys.agent_id`
- `platform-spec.yaml#engine.phase2_uri_merging.process`
- `platform-spec.yaml#agent_identity_model`

Binding adjacent context is #2133 (declaration name x flow route concrete identity), #2125 (declaration-owned topology parent), #977 (separate future cross-bundle UUID authority), and the approved #2169 Gate A ruling.

## Semantic Migration

The new canonical owner is `semanticview.AgentDeclaration` plus its typed `AgentNamePlan`; `AgentNamePlan.Materialize` is the only declared-name conversion to `agentidentity.Name`.

Old paths now invalid are raw `AgentRegistryEntry.ID`, map-key public-name reconstruction, renderer/regex/template identity matching, and local fallback helpers in routing, activation, static connect, lookup, collision, authority, tools, diagnostics, and public projections. Production paths were compiler-censused and guarded across every Gate A package. The migration is complete: no compatibility reader, dual writer, old-store migration, or fallback remains.

## Verification

- focused loader/semanticview/bus/manager/authoring/tool/runtime hostile matrix at `-count=3`
- `TestHandleEmitTool_TemplateAgentEmissionReachesSameInstanceNodeAndTerminalizesEntity` on SQLite and PostgreSQL, omitted ID and literal override, N=1/2/3, at `-count=3`
- full runtime, serve, release-binary, and affected package suites
- `go test ./...` ran with the host PostgreSQL DSN; all product/runtime/store packages passed. The command's only failure was the pre-existing local Colima infrastructure proof `TestServiceRegistryConcurrentLiveRunnersRemainUntouched`, whose intentionally DSN-free Docker runners timed out waiting for host port forwarding.

Closes #2169
