### PR TITLE
[agent-a][issue #2236] Canonicalize durable join schedule identity

### DIFF
--- a/internal/runtime/bootverify/workflow_join_checks.go
+++ b/internal/runtime/bootverify/workflow_join_checks.go
@@ -32,7 +32,12 @@ func checkJoinValidation(c *checkerContext) []Finding {
 			if err := runtimecontracts.ValidateJoinHandlerIsolation(handler); err != nil {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, err.Error()))
 			}
-			plan, ok := semanticview.WorkflowJoinPlanForHandler(c.source, flowID, nodeID, eventType)
+			ref, refErr := timeridentity.NewJoinRef(flowID, nodeID, eventType, handler.Join.Stage, handler.Join.EffectiveID(), "")
+			if refErr != nil {
+				findings = append(findings, joinFinding(flowID, nodeID, eventType, "join has incomplete declaration identity: "+refErr.Error()))
+				continue
+			}
+			plan, ok := semanticview.WorkflowJoinPlanForRef(c.source, ref)
 			if !ok {
 				findings = append(findings, joinFinding(flowID, nodeID, eventType, "join has no effective WorkflowJoinPlan; reload the workflow contract and declare exactly one canonical join row"))
 				continue

--- a/internal/runtime/bootverify/workflow_join_checks_test.go
+++ b/internal/runtime/bootverify/workflow_join_checks_test.go
@@ -135,6 +135,28 @@ func TestRun_ValidatesStagedJoinContract(t *testing.T) {
 	}
 }
 
+func TestRun_JoinValidationRequiresExactDeclarationFlow(t *testing.T) {
+	t.Run("same-leaf sibling cannot replace root", func(t *testing.T) {
+		bundle := joinValidationBundle()
+		bundle.Semantics.Joins[0].FlowID = "orders"
+		report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+		if !reportContains(report.HardInvalidities(), joinValidationCheckID, "no effective WorkflowJoinPlan") {
+			t.Fatalf("hard invalidities = %#v", report.HardInvalidities())
+		}
+	})
+
+	t.Run("root remains exact beside same-leaf sibling", func(t *testing.T) {
+		bundle := joinValidationBundle()
+		sibling := bundle.Semantics.Joins[0]
+		sibling.FlowID = "orders"
+		bundle.Semantics.Joins = append(bundle.Semantics.Joins, sibling)
+		report := Run(context.Background(), semanticview.Wrap(bundle), Options{})
+		if reportContains(report.HardInvalidities(), joinValidationCheckID, "no effective WorkflowJoinPlan") {
+			t.Fatalf("root declaration was shadowed by sibling: %#v", report.HardInvalidities())
+		}
+	})
+}
+
 func TestJoinMembersContributeCanonicalEntityReaderCoverage(t *testing.T) {
 	bundle := joinValidationBundle()
 	source := semanticview.Wrap(bundle)

--- a/internal/runtime/bus/delivery_planner.go
+++ b/internal/runtime/bus/delivery_planner.go
@@ -192,6 +192,19 @@ func (p deliveryPlanner) planAtGeneration(ctx context.Context, evt events.Event)
 		return RoutePlan{}, err
 	}
 	ctx = withSelectedRunTargetOwnerProjection(ctx, projection)
+	joinRecipient, joinTarget, joinHandler, joinOccurrence, err := runtimepipeline.ResolveWorkflowJoinOccurrenceDeliveryTarget(
+		p.recipientPolicy.semanticSource, evt,
+	)
+	if err != nil {
+		return RoutePlan{}, err
+	}
+	if joinOccurrence {
+		routePlan.AddDeliveryIntents(RoutePlanDeliveryIntent{
+			Recipient: joinRecipient, TargetBlueprint: joinTarget, Handler: joinHandler,
+			Producer: routeIntentProducerInternalTargetCarrier, Persist: true,
+		})
+		return projection.resolveRoutePlan(routePlan)
+	}
 	connectPlan, err := p.connectPlanner.Plan(ctx, evt)
 	if err != nil {
 		return RoutePlan{}, err

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -108,7 +108,7 @@ func TestAdmitNodeExecutionRoutingSourcePreservesEntitylessSelectedRun(t *testin
 	})
 	route := events.RouteIdentity{FlowID: "root-workflow", FlowInstance: "run-one"}
 
-	got, err := AdmitNodeExecutionRoutingSource(source, "root-node", route)
+	got, err := AdmitNodeExecutionRoutingSource(source, "root-workflow", "root-node", route)
 	if err != nil {
 		t.Fatalf("AdmitNodeExecutionRoutingSource: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestAdmitNodeExecutionRoutingSourcePreservesEntitylessSelectedRun(t *testin
 		t.Fatalf("routing source = %s %#v, want entityless static flow %#v", got.Kind().StorageCode(), got.Route(), route)
 	}
 
-	if _, err := AdmitNodeExecutionRoutingSource(source, "root-node", events.RouteIdentity{FlowID: "root-workflow"}); err == nil || !strings.Contains(err.Error(), "exact selected-run flow route") {
+	if _, err := AdmitNodeExecutionRoutingSource(source, "root-workflow", "root-node", events.RouteIdentity{FlowID: "root-workflow"}); err == nil || !strings.Contains(err.Error(), "exact selected-run flow route") {
 		t.Fatalf("incomplete entityless source error = %v", err)
 	}
 }

--- a/internal/runtime/core/pinrouting/routing_source.go
+++ b/internal/runtime/core/pinrouting/routing_source.go
@@ -12,22 +12,30 @@ import (
 
 // AdmitNodeExecutionRoutingSource admits the exact source fact at the node
 // execution boundary. Downstream event producers copy this value unchanged.
-func AdmitNodeExecutionRoutingSource(source semanticview.Source, nodeID string, route events.RouteIdentity) (events.RoutingSource, error) {
+func AdmitNodeExecutionRoutingSource(source semanticview.Source, executionFlowID, nodeID string, route events.RouteIdentity) (events.RoutingSource, error) {
 	if source == nil {
 		return events.RoutingSource{}, fmt.Errorf("node execution routing source requires semantic source")
 	}
-	owner, ok := source.NodeContractSource(strings.TrimSpace(nodeID))
-	if !ok {
-		return events.RoutingSource{}, fmt.Errorf("node execution routing source requires declared node %q", strings.TrimSpace(nodeID))
+	executionFlowID = strings.TrimSpace(executionFlowID)
+	nodeID = strings.TrimSpace(nodeID)
+	if executionFlowID == "" || nodeID == "" {
+		return events.RoutingSource{}, fmt.Errorf("node execution routing source requires exact flow and node owners")
+	}
+	if _, _, ok := semanticview.ResolveFlowNodeDeclaration(source, executionFlowID, nodeID); !ok {
+		return events.RoutingSource{}, fmt.Errorf("node execution routing source requires node %q in exact flow scope %q", nodeID, executionFlowID)
+	}
+	owner := runtimecontracts.ContractItemSource{Layer: "flow", FlowID: executionFlowID}
+	if executionFlowID == semanticview.RootExecutionFlowID(source) {
+		owner = runtimecontracts.ContractItemSource{Layer: "project"}
 	}
 	route = route.Normalized()
 	if strings.TrimSpace(owner.Layer) == "project" && route.EntityID == "" {
 		if route.FlowID != strings.TrimSpace(source.WorkflowName()) || route.FlowInstance == "" {
-			return events.RoutingSource{}, fmt.Errorf("project node %q entityless routing source requires the exact selected-run flow route", strings.TrimSpace(nodeID))
+			return events.RoutingSource{}, fmt.Errorf("project node %q entityless routing source requires the exact selected-run flow route", nodeID)
 		}
 		return events.NewStaticFlowRoutingSource(route)
 	}
-	return admitDeclaredExecutionRoutingSource(source, "node", strings.TrimSpace(nodeID), owner, route)
+	return admitDeclaredExecutionRoutingSource(source, "node", nodeID, owner, route)
 }
 
 // AdmitAgentExecutionRoutingSource admits the exact source fact from the

--- a/internal/runtime/core/timeridentity/timeridentity.go
+++ b/internal/runtime/core/timeridentity/timeridentity.go
@@ -220,20 +220,20 @@ func decodeStrictJSON(raw []byte, target any) error {
 }
 
 type TimerHandle struct {
-	Kind       TimerHandleKind
-	TimerID    string
-	Join       JoinRef
-	Generation attemptgeneration.Generation
+	kind       TimerHandleKind
+	timerID    string
+	join       JoinRef
+	generation attemptgeneration.Generation
 }
 
 type JoinRef struct {
-	FlowID       string
-	NodeID       string
-	HandlerEvent string
-	Stage        string
-	JoinID       string
-	Window       string
-	Generation   attemptgeneration.Generation
+	flowID       string
+	nodeID       string
+	handlerEvent string
+	stage        string
+	joinID       string
+	window       string
+	generation   attemptgeneration.Generation
 }
 
 type AccumulatorBucketRef struct {
@@ -342,45 +342,89 @@ func (t Trigger) String() string {
 
 func WorkflowTimerHandle(timerID string) TimerHandle {
 	return TimerHandle{
-		Kind:    TimerHandleWorkflowTimer,
-		TimerID: strings.TrimSpace(timerID),
+		kind:    TimerHandleWorkflowTimer,
+		timerID: strings.TrimSpace(timerID),
 	}
 }
 
-func JoinTimeoutHandle(ref JoinRef) TimerHandle {
-	return TimerHandle{Kind: TimerHandleJoinTimeout, Join: ref.Normalize(), Generation: ref.Generation.Normalize()}
+func WorkflowTimerHandleForGeneration(timerID string, generation attemptgeneration.Generation) TimerHandle {
+	handle := WorkflowTimerHandle(timerID)
+	handle.generation = generation.Normalize()
+	return handle
 }
 
-func JoinCompleteHandle(ref JoinRef) TimerHandle {
-	return TimerHandle{Kind: TimerHandleJoinComplete, Join: ref.Normalize(), Generation: ref.Generation.Normalize()}
+func JoinTimeoutHandle(ref JoinRef) (TimerHandle, error) {
+	return newJoinHandle(TimerHandleJoinTimeout, ref)
+}
+
+func JoinCompleteHandle(ref JoinRef) (TimerHandle, error) {
+	return newJoinHandle(TimerHandleJoinComplete, ref)
+
+}
+
+func newJoinHandle(kind TimerHandleKind, ref JoinRef) (TimerHandle, error) {
+	ref = ref.Normalize()
+	if !ref.Valid() {
+		return TimerHandle{}, fmt.Errorf("join timer handle requires a complete declaration reference")
+	}
+	return TimerHandle{kind: kind, join: ref}, nil
 }
 
 func (h TimerHandle) Valid() bool {
-	switch h.Kind {
+	switch h.kind {
 	case TimerHandleWorkflowTimer:
-		return strings.TrimSpace(h.TimerID) != ""
+		return strings.TrimSpace(h.timerID) != ""
 	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
-		return h.Join.Valid()
+		return h.join.Valid() && !h.generation.Valid()
 	default:
 		return false
 	}
 }
 
+func (h TimerHandle) Kind() TimerHandleKind { return h.kind }
+
+func (h TimerHandle) TimerID() string { return strings.TrimSpace(h.timerID) }
+
+func (h TimerHandle) JoinRef() (JoinRef, bool) {
+	if h.kind != TimerHandleJoinTimeout && h.kind != TimerHandleJoinComplete || !h.join.Valid() {
+		return JoinRef{}, false
+	}
+	return h.join.Normalize(), true
+}
+
+func (h TimerHandle) Generation() attemptgeneration.Generation {
+	if ref, ok := h.JoinRef(); ok {
+		return ref.Generation()
+	}
+	return h.generation.Normalize()
+}
+
+func (h TimerHandle) EventType() string {
+	switch h.kind {
+	case TimerHandleJoinTimeout:
+		return "platform.join_timeout"
+	case TimerHandleJoinComplete:
+		return "platform.join_complete"
+	default:
+		return ""
+	}
+}
+
 func (h TimerHandle) TaskID() string {
-	generationSuffix := h.Generation.Normalize().KeySuffix()
+	generationSuffix := h.generation.Normalize().KeySuffix()
 	appendGeneration := func(value string) string {
 		if generationSuffix == "" {
 			return value
 		}
 		return value + ":generation:" + generationSuffix
 	}
-	switch h.Kind {
+	switch h.kind {
 	case TimerHandleWorkflowTimer:
-		return appendGeneration(strings.TrimSpace(h.TimerID))
+		return appendGeneration(strings.TrimSpace(h.timerID))
 	case TimerHandleJoinTimeout:
-		return joinTimeoutTaskPrefix + h.Join.Key()
+		return joinTimeoutTaskPrefix + h.join.Key()
 	case TimerHandleJoinComplete:
-		return joinCompleteTaskPrefix + h.Join.Key()
+		return joinCompleteTaskPrefix + h.join.Key()
 	default:
 		return ""
 	}
@@ -391,20 +435,26 @@ func (h TimerHandle) PayloadMetadata() map[string]any {
 		return nil
 	}
 	handle := map[string]any{
-		"kind": string(h.Kind),
+		"kind": string(h.kind),
 	}
-	switch h.Kind {
+	switch h.kind {
 	case TimerHandleWorkflowTimer:
-		handle["timer_id"] = strings.TrimSpace(h.TimerID)
+		handle["timer_id"] = strings.TrimSpace(h.timerID)
 	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
-		handle["join"] = h.Join.PayloadValue()
+		handle["join"] = h.join.PayloadValue()
 	}
-	if generation := h.Generation.Normalize(); generation.Valid() {
+	if generation := h.generation.Normalize(); generation.Valid() {
 		handle[attemptgeneration.PayloadKey] = generation.PayloadValue()
 	}
-	return map[string]any{
+	payload := map[string]any{
 		timerHandlePayloadKey: handle,
 	}
+	if ref, ok := h.JoinRef(); ok {
+		if generation := ref.Generation(); generation.Valid() {
+			payload[generation.RevisionField] = generation.RevisionID
+		}
+	}
+	return payload
 }
 
 func ParseTimerHandle(payload map[string]any) (TimerHandle, bool) {
@@ -412,65 +462,118 @@ func ParseTimerHandle(payload map[string]any) (TimerHandle, bool) {
 	if !ok {
 		return TimerHandle{}, false
 	}
-	generation, _ := attemptgeneration.FromPayload(map[string]any{attemptgeneration.PayloadKey: handleMap[attemptgeneration.PayloadKey]})
-	switch TimerHandleKind(strings.TrimSpace(asString(handleMap["kind"]))) {
+	return parseTimerHandleMap(handleMap)
+}
+
+func parseTimerHandleMap(handleMap map[string]any) (TimerHandle, bool) {
+	kind := TimerHandleKind(strings.TrimSpace(asString(handleMap["kind"])))
+	switch kind {
 	case TimerHandleWorkflowTimer:
+		if !onlyKeys(handleMap, "kind", "timer_id", attemptgeneration.PayloadKey) {
+			return TimerHandle{}, false
+		}
+		generation := attemptgeneration.Generation{}
+		if _, present := handleMap[attemptgeneration.PayloadKey]; present {
+			var ok bool
+			generation, ok = attemptgeneration.FromPayload(map[string]any{attemptgeneration.PayloadKey: handleMap[attemptgeneration.PayloadKey]})
+			if !ok {
+				return TimerHandle{}, false
+			}
+		}
 		handle := WorkflowTimerHandle(asString(handleMap["timer_id"]))
-		handle.Generation = generation
+		handle.generation = generation
 		return handle, handle.Valid()
 	case TimerHandleJoinTimeout, TimerHandleJoinComplete:
+		if !onlyKeys(handleMap, "kind", "join") {
+			return TimerHandle{}, false
+		}
 		ref, ok := joinRefFromAny(handleMap["join"])
 		if !ok {
 			return TimerHandle{}, false
 		}
-		handle := JoinTimeoutHandle(ref)
-		if TimerHandleKind(strings.TrimSpace(asString(handleMap["kind"]))) == TimerHandleJoinComplete {
-			handle = JoinCompleteHandle(ref)
+		var handle TimerHandle
+		var err error
+		if kind == TimerHandleJoinComplete {
+			handle, err = JoinCompleteHandle(ref)
+		} else {
+			handle, err = JoinTimeoutHandle(ref)
 		}
-		handle.Generation = generation
-		return handle, handle.Valid()
+		return handle, err == nil && handle.Valid()
 	default:
 		return TimerHandle{}, false
 	}
 }
 
-func NewJoinRef(flowID, nodeID, handlerEvent, stage, joinID, window string) JoinRef {
-	return JoinRef{
-		FlowID:       strings.TrimSpace(flowID),
-		NodeID:       strings.TrimSpace(nodeID),
-		HandlerEvent: strings.TrimSpace(handlerEvent),
-		Stage:        strings.TrimSpace(stage),
-		JoinID:       strings.TrimSpace(joinID),
-		Window:       strings.TrimSpace(window),
-	}
+func NewJoinRef(flowID, nodeID, handlerEvent, stage, joinID, window string) (JoinRef, error) {
+	return NewJoinRefForGeneration(flowID, nodeID, handlerEvent, stage, joinID, window, attemptgeneration.Generation{})
 }
 
-func NewJoinRefForGeneration(flowID, nodeID, handlerEvent, stage, joinID, window string, generation attemptgeneration.Generation) JoinRef {
-	ref := NewJoinRef(flowID, nodeID, handlerEvent, stage, joinID, window)
-	ref.Generation = generation.Normalize()
-	return ref
+func NewJoinRefForGeneration(flowID, nodeID, handlerEvent, stage, joinID, window string, generation attemptgeneration.Generation) (JoinRef, error) {
+	ref := JoinRef{
+		flowID:       strings.TrimSpace(flowID),
+		nodeID:       strings.TrimSpace(nodeID),
+		handlerEvent: strings.TrimSpace(handlerEvent),
+		stage:        strings.TrimSpace(stage),
+		joinID:       strings.TrimSpace(joinID),
+		window:       strings.TrimSpace(window),
+		generation:   generation.Normalize(),
+	}
+	if !ref.Valid() {
+		return JoinRef{}, fmt.Errorf("join declaration reference requires node, handler event, stage, and join identity")
+	}
+	if generation != (attemptgeneration.Generation{}) && !ref.generation.Valid() {
+		return JoinRef{}, fmt.Errorf("join declaration reference generation is invalid")
+	}
+	return ref, nil
 }
 
 func (r JoinRef) Normalize() JoinRef {
-	return NewJoinRefForGeneration(r.FlowID, r.NodeID, r.HandlerEvent, r.Stage, r.JoinID, r.Window, r.Generation)
+	return JoinRef{
+		flowID: strings.TrimSpace(r.flowID), nodeID: strings.TrimSpace(r.nodeID),
+		handlerEvent: strings.TrimSpace(r.handlerEvent), stage: strings.TrimSpace(r.stage),
+		joinID: strings.TrimSpace(r.joinID), window: strings.TrimSpace(r.window),
+		generation: r.generation.Normalize(),
+	}
 }
 
 func (r JoinRef) Valid() bool {
 	r = r.Normalize()
-	return r.NodeID != "" && r.HandlerEvent != "" && r.Stage != "" && r.JoinID != ""
+	return r.nodeID != "" && r.handlerEvent != "" && r.stage != "" && r.joinID != "" &&
+		(r.generation == (attemptgeneration.Generation{}) || r.generation.Valid())
 }
+
+func (r JoinRef) FlowID() string       { return r.Normalize().flowID }
+func (r JoinRef) NodeID() string       { return r.Normalize().nodeID }
+func (r JoinRef) HandlerEvent() string { return r.Normalize().handlerEvent }
+func (r JoinRef) Stage() string        { return r.Normalize().stage }
+func (r JoinRef) JoinID() string       { return r.Normalize().joinID }
+func (r JoinRef) Window() string       { return r.Normalize().window }
+func (r JoinRef) Generation() attemptgeneration.Generation {
+	return r.Normalize().generation
+}
+
+func (r JoinRef) WithGeneration(generation attemptgeneration.Generation) (JoinRef, error) {
+	return NewJoinRefForGeneration(r.FlowID(), r.NodeID(), r.HandlerEvent(), r.Stage(), r.JoinID(), r.Window(), generation)
+}
+
+func (r JoinRef) Declaration() JoinRef {
+	ref, _ := NewJoinRef(r.FlowID(), r.NodeID(), r.HandlerEvent(), r.Stage(), r.JoinID(), "")
+	return ref
+}
+
+func (r JoinRef) Equal(other JoinRef) bool { return r.Normalize() == other.Normalize() }
 
 func (r JoinRef) Key() string {
 	r = r.Normalize()
 	if !r.Valid() {
 		return ""
 	}
-	parts := []string{r.FlowID, r.NodeID, r.HandlerEvent, r.Stage, r.JoinID, r.Window}
+	parts := []string{r.flowID, r.nodeID, r.handlerEvent, r.stage, r.joinID, r.window}
 	for i := range parts {
 		parts[i] = base64.RawURLEncoding.EncodeToString([]byte(parts[i]))
 	}
 	key := strings.Join(parts, ".")
-	if suffix := r.Generation.KeySuffix(); suffix != "" {
+	if suffix := r.generation.KeySuffix(); suffix != "" {
 		key += ".generation." + suffix
 	}
 	return key
@@ -482,25 +585,44 @@ func (r JoinRef) PayloadValue() map[string]any {
 		return nil
 	}
 	payload := map[string]any{
-		"flow_id":       r.FlowID,
-		"node_id":       r.NodeID,
-		"handler_event": r.HandlerEvent,
-		"stage":         r.Stage,
-		"join_id":       r.JoinID,
-		"window":        r.Window,
+		"flow_id":       r.flowID,
+		"node_id":       r.nodeID,
+		"handler_event": r.handlerEvent,
+		"stage":         r.stage,
+		"join_id":       r.joinID,
+		"window":        r.window,
 	}
-	if generation := r.Generation.Normalize(); generation.Valid() {
+	if generation := r.generation.Normalize(); generation.Valid() {
 		payload[attemptgeneration.PayloadKey] = generation.PayloadValue()
 	}
 	return payload
 }
 
-func ParseJoinRef(payload map[string]any) (JoinRef, TimerHandleKind, bool) {
+func ParseJoinHandle(payload map[string]any) (TimerHandle, JoinRef, bool) {
 	handle, ok := ParseTimerHandle(payload)
-	if !ok || (handle.Kind != TimerHandleJoinTimeout && handle.Kind != TimerHandleJoinComplete) {
-		return JoinRef{}, "", false
+	if !ok || (handle.Kind() != TimerHandleJoinTimeout && handle.Kind() != TimerHandleJoinComplete) {
+		return TimerHandle{}, JoinRef{}, false
 	}
-	return handle.Join, handle.Kind, handle.Join.Valid()
+	ref, ok := handle.JoinRef()
+	if !ok {
+		return TimerHandle{}, JoinRef{}, false
+	}
+	allowed := []string{timerHandlePayloadKey}
+	if generation := ref.Generation(); generation.Valid() {
+		allowed = append(allowed, generation.RevisionField)
+		if strings.TrimSpace(asString(payload[generation.RevisionField])) != generation.RevisionID {
+			return TimerHandle{}, JoinRef{}, false
+		}
+	}
+	if !onlyKeys(payload, allowed...) {
+		return TimerHandle{}, JoinRef{}, false
+	}
+	return handle, ref, true
+}
+
+func ParseJoinRef(payload map[string]any) (JoinRef, TimerHandleKind, bool) {
+	handle, ref, ok := ParseJoinHandle(payload)
+	return ref, handle.Kind(), ok
 }
 
 func joinRefFromAny(value any) (JoinRef, bool) {
@@ -512,9 +634,56 @@ func joinRefFromAny(value any) (JoinRef, bool) {
 	if !hasFlowID {
 		return JoinRef{}, false
 	}
-	generation, _ := attemptgeneration.FromPayload(map[string]any{attemptgeneration.PayloadKey: raw[attemptgeneration.PayloadKey]})
-	ref := NewJoinRefForGeneration(flowID, asString(raw["node_id"]), asString(raw["handler_event"]), asString(raw["stage"]), asString(raw["join_id"]), asString(raw["window"]), generation)
-	return ref, ref.Valid()
+	if !onlyKeys(raw, "flow_id", "node_id", "handler_event", "stage", "join_id", "window", attemptgeneration.PayloadKey) {
+		return JoinRef{}, false
+	}
+	generation := attemptgeneration.Generation{}
+	if _, present := raw[attemptgeneration.PayloadKey]; present {
+		var generationOK bool
+		generation, generationOK = attemptgeneration.FromPayload(map[string]any{attemptgeneration.PayloadKey: raw[attemptgeneration.PayloadKey]})
+		if !generationOK {
+			return JoinRef{}, false
+		}
+	}
+	ref, err := NewJoinRefForGeneration(flowID, asString(raw["node_id"]), asString(raw["handler_event"]), asString(raw["stage"]), asString(raw["join_id"]), asString(raw["window"]), generation)
+	return ref, err == nil
+}
+
+func (h TimerHandle) MarshalJSON() ([]byte, error) {
+	metadata := h.PayloadMetadata()
+	if metadata == nil {
+		return nil, fmt.Errorf("timer handle is invalid")
+	}
+	return json.Marshal(metadata[timerHandlePayloadKey])
+}
+
+func (h *TimerHandle) UnmarshalJSON(raw []byte) error {
+	if h == nil {
+		return fmt.Errorf("timer handle target is nil")
+	}
+	var value map[string]any
+	if err := decodeStrictJSON(raw, &value); err != nil {
+		return err
+	}
+	parsed, ok := parseTimerHandleMap(value)
+	if !ok {
+		return fmt.Errorf("timer handle is invalid")
+	}
+	*h = parsed
+	return nil
+}
+
+func onlyKeys(values map[string]any, allowed ...string) bool {
+	set := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		set[key] = struct{}{}
+	}
+	for key := range values {
+		if _, ok := set[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func NewAccumulatorBucketRef(nodeID, eventType string) AccumulatorBucketRef {

--- a/internal/runtime/core/timeridentity/timeridentity_test.go
+++ b/internal/runtime/core/timeridentity/timeridentity_test.go
@@ -1,6 +1,7 @@
 package timeridentity
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,10 +10,9 @@ import (
 
 func TestTimerHandleRoundTripPreservesLoopGeneration(t *testing.T) {
 	generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
-	handle := WorkflowTimerHandle("review.expiry")
-	handle.Generation = generation
+	handle := WorkflowTimerHandleForGeneration("review.expiry", generation)
 	parsed, ok := ParseTimerHandle(handle.PayloadMetadata())
-	if !ok || !parsed.Generation.Equal(generation) || parsed.TaskID() != handle.TaskID() {
+	if !ok || !parsed.Generation().Equal(generation) || parsed.TaskID() != handle.TaskID() {
 		t.Fatalf("parsed handle = %#v ok=%v", parsed, ok)
 	}
 }
@@ -92,7 +92,7 @@ func TestTimerHandlePayloadRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatal("expected workflow timer handle payload to round trip")
 	}
-	if parsed.Kind != TimerHandleWorkflowTimer || parsed.TimerID != "check_timer" {
+	if parsed.Kind() != TimerHandleWorkflowTimer || parsed.TimerID() != "check_timer" {
 		t.Fatalf("parsed = %#v", parsed)
 	}
 	if parsed.TaskID() != "check_timer" {
@@ -122,9 +122,9 @@ func TestParseAccumulatorBucketKey(t *testing.T) {
 }
 
 func TestJoinHandleRoundTripIncludesOwningFlowAndStageIdentity(t *testing.T) {
-	awaiting := JoinTimeoutHandle(NewJoinRef("orders", "join-node", "item.completed", "awaiting", "shared", "window-1"))
-	reviewing := JoinTimeoutHandle(NewJoinRef("orders", "join-node", "item.completed", "reviewing", "shared", "window-1"))
-	foreignFlow := JoinTimeoutHandle(NewJoinRef("returns", "join-node", "item.completed", "awaiting", "shared", "window-1"))
+	awaiting := mustJoinHandle(t, TimerHandleJoinTimeout, "orders", "join-node", "item.completed", "awaiting", "shared", "window-1", attemptgeneration.Generation{})
+	reviewing := mustJoinHandle(t, TimerHandleJoinTimeout, "orders", "join-node", "item.completed", "reviewing", "shared", "window-1", attemptgeneration.Generation{})
+	foreignFlow := mustJoinHandle(t, TimerHandleJoinTimeout, "returns", "join-node", "item.completed", "awaiting", "shared", "window-1", attemptgeneration.Generation{})
 	if awaiting.TaskID() == reviewing.TaskID() {
 		t.Fatalf("join task ids collide across stages: %q", awaiting.TaskID())
 	}
@@ -132,7 +132,8 @@ func TestJoinHandleRoundTripIncludesOwningFlowAndStageIdentity(t *testing.T) {
 		t.Fatalf("join task ids collide across owning flows: %q", awaiting.TaskID())
 	}
 	parsed, ok := ParseTimerHandle(awaiting.PayloadMetadata())
-	if !ok || parsed.Join.FlowID != "orders" || parsed.Join.Stage != "awaiting" || parsed.Join.JoinID != "shared" || parsed.Join.Window != "window-1" {
+	ref, refOK := parsed.JoinRef()
+	if !ok || !refOK || ref.FlowID() != "orders" || ref.Stage() != "awaiting" || ref.JoinID() != "shared" || ref.Window() != "window-1" {
 		t.Fatalf("parsed join handle = %#v, %v", parsed, ok)
 	}
 	payload := awaiting.PayloadMetadata()
@@ -140,4 +141,83 @@ func TestJoinHandleRoundTripIncludesOwningFlowAndStageIdentity(t *testing.T) {
 	if parsed, ok := ParseTimerHandle(payload); ok {
 		t.Fatalf("join handle without explicit flow owner parsed as %#v", parsed)
 	}
+}
+
+func TestJoinHandleGenerationHasOneCanonicalOwner(t *testing.T) {
+	generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+	handle := mustJoinHandle(t, TimerHandleJoinTimeout, "", "join-node", "item.completed", "awaiting", "shared", "window-1", generation)
+	payload := handle.PayloadMetadata()
+	inner := payload["timer_handle"].(map[string]any)
+	if _, duplicated := inner[attemptgeneration.PayloadKey]; duplicated {
+		t.Fatal("join generation was duplicated outside JoinRef")
+	}
+	inner[attemptgeneration.PayloadKey] = generation.PayloadValue()
+	if parsed, ok := ParseTimerHandle(payload); ok {
+		t.Fatalf("join handle with duplicate outer generation parsed as %#v", parsed)
+	}
+}
+
+func TestJoinHandleCodecRejectsMissingOrContradictoryDeclarationIdentity(t *testing.T) {
+	generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+	root := mustJoinHandle(t, TimerHandleJoinTimeout, "", "join-node", "item.completed", "awaiting", "shared", "window-1", generation)
+	if _, ref, ok := ParseJoinHandle(root.PayloadMetadata()); !ok || ref.FlowID() != "" || !ref.Generation().Equal(generation) {
+		t.Fatalf("explicit root handle failed strict round trip: ref=%#v ok=%v", ref, ok)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "missing explicit flow", mutate: func(payload map[string]any) {
+			delete(payload["timer_handle"].(map[string]any)["join"].(map[string]any), "flow_id")
+		}},
+		{name: "missing derived revision", mutate: func(payload map[string]any) { delete(payload, "revision_id") }},
+		{name: "contradictory derived revision", mutate: func(payload map[string]any) { payload["revision_id"] = "rev-hostile" }},
+		{name: "duplicate outer generation", mutate: func(payload map[string]any) {
+			payload["timer_handle"].(map[string]any)[attemptgeneration.PayloadKey] = generation.PayloadValue()
+		}},
+		{name: "unknown join field", mutate: func(payload map[string]any) {
+			payload["timer_handle"].(map[string]any)["join"].(map[string]any)["flow_name"] = "root"
+		}},
+		{name: "unknown payload field", mutate: func(payload map[string]any) { payload["workflow_name"] = "root" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := cloneTimerPayload(t, root.PayloadMetadata())
+			tc.mutate(payload)
+			if handle, ref, ok := ParseJoinHandle(payload); ok {
+				t.Fatalf("hostile payload parsed as handle=%#v ref=%#v", handle, ref)
+			}
+		})
+	}
+}
+
+func cloneTimerPayload(t *testing.T, payload map[string]any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		t.Fatal(err)
+	}
+	return cloned
+}
+
+func mustJoinHandle(t *testing.T, kind TimerHandleKind, flowID, nodeID, handlerEvent, stage, joinID, window string, generation attemptgeneration.Generation) TimerHandle {
+	t.Helper()
+	ref, err := NewJoinRefForGeneration(flowID, nodeID, handlerEvent, stage, joinID, window, generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var handle TimerHandle
+	if kind == TimerHandleJoinComplete {
+		handle, err = JoinCompleteHandle(ref)
+	} else {
+		handle, err = JoinTimeoutHandle(ref)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
 }

--- a/internal/runtime/engine/executor.go
+++ b/internal/runtime/engine/executor.go
@@ -725,7 +725,11 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	frame.joinResultType = plan.ResultType
 	payload := frame.payload
 	ref, timerKind, internal := timeridentity.ParseJoinRef(payload)
-	if internal && (ref.NodeID != frame.req.NodeID.String() || ref.HandlerEvent != strings.TrimSpace(frame.req.HandlerEventKey) || ref.Stage != strings.TrimSpace(spec.Stage) || ref.JoinID != spec.EffectiveID()) {
+	declaration := frame.req.JoinDeclaration.Declaration()
+	if !declaration.Valid() {
+		return false, fmt.Errorf("join %s execution is missing its exact declaration identity", spec.EffectiveID())
+	}
+	if internal && !ref.Declaration().Equal(declaration) {
 		return false, failures.New(failures.ClassUnexpectedArrival, "join_timer_identity_mismatch", "runtime.engine", "join", map[string]any{
 			"row_id": spec.EffectiveID(), "node_id": frame.req.NodeID.String(), "handler_event": strings.TrimSpace(frame.req.HandlerEventKey),
 		})
@@ -733,8 +737,8 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	window := ""
 	generation := attemptgeneration.Generation{}
 	if internal {
-		window = ref.Window
-		generation = ref.Generation
+		window = ref.Window()
+		generation = ref.Generation()
 	} else if spec.Window != nil {
 		value, ok := resolveContractPath(e.currentContext(frame), frame.state, spec.Window.ByPath, spec.Window.By)
 		if !ok || strings.TrimSpace(asString(value)) == "" {
@@ -754,6 +758,14 @@ func (e *Executor) stepJoin(frame *executionFrame) (bool, error) {
 	}
 	if !found {
 		return false, e.joinArrivalFailure(frame, failures.ClassEarlyArrival, "join_not_armed", spec, window, "")
+	}
+	expectedRef, err := timeridentity.NewJoinRefForGeneration(
+		declaration.FlowID(), declaration.NodeID(), declaration.HandlerEvent(), declaration.Stage(), declaration.JoinID(), window, generation,
+	)
+	if err != nil || !activation.JoinRef().Equal(expectedRef) {
+		return false, failures.New(failures.ClassUnexpectedArrival, "join_activation_identity_mismatch", "runtime.engine", "join", map[string]any{
+			"row_id": spec.EffectiveID(), "node_id": frame.req.NodeID.String(), "handler_event": strings.TrimSpace(frame.req.HandlerEventKey),
+		})
 	}
 	if internal && timerKind == timeridentity.TimerHandleJoinComplete {
 		if activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonComplete || !activation.OutcomePending || activation.OutcomeFired {
@@ -1902,17 +1914,10 @@ func joinExpressionOptions(frame *executionFrame) workflowexpr.ValueExpressionOp
 }
 
 func (e *Executor) joinPlan(req ExecutionRequest) (runtimecontracts.WorkflowJoinPlan, bool) {
-	if e == nil || e.deps.Source == nil {
+	if e == nil || e.deps.Source == nil || !req.JoinDeclaration.Valid() {
 		return runtimecontracts.WorkflowJoinPlan{}, false
 	}
-	requestFlowID := strings.TrimSpace(req.FlowID.String())
-	if plan, ok := semanticview.WorkflowJoinPlanForHandler(e.deps.Source, requestFlowID, req.NodeID.String(), req.HandlerEventKey); ok {
-		return plan, true
-	}
-	if requestFlowID == "" {
-		return semanticview.WorkflowJoinPlanForHandler(e.deps.Source, strings.TrimSpace(e.deps.Source.WorkflowName()), req.NodeID.String(), req.HandlerEventKey)
-	}
-	return runtimecontracts.WorkflowJoinPlan{}, false
+	return semanticview.WorkflowJoinPlanForRef(e.deps.Source, req.JoinDeclaration)
 }
 
 func (e *Executor) stepProjection(frame *executionFrame) error {

--- a/internal/runtime/engine/executor_test.go
+++ b/internal/runtime/engine/executor_test.go
@@ -23,6 +23,7 @@ import (
 	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	runtimeregistry "github.com/division-sh/swarm/internal/runtime/core/registry"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimedelivery "github.com/division-sh/swarm/internal/runtime/deliverylifecycle"
 	"github.com/division-sh/swarm/internal/runtime/failures"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
@@ -1796,7 +1797,7 @@ func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	activation, err := joinruntime.NewActivation(spec.ID, spec.Stage, "join-node", "item.completed", "", []string{"a", "b"}, now, now.Add(time.Hour), "join-timeout", "platform.join_timeout")
+	activation, err := newEngineTestJoinActivation("orders", "join-node", "item.completed", spec, "", []string{"a", "b"}, now, now.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1807,8 +1808,9 @@ func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
 	handler := runtimecontracts.SystemNodeEventHandler{Join: &spec}
 	first, err := exec.ExecuteSemanticFixture(context.Background(), ExecutionRequest{
 		EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: handler,
-		Event: eventtest.RunCreatingRootIngress("evt-b", "item.completed", "", "", json.RawMessage(`{"member_id":"b","result":{"score":2}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
-		State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, buckets),
+		JoinDeclaration: activation.JoinRef().Declaration(),
+		Event:           eventtest.RunCreatingRootIngress("evt-b", "item.completed", "", "", json.RawMessage(`{"member_id":"b","result":{"score":2}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
+		State:           testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, buckets),
 	})
 	if err != nil {
 		t.Fatalf("first arrival: %v", err)
@@ -1818,8 +1820,9 @@ func TestExecutor_JoinUsesPersistedActivationAndMembershipOrder(t *testing.T) {
 	}
 	second, err := exec.ExecuteSemanticFixture(context.Background(), ExecutionRequest{
 		EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: handler,
-		Event: eventtest.RunCreatingRootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now.Add(time.Second)),
-		State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, first.StateMutation.StateCarrier.StateBuckets),
+		JoinDeclaration: activation.JoinRef().Declaration(),
+		Event:           eventtest.RunCreatingRootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now.Add(time.Second)),
+		State:           testStateSnapshot("awaiting", map[string]any{"expected": []any{"a", "b"}}, nil, first.StateMutation.StateCarrier.StateBuckets),
 	})
 	if err != nil {
 		t.Fatalf("second arrival: %v", err)
@@ -1870,7 +1873,7 @@ func TestFanInBarrierExecutorConsumesEffectiveJoinPlan(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
-	activation, err := joinruntime.NewActivation(plan.Spec.EffectiveID(), plan.Spec.Stage, plan.NodeID, plan.HandlerEvent, "2026-Q3", []string{"operating-a"}, now, now.Add(5*time.Minute), "join-timeout", "platform.join_timeout")
+	activation, err := newEngineTestJoinActivation(plan.FlowID, plan.NodeID, plan.HandlerEvent, plan.Spec, "2026-Q3", []string{"operating-a"}, now, now.Add(5*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1880,8 +1883,9 @@ func TestFanInBarrierExecutorConsumesEffectiveJoinPlan(t *testing.T) {
 	}
 	result, err := exec.ExecuteSemanticFixture(context.Background(), ExecutionRequest{
 		EntityID: "portfolio/portfolio", NodeID: "portfolio-collector", FlowID: "portfolio", HandlerEventKey: "operating.reported", Handler: rawHandler,
-		Event: eventtest.RunCreatingRootIngress("evt-operating-a", "operating.reported", "", "", json.RawMessage(`{"operating_id":"operating-a","period_id":"2026-Q3","revenue":42}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "portfolio/portfolio"), now),
-		State: testStateSnapshot("awaiting", map[string]any{"expected_operating_ids": []any{"operating-a"}, "period_id": "2026-Q3"}, nil, buckets),
+		JoinDeclaration: activation.JoinRef().Declaration(),
+		Event:           eventtest.RunCreatingRootIngress("evt-operating-a", "operating.reported", "", "", json.RawMessage(`{"operating_id":"operating-a","period_id":"2026-Q3","revenue":42}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "portfolio/portfolio"), now),
+		State:           testStateSnapshot("awaiting", map[string]any{"expected_operating_ids": []any{"operating-a"}, "period_id": "2026-Q3"}, nil, buckets),
 	})
 	if err != nil {
 		t.Fatalf("execute barrier arrival: %v", err)
@@ -1926,7 +1930,7 @@ func TestExecutor_JoinCompletionConsumesCatalogResultType(t *testing.T) {
 				t.Fatal(err)
 			}
 			now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-			activation, err := joinruntime.NewActivation(spec.ID, spec.Stage, "join-node", "item.completed", "", []string{"a"}, now, now.Add(time.Hour), "join-timeout", "platform.join_timeout")
+			activation, err := newEngineTestJoinActivation("orders", "join-node", "item.completed", spec, "", []string{"a"}, now, now.Add(time.Hour))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1936,8 +1940,9 @@ func TestExecutor_JoinCompletionConsumesCatalogResultType(t *testing.T) {
 			}
 			result, err := exec.ExecuteSemanticFixture(context.Background(), ExecutionRequest{
 				EntityID: "entity-1", NodeID: "join-node", FlowID: "orders", HandlerEventKey: "item.completed", Handler: runtimecontracts.SystemNodeEventHandler{Join: &spec},
-				Event: eventtest.RunCreatingRootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
-				State: testStateSnapshot("awaiting", map[string]any{"expected": []any{"a"}}, nil, buckets),
+				JoinDeclaration: activation.JoinRef().Declaration(),
+				Event:           eventtest.RunCreatingRootIngress("evt-a", "item.completed", "", "", json.RawMessage(`{"member_id":"a","result":{"score":1}}`), 0, "", "", events.EnvelopeForEntityID(events.EventEnvelope{}, "entity-1"), now),
+				State:           testStateSnapshot("awaiting", map[string]any{"expected": []any{"a"}}, nil, buckets),
 			})
 			if tc.wantErr {
 				if err == nil || !strings.Contains(err.Error(), "no matching overload") {
@@ -1953,6 +1958,18 @@ func TestExecutor_JoinCompletionConsumesCatalogResultType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newEngineTestJoinActivation(flowID, nodeID, handlerEvent string, spec runtimecontracts.JoinSpec, window string, members []string, armedAt, fireAt time.Time) (joinruntime.Activation, error) {
+	ref, err := timeridentity.NewJoinRef(flowID, nodeID, handlerEvent, spec.Stage, spec.EffectiveID(), window)
+	if err != nil {
+		return joinruntime.Activation{}, err
+	}
+	handle, err := timeridentity.JoinTimeoutHandle(ref)
+	if err != nil {
+		return joinruntime.Activation{}, err
+	}
+	return joinruntime.NewActivation(handle, members, armedAt, fireAt)
 }
 
 func TestExecutor_ComputeReadsAccumulatorByMatchedHandlerEventKey(t *testing.T) {

--- a/internal/runtime/engine/types.go
+++ b/internal/runtime/engine/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/core/values"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	"github.com/division-sh/swarm/internal/runtime/failures"
@@ -220,6 +221,10 @@ type ExecutionRequest struct {
 	// runtime dispatch. Concrete Event.Type remains event provenance.
 	HandlerEventKey string
 	Handler         runtimecontracts.SystemNodeEventHandler
+	// JoinDeclaration is the exact authored join identity selected before
+	// execution. Internal timer occurrences carry the same declaration plus
+	// their durable window and generation.
+	JoinDeclaration timeridentity.JoinRef
 	State           StateSnapshot
 	// InitialFieldValues is the exact authored create-entity projection that the
 	// persistence owner records separately from subsequent handler mutations.

--- a/internal/runtime/genericschedule/owner_test.go
+++ b/internal/runtime/genericschedule/owner_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	"github.com/division-sh/swarm/internal/runtime/executionposture"
@@ -69,6 +72,111 @@ func TestAdmissionCommandRequiresHashBearingExecutionMode(t *testing.T) {
 	if liveHash == mockHash {
 		t.Fatalf("live and mock commands shared immutable hash %q", liveHash)
 	}
+}
+
+func TestSystemJoinScheduleAdmissionRejectsDeclarationDrift(t *testing.T) {
+	generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+	root := testJoinScheduleCommand(t, "", "", generation)
+	flow := testJoinScheduleCommand(t, "orders", "orders/order-1", generation)
+	scalarPayload, err := canonicaljson.FromGo("hostile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.Validate(); err != nil {
+		t.Fatalf("valid root join schedule: %v", err)
+	}
+	if err := flow.Validate(); err != nil {
+		t.Fatalf("valid flow join schedule: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		base   AdmissionCommand
+		mutate func(*AdmissionCommand)
+	}{
+		{name: "event kind", base: root, mutate: func(c *AdmissionCommand) { c.EventType = "platform.join_complete" }},
+		{name: "scalar payload", base: root, mutate: func(c *AdmissionCommand) { c.Payload = scalarPayload }},
+		{name: "schedule key", base: root, mutate: func(c *AdmissionCommand) { c.ScheduleKey += "-hostile" }},
+		{name: "task id", base: root, mutate: func(c *AdmissionCommand) { c.TaskID += "-hostile" }},
+		{name: "owner", base: root, mutate: func(c *AdmissionCommand) { c.OwnerID = "runtime" }},
+		{name: "entity", base: root, mutate: func(c *AdmissionCommand) { c.EntityID = uuid.NewString() }},
+		{name: "root routed as flow", base: root, mutate: func(c *AdmissionCommand) {
+			c.FlowInstance = "orders/order-1"
+			c.RoutingSource, _ = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "orders", FlowInstance: c.FlowInstance, EntityID: c.EntityID})
+		}},
+		{name: "flow routed as root", base: flow, mutate: func(c *AdmissionCommand) {
+			c.FlowInstance = ""
+			c.RoutingSource, _ = events.NewRootRoutingSource(c.EntityID)
+		}},
+		{name: "wrong flow", base: flow, mutate: func(c *AdmissionCommand) {
+			c.RoutingSource, _ = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "returns", FlowInstance: c.FlowInstance, EntityID: c.EntityID})
+		}},
+		{name: "wrong flow instance", base: flow, mutate: func(c *AdmissionCommand) {
+			c.FlowInstance = "orders/order-2"
+		}},
+		{name: "missing derived revision", base: root, mutate: func(c *AdmissionCommand) {
+			payload := cloneSchedulePayload(t, c.Payload)
+			delete(payload, generation.RevisionField)
+			c.Payload, _ = canonicaljson.FromGo(payload)
+		}},
+		{name: "contradictory derived revision", base: root, mutate: func(c *AdmissionCommand) {
+			payload := cloneSchedulePayload(t, c.Payload)
+			payload[generation.RevisionField] = "rev-hostile"
+			c.Payload, _ = canonicaljson.FromGo(payload)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			command := tc.base
+			tc.mutate(&command)
+			if err := command.Validate(); err == nil {
+				t.Fatalf("hostile command validated: %#v", command)
+			}
+		})
+	}
+}
+
+func testJoinScheduleCommand(t *testing.T, flowID, flowInstance string, generation attemptgeneration.Generation) AdmissionCommand {
+	t.Helper()
+	entityID := uuid.NewString()
+	ref, err := timeridentity.NewJoinRefForGeneration(flowID, "join-node", "item.completed", "awaiting", "shared", "window-1", generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := timeridentity.JoinTimeoutHandle(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := canonicaljson.FromGo(handle.PayloadMetadata())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var routing events.RoutingSource
+	if flowID == "" {
+		routing, err = events.NewRootRoutingSource(entityID)
+	} else {
+		routing, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: flowID, FlowInstance: flowInstance, EntityID: entityID})
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return AdmissionCommand{
+		ScheduleKey: handle.TaskID(), RunID: uuid.NewString(), EntityID: entityID, FlowInstance: flowInstance,
+		OwnerKind: OwnerSystem, OwnerID: "workflow-runtime", EventType: handle.EventType(), Payload: payload,
+		RoutingSource: routing, ExecutionMode: executionmode.Live, Due: AbsoluteDue(time.Now().UTC().Add(time.Hour)), TaskID: handle.TaskID(),
+	}
+}
+
+func cloneSchedulePayload(t *testing.T, value semanticvalue.Value) map[string]any {
+	t.Helper()
+	payload, ok := value.Interface().(map[string]any)
+	if !ok {
+		t.Fatalf("schedule payload = %#v", value.Interface())
+	}
+	cloned := make(map[string]any, len(payload))
+	for key, item := range payload {
+		cloned[key] = item
+	}
+	return cloned
 }
 
 func TestMockOnlyPostureRejectsLiveScheduleBeforePersistence(t *testing.T) {

--- a/internal/runtime/genericschedule/types.go
+++ b/internal/runtime/genericschedule/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
 	"github.com/google/uuid"
@@ -225,8 +226,46 @@ func (c AdmissionCommand) Validate() error {
 	if err := validateRoutingScope(c); err != nil {
 		return err
 	}
+	if err := validateSystemJoinSchedule(c); err != nil {
+		return err
+	}
 	if _, err := events.AdmitRuntimeControlEventType(events.EventType(c.EventType), c.RoutingSource); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateSystemJoinSchedule(c AdmissionCommand) error {
+	hasJoinEvent := c.EventType == "platform.join_timeout" || c.EventType == "platform.join_complete"
+	payload, ok := c.Payload.Interface().(map[string]any)
+	if !ok {
+		if hasJoinEvent {
+			return errors.New("join generic schedule requires a typed handle payload")
+		}
+		return nil
+	}
+	handle, ref, hasJoinHandle := timeridentity.ParseJoinHandle(payload)
+	if !hasJoinHandle && !hasJoinEvent {
+		return nil
+	}
+	if !hasJoinHandle || !hasJoinEvent || handle.EventType() != c.EventType {
+		return errors.New("join generic schedule event does not match its typed handle")
+	}
+	if c.OwnerKind != OwnerSystem || c.OwnerID != "workflow-runtime" {
+		return errors.New("join generic schedule requires the workflow-runtime system owner")
+	}
+	if c.ScheduleKey != handle.TaskID() || c.TaskID != handle.TaskID() {
+		return errors.New("join generic schedule task does not match its typed handle")
+	}
+	route := c.RoutingSource.Route().Normalized()
+	if ref.FlowID() == "" {
+		if c.RoutingSource.Kind() != events.RoutingSourceRoot || route.FlowID != "" || c.FlowInstance != "" {
+			return errors.New("root join generic schedule source contradicts its explicit root declaration")
+		}
+		return nil
+	}
+	if c.RoutingSource.Kind() != events.RoutingSourceFlowOwnedControl || route.FlowID != ref.FlowID() || route.FlowInstance != c.FlowInstance {
+		return errors.New("flow-owned join generic schedule source contradicts its declaration")
 	}
 	return nil
 }

--- a/internal/runtime/joinruntime/join.go
+++ b/internal/runtime/joinruntime/join.go
@@ -4,11 +4,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"github.com/division-sh/swarm/internal/runtime/computemodule"
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 )
 
 const bucketKey = "handler_joins"
@@ -34,24 +36,31 @@ type MemberOutput struct {
 }
 
 type Activation struct {
-	JoinID          string                       `json:"join_id"`
-	Stage           string                       `json:"stage"`
-	NodeID          string                       `json:"node_id"`
-	HandlerEvent    string                       `json:"handler_event"`
-	Window          string                       `json:"window,omitempty"`
-	Members         []string                     `json:"members"`
-	Outputs         map[string]MemberOutput      `json:"outputs"`
-	Status          Status                       `json:"status"`
-	CloseReason     CloseReason                  `json:"close_reason,omitempty"`
-	ArmedAt         time.Time                    `json:"armed_at"`
-	FireAt          time.Time                    `json:"fire_at"`
-	TimerTaskID     string                       `json:"timer_task_id"`
-	TimerEventType  string                       `json:"timer_event_type"`
-	TimerCancelled  bool                         `json:"timer_cancelled,omitempty"`
-	OutcomePending  bool                         `json:"outcome_pending,omitempty"`
-	OutcomeFired    bool                         `json:"outcome_fired,omitempty"`
-	CompletionEvent string                       `json:"completion_event,omitempty"`
-	Generation      attemptgeneration.Generation `json:"loop_generation,omitempty"`
+	handle          timeridentity.TimerHandle
+	Members         []string                `json:"members"`
+	Outputs         map[string]MemberOutput `json:"outputs"`
+	Status          Status                  `json:"status"`
+	CloseReason     CloseReason             `json:"close_reason,omitempty"`
+	ArmedAt         time.Time               `json:"armed_at"`
+	FireAt          time.Time               `json:"fire_at"`
+	TimerCancelled  bool                    `json:"timer_cancelled,omitempty"`
+	OutcomePending  bool                    `json:"outcome_pending,omitempty"`
+	OutcomeFired    bool                    `json:"outcome_fired,omitempty"`
+	CompletionEvent string                  `json:"completion_event,omitempty"`
+}
+
+type activationJSON struct {
+	Handle          timeridentity.TimerHandle `json:"timer_handle"`
+	Members         []string                  `json:"members"`
+	Outputs         map[string]MemberOutput   `json:"outputs"`
+	Status          Status                    `json:"status"`
+	CloseReason     CloseReason               `json:"close_reason,omitempty"`
+	ArmedAt         time.Time                 `json:"armed_at"`
+	FireAt          time.Time                 `json:"fire_at"`
+	TimerCancelled  bool                      `json:"timer_cancelled,omitempty"`
+	OutcomePending  bool                      `json:"outcome_pending,omitempty"`
+	OutcomeFired    bool                      `json:"outcome_fired,omitempty"`
+	CompletionEvent string                    `json:"completion_event,omitempty"`
 }
 
 type AddDisposition string
@@ -63,27 +72,18 @@ const (
 	AddUnexpected           AddDisposition = "unexpected"
 )
 
-func NewActivation(joinID, stage, nodeID, handlerEvent, window string, members []string, armedAt, fireAt time.Time, taskID, eventType string, generations ...attemptgeneration.Generation) (Activation, error) {
+func NewActivation(handle timeridentity.TimerHandle, members []string, armedAt, fireAt time.Time) (Activation, error) {
 	normalizedMembers, err := normalizeMembers(members)
 	if err != nil {
 		return Activation{}, err
 	}
 	activation := Activation{
-		JoinID:         strings.TrimSpace(joinID),
-		Stage:          strings.TrimSpace(stage),
-		NodeID:         strings.TrimSpace(nodeID),
-		HandlerEvent:   strings.TrimSpace(handlerEvent),
-		Window:         strings.TrimSpace(window),
-		Members:        normalizedMembers,
-		Outputs:        map[string]MemberOutput{},
-		Status:         StatusOpen,
-		ArmedAt:        armedAt.UTC(),
-		FireAt:         fireAt.UTC(),
-		TimerTaskID:    strings.TrimSpace(taskID),
-		TimerEventType: strings.TrimSpace(eventType),
-	}
-	if len(generations) > 0 {
-		activation.Generation = generations[0].Normalize()
+		handle:  handle,
+		Members: normalizedMembers,
+		Outputs: map[string]MemberOutput{},
+		Status:  StatusOpen,
+		ArmedAt: armedAt.UTC(),
+		FireAt:  fireAt.UTC(),
 	}
 	if err := activation.Validate(); err != nil {
 		return Activation{}, err
@@ -92,8 +92,8 @@ func NewActivation(joinID, stage, nodeID, handlerEvent, window string, members [
 }
 
 func (a Activation) Validate() error {
-	if strings.TrimSpace(a.JoinID) == "" || strings.TrimSpace(a.Stage) == "" || strings.TrimSpace(a.NodeID) == "" || strings.TrimSpace(a.HandlerEvent) == "" {
-		return fmt.Errorf("join activation identity is incomplete")
+	if !a.handle.Valid() || a.handle.Kind() != timeridentity.TimerHandleJoinTimeout && a.handle.Kind() != timeridentity.TimerHandleJoinComplete {
+		return fmt.Errorf("join activation requires one valid typed timer handle")
 	}
 	if a.Status != StatusOpen && a.Status != StatusClosed {
 		return fmt.Errorf("join activation status %q is invalid", a.Status)
@@ -126,23 +126,80 @@ func (a Activation) Validate() error {
 }
 
 func (a Activation) Key() string {
-	return ActivationKeyForGeneration(a.Stage, a.JoinID, a.Window, a.Generation)
+	ref, _ := a.handle.JoinRef()
+	return ActivationKeyForGeneration(ref.Stage(), ref.JoinID(), ref.Window(), ref.Generation())
 }
 
 func ReplaceGeneration(buckets map[string]map[string]any, activation Activation, generation attemptgeneration.Generation) error {
 	oldKey := activation.Key()
-	activation.Generation = generation.Normalize()
+	oldNodeID := activation.NodeID()
+	ref, ok := activation.handle.JoinRef()
+	if !ok {
+		return fmt.Errorf("join activation is missing its typed declaration handle")
+	}
+	ref, err := ref.WithGeneration(generation)
+	if err != nil {
+		return err
+	}
+	activation.handle, err = joinHandleForKind(activation.handle.Kind(), ref)
+	if err != nil {
+		return err
+	}
 	if err := Store(buckets, activation); err != nil {
 		return err
 	}
 	if oldKey != activation.Key() {
-		if nodeBucket := buckets[activation.NodeID]; nodeBucket != nil {
+		if nodeBucket := buckets[oldNodeID]; nodeBucket != nil {
 			if joins, ok := nodeBucket[bucketKey].(map[string]any); ok {
 				delete(joins, oldKey)
 			}
 		}
 	}
 	return nil
+}
+
+func (a Activation) TimerHandle() timeridentity.TimerHandle { return a.handle }
+
+func (a Activation) JoinRef() timeridentity.JoinRef {
+	ref, _ := a.handle.JoinRef()
+	return ref
+}
+
+func (a Activation) FlowID() string       { return a.JoinRef().FlowID() }
+func (a Activation) NodeID() string       { return a.JoinRef().NodeID() }
+func (a Activation) HandlerEvent() string { return a.JoinRef().HandlerEvent() }
+func (a Activation) Stage() string        { return a.JoinRef().Stage() }
+func (a Activation) JoinID() string       { return a.JoinRef().JoinID() }
+func (a Activation) Window() string       { return a.JoinRef().Window() }
+func (a Activation) Generation() attemptgeneration.Generation {
+	return a.JoinRef().Generation()
+}
+func (a Activation) TimerTaskID() string    { return a.handle.TaskID() }
+func (a Activation) TimerEventType() string { return a.handle.EventType() }
+
+func (a Activation) WithTimerHandle(handle timeridentity.TimerHandle, fireAt time.Time) (Activation, error) {
+	current, currentOK := a.handle.JoinRef()
+	next, nextOK := handle.JoinRef()
+	if !currentOK || !nextOK || !current.Equal(next) {
+		return Activation{}, fmt.Errorf("join activation timer replacement must preserve declaration identity")
+	}
+	a.handle = handle
+	a.FireAt = fireAt.UTC()
+	if err := a.Validate(); err != nil {
+		return Activation{}, err
+	}
+	return a, nil
+}
+
+func joinHandleForKind(kind timeridentity.TimerHandleKind, ref timeridentity.JoinRef) (timeridentity.TimerHandle, error) {
+	switch kind {
+	case timeridentity.TimerHandleJoinTimeout:
+		return timeridentity.JoinTimeoutHandle(ref)
+	case timeridentity.TimerHandleJoinComplete:
+		return timeridentity.JoinCompleteHandle(ref)
+	default:
+		return timeridentity.TimerHandle{}, fmt.Errorf("join timer handle kind %q is invalid", kind)
+	}
 }
 
 func ActivationKey(stage, joinID, window string) string {
@@ -299,7 +356,7 @@ func Load(stateBuckets map[string]map[string]any, nodeID, key string) (Activatio
 		return Activation{}, false, err
 	}
 	var activation Activation
-	if err := json.Unmarshal(encoded, &activation); err != nil {
+	if err := decodeStrictJSON(encoded, &activation); err != nil {
 		return Activation{}, false, err
 	}
 	if activation.Outputs == nil {
@@ -315,7 +372,7 @@ func Store(stateBuckets map[string]map[string]any, activation Activation) error 
 	if err := activation.Validate(); err != nil {
 		return err
 	}
-	nodeID := strings.TrimSpace(activation.NodeID)
+	nodeID := activation.NodeID()
 	if stateBuckets == nil {
 		return fmt.Errorf("join state bucket set is nil")
 	}
@@ -338,6 +395,45 @@ func Store(stateBuckets map[string]map[string]any, activation Activation) error 
 		return err
 	}
 	joins[activation.Key()] = raw
+	return nil
+}
+
+func (a Activation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(activationJSON{
+		Handle: a.handle, Members: a.Members, Outputs: a.Outputs, Status: a.Status,
+		CloseReason: a.CloseReason, ArmedAt: a.ArmedAt, FireAt: a.FireAt,
+		TimerCancelled: a.TimerCancelled, OutcomePending: a.OutcomePending,
+		OutcomeFired: a.OutcomeFired, CompletionEvent: a.CompletionEvent,
+	})
+}
+
+func (a *Activation) UnmarshalJSON(raw []byte) error {
+	if a == nil {
+		return fmt.Errorf("join activation target is nil")
+	}
+	var persisted activationJSON
+	if err := decodeStrictJSON(raw, &persisted); err != nil {
+		return err
+	}
+	*a = Activation{
+		handle: persisted.Handle, Members: persisted.Members, Outputs: persisted.Outputs,
+		Status: persisted.Status, CloseReason: persisted.CloseReason,
+		ArmedAt: persisted.ArmedAt, FireAt: persisted.FireAt,
+		TimerCancelled: persisted.TimerCancelled, OutcomePending: persisted.OutcomePending,
+		OutcomeFired: persisted.OutcomeFired, CompletionEvent: persisted.CompletionEvent,
+	}
+	return nil
+}
+
+func decodeStrictJSON(raw []byte, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("unexpected trailing JSON")
+	}
 	return nil
 }
 

--- a/internal/runtime/joinruntime/join_test.go
+++ b/internal/runtime/joinruntime/join_test.go
@@ -1,11 +1,13 @@
 package joinruntime
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 )
 
 func TestActivationKeyIsolatesLoopGenerations(t *testing.T) {
@@ -19,7 +21,7 @@ func TestActivationKeyIsolatesLoopGenerations(t *testing.T) {
 
 func TestActivationOrdersResultsByMembershipAndClassifiesDuplicates(t *testing.T) {
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	activation, err := NewActivation("line_items", "awaiting", "node", "item.done", "dispatch-1", []string{"a", "b"}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	activation, err := NewActivation(testJoinHandle(t, "", "line_items", "awaiting", "node", "item.done", "dispatch-1", attemptgeneration.Generation{}), []string{"a", "b"}, now, now.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +47,7 @@ func TestActivationOrdersResultsByMembershipAndClassifiesDuplicates(t *testing.T
 
 func TestActivationPersistsThroughTypedStateBuckets(t *testing.T) {
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
-	activation, err := NewActivation("join", "awaiting", "node", "item.done", "", []string{}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	activation, err := NewActivation(testJoinHandle(t, "", "join", "awaiting", "node", "item.done", "", attemptgeneration.Generation{}), []string{}, now, now.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,10 +65,64 @@ func TestActivationPersistsThroughTypedStateBuckets(t *testing.T) {
 	}
 }
 
+func TestJoinActivationPersistsTypedDeclarationHandle(t *testing.T) {
+	generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	activation, err := NewActivation(testJoinHandle(t, "", "shared", "awaiting", "join-node", "item.completed", "window-1", generation), []string{"a"}, now, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buckets := map[string]map[string]any{}
+	if err := Store(buckets, activation); err != nil {
+		t.Fatal(err)
+	}
+	raw := buckets["join-node"][bucketKey].(map[string]any)[activation.Key()].(map[string]any)
+	for _, retired := range []string{"flow_id", "node_id", "handler_event", "stage", "join_id", "window", "loop_generation", "timer_task_id", "timer_event_type"} {
+		if _, exists := raw[retired]; exists {
+			t.Fatalf("activation persisted retired authority %q: %#v", retired, raw)
+		}
+	}
+	handle, ok := raw["timer_handle"].(map[string]any)
+	join, joinOK := handle["join"].(map[string]any)
+	persistedGeneration, generationOK := join[attemptgeneration.PayloadKey].(map[string]any)
+	if !ok || !joinOK || !generationOK || join["flow_id"] != "" || join["node_id"] != "join-node" || persistedGeneration["revision_id"] != "rev-2" {
+		t.Fatalf("persisted typed handle = %#v", raw["timer_handle"])
+	}
+	loaded, found, err := Load(buckets, "join-node", activation.Key())
+	if err != nil || !found || !loaded.JoinRef().Equal(activation.JoinRef()) || loaded.TimerTaskID() != activation.TimerTaskID() {
+		t.Fatalf("typed activation readback = found:%v activation:%#v err:%v", found, loaded, err)
+	}
+}
+
+func TestJoinActivationRejectsRetiredFlatIdentityRows(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	for _, retired := range []string{"flow_id", "join_id", "timer_task_id", "loop_generation"} {
+		t.Run(retired, func(t *testing.T) {
+			activation, err := NewActivation(testJoinHandle(t, "", "shared", "awaiting", "join-node", "item.completed", "", attemptgeneration.Generation{}), []string{"a"}, now, now.Add(time.Hour))
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := json.Marshal(activation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var row map[string]any
+			if err := json.Unmarshal(raw, &row); err != nil {
+				t.Fatal(err)
+			}
+			row[retired] = "retired-authority"
+			buckets := map[string]map[string]any{"join-node": {bucketKey: map[string]any{activation.Key(): row}}}
+			if loaded, found, err := Load(buckets, "join-node", activation.Key()); err == nil || found {
+				t.Fatalf("retired row loaded as %#v found=%v err=%v", loaded, found, err)
+			}
+		})
+	}
+}
+
 func TestNewActivationRejectsInvalidMembership(t *testing.T) {
 	now := time.Now().UTC()
 	for _, members := range [][]string{{""}, {"a", "a"}} {
-		if _, err := NewActivation("join", "awaiting", "node", "item.done", "", members, now, now.Add(time.Hour), "task", "platform.join_timeout"); err == nil {
+		if _, err := NewActivation(testJoinHandle(t, "", "join", "awaiting", "node", "item.done", "", attemptgeneration.Generation{}), members, now, now.Add(time.Hour)); err == nil {
 			t.Fatalf("members %#v accepted", members)
 		}
 	}
@@ -82,7 +138,7 @@ func TestActivationKeyIncludesStageIdentity(t *testing.T) {
 
 func TestCompletionSatisfiedUsesOneDefaultAndCustomOwner(t *testing.T) {
 	now := time.Now().UTC()
-	activation, err := NewActivation("join", "awaiting", "node", "item.done", "", []string{}, now, now.Add(time.Hour), "task", "platform.join_timeout")
+	activation, err := NewActivation(testJoinHandle(t, "", "join", "awaiting", "node", "item.done", "", attemptgeneration.Generation{}), []string{}, now, now.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,4 +156,17 @@ func TestCompletionSatisfiedUsesOneDefaultAndCustomOwner(t *testing.T) {
 	if err != nil || complete || !called {
 		t.Fatalf("custom zero-member completion = complete:%v called:%v err:%v, want false/true/nil", complete, called, err)
 	}
+}
+
+func testJoinHandle(t *testing.T, flowID, joinID, stage, nodeID, handlerEvent, window string, generation attemptgeneration.Generation) timeridentity.TimerHandle {
+	t.Helper()
+	ref, err := timeridentity.NewJoinRefForGeneration(flowID, nodeID, handlerEvent, stage, joinID, window, generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := timeridentity.JoinTimeoutHandle(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
 }

--- a/internal/runtime/pipeline/action_result_context.go
+++ b/internal/runtime/pipeline/action_result_context.go
@@ -22,7 +22,7 @@ func workflowNodeProducerSource(ctx context.Context, source semanticview.Source,
 		route = delivery.Target.Route()
 		route.EntityID = strings.TrimSpace(entityID)
 	}
-	return runtimepinrouting.AdmitNodeExecutionRoutingSource(source, nodeID, route)
+	return runtimepinrouting.AdmitNodeExecutionRoutingSource(source, flowID, nodeID, route)
 }
 
 func actionResultFlowPath(source semanticview.Source, flowID string) string {

--- a/internal/runtime/pipeline/coordinator.go
+++ b/internal/runtime/pipeline/coordinator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/eventreceiver"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/core/managedexecution"
-	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	worklifetime "github.com/division-sh/swarm/internal/runtime/core/worklifetime"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
@@ -588,22 +587,33 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResultWithEmissionPlan(ctx 
 	if trigger == "" {
 		return false, nil
 	}
-	resolved := workflowNodeEventHandlerResolutionForDeliveryContext(ctx, source, nodeID, evt)
-	if resolved.Failure != "" {
-		return false, fmt.Errorf("resolve workflow handler for node %s: %s", nodeID, resolved.Failure)
+	resolved := workflowNodeEventHandlerResolution{}
+	if isJoinLifecycleEvent(events.EventType(trigger)) {
+		resolution, refOK, err := resolveWorkflowJoinOccurrence(source, evt)
+		if err != nil {
+			return false, err
+		}
+		if refOK && resolution.Ref.NodeID() == nodeID {
+			handlerFlowID := resolution.Ref.FlowID()
+			if handlerFlowID == "" {
+				handlerFlowID = semanticview.RootExecutionFlowID(source)
+			}
+			resolved = workflowNodeEventHandlerResolution{
+				Handler: resolution.Handler, HandlerEventKey: resolution.Ref.HandlerEvent(),
+				FlowID: handlerFlowID, Matched: true,
+			}
+		}
+	} else {
+		resolved = workflowNodeEventHandlerResolutionForDeliveryContext(ctx, source, nodeID, evt)
+		if resolved.Failure != "" {
+			return false, fmt.Errorf("resolve workflow handler for node %s: %s", nodeID, resolved.Failure)
+		}
+	}
+	if !resolved.Matched {
+		return false, nil
 	}
 	handler := resolved.Handler
 	handlerEventKey := resolved.HandlerEventKey
-	ok := resolved.Matched
-	if !ok && isJoinLifecycleEvent(events.EventType(trigger)) {
-		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == nodeID {
-			handler, ok = findJoinHandlerForRef(source, ref)
-			handlerEventKey = ref.HandlerEvent
-		}
-	}
-	if !ok {
-		return false, nil
-	}
 	deliveryStore := pc.deliveryStore
 	if deliveryStore == nil {
 		return false, fmt.Errorf("workflow node delivery lifecycle owner is required")
@@ -650,7 +660,7 @@ func (pc *PipelineCoordinator) executeNodeHandlerPlanResultWithEmissionPlan(ctx 
 		}
 		attemptCtx := runtimedelivery.WithClaim(ctx, claim)
 		pc.notifyTestLifecycleDeliveryStatus(attemptCtx, nodeID, evt, string(runtimedelivery.StatusInProgress))
-		attemptCtx = withPipelineFlowScope(attemptCtx, workflowNodeFlowID(source, nodeID))
+		attemptCtx = withPipelineFlowScope(attemptCtx, nodeFlowID)
 		if err := pc.notifyTestWorkflowNodeHandlerStarting(attemptCtx, nodeID, evt); err != nil {
 			return false, err
 		}

--- a/internal/runtime/pipeline/delivery_target_ownership.go
+++ b/internal/runtime/pipeline/delivery_target_ownership.go
@@ -65,6 +65,13 @@ func (h DeliveryTargetHandler) FlowID() string {
 	return h.flowID
 }
 
+func (h DeliveryTargetHandler) NodeID() string {
+	if !h.present {
+		return ""
+	}
+	return h.nodeID
+}
+
 func (h DeliveryTargetHandler) ForEvent(eventType events.EventType) DeliveryTargetHandler {
 	if !h.present {
 		return DeliveryTargetHandler{}
@@ -119,6 +126,24 @@ type DeliveryTargetOwnershipRequest struct {
 func ClassifyDeliveryTargetOwnership(req DeliveryTargetOwnershipRequest) (events.DeliveryTargetOwnership, error) {
 	if !req.Recipient.IsNode() {
 		return events.DeliveryTargetOwnership{}, fmt.Errorf("delivery target ownership classification requires a node recipient")
+	}
+	if isJoinLifecycleEvent(req.Event.Type()) {
+		recipient, target, handler, ok, err := ResolveWorkflowJoinOccurrenceDeliveryTarget(req.Source, req.Event)
+		if err != nil {
+			return events.DeliveryTargetOwnership{}, err
+		}
+		if !ok {
+			return events.DeliveryTargetOwnership{}, fmt.Errorf("join lifecycle delivery requires its exact declaration handle")
+		}
+		if req.Recipient != recipient || (!req.Handler.Empty() &&
+			(req.Handler.FlowID() != handler.FlowID() || req.Handler.NodeID() != handler.NodeID())) {
+			return events.DeliveryTargetOwnership{}, fmt.Errorf("join lifecycle delivery route contradicts its exact declaration handler")
+		}
+		if blueprint := req.Blueprint.Normalized(); !blueprint.Empty() && blueprint != target {
+			return events.DeliveryTargetOwnership{}, fmt.Errorf("join lifecycle delivery route contradicts its exact declaration target")
+		}
+		req.Handler = handler
+		req.Blueprint = target
 	}
 	blueprint := req.Blueprint.Normalized()
 	handler, admitted := req.Handler.resolve(req.Source, req.Event.Type())

--- a/internal/runtime/pipeline/engine_bridge.go
+++ b/internal/runtime/pipeline/engine_bridge.go
@@ -9,7 +9,6 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
-	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -72,33 +71,41 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 		nodeID          string
 		handler         runtimecontracts.SystemNodeEventHandler
 		handlerEventKey string
+		handlerFlowID   string
 		matched         bool
 	)
-	for _, owner := range owners {
-		resolved := workflowNodeEventHandlerResolutionForDeliveryContext(ctx, source, owner, evt)
-		if resolved.Failure != "" {
-			return contractHandlerExecutionResult{}, fmt.Errorf("resolve workflow handler for node %s: %s", strings.TrimSpace(owner), resolved.Failure)
+	if isJoinLifecycleEvent(events.EventType(trigger)) {
+		resolution, ok, err := resolveWorkflowJoinOccurrence(source, evt)
+		if err != nil {
+			return contractHandlerExecutionResult{}, err
 		}
-		if !resolved.Matched {
-			continue
-		}
-		if matched {
-			return contractHandlerExecutionResult{}, nil
-		}
-		nodeID = strings.TrimSpace(owner)
-		handler = resolved.Handler
-		handlerEventKey = resolved.HandlerEventKey
-		matched = true
-	}
-	if !matched && isJoinLifecycleEvent(events.EventType(trigger)) {
-		if ref, _, ok := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); ok {
-			joinHandler, ok := findJoinHandlerForRef(source, ref)
-			if ok {
-				nodeID = ref.NodeID
-				handler = joinHandler
-				handlerEventKey = ref.HandlerEvent
-				matched = true
+		if ok {
+			nodeID = resolution.Ref.NodeID()
+			handler = resolution.Handler
+			handlerEventKey = resolution.Ref.HandlerEvent()
+			handlerFlowID = resolution.Ref.FlowID()
+			if handlerFlowID == "" {
+				handlerFlowID = semanticview.RootExecutionFlowID(source)
 			}
+			matched = true
+		}
+	} else {
+		for _, owner := range owners {
+			resolved := workflowNodeEventHandlerResolutionForDeliveryContext(ctx, source, owner, evt)
+			if resolved.Failure != "" {
+				return contractHandlerExecutionResult{}, fmt.Errorf("resolve workflow handler for node %s: %s", strings.TrimSpace(owner), resolved.Failure)
+			}
+			if !resolved.Matched {
+				continue
+			}
+			if matched {
+				return contractHandlerExecutionResult{}, nil
+			}
+			nodeID = strings.TrimSpace(owner)
+			handler = resolved.Handler
+			handlerEventKey = resolved.HandlerEventKey
+			handlerFlowID = resolved.FlowID
+			matched = true
 		}
 	}
 	if !matched {
@@ -107,27 +114,13 @@ func (pc *PipelineCoordinator) executeAuthoritativeNodeHandler(ctx context.Conte
 	if strings.TrimSpace(triggerCtx.HandlerEventKey) == "" {
 		triggerCtx.HandlerEventKey = handlerEventKey
 	}
+	ctx = withPipelineFlowScope(ctx, handlerFlowID)
 	return pc.executeNodeContractHandler(ctx, nodeID, handler, triggerCtx, false, true)
 }
 
 func isJoinLifecycleEvent(eventType events.EventType) bool {
 	eventName := strings.TrimSpace(string(eventType))
 	return eventName == joinTimeoutEvent || eventName == joinCompleteEvent
-}
-
-func findJoinHandlerForRef(source interface {
-	NodeEntries() map[string]runtimecontracts.SystemNodeContract
-	NodeEventHandlers(nodeID string) map[string]runtimecontracts.SystemNodeEventHandler
-}, ref timeridentity.JoinRef) (runtimecontracts.SystemNodeEventHandler, bool) {
-	ref = ref.Normalize()
-	if source == nil || !ref.Valid() {
-		return runtimecontracts.SystemNodeEventHandler{}, false
-	}
-	if _, ok := source.NodeEntries()[ref.NodeID]; !ok {
-		return runtimecontracts.SystemNodeEventHandler{}, false
-	}
-	handler, ok := source.NodeEventHandlers(ref.NodeID)[ref.HandlerEvent]
-	return handler, ok && handler.Join != nil && handler.Join.EffectiveID() == ref.JoinID && strings.TrimSpace(handler.Join.Stage) == ref.Stage
 }
 
 func (pc *PipelineCoordinator) executeNodeContractHandler(
@@ -143,14 +136,22 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if nodeID == "" {
 		return contractHandlerExecutionResult{}, nil
 	}
-	flowID := workflowNodeFlowID(pc.SemanticSource(), nodeID)
+	source := pc.SemanticSource()
+	flowID := workflowNodeFlowID(source, nodeID)
+	if handler.Join != nil {
+		if executionFlowID := strings.TrimSpace(pipelineFlowScope(ctx)); executionFlowID != "" {
+			flowID = executionFlowID
+		}
+	}
 	entityID := strings.TrimSpace(firstNonEmptyString(
 		triggerCtx.State.EntityID,
 		workflowEventEntityID(triggerCtx.Event),
 	))
-	source := pc.SemanticSource()
 	stampedOwner, exactDelivery := stampedDeliveryTargetOwnership(ctx)
 	if exactDelivery {
+		if targetFlowID := strings.TrimSpace(stampedOwner.Route().FlowID); targetFlowID != "" {
+			flowID = targetFlowID
+		}
 		entityID = stampedOwner.Route().EntityID
 		if err := prepareStampedSelectOrCreateState(source, flowID, handler, triggerCtx.Event, stampedOwner, &triggerCtx.State); err != nil {
 			return contractHandlerExecutionResult{}, err
@@ -263,6 +264,10 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 	if err != nil {
 		return contractHandlerExecutionResult{}, fmt.Errorf("admit workflow node producer source: %w", err)
 	}
+	joinDeclaration, err := workflowJoinDeclarationForExecution(source, triggerCtx.Event, flowID, nodeID, handlerEventKey, handler)
+	if err != nil {
+		return contractHandlerExecutionResult{}, err
+	}
 	result, err := exec.Execute(ctx, runtimeengine.ExecutionRequest{
 		EntityID:               identity.NormalizeEntityID(entityID),
 		NodeID:                 identity.NormalizeNodeID(nodeID),
@@ -271,6 +276,7 @@ func (pc *PipelineCoordinator) executeNodeContractHandler(
 		Event:                  triggerCtx.Event,
 		ProducerSource:         producerSource,
 		HandlerEventKey:        handlerEventKey,
+		JoinDeclaration:        joinDeclaration,
 		ChainDepth:             triggerCtx.Event.ChainDepth(),
 		Handler:                handler,
 		Preview:                preview,

--- a/internal/runtime/pipeline/handler_engine_transaction_test.go
+++ b/internal/runtime/pipeline/handler_engine_transaction_test.go
@@ -104,6 +104,7 @@ type recordingPipelineBus struct {
 
 func handlerEngineProjectNodeModule() *previewWorkflowModule {
 	return &previewWorkflowModule{bundle: &runtimecontracts.WorkflowContractBundle{
+		Semantics: runtimecontracts.WorkflowSemanticView{Name: "handler-engine-test"},
 		Nodes: map[string]runtimecontracts.SystemNodeContract{
 			"node-a": {ID: "node-a", ExecutionType: "system_node"},
 		},

--- a/internal/runtime/pipeline/node_declarative.go
+++ b/internal/runtime/pipeline/node_declarative.go
@@ -10,7 +10,6 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identity"
-	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
 	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
@@ -97,8 +96,8 @@ func (n *declarativeWorkflowNode) InterceptPolicy(eventType string, evt events.E
 	}
 	policy, ok := workflowNodeEventPolicy(n.coordinator.WorkflowNodes(), n.NodeID(), eventType)
 	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
-		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
-			policy, ok = workflowNodeEventPolicy(n.coordinator.WorkflowNodes(), n.NodeID(), ref.HandlerEvent)
+		if resolution, refOK, err := resolveWorkflowJoinOccurrence(n.coordinator.SemanticSource(), evt); err == nil && refOK && resolution.Ref.NodeID() == n.NodeID() {
+			policy, ok = workflowNodeEventPolicy(n.coordinator.WorkflowNodes(), n.NodeID(), resolution.Ref.HandlerEvent())
 		}
 	}
 	if !ok {
@@ -154,8 +153,8 @@ func (n *DeclarativeNode) InterceptPolicy(eventType string, evt events.Event) (b
 	}
 	policy, ok := n.policies[eventType]
 	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
-		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
-			policy, ok = n.policies[ref.HandlerEvent]
+		if resolution, refOK, err := resolveWorkflowJoinOccurrence(n.source, evt); err == nil && refOK && resolution.Ref.NodeID() == n.NodeID() {
+			policy, ok = n.policies[resolution.Ref.HandlerEvent()]
 		}
 	}
 	if !ok {
@@ -184,13 +183,14 @@ func (n *DeclarativeNode) HandleEvent(ctx context.Context, evt Event) (*HandlerO
 		handlerEventKey = workflowNodeHandlerEventKeyForExecution(ctx, n.source, n.NodeID(), evt)
 	}
 	if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
-		if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == n.NodeID() {
-			candidate := semanticview.ResolveNodeSubscriptionHandler(n.source, n.NodeID(), ref.HandlerEvent)
-			if candidate.Matched && candidate.Handler.Join != nil && candidate.Handler.Join.EffectiveID() == ref.JoinID {
-				handler = candidate.Handler
-				handlerEventKey = candidate.HandlerEventKey
-				ok = true
-			}
+		resolution, refOK, err := resolveWorkflowJoinOccurrence(n.source, evt)
+		if err != nil {
+			return nil, err
+		}
+		if refOK && resolution.Ref.NodeID() == n.NodeID() {
+			handler = resolution.Handler
+			handlerEventKey = resolution.Ref.HandlerEvent()
+			ok = true
 		}
 	}
 	if !ok {
@@ -299,10 +299,18 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 	source := e.coordinator.SemanticSource()
 	entityID := workflowEventEntityID(evt)
 	flowID := workflowNodeFlowID(source, e.nodeID)
+	if handler.Join != nil {
+		if executionFlowID := strings.TrimSpace(pipelineFlowScope(ctx)); executionFlowID != "" {
+			flowID = executionFlowID
+		}
+	}
 	selectedState := WorkflowState{}
 	hasSelectedState := false
 	stampedOwner, exactDelivery := stampedDeliveryTargetOwnership(ctx)
 	if exactDelivery {
+		if targetFlowID := strings.TrimSpace(stampedOwner.Route().FlowID); targetFlowID != "" {
+			flowID = targetFlowID
+		}
 		entityID = stampedOwner.Route().EntityID
 		if err := prepareStampedSelectOrCreateState(source, flowID, handler, evt, stampedOwner, &selectedState); err != nil {
 			return nil, err
@@ -384,6 +392,10 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 	if err != nil {
 		return nil, fmt.Errorf("admit workflow node producer source: %w", err)
 	}
+	joinDeclaration, err := workflowJoinDeclarationForExecution(source, evt, flowID, e.nodeID, handlerEventKey, handler)
+	if err != nil {
+		return nil, err
+	}
 	result, err := node.Handle(ctx, runtimeengine.ExecutionRequest{
 		EntityID:        identity.NormalizeEntityID(entityID),
 		NodeID:          identity.NormalizeNodeID(e.nodeID),
@@ -392,6 +404,7 @@ func (e *coordinatorHandlerExecutionEngine) ExecuteHandlerSteps(ctx context.Cont
 		Event:           evt,
 		ProducerSource:  producerSource,
 		HandlerEventKey: handlerEventKey,
+		JoinDeclaration: joinDeclaration,
 		ChainDepth:      evt.ChainDepth(),
 		Handler:         handler,
 		State:           stateSnapshot,

--- a/internal/runtime/pipeline/workflow_join_identity_test.go
+++ b/internal/runtime/pipeline/workflow_join_identity_test.go
@@ -1,0 +1,1076 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/executionmode"
+	runtimefailures "github.com/division-sh/swarm/internal/runtime/failures"
+	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
+	"github.com/division-sh/swarm/internal/runtime/loopruntime"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	authoractivityfixture "github.com/division-sh/swarm/internal/store/testutil/authoractivityfixture"
+	"github.com/google/uuid"
+)
+
+type exactWorkflowJoinSource struct {
+	semanticview.Source
+	plans             []runtimecontracts.WorkflowJoinPlan
+	nodeFlowID        string
+	overrideNodeOwner bool
+}
+
+type exactWorkflowJoinHarness struct {
+	t         *testing.T
+	store     *workflowInstanceStore
+	ctx       context.Context
+	bundle    *runtimecontracts.WorkflowContractBundle
+	source    exactWorkflowJoinSource
+	schedules *recordingGenericScheduleWakeupOwner
+	bus       *recordingPipelineBus
+	pc        *PipelineCoordinator
+	flowID    string
+	path      string
+	route     runtimeflowidentity.Route
+	entityID  string
+}
+
+func (s exactWorkflowJoinSource) WorkflowJoins() []runtimecontracts.WorkflowJoinPlan {
+	return append([]runtimecontracts.WorkflowJoinPlan(nil), s.plans...)
+}
+
+func (s exactWorkflowJoinSource) NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool) {
+	if s.overrideNodeOwner && (nodeID == "join-node" || nodeID == "dispatcher" || nodeID == "observer") {
+		layer := "flow"
+		if s.nodeFlowID == "" {
+			layer = "project"
+		}
+		return runtimecontracts.ContractItemSource{FlowID: s.nodeFlowID, Layer: layer}, true
+	}
+	return s.Source.NodeContractSource(nodeID)
+}
+
+func newExactWorkflowJoinHarness(
+	t *testing.T,
+	storeCase workflowJoinStoreCase,
+	flowID string,
+	initialState string,
+	members []any,
+) *exactWorkflowJoinHarness {
+	t.Helper()
+	store, ctx := storeCase.open(t)
+	bundle := workflowJoinLifecycleBundle()
+	plan := bundle.Semantics.Joins[0]
+	plan.FlowID = flowID
+	source := exactWorkflowJoinSource{
+		Source: workflowJoinLifecycleSource(bundle), plans: []runtimecontracts.WorkflowJoinPlan{plan},
+		nodeFlowID: flowID, overrideNodeOwner: true,
+	}
+	harness := &exactWorkflowJoinHarness{
+		t: t, store: store, ctx: ctx, bundle: bundle, source: source,
+		schedules: &recordingGenericScheduleWakeupOwner{}, bus: &recordingPipelineBus{}, flowID: flowID,
+	}
+	harness.path = runtimecorrelation.RunIDFromContext(ctx)
+	workflowName := source.WorkflowName()
+	if flowID != "" {
+		harness.path = flowID + "/" + uuid.NewString()
+		workflowName = flowID
+	}
+	harness.route = testWorkflowInstanceRoute(harness.path)
+	harness.entityID = FlowInstanceEntityID(harness.path)
+	harness.pc = harness.newCoordinator()
+	if err := store.upsert(ctx, materializedWorkflowInstanceForTest(WorkflowInstance{
+		InstanceID: uuid.NewString(), StorageRef: harness.path, WorkflowName: workflowName, WorkflowVersion: "1.0.0",
+		CurrentState: initialState, EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{
+			"entity_id": harness.entityID, "flow_path": harness.path, "instance_id": harness.route.InstanceID,
+			"expected": append([]any{}, members...),
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+	return harness
+}
+
+func (h *exactWorkflowJoinHarness) newCoordinator() *PipelineCoordinator {
+	h.t.Helper()
+	return newWorkflowJoinPipelineCoordinator(h.bus, h.store.testDB(), PipelineCoordinatorOptions{
+		Module: &pipelineFixtureWorkflowModule{source: h.source}, Persistence: workflowPersistenceForTest(h.store), GenericSchedules: h.schedules,
+	})
+}
+
+func (h *exactWorkflowJoinHarness) restart() {
+	h.t.Helper()
+	h.pc = h.newCoordinator()
+}
+
+func (h *exactWorkflowJoinHarness) envelope() events.EventEnvelope {
+	h.t.Helper()
+	if h.flowID == "" {
+		return events.EnvelopeForEntityID(events.EventEnvelope{}, h.entityID)
+	}
+	return workflowJoinTestEnvelope(h.path, h.entityID)
+}
+
+func (h *exactWorkflowJoinHarness) armInitial() runtimegenericschedule.Activation {
+	h.t.Helper()
+	if err := applyTestInitialEntryEffect(h.ctx, h.pc, h.route, h.entityID); err != nil {
+		h.t.Fatalf("arm exact join: %v", err)
+	}
+	upserts, _ := committedWorkflowSchedulesForTest(h.t, h.store)
+	if len(upserts) != 1 {
+		h.t.Fatalf("armed schedules = %#v", upserts)
+	}
+	_, ref, ok := timeridentity.ParseJoinHandle(parsePayloadMap(genericSchedulePayloadForTest(h.t, upserts[0])))
+	if !ok || ref.FlowID() != h.flowID || upserts[0].Command.RoutingSource.Route().FlowID != h.flowID {
+		h.t.Fatalf("armed declaration = ref:%#v schedule:%#v ok=%v", ref, upserts[0], ok)
+	}
+	return upserts[0]
+}
+
+func (h *exactWorkflowJoinHarness) transition(nextState, eventType string) {
+	h.t.Helper()
+	transitionCtx := testPersistedWorkflowStateTransitionContext(h.t, h.store, h.ctx, h.route, h.entityID, eventType)
+	if err := h.pc.persistWorkflowStateForTest(transitionCtx, h.route, h.entityID, nextState, eventType); err != nil {
+		h.t.Fatalf("transition workflow to %s: %v", nextState, err)
+	}
+}
+
+func (h *exactWorkflowJoinHarness) instance() WorkflowInstance {
+	h.t.Helper()
+	instance, found, err := h.store.Load(h.ctx, h.route)
+	if err != nil || !found {
+		h.t.Fatalf("load workflow instance: found=%v err=%v", found, err)
+	}
+	return instance
+}
+
+func (h *exactWorkflowJoinHarness) activation() joinruntime.Activation {
+	h.t.Helper()
+	instance := h.instance()
+	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	activation, found, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
+	if err != nil || !found {
+		h.t.Fatalf("load join activation: found=%v err=%v", found, err)
+	}
+	return activation
+}
+
+func (h *exactWorkflowJoinHarness) scheduleEvent(schedule runtimegenericschedule.Activation, eventID string) events.Event {
+	h.t.Helper()
+	return workflowJoinScheduleEventForTest(
+		h.t, eventID, schedule, runtimecorrelation.RunIDFromContext(h.ctx), h.envelope(), time.Now().UTC(),
+	)
+}
+
+func (h *exactWorkflowJoinHarness) fire(event events.Event) (contractHandlerExecutionResult, error) {
+	h.t.Helper()
+	return h.pc.executeAuthoritativeNodeHandler(h.ctx, event, workflowTriggerContext{
+		Event: event, State: mustCurrentWorkflowState(h.t, h.pc, h.ctx, h.route, h.entityID),
+	})
+}
+
+func exactJoinSemanticStateEqual(left, right WorkflowInstance) bool {
+	return left.CurrentState == right.CurrentState &&
+		reflect.DeepEqual(left.TransitionHistory, right.TransitionHistory) &&
+		reflect.DeepEqual(left.StateBuckets, right.StateBuckets) &&
+		reflect.DeepEqual(left.Metadata, right.Metadata)
+}
+
+type exactJoinScope struct {
+	declarationFlowID string
+	executionFlowID   string
+	path              string
+	route             runtimeflowidentity.Route
+	entityID          string
+}
+
+func exactRootAndFlowJoinSource(bundle *runtimecontracts.WorkflowContractBundle) exactWorkflowJoinSource {
+	plan := bundle.Semantics.Joins[0]
+	rootPlan := plan
+	rootPlan.FlowID = ""
+	flowPlan := plan
+	flowPlan.FlowID = "orders"
+	return exactWorkflowJoinSource{
+		Source: workflowJoinLifecycleSource(bundle),
+		plans:  []runtimecontracts.WorkflowJoinPlan{rootPlan, flowPlan},
+	}
+}
+
+func seedExactJoinScope(t *testing.T, store *workflowInstanceStore, ctx context.Context, source semanticview.Source, declarationFlowID, path string) exactJoinScope {
+	t.Helper()
+	executionFlowID := declarationFlowID
+	if executionFlowID == "" {
+		executionFlowID = source.WorkflowName()
+	}
+	route := testWorkflowInstanceRoute(path)
+	entityID := FlowInstanceEntityID(path)
+	if err := store.upsert(ctx, materializedWorkflowInstanceForTest(WorkflowInstance{
+		InstanceID: route.InstanceID, StorageRef: path, WorkflowName: executionFlowID, WorkflowVersion: "1.0.0",
+		CurrentState: "awaiting", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{
+			"entity_id": entityID, "flow_path": path, "instance_id": route.InstanceID, "expected": []any{"a", "b"},
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+	return exactJoinScope{declarationFlowID: declarationFlowID, executionFlowID: executionFlowID, path: path, route: route, entityID: entityID}
+}
+
+func exactJoinActivationForScope(t *testing.T, pc *PipelineCoordinator, store *workflowInstanceStore, ctx context.Context, scope exactJoinScope) joinruntime.Activation {
+	t.Helper()
+	instance, found, err := store.Load(ctx, scope.route)
+	if err != nil || !found {
+		t.Fatalf("load exact join scope %s: found=%v err=%v", scope.path, found, err)
+	}
+	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activations, err := joinruntime.List(carrier.StateBuckets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(activations) != 1 {
+		t.Fatalf("join activations for %s = %#v", scope.path, activations)
+	}
+	return activations[0]
+}
+
+func deliverExactJoinMember(t *testing.T, pc *PipelineCoordinator, store *workflowInstanceStore, ctx context.Context, source semanticview.Source, scope exactJoinScope, member string) error {
+	t.Helper()
+	envelope := events.EnvelopeForEntityID(events.EventEnvelope{}, scope.entityID)
+	if scope.declarationFlowID != "" {
+		envelope = workflowJoinTestEnvelope(scope.path, scope.entityID)
+	}
+	event := eventtest.RunCreatingRootIngress(
+		uuid.NewString(), events.EventType("item.completed"), "operator", "",
+		mustJSON(map[string]any{"member_id": member, "result": map[string]any{"value": member}}), 0,
+		runtimecorrelation.RunIDFromContext(ctx), "", envelope, time.Now().UTC(),
+	)
+	persistExactJoinEvent(t, store, ctx, event)
+	target := events.RouteIdentity{FlowID: scope.executionFlowID, FlowInstance: scope.path, EntityID: scope.entityID}
+	deliveryCtx := withWorkflowNodeDeliveryRoute(ctx, events.DeliveryRoute{
+		Recipient: events.MustNodeDeliveryRecipient("join-node"),
+		Target:    events.MustExistingEntityTarget(target),
+	})
+	handler := source.NodeEventHandlers("join-node")["item.completed"]
+	_, err := pc.executeNodeContractHandler(deliveryCtx, "join-node", handler, workflowTriggerContext{
+		Event: event, State: mustCurrentWorkflowState(t, pc, ctx, scope.route, scope.entityID), HandlerEventKey: "item.completed",
+	}, false)
+	return err
+}
+
+func persistExactJoinEvent(t testing.TB, store *workflowInstanceStore, ctx context.Context, event events.Event) {
+	t.Helper()
+	dialect := authoractivityfixture.DialectPostgres
+	if store.isSQLite() {
+		dialect = authoractivityfixture.DialectSQLite
+	}
+	seedPipelineEventRecordForDialect(t, ctx, store.testDB(), dialect, event)
+}
+
+func TestJoinScheduleFactsAreDerivedOnlyFromTypedDeclarationHandle(t *testing.T) {
+	source := workflowJoinLifecycleSource(workflowJoinLifecycleBundle())
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	entityID := uuid.NewString()
+	instanceRoute := testWorkflowInstanceRoute("orders/order-1")
+	for _, tc := range []struct {
+		name             string
+		flowID           string
+		wantKind         events.RoutingSourceKind
+		wantFlowInstance string
+	}{
+		{name: "explicit root", flowID: "", wantKind: events.RoutingSourceRoot},
+		{name: "flow owned", flowID: "orders", wantKind: events.RoutingSourceFlowOwnedControl, wantFlowInstance: instanceRoute.InstancePath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handle := pipelineJoinHandle(t, tc.flowID, timeridentity.TimerHandleJoinTimeout)
+			activation, err := joinruntime.NewActivation(handle, []string{"a"}, now, now.Add(time.Hour))
+			if err != nil {
+				t.Fatal(err)
+			}
+			command, err := joinSchedule(source, entityID, instanceRoute, activation, executionmode.Live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parsed, ref, ok := timeridentity.ParseJoinHandle(parsePayloadMap(mustJSON(command.Payload.Interface())))
+			if !ok || !ref.Equal(activation.JoinRef()) || parsed.TaskID() != command.TaskID || command.ScheduleKey != command.TaskID || command.EventType != parsed.EventType() {
+				t.Fatalf("derived command disagrees with handle: command=%#v ref=%#v ok=%v", command, ref, ok)
+			}
+			if command.RoutingSource.Kind() != tc.wantKind || command.FlowInstance != tc.wantFlowInstance || command.RoutingSource.Route().FlowID != tc.flowID {
+				t.Fatalf("derived route = kind:%q flow:%q instance:%q", command.RoutingSource.Kind(), command.RoutingSource.Route().FlowID, command.FlowInstance)
+			}
+		})
+	}
+}
+
+func TestJoinLifecycleHandlerResolutionRequiresExactDeclarationRef(t *testing.T) {
+	bundle := workflowJoinLifecycleBundle()
+	base := workflowJoinLifecycleSource(bundle)
+	plan := bundle.Semantics.Joins[0]
+	rootPlan := plan
+	rootPlan.FlowID = ""
+	flowPlan := plan
+	flowPlan.FlowID = "orders"
+	source := exactWorkflowJoinSource{Source: base, plans: []runtimecontracts.WorkflowJoinPlan{rootPlan, flowPlan}}
+	entityID := uuid.NewString()
+	flowInstance := "orders/order-1"
+	rootHandle := pipelineJoinHandle(t, "", timeridentity.TimerHandleJoinTimeout)
+	flowHandle := pipelineJoinHandle(t, "orders", timeridentity.TimerHandleJoinTimeout)
+	otherFlowHandle := pipelineJoinHandle(t, "returns", timeridentity.TimerHandleJoinTimeout)
+	if rootHandle.TaskID() == flowHandle.TaskID() {
+		t.Fatal("root and flow-owned same-leaf declarations share a task identity")
+	}
+	rootSource, err := events.NewRootRoutingSource(entityID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flowSource, err := events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "orders", FlowInstance: flowInstance, EntityID: entityID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherFlowInstance := "returns/order-1"
+	otherFlowSource, err := events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "returns", FlowInstance: otherFlowInstance, EntityID: entityID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherFlowEnvelope := events.EnvelopeForSourceRoute(
+		events.EnvelopeForFlowInstance(events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), otherFlowInstance),
+		events.RouteIdentity{FlowID: "returns", FlowInstance: otherFlowInstance, EntityID: entityID},
+	)
+	rootEvent := exactJoinOccurrenceEvent(t, "root", rootHandle, rootSource, events.EventEnvelope{EntityID: entityID})
+	flowEvent := exactJoinOccurrenceEvent(t, "flow", flowHandle, flowSource, workflowJoinTestEnvelope(flowInstance, entityID))
+	for _, tc := range []struct {
+		name   string
+		event  events.Event
+		flowID string
+	}{
+		{name: "root", event: rootEvent, flowID: ""},
+		{name: "flow", event: flowEvent, flowID: "orders"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resolution, ok, err := resolveWorkflowJoinOccurrence(source, tc.event)
+			if err != nil || !ok || resolution.Ref.FlowID() != tc.flowID || resolution.Plan.FlowID != tc.flowID {
+				t.Fatalf("resolution = %#v ok=%v err=%v", resolution, ok, err)
+			}
+			recipient, target, handler, ok, err := ResolveWorkflowJoinOccurrenceDeliveryTarget(source, tc.event)
+			if err != nil || !ok || recipient.ID() != "join-node" || handler.NodeID() != "join-node" || handler.Empty() {
+				t.Fatalf("delivery target = recipient:%#v target:%#v handler:%#v ok=%v err=%v", recipient, target, handler, ok, err)
+			}
+			wantExecutionFlow := tc.flowID
+			wantInstance := flowInstance
+			if tc.flowID == "" {
+				wantExecutionFlow = source.WorkflowName()
+				wantInstance = tc.event.RunID()
+			}
+			if target.FlowID != wantExecutionFlow || target.FlowInstance != wantInstance || target.EntityID != entityID || handler.FlowID() != wantExecutionFlow {
+				t.Fatalf("delivery target = %#v handler=%#v, want flow=%q instance=%q entity=%q", target, handler, wantExecutionFlow, wantInstance, entityID)
+			}
+		})
+	}
+
+	for _, hostile := range []struct {
+		name  string
+		event events.Event
+	}{
+		{name: "root handle on flow route", event: exactJoinOccurrenceEvent(t, "root-on-flow", rootHandle, flowSource, workflowJoinTestEnvelope(flowInstance, entityID))},
+		{name: "flow handle on root route", event: exactJoinOccurrenceEvent(t, "flow-on-root", flowHandle, rootSource, events.EventEnvelope{EntityID: entityID})},
+		{name: "wrong producer", event: exactJoinOccurrenceEventWithFacts(t, "wrong-producer", joinTimeoutEvent, "runtime", rootHandle.TaskID(), rootHandle, rootSource, events.EventEnvelope{EntityID: entityID})},
+		{name: "wrong task", event: exactJoinOccurrenceEventWithFacts(t, "wrong-task", joinTimeoutEvent, "runtime.generic_schedule", rootHandle.TaskID()+"-hostile", rootHandle, rootSource, events.EventEnvelope{EntityID: entityID})},
+		{name: "wrong event kind", event: exactJoinOccurrenceEventWithFacts(t, "wrong-kind", joinCompleteEvent, "runtime.generic_schedule", rootHandle.TaskID(), rootHandle, rootSource, events.EventEnvelope{EntityID: entityID})},
+		{name: "same leaf unrelated flow", event: exactJoinOccurrenceEvent(t, "other-flow", otherFlowHandle, otherFlowSource, otherFlowEnvelope)},
+	} {
+		t.Run(hostile.name, func(t *testing.T) {
+			if resolution, ok, err := resolveWorkflowJoinOccurrence(source, hostile.event); err == nil || ok {
+				t.Fatalf("hostile occurrence resolved: %#v ok=%v err=%v", resolution, ok, err)
+			}
+			if recipient, target, handler, ok, err := ResolveWorkflowJoinOccurrenceDeliveryTarget(source, hostile.event); err == nil || ok || !recipient.Empty() || !target.Empty() || !handler.Empty() {
+				t.Fatalf("hostile delivery target resolved: recipient=%#v target=%#v handler=%#v ok=%v err=%v", recipient, target, handler, ok, err)
+			}
+		})
+	}
+}
+
+func TestWorkflowJoinDeclarationRefUsesExactExecutionScope(t *testing.T) {
+	bundle := workflowJoinLifecycleBundle()
+	plan := bundle.Semantics.Joins[0]
+	rootPlan := plan
+	rootPlan.FlowID = ""
+	flowPlan := plan
+	flowPlan.FlowID = "orders"
+	source := exactWorkflowJoinSource{
+		Source: workflowJoinLifecycleSource(bundle),
+		plans:  []runtimecontracts.WorkflowJoinPlan{rootPlan, flowPlan},
+	}
+	handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+
+	rootRef, err := workflowJoinDeclarationRef(source, source.WorkflowName(), "join-node", "item.completed", handler)
+	if err != nil || rootRef.FlowID() != "" {
+		t.Fatalf("root declaration = %#v err=%v", rootRef, err)
+	}
+	flowRef, err := workflowJoinDeclarationRef(source, "orders", "join-node", "item.completed", handler)
+	if err != nil || flowRef.FlowID() != "orders" {
+		t.Fatalf("flow declaration = %#v err=%v", flowRef, err)
+	}
+	if rootRef.Equal(flowRef) {
+		t.Fatal("same-leaf root and flow declarations collapsed to one identity")
+	}
+	if _, err := workflowJoinDeclarationRef(source, "returns", "join-node", "item.completed", handler); err == nil {
+		t.Fatal("unrelated flow scope selected a same-leaf join declaration")
+	}
+}
+
+func TestRootAndFlowWorkflowJoinArrivalCompletionCancelsExactScheduleOnBothStores(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, scope := range []struct {
+			name   string
+			flowID string
+		}{
+			{name: "root", flowID: ""},
+			{name: "flow", flowID: "orders"},
+		} {
+			t.Run(storeCase.name+"/"+scope.name, func(t *testing.T) {
+				store, ctx := storeCase.open(t)
+				bundle := workflowJoinLifecycleBundle()
+				plan := bundle.Semantics.Joins[0]
+				plan.FlowID = scope.flowID
+				source := exactWorkflowJoinSource{
+					Source: workflowJoinLifecycleSource(bundle), plans: []runtimecontracts.WorkflowJoinPlan{plan},
+					nodeFlowID: scope.flowID, overrideNodeOwner: true,
+				}
+				schedules := &recordingGenericScheduleWakeupOwner{}
+				newCoordinator := func() *PipelineCoordinator {
+					return newWorkflowJoinPipelineCoordinator(&recordingPipelineBus{}, store.testDB(), PipelineCoordinatorOptions{
+						Module: &pipelineFixtureWorkflowModule{source: source}, Persistence: workflowPersistenceForTest(store), GenericSchedules: schedules,
+					})
+				}
+				pc := newCoordinator()
+				path := runtimecorrelation.RunIDFromContext(ctx)
+				workflowName := source.WorkflowName()
+				if scope.flowID != "" {
+					path = scope.flowID + "/" + uuid.NewString()
+					workflowName = scope.flowID
+				}
+				route := testWorkflowInstanceRoute(path)
+				entityID := FlowInstanceEntityID(path)
+				if err := store.upsert(ctx, materializedWorkflowInstanceForTest(WorkflowInstance{
+					InstanceID: uuid.NewString(), StorageRef: path, WorkflowName: workflowName, WorkflowVersion: "1.0.0",
+					CurrentState: "dispatching", EnteredStageAt: time.Now().UTC(), Metadata: map[string]any{
+						"entity_id": entityID, "flow_path": path, "instance_id": route.InstanceID, "expected": []any{"a", "b"},
+					},
+				})); err != nil {
+					t.Fatal(err)
+				}
+				transitionCtx := testPersistedWorkflowStateTransitionContext(t, store, ctx, route, entityID, "dispatch.completed")
+				if err := pc.persistWorkflowStateForTest(transitionCtx, route, entityID, "awaiting", "dispatch.completed"); err != nil {
+					t.Fatalf("arm exact %s join: %v", scope.name, err)
+				}
+				upserts, _ := committedWorkflowSchedulesForTest(t, store)
+				if len(upserts) != 1 {
+					t.Fatalf("armed schedules = %#v", upserts)
+				}
+				_, armedRef, ok := timeridentity.ParseJoinHandle(parsePayloadMap(genericSchedulePayloadForTest(t, upserts[0])))
+				if !ok || armedRef.FlowID() != scope.flowID || upserts[0].Command.RoutingSource.Route().FlowID != scope.flowID {
+					t.Fatalf("armed declaration = ref:%#v command:%#v ok=%v", armedRef, upserts[0].Command, ok)
+				}
+				armedInstance, found, err := store.Load(ctx, route)
+				if err != nil || !found {
+					t.Fatalf("load armed instance: found=%v err=%v", found, err)
+				}
+				armedCarrier, err := runtimeengine.StateCarrierFromPersisted(armedInstance.Metadata, armedInstance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				armedActivation, found, err := joinruntime.Load(armedCarrier.StateBuckets, "join-node", workflowJoinActivationKey())
+				if err != nil || !found || !armedActivation.JoinRef().Equal(armedRef) {
+					t.Fatalf("armed activation = found:%v activation:%#v ref:%#v err:%v", found, armedActivation, armedRef, err)
+				}
+
+				handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
+				deliver := func(coordinator *PipelineCoordinator, id, member string) error {
+					envelope := events.EnvelopeForEntityID(events.EventEnvelope{}, entityID)
+					if scope.flowID != "" {
+						envelope = workflowJoinTestEnvelope(path, entityID)
+					}
+					event := eventtest.RunCreatingRootIngress(id, events.EventType("item.completed"), "", "", mustJSON(map[string]any{"member_id": member, "result": map[string]any{"value": member}}), 0, runtimecorrelation.RunIDFromContext(ctx), "", envelope, time.Now().UTC())
+					_, err := coordinator.executeNodeContractHandler(ctx, "join-node", handler, workflowTriggerContext{Event: event, State: mustCurrentWorkflowState(t, coordinator, ctx, route, entityID), HandlerEventKey: "item.completed"}, false)
+					return err
+				}
+				if err := deliver(pc, "member-a", "a"); err != nil {
+					t.Fatal(err)
+				}
+				pc = newCoordinator()
+				if err := deliver(pc, "member-b", "b"); err != nil {
+					t.Fatal(err)
+				}
+				instance, found, err := store.Load(ctx, route)
+				if err != nil || !found {
+					t.Fatalf("load closed instance: found=%v err=%v", found, err)
+				}
+				carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				activation, found, err := joinruntime.Load(carrier.StateBuckets, "join-node", workflowJoinActivationKey())
+				if err != nil || !found || activation.Status != joinruntime.StatusClosed || activation.FlowID() != scope.flowID || activation.Completed() != 2 || !activation.TimerCancelled {
+					t.Fatalf("closed activation = found:%v activation:%#v err:%v", found, activation, err)
+				}
+				_, cancellations := committedWorkflowSchedulesForTest(t, store)
+				if len(cancellations) != 1 || cancellations[0].Command.ScheduleKey != upserts[0].Command.ScheduleKey {
+					t.Fatalf("exact cancellation = %#v, want task %q", cancellations, upserts[0].Command.ScheduleKey)
+				}
+				if err := deliver(pc, "member-b-duplicate", "b"); err == nil {
+					t.Fatal("stale duplicate mutated a closed join")
+				}
+			})
+		}
+	}
+}
+
+func TestRootAndFlowWorkflowJoinStageExitCancelsExactScheduleOnBothStores(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, flowID := range []string{"", "orders"} {
+			name := "root"
+			if flowID != "" {
+				name = "flow"
+			}
+			t.Run(storeCase.name+"/"+name, func(t *testing.T) {
+				h := newExactWorkflowJoinHarness(t, storeCase, flowID, "awaiting", []any{"a", "b"})
+				schedule := h.armInitial()
+				h.transition("dispatching", "manual.abort")
+				activation := h.activation()
+				if activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonStageExit ||
+					!activation.TimerCancelled || activation.FlowID() != flowID {
+					t.Fatalf("stage-exit activation = %#v", activation)
+				}
+				_, cancellations := committedWorkflowSchedulesForTest(t, h.store)
+				if len(cancellations) != 1 || cancellations[0].Command.ScheduleKey != schedule.Command.ScheduleKey {
+					t.Fatalf("stage-exit cancellations = %#v, want %q", cancellations, schedule.Command.ScheduleKey)
+				}
+
+				beforeLate := h.instance()
+				h.restart()
+				late := h.scheduleEvent(schedule, "late-after-stage-exit")
+				if _, err := h.fire(late); err != nil {
+					t.Fatalf("late cancelled occurrence: %v", err)
+				}
+				afterLate := h.instance()
+				if !exactJoinSemanticStateEqual(beforeLate, afterLate) {
+					t.Fatalf("late cancelled occurrence mutated workflow\nbefore=%#v\nafter=%#v", beforeLate, afterLate)
+				}
+				_, afterCancellations := committedWorkflowSchedulesForTest(t, h.store)
+				if len(afterCancellations) != 1 {
+					t.Fatalf("late occurrence emitted extra cancellations: %#v", afterCancellations)
+				}
+			})
+		}
+	}
+}
+
+func TestRootAndFlowWorkflowJoinImmediateCompletionFiresExactHandleAfterRestartOnBothStores(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, flowID := range []string{"", "orders"} {
+			name := "root"
+			if flowID != "" {
+				name = "flow"
+			}
+			t.Run(storeCase.name+"/"+name, func(t *testing.T) {
+				h := newExactWorkflowJoinHarness(t, storeCase, flowID, "awaiting", nil)
+				schedule := h.armInitial()
+				if schedule.Command.EventType != joinCompleteEvent {
+					t.Fatalf("immediate schedule = %#v", schedule)
+				}
+				activation := h.activation()
+				if activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonComplete ||
+					!activation.OutcomePending || activation.FlowID() != flowID {
+					t.Fatalf("immediate activation = %#v", activation)
+				}
+
+				h.restart()
+				event := h.scheduleEvent(schedule, "immediate-completion")
+				result, err := h.fire(event)
+				if err != nil || !result.Handled {
+					t.Fatalf("immediate completion = handled:%v err:%v", result.Handled, err)
+				}
+				beforeDuplicate := h.instance()
+				if _, err := h.fire(event); err != nil {
+					t.Fatalf("duplicate completion: %v", err)
+				}
+				afterDuplicate := h.instance()
+				if !exactJoinSemanticStateEqual(beforeDuplicate, afterDuplicate) {
+					t.Fatalf("duplicate completion mutated workflow\nbefore=%#v\nafter=%#v", beforeDuplicate, afterDuplicate)
+				}
+				activation = h.activation()
+				if !activation.OutcomeFired || activation.OutcomePending || !activation.TimerCancelled || activation.FlowID() != flowID {
+					t.Fatalf("fired immediate activation = %#v", activation)
+				}
+				if afterDuplicate.CurrentState != "ready" {
+					t.Fatalf("immediate completion state = %q", afterDuplicate.CurrentState)
+				}
+				_, cancellations := committedWorkflowSchedulesForTest(t, h.store)
+				if len(cancellations) != 1 || cancellations[0].Command.ScheduleKey != schedule.Command.ScheduleKey {
+					t.Fatalf("immediate completion cancellations = %#v", cancellations)
+				}
+			})
+		}
+	}
+}
+
+func TestRootAndFlowWorkflowJoinTimeoutFiresExactHandleAfterRestartOnBothStores(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, flowID := range []string{"", "orders"} {
+			name := "root"
+			if flowID != "" {
+				name = "flow"
+			}
+			t.Run(storeCase.name+"/"+name, func(t *testing.T) {
+				h := newExactWorkflowJoinHarness(t, storeCase, flowID, "awaiting", []any{"a", "b"})
+				schedule := h.armInitial()
+				if schedule.Command.EventType != joinTimeoutEvent {
+					t.Fatalf("timeout schedule = %#v", schedule)
+				}
+				h.restart()
+				event := h.scheduleEvent(schedule, "join-timeout")
+				result, err := h.fire(event)
+				if err != nil || !result.Handled {
+					t.Fatalf("timeout fire = handled:%v err:%v", result.Handled, err)
+				}
+				beforeDuplicate := h.instance()
+				if _, err := h.fire(event); err != nil {
+					t.Fatalf("duplicate timeout: %v", err)
+				}
+				afterDuplicate := h.instance()
+				if !exactJoinSemanticStateEqual(beforeDuplicate, afterDuplicate) {
+					t.Fatalf("duplicate timeout mutated workflow\nbefore=%#v\nafter=%#v", beforeDuplicate, afterDuplicate)
+				}
+				activation := h.activation()
+				if activation.Status != joinruntime.StatusClosed || activation.CloseReason != joinruntime.CloseReasonTimeout ||
+					!activation.OutcomeFired || !activation.TimerCancelled || activation.FlowID() != flowID {
+					t.Fatalf("timed-out activation = %#v", activation)
+				}
+				if afterDuplicate.CurrentState != "attention" {
+					t.Fatalf("timeout state = %q", afterDuplicate.CurrentState)
+				}
+				_, cancellations := committedWorkflowSchedulesForTest(t, h.store)
+				if len(cancellations) != 1 || cancellations[0].Command.ScheduleKey != schedule.Command.ScheduleKey {
+					t.Fatalf("timeout cancellations = %#v", cancellations)
+				}
+			})
+		}
+	}
+}
+
+func TestRootAndFlowWorkflowJoinLoopSupersessionCancelsExactGenerationOnBothStores(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, flowID := range []string{"", "orders"} {
+			name := "root"
+			if flowID != "" {
+				name = "flow"
+			}
+			t.Run(storeCase.name+"/"+name, func(t *testing.T) {
+				h := newExactWorkflowJoinHarness(t, storeCase, flowID, "awaiting", []any{"a", "b"})
+				observer := runtimecontracts.SystemNodeContract{ID: "observer", ExecutionType: "system_node"}
+				h.bundle.Nodes["observer"] = observer
+				h.bundle.FlowTree.ByID["orders"].Nodes["observer"] = observer
+				h.bundle.Semantics.Loops = []runtimecontracts.WorkflowLoopPlan{{
+					FlowID: flowID, ID: "revision", RevisionField: "revision_id",
+					MaxAttempts: runtimecontracts.LoopAttemptLimit{Literal: 3}, EntryStage: "awaiting", RegionStages: []string{"awaiting"},
+				}}
+				createdAt := time.Now().UTC()
+				loop, err := loopruntime.New(
+					runtimecorrelation.RunIDFromContext(h.ctx), h.entityID, flowID, "revision", "revision_id",
+					uuid.NewString(), "awaiting", 3, createdAt,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				instance := h.instance()
+				carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := loopruntime.Store(carrier.StateBuckets, loop); err != nil {
+					t.Fatal(err)
+				}
+				instance.StateBuckets = carrier.PersistedStateBuckets()
+				if err := h.store.upsert(h.ctx, instance); err != nil {
+					t.Fatal(err)
+				}
+
+				schedule := h.armInitial()
+				_, firstRef, ok := timeridentity.ParseJoinHandle(parsePayloadMap(genericSchedulePayloadForTest(t, schedule)))
+				if !ok || !firstRef.Generation().Equal(loop.Generation()) || firstRef.FlowID() != flowID {
+					t.Fatalf("first generation handle = %#v ok=%v, loop=%#v", firstRef, ok, loop.Generation())
+				}
+
+				eventID := uuid.NewString()
+				payload := mustJSON(map[string]any{"revision_id": loop.Generation().RevisionID})
+				eventAt := createdAt.Add(time.Minute)
+				event := eventtest.RunCreatingRootIngress(
+					eventID, events.EventType("loop.repeat"), "operator", "", payload, 0,
+					runtimecorrelation.RunIDFromContext(h.ctx), "", h.envelope(), eventAt,
+				)
+				persistWorkflowTimerEvent(t, h.store, h.ctx, eventID, "loop.repeat", runtimecorrelation.RunIDFromContext(h.ctx), h.entityID, payload, eventAt)
+				repeat := runtimecontracts.SystemNodeEventHandler{
+					Loop: &runtimecontracts.LoopOperationSpec{Repeat: "revision", From: "awaiting"}, AdvancesTo: "awaiting",
+				}
+				result, err := h.pc.executeNodeContractHandler(h.ctx, "observer", repeat, workflowTriggerContext{
+					Event: event, State: mustCurrentWorkflowState(t, h.pc, h.ctx, h.route, h.entityID),
+				}, false)
+				if err != nil || !result.Handled {
+					t.Fatalf("repeat loop = handled:%v err:%v", result.Handled, err)
+				}
+
+				instance = h.instance()
+				carrier, err = runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				nextLoop, found, err := loopruntime.Load(carrier.StateBuckets, flowID, "revision")
+				if err != nil || !found || nextLoop.Generation().Equal(loop.Generation()) {
+					t.Fatalf("next loop = found:%v activation:%#v err:%v", found, nextLoop, err)
+				}
+				firstActivation, found, err := joinruntime.Load(
+					carrier.StateBuckets, "join-node",
+					joinruntime.ActivationKeyForGeneration("awaiting", "awaiting", "", loop.Generation()),
+				)
+				if err != nil || !found || firstActivation.Status != joinruntime.StatusClosed ||
+					firstActivation.CloseReason != joinruntime.CloseReasonStageExit || !firstActivation.TimerCancelled ||
+					!firstActivation.JoinRef().Equal(firstRef) {
+					t.Fatalf("superseded join = found:%v activation:%#v err:%v", found, firstActivation, err)
+				}
+				_, cancellations := committedWorkflowSchedulesForTest(t, h.store)
+				if len(cancellations) != 1 || cancellations[0].Command.ScheduleKey != schedule.Command.ScheduleKey {
+					t.Fatalf("superseded cancellations = %#v, want %q", cancellations, schedule.Command.ScheduleKey)
+				}
+
+				beforeStale := h.instance()
+				h.restart()
+				if _, err := h.fire(h.scheduleEvent(schedule, "superseded-generation")); err == nil {
+					t.Fatal("stale superseded occurrence was accepted")
+				} else if envelope, ok := runtimefailures.EnvelopeFromError(err); !ok || envelope.Class != runtimefailures.ClassUnexpectedArrival {
+					t.Fatalf("stale superseded occurrence = %v, envelope=%#v", err, envelope)
+				}
+				afterStale := h.instance()
+				if !exactJoinSemanticStateEqual(beforeStale, afterStale) {
+					t.Fatalf("stale generation mutated semantic state\nbefore=%#v\nafter=%#v", beforeStale, afterStale)
+				}
+			})
+		}
+	}
+}
+
+func TestNestedFanOutDiamondJoinsRetainIndependentDeclarationHandles(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, ctx := storeCase.open(t)
+			bundle := workflowJoinLifecycleBundle()
+			source := exactRootAndFlowJoinSource(bundle)
+			schedules := &recordingGenericScheduleWakeupOwner{}
+			newCoordinator := func() *PipelineCoordinator {
+				return newWorkflowJoinPipelineCoordinator(&recordingPipelineBus{}, store.testDB(), PipelineCoordinatorOptions{
+					Module: &pipelineFixtureWorkflowModule{source: source}, Persistence: workflowPersistenceForTest(store), GenericSchedules: schedules,
+				})
+			}
+			pc := newCoordinator()
+			runID := runtimecorrelation.RunIDFromContext(ctx)
+			root := seedExactJoinScope(t, store, ctx, source, "", runID)
+			left := seedExactJoinScope(t, store, ctx, source, "orders", "orders/"+uuid.NewString())
+			right := seedExactJoinScope(t, store, ctx, source, "orders", "orders/"+uuid.NewString())
+			for _, scope := range []exactJoinScope{root, left, right} {
+				if err := applyTestInitialEntryEffect(ctx, pc, scope.route, scope.entityID); err != nil {
+					t.Fatalf("arm %s diamond join: %v", scope.path, err)
+				}
+			}
+			upserts, _ := committedWorkflowSchedulesForTest(t, store)
+			if len(upserts) != 3 {
+				t.Fatalf("diamond schedules = %#v", upserts)
+			}
+			if upserts[1].Command.TaskID != upserts[2].Command.TaskID || upserts[1].Command.EntityID == upserts[2].Command.EntityID {
+				t.Fatalf("concrete child schedules lost declaration/owner distinction: left=%#v right=%#v", upserts[1].Command, upserts[2].Command)
+			}
+
+			pc = newCoordinator()
+			for _, child := range []exactJoinScope{left, right} {
+				for _, member := range []string{"a", "b"} {
+					if err := deliverExactJoinMember(t, pc, store, ctx, source, child, member); err != nil {
+						t.Fatalf("complete child %s member %s: %v", child.path, member, err)
+					}
+				}
+				activation := exactJoinActivationForScope(t, pc, store, ctx, child)
+				if activation.Status != joinruntime.StatusClosed || activation.FlowID() != "orders" || activation.Completed() != 2 {
+					t.Fatalf("child %s activation = %#v", child.path, activation)
+				}
+			}
+			if rootActivation := exactJoinActivationForScope(t, pc, store, ctx, root); rootActivation.Status != joinruntime.StatusOpen || rootActivation.FlowID() != "" {
+				t.Fatalf("child completion mutated root activation: %#v", rootActivation)
+			}
+			for _, member := range []string{"a", "b"} {
+				if err := deliverExactJoinMember(t, pc, store, ctx, source, root, member); err != nil {
+					t.Fatalf("complete root diamond member %s: %v", member, err)
+				}
+			}
+			if activation := exactJoinActivationForScope(t, pc, store, ctx, root); activation.Status != joinruntime.StatusClosed || activation.FlowID() != "" || activation.Completed() != 2 {
+				t.Fatalf("root diamond activation = %#v", activation)
+			}
+
+			before := make([]WorkflowInstance, 0, 3)
+			for _, scope := range []exactJoinScope{root, left, right} {
+				instance, _, _ := store.Load(ctx, scope.route)
+				before = append(before, instance)
+			}
+			hostile := root
+			hostile.executionFlowID = "returns"
+			if err := deliverExactJoinMember(t, pc, store, ctx, source, hostile, "a"); err == nil {
+				t.Fatal("unrelated same-leaf flow scope selected the root declaration")
+			}
+			for index, scope := range []exactJoinScope{root, left, right} {
+				after, _, _ := store.Load(ctx, scope.route)
+				if !exactJoinSemanticStateEqual(before[index], after) {
+					t.Fatalf("hostile same-leaf event mutated %s", scope.path)
+				}
+			}
+			_, cancellations := committedWorkflowSchedulesForTest(t, store)
+			if len(cancellations) != 3 {
+				t.Fatalf("diamond cancellations = %#v", cancellations)
+			}
+		})
+	}
+}
+
+func TestReentrantJoinCompletionDoesNotCancelNextGeneration(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			h := newExactWorkflowJoinHarness(t, storeCase, "orders", "awaiting", []any{"a", "b"})
+			observer := runtimecontracts.SystemNodeContract{ID: "observer", ExecutionType: "system_node"}
+			h.bundle.Nodes["observer"] = observer
+			h.bundle.FlowTree.ByID["orders"].Nodes["observer"] = observer
+			h.bundle.Semantics.Loops = []runtimecontracts.WorkflowLoopPlan{{
+				FlowID: "orders", ID: "revision", RevisionField: "revision_id",
+				MaxAttempts: runtimecontracts.LoopAttemptLimit{Literal: 3}, EntryStage: "awaiting", RegionStages: []string{"awaiting", "ready"},
+			}}
+			createdAt := time.Now().UTC()
+			loop, err := loopruntime.New(
+				runtimecorrelation.RunIDFromContext(h.ctx), h.entityID, "orders", "revision", "revision_id",
+				uuid.NewString(), "awaiting", 3, createdAt,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			instance := h.instance()
+			carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := loopruntime.Store(carrier.StateBuckets, loop); err != nil {
+				t.Fatal(err)
+			}
+			instance.StateBuckets = carrier.PersistedStateBuckets()
+			if err := h.store.upsert(h.ctx, instance); err != nil {
+				t.Fatal(err)
+			}
+
+			firstSchedule := h.armInitial()
+			handler := h.bundle.Nodes["join-node"].EventHandlers["item.completed"]
+			handler.Loop = &runtimecontracts.LoopOperationSpec{Admit: "revision", From: "awaiting"}
+			for _, member := range []string{"a", "b"} {
+				event := eventtest.RunCreatingRootIngress(
+					uuid.NewString(), events.EventType("item.completed"), "operator", "",
+					mustJSON(map[string]any{"member_id": member, "result": map[string]any{"value": member}, "revision_id": loop.Generation().RevisionID}), 0,
+					runtimecorrelation.RunIDFromContext(h.ctx), "", h.envelope(), time.Now().UTC(),
+				)
+				persistExactJoinEvent(t, h.store, h.ctx, event)
+				if _, err := h.pc.executeNodeContractHandler(h.ctx, "join-node", handler, workflowTriggerContext{
+					Event: event, State: mustCurrentWorkflowState(t, h.pc, h.ctx, h.route, h.entityID), HandlerEventKey: "item.completed",
+				}, false); err != nil {
+					t.Fatalf("complete first generation member %s: %v", member, err)
+				}
+			}
+			if got := h.instance().CurrentState; got != "ready" {
+				t.Fatalf("first generation state = %q", got)
+			}
+
+			repeatEventID := uuid.NewString()
+			repeatPayload := mustJSON(map[string]any{"revision_id": loop.Generation().RevisionID})
+			repeatAt := createdAt.Add(time.Minute)
+			repeatEvent := eventtest.RunCreatingRootIngress(
+				repeatEventID, events.EventType("loop.repeat"), "operator", "", repeatPayload, 0,
+				runtimecorrelation.RunIDFromContext(h.ctx), "", h.envelope(), repeatAt,
+			)
+			persistWorkflowTimerEvent(t, h.store, h.ctx, repeatEventID, "loop.repeat", runtimecorrelation.RunIDFromContext(h.ctx), h.entityID, repeatPayload, repeatAt)
+			repeat := runtimecontracts.SystemNodeEventHandler{
+				Loop: &runtimecontracts.LoopOperationSpec{Repeat: "revision", From: "ready"}, AdvancesTo: "awaiting",
+			}
+			result, err := h.pc.executeNodeContractHandler(h.ctx, "observer", repeat, workflowTriggerContext{
+				Event: repeatEvent, State: mustCurrentWorkflowState(t, h.pc, h.ctx, h.route, h.entityID),
+			}, false)
+			if err != nil || !result.Handled {
+				t.Fatalf("re-enter next generation = handled:%v err:%v", result.Handled, err)
+			}
+
+			instance = h.instance()
+			carrier, err = runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nextLoop, found, err := loopruntime.Load(carrier.StateBuckets, "orders", "revision")
+			if err != nil || !found || nextLoop.Generation().Equal(loop.Generation()) {
+				t.Fatalf("next loop generation = found:%v loop:%#v err:%v", found, nextLoop, err)
+			}
+			nextKey := joinruntime.ActivationKeyForGeneration("awaiting", "awaiting", "", nextLoop.Generation())
+			nextJoin, found, err := joinruntime.Load(carrier.StateBuckets, "join-node", nextKey)
+			if err != nil || !found || nextJoin.Status != joinruntime.StatusOpen || !nextJoin.Generation().Equal(nextLoop.Generation()) {
+				t.Fatalf("next generation join = found:%v activation:%#v err:%v", found, nextJoin, err)
+			}
+
+			beforeStale := h.instance()
+			h.restart()
+			if _, err := h.fire(h.scheduleEvent(firstSchedule, "stale-first-generation")); err != nil {
+				if envelope, ok := runtimefailures.EnvelopeFromError(err); !ok || envelope.Class != runtimefailures.ClassUnexpectedArrival {
+					t.Fatalf("stale generation result = %v envelope=%#v", err, envelope)
+				}
+			}
+			afterStale := h.instance()
+			if !exactJoinSemanticStateEqual(beforeStale, afterStale) {
+				t.Fatal("stale first-generation occurrence mutated the live next generation")
+			}
+			h.transition("dispatching", "manual.abort")
+			instance = h.instance()
+			carrier, err = runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nextJoin, found, err = joinruntime.Load(carrier.StateBuckets, "join-node", nextKey)
+			if err != nil || !found || nextJoin.Status != joinruntime.StatusClosed || !nextJoin.Generation().Equal(nextLoop.Generation()) || !nextJoin.TimerCancelled {
+				t.Fatalf("next generation cancellation = found:%v activation:%#v err:%v", found, nextJoin, err)
+			}
+		})
+	}
+}
+
+func TestConcurrentRootAndFlowSameLeafJoinsRemainDistinctAcrossRestart(t *testing.T) {
+	for _, storeCase := range workflowJoinStoreCases() {
+		for _, fireRoot := range []bool{false, true} {
+			name := "fire-flow-cancel-root"
+			if fireRoot {
+				name = "fire-root-cancel-flow"
+			}
+			t.Run(storeCase.name+"/"+name, func(t *testing.T) {
+				store, ctx := storeCase.open(t)
+				bundle := workflowJoinLifecycleBundle()
+				source := exactRootAndFlowJoinSource(bundle)
+				schedules := &recordingGenericScheduleWakeupOwner{}
+				newCoordinator := func() *PipelineCoordinator {
+					return newWorkflowJoinPipelineCoordinator(&recordingPipelineBus{}, store.testDB(), PipelineCoordinatorOptions{
+						Module: &pipelineFixtureWorkflowModule{source: source}, Persistence: workflowPersistenceForTest(store), GenericSchedules: schedules,
+					})
+				}
+				pc := newCoordinator()
+				runID := runtimecorrelation.RunIDFromContext(ctx)
+				root := seedExactJoinScope(t, store, ctx, source, "", runID)
+				flow := seedExactJoinScope(t, store, ctx, source, "orders", "orders/"+uuid.NewString())
+				for _, scope := range []exactJoinScope{root, flow} {
+					if err := applyTestInitialEntryEffect(ctx, pc, scope.route, scope.entityID); err != nil {
+						t.Fatalf("arm %s: %v", scope.path, err)
+					}
+				}
+				upserts, _ := committedWorkflowSchedulesForTest(t, store)
+				if len(upserts) != 2 {
+					t.Fatalf("same-leaf schedules = %#v", upserts)
+				}
+				scheduleByEntity := map[string]runtimegenericschedule.Activation{}
+				for _, schedule := range upserts {
+					scheduleByEntity[schedule.Command.EntityID] = schedule
+				}
+				rootSchedule, flowSchedule := scheduleByEntity[root.entityID], scheduleByEntity[flow.entityID]
+				_, rootRef, rootOK := timeridentity.ParseJoinHandle(parsePayloadMap(genericSchedulePayloadForTest(t, rootSchedule)))
+				_, flowRef, flowOK := timeridentity.ParseJoinHandle(parsePayloadMap(genericSchedulePayloadForTest(t, flowSchedule)))
+				if !rootOK || !flowOK || rootRef.FlowID() != "" || flowRef.FlowID() != "orders" || rootRef.Equal(flowRef) {
+					t.Fatalf("same-leaf handles = root:%#v/%v flow:%#v/%v", rootRef, rootOK, flowRef, flowOK)
+				}
+
+				pc = newCoordinator()
+				firedScope, cancelledScope := flow, root
+				firedSchedule := flowSchedule
+				if fireRoot {
+					firedScope, cancelledScope = root, flow
+					firedSchedule = rootSchedule
+				}
+				fireEnvelope := events.EnvelopeForEntityID(events.EventEnvelope{}, firedScope.entityID)
+				if firedScope.declarationFlowID != "" {
+					fireEnvelope = workflowJoinTestEnvelope(firedScope.path, firedScope.entityID)
+				}
+				fireEvent := workflowJoinScheduleEventForTest(t, uuid.NewString(), firedSchedule, runID, fireEnvelope, time.Now().UTC())
+				persistExactJoinEvent(t, store, ctx, fireEvent)
+				result, err := pc.executeAuthoritativeNodeHandler(ctx, fireEvent, workflowTriggerContext{
+					Event: fireEvent, State: mustCurrentWorkflowState(t, pc, ctx, firedScope.route, firedScope.entityID),
+				})
+				if err != nil || !result.Handled {
+					t.Fatalf("fire exact same-leaf join = handled:%v err:%v", result.Handled, err)
+				}
+				transitionCtx := testPersistedWorkflowStateTransitionContext(t, store, ctx, cancelledScope.route, cancelledScope.entityID, "manual.abort")
+				if err := pc.persistWorkflowStateForTest(transitionCtx, cancelledScope.route, cancelledScope.entityID, "dispatching", "manual.abort"); err != nil {
+					t.Fatalf("cancel other same-leaf join: %v", err)
+				}
+				fired := exactJoinActivationForScope(t, pc, store, ctx, firedScope)
+				cancelled := exactJoinActivationForScope(t, pc, store, ctx, cancelledScope)
+				if fired.CloseReason != joinruntime.CloseReasonTimeout || fired.FlowID() != firedScope.declarationFlowID || !fired.OutcomeFired {
+					t.Fatalf("fired same-leaf activation = %#v", fired)
+				}
+				if cancelled.CloseReason != joinruntime.CloseReasonStageExit || cancelled.FlowID() != cancelledScope.declarationFlowID || !cancelled.TimerCancelled {
+					t.Fatalf("cancelled same-leaf activation = %#v", cancelled)
+				}
+			})
+		}
+	}
+}
+
+func pipelineJoinHandle(t *testing.T, flowID string, kind timeridentity.TimerHandleKind) timeridentity.TimerHandle {
+	t.Helper()
+	ref, err := timeridentity.NewJoinRef(flowID, "join-node", "item.completed", "awaiting", "awaiting", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind == timeridentity.TimerHandleJoinComplete {
+		handle, err := timeridentity.JoinCompleteHandle(ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return handle
+	}
+	handle, err := timeridentity.JoinTimeoutHandle(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}
+
+func exactJoinOccurrenceEvent(t *testing.T, id string, handle timeridentity.TimerHandle, source events.RoutingSource, envelope events.EventEnvelope) events.Event {
+	t.Helper()
+	return exactJoinOccurrenceEventWithFacts(t, id, handle.EventType(), "runtime.generic_schedule", handle.TaskID(), handle, source, envelope)
+}
+
+func exactJoinOccurrenceEventWithFacts(t *testing.T, id, eventType, producer, taskID string, handle timeridentity.TimerHandle, source events.RoutingSource, envelope events.EventEnvelope) events.Event {
+	t.Helper()
+	payload, err := json.Marshal(handle.PayloadMetadata())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eventtest.RuntimeControlWithRoutingSource(
+		id, events.EventType(eventType), producer, taskID, payload, 0,
+		uuid.NewString(), "", envelope, source, time.Now().UTC(),
+	)
+}

--- a/internal/runtime/pipeline/workflow_join_lifecycle.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle.go
@@ -9,7 +9,6 @@ import (
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
-	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
 	"github.com/division-sh/swarm/internal/runtime/joinruntime"
@@ -21,19 +20,25 @@ const (
 	joinCompleteEvent = "platform.join_complete"
 )
 
-func workflowJoinPlansForStage(source semanticview.Source, flowID, stage string) []runtimecontracts.WorkflowJoinPlan {
-	if source == nil {
+func workflowJoinPlansForStage(source semanticview.Source, route runtimeflowidentity.Route, stage string) []runtimecontracts.WorkflowJoinPlan {
+	if source == nil || !route.Valid() {
 		return nil
 	}
-	flowID = strings.TrimSpace(flowID)
 	stage = strings.TrimSpace(stage)
+	ownerScope := strings.Trim(strings.TrimSpace(route.ScopeKey), "/")
+	hasFlowOwner := false
+	for _, plan := range source.WorkflowJoins() {
+		flowID := strings.TrimSpace(plan.FlowID)
+		if flowID != "" && runtimeflowidentity.ScopeKey(source, flowID) == ownerScope {
+			hasFlowOwner = true
+			break
+		}
+	}
 	out := make([]runtimecontracts.WorkflowJoinPlan, 0, 1)
 	for _, plan := range source.WorkflowJoins() {
 		planFlowID := strings.TrimSpace(plan.FlowID)
-		flowMatches := planFlowID == flowID
-		if planFlowID == "" {
-			flowMatches = flowID == "" || flowID == strings.TrimSpace(source.WorkflowName())
-		}
+		flowMatches := planFlowID == "" && !hasFlowOwner ||
+			planFlowID != "" && runtimeflowidentity.ScopeKey(source, planFlowID) == ownerScope
 		if flowMatches && strings.TrimSpace(plan.Spec.Stage) == stage {
 			out = append(out, plan)
 		}
@@ -88,34 +93,17 @@ func joinTopLevelField(path, root string) string {
 	return field
 }
 
-func joinSchedule(source semanticview.Source, flowID, entityID string, instanceRoute runtimeflowidentity.Route, activation joinruntime.Activation, kind timeridentity.TimerHandleKind, mode executionmode.Mode) (runtimegenericschedule.AdmissionCommand, error) {
+func joinSchedule(source semanticview.Source, entityID string, instanceRoute runtimeflowidentity.Route, activation joinruntime.Activation, mode executionmode.Mode) (runtimegenericschedule.AdmissionCommand, error) {
 	if !mode.Valid() {
 		return runtimegenericschedule.AdmissionCommand{}, fmt.Errorf("join schedule requires exact causal execution mode")
 	}
-	ref := timeridentity.NewJoinRefForGeneration(flowID, activation.NodeID, activation.HandlerEvent, activation.Stage, activation.JoinID, activation.Window, activation.Generation)
-	var handle timeridentity.TimerHandle
-	var eventType string
-	switch kind {
-	case timeridentity.TimerHandleJoinTimeout:
-		handle = timeridentity.JoinTimeoutHandle(ref)
-		eventType = joinTimeoutEvent
-	case timeridentity.TimerHandleJoinComplete:
-		handle = timeridentity.JoinCompleteHandle(ref)
-		eventType = joinCompleteEvent
-	default:
-		return runtimegenericschedule.AdmissionCommand{}, fmt.Errorf("join schedule handle kind %q is invalid", kind)
-	}
-	if activation.TimerTaskID != handle.TaskID() || activation.TimerEventType != eventType {
-		return runtimegenericschedule.AdmissionCommand{}, fmt.Errorf(
-			"join schedule declaration does not match persisted activation (task=%q want=%q event=%q want=%q)",
-			activation.TimerTaskID, handle.TaskID(), activation.TimerEventType, eventType,
-		)
+	handle := activation.TimerHandle()
+	ref, ok := handle.JoinRef()
+	if !ok || activation.TimerTaskID() == "" || activation.TimerEventType() == "" {
+		return runtimegenericschedule.AdmissionCommand{}, fmt.Errorf("join schedule requires the activation's typed declaration handle")
 	}
 	payload := handle.PayloadMetadata()
-	if generation := activation.Generation.Normalize(); generation.Valid() {
-		payload[generation.RevisionField] = generation.RevisionID
-	}
-	flowID = strings.TrimSpace(flowID)
+	flowID := ref.FlowID()
 	route := events.RouteIdentity{EntityID: entityID}
 	scheduleFlowInstance := ""
 	if flowID != "" {
@@ -142,7 +130,7 @@ func joinSchedule(source semanticview.Source, flowID, entityID string, instanceR
 		ScheduleKey:   handle.TaskID(),
 		OwnerID:       runtimeWorkflowID,
 		OwnerKind:     runtimegenericschedule.OwnerSystem,
-		EventType:     eventType,
+		EventType:     handle.EventType(),
 		EntityID:      strings.TrimSpace(entityID),
 		FlowInstance:  strings.Trim(strings.TrimSpace(scheduleFlowInstance), "/"),
 		TaskID:        handle.TaskID(),

--- a/internal/runtime/pipeline/workflow_join_lifecycle_test.go
+++ b/internal/runtime/pipeline/workflow_join_lifecycle_test.go
@@ -220,7 +220,8 @@ func TestArmWorkflowJoinPersistsActivationAndScheduleAtomically(t *testing.T) {
 				t.Fatalf("schedule = %#v", schedule)
 			}
 			handle, ok := timeridentity.ParseTimerHandle(parsePayloadMap(genericSchedulePayloadForTest(t, schedule)))
-			if !ok || handle.Kind != tc.wantKind || handle.Join.JoinID != "awaiting" {
+			ref, refOK := handle.JoinRef()
+			if !ok || !refOK || handle.Kind() != tc.wantKind || ref.JoinID() != "awaiting" {
 				t.Fatalf("timer handle = %#v, %v", handle, ok)
 			}
 		})
@@ -440,7 +441,7 @@ func TestWorkflowJoinDurableIdentityIncludesStageOnBothStores(t *testing.T) {
 				t.Fatalf("awaiting activation = %#v, %v, %v", awaiting, ok, err)
 			}
 			reviewing, ok, err := joinruntime.Load(carrier.StateBuckets, "join-node", joinruntime.ActivationKey("reviewing", "shared", ""))
-			if err != nil || !ok || reviewing.Status != joinruntime.StatusOpen || reviewing.Stage != "reviewing" {
+			if err != nil || !ok || reviewing.Status != joinruntime.StatusOpen || reviewing.Stage() != "reviewing" {
 				t.Fatalf("reviewing activation = %#v, %v, %v", reviewing, ok, err)
 			}
 			upserts, _ := committedWorkflowSchedulesForTest(t, store)
@@ -474,6 +475,44 @@ func genericSchedulePayloadForTest(t *testing.T, activation runtimegenericschedu
 		t.Fatalf("encode generic schedule payload: %v", err)
 	}
 	return payload
+}
+
+func workflowJoinScheduleEventForTest(t *testing.T, id string, activation runtimegenericschedule.Activation, runID string, envelope events.EventEnvelope, at time.Time) events.Event {
+	t.Helper()
+	return eventtest.RuntimeControlWithRoutingSource(
+		id,
+		events.EventType(activation.Command.EventType),
+		runtimegenericschedule.OccurrenceProducerID(),
+		activation.Command.TaskID,
+		genericSchedulePayloadForTest(t, activation),
+		0,
+		runID,
+		"",
+		envelope,
+		activation.Command.RoutingSource,
+		at,
+	)
+}
+
+func workflowJoinTimerEventForTest(t *testing.T, id, eventType string, handle timeridentity.TimerHandle, runID string, envelope events.EventEnvelope, at time.Time) events.Event {
+	t.Helper()
+	routingSource, err := events.NewFlowOwnedControlRoutingSource(envelope.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eventtest.RuntimeControlWithRoutingSource(
+		id,
+		events.EventType(eventType),
+		runtimegenericschedule.OccurrenceProducerID(),
+		handle.TaskID(),
+		mustJSON(handle.PayloadMetadata()),
+		0,
+		runID,
+		"",
+		envelope,
+		routingSource,
+		at,
+	)
 }
 
 func workflowJoinStoreCases() []workflowJoinStoreCase {
@@ -531,9 +570,15 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 			path := "orders/" + uuid.NewString()
 			entityID := FlowInstanceEntityID(path)
 			now := time.Now().UTC()
-			ref := timeridentity.NewJoinRef("orders", "join-node", "item.completed", "awaiting", "awaiting", "")
-			handle := timeridentity.JoinTimeoutHandle(ref)
-			activation, err := joinruntime.NewActivation("awaiting", "awaiting", "join-node", "item.completed", "", []string{"a"}, now, now.Add(time.Hour), handle.TaskID(), joinTimeoutEvent)
+			ref, err := timeridentity.NewJoinRef("orders", "join-node", "item.completed", "awaiting", "awaiting", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			handle, err := timeridentity.JoinTimeoutHandle(ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			activation, err := joinruntime.NewActivation(handle, []string{"a"}, now, now.Add(time.Hour))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -546,7 +591,7 @@ func TestWorkflowJoinArrivalTimeoutRaceHasOneCloseWinnerOnBothStores(t *testing.
 			}
 			handler := bundle.Nodes["join-node"].EventHandlers["item.completed"]
 			member := eventtest.RunCreatingRootIngress("member-a", events.EventType("item.completed"), "", "", json.RawMessage(`{"member_id":"a","result":{"ok":true}}`), 0, runtimecorrelation.RunIDFromContext(ctx), "", workflowJoinTestEnvelope(path, entityID), now)
-			timeout := eventtest.RunCreatingRootIngress("timeout-a", events.EventType(joinTimeoutEvent), "", handle.TaskID(), mustJSON(handle.PayloadMetadata()), 0, runtimecorrelation.RunIDFromContext(ctx), "", workflowJoinTestEnvelope(path, entityID), now.Add(time.Hour))
+			timeout := workflowJoinTimerEventForTest(t, "timeout-a", joinTimeoutEvent, handle, runtimecorrelation.RunIDFromContext(ctx), workflowJoinTestEnvelope(path, entityID), now.Add(time.Hour))
 			triggerState := mustCurrentWorkflowState(t, pc, ctx, testWorkflowInstanceRoute(path), entityID)
 			type raceResult struct {
 				result contractHandlerExecutionResult
@@ -840,7 +885,7 @@ func TestWorkflowJoinExpectedZeroCompletesAfterRestartOnBothStores(t *testing.T)
 			}
 			schedule := committedSchedules[0]
 			pc = newCoordinator()
-			fire := eventtest.RunCreatingRootIngress("join-zero-fire", events.EventType(schedule.Command.EventType), "", schedule.Command.TaskID, genericSchedulePayloadForTest(t, schedule), 0, runtimecorrelation.RunIDFromContext(ctx), "", workflowJoinTestEnvelope(path, entityID), time.Now().UTC())
+			fire := workflowJoinScheduleEventForTest(t, "join-zero-fire", schedule, runtimecorrelation.RunIDFromContext(ctx), workflowJoinTestEnvelope(path, entityID), time.Now().UTC())
 			result, err = pc.executeAuthoritativeNodeHandler(ctx, fire, workflowTriggerContext{Event: fire, State: mustCurrentWorkflowState(t, pc, ctx, testWorkflowInstanceRoute(path), entityID)})
 			if err != nil || !result.Handled {
 				t.Fatalf("completion fire = handled:%v err:%v", result.Handled, err)
@@ -937,7 +982,7 @@ func TestWorkflowJoinExpectedZeroStageExitCancelsPendingCompletionOnBothStores(t
 				t.Fatalf("exited zero activation = %#v, %v, %v", activation, ok, err)
 			}
 
-			fire := eventtest.RunCreatingRootIngress("join-zero-after-exit", events.EventType(completion.Command.EventType), "", completion.Command.TaskID, genericSchedulePayloadForTest(t, completion), 0, runtimecorrelation.RunIDFromContext(ctx), "", workflowJoinTestEnvelope(path, entityID), time.Now().UTC())
+			fire := workflowJoinScheduleEventForTest(t, "join-zero-after-exit", completion, runtimecorrelation.RunIDFromContext(ctx), workflowJoinTestEnvelope(path, entityID), time.Now().UTC())
 			result, err := pc.executeAuthoritativeNodeHandler(ctx, fire, workflowTriggerContext{Event: fire, State: mustCurrentWorkflowState(t, pc, ctx, testWorkflowInstanceRoute(path), entityID)})
 			if err != nil || result.Handled {
 				t.Fatalf("late discarded completion fire = handled:%v err:%v, want unhandled", result.Handled, err)

--- a/internal/runtime/pipeline/workflow_join_resolution.go
+++ b/internal/runtime/pipeline/workflow_join_resolution.go
@@ -1,0 +1,142 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/events"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+type workflowJoinOccurrenceResolution struct {
+	Handle  timeridentity.TimerHandle
+	Ref     timeridentity.JoinRef
+	Plan    runtimecontracts.WorkflowJoinPlan
+	Handler runtimecontracts.SystemNodeEventHandler
+}
+
+// ResolveWorkflowJoinOccurrenceDeliveryTarget projects one strict lifecycle
+// handle into the exact authored receiver and selected-run target. Synthetic
+// lifecycle event names never become an alternate handler authority.
+func ResolveWorkflowJoinOccurrenceDeliveryTarget(
+	source semanticview.Source,
+	evt events.Event,
+) (events.DeliveryRecipient, events.RouteIdentity, DeliveryTargetHandler, bool, error) {
+	var noRecipient events.DeliveryRecipient
+	resolution, ok, err := resolveWorkflowJoinOccurrence(source, evt)
+	if err != nil || !ok {
+		return noRecipient, events.RouteIdentity{}, DeliveryTargetHandler{}, ok, err
+	}
+	executionFlowID := resolution.Ref.FlowID()
+	target := events.RouteIdentity{EntityID: strings.TrimSpace(evt.EntityID())}
+	if executionFlowID == "" {
+		executionFlowID = semanticview.RootExecutionFlowID(source)
+		target.FlowID = executionFlowID
+		target.FlowInstance = strings.TrimSpace(evt.RunID())
+	} else {
+		target.FlowID = executionFlowID
+		target.FlowInstance = strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+	}
+	target = target.Normalized()
+	if target.FlowID == "" || target.FlowInstance == "" || target.EntityID == "" {
+		return noRecipient, events.RouteIdentity{}, DeliveryTargetHandler{}, false,
+			fmt.Errorf("join lifecycle delivery target requires exact flow, instance, and entity identity")
+	}
+	handler, err := NewDeliveryTargetHandler(executionFlowID, resolution.Ref.NodeID())
+	if err != nil {
+		return noRecipient, events.RouteIdentity{}, DeliveryTargetHandler{}, false, err
+	}
+	handler = handler.ForEvent(events.EventType(resolution.Ref.HandlerEvent()))
+	return events.MustNodeDeliveryRecipient(resolution.Ref.NodeID()), target, handler, true, nil
+}
+
+func resolveWorkflowJoinOccurrence(source semanticview.Source, evt events.Event) (workflowJoinOccurrenceResolution, bool, error) {
+	if !isJoinLifecycleEvent(evt.Type()) {
+		return workflowJoinOccurrenceResolution{}, false, nil
+	}
+	handle, ref, ok := timeridentity.ParseJoinHandle(parsePayloadMap(evt.Payload()))
+	if !ok {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle event is missing its strict typed timer handle")
+	}
+	if handle.EventType() != strings.TrimSpace(string(evt.Type())) || handle.TaskID() != evt.TaskID() {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle event contradicts its typed timer handle")
+	}
+	producer := evt.Producer()
+	if producer.Type() != events.EventProducerPlatform || producer.ID() != runtimegenericschedule.OccurrenceProducerID() {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle event requires the generic-schedule occurrence producer")
+	}
+	routing := evt.RoutingSource()
+	route := routing.Route().Normalized()
+	if route.EntityID != strings.TrimSpace(evt.EntityID()) {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle event routing source disagrees with its entity")
+	}
+	if ref.FlowID() == "" {
+		flowInstance := strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/")
+		if routing.Kind() != events.RoutingSourceRoot || route.FlowID != "" ||
+			(flowInstance != "" && flowInstance != strings.TrimSpace(evt.RunID())) {
+			return workflowJoinOccurrenceResolution{}, false, fmt.Errorf(
+				"root join lifecycle event contradicts its explicit root declaration: source=%v route=%#v flow_instance=%q",
+				routing.Kind(), route, evt.FlowInstance(),
+			)
+		}
+	} else if routing.Kind() != events.RoutingSourceFlowOwnedControl || route.FlowID != ref.FlowID() || route.FlowInstance != strings.Trim(strings.TrimSpace(evt.FlowInstance()), "/") {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("flow-owned join lifecycle event contradicts its declaration route")
+	}
+	plan, ok := semanticview.WorkflowJoinPlanForRef(source, ref)
+	if !ok {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle event references an unknown exact declaration")
+	}
+	handler, ok := source.NodeEventHandlers(ref.NodeID())[ref.HandlerEvent()]
+	if !ok || handler.Join == nil {
+		return workflowJoinOccurrenceResolution{}, false, fmt.Errorf("join lifecycle declaration has no executable handler")
+	}
+	return workflowJoinOccurrenceResolution{Handle: handle, Ref: ref, Plan: plan, Handler: handler}, true, nil
+}
+
+func workflowJoinDeclarationForExecution(
+	source semanticview.Source,
+	evt events.Event,
+	handlerFlowID, nodeID, handlerEvent string,
+	handler runtimecontracts.SystemNodeEventHandler,
+) (timeridentity.JoinRef, error) {
+	if handler.Join == nil {
+		return timeridentity.JoinRef{}, nil
+	}
+	if isJoinLifecycleEvent(evt.Type()) {
+		resolution, ok, err := resolveWorkflowJoinOccurrence(source, evt)
+		if err != nil {
+			return timeridentity.JoinRef{}, err
+		}
+		if !ok || resolution.Ref.NodeID() != strings.TrimSpace(nodeID) || resolution.Ref.HandlerEvent() != strings.TrimSpace(handlerEvent) {
+			return timeridentity.JoinRef{}, fmt.Errorf("join lifecycle event does not select the exact handler declaration")
+		}
+		return resolution.Ref.Declaration(), nil
+	}
+	return workflowJoinDeclarationRef(source, handlerFlowID, nodeID, handlerEvent, handler)
+}
+
+func workflowJoinDeclarationRef(source semanticview.Source, handlerFlowID, nodeID, handlerEvent string, handler runtimecontracts.SystemNodeEventHandler) (timeridentity.JoinRef, error) {
+	if source == nil || handler.Join == nil {
+		return timeridentity.JoinRef{}, fmt.Errorf("join declaration resolution requires semantic source and join handler")
+	}
+	handlerFlowID = strings.TrimSpace(handlerFlowID)
+	nodeID = strings.TrimSpace(nodeID)
+	if handlerFlowID == "" || nodeID == "" {
+		return timeridentity.JoinRef{}, fmt.Errorf("join handler requires its exact compiled execution scope")
+	}
+	plan, ok := semanticview.WorkflowJoinPlanForExecutionHandler(source, handlerFlowID, nodeID, handlerEvent, *handler.Join)
+	if !ok {
+		return timeridentity.JoinRef{}, fmt.Errorf("join handler has no declaration in exact flow scope %q", handlerFlowID)
+	}
+	ref, err := timeridentity.NewJoinRef(plan.FlowID, nodeID, handlerEvent, handler.Join.Stage, handler.Join.EffectiveID(), "")
+	if err != nil {
+		return timeridentity.JoinRef{}, err
+	}
+	if resolved, ok := semanticview.WorkflowJoinPlanForRef(source, ref); !ok || strings.TrimSpace(resolved.FlowID) != strings.TrimSpace(plan.FlowID) {
+		return timeridentity.JoinRef{}, fmt.Errorf("join handler has no exact semantic declaration")
+	}
+	return ref, nil
+}

--- a/internal/runtime/pipeline/workflow_join_supported_surface_external_test.go
+++ b/internal/runtime/pipeline/workflow_join_supported_surface_external_test.go
@@ -1,0 +1,518 @@
+package pipeline_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimepaths "github.com/division-sh/swarm/internal/runtime/core/paths"
+	worklifetime "github.com/division-sh/swarm/internal/runtime/core/worklifetime"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimeengine "github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/executionposture"
+	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
+	runtimelifecycleprobe "github.com/division-sh/swarm/internal/runtime/lifecycleprobe"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/google/uuid"
+)
+
+type exactExternalJoinSource struct {
+	semanticview.Source
+	flowID string
+	plans  []runtimecontracts.WorkflowJoinPlan
+}
+
+func (s exactExternalJoinSource) WorkflowJoins() []runtimecontracts.WorkflowJoinPlan {
+	return append([]runtimecontracts.WorkflowJoinPlan(nil), s.plans...)
+}
+
+func (s exactExternalJoinSource) NodeContractSource(nodeID string) (runtimecontracts.ContractItemSource, bool) {
+	if strings.TrimSpace(nodeID) == "join-node" {
+		layer := "flow"
+		if s.flowID == "" {
+			layer = "project"
+		}
+		return runtimecontracts.ContractItemSource{FlowID: s.flowID, Layer: layer}, true
+	}
+	return s.Source.NodeContractSource(nodeID)
+}
+
+type joinProofGenericScheduleWakeups struct{}
+
+func (joinProofGenericScheduleWakeups) ReconcileWakeupWithRecovery(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+type exactJoinScheduleLogger struct{ t *testing.T }
+
+func (l exactJoinScheduleLogger) GenericScheduleFailure(_ context.Context, action, activationID string, err error) {
+	l.t.Helper()
+	l.t.Logf("generic schedule %s for %s failed: %v", action, activationID, err)
+}
+
+func (exactJoinScheduleLogger) GenericScheduleCatchupWarning(context.Context, string, int) {}
+
+func TestWorkflowJoinDurableEventBusDeliveryClaimPreservesExactDeclarationOnBothStores(t *testing.T) {
+	for _, storeCase := range []struct {
+		name string
+		open func(*testing.T) gateRecoveryStoreCase
+	}{
+		{name: "sqlite", open: openSQLiteGateRecoveryStore},
+		{name: "postgres", open: openPostgresGateRecoveryStore},
+	} {
+		for _, flowID := range []string{"", "orders"} {
+			scope := "root"
+			if flowID != "" {
+				scope = "flow"
+			}
+			t.Run(storeCase.name+"/"+scope, func(t *testing.T) {
+				selected := storeCase.open(t)
+				runID := uuid.NewString()
+				insertGateRecoveryRun(t, selected, runID)
+				ctx := withLiveGateExecution(runtimecorrelation.WithRunID(testAuthorActivityContext(t, context.Background()), runID))
+				source := exactExternalWorkflowJoinSource(flowID)
+				path := runID
+				workflowName := source.WorkflowName()
+				instanceID := runID
+				if flowID != "" {
+					instanceID = uuid.NewString()
+					path = flowID + "/" + instanceID
+					workflowName = flowID
+				}
+				eventType := "item.completed"
+				subscriptionType := source.WorkflowName() + "/item.completed"
+				var additionalDescriptors []string
+				if flowID != "" {
+					eventType = path + "/item.completed"
+					subscriptionType = eventType
+					additionalDescriptors = append(additionalDescriptors, eventType)
+				}
+				if owners := source.RuntimeEventOwners("item.completed"); len(owners) != 1 || owners[0] != "join-node" {
+					t.Fatalf("join event owners = %#v", owners)
+				}
+				module := proposedEffectProofModule{
+					source: source,
+					workflow: runtimepipeline.NewWorkflowDefinition(workflowName, []runtimepipeline.WorkflowStage{
+						{Name: "awaiting"},
+						{Name: "ready", Terminal: true},
+						{Name: "attention", Terminal: true},
+					}, []runtimepipeline.WorkflowTransition{{
+						Name: "complete-join", From: []runtimepipeline.WorkflowStateID{"awaiting"}, To: "ready",
+						Trigger: "item.completed", Node: "join-node",
+					}}),
+					nodes: []runtimepipeline.WorkflowNode{{
+						ID: "join-node", Subscriptions: []events.EventType{events.EventType(subscriptionType)},
+						ExecutionType: runtimecontracts.SystemNodeExecutionType,
+						Policies: map[string]runtimepipeline.WorkflowEventPolicy{
+							subscriptionType: {Consume: true},
+						},
+					}},
+				}
+				probe := runtimelifecycleprobe.New()
+				eventBus, err := newScopedTestEventBus(t, selected.events, runtimebus.EventBusOptions{
+					ContractBundle: source, TestLifecycleProbe: probe,
+				}, additionalDescriptors...)
+				if err != nil {
+					t.Fatalf("new join EventBus: %v", err)
+				}
+				coordinator := newGateRecoveryCoordinator(eventBus, selected, runtimepipeline.PipelineCoordinatorOptions{
+					Module: module, Persistence: selected.persistence,
+					GenericSchedules: joinProofGenericScheduleWakeups{}, TestLifecycleProbe: probe,
+				})
+				eventBus.SetInterceptors(coordinator)
+
+				route := runtimeflowidentity.RouteForInstancePath(path)
+				entityID := runtimeflowidentity.EntityID(path)
+				createdAt := time.Now().UTC()
+				if _, err := coordinator.MaterializeInitialEntry(ctx, runtimepipeline.WorkflowInstance{
+					InstanceID: instanceID, StorageRef: path, WorkflowName: workflowName, WorkflowVersion: "1.0.0",
+					CurrentState: "awaiting", EnteredStageAt: createdAt, CreatedAt: createdAt,
+					Metadata: map[string]any{
+						"run_id": runID, "entity_id": entityID, "flow_path": path, "instance_id": route.InstanceID,
+						"expected": []any{"a", "b"},
+					},
+				}, createdAt); err != nil {
+					t.Fatalf("materialize exact join owner: %v", err)
+				}
+				if flowID != "" {
+					if err := eventBus.PublishPersistedFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: route}); err != nil {
+						t.Fatalf("add flow join route: %v", err)
+					}
+				}
+
+				eventsByMember := make([]events.Event, 0, 2)
+				for _, member := range []string{"a", "b"} {
+					wantTargetFlow := flowID
+					envelope := events.EnvelopeForFlowInstance(
+						events.EnvelopeForEntityID(events.EventEnvelope{}, entityID), workflowName,
+					)
+					if flowID == "" {
+						wantTargetFlow = source.WorkflowName()
+					} else {
+						envelope = events.EnvelopeForTargetRoute(
+							events.EnvelopeForFlowInstance(envelope, path),
+							events.RouteIdentity{FlowID: flowID, FlowInstance: path, EntityID: entityID},
+						)
+					}
+					event := eventtest.ExistingRunRootIngress(
+						uuid.NewString(), events.EventType(eventType), "operator", "",
+						[]byte(`{"member_id":"`+member+`","result":{"value":"`+member+`"}}`),
+						0, runID, envelope, time.Now().UTC(),
+					)
+					plan, err := eventBus.CheckPublishRecipientPlan(ctx, event)
+					if err != nil {
+						t.Fatalf("plan member %s: %v", member, err)
+					}
+					if len(plan.DeliveryRoutes) != 1 || plan.DeliveryRoutes[0].Recipient.ID() != "join-node" {
+						t.Fatalf("member %s delivery plan = %#v", member, plan)
+					}
+					if target := plan.DeliveryRoutes[0].Target.Route(); target.FlowID != wantTargetFlow || target.FlowInstance != path || target.EntityID != entityID {
+						t.Fatalf("member %s target = %#v, want flow=%q path=%q entity=%q", member, target, wantTargetFlow, path, entityID)
+					}
+					if err := eventBus.PublishAcknowledged(ctx, event); err != nil {
+						t.Fatalf("publish member %s: %v", member, err)
+					}
+					waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+					if err := eventBus.WaitForQuiescence(waitCtx); err != nil {
+						cancel()
+						t.Fatalf("wait member %s quiescence: %v", member, err)
+					}
+					cancel()
+					assertExactJoinDeliveryStatus(t, selected, ctx, event.ID(), "delivered")
+					eventsByMember = append(eventsByMember, event)
+				}
+
+				instance, found, err := coordinator.Load(ctx, route)
+				if err != nil || !found || instance.CurrentState != "ready" {
+					t.Fatalf("closed workflow = found:%v state:%q err:%v", found, instance.CurrentState, err)
+				}
+				carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				joins, err := joinruntime.List(carrier.StateBuckets)
+				if err != nil || len(joins) != 1 {
+					t.Fatalf("join readback = %#v err=%v", joins, err)
+				}
+				if joins[0].Status != joinruntime.StatusClosed || joins[0].CloseReason != joinruntime.CloseReasonComplete ||
+					joins[0].FlowID() != flowID || joins[0].Completed() != 2 || !joins[0].TimerCancelled {
+					t.Fatalf("closed join = %#v", joins[0])
+				}
+
+				beforeReplayRevision := instance.Revision
+				if err := eventBus.PublishAcknowledged(ctx, eventsByMember[1]); err != nil {
+					t.Fatalf("replay exact member event: %v", err)
+				}
+				waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				if err := eventBus.WaitForQuiescence(waitCtx); err != nil {
+					cancel()
+					t.Fatalf("wait replay quiescence: %v", err)
+				}
+				cancel()
+				afterReplay, found, err := coordinator.Load(ctx, route)
+				if err != nil || !found || afterReplay.Revision != beforeReplayRevision {
+					t.Fatalf("replay mutated workflow = found:%v before:%d after:%d err:%v", found, beforeReplayRevision, afterReplay.Revision, err)
+				}
+				assertExactJoinDeliveryCount(t, selected, ctx, eventsByMember[1].ID(), 1)
+			})
+		}
+	}
+}
+
+func TestWorkflowJoinScheduleOccurrencePreservesExactDeclarationThroughDurableEventBusOnBothStores(t *testing.T) {
+	for _, storeCase := range []struct {
+		name string
+		open func(*testing.T) gateRecoveryStoreCase
+	}{
+		{name: "sqlite", open: openSQLiteGateRecoveryStore},
+		{name: "postgres", open: openPostgresGateRecoveryStore},
+	} {
+		for _, flowID := range []string{"", "orders"} {
+			scope := "root"
+			if flowID != "" {
+				scope = "flow"
+			}
+			t.Run(storeCase.name+"/"+scope, func(t *testing.T) {
+				selected := storeCase.open(t)
+				store, ok := selected.events.(interface {
+					runtimegenericschedule.Store
+					runtimebus.PreparedPublishEventReader
+				})
+				if !ok {
+					t.Fatalf("selected store %T lacks generic schedule or event readback ownership", selected.events)
+				}
+				runID := uuid.NewString()
+				insertGateRecoveryRun(t, selected, runID)
+				ctx := withLiveGateExecution(runtimecorrelation.WithRunID(testAuthorActivityContext(t, context.Background()), runID))
+				source := exactExternalWorkflowJoinSource(flowID)
+				path := runID
+				workflowName := source.WorkflowName()
+				instanceID := runID
+				if flowID != "" {
+					instanceID = uuid.NewString()
+					path = flowID + "/" + instanceID
+					workflowName = flowID
+				}
+
+				module := proposedEffectProofModule{
+					source: source,
+					workflow: runtimepipeline.NewWorkflowDefinition(workflowName, []runtimepipeline.WorkflowStage{
+						{Name: "awaiting"},
+						{Name: "ready", Terminal: true},
+						{Name: "attention", Terminal: true},
+					}, []runtimepipeline.WorkflowTransition{{
+						Name: "complete-join", From: []runtimepipeline.WorkflowStateID{"awaiting"}, To: "ready",
+						Trigger: "item.completed", Node: "join-node",
+					}}),
+					nodes: []runtimepipeline.WorkflowNode{{
+						ID: "join-node", ExecutionType: runtimecontracts.SystemNodeExecutionType,
+						Subscriptions: []events.EventType{"item.completed"},
+						Policies: map[string]runtimepipeline.WorkflowEventPolicy{
+							"item.completed": {Consume: true},
+						},
+					}},
+				}
+				probe := runtimelifecycleprobe.New()
+				eventBus, err := newScopedTestEventBus(t, selected.events, runtimebus.EventBusOptions{
+					ContractBundle: source, TestLifecycleProbe: probe,
+				}, "platform.join_complete")
+				if err != nil {
+					t.Fatalf("new schedule occurrence EventBus: %v", err)
+				}
+				workOwner, ok := worklifetime.OccurrenceFromContext(ctx)
+				if !ok {
+					t.Fatal("join occurrence proof context lacks work owner")
+				}
+				scheduler := runtimepipeline.NewSchedulerWithWorkOwner(workOwner)
+				lifecycle, err := runtimegenericschedule.NewLifecycle(
+					store, scheduler, eventBus, eventBus.EngineDispatcher(), exactJoinScheduleLogger{t: t}, executionposture.Live,
+				)
+				if err != nil {
+					t.Fatalf("new generic schedule lifecycle: %v", err)
+				}
+				t.Cleanup(func() {
+					stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					if err := lifecycle.Stop(stopCtx); err != nil {
+						t.Errorf("stop generic schedule lifecycle: %v", err)
+					}
+				})
+				coordinator := newGateRecoveryCoordinator(eventBus, selected, runtimepipeline.PipelineCoordinatorOptions{
+					Module: module, Persistence: selected.persistence,
+					GenericSchedules: lifecycle, TestLifecycleProbe: probe,
+				})
+				eventBus.SetInterceptors(coordinator)
+
+				route := runtimeflowidentity.RouteForInstancePath(path)
+				entityID := runtimeflowidentity.EntityID(path)
+				createdAt := time.Now().UTC()
+				if _, err := coordinator.MaterializeInitialEntry(ctx, runtimepipeline.WorkflowInstance{
+					InstanceID: instanceID, StorageRef: path, WorkflowName: workflowName, WorkflowVersion: "1.0.0",
+					CurrentState: "awaiting", EnteredStageAt: createdAt, CreatedAt: createdAt,
+					Metadata: map[string]any{
+						"run_id": runID, "entity_id": entityID, "flow_path": path, "instance_id": route.InstanceID,
+						"expected": []any{},
+					},
+				}, createdAt); err != nil {
+					t.Fatalf("materialize immediate join owner: %v", err)
+				}
+				if flowID != "" {
+					if err := eventBus.PublishPersistedFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: route}); err != nil {
+						t.Fatalf("add flow join route: %v", err)
+					}
+				}
+
+				eventID := exactJoinOccurrenceEventID(t, selected, ctx, runID)
+				waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				if err := eventBus.WaitForQuiescence(waitCtx); err != nil {
+					cancel()
+					t.Fatalf("wait occurrence delivery quiescence: %v", err)
+				}
+				cancel()
+				assertExactJoinDeliveryStatus(t, selected, ctx, eventID, "delivered")
+				instance := waitForExactJoinState(t, ctx, coordinator, route, "ready")
+				carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
+				if err != nil {
+					t.Fatal(err)
+				}
+				joins, err := joinruntime.List(carrier.StateBuckets)
+				if err != nil || len(joins) != 1 {
+					t.Fatalf("join occurrence readback = %#v err=%v", joins, err)
+				}
+				if joins[0].Status != joinruntime.StatusClosed || joins[0].FlowID() != flowID ||
+					joins[0].CloseReason != joinruntime.CloseReasonComplete || !joins[0].OutcomeFired {
+					t.Fatalf("fired join occurrence = %#v", joins[0])
+				}
+
+				prepared, found, err := store.LoadPreparedPublishEvent(ctx, eventID)
+				if err != nil || !found {
+					t.Fatalf("load persisted join occurrence = found:%v err:%v", found, err)
+				}
+				beforeReplayRevision := instance.Revision
+				if err := eventBus.PublishAcknowledged(ctx, prepared.Event.Event()); err != nil {
+					t.Fatalf("replay persisted join occurrence: %v", err)
+				}
+				waitCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+				if err := eventBus.WaitForQuiescence(waitCtx); err != nil {
+					cancel()
+					t.Fatalf("wait occurrence replay quiescence: %v", err)
+				}
+				cancel()
+				afterReplay, found, err := coordinator.Load(ctx, route)
+				if err != nil || !found || afterReplay.Revision != beforeReplayRevision {
+					t.Fatalf("occurrence replay mutated workflow = found:%v before:%d after:%d err:%v", found, beforeReplayRevision, afterReplay.Revision, err)
+				}
+				assertExactJoinDeliveryCount(t, selected, ctx, eventID, 1)
+			})
+		}
+	}
+}
+
+func exactExternalWorkflowJoinSource(flowID string) semanticview.Source {
+	stages := runtimecontracts.FlowStageDeclarations{Declared: true, Entries: []runtimecontracts.FlowStageDeclaration{
+		{ID: "awaiting", Initial: true}, {ID: "ready", Terminal: true}, {ID: "attention", Terminal: true},
+	}}
+	spec := runtimecontracts.JoinSpec{
+		ID: "awaiting", Stage: "awaiting",
+		Members: runtimecontracts.JoinMembersSpec{
+			From: "entity.expected", FromPath: runtimepaths.Parse("entity.expected"),
+			By: "payload.member_id", ByPath: runtimepaths.Parse("payload.member_id"),
+		},
+		Output: "payload.result", OutputPath: runtimepaths.Parse("payload.result"),
+		OnCompleteFound: true, OnComplete: runtimecontracts.HandlerRuleEntry{AdvancesTo: "ready"},
+		TimeoutFound: true, Timeout: runtimecontracts.JoinTimeoutSpec{
+			After: "1h", Outcome: runtimecontracts.HandlerRuleEntry{AdvancesTo: "attention"},
+		},
+	}
+	handler := runtimecontracts.SystemNodeEventHandler{Join: &spec}
+	node := runtimecontracts.SystemNodeContract{ID: "join-node", ExecutionType: runtimecontracts.SystemNodeExecutionType, EventHandlers: map[string]runtimecontracts.SystemNodeEventHandler{
+		"item.completed": handler,
+	}}
+	catalog := map[string]runtimecontracts.EventCatalogEntry{
+		"item.completed": {Payload: runtimecontracts.EventPayloadSpec{Properties: map[string]runtimecontracts.EventFieldSpec{
+			"member_id": {Type: "text"}, "result": {Type: "jsonb"},
+		}}},
+	}
+	const rootFlowID = "join-eventbus-proof"
+	root := runtimecontracts.FlowContractView{
+		Path: rootFlowID, Paths: runtimecontracts.FlowContractPaths{ID: rootFlowID, Flow: rootFlowID, Mode: runtimecontracts.FlowModeStatic},
+		Schema: runtimecontracts.FlowSchemaDocument{Name: rootFlowID, Mode: runtimecontracts.FlowModeStatic, StageDeclarations: stages},
+		Events: catalog,
+	}
+	flowSchemas := map[string]runtimecontracts.FlowSchemaDocument{rootFlowID: root.Schema}
+	flowInitial := map[string]string{}
+	flowTerminal := map[string][]string{}
+	if flowID == "" {
+		root.Nodes = map[string]runtimecontracts.SystemNodeContract{"join-node": node}
+	} else {
+		flow := runtimecontracts.FlowContractView{
+			Path: flowID, Paths: runtimecontracts.FlowContractPaths{ID: flowID, Flow: flowID},
+			Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate, StageDeclarations: stages},
+			Nodes:  map[string]runtimecontracts.SystemNodeContract{"join-node": node}, Events: catalog,
+		}
+		root.Children = []runtimecontracts.FlowContractView{flow}
+		flowSchemas[flowID] = flow.Schema
+		flowInitial[flowID] = "awaiting"
+		flowTerminal[flowID] = []string{"ready", "attention"}
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		RootSchema: &runtimecontracts.FlowSchemaDocument{StageDeclarations: stages},
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root, ByID: map[string]*runtimecontracts.FlowContractView{rootFlowID: &root},
+		}, FlowSchemas: flowSchemas,
+		Nodes: map[string]runtimecontracts.SystemNodeContract{"join-node": node}, Events: catalog,
+		Semantics: runtimecontracts.WorkflowSemanticView{
+			Name: "join-eventbus-proof", Version: "1.0.0", InitialStage: "awaiting",
+			Stages:         []runtimecontracts.WorkflowStageContract{{ID: "awaiting"}, {ID: "ready"}, {ID: "attention"}},
+			TerminalStages: []string{"ready", "attention"}, FlowInitial: flowInitial, FlowTerminal: flowTerminal,
+			Joins: []runtimecontracts.WorkflowJoinPlan{{
+				FlowID: flowID, NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec,
+				ResultType: runtimecontracts.CatalogTypeReference{Type: "jsonb"},
+			}},
+			EffectiveNodes: map[string]runtimecontracts.SystemNodeEffectiveSemantics{
+				"join-node": {ID: "join-node", RuntimeSubscriptions: runtimecontracts.EffectiveSystemNodeSubscriptions(node)},
+			},
+			NodeHandlers: map[string]map[string]runtimecontracts.SystemNodeEventHandler{"join-node": node.EventHandlers},
+			EventOwners:  map[string][]string{"item.completed": {"join-node"}},
+		},
+	}
+	if flowID != "" {
+		bundle.FlowTree.ByID[flowID] = &bundle.FlowTree.Root.Children[0]
+	}
+	base := semanticview.Wrap(bundle)
+	return exactExternalJoinSource{Source: base, flowID: flowID, plans: bundle.Semantics.Joins}
+}
+
+func assertExactJoinDeliveryStatus(t *testing.T, selected gateRecoveryStoreCase, ctx context.Context, eventID, want string) {
+	t.Helper()
+	query := `SELECT status, CAST(COALESCE(failure, '{}') AS TEXT) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'join-node'`
+	if selected.postgres {
+		query = `SELECT status, COALESCE(failure, '{}'::jsonb)::text FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'join-node'`
+	}
+	var status, failure string
+	if err := selected.db.QueryRowContext(ctx, query, eventID).Scan(&status, &failure); err != nil || status != want {
+		var runtimeLog string
+		logQuery := `SELECT CAST(payload AS TEXT) FROM events WHERE event_name = 'platform.runtime_log' ORDER BY created_at DESC LIMIT 1`
+		_ = selected.db.QueryRowContext(ctx, logQuery).Scan(&runtimeLog)
+		t.Fatalf("delivery %s status = %q failure=%s err=%v, want %q; runtime_log=%s", eventID, status, failure, err, want, runtimeLog)
+	}
+}
+
+func assertExactJoinDeliveryCount(t *testing.T, selected gateRecoveryStoreCase, ctx context.Context, eventID string, want int) {
+	t.Helper()
+	query := `SELECT COUNT(*) FROM event_deliveries WHERE event_id = ? AND subscriber_type = 'node' AND subscriber_id = 'join-node'`
+	if selected.postgres {
+		query = `SELECT COUNT(*) FROM event_deliveries WHERE event_id = $1::uuid AND subscriber_type = 'node' AND subscriber_id = 'join-node'`
+	}
+	var count int
+	if err := selected.db.QueryRowContext(ctx, query, eventID).Scan(&count); err != nil || count != want {
+		t.Fatalf("delivery %s rows = %d err=%v, want %d", eventID, count, err, want)
+	}
+}
+
+func waitForExactJoinState(
+	t *testing.T,
+	ctx context.Context,
+	coordinator *runtimepipeline.PipelineCoordinator,
+	route runtimeflowidentity.Route,
+	want string,
+) runtimepipeline.WorkflowInstance {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		instance, found, err := coordinator.Load(ctx, route)
+		if err == nil && found && instance.CurrentState == want {
+			return instance
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	instance, found, err := coordinator.Load(ctx, route)
+	t.Fatalf("workflow did not reach %q = found:%v state:%q err:%v", want, found, instance.CurrentState, err)
+	return runtimepipeline.WorkflowInstance{}
+}
+
+func exactJoinOccurrenceEventID(t *testing.T, selected gateRecoveryStoreCase, ctx context.Context, runID string) string {
+	t.Helper()
+	query := `SELECT event_id FROM events WHERE run_id = ? AND event_name = 'platform.join_complete'`
+	if selected.postgres {
+		query = `SELECT event_id::text FROM events WHERE run_id = $1::uuid AND event_name = 'platform.join_complete'`
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var eventID string
+		if err := selected.db.QueryRowContext(ctx, query, runID).Scan(&eventID); err == nil {
+			return eventID
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("durable join occurrence event was not published")
+	return ""
+}

--- a/internal/runtime/pipeline/workflow_lifecycle_identity_guard_test.go
+++ b/internal/runtime/pipeline/workflow_lifecycle_identity_guard_test.go
@@ -1,7 +1,12 @@
 package pipeline
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -39,4 +44,69 @@ func TestWorkflowLifecycleIdentityConsumersDoNotReintroduceFallbacks(t *testing.
 			}
 		}
 	}
+
+	_, current, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate workflow lifecycle identity guard")
+	}
+	pipelineDir := filepath.Dir(current)
+	checks := []struct {
+		file      string
+		function  string
+		forbidden []string
+		required  []string
+	}{
+		{file: filepath.Join(pipelineDir, "workflow_join_lifecycle.go"), function: "workflowJoinPlansForStage", forbidden: []string{"WorkflowName"}, required: []string{"runtimeflowidentity.ScopeKey"}},
+		{file: filepath.Join(pipelineDir, "workflow_join_lifecycle.go"), function: "joinSchedule", forbidden: []string{"WorkflowName", "NewJoinRef", "ParseJoinRef"}, required: []string{"activation.TimerHandle()", "handle.JoinRef"}},
+		{file: filepath.Join(pipelineDir, "workflow_lifecycle_plan.go"), function: "planWorkflowJoinEffect", forbidden: []string{"instance.WorkflowName"}, required: []string{"NewJoinRefForGeneration", "joinruntime.NewActivation"}},
+		{file: filepath.Join(pipelineDir, "workflow_join_resolution.go"), function: "resolveWorkflowJoinOccurrence", forbidden: []string{"WorkflowName", "ParseTimerHandle", "WorkflowJoinPlanForHandler"}, required: []string{"ParseJoinHandle", "WorkflowJoinPlanForRef"}},
+		{file: filepath.Join(pipelineDir, "workflow_join_resolution.go"), function: "ResolveWorkflowJoinOccurrenceDeliveryTarget", forbidden: []string{"WorkflowName", "NodeContractSource", "RuntimeEventOwners"}, required: []string{"resolveWorkflowJoinOccurrence", "RootExecutionFlowID", "NewDeliveryTargetHandler"}},
+		{file: filepath.Join(pipelineDir, "workflow_nodes.go"), function: "workflowNodeEventHandlerResolutionForDeliveryContext", forbidden: []string{"NodeContractSource", "RuntimeEventOwners"}, required: []string{"resolveWorkflowJoinOccurrence", "RootExecutionFlowID"}},
+		{file: filepath.Join(pipelineDir, "delivery_target_ownership.go"), function: "ClassifyDeliveryTargetOwnership", forbidden: []string{"ParseJoinHandle", "WorkflowJoinPlanForHandler"}, required: []string{"ResolveWorkflowJoinOccurrenceDeliveryTarget"}},
+		{file: filepath.Join(pipelineDir, "..", "bus", "delivery_planner.go"), function: "planAtGeneration", forbidden: []string{"ParseJoinHandle", "WorkflowJoinPlanForHandler", "RuntimeEventOwners"}, required: []string{"ResolveWorkflowJoinOccurrenceDeliveryTarget"}},
+		{file: filepath.Join(pipelineDir, "workflow_join_resolution.go"), function: "workflowJoinDeclarationRef", forbidden: []string{"WorkflowName", "NodeContractSource", "candidates"}, required: []string{"WorkflowJoinPlanForExecutionHandler", "WorkflowJoinPlanForRef"}},
+		{file: filepath.Join(pipelineDir, "workflow_join_resolution.go"), function: "workflowJoinDeclarationForExecution", forbidden: []string{"WorkflowName", "WorkflowJoinPlanForHandler"}, required: []string{"resolveWorkflowJoinOccurrence", "workflowJoinDeclarationRef"}},
+		{file: filepath.Join(pipelineDir, "engine_bridge.go"), function: "executeNodeContractHandler", forbidden: []string{"WorkflowJoinPlanForHandler", "ParseJoinHandle"}, required: []string{"workflowJoinDeclarationForExecution", "JoinDeclaration:"}},
+		{file: filepath.Join(pipelineDir, "node_declarative.go"), function: "ExecuteHandlerSteps", forbidden: []string{"WorkflowJoinPlanForHandler", "ParseJoinHandle"}, required: []string{"workflowJoinDeclarationForExecution", "JoinDeclaration:"}},
+		{file: filepath.Join(pipelineDir, "..", "engine", "executor.go"), function: "joinPlan", forbidden: []string{"WorkflowName", "WorkflowJoinPlanForHandler", "NewJoinRef"}, required: []string{"WorkflowJoinPlanForRef", "JoinDeclaration.Valid"}},
+	}
+	for _, check := range checks {
+		t.Run(filepath.Base(check.file)+"/"+check.function, func(t *testing.T) {
+			body := workflowLifecycleFunctionSource(t, check.file, check.function)
+			for _, token := range check.forbidden {
+				if strings.Contains(body, token) {
+					t.Fatalf("%s reintroduced forbidden join identity authority %q:\n%s", check.function, token, body)
+				}
+			}
+			for _, token := range check.required {
+				if !strings.Contains(body, token) {
+					t.Fatalf("%s stopped consuming canonical join identity owner %q:\n%s", check.function, token, body)
+				}
+			}
+		})
+	}
+}
+
+func workflowLifecycleFunctionSource(t *testing.T, path, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set := token.NewFileSet()
+	file, err := parser.ParseFile(set, path, raw, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != name {
+			continue
+		}
+		start := set.Position(function.Pos()).Offset
+		end := set.Position(function.End()).Offset
+		return string(raw[start:end])
+	}
+	t.Fatalf("function %s not found in %s", name, path)
+	return ""
 }

--- a/internal/runtime/pipeline/workflow_lifecycle_plan.go
+++ b/internal/runtime/pipeline/workflow_lifecycle_plan.go
@@ -293,17 +293,13 @@ func (pc *PipelineCoordinator) planSupersededWorkflowArtifacts(ctx context.Conte
 	}
 	joinStateChanged := false
 	for _, activation := range joins {
-		if activation.Status != joinruntime.StatusClosed || activation.TimerCancelled || strings.TrimSpace(activation.TimerTaskID) == "" {
+		if activation.Status != joinruntime.StatusClosed || activation.TimerCancelled || activation.TimerTaskID() == "" {
 			continue
 		}
-		if activation.TimerEventType == joinCompleteEvent && activation.OutcomePending && !activation.OutcomeFired {
+		if activation.TimerEventType() == joinCompleteEvent && activation.OutcomePending && !activation.OutcomeFired {
 			continue
 		}
-		kind := timeridentity.TimerHandleJoinTimeout
-		if activation.TimerEventType == joinCompleteEvent {
-			kind = timeridentity.TimerHandleJoinComplete
-		}
-		command, err := joinSchedule(pc.SemanticSource(), instance.WorkflowName, entityID.String(), route, activation, kind, mode)
+		command, err := joinSchedule(pc.SemanticSource(), entityID.String(), route, activation, mode)
 		if err != nil {
 			return err
 		}
@@ -453,7 +449,7 @@ func (pc *PipelineCoordinator) planWorkflowJoinEffect(ctx context.Context, insta
 	}
 	currentStage = strings.TrimSpace(currentStage)
 	nextStage = strings.TrimSpace(nextStage)
-	if instance == nil || entityID.IsZero() || nextStage == "" || currentStage == nextStage {
+	if instance == nil || entityID.IsZero() || nextStage == "" {
 		return nil
 	}
 	carrier, err := runtimeengine.StateCarrierFromPersisted(instance.Metadata, instance.StateBuckets)
@@ -465,18 +461,14 @@ func (pc *PipelineCoordinator) planWorkflowJoinEffect(ctx context.Context, insta
 		return fmt.Errorf("list join state: %w", err)
 	}
 	for _, activation := range activations {
-		if activation.Stage != currentStage || activation.Stage == nextStage || !activation.CloseForStageExit() {
+		if activation.Stage() != currentStage || activation.Stage() == nextStage || !activation.CloseForStageExit() {
 			continue
-		}
-		kind := timeridentity.TimerHandleJoinTimeout
-		if activation.TimerEventType == joinCompleteEvent {
-			kind = timeridentity.TimerHandleJoinComplete
 		}
 		activation.TimerCancelled = true
 		if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
 			return fmt.Errorf("close join %s on stage exit: %w", activation.Key(), err)
 		}
-		command, err := joinSchedule(pc.SemanticSource(), instance.WorkflowName, entityID.String(), route, activation, kind, mode)
+		command, err := joinSchedule(pc.SemanticSource(), entityID.String(), route, activation, mode)
 		if err != nil {
 			return err
 		}
@@ -488,7 +480,7 @@ func (pc *PipelineCoordinator) planWorkflowJoinEffect(ctx context.Context, insta
 	if now.IsZero() {
 		return fmt.Errorf("workflow join lifecycle requires an exact occurrence time")
 	}
-	for _, joinPlan := range workflowJoinPlansForStage(pc.SemanticSource(), instance.WorkflowName, nextStage) {
+	for _, joinPlan := range workflowJoinPlansForStage(pc.SemanticSource(), route, nextStage) {
 		if joinPlan.ResultType.Empty() {
 			return fmt.Errorf("join %s has no resolved output type in the semantic plan", joinPlan.Spec.EffectiveID())
 		}
@@ -518,13 +510,18 @@ func (pc *PipelineCoordinator) planWorkflowJoinEffect(ctx context.Context, insta
 		if !ok {
 			return fmt.Errorf("join %s timeout.after %q did not resolve to a positive duration", joinPlan.Spec.EffectiveID(), joinPlan.Spec.Timeout.After)
 		}
-		ref := timeridentity.NewJoinRefForGeneration(joinPlan.FlowID, joinPlan.NodeID, joinPlan.HandlerEvent, joinPlan.Spec.Stage, joinPlan.Spec.EffectiveID(), window, generation)
-		handle := timeridentity.JoinTimeoutHandle(ref)
-		activation, err := joinruntime.NewActivation(joinPlan.Spec.EffectiveID(), joinPlan.Spec.Stage, joinPlan.NodeID, joinPlan.HandlerEvent, window, members, now, now.Add(interval), handle.TaskID(), joinTimeoutEvent, generation)
+		ref, err := timeridentity.NewJoinRefForGeneration(joinPlan.FlowID, joinPlan.NodeID, joinPlan.HandlerEvent, joinPlan.Spec.Stage, joinPlan.Spec.EffectiveID(), window, generation)
+		if err != nil {
+			return fmt.Errorf("arm join %s identity: %w", joinPlan.Spec.EffectiveID(), err)
+		}
+		handle, err := timeridentity.JoinTimeoutHandle(ref)
+		if err != nil {
+			return fmt.Errorf("arm join %s timer: %w", joinPlan.Spec.EffectiveID(), err)
+		}
+		activation, err := joinruntime.NewActivation(handle, members, now, now.Add(interval))
 		if err != nil {
 			return fmt.Errorf("arm join %s: %w", joinPlan.Spec.EffectiveID(), err)
 		}
-		kind := timeridentity.TimerHandleJoinTimeout
 		complete, err := joinruntime.CompletionSatisfied(activation, joinPlan.Spec.CompleteWhen, func(expression string, joinContext map[string]any) (bool, error) {
 			return workflowexpr.EvalJoinBool(expression, joinContext, joinPlan.ResultType)
 		})
@@ -533,16 +530,19 @@ func (pc *PipelineCoordinator) planWorkflowJoinEffect(ctx context.Context, insta
 		}
 		if complete {
 			activation.Close(joinruntime.CloseReasonComplete, true, false)
-			kind = timeridentity.TimerHandleJoinComplete
-			completionHandle := timeridentity.JoinCompleteHandle(ref)
-			activation.FireAt = now
-			activation.TimerTaskID = completionHandle.TaskID()
-			activation.TimerEventType = joinCompleteEvent
+			completionHandle, handleErr := timeridentity.JoinCompleteHandle(ref)
+			if handleErr != nil {
+				return fmt.Errorf("arm join %s completion timer: %w", joinPlan.Spec.EffectiveID(), handleErr)
+			}
+			activation, err = activation.WithTimerHandle(completionHandle, now)
+			if err != nil {
+				return fmt.Errorf("arm join %s completion identity: %w", joinPlan.Spec.EffectiveID(), err)
+			}
 		}
 		if err := joinruntime.Store(carrier.StateBuckets, activation); err != nil {
 			return fmt.Errorf("persist join %s: %w", activation.Key(), err)
 		}
-		command, err := joinSchedule(pc.SemanticSource(), joinPlan.FlowID, entityID.String(), route, activation, kind, mode)
+		command, err := joinSchedule(pc.SemanticSource(), entityID.String(), route, activation, mode)
 		if err != nil {
 			return err
 		}

--- a/internal/runtime/pipeline/workflow_loop_supersession.go
+++ b/internal/runtime/pipeline/workflow_loop_supersession.go
@@ -34,10 +34,9 @@ func supersedePriorLoopGenerationArtifacts(instance *WorkflowInstance, previousB
 			return fmt.Errorf("list joins for loop supersession: %w", err)
 		}
 		for _, activation := range joins {
-			if !activation.Generation.Equal(priorGeneration) || !activation.CloseForStageExit() {
+			if !activation.Generation().Equal(priorGeneration) || !activation.CloseForStageExit() {
 				continue
 			}
-			activation.TimerCancelled = true
 			if err := joinruntime.Store(nextCarrier.StateBuckets, activation); err != nil {
 				return fmt.Errorf("supersede join %s: %w", activation.Key(), err)
 			}

--- a/internal/runtime/pipeline/workflow_nodes.go
+++ b/internal/runtime/pipeline/workflow_nodes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
-	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
 
@@ -144,6 +143,23 @@ func workflowNodeEventHandlerResolutionForDeliveryContext(ctx context.Context, s
 	if rawEventType == "" {
 		return workflowNodeEventHandlerResolution{}
 	}
+	if isJoinLifecycleEvent(evt.Type()) {
+		resolution, ok, err := resolveWorkflowJoinOccurrence(source, evt)
+		if err != nil {
+			return workflowNodeEventHandlerResolution{Failure: err.Error()}
+		}
+		if !ok || resolution.Ref.NodeID() != strings.TrimSpace(nodeID) {
+			return workflowNodeEventHandlerResolution{}
+		}
+		handlerFlowID := resolution.Ref.FlowID()
+		if handlerFlowID == "" {
+			handlerFlowID = semanticview.RootExecutionFlowID(source)
+		}
+		return workflowNodeEventHandlerResolution{
+			Handler: resolution.Handler, HandlerEventKey: resolution.Ref.HandlerEvent(),
+			FlowID: handlerFlowID, Matched: true,
+		}
+	}
 	route, deliveryRouted := workflowNodeDeliveryRoute(ctx)
 	if deliveryRouted && !route.ConnectClaim.Empty() {
 		handlerFlowID, handlerNodeID, handlerEvent, authorized := route.ConnectClaim.NodeHandlerOwner(nodeID)
@@ -246,11 +262,6 @@ func workflowNodeEventHandlerResolutionForEventType(source semanticview.Source, 
 }
 
 func workflowNodeHandlerEventKeyForExecution(ctx context.Context, source semanticview.Source, nodeID string, evt events.Event) string {
-	if isJoinLifecycleEvent(evt.Type()) {
-		if ref, _, ok := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); ok && ref.NodeID == strings.TrimSpace(nodeID) {
-			return ref.HandlerEvent
-		}
-	}
 	resolved := workflowNodeEventHandlerResolutionForDeliveryContext(ctx, source, nodeID, evt)
 	if resolved.Matched {
 		return resolved.HandlerEventKey
@@ -637,9 +648,11 @@ func (pc *PipelineCoordinator) workflowNodeInterceptPolicy(ctx context.Context, 
 			return false, true, err
 		}
 		if !ok && isJoinLifecycleEvent(events.EventType(eventType)) {
-			if ref, _, refOK := timeridentity.ParseJoinRef(parsePayloadMap(evt.Payload())); refOK && ref.NodeID == strings.TrimSpace(node.ID) {
+			if resolution, refOK, resolveErr := resolveWorkflowJoinOccurrence(source, evt); resolveErr != nil {
+				return false, true, resolveErr
+			} else if refOK && resolution.Ref.NodeID() == strings.TrimSpace(node.ID) {
 				if node.Policies != nil {
-					policy, ok = workflowNodePolicyForEventType(node.Policies, ref.HandlerEvent)
+					policy, ok = workflowNodePolicyForEventType(node.Policies, resolution.Ref.HandlerEvent())
 				}
 			}
 		}

--- a/internal/runtime/semanticview/scopes.go
+++ b/internal/runtime/semanticview/scopes.go
@@ -59,6 +59,25 @@ func FlowScopeByID(source Source, flowID string) (FlowScope, bool) {
 	return source.FlowScopeByID(flowID)
 }
 
+// RootExecutionFlowID returns the authored flow scope used to execute root
+// handlers. Durable declaration identities may still represent root as an
+// explicit empty FlowID.
+func RootExecutionFlowID(source Source) string {
+	if source == nil {
+		return ""
+	}
+	bundle, ok := Bundle(source)
+	if ok && bundle != nil && bundle.FlowTree.Root != nil {
+		root := bundle.FlowTree.Root
+		for _, candidate := range []string{root.Paths.ID, root.Paths.Flow, root.Path, root.Schema.Name} {
+			if candidate = strings.Trim(strings.TrimSpace(candidate), "/"); candidate != "" {
+				return candidate
+			}
+		}
+	}
+	return strings.TrimSpace(source.WorkflowName())
+}
+
 func flowModeFromView(view runtimecontracts.FlowContractView) string {
 	if mode := strings.TrimSpace(view.Schema.Mode); mode != "" {
 		return mode

--- a/internal/runtime/semanticview/workflow_joins.go
+++ b/internal/runtime/semanticview/workflow_joins.go
@@ -5,6 +5,7 @@ import (
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 )
 
 // effectiveWorkflowJoins lowers fan-in barrier seam identity into the join
@@ -61,21 +62,51 @@ func WorkflowJoinPlanForHandler(source Source, flowID, nodeID, handlerEvent stri
 	if source == nil {
 		return runtimecontracts.WorkflowJoinPlan{}, false
 	}
-	flowID, nodeID, handlerEvent = canonicalWorkflowJoinFlowID(source, flowID), strings.TrimSpace(nodeID), strings.TrimSpace(handlerEvent)
+	flowID, nodeID, handlerEvent = strings.TrimSpace(flowID), strings.TrimSpace(nodeID), strings.TrimSpace(handlerEvent)
 	for _, plan := range source.WorkflowJoins() {
-		if canonicalWorkflowJoinFlowID(source, plan.FlowID) == flowID && strings.TrimSpace(plan.NodeID) == nodeID && strings.TrimSpace(plan.HandlerEvent) == handlerEvent {
+		if strings.TrimSpace(plan.FlowID) == flowID && strings.TrimSpace(plan.NodeID) == nodeID && strings.TrimSpace(plan.HandlerEvent) == handlerEvent {
 			return plan, true
 		}
 	}
 	return runtimecontracts.WorkflowJoinPlan{}, false
 }
 
-func canonicalWorkflowJoinFlowID(source Source, flowID string) string {
-	flowID = strings.TrimSpace(flowID)
-	if flowID == "" && source != nil {
-		return strings.TrimSpace(source.WorkflowName())
+// WorkflowJoinPlanForExecutionHandler maps one exact authored handler scope to
+// its join declaration. Root declarations retain an explicit empty FlowID even
+// though their handlers execute in the authored root flow scope.
+func WorkflowJoinPlanForExecutionHandler(source Source, executionFlowID, nodeID, handlerEvent string, spec runtimecontracts.JoinSpec) (runtimecontracts.WorkflowJoinPlan, bool) {
+	if source == nil {
+		return runtimecontracts.WorkflowJoinPlan{}, false
 	}
-	return flowID
+	executionFlowID = strings.TrimSpace(executionFlowID)
+	nodeID = strings.TrimSpace(nodeID)
+	handlerEvent = strings.TrimSpace(handlerEvent)
+	if executionFlowID == "" || nodeID == "" || handlerEvent == "" {
+		return runtimecontracts.WorkflowJoinPlan{}, false
+	}
+	if _, _, ok := ResolveFlowNodeDeclaration(source, executionFlowID, nodeID); !ok {
+		return runtimecontracts.WorkflowJoinPlan{}, false
+	}
+	declarationFlowID := executionFlowID
+	if executionFlowID == RootExecutionFlowID(source) {
+		declarationFlowID = ""
+	}
+	plan, ok := WorkflowJoinPlanForHandler(source, declarationFlowID, nodeID, handlerEvent)
+	if !ok || strings.TrimSpace(plan.Spec.Stage) != strings.TrimSpace(spec.Stage) || plan.Spec.EffectiveID() != spec.EffectiveID() {
+		return runtimecontracts.WorkflowJoinPlan{}, false
+	}
+	return plan, true
+}
+
+func WorkflowJoinPlanForRef(source Source, ref timeridentity.JoinRef) (runtimecontracts.WorkflowJoinPlan, bool) {
+	if source == nil || !ref.Valid() {
+		return runtimecontracts.WorkflowJoinPlan{}, false
+	}
+	plan, ok := WorkflowJoinPlanForHandler(source, ref.FlowID(), ref.NodeID(), ref.HandlerEvent())
+	if !ok || strings.TrimSpace(plan.Spec.Stage) != ref.Stage() || plan.Spec.EffectiveID() != ref.JoinID() {
+		return runtimecontracts.WorkflowJoinPlan{}, false
+	}
+	return plan, true
 }
 
 func normalizedJoinDerivationValues(values []string) []string {

--- a/internal/runtime/semanticview/workflow_joins_test.go
+++ b/internal/runtime/semanticview/workflow_joins_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 )
@@ -37,6 +38,32 @@ func TestFanInBarrierContractDerivesEffectiveJoinPlan(t *testing.T) {
 	rawAfter := requireSingleJoinPlan(t, bundle.WorkflowJoins())
 	if rawAfter.Spec.Members.By != "" || rawAfter.Spec.Window == nil || rawAfter.Spec.Window.By != "" {
 		t.Fatalf("effective lowering mutated authored join: %#v", rawAfter.Spec)
+	}
+}
+
+func TestWorkflowJoinPlanForRefDistinguishesRootAndSameLeafFlowDeclarations(t *testing.T) {
+	spec := runtimecontracts.JoinSpec{ID: "awaiting", Stage: "awaiting"}
+	bundle := &runtimecontracts.WorkflowContractBundle{Semantics: runtimecontracts.WorkflowSemanticView{Joins: []runtimecontracts.WorkflowJoinPlan{
+		{FlowID: "", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec},
+		{FlowID: "orders", NodeID: "join-node", HandlerEvent: "item.completed", Spec: spec},
+	}}}
+	source := semanticview.Wrap(bundle)
+	for _, flowID := range []string{"", "orders"} {
+		ref, err := timeridentity.NewJoinRef(flowID, "join-node", "item.completed", "awaiting", "awaiting", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, ok := semanticview.WorkflowJoinPlanForRef(source, ref)
+		if !ok || plan.FlowID != flowID {
+			t.Fatalf("plan for flow %q = %#v, ok=%v", flowID, plan, ok)
+		}
+	}
+	hostile, err := timeridentity.NewJoinRef("unrelated", "join-node", "item.completed", "awaiting", "awaiting", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan, ok := semanticview.WorkflowJoinPlanForRef(source, hostile); ok {
+		t.Fatalf("unrelated same-leaf declaration resolved: %#v", plan)
 	}
 }
 

--- a/internal/store/internal/backend/genericschedule/owner.go
+++ b/internal/store/internal/backend/genericschedule/owner.go
@@ -32,7 +32,18 @@ const (
 	postgresDialect
 )
 
-type malformedActivationError struct{ cause error }
+type persistedScheduleFamily uint8
+
+const (
+	persistedScheduleFamilyUnclassified persistedScheduleFamily = iota
+	persistedScheduleFamilyNonJoin
+	persistedScheduleFamilyJoin
+)
+
+type malformedActivationError struct {
+	cause  error
+	family persistedScheduleFamily
+}
 
 func (e *malformedActivationError) Error() string { return e.cause.Error() }
 func (e *malformedActivationError) Unwrap() error { return e.cause }
@@ -41,6 +52,52 @@ func asMalformedActivation(err error) (*malformedActivationError, bool) {
 	var malformed *malformedActivationError
 	ok := errors.As(err, &malformed)
 	return malformed, ok
+}
+
+type malformedActivationDisposition uint8
+
+const (
+	malformedActivationReject malformedActivationDisposition = iota
+	malformedActivationTerminalize
+)
+
+func dispositionForMalformedActivation(malformed *malformedActivationError) malformedActivationDisposition {
+	if malformed != nil && malformed.family == persistedScheduleFamilyNonJoin {
+		return malformedActivationTerminalize
+	}
+	return malformedActivationReject
+}
+
+func classifyPersistedScheduleFamily(eventType string, payloadRaw any) persistedScheduleFamily {
+	switch strings.TrimSpace(eventType) {
+	case "platform.join_timeout", "platform.join_complete":
+		return persistedScheduleFamilyJoin
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(jsonBytes(payloadRaw), &payload); err != nil {
+		return persistedScheduleFamilyUnclassified
+	}
+	rawHandle, present := payload["timer_handle"]
+	if !present {
+		return persistedScheduleFamilyNonJoin
+	}
+	handle, ok := rawHandle.(map[string]any)
+	if !ok {
+		return persistedScheduleFamilyUnclassified
+	}
+	kind, ok := handle["kind"].(string)
+	if !ok {
+		return persistedScheduleFamilyUnclassified
+	}
+	switch timeridentity.TimerHandleKind(strings.TrimSpace(kind)) {
+	case timeridentity.TimerHandleJoinTimeout, timeridentity.TimerHandleJoinComplete:
+		return persistedScheduleFamilyJoin
+	case timeridentity.TimerHandleWorkflowTimer:
+		return persistedScheduleFamilyNonJoin
+	default:
+		return persistedScheduleFamilyUnclassified
+	}
 }
 
 type PostgresOwner struct {
@@ -286,8 +343,8 @@ func (o *PostgresOwner) listActive(ctx context.Context) ([]runtimegenericschedul
 	for _, id := range ids {
 		activation, found, loadErr := o.LoadGenericScheduleActivation(ctx, id)
 		if malformed, ok := asMalformedActivation(loadErr); ok {
-			if isJoinScheduleActivation(activation) {
-				return nil, fmt.Errorf("restore join generic schedule %s: %w", id, malformed)
+			if dispositionForMalformedActivation(malformed) == malformedActivationReject {
+				return nil, fmt.Errorf("restore malformed mandatory or unclassified generic schedule %s: %w", id, malformed)
 			}
 			if err := o.failMalformed(ctx, id, malformed); err != nil {
 				return nil, err
@@ -313,8 +370,8 @@ func (o *SQLiteOwner) listActive(ctx context.Context) ([]runtimegenericschedule.
 	for _, id := range ids {
 		activation, found, loadErr := o.LoadGenericScheduleActivation(ctx, id)
 		if malformed, ok := asMalformedActivation(loadErr); ok {
-			if isJoinScheduleActivation(activation) {
-				return nil, fmt.Errorf("restore join generic schedule %s: %w", id, malformed)
+			if dispositionForMalformedActivation(malformed) == malformedActivationReject {
+				return nil, fmt.Errorf("restore malformed mandatory or unclassified generic schedule %s: %w", id, malformed)
 			}
 			if err := o.failMalformed(ctx, id, malformed); err != nil {
 				return nil, err
@@ -329,19 +386,6 @@ func (o *SQLiteOwner) listActive(ctx context.Context) ([]runtimegenericschedule.
 		}
 	}
 	return result, nil
-}
-
-func isJoinScheduleActivation(activation runtimegenericschedule.Activation) bool {
-	switch strings.TrimSpace(activation.Command.EventType) {
-	case "platform.join_timeout", "platform.join_complete":
-		return true
-	}
-	payload, ok := activation.Command.Payload.Interface().(map[string]any)
-	if !ok {
-		return false
-	}
-	_, _, ok = timeridentity.ParseJoinHandle(payload)
-	return ok
 }
 
 func (o *PostgresOwner) failMalformed(ctx context.Context, activationID string, malformed error) error {
@@ -403,6 +447,9 @@ func PrepareOccurrenceTx(ctx context.Context, tx *sql.Tx, postgres bool, wakeup 
 	activation, found, err := loadByIDTx(ctx, tx, dialectFor(postgres), wakeup.ActivationID(), postgres)
 	if err != nil {
 		if malformed, ok := asMalformedActivation(err); ok {
+			if dispositionForMalformedActivation(malformed) == malformedActivationReject {
+				return runtimegenericschedule.PreparedOccurrence{}, fmt.Errorf("prepare malformed mandatory or unclassified generic schedule %s: %w", wakeup.ActivationID(), malformed)
+			}
 			if failErr := failMalformedByIDTx(ctx, tx, postgres, wakeup.ActivationID(), malformed, admittedAt); failErr != nil {
 				return runtimegenericschedule.PreparedOccurrence{}, failErr
 			}
@@ -702,9 +749,10 @@ func scanActivationRow(row rowScanner, _ dialect) (runtimegenericschedule.Activa
 	if err != nil {
 		return runtimegenericschedule.Activation{}, err
 	}
+	family := classifyPersistedScheduleFamily(eventType, payloadRaw)
 	activation.Command.ExecutionMode = executionmode.Mode(executionMode)
 	malformed := func(err error) (runtimegenericschedule.Activation, error) {
-		return activation, &malformedActivationError{cause: err}
+		return activation, &malformedActivationError{cause: err, family: family}
 	}
 	if immutableHash != immutableHashDuplicate {
 		return malformed(errors.New("generic schedule immutable hash projection is inconsistent"))

--- a/internal/store/internal/backend/genericschedule/owner.go
+++ b/internal/store/internal/backend/genericschedule/owner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
 	runtimerunlifecycle "github.com/division-sh/swarm/internal/runtime/runlifecycle"
@@ -285,6 +286,9 @@ func (o *PostgresOwner) listActive(ctx context.Context) ([]runtimegenericschedul
 	for _, id := range ids {
 		activation, found, loadErr := o.LoadGenericScheduleActivation(ctx, id)
 		if malformed, ok := asMalformedActivation(loadErr); ok {
+			if isJoinScheduleActivation(activation) {
+				return nil, fmt.Errorf("restore join generic schedule %s: %w", id, malformed)
+			}
 			if err := o.failMalformed(ctx, id, malformed); err != nil {
 				return nil, err
 			}
@@ -309,6 +313,9 @@ func (o *SQLiteOwner) listActive(ctx context.Context) ([]runtimegenericschedule.
 	for _, id := range ids {
 		activation, found, loadErr := o.LoadGenericScheduleActivation(ctx, id)
 		if malformed, ok := asMalformedActivation(loadErr); ok {
+			if isJoinScheduleActivation(activation) {
+				return nil, fmt.Errorf("restore join generic schedule %s: %w", id, malformed)
+			}
 			if err := o.failMalformed(ctx, id, malformed); err != nil {
 				return nil, err
 			}
@@ -322,6 +329,19 @@ func (o *SQLiteOwner) listActive(ctx context.Context) ([]runtimegenericschedule.
 		}
 	}
 	return result, nil
+}
+
+func isJoinScheduleActivation(activation runtimegenericschedule.Activation) bool {
+	switch strings.TrimSpace(activation.Command.EventType) {
+	case "platform.join_timeout", "platform.join_complete":
+		return true
+	}
+	payload, ok := activation.Command.Payload.Interface().(map[string]any)
+	if !ok {
+		return false
+	}
+	_, _, ok = timeridentity.ParseJoinHandle(payload)
+	return ok
 }
 
 func (o *PostgresOwner) failMalformed(ctx context.Context, activationID string, malformed error) error {

--- a/internal/store/internal/backend/runforkpersistence/run_fork_loop_generation.go
+++ b/internal/store/internal/backend/runforkpersistence/run_fork_loop_generation.go
@@ -53,7 +53,7 @@ func forkAttemptGenerationState(raw map[string]any, forkRunID, entityID string) 
 		return nil, err
 	}
 	for _, activation := range joins {
-		replacement, ok := replacements[activation.Generation.RevisionID]
+		replacement, ok := replacements[activation.Generation().RevisionID]
 		if !ok {
 			continue
 		}

--- a/internal/store/internal/runtimepersistence/generic_schedule_join_identity_test.go
+++ b/internal/store/internal/runtimepersistence/generic_schedule_join_identity_test.go
@@ -1,0 +1,434 @@
+package runtimepersistence
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	"github.com/division-sh/swarm/internal/runtime/core/attemptgeneration"
+	"github.com/division-sh/swarm/internal/runtime/core/timeridentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	"github.com/division-sh/swarm/internal/runtime/executionmode"
+	"github.com/division-sh/swarm/internal/runtime/executionposture"
+	runtimegenericschedule "github.com/division-sh/swarm/internal/runtime/genericschedule"
+	"github.com/google/uuid"
+)
+
+func TestSystemJoinScheduleAdmissionAndHydrationRejectDeclarationDriftOnBothStores(t *testing.T) {
+	for _, storeCase := range selectedScheduleStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, db, ctx := storeCase.open(t)
+			runID := runtimecorrelation.RunIDFromContext(ctx)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+			bases := map[string]runtimegenericschedule.AdmissionCommand{
+				"root": selectedStoreJoinScheduleCommand(t, runID, "", "", generation),
+				"flow": selectedStoreJoinScheduleCommand(t, runID, "orders", "orders/order-1", generation),
+			}
+			hostiles := selectedStoreJoinScheduleHostileCases(generation)
+
+			for _, hostile := range hostiles {
+				t.Run("admission_"+hostile.scope+"_"+hostile.name, func(t *testing.T) {
+					before := selectedStoreTimerCount(t, ctx, db)
+					command := bases[hostile.scope]
+					hostile.mutate(t, &command)
+					if _, err := store.AdmitGenericSchedule(ctx, command); err == nil {
+						t.Fatal("hostile join schedule reached persistence")
+					}
+					if after := selectedStoreTimerCount(t, ctx, db); after != before {
+						t.Fatalf("hostile admission mutated timers: before=%d after=%d", before, after)
+					}
+				})
+			}
+
+			admitted := make(map[string]runtimegenericschedule.Activation, len(bases))
+			for scope, command := range bases {
+				result, err := store.AdmitGenericSchedule(ctx, command)
+				if err != nil {
+					t.Fatalf("admit valid %s join schedule: %v", scope, err)
+				}
+				admitted[scope] = result.Activation
+			}
+
+			for _, hostile := range hostiles {
+				t.Run("hydration_"+hostile.scope+"_"+hostile.name, func(t *testing.T) {
+					command := bases[hostile.scope]
+					hostile.mutate(t, &command)
+					activationID := admitted[hostile.scope].ID
+					validSnapshot := selectedStoreTimerSnapshotForID(t, ctx, db, store, activationID)
+					err := writeSelectedStoreScheduleProjection(ctx, db, store, activationID, command)
+					if hostile.storageRejects {
+						if err == nil {
+							t.Fatal("selected-store schema accepted an impossible hostile projection")
+						}
+						if after := selectedStoreTimerSnapshotForID(t, ctx, db, store, activationID); validSnapshot != after {
+							t.Fatalf("rejected hostile storage write mutated timer row\nbefore=%#v\nafter=%#v", validSnapshot, after)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					before := selectedStoreTimerSnapshotForID(t, ctx, db, store, activationID)
+					if activation, found, err := store.LoadGenericScheduleActivation(ctx, activationID); err == nil || found {
+						t.Fatalf("hostile activation loaded: found=%v activation=%#v err=%v", found, activation, err)
+					}
+					after := selectedStoreTimerSnapshotForID(t, ctx, db, store, activationID)
+					if before != after {
+						t.Fatalf("failed hydration mutated timer row\nbefore=%#v\nafter=%#v", before, after)
+					}
+					if err := writeSelectedStoreScheduleProjection(ctx, db, store, activationID, bases[hostile.scope]); err != nil {
+						t.Fatal(err)
+					}
+					if restored, found, err := store.LoadGenericScheduleActivation(ctx, activationID); err != nil || !found || restored.ID != activationID {
+						t.Fatalf("restored valid activation = found:%v activation:%#v err:%v", found, restored, err)
+					}
+				})
+			}
+
+			poisoned := bases["root"]
+			selectedStoreMutateJoinPayload(t, &poisoned, func(payload, _, _ map[string]any) {
+				payload[generation.RevisionField] = "rev-hostile"
+			})
+			if err := writeSelectedStoreScheduleProjection(ctx, db, store, admitted["root"].ID, poisoned); err != nil {
+				t.Fatal(err)
+			}
+			beforeRestore := selectedStoreTimerSnapshotForID(t, ctx, db, store, admitted["root"].ID)
+
+			scheduler := &selectedStoreLifecycleScheduler{}
+			lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, &terminalSchedulePlannerProbe{}, &terminalScheduleDispatcherProbe{}, nil, executionposture.Live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = lifecycle.Stop(context.Background()) })
+			if restored, err := lifecycle.Restore(ctx); err == nil || restored != 0 {
+				t.Fatalf("poisoned restore = restored:%d err:%v", restored, err)
+			}
+			if len(scheduler.registered) != 0 {
+				t.Fatalf("poisoned restore partially registered wakeups: %#v", scheduler.registered)
+			}
+			if afterRestore := selectedStoreTimerSnapshotForID(t, ctx, db, store, admitted["root"].ID); beforeRestore != afterRestore {
+				t.Fatalf("failed restore mutated poisoned row\nbefore=%#v\nafter=%#v", beforeRestore, afterRestore)
+			}
+		})
+	}
+}
+
+type selectedStoreJoinScheduleHostileCase struct {
+	name           string
+	scope          string
+	storageRejects bool
+	mutate         func(testing.TB, *runtimegenericschedule.AdmissionCommand)
+}
+
+func selectedStoreJoinScheduleHostileCases(generation attemptgeneration.Generation) []selectedStoreJoinScheduleHostileCase {
+	payload := func(mutate func(map[string]any, map[string]any, map[string]any)) func(testing.TB, *runtimegenericschedule.AdmissionCommand) {
+		return func(t testing.TB, command *runtimegenericschedule.AdmissionCommand) {
+			selectedStoreMutateJoinPayload(t, command, mutate)
+		}
+	}
+	return []selectedStoreJoinScheduleHostileCase{
+		{name: "schedule_key", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.ScheduleKey += "-hostile" }},
+		{name: "task_id", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.TaskID += "-hostile" }},
+		{name: "event_kind", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.EventType = "platform.join_complete" }},
+		{name: "scalar_payload", scope: "root", mutate: func(t testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			var err error
+			c.Payload, err = canonicaljson.FromGo("hostile")
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "unrelated_event", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			c.EventType = "platform.test_timer_fired"
+		}},
+		{name: "owner_id", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.OwnerID = "runtime" }},
+		{name: "owner_kind", scope: "root", storageRejects: true, mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			c.OwnerKind = runtimegenericschedule.OwnerAgent
+		}},
+		{name: "run_missing", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.RunID = "" }},
+		{name: "entity", scope: "root", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.EntityID = uuid.NewString() }},
+		{name: "routing_kind", scope: "root", mutate: func(t testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			var err error
+			c.RoutingSource, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "orders", FlowInstance: "orders/order-1", EntityID: c.EntityID})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "flow_id_runtime_alias", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["flow_id"] = "workflow-runtime-name" })},
+		{name: "flow_id_missing", scope: "root", mutate: payload(func(_, _, join map[string]any) { delete(join, "flow_id") })},
+		{name: "node_id", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["node_id"] = "other-node" })},
+		{name: "handler_event", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["handler_event"] = "other.completed" })},
+		{name: "stage", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["stage"] = "other-stage" })},
+		{name: "join_id", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["join_id"] = "other-join" })},
+		{name: "window", scope: "root", mutate: payload(func(_, _, join map[string]any) { join["window"] = "other-window" })},
+		{name: "generation", scope: "root", mutate: payload(func(_, _, join map[string]any) {
+			join[attemptgeneration.PayloadKey].(map[string]any)["revision_id"] = "rev-hostile"
+		})},
+		{name: "duplicate_generation", scope: "root", mutate: payload(func(_, handle, join map[string]any) {
+			handle[attemptgeneration.PayloadKey] = join[attemptgeneration.PayloadKey]
+		})},
+		{name: "handle_kind", scope: "root", mutate: payload(func(_, handle, _ map[string]any) { handle["kind"] = "join_complete" })},
+		{name: "revision_pin", scope: "root", mutate: payload(func(payload, _, _ map[string]any) { payload[generation.RevisionField] = "rev-hostile" })},
+		{name: "revision_pin_missing", scope: "root", mutate: payload(func(payload, _, _ map[string]any) { delete(payload, generation.RevisionField) })},
+		{name: "flow_id_root_alias", scope: "flow", mutate: payload(func(_, _, join map[string]any) { join["flow_id"] = "" })},
+		{name: "flow_id_other", scope: "flow", mutate: payload(func(_, _, join map[string]any) { join["flow_id"] = "returns" })},
+		{name: "flow_instance", scope: "flow", mutate: func(_ testing.TB, c *runtimegenericschedule.AdmissionCommand) { c.FlowInstance = "orders/order-2" }},
+		{name: "routing_flow", scope: "flow", mutate: func(t testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			var err error
+			c.RoutingSource, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "returns", FlowInstance: c.FlowInstance, EntityID: c.EntityID})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "routing_instance", scope: "flow", mutate: func(t testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			var err error
+			c.RoutingSource, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "orders", FlowInstance: "orders/order-2", EntityID: c.EntityID})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "routing_entity", scope: "flow", mutate: func(t testing.TB, c *runtimegenericschedule.AdmissionCommand) {
+			var err error
+			c.RoutingSource, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: "orders", FlowInstance: c.FlowInstance, EntityID: uuid.NewString()})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+}
+
+func selectedStoreMutateJoinPayload(t testing.TB, command *runtimegenericschedule.AdmissionCommand, mutate func(map[string]any, map[string]any, map[string]any)) {
+	t.Helper()
+	payload := selectedStoreSchedulePayload(t, command)
+	handle, ok := payload["timer_handle"].(map[string]any)
+	if !ok {
+		t.Fatalf("join payload lacks timer_handle: %#v", payload)
+	}
+	join, ok := handle["join"].(map[string]any)
+	if !ok {
+		t.Fatalf("join payload lacks declaration: %#v", payload)
+	}
+	mutate(payload, handle, join)
+	value, err := canonicaljson.FromGo(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command.Payload = value
+}
+
+type selectedStoreTimerSnapshot [14]string
+
+func selectedStoreTimerSnapshotForID(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activationID string) selectedStoreTimerSnapshot {
+	t.Helper()
+	query := `SELECT schedule_key, COALESCE(CAST(run_id AS TEXT), ''), COALESCE(CAST(entity_id AS TEXT), ''),
+		COALESCE(flow_instance, ''), owner_kind, COALESCE(owner_agent, ''), fire_event,
+		CAST(fire_payload AS TEXT), CAST(routing_source AS TEXT), COALESCE(task_id, ''), immutable_hash,
+		status, COALESCE(cancel_cause, ''), COALESCE(CAST(occurrence_event_id AS TEXT), '')
+		FROM timers WHERE timer_id = ?`
+	if _, ok := store.(*PostgresStore); ok {
+		query = `SELECT schedule_key, COALESCE(CAST(run_id AS TEXT), ''), COALESCE(CAST(entity_id AS TEXT), ''),
+			COALESCE(flow_instance, ''), owner_kind, COALESCE(owner_agent, ''), fire_event,
+			CAST(fire_payload AS TEXT), CAST(routing_source AS TEXT), COALESCE(task_id, ''), immutable_hash,
+			status, COALESCE(cancel_cause, ''), COALESCE(CAST(occurrence_event_id AS TEXT), '')
+			FROM timers WHERE timer_id = $1::uuid`
+	}
+	var snapshot selectedStoreTimerSnapshot
+	dest := make([]any, len(snapshot))
+	for i := range snapshot {
+		dest[i] = &snapshot[i]
+	}
+	if err := db.QueryRowContext(ctx, query, activationID).Scan(dest...); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func writeSelectedStoreScheduleProjection(ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activationID string, command runtimegenericschedule.AdmissionCommand) error {
+	payload, err := canonicaljson.Encode(command.Payload)
+	if err != nil {
+		return err
+	}
+	routing, err := json.Marshal(command.RoutingSource)
+	if err != nil {
+		return err
+	}
+	args := []any{
+		command.ScheduleKey, command.RunID, command.EntityID, command.FlowInstance, command.OwnerKind,
+		command.OwnerID, command.EventType, string(payload), string(routing), command.TaskID, activationID,
+	}
+	query := `UPDATE timers SET schedule_key = ?, run_id = NULLIF(?, ''), entity_id = NULLIF(?, ''),
+		flow_instance = NULLIF(?, ''), owner_kind = ?, owner_agent = ?, fire_event = ?, fire_payload = ?,
+		routing_source = ?, task_id = NULLIF(?, '') WHERE timer_id = ?`
+	if _, ok := store.(*PostgresStore); ok {
+		query = `UPDATE timers SET schedule_key = $1, run_id = NULLIF($2, '')::uuid, entity_id = NULLIF($3, '')::uuid,
+			flow_instance = NULLIF($4, ''), owner_kind = $5, owner_agent = $6, fire_event = $7, fire_payload = $8::jsonb,
+			routing_source = $9::jsonb, task_id = NULLIF($10, '') WHERE timer_id = $11::uuid`
+	}
+	_, err = db.ExecContext(ctx, query, args...)
+	return err
+}
+
+func TestJoinScheduleRestoreRejectsPoisonedSameLeafIdentityWithoutRegisteringPartialState(t *testing.T) {
+	for _, storeCase := range selectedScheduleStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, db, ctx := storeCase.open(t)
+			runID := runtimecorrelation.RunIDFromContext(ctx)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+			root := selectedStoreJoinScheduleCommand(t, runID, "", "", generation)
+			flow := selectedStoreJoinScheduleCommand(t, runID, "orders", "orders/order-1", generation)
+			poison := selectedStoreJoinScheduleCommand(t, runID, "returns", "returns/order-1", generation)
+			rootResult, err := store.AdmitGenericSchedule(ctx, root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			flowResult, err := store.AdmitGenericSchedule(ctx, flow)
+			if err != nil {
+				t.Fatal(err)
+			}
+			poisonResult, err := store.AdmitGenericSchedule(ctx, poison)
+			if err != nil {
+				t.Fatal(err)
+			}
+			poisonedPayload := selectedStoreSchedulePayload(t, &poison)
+			poisonedPayload[generation.RevisionField] = "rev-hostile"
+			raw, err := json.Marshal(poisonedPayload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			update := `UPDATE timers SET fire_payload = ? WHERE timer_id = ?`
+			args := []any{string(raw), poisonResult.Activation.ID}
+			if _, ok := store.(*PostgresStore); ok {
+				update = `UPDATE timers SET fire_payload = $1::jsonb WHERE timer_id = $2::uuid`
+			}
+			if _, err := db.ExecContext(ctx, update, args...); err != nil {
+				t.Fatal(err)
+			}
+
+			scheduler := &selectedStoreLifecycleScheduler{}
+			lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, &terminalSchedulePlannerProbe{}, &terminalScheduleDispatcherProbe{}, nil, executionposture.Live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = lifecycle.Stop(context.Background()) })
+			if restored, err := lifecycle.Restore(ctx); err == nil || restored != 0 || len(scheduler.registered) != 0 {
+				t.Fatalf("mixed poisoned restore = restored:%d registered:%#v err:%v", restored, scheduler.registered, err)
+			}
+
+			deleteSQL := `DELETE FROM timers WHERE timer_id = ?`
+			if _, ok := store.(*PostgresStore); ok {
+				deleteSQL = `DELETE FROM timers WHERE timer_id = $1::uuid`
+			}
+			if _, err := db.ExecContext(ctx, deleteSQL, poisonResult.Activation.ID); err != nil {
+				t.Fatal(err)
+			}
+			if restored, err := lifecycle.Restore(ctx); err != nil || restored != 2 || len(scheduler.registered) != 2 {
+				t.Fatalf("clean restore = restored:%d registered:%#v err:%v", restored, scheduler.registered, err)
+			}
+			registered := map[string]bool{}
+			for _, wakeup := range scheduler.registered {
+				registered[wakeup.ActivationID()] = true
+			}
+			if !registered[rootResult.Activation.ID] || !registered[flowResult.Activation.ID] {
+				t.Fatalf("clean restore registered wrong identities: %#v", registered)
+			}
+		})
+	}
+}
+
+func TestJoinScheduleRestoreRejectsDriftedEventWithoutFailingTypedJoinRow(t *testing.T) {
+	for _, storeCase := range selectedScheduleStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, db, ctx := storeCase.open(t)
+			runID := runtimecorrelation.RunIDFromContext(ctx)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-2", Attempt: 2}
+			root := selectedStoreJoinScheduleCommand(t, runID, "", "", generation)
+			flow := selectedStoreJoinScheduleCommand(t, runID, "orders", "orders/order-1", generation)
+			if _, err := store.AdmitGenericSchedule(ctx, root); err != nil {
+				t.Fatal(err)
+			}
+			flowResult, err := store.AdmitGenericSchedule(ctx, flow)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			update := `UPDATE timers SET fire_event = ? WHERE timer_id = ?`
+			args := []any{"platform.test_timer_fired", flowResult.Activation.ID}
+			if _, ok := store.(*PostgresStore); ok {
+				update = `UPDATE timers SET fire_event = $1 WHERE timer_id = $2::uuid`
+			}
+			if _, err := db.ExecContext(ctx, update, args...); err != nil {
+				t.Fatal(err)
+			}
+			before := selectedStoreTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID)
+
+			scheduler := &selectedStoreLifecycleScheduler{}
+			lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, &terminalSchedulePlannerProbe{}, &terminalScheduleDispatcherProbe{}, nil, executionposture.Live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = lifecycle.Stop(context.Background()) })
+			if restored, err := lifecycle.Restore(ctx); err == nil || restored != 0 || len(scheduler.registered) != 0 {
+				t.Fatalf("event-drift restore = restored:%d registered:%#v err:%v", restored, scheduler.registered, err)
+			}
+			if after := selectedStoreTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID); before != after {
+				t.Fatalf("event-drift restore mutated typed join row\nbefore=%#v\nafter=%#v", before, after)
+			}
+		})
+	}
+}
+
+func selectedStoreJoinScheduleCommand(t *testing.T, runID, flowID, flowInstance string, generation attemptgeneration.Generation) runtimegenericschedule.AdmissionCommand {
+	t.Helper()
+	entityID := uuid.NewString()
+	ref, err := timeridentity.NewJoinRefForGeneration(flowID, "join-node", "item.completed", "awaiting", "shared", "window-1", generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := timeridentity.JoinTimeoutHandle(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := canonicaljson.FromGo(handle.PayloadMetadata())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var routing events.RoutingSource
+	if flowID == "" {
+		routing, err = events.NewRootRoutingSource(entityID)
+	} else {
+		routing, err = events.NewFlowOwnedControlRoutingSource(events.RouteIdentity{FlowID: flowID, FlowInstance: flowInstance, EntityID: entityID})
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runtimegenericschedule.AdmissionCommand{
+		ScheduleKey: handle.TaskID(), RunID: runID, EntityID: entityID, FlowInstance: flowInstance,
+		OwnerKind: runtimegenericschedule.OwnerSystem, OwnerID: "workflow-runtime", EventType: handle.EventType(), Payload: payload,
+		RoutingSource: routing, ExecutionMode: executionmode.Live, Due: runtimegenericschedule.AbsoluteDue(time.Now().UTC().Add(time.Hour)), TaskID: handle.TaskID(),
+	}
+}
+
+func selectedStoreSchedulePayload(t testing.TB, command *runtimegenericschedule.AdmissionCommand) map[string]any {
+	t.Helper()
+	raw, err := canonicaljson.Encode(command.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func selectedStoreTimerCount(t *testing.T, ctx context.Context, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM timers`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/internal/store/internal/runtimepersistence/generic_schedule_join_identity_test.go
+++ b/internal/store/internal/runtimepersistence/generic_schedule_join_identity_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -271,6 +273,215 @@ func writeSelectedStoreScheduleProjection(ctx context.Context, db *sql.DB, store
 	return err
 }
 
+func TestJoinScheduleRestoreRejectsEarlyHydrationFailuresWithoutMutationOnBothStores(t *testing.T) {
+	type earlyFailure struct {
+		name   string
+		mutate func(testing.TB, context.Context, *sql.DB, runtimegenericschedule.Store, runtimegenericschedule.Activation)
+	}
+	failures := []earlyFailure{
+		{
+			name: "semantic_payload_decode",
+			mutate: func(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activation runtimegenericschedule.Activation) {
+				selectedStoreUpdateTimer(t, ctx, db, store,
+					`UPDATE timers SET fire_payload = ? WHERE timer_id = ?`,
+					`UPDATE timers SET fire_payload = $1::jsonb WHERE timer_id = $2::uuid`,
+					`9007199254740992`, activation.ID,
+				)
+			},
+		},
+		{
+			name: "routing_source_decode",
+			mutate: func(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activation runtimegenericschedule.Activation) {
+				routing, err := json.Marshal(activation.Command.RoutingSource)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var hostile map[string]any
+				if err := json.Unmarshal(routing, &hostile); err != nil {
+					t.Fatal(err)
+				}
+				hostile["unexpected"] = true
+				routing, err = json.Marshal(hostile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				selectedStoreUpdateTimer(t, ctx, db, store,
+					`UPDATE timers SET routing_source = ? WHERE timer_id = ?`,
+					`UPDATE timers SET routing_source = $1::jsonb WHERE timer_id = $2::uuid`,
+					string(routing), activation.ID,
+				)
+			},
+		},
+		{
+			name: "due_basis_decode",
+			mutate: func(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activation runtimegenericschedule.Activation) {
+				selectedStoreUpdateTimer(t, ctx, db, store,
+					`UPDATE timers SET due_basis_kind = 'delay', due_basis_absolute = NULL, due_basis_duration = 'not-a-duration' WHERE timer_id = ?`,
+					`UPDATE timers SET due_basis_kind = 'delay', due_basis_absolute = NULL, due_basis_duration = 'not-a-duration' WHERE timer_id = $1::uuid`,
+					activation.ID,
+				)
+			},
+		},
+	}
+
+	for _, storeCase := range selectedScheduleStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, db, ctx := storeCase.open(t)
+			runID := runtimecorrelation.RunIDFromContext(ctx)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-early", Attempt: 2}
+			for _, failure := range failures {
+				t.Run(failure.name, func(t *testing.T) {
+					command := selectedStoreJoinScheduleCommand(t, runID, "orders", "orders/order-1", generation)
+					admitted, err := store.AdmitGenericSchedule(ctx, command)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() { selectedStoreDeleteTimer(t, ctx, db, store, admitted.Activation.ID) })
+					failure.mutate(t, ctx, db, store, admitted.Activation)
+					before := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, admitted.Activation.ID)
+
+					scheduler := &selectedStoreLifecycleScheduler{}
+					planner := &terminalSchedulePlannerProbe{}
+					dispatcher := &terminalScheduleDispatcherProbe{}
+					lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, planner, dispatcher, nil, executionposture.Live)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() { stopSelectedStoreScheduleLifecycle(t, lifecycle) })
+					if restored, err := lifecycle.Restore(ctx); err == nil || restored != 0 {
+						t.Fatalf("early malformed restore = restored:%d err:%v", restored, err)
+					}
+					if len(scheduler.registered) != 0 || len(scheduler.retired) != 0 || planner.prepareCalls != 0 || dispatcher.calls != 0 {
+						t.Fatalf("early malformed restore crossed a side-effect boundary: registered=%#v retired=%#v planned=%d dispatched=%d", scheduler.registered, scheduler.retired, planner.prepareCalls, dispatcher.calls)
+					}
+					if after := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, admitted.Activation.ID); before != after {
+						t.Fatalf("early malformed restore mutated timer row\nbefore=%s\nafter=%s", before, after)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestJoinSchedulePostRegistrationPrepareRejectsMalformedRowWithoutMutationOnBothStores(t *testing.T) {
+	for _, storeCase := range selectedScheduleStoreCases() {
+		t.Run(storeCase.name, func(t *testing.T) {
+			store, db, ctx := storeCase.open(t)
+			generation := attemptgeneration.Generation{LoopID: "revision", ActivationID: "activation", RevisionField: "revision_id", RevisionID: "rev-fire", Attempt: 2}
+			command := selectedStoreJoinScheduleCommand(t, runtimecorrelation.RunIDFromContext(ctx), "orders", "orders/order-1", generation)
+			scheduler := &selectedStoreLifecycleScheduler{}
+			planner := &terminalSchedulePlannerProbe{}
+			dispatcher := &terminalScheduleDispatcherProbe{}
+			lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, planner, dispatcher, nil, executionposture.Live)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stopped := false
+			t.Cleanup(func() {
+				if !stopped {
+					stopSelectedStoreScheduleLifecycle(t, lifecycle)
+				}
+			})
+			admitted, err := lifecycle.Admit(ctx, command)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(scheduler.registered) != 1 || scheduler.callback == nil {
+				t.Fatalf("join schedule registration = %#v callback=%v", scheduler.registered, scheduler.callback != nil)
+			}
+			wakeup := scheduler.registered[0]
+			selectedStoreUpdateTimer(t, ctx, db, store,
+				`UPDATE timers SET fire_payload = ? WHERE timer_id = ?`,
+				`UPDATE timers SET fire_payload = $1::jsonb WHERE timer_id = $2::uuid`,
+				`9007199254740992`, admitted.Activation.ID,
+			)
+			before := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, admitted.Activation.ID)
+
+			if prepared, err := store.PrepareGenericScheduleOccurrence(ctx, wakeup); err == nil || prepared.Outcome != "" {
+				t.Fatalf("prepare malformed registered join = %#v err:%v", prepared, err)
+			}
+			if after := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, admitted.Activation.ID); before != after {
+				t.Fatalf("direct prepare mutated malformed join row\nbefore=%s\nafter=%s", before, after)
+			}
+
+			scheduler.callback(ctx, wakeup)
+			stopSelectedStoreScheduleLifecycle(t, lifecycle)
+			stopped = true
+			if len(scheduler.retired) != 0 || planner.prepareCalls != 0 || dispatcher.calls != 0 {
+				t.Fatalf("malformed join fire crossed a side-effect boundary: retired=%#v planned=%d dispatched=%d", scheduler.retired, planner.prepareCalls, dispatcher.calls)
+			}
+			if after := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, admitted.Activation.ID); before != after {
+				t.Fatalf("lifecycle fire mutated malformed join row\nbefore=%s\nafter=%s", before, after)
+			}
+		})
+	}
+}
+
+func selectedStoreUpdateTimer(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, sqliteQuery, postgresQuery string, args ...any) {
+	t.Helper()
+	query := sqliteQuery
+	if _, ok := store.(*PostgresStore); ok {
+		query = postgresQuery
+	}
+	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		t.Fatalf("mutate selected-store timer: %v", err)
+	}
+}
+
+func selectedStoreDeleteTimer(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activationID string) {
+	t.Helper()
+	selectedStoreUpdateTimer(t, ctx, db, store,
+		`DELETE FROM timers WHERE timer_id = ?`,
+		`DELETE FROM timers WHERE timer_id = $1::uuid`,
+		activationID,
+	)
+}
+
+func selectedStoreFullTimerSnapshotForID(t testing.TB, ctx context.Context, db *sql.DB, store runtimegenericschedule.Store, activationID string) string {
+	t.Helper()
+	query := `SELECT * FROM timers WHERE timer_id = ?`
+	if _, ok := store.(*PostgresStore); ok {
+		query = `SELECT * FROM timers WHERE timer_id = $1::uuid`
+	}
+	rows, err := db.QueryContext(ctx, query, activationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rows.Next() {
+		t.Fatalf("timer %s is missing", activationID)
+	}
+	values := make([]any, len(columns))
+	destinations := make([]any, len(columns))
+	for index := range values {
+		destinations[index] = &values[index]
+	}
+	if err := rows.Scan(destinations...); err != nil {
+		t.Fatal(err)
+	}
+	parts := make([]string, len(columns))
+	for index, value := range values {
+		if raw, ok := value.([]byte); ok {
+			value = string(raw)
+		}
+		parts[index] = fmt.Sprintf("%s=%T:%v", columns[index], value, value)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func stopSelectedStoreScheduleLifecycle(t testing.TB, lifecycle *runtimegenericschedule.Lifecycle) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := lifecycle.Stop(ctx); err != nil {
+		t.Fatalf("stop selected-store generic schedule lifecycle: %v", err)
+	}
+}
+
 func TestJoinScheduleRestoreRejectsPoisonedSameLeafIdentityWithoutRegisteringPartialState(t *testing.T) {
 	for _, storeCase := range selectedScheduleStoreCases() {
 		t.Run(storeCase.name, func(t *testing.T) {
@@ -362,7 +573,7 @@ func TestJoinScheduleRestoreRejectsDriftedEventWithoutFailingTypedJoinRow(t *tes
 			if _, err := db.ExecContext(ctx, update, args...); err != nil {
 				t.Fatal(err)
 			}
-			before := selectedStoreTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID)
+			before := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID)
 
 			scheduler := &selectedStoreLifecycleScheduler{}
 			lifecycle, err := runtimegenericschedule.NewLifecycle(store, scheduler, &terminalSchedulePlannerProbe{}, &terminalScheduleDispatcherProbe{}, nil, executionposture.Live)
@@ -373,8 +584,8 @@ func TestJoinScheduleRestoreRejectsDriftedEventWithoutFailingTypedJoinRow(t *tes
 			if restored, err := lifecycle.Restore(ctx); err == nil || restored != 0 || len(scheduler.registered) != 0 {
 				t.Fatalf("event-drift restore = restored:%d registered:%#v err:%v", restored, scheduler.registered, err)
 			}
-			if after := selectedStoreTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID); before != after {
-				t.Fatalf("event-drift restore mutated typed join row\nbefore=%#v\nafter=%#v", before, after)
+			if after := selectedStoreFullTimerSnapshotForID(t, ctx, db, store, flowResult.Activation.ID); before != after {
+				t.Fatalf("event-drift restore mutated typed join row\nbefore=%s\nafter=%s", before, after)
 			}
 		})
 	}

--- a/internal/store/internal/runtimepersistence/run_fork_loop_generation_test.go
+++ b/internal/store/internal/runtimepersistence/run_fork_loop_generation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/loopruntime"
 )
 
-func TestForkAttemptGenerationRemintsActivationIdentity(t *testing.T) {
+func TestForkAttemptGenerationRemintsJoinHandleIdentity(t *testing.T) {
 	now := time.Date(2026, time.July, 11, 12, 0, 0, 0, time.UTC)
 	activation, err := loopruntime.New("source-run", "entity-1", "validation", "revision", "revision_id", "event-1", "drafting", 3, now)
 	if err != nil {
@@ -22,7 +22,15 @@ func TestForkAttemptGenerationRemintsActivationIdentity(t *testing.T) {
 	if err := loopruntime.Store(buckets, activation); err != nil {
 		t.Fatal(err)
 	}
-	join, err := joinruntime.NewActivation("review", "review", "review-node", "review.result", "", []string{"a"}, now, now.Add(time.Hour), "join-timeout", "platform.join_timeout", activation.Generation())
+	joinRef, err := timeridentity.NewJoinRefForGeneration("", "review-node", "review.result", "review", "review", "", activation.Generation())
+	if err != nil {
+		t.Fatal(err)
+	}
+	joinHandle, err := timeridentity.JoinTimeoutHandle(joinRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	join, err := joinruntime.NewActivation(joinHandle, []string{"a"}, now, now.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,8 +56,13 @@ func TestForkAttemptGenerationRemintsActivationIdentity(t *testing.T) {
 		t.Fatalf("forked activation = %#v, source %#v", forked, activation)
 	}
 	forkedJoins, err := joinruntime.List(forkedCarrier.StateBuckets)
-	if err != nil || len(forkedJoins) != 1 || !forkedJoins[0].Generation.Equal(forked.Generation()) || forkedJoins[0].Key() == join.Key() {
+	if err != nil || len(forkedJoins) != 1 || !forkedJoins[0].Generation().Equal(forked.Generation()) || forkedJoins[0].Key() == join.Key() {
 		t.Fatalf("forked joins = %#v err=%v", forkedJoins, err)
+	}
+	if !forkedJoins[0].JoinRef().Declaration().Equal(join.JoinRef().Declaration()) ||
+		forkedJoins[0].TimerTaskID() == join.TimerTaskID() ||
+		forkedJoins[0].TimerHandle().TaskID() != forkedJoins[0].TimerTaskID() {
+		t.Fatalf("fork remint left stale declaration/task facts: source=%#v fork=%#v", join.JoinRef(), forkedJoins[0].JoinRef())
 	}
 	forkedAccumulators, _ := forkedCarrier.StateBuckets["review-node"]["handler_accumulators"].(map[string]any)
 	if len(forkedAccumulators) != 1 {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5098,8 +5098,11 @@ engine:
     recovery: >-
       Restart, replay, and fork consume persisted members/window/close/timer facts. They do not re-read mutable entity
       membership, synthesize an arrival-owned activation, or resurrect a closed timeout. Hydration validates every active
-      join schedule before registering any wakeup; malformed same-leaf siblings leave the complete registration set
-      unchanged. Forking remints the complete typed handle for the destination route and rejects partial identity.
+      join schedule before registering any wakeup; malformed persisted rows retaining join-family evidence abort both
+      restoration and occurrence preparation without mutating the row or retiring its mandatory wakeup. Only a proven
+      non-join malformed generic schedule follows generic fail-loud terminalization. Malformed same-leaf siblings leave the
+      complete registration set unchanged. Forking remints the complete typed handle for the destination route and rejects
+      partial identity.
   runtime_store_backend_selection:
     promoted_by: '#1084'
     parent_tracker: '#1066'
@@ -7146,9 +7149,10 @@ engine:
         recurrence is forbidden: each recurring occurrence advances the durable coordinate and registers a new inert
         one-shot wakeup only after commit. Cron is UTC; @every advances from the prior persisted coordinate. Downtime catch-up
         processes every persisted coordinate in order and emits a typed depth warning rather than skipping work. Every
-        terminal preparation, including a concurrently missing row or fail-loud malformed row with no reloadable activation,
-        retires and releases the original exact wakeup. Retirement/release failure retries from that exact wakeup and never
-        reconstructs it from absent state.
+        terminal preparation, including a concurrently missing row or proven non-join fail-loud malformed row with no
+        reloadable activation, retires and releases the original exact wakeup. A malformed row retaining mandatory join-family
+        evidence, or whose family cannot be proven non-join, fails preparation without mutation or wakeup retirement.
+        Retirement/release failure retries from that exact wakeup and never reconstructs it from absent state.
       occurrence: >
         Occurrence event identity is deterministic from activation identity plus persisted due coordinate. The selected
         store stamps occurrence admission once and retries/restarts preserve event identity, admitted_at, and due_at exactly.

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -5048,9 +5048,13 @@ engine:
       surfaces do not reconstruct join semantics independently.
     persisted_activation:
       identity: >-
-        flow instance + stage + effective join ID + optional window. Node and handler event remain exact internal routing
-        identity for arrival and timer delivery, but may not narrow or replace the verified stage-scoped semantic identity.
+        One immutable typed declaration handle: explicit flow presence (present with the exact authored flow ID, or explicitly
+        absent for a root declaration), node, authored handler event, stage, effective join ID, optional window, and loop
+        generation. The selected execution route is a separate exact fact: root uses the selected run instance and flow-owned
+        declarations use the concrete flow instance. Runtime naming, source-event paths, descriptor rows, and singleton
+        fan-in cannot reconstruct or replace either fact.
       fields:
+      - exact typed declaration handle
       - ordered snapshotted members
       - per-member canonical output value and hash
       - open/closed status and close reason
@@ -5068,6 +5072,11 @@ engine:
     close: >-
       Completion, timeout, and stage exit persist one closed reason. Completion/timeout outcomes and timer cancellation share
       the selected-store transaction; in-memory scheduler registration/cancellation happens only after commit.
+    generation_ownership: >-
+      The declaration handle is the sole generation owner for join activation, schedule task identity, occurrence payload,
+      close, stage-exit cancellation, supersession, settlement, persistence, hydration, and fork reminting. Re-entry into the
+      same stage creates the next exact generation rather than treating the unchanged stage name as an already-armed join.
+      Replacement of one generation is atomic and cannot cancel or mutate a sibling declaration or the next generation.
     schedule_ownership: >-
       A join activation that creates its mandatory completion or timeout schedule must have at least one exact owner before
       the selected mutation can commit: either a durable generic schedule store or a process scheduler. If neither capability
@@ -5078,9 +5087,19 @@ engine:
       handler event, stage, join, window, generation, and timeout/completion kind. Generic schedule admission and restoration
       require the persisted task ID, workflow-runtime owner, fire event, and routing-source flow to agree exactly with that
       handle; durable scope fields or a valid routing-source shape alone never authorize a join timer.
+    occurrence_routing: >-
+      Generic schedule publication preserves the typed declaration handle unchanged. EventBus projects that handle directly
+      to exactly one authored node/handler and one selected execution target before durable delivery admission. The synthetic
+      platform.join_complete and platform.join_timeout names are occurrence kinds, never authored-handler aliases. Root
+      occurrences retain explicit root declaration absence while their durable target is the exact selected run; flow-owned
+      occurrences retain the exact authored flow and concrete instance. Delivery planning, claim, handler execution,
+      settlement, replay, and public readback consume the same projection and fail closed on any contradiction before state
+      mutation.
     recovery: >-
       Restart, replay, and fork consume persisted members/window/close/timer facts. They do not re-read mutable entity
-      membership, synthesize an arrival-owned activation, or resurrect a closed timeout.
+      membership, synthesize an arrival-owned activation, or resurrect a closed timeout. Hydration validates every active
+      join schedule before registering any wakeup; malformed same-leaf siblings leave the complete registration set
+      unchanged. Forking remints the complete typed handle for the destination route and rejects partial identity.
   runtime_store_backend_selection:
     promoted_by: '#1084'
     parent_tracker: '#1066'


### PR DESCRIPTION
## Summary

- Persist one immutable typed join declaration handle from arm through close, cancellation, restore, fire, replay, and fork remint.
- Make semantic lookup, boot verification, generic-schedule admission/hydration, EventBus join-occurrence delivery, pipeline execution, and engine settlement consume the exact declaration identity.
- Reject retired flat activation rows and every contradictory handle/task/event/source/owner/generation projection before mutation on SQLite and PostgreSQL.
- Add the complete root/flow lifecycle, restart/replay, race, hostile, same-leaf, and exotic topology matrix.

Closes #2236

## Governing Contract

Binding specification sections:

- `platform-spec.yaml#engine.join_engine.persisted_activation`
- `platform-spec.yaml#engine.join_engine.close`
- `platform-spec.yaml#engine.join_engine.generation_ownership`
- `platform-spec.yaml#engine.join_engine.schedule_ownership`
- `platform-spec.yaml#engine.join_engine.occurrence_routing`
- `platform-spec.yaml#engine.join_engine.recovery`

Binding gate records:

- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/2236#issuecomment-5288755238
- Proof-matrix amendment: https://github.com/division-sh/swarm/issues/2236#issuecomment-5288771036
- Gate A approval: https://github.com/division-sh/swarm/issues/2236#issuecomment-5288839629
- Gate A split/repair ruling: https://github.com/division-sh/swarm/issues/2236#issuecomment-5291052457

The specification is updated in this PR because the authoritative runtime ownership and persisted wire semantics change.

## Semantic Migration

New canonical owner: `timeridentity.JoinRef` inside one typed `timeridentity.TimerHandle`, persisted privately by `joinruntime.Activation`. `WorkflowJoinPlan` remains the authored declaration owner; the durable handle is its exact runtime projection.

Invalid old paths: flat activation identity/task/event fields, duplicate outer join generation, `WorkflowInstance.WorkflowName` reconstruction, caller-selected flow reconstruction in `joinSchedule`, task parsing as authority, FlowID-blind same-leaf resolution, and partial fork generation remint.

Production paths checked: semantic lowering and boot verification; arm and immediate completion; N>=2 close; stage exit and supersession; timeout/completion occurrence publication; EventBus planning, durable delivery, claim, retry, and settlement; strict SQLite/PostgreSQL admission and hydration; restart, replay, and fork remint; coordinator, declarative-node, and engine execution.

Migration is complete for the selected-store model. Retired rows are rejected; there is no compatibility reader, migration, fallback, dual write, or synthetic repair.

## Verification

- `go test ./internal/runtime/core/timeridentity ./internal/runtime/joinruntime ./internal/runtime/genericschedule ./internal/runtime/semanticview ./internal/runtime/bootverify ./internal/runtime/engine ./internal/runtime/core/pinrouting -count=3`
- `go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/pipeline ./internal/store/internal/runtimepersistence -run 'Test(.*WorkflowJoin.*|.*JoinSchedule.*|.*JoinLifecycle.*|ForkAttemptGenerationRemintsJoinHandleIdentity)' -count=3`
- `go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/pipeline ./internal/store/internal/runtimepersistence -run 'Test(.*WorkflowJoin.*|.*JoinSchedule.*|.*JoinLifecycle.*|ForkAttemptGenerationRemintsJoinHandleIdentity)' -race -count=3`
- `go run ./cmd/swarm-test-postgres -- go test ./internal/runtime/pipeline -count=1`
- `GOFLAGS='-p=1' go run ./cmd/swarm-test-postgres -- go test ./...`

The unchanged #2168 fixture proves both candidate arrivals, exact root join closure, exact timer cancellation, and no join mismatch/dead-letter/orphan through the approved checkpoint. Its later terminal mixed-subscriber routing failure is explicitly split to #2246 and is not changed here.
