### PR TITLE
[agent-f][issue #2258] Resolve mock modules from declaring packages

### DIFF
--- a/internal/cliapp/mock_module_package_parity_test.go
+++ b/internal/cliapp/mock_module_package_parity_test.go
@@ -1,0 +1,70 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyCommandLoadsPackageRelativeMockModuleStandaloneAndImported(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "bot")
+	writeVerifyMockPackageFile(t, filepath.Join(root, "package.yaml"), `name: outer
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - id: bot
+    path: bot
+flows: []
+`)
+	writeVerifyMockPackageFile(t, filepath.Join(root, "events.yaml"), "assistant.requested:\n  message: text\n")
+	writeVerifyMockPackageFile(t, filepath.Join(child, "package.yaml"), `name: bot
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows: []
+`)
+	writeVerifyMockPackageFile(t, filepath.Join(child, "agents.yaml"), `assistant:
+  id: assistant
+  role: helper
+  model: regular
+  intent: {inline: "Reply deterministically."}
+  subscriptions: [assistant.requested]
+  emit_events: [assistant.requested]
+  mock:
+    kind: python
+    module: mocks/assistant.py
+`)
+	writeVerifyMockPackageFile(t, filepath.Join(child, "events.yaml"), `assistant.requested:
+  message: text
+`)
+	writeVerifyMockPackageFile(t, filepath.Join(child, "mocks", "assistant.py"), "def handle(input):\n    return {'text': 'verified'}\n")
+	config := writeTestVerifyRuntimeConfig(t)
+	for _, contractsRoot := range []string{child, root} {
+		t.Run(filepath.Base(contractsRoot), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			code := executeRootCommand(context.Background(), RepoRoot(), []string{
+				"verify", "--contracts", contractsRoot, "--config", config,
+			}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("verify %s code=%d stdout=%s stderr=%s", contractsRoot, code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "verify ok: contracts="+contractsRoot) {
+				t.Fatalf("verify %s output missing success marker: %s", contractsRoot, stdout.String())
+			}
+		})
+	}
+}
+
+func writeVerifyMockPackageFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runtime/bootverify/mock_connector_credentials_test.go
+++ b/internal/runtime/bootverify/mock_connector_credentials_test.go
@@ -393,10 +393,10 @@ root-node:
 	} {
 		dir := filepath.Join(root, "packages", project.name)
 		writeBootverifyFixtureFile(t, filepath.Join(dir, "package.yaml"), "name: "+project.name+"\nversion: \"1.0.0\"\nflows: []\n")
-		module := filepath.ToSlash(filepath.Join("packages", project.name, "mocks", "shared-worker.py"))
+		module := "mocks/shared-worker.py"
 		writeScopedReachabilityAgentFile(t, filepath.Join(dir, "agents.yaml"), "shared-worker", module, project.live, scopedReachabilityNativeTools(includeInvalidNativeTools))
 		if !project.live {
-			writeBootverifyFixtureFile(t, filepath.Join(root, module), "def handle(input):\n    return {'text': 'mock'}\n")
+			writeBootverifyFixtureFile(t, filepath.Join(dir, filepath.FromSlash(module)), "def handle(input):\n    return {'text': 'mock'}\n")
 		}
 		writeBootverifyFixtureFile(t, filepath.Join(dir, "nodes.yaml"), scopedReachabilityNodeYAML())
 	}

--- a/internal/runtime/contracts/bundle_build.go
+++ b/internal/runtime/contracts/bundle_build.go
@@ -637,7 +637,7 @@ func bundleBuildRecursiveInputDirs(bundle *WorkflowContractBundle) ([]string, er
 		if dir == "" {
 			continue
 		}
-		abs, err := canonicalAbsDir(dir, "bundle recursive input")
+		abs, err := canonicalContractsRootInput(bundle.Paths.ContractsRoot, dir, "bundle recursive input", true)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runtime/contracts/bundle_build.go
+++ b/internal/runtime/contracts/bundle_build.go
@@ -375,7 +375,11 @@ func materializeBundleInputs(entries []bundleHashEntry, outputDir string) error 
 			return fmt.Errorf("read bundle build input %s: %w", rel, err)
 		}
 		if entry.ExpectedExact != nil && !bytes.Equal(raw, entry.ExpectedExact) {
-			return fmt.Errorf("read bundle build input %s: canonical input changed after exact agent intent resolution", rel)
+			owner := strings.TrimSpace(entry.ExactOwner)
+			if owner == "" {
+				owner = "exact artifact compilation"
+			}
+			return fmt.Errorf("read bundle build input %s: canonical input changed after %s", rel, owner)
 		}
 		if err := os.WriteFile(dst, raw, 0o644); err != nil {
 			return fmt.Errorf("write materialized input %s: %w", rel, err)

--- a/internal/runtime/contracts/bundle_build_test.go
+++ b/internal/runtime/contracts/bundle_build_test.go
@@ -389,6 +389,53 @@ func TestBuildBundleMaterializationMaterializesAgentMockModules(t *testing.T) {
 	}
 }
 
+func TestBuildBundleMaterializationUsesCanonicalImportedMockModulePaths(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root, _ := writeImportedAgentMockFixture(t, []string{"child"})
+	report, err := BuildBundleMaterialization(context.Background(), BundleBuildRequest{
+		RepoRoot:         repo,
+		ContractsRoot:    root,
+		PlatformSpecPath: DefaultPlatformSpecFile(repo),
+		OutputRoot:       filepath.Join(t.TempDir(), "build"),
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleMaterialization: %v", err)
+	}
+	wantSource := validAgentMockSource("child-project")
+	materialized, err := os.ReadFile(filepath.Join(report.OutputPath, "child", "mocks", "child-project.py"))
+	if err != nil {
+		t.Fatalf("materialized imported mock module missing: %v", err)
+	}
+	if string(materialized) != wantSource {
+		t.Fatalf("materialized imported mock module = %q, want %q", materialized, wantSource)
+	}
+	var manifest BundleBuildManifest
+	if err := json.Unmarshal([]byte(readBundleBuildFile(t, report.OutputPath, "build-manifest.json")), &manifest); err != nil {
+		t.Fatalf("decode build manifest: %v", err)
+	}
+	found := false
+	for _, input := range manifest.Inputs {
+		if input.Label == "bundle/child/mocks/child-project.py" {
+			found = true
+			if input.Policy != "raw_data" || input.SizeBytes != int64(len(wantSource)) {
+				t.Fatalf("imported mock build input = %#v", input)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("manifest inputs omit canonical imported mock label: %#v", manifest.Inputs)
+	}
+	reloaded, err := LoadWorkflowContractBundleWithOverrides(repo, report.OutputPath, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("reload materialized imported bundle: %v", err)
+	}
+	child, ok := reloaded.ProjectViewByKey("child")
+	if !ok {
+		t.Fatal("reloaded child project view missing")
+	}
+	assertAgentMockPerformance(t, child.Agents["project-agent"].Mock, "mocks/child-project.py", "child/mocks/child-project.py", wantSource)
+}
+
 func TestBuildBundleMaterializationChangesHashWhenMockBytesChange(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	root := writeMockedAgentContractsDir(t)

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -42,6 +42,7 @@ type bundleHashEntry struct {
 	Path          string
 	Policy        bundleHashContentPolicy
 	ExpectedExact []byte
+	ExactOwner    string
 }
 
 type canonicalJSONNumber float64
@@ -242,6 +243,7 @@ func (b *bundleHashEntryBuilder) addExactIntentFile(path string, expected []byte
 			}
 			b.entries[i].Policy = bundleHashIntent
 			b.entries[i].ExpectedExact = append([]byte(nil), expected...)
+			b.entries[i].ExactOwner = mergeBundleHashExactOwners(b.entries[i].ExactOwner, "exact agent intent resolution")
 			return nil
 		}
 		return fmt.Errorf("declared intent %s has no canonical input record", label)
@@ -250,6 +252,7 @@ func (b *bundleHashEntryBuilder) addExactIntentFile(path string, expected []byte
 		return err
 	}
 	b.entries[len(b.entries)-1].ExpectedExact = append([]byte(nil), expected...)
+	b.entries[len(b.entries)-1].ExactOwner = "exact agent intent resolution"
 	return nil
 }
 
@@ -290,16 +293,91 @@ func (b *bundleHashEntryBuilder) addAgentMockModuleFiles(bundle *WorkflowContrac
 		if !agent.Mock.Configured() {
 			continue
 		}
-		sourcePath := strings.TrimSpace(agent.Mock.SourcePath)
+		sourcePath := agent.Mock.SourcePath
 		if sourcePath == "" {
 			return fmt.Errorf("agent %s mock module is configured but has no source path", agentID)
 		}
+		canonicalSourcePath, pathErr := validateAgentMockModulePath(sourcePath)
+		if pathErr != nil {
+			return fmt.Errorf("agent %s mock module source path %q is not a canonical contracts-root-relative path: %w", agentID, sourcePath, pathErr)
+		}
+		if canonicalSourcePath != sourcePath {
+			return fmt.Errorf("agent %s mock module source path %q is not canonical; want %q", agentID, sourcePath, canonicalSourcePath)
+		}
+		if err := validateBundleHashLabel("bundle/" + sourcePath); err != nil {
+			return fmt.Errorf("agent %s mock module source path %q is not canonical: %w", agentID, sourcePath, err)
+		}
+		if clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(sourcePath))); clean != sourcePath {
+			return fmt.Errorf("agent %s mock module source path %q is not canonical; want %q", agentID, sourcePath, clean)
+		}
+		if len(agent.Mock.Source) == 0 {
+			return fmt.Errorf("agent %s mock module %s has no compiled source bytes", agentID, sourcePath)
+		}
+		sum := sha256.Sum256(agent.Mock.Source)
+		compiledDigest := "sha256:" + hex.EncodeToString(sum[:])
+		if strings.TrimSpace(agent.Mock.Digest) != compiledDigest {
+			return fmt.Errorf("agent %s mock module %s compiled digest %q does not match compiled source bytes %s", agentID, sourcePath, strings.TrimSpace(agent.Mock.Digest), compiledDigest)
+		}
 		path := filepath.Join(b.contractsRoot, filepath.FromSlash(sourcePath))
-		if err := b.addOptionalBundleFile(path, bundleHashRaw); err != nil {
+		canonicalRel, err := contractsRootRelativePath(b.contractsRoot, path)
+		if err != nil {
+			return fmt.Errorf("agent %s mock module: %w", agentID, err)
+		}
+		if canonicalRel != sourcePath {
+			return fmt.Errorf("agent %s mock module source path %q resolves as non-canonical %q", agentID, sourcePath, canonicalRel)
+		}
+		if err := b.addExactAgentMockModuleFile(path, agent.Mock.Source); err != nil {
 			return fmt.Errorf("agent %s mock module: %w", agentID, err)
 		}
 	}
 	return nil
+}
+
+func (b *bundleHashEntryBuilder) addExactAgentMockModuleFile(path string, expected []byte) error {
+	abs, err := canonicalRegularFile(path, "agent mock module input")
+	if err != nil {
+		return err
+	}
+	label, err := bundleHashBundleLabel(b.contractsRoot, abs)
+	if err != nil {
+		return err
+	}
+	if _, exists := b.seenPaths[abs]; exists {
+		for i := range b.entries {
+			if b.entries[i].Path != abs {
+				continue
+			}
+			if b.entries[i].Policy != bundleHashRaw {
+				return fmt.Errorf("compiled mock module %s overlaps canonical input %s with non-raw policy", label, b.entries[i].Label)
+			}
+			if b.entries[i].ExpectedExact != nil && !bytes.Equal(b.entries[i].ExpectedExact, expected) {
+				return fmt.Errorf("compiled mock module %s has conflicting exact content owners", label)
+			}
+			b.entries[i].ExpectedExact = append([]byte(nil), expected...)
+			b.entries[i].ExactOwner = mergeBundleHashExactOwners(b.entries[i].ExactOwner, "exact agent mock module compilation")
+			return nil
+		}
+		return fmt.Errorf("compiled mock module %s has no canonical input record", label)
+	}
+	if err := b.addEntry(abs, label, bundleHashRaw); err != nil {
+		return err
+	}
+	b.entries[len(b.entries)-1].ExpectedExact = append([]byte(nil), expected...)
+	b.entries[len(b.entries)-1].ExactOwner = "exact agent mock module compilation"
+	return nil
+}
+
+func mergeBundleHashExactOwners(existing, owner string) string {
+	existing = strings.TrimSpace(existing)
+	owner = strings.TrimSpace(owner)
+	switch {
+	case existing == "":
+		return owner
+	case owner == "" || existing == owner:
+		return existing
+	default:
+		return existing + " and " + owner
+	}
 }
 
 func (b *bundleHashEntryBuilder) addRequiredPlatformSpec(path string) error {
@@ -541,7 +619,11 @@ func canonicalBundleHashEntryContent(entry bundleHashEntry) ([]byte, error) {
 		return nil, err
 	}
 	if entry.ExpectedExact != nil && !bytes.Equal(content, entry.ExpectedExact) {
-		return nil, fmt.Errorf("canonical input changed after exact agent intent resolution")
+		owner := strings.TrimSpace(entry.ExactOwner)
+		if owner == "" {
+			owner = "exact artifact compilation"
+		}
+		return nil, fmt.Errorf("canonical input changed after %s", owner)
 	}
 	return content, nil
 }

--- a/internal/runtime/contracts/bundle_hash.go
+++ b/internal/runtime/contracts/bundle_hash.go
@@ -222,7 +222,7 @@ func (b *bundleHashEntryBuilder) addAgentIntentFiles(bundle *WorkflowContractBun
 }
 
 func (b *bundleHashEntryBuilder) addExactIntentFile(path string, expected []byte) error {
-	abs, err := canonicalRegularFile(path, "agent intent input")
+	abs, err := canonicalContractsRootInput(b.contractsRoot, path, "agent intent input", false)
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func (b *bundleHashEntryBuilder) addAgentMockModuleFiles(bundle *WorkflowContrac
 }
 
 func (b *bundleHashEntryBuilder) addExactAgentMockModuleFile(path string, expected []byte) error {
-	abs, err := canonicalRegularFile(path, "agent mock module input")
+	abs, err := canonicalContractsRootInput(b.contractsRoot, path, "agent mock module input", false)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func (b *bundleHashEntryBuilder) addRequiredPlatformSpec(path string) error {
 }
 
 func (b *bundleHashEntryBuilder) addRequiredBundleYAML(path string) error {
-	abs, err := canonicalRegularFile(path, "root package manifest")
+	abs, err := canonicalContractsRootInput(b.contractsRoot, path, "root package manifest", false)
 	if err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func (b *bundleHashEntryBuilder) addOptionalBundleFile(path string, policy bundl
 	if path == "" {
 		return nil
 	}
-	abs, err := canonicalRegularFile(path, "bundle input")
+	abs, err := canonicalContractsRootInput(b.contractsRoot, path, "bundle input", false)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func (b *bundleHashEntryBuilder) addRecursiveDir(dir string, policy bundleHashCo
 	if dir == "" {
 		return nil
 	}
-	absDir, err := canonicalAbsDir(dir, "bundle recursive input")
+	absDir, err := canonicalContractsRootInput(b.contractsRoot, dir, "bundle recursive input", true)
 	if err != nil {
 		return err
 	}
@@ -527,6 +527,36 @@ func canonicalAbsDir(path, label string) (string, error) {
 		return "", fmt.Errorf("%s %s is not a directory", label, abs)
 	}
 	return filepath.Clean(abs), nil
+}
+
+func canonicalContractsRootInput(root, path, label string, wantDir bool) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("%s path %q: %w", label, path, err)
+	}
+	abs = filepath.Clean(abs)
+	rel, err := pathRelativeToRoot(root, abs)
+	if err != nil {
+		return "", fmt.Errorf("%s %s: %w", label, abs, err)
+	}
+	info, err := lstatNoSymlinkPath(root, rel, abs)
+	if err != nil {
+		return "", fmt.Errorf("%s %s: %w", label, abs, err)
+	}
+	if wantDir {
+		if !info.IsDir() {
+			return "", fmt.Errorf("%s %s is not a directory", label, abs)
+		}
+		return abs, nil
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s %s is not a regular file", label, abs)
+	}
+	return abs, nil
 }
 
 func bundleHashBundleLabel(root, path string) (string, error) {

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -144,6 +144,26 @@ func TestBundleHashV1RejectsMockModuleMutationAfterCompilation(t *testing.T) {
 	}
 }
 
+func TestBundleHashV1RejectsMockModuleParentSymlinkAfterCompilation(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load mocked agent bundle: %v", err)
+	}
+	externalMocks := filepath.Join(t.TempDir(), "mocks")
+	writeBundleHashText(t, filepath.Join(externalMocks, "assistant.py"), mockAssistantSource)
+	if err := os.RemoveAll(filepath.Join(root, "mocks")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalMocks, filepath.Join(root, "mocks")); err != nil {
+		t.Skipf("symlink creation unsupported: %v", err)
+	}
+	if _, err := BundleHash(bundle); err == nil || !strings.Contains(err.Error(), "symlinks are not allowed") {
+		t.Fatalf("BundleHash error = %v, want intermediate symlink rejection", err)
+	}
+}
+
 func TestBundleHashV1RejectsCompiledMockDigestContradiction(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	root := writeMockedAgentContractsDir(t)
@@ -646,6 +666,35 @@ func TestBundleHashV1RejectsSymlinksWhenSupported(t *testing.T) {
 	}
 	if _, err := LoadWorkflowContractBundleWithOverrides(filepath.Dir(root), root, platform); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("BundleHash symlink error = %v, want symlink rejection", err)
+	}
+}
+
+func TestBundleHashV1RejectsExplicitInputThroughIntermediateSymlink(t *testing.T) {
+	root, platform := writeEquivalentBundleHashFixture(t, "\n", "name: explicit-symlink\nversion: \"1.0.0\"\nflows: []\n")
+	external := t.TempDir()
+	writeBundleHashText(t, filepath.Join(external, "events.yaml"), "events: {}\n")
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(external, link); err != nil {
+		t.Skipf("symlink creation unsupported: %v", err)
+	}
+	bundle := bundleHashTestBundle(root, platform)
+	bundle.Paths.ProjectEventsFile = filepath.Join(link, "events.yaml")
+	if _, err := BundleHash(bundle); err == nil || !strings.Contains(err.Error(), "symlinks are not allowed") {
+		t.Fatalf("BundleHash error = %v, want contracts-root intermediate symlink rejection", err)
+	}
+}
+
+func TestBundleHashV1RejectsRecursiveRootThroughIntermediateSymlink(t *testing.T) {
+	root, platform := writeEquivalentBundleHashFixture(t, "\n", "name: recursive-symlink\nversion: \"1.0.0\"\nflows:\n  - id: alpha\n    flow: alpha\n")
+	writeBundleHashText(t, filepath.Join(root, "flows", "alpha", "schema.yaml"), "name: alpha\n")
+	externalData := filepath.Join(t.TempDir(), "data")
+	writeBundleHashBytes(t, filepath.Join(externalData, "payload.bin"), []byte("outside"))
+	dataLink := filepath.Join(root, "flows", "alpha", "data")
+	if err := os.Symlink(externalData, dataLink); err != nil {
+		t.Skipf("symlink creation unsupported: %v", err)
+	}
+	if _, err := BundleHash(bundleHashTestBundle(root, platform)); err == nil || !strings.Contains(err.Error(), "symlinks are not allowed") {
+		t.Fatalf("BundleHash error = %v, want recursive-root intermediate symlink rejection", err)
 	}
 }
 

--- a/internal/runtime/contracts/bundle_hash_test.go
+++ b/internal/runtime/contracts/bundle_hash_test.go
@@ -131,6 +131,69 @@ func TestBundleHashV1IncludesAgentMockModuleBytes(t *testing.T) {
 	}
 }
 
+func TestBundleHashV1RejectsMockModuleMutationAfterCompilation(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load mocked agent bundle: %v", err)
+	}
+	writeBundleHashText(t, filepath.Join(root, "mocks", "assistant.py"), strings.Replace(mockAssistantSource, "hello from mock", "mutated behavior", 1))
+	if _, err := BundleHash(bundle); err == nil || !strings.Contains(err.Error(), "changed after exact agent mock module compilation") {
+		t.Fatalf("BundleHash error = %v, want compiled mock exact-byte rejection", err)
+	}
+}
+
+func TestBundleHashV1RejectsCompiledMockDigestContradiction(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeMockedAgentContractsDir(t)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load mocked agent bundle: %v", err)
+	}
+	view, ok := bundle.ProjectViewByKey(".")
+	if !ok {
+		t.Fatal("root project view missing")
+	}
+	entry := view.Agents["assistant"]
+	entry.Mock.Digest = "sha256:" + strings.Repeat("0", 64)
+	view.Agents["assistant"] = entry
+	bundle.projectContracts["."] = view
+	if _, err := BundleHash(bundle); err == nil || !strings.Contains(err.Error(), "does not match compiled source bytes") {
+		t.Fatalf("BundleHash error = %v, want compiled source/digest rejection", err)
+	}
+}
+
+func TestBundleHashV1RejectsNonCanonicalCompiledMockSourcePath(t *testing.T) {
+	tests := []string{
+		" mocks/assistant.py",
+		"C:/mocks/assistant.py",
+		"mocks\\assistant.py",
+		"mocks/../assistant.py",
+	}
+	for _, sourcePath := range tests {
+		t.Run(sourcePath, func(t *testing.T) {
+			repo := repoRootForContractsTest(t)
+			root := writeMockedAgentContractsDir(t)
+			bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+			if err != nil {
+				t.Fatalf("load mocked agent bundle: %v", err)
+			}
+			view, ok := bundle.ProjectViewByKey(".")
+			if !ok {
+				t.Fatal("root project view missing")
+			}
+			entry := view.Agents["assistant"]
+			entry.Mock.SourcePath = sourcePath
+			view.Agents["assistant"] = entry
+			bundle.projectContracts["."] = view
+			if _, err := BundleHash(bundle); err == nil || !strings.Contains(err.Error(), "not a canonical contracts-root-relative path") {
+				t.Fatalf("BundleHash error = %v, want non-canonical compiled source path rejection", err)
+			}
+		})
+	}
+}
+
 func TestBundleHashV1IncludesPolicyModuleBytes(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	root := t.TempDir()

--- a/internal/runtime/contracts/bundle_registration_upload.go
+++ b/internal/runtime/contracts/bundle_registration_upload.go
@@ -71,7 +71,11 @@ func BuildBundleRegistrationDirectoryUpload(repoRoot, contractsRoot, platformSpe
 			return BundleRegistrationUpload{}, fmt.Errorf("read %s: %w", rel, err)
 		}
 		if entry.ExpectedExact != nil && !bytes.Equal(raw, entry.ExpectedExact) {
-			return BundleRegistrationUpload{}, fmt.Errorf("read %s: canonical input changed after exact agent intent resolution", rel)
+			owner := strings.TrimSpace(entry.ExactOwner)
+			if owner == "" {
+				owner = "exact artifact compilation"
+			}
+			return BundleRegistrationUpload{}, fmt.Errorf("read %s: canonical input changed after %s", rel, owner)
 		}
 		switch entry.Policy {
 		case bundleHashRaw:

--- a/internal/runtime/contracts/bundle_registration_upload_test.go
+++ b/internal/runtime/contracts/bundle_registration_upload_test.go
@@ -178,6 +178,74 @@ func TestBuildBundleRegistrationDirectoryUploadCarriesDeclaredMockModules(t *tes
 	}
 }
 
+func TestImportedMockModuleRegistrationAndCatalogReloadUseCanonicalPaths(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root, _ := writeImportedAgentMockFixture(t, []string{"child"})
+	platform := DefaultPlatformSpecFile(repo)
+	upload, err := BuildBundleRegistrationDirectoryUpload(repo, root, platform)
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload: %v", err)
+	}
+	if upload.DataBlob == nil {
+		t.Fatal("DataBlob = nil, want imported mock module entries")
+	}
+	var paths []string
+	for _, entry := range upload.DataBlob.Entries {
+		paths = append(paths, entry.Path)
+	}
+	wantPaths := []string{
+		"child/mocks/child-flow.py",
+		"child/mocks/child-project.py",
+		"mocks/root-flow.py",
+		"mocks/root-project.py",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("imported mock data entries = %#v, want %#v", paths, wantPaths)
+	}
+	wantChildSource := validAgentMockSource("child-project")
+	if got := upload.DataBlob.Entries[1].DataBase64; got != base64.StdEncoding.EncodeToString([]byte(wantChildSource)) {
+		t.Fatalf("imported mock bytes = %q, want exact child source", got)
+	}
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, platform)
+	if err != nil {
+		t.Fatalf("load imported mock bundle: %v", err)
+	}
+	bundleHash, err := BundleHash(bundle)
+	if err != nil {
+		t.Fatalf("BundleHash: %v", err)
+	}
+	projection, err := BuildBundleCatalogProjectionWithOptions(bundle, BundleCatalogProjectionOptions{Source: "test"})
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection: %v", err)
+	}
+	source, err := LoadBundleCatalogRuntimeSource(repo, BundleCatalogRuntimeLoadRequest{
+		BundleHash:              bundleHash,
+		ContentYAML:             projection.ContentYAML,
+		DataBlob:                projection.DataBlob,
+		RunningPlatformSpecPath: platform,
+	})
+	if err != nil {
+		t.Fatalf("LoadBundleCatalogRuntimeSource: %v", err)
+	}
+	defer source.Cleanup()
+	reloadedHash, err := BundleHash(source.Bundle)
+	if err != nil {
+		t.Fatalf("reloaded BundleHash: %v", err)
+	}
+	if reloadedHash != bundleHash {
+		t.Fatalf("reloaded hash = %s, want %s", reloadedHash, bundleHash)
+	}
+	child, ok := source.Bundle.ProjectViewByKey("child")
+	if !ok {
+		t.Fatal("reloaded imported project view missing")
+	}
+	assertAgentMockPerformance(t, child.Agents["project-agent"].Mock, "mocks/child-project.py", "child/mocks/child-project.py", wantChildSource)
+	if raw, err := os.ReadFile(filepath.Join(source.ContractsRoot, "child", "mocks", "child-project.py")); err != nil || string(raw) != wantChildSource {
+		t.Fatalf("reconstructed imported module bytes = %q, err=%v", raw, err)
+	}
+}
+
 func TestBuildBundleRegistrationDirectoryUploadCarriesPolicyModules(t *testing.T) {
 	repo := repoRootForContractsTest(t)
 	root := writePolicyModuleContractsDir(t)

--- a/internal/runtime/contracts/mock_performance_loading.go
+++ b/internal/runtime/contracts/mock_performance_loading.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,21 +15,32 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/pythonmodule"
 )
 
-func materializeAgentMockPerformances(contractsRoot, sourceFile string, entries map[string]AgentRegistryEntry) (map[string]AgentRegistryEntry, error) {
+var windowsAbsoluteAgentMockModulePath = regexp.MustCompile(`^[A-Za-z]:`)
+
+type agentMockMaterializationSource struct {
+	ContractsRoot string
+	PackageRoot   string
+	Declaration   ContractItemSource
+}
+
+type resolvedAgentMockMaterializationSource struct {
+	contractsRoot  string
+	packageRoot    string
+	declaration    ContractItemSource
+	declarationRel string
+}
+
+func materializeAgentMockPerformances(source agentMockMaterializationSource, entries map[string]AgentRegistryEntry) (map[string]AgentRegistryEntry, error) {
 	if len(entries) == 0 {
 		return entries, nil
 	}
-	root, err := filepath.Abs(strings.TrimSpace(contractsRoot))
+	resolvedSource, err := resolveAgentMockMaterializationSource(source)
 	if err != nil {
-		return nil, fmt.Errorf("resolve contracts root for mock performances: %w", err)
-	}
-	root, err = filepath.EvalSymlinks(root)
-	if err != nil {
-		return nil, fmt.Errorf("resolve contracts root for mock performances: %w", err)
+		return nil, err
 	}
 	out := make(map[string]AgentRegistryEntry, len(entries))
 	for key, entry := range entries {
-		performance, err := materializeAgentMockPerformance(root, sourceFile, key, entry.Mock)
+		performance, err := materializeAgentMockPerformance(resolvedSource, key, entry.Mock)
 		if err != nil {
 			return nil, err
 		}
@@ -38,50 +50,139 @@ func materializeAgentMockPerformances(contractsRoot, sourceFile string, entries 
 	return out, nil
 }
 
-func materializeAgentMockPerformance(contractsRoot, sourceFile, agentID string, performance mockperformance.Performance) (mockperformance.Performance, error) {
+func resolveAgentMockMaterializationSource(source agentMockMaterializationSource) (resolvedAgentMockMaterializationSource, error) {
+	contractsRoot, err := canonicalAbsDir(source.ContractsRoot, "contracts root for agent mock performances")
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, err
+	}
+	packageKey, err := validateAgentMockPackageKey(source.Declaration.PackageKey)
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, err
+	}
+	packageRoot, err := filepath.Abs(strings.TrimSpace(source.PackageRoot))
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("resolve declaring package root for agent mock performances: %w", err)
+	}
+	packageRoot = filepath.Clean(packageRoot)
+	expectedPackageRoot := contractsRoot
+	if packageKey != "." {
+		expectedPackageRoot = filepath.Join(contractsRoot, filepath.FromSlash(packageKey))
+	}
+	if packageRoot != expectedPackageRoot {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf(
+			"agent mock declaration package %q root %q disagrees with contracts-root location %q",
+			packageKey,
+			packageRoot,
+			expectedPackageRoot,
+		)
+	}
+	if packageKey != "." {
+		info, statErr := lstatNoSymlinkPath(contractsRoot, filepath.FromSlash(packageKey), packageKey)
+		if statErr != nil {
+			return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaring package %q cannot be admitted: %w", packageKey, statErr)
+		}
+		if !info.IsDir() {
+			return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaring package %q root must be a directory", packageKey)
+		}
+	}
+	declarationFile := strings.TrimSpace(source.Declaration.File)
+	if declarationFile == "" {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock materialization requires the exact declaring agents.yaml source")
+	}
+	declarationFile, err = filepath.Abs(declarationFile)
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("resolve agent mock declaration source %q: %w", source.Declaration.File, err)
+	}
+	declarationFile = filepath.Clean(declarationFile)
+	declarationRel, err := pathRelativeToRoot(packageRoot, declarationFile)
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaration source %q is outside declaring package %q: %w", source.Declaration.File, packageKey, err)
+	}
+	declarationInfo, err := lstatNoSymlinkPath(packageRoot, declarationRel, source.Declaration.File)
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaration source %q cannot be admitted: %w", source.Declaration.File, err)
+	}
+	if !declarationInfo.Mode().IsRegular() {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaration source %q must be a regular file", source.Declaration.File)
+	}
+	outerDeclarationRel, err := pathRelativeToRoot(contractsRoot, declarationFile)
+	if err != nil {
+		return resolvedAgentMockMaterializationSource{}, fmt.Errorf("agent mock declaration source %q is outside contracts root: %w", source.Declaration.File, err)
+	}
+	resolvedDeclaration := source.Declaration
+	resolvedDeclaration.PackageKey = packageKey
+	resolvedDeclaration.File = declarationFile
+	return resolvedAgentMockMaterializationSource{
+		contractsRoot:  contractsRoot,
+		packageRoot:    packageRoot,
+		declaration:    resolvedDeclaration,
+		declarationRel: filepath.ToSlash(outerDeclarationRel),
+	}, nil
+}
+
+func validateAgentMockPackageKey(raw string) (string, error) {
+	key := strings.TrimSpace(raw)
+	if key == "." {
+		return key, nil
+	}
+	if key == "" {
+		return "", fmt.Errorf("agent mock declaration package key is required")
+	}
+	if strings.ContainsRune(key, '\x00') || strings.Contains(key, `\`) || filepath.IsAbs(key) || strings.HasPrefix(key, "/") || windowsAbsoluteAgentMockModulePath.MatchString(key) {
+		return "", fmt.Errorf("agent mock declaration package key %q is not a canonical contracts-root-relative path", raw)
+	}
+	segments := strings.Split(key, "/")
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", fmt.Errorf("agent mock declaration package key %q contains an empty, dot, or traversal segment", raw)
+		}
+	}
+	return strings.Join(segments, "/"), nil
+}
+
+func materializeAgentMockPerformance(source resolvedAgentMockMaterializationSource, agentID string, performance mockperformance.Performance) (mockperformance.Performance, error) {
 	if !performance.Configured() {
 		return mockperformance.Performance{}, nil
 	}
 	if strings.TrimSpace(performance.Kind) != mockperformance.KindPython {
 		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.kind %q is unsupported; use %q", agentID, performance.Kind, mockperformance.KindPython)
 	}
-	module := filepath.Clean(strings.TrimSpace(performance.Module))
-	if module == "." || filepath.IsAbs(module) || module == ".." || strings.HasPrefix(module, ".."+string(filepath.Separator)) {
-		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q must be a file below the contracts root", agentID, performance.Module)
+	module, err := validateAgentMockModulePath(performance.Module)
+	if err != nil {
+		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q: %w", agentID, performance.Module, err)
 	}
-	path := filepath.Join(contractsRoot, module)
-	info, err := os.Lstat(path)
+	path := filepath.Join(source.packageRoot, filepath.FromSlash(module))
+	info, err := lstatNoSymlinkPath(source.packageRoot, filepath.FromSlash(module), performance.Module)
 	if err != nil {
 		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q cannot be read: %w", agentID, performance.Module, err)
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q must not be a symlink", agentID, performance.Module)
-	}
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q cannot be resolved: %w", agentID, performance.Module, err)
-	}
-	if !pathWithinRoot(contractsRoot, resolved) {
-		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q resolves outside the contracts root", agentID, performance.Module)
-	}
-	resolvedInfo, err := os.Stat(resolved)
-	if err != nil || !resolvedInfo.Mode().IsRegular() {
+	if !info.Mode().IsRegular() {
 		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q must be a regular file", agentID, performance.Module)
 	}
-	source, err := os.ReadFile(resolved)
+	if info.Mode().Perm()&0o444 == 0 {
+		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q is not readable", agentID, performance.Module)
+	}
+	if _, err := pathRelativeToRoot(source.packageRoot, path); err != nil {
+		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q resolves outside declaring package %q: %w", agentID, performance.Module, source.declaration.PackageKey, err)
+	}
+	sourcePath, err := pathRelativeToRoot(source.contractsRoot, path)
+	if err != nil {
+		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q resolves outside the contracts root: %w", agentID, performance.Module, err)
+	}
+	moduleSource, err := os.ReadFile(path)
 	if err != nil {
 		return mockperformance.Performance{}, fmt.Errorf("agent %s mock.module %q cannot be read: %w", agentID, performance.Module, err)
 	}
-	sum := sha256.Sum256(source)
+	sum := sha256.Sum256(moduleSource)
 	digest := "sha256:" + hex.EncodeToString(sum[:])
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := pythonmodule.ValidateSource(ctx, pythonmodule.Request{
 		ModuleID:    "agent.mock." + strings.TrimSpace(agentID),
-		RowID:       strings.TrimSpace(sourceFile),
+		RowID:       source.declarationRel,
 		Digest:      digest,
 		Entry:       mockperformance.EntryHandle,
-		Source:      source,
+		Source:      moduleSource,
 		MemoryPages: mockperformance.ValidationMemoryPages,
 		OutputBytes: mockperformance.ValidationOutputBytes,
 	}); err != nil {
@@ -89,14 +190,35 @@ func materializeAgentMockPerformance(contractsRoot, sourceFile, agentID string, 
 	}
 	return mockperformance.Performance{
 		Kind:       mockperformance.KindPython,
-		Module:     filepath.ToSlash(module),
-		Source:     append([]byte(nil), source...),
+		Module:     module,
+		Source:     append([]byte(nil), moduleSource...),
 		Digest:     digest,
-		SourcePath: filepath.ToSlash(module),
+		SourcePath: filepath.ToSlash(sourcePath),
 	}, nil
 }
 
-func pathWithinRoot(root, candidate string) bool {
-	rel, err := filepath.Rel(root, candidate)
-	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+func validateAgentMockModulePath(raw string) (string, error) {
+	module := strings.TrimSpace(raw)
+	if module == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if module != raw {
+		return "", fmt.Errorf("path must not contain leading or trailing whitespace")
+	}
+	if strings.ContainsRune(module, '\x00') {
+		return "", fmt.Errorf("path contains a NUL byte")
+	}
+	if strings.Contains(module, `\`) {
+		return "", fmt.Errorf("path must use forward separators and cannot use backslashes")
+	}
+	if filepath.IsAbs(module) || strings.HasPrefix(module, "/") || windowsAbsoluteAgentMockModulePath.MatchString(module) {
+		return "", fmt.Errorf("path must be relative and canonical")
+	}
+	segments := strings.Split(module, "/")
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", fmt.Errorf("path contains an empty, dot, or traversal segment")
+		}
+	}
+	return strings.Join(segments, "/"), nil
 }

--- a/internal/runtime/contracts/mock_performance_loading_test.go
+++ b/internal/runtime/contracts/mock_performance_loading_test.go
@@ -1,8 +1,10 @@
 package contracts
 
 import (
+	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -12,21 +14,17 @@ import (
 func TestMaterializeAgentMockPerformancesCapturesExactGenerationBytes(t *testing.T) {
 	root := t.TempDir()
 	module := filepath.Join(root, "mocks", "assistant.py")
-	if err := os.MkdirAll(filepath.Dir(module), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentMockTestFile(t, filepath.Join(root, "agents.yaml"), "assistant: {}\n")
 	original := []byte("def handle(input):\n    return {'text': 'first'}\n")
-	if err := os.WriteFile(module, original, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	entries, err := materializeAgentMockPerformances(root, filepath.Join(root, "agents.yaml"), map[string]AgentRegistryEntry{
+	writeAgentMockTestFile(t, module, string(original))
+	entries, err := materializeAgentMockPerformances(agentMockTestSource(root, root, ".", filepath.Join(root, "agents.yaml")), map[string]AgentRegistryEntry{
 		"assistant": {Mock: mockperformance.Performance{Kind: "python", Module: "mocks/assistant.py"}},
 	})
 	if err != nil {
 		t.Fatalf("materialize mock performance: %v", err)
 	}
 	performance := entries["assistant"].Mock
-	if string(performance.Source) != string(original) || !strings.HasPrefix(performance.Digest, "sha256:") || performance.SourcePath != "mocks/assistant.py" {
+	if performance.Module != "mocks/assistant.py" || string(performance.Source) != string(original) || !strings.HasPrefix(performance.Digest, "sha256:") || performance.SourcePath != "mocks/assistant.py" {
 		t.Fatalf("materialized performance = %#v", performance)
 	}
 	if err := os.WriteFile(module, []byte("def handle(input):\n    return {'text': 'second'}\n"), 0o600); err != nil {
@@ -37,26 +35,278 @@ func TestMaterializeAgentMockPerformancesCapturesExactGenerationBytes(t *testing
 	}
 }
 
-func TestMaterializeAgentMockPerformancesRejectsOutsideAndInvalidModules(t *testing.T) {
-	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "outside.py")
-	if err := os.WriteFile(outside, []byte("def handle(input): return {'text': 'bad'}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for name, tc := range map[string]struct {
+func TestMaterializeAgentMockPerformancesRejectsHostileModulePaths(t *testing.T) {
+	tests := []struct {
+		name   string
 		module string
+		setup  func(*testing.T, string)
 		want   string
 	}{
-		"traversal": {module: "../outside.py", want: "below the contracts root"},
-		"missing":   {module: "mocks/missing.py", want: "cannot be read"},
-	} {
-		t.Run(name, func(t *testing.T) {
-			_, err := materializeAgentMockPerformances(root, "agents.yaml", map[string]AgentRegistryEntry{
+		{name: "blank", module: "   ", want: "path is required"},
+		{name: "leading whitespace", module: " mocks/assistant.py", want: "whitespace"},
+		{name: "trailing whitespace", module: "mocks/assistant.py ", want: "whitespace"},
+		{name: "dot", module: ".", want: "dot"},
+		{name: "dot segment", module: "mocks/./assistant.py", want: "dot"},
+		{name: "traversal outside package inside root", module: "../sibling/outside.py", setup: func(t *testing.T, root string) {
+			writeAgentMockTestFile(t, filepath.Join(root, "sibling", "outside.py"), validAgentMockSource("outside"))
+		}, want: "traversal"},
+		{name: "empty segment", module: "mocks//assistant.py", want: "empty"},
+		{name: "absolute posix", module: "/tmp/assistant.py", want: "relative"},
+		{name: "absolute windows slash", module: "C:/mocks/assistant.py", want: "relative"},
+		{name: "absolute windows backslash", module: `C:\mocks\assistant.py`, want: "backslashes"},
+		{name: "unc", module: `\\server\share\assistant.py`, want: "backslashes"},
+		{name: "nul", module: "mocks/assistant\x00.py", want: "NUL"},
+		{name: "missing", module: "mocks/missing.py", want: "cannot be read"},
+		{name: "directory", module: "mocks", setup: func(t *testing.T, root string) {
+			if err := os.MkdirAll(filepath.Join(root, "child", "mocks"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "regular file"},
+		{name: "unreadable", module: "mocks/unreadable.py", setup: func(t *testing.T, root string) {
+			path := filepath.Join(root, "child", "mocks", "unreadable.py")
+			writeAgentMockTestFile(t, path, validAgentMockSource("unreadable"))
+			if err := os.Chmod(path, 0); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+		}, want: "not readable"},
+		{name: "final symlink", module: "mocks/link.py", setup: func(t *testing.T, root string) {
+			target := filepath.Join(root, "child", "mocks", "target.py")
+			writeAgentMockTestFile(t, target, validAgentMockSource("target"))
+			if err := os.Symlink(target, filepath.Join(root, "child", "mocks", "link.py")); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+		}, want: "symlinks"},
+		{name: "intermediate symlink", module: "linked/assistant.py", setup: func(t *testing.T, root string) {
+			targetDir := filepath.Join(root, "child", "actual")
+			writeAgentMockTestFile(t, filepath.Join(targetDir, "assistant.py"), validAgentMockSource("target"))
+			if err := os.Symlink(targetDir, filepath.Join(root, "child", "linked")); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+		}, want: "symlinks"},
+		{name: "non regular socket", module: "mocks/socket.py", setup: func(t *testing.T, root string) {
+			path := filepath.Join(root, "child", "mocks", "socket.py")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			listener, err := net.Listen("unix", path)
+			if err != nil {
+				t.Skipf("unix socket unavailable: %v", err)
+			}
+			t.Cleanup(func() { _ = listener.Close() })
+		}, want: "regular file"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			packageRoot := filepath.Join(root, "child")
+			declaration := filepath.Join(packageRoot, "agents.yaml")
+			writeAgentMockTestFile(t, declaration, "assistant: {}\n")
+			if tc.setup != nil {
+				tc.setup(t, root)
+			}
+			_, err := materializeAgentMockPerformances(agentMockTestSource(root, packageRoot, "child", declaration), map[string]AgentRegistryEntry{
 				"assistant": {Mock: mockperformance.Performance{Kind: "python", Module: tc.module}},
 			})
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestMaterializeAgentMockPerformancesRejectsDeclarationProvenanceContradictions(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	declaration := filepath.Join(child, "agents.yaml")
+	writeAgentMockTestFile(t, declaration, "assistant: {}\n")
+	writeAgentMockTestFile(t, filepath.Join(child, "mocks", "assistant.py"), validAgentMockSource("child"))
+	writeAgentMockTestFile(t, filepath.Join(root, "agents.yaml"), "assistant: {}\n")
+
+	tests := []struct {
+		name   string
+		source agentMockMaterializationSource
+		want   string
+	}{
+		{name: "missing package key", source: agentMockTestSource(root, child, "", declaration), want: "package key is required"},
+		{name: "package root disagrees", source: agentMockTestSource(root, root, "child", declaration), want: "disagrees"},
+		{name: "declaration outside package", source: agentMockTestSource(root, child, "child", filepath.Join(root, "agents.yaml")), want: "outside declaring package"},
+		{name: "package traversal", source: agentMockTestSource(root, child, "../child", declaration), want: "traversal"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := materializeAgentMockPerformances(tc.source, map[string]AgentRegistryEntry{
+				"assistant": {Mock: mockperformance.Performance{Kind: "python", Module: "mocks/assistant.py"}},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadWorkflowContractBundleResolvesMockModulesFromExactDeclaringPackages(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root, child := writeImportedAgentMockFixture(t, []string{"child"})
+	platform := DefaultPlatformSpecFile(repo)
+
+	standalone, err := LoadWorkflowContractBundleWithOverrides(repo, child, platform)
+	if err != nil {
+		t.Fatalf("load standalone child: %v", err)
+	}
+	imported, err := LoadWorkflowContractBundleWithOverrides(repo, root, platform)
+	if err != nil {
+		t.Fatalf("load imported child: %v", err)
+	}
+
+	rootProject, ok := imported.ProjectViewByKey(".")
+	if !ok {
+		t.Fatal("root project view missing")
+	}
+	assertAgentMockPerformance(t, rootProject.Agents["project-agent"].Mock, "mocks/root-project.py", "mocks/root-project.py", validAgentMockSource("root-project"))
+	rootFlow, ok := imported.FlowViewByID("root-flow")
+	if !ok {
+		t.Fatal("root flow view missing")
+	}
+	assertAgentMockPerformance(t, rootFlow.Agents["flow-agent"].Mock, "mocks/root-flow.py", "mocks/root-flow.py", validAgentMockSource("root-flow"))
+
+	standaloneProject, ok := standalone.ProjectViewByKey(".")
+	if !ok {
+		t.Fatal("standalone project view missing")
+	}
+	importedProject, ok := imported.ProjectViewByKey("child")
+	if !ok {
+		t.Fatal("imported project view missing")
+	}
+	standaloneProjectMock := standaloneProject.Agents["project-agent"].Mock
+	importedProjectMock := importedProject.Agents["project-agent"].Mock
+	assertAgentMockPerformance(t, standaloneProjectMock, "mocks/child-project.py", "mocks/child-project.py", validAgentMockSource("child-project"))
+	assertAgentMockPerformance(t, importedProjectMock, "mocks/child-project.py", "child/mocks/child-project.py", validAgentMockSource("child-project"))
+	if standaloneProjectMock.Digest != importedProjectMock.Digest || !reflect.DeepEqual(standaloneProjectMock.Source, importedProjectMock.Source) {
+		t.Fatalf("standalone/imported project artifacts differ: standalone=%#v imported=%#v", standaloneProjectMock, importedProjectMock)
+	}
+
+	standaloneFlow, ok := standalone.FlowViewByID("child-flow")
+	if !ok {
+		t.Fatal("standalone child flow missing")
+	}
+	importedFlow, ok := imported.FlowViewByID("child-flow")
+	if !ok {
+		t.Fatal("imported child flow missing")
+	}
+	standaloneFlowMock := standaloneFlow.Agents["flow-agent"].Mock
+	importedFlowMock := importedFlow.Agents["flow-agent"].Mock
+	assertAgentMockPerformance(t, standaloneFlowMock, "mocks/child-flow.py", "mocks/child-flow.py", validAgentMockSource("child-flow"))
+	assertAgentMockPerformance(t, importedFlowMock, "mocks/child-flow.py", "child/mocks/child-flow.py", validAgentMockSource("child-flow"))
+	if standaloneFlowMock.Digest != importedFlowMock.Digest || !reflect.DeepEqual(standaloneFlowMock.Source, importedFlowMock.Source) {
+		t.Fatalf("standalone/imported flow artifacts differ: standalone=%#v imported=%#v", standaloneFlowMock, importedFlowMock)
+	}
+}
+
+func TestLoadWorkflowContractBundleMockModuleOwnershipIsPackageOrderIndependent(t *testing.T) {
+	for _, order := range [][]string{{"left", "right"}, {"right", "left"}} {
+		t.Run(strings.Join(order, "-then-"), func(t *testing.T) {
+			repo := repoRootForContractsTest(t)
+			root, _ := writeImportedAgentMockFixture(t, order)
+			bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+			if err != nil {
+				t.Fatalf("load package order %v: %v", order, err)
+			}
+			for _, packageKey := range order {
+				view, ok := bundle.ProjectViewByKey(packageKey)
+				if !ok {
+					t.Fatalf("project package %q missing", packageKey)
+				}
+				assertAgentMockPerformance(t, view.Agents["project-agent"].Mock, "mocks/child-project.py", packageKey+"/mocks/child-project.py", validAgentMockSource(packageKey+"-project"))
+			}
+		})
+	}
+}
+
+func agentMockTestSource(contractsRoot, packageRoot, packageKey, declarationFile string) agentMockMaterializationSource {
+	return agentMockMaterializationSource{
+		ContractsRoot: contractsRoot,
+		PackageRoot:   packageRoot,
+		Declaration:   ContractItemSource{PackageKey: packageKey, Layer: "project", File: declarationFile},
+	}
+}
+
+func assertAgentMockPerformance(t *testing.T, got mockperformance.Performance, module, sourcePath, source string) {
+	t.Helper()
+	if got.Module != module || got.SourcePath != sourcePath || string(got.Source) != source || !strings.HasPrefix(got.Digest, "sha256:") {
+		t.Fatalf("mock performance = %#v, want module=%q source_path=%q source=%q", got, module, sourcePath, source)
+	}
+}
+
+func validAgentMockSource(text string) string {
+	return "def handle(input):\n    return {'text': '" + text + "'}\n"
+}
+
+func writeImportedAgentMockFixture(t *testing.T, childOrder []string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	var packages strings.Builder
+	if len(childOrder) > 0 {
+		packages.WriteString("packages:\n")
+		for _, child := range childOrder {
+			packages.WriteString("  - id: " + child + "\n    path: " + child + "\n")
+		}
+	}
+	writeAgentMockTestFile(t, filepath.Join(root, "package.yaml"), `name: outer
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+`+packages.String()+`flows:
+  - id: root-flow
+    flow: root-flow
+    mode: static
+`)
+	writeAgentMockTestFile(t, filepath.Join(root, "agents.yaml"), agentMockRegistryYAML("project-agent", "root-project.py", "Root project intent."))
+	writeAgentMockTestFile(t, filepath.Join(root, "mocks", "root-project.py"), validAgentMockSource("root-project"))
+	writeAgentMockTestFile(t, filepath.Join(root, "mocks", "root-flow.py"), validAgentMockSource("root-flow"))
+	writeAgentMockTestFile(t, filepath.Join(root, "flows", "root-flow", "schema.yaml"), "name: root-flow\nmode: static\n")
+	writeAgentMockTestFile(t, filepath.Join(root, "flows", "root-flow", "agents.yaml"), agentMockRegistryYAML("flow-agent", "root-flow.py", "Root flow intent."))
+
+	for _, child := range childOrder {
+		childRoot := filepath.Join(root, child)
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "package.yaml"), `name: `+child+`
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: `+child+`-flow
+    flow: child-flow
+    mode: static
+`)
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "agents.yaml"), agentMockRegistryYAML("project-agent", "child-project.py", "Child project intent."))
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "mocks", "child-project.py"), validAgentMockSource(child+"-project"))
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "mocks", "child-flow.py"), validAgentMockSource(child+"-flow"))
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "flows", "child-flow", "schema.yaml"), "name: child-flow\nmode: static\n")
+		writeAgentMockTestFile(t, filepath.Join(childRoot, "flows", "child-flow", "agents.yaml"), agentMockRegistryYAML("flow-agent", "child-flow.py", "Child flow intent."))
+	}
+	child := ""
+	if len(childOrder) > 0 {
+		child = filepath.Join(root, childOrder[0])
+	}
+	return root, child
+}
+
+func agentMockRegistryYAML(agentID, module, intent string) string {
+	return agentID + `:
+  id: ` + agentID + `
+  role: helper
+  model: regular
+  intent: {inline: "` + intent + `"}
+  mock:
+    kind: python
+    module: mocks/` + module + `
+`
+}
+
+func writeAgentMockTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/runtime/contracts/mock_performance_ownership_guard_test.go
+++ b/internal/runtime/contracts/mock_performance_ownership_guard_test.go
@@ -1,0 +1,170 @@
+package contracts
+
+import (
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type mockPerformanceCoordinateReader struct {
+	Path      string
+	Enclosing string
+	Field     string
+}
+
+func (r mockPerformanceCoordinateReader) key() string {
+	return strings.Join([]string{r.Path, r.Enclosing, r.Field}, "::")
+}
+
+func TestMockPerformanceCoordinateReaderBoundary(t *testing.T) {
+	readers := loadMockPerformanceCoordinateReaders(t, nil)
+	var unclassified []string
+	for _, reader := range readers {
+		if _, ok := allowedMockPerformanceCoordinateReaders()[reader.key()]; !ok {
+			unclassified = append(unclassified, reader.key())
+		}
+	}
+	if len(unclassified) > 0 {
+		t.Fatalf("unclassified mock performance coordinate readers:\n%s", strings.Join(unclassified, "\n"))
+	}
+}
+
+func TestMockPerformanceCoordinateReaderBoundaryRejectsHostileReaders(t *testing.T) {
+	root := mockPerformanceGuardRepoRoot(t)
+	path := filepath.Join(root, "internal", "runtime", "contracts", "mock_performance_guard_hostile.go")
+	overlay := map[string][]byte{path: []byte(`package contracts
+
+import (
+    "os"
+    "path/filepath"
+
+    "github.com/division-sh/swarm/internal/runtime/mockperformance"
+)
+
+func hostileAuthoredModuleReader(root string, performance mockperformance.Performance) string {
+    return filepath.Join(root, performance.Module)
+}
+
+func hostileCompiledSourcePathReader(root string, performance mockperformance.Performance) ([]byte, error) {
+    return os.ReadFile(filepath.Join(root, performance.SourcePath))
+}
+`)}
+	readers := loadMockPerformanceCoordinateReaders(t, overlay)
+	want := map[string]bool{"Module": false, "SourcePath": false}
+	for _, reader := range readers {
+		if strings.Contains(reader.Enclosing, "hostile") {
+			want[reader.Field] = true
+		}
+	}
+	for field, found := range want {
+		if !found {
+			t.Fatalf("hostile ownership guard did not detect %s reader: %#v", field, readers)
+		}
+	}
+}
+
+func allowedMockPerformanceCoordinateReaders() map[string]string {
+	return map[string]string{
+		"internal/runtime/contracts/bundle_hash.go::(*bundleHashEntryBuilder).addAgentMockModuleFiles::SourcePath":          "canonical compiled path identity and exact-byte bundle input owner",
+		"internal/runtime/contracts/mock_performance_loading.go::materializeAgentMockPerformance::Module":                   "sole authored module filesystem interpreter",
+		"internal/runtime/core/actors/agent_config.go::(*AgentConfig).NormalizeRuntimeDescriptor::Module":                   "immutable runtime carrier normalization",
+		"internal/runtime/core/actors/agent_config.go::(*AgentConfig).NormalizeRuntimeDescriptor::SourcePath":               "immutable runtime carrier normalization",
+		"internal/runtime/llm/mock_runtime.go::executeMockCompletion::SourcePath":                                           "diagnostic Python row identity; executes captured Source and Digest",
+		"internal/runtime/mockperformance/model.go::(Performance).Configured::Module":                                       "authored artifact presence predicate",
+		"internal/store/internal/backend/agentpersistence/projection.go::decodePersistedAgentRuntimeDescriptor::Module":     "immutable persistence carrier normalization",
+		"internal/store/internal/backend/agentpersistence/projection.go::decodePersistedAgentRuntimeDescriptor::SourcePath": "immutable persistence carrier normalization",
+	}
+}
+
+func loadMockPerformanceCoordinateReaders(t *testing.T, overlay map[string][]byte) []mockPerformanceCoordinateReader {
+	t.Helper()
+	root := mockPerformanceGuardRepoRoot(t)
+	cfg := &packages.Config{
+		Dir: root,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports,
+		Tests:   false,
+		Overlay: overlay,
+	}
+	pkgs, err := packages.Load(cfg, "./internal/...")
+	if err != nil {
+		t.Fatalf("load mock performance ownership packages: %v", err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		t.Fatal("load mock performance ownership packages reported type errors")
+	}
+	var readers []mockPerformanceCoordinateReader
+	for _, pkg := range pkgs {
+		for index, file := range pkg.Syntax {
+			if index >= len(pkg.CompiledGoFiles) || strings.HasSuffix(pkg.CompiledGoFiles[index], "_test.go") {
+				continue
+			}
+			rel, err := filepath.Rel(root, pkg.CompiledGoFiles[index])
+			if err != nil {
+				t.Fatal(err)
+			}
+			readers = append(readers, collectMockPerformanceCoordinateReaders(filepath.ToSlash(rel), file, pkg.TypesInfo)...)
+		}
+	}
+	sort.Slice(readers, func(i, j int) bool { return readers[i].key() < readers[j].key() })
+	return readers
+}
+
+func collectMockPerformanceCoordinateReaders(path string, file *ast.File, info *types.Info) []mockPerformanceCoordinateReader {
+	var readers []mockPerformanceCoordinateReader
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		enclosing := mockPerformanceGuardFunctionName(function)
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok || !isMockPerformanceCoordinateField(selector, info) {
+				return true
+			}
+			readers = append(readers, mockPerformanceCoordinateReader{Path: path, Enclosing: enclosing, Field: selector.Sel.Name})
+			return true
+		})
+	}
+	return readers
+}
+
+func isMockPerformanceCoordinateField(selector *ast.SelectorExpr, info *types.Info) bool {
+	if selector == nil || selector.Sel == nil || info == nil || (selector.Sel.Name != "Module" && selector.Sel.Name != "SourcePath") {
+		return false
+	}
+	field, ok := info.Uses[selector.Sel].(*types.Var)
+	return ok && field.IsField() && field.Pkg() != nil &&
+		field.Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/mockperformance"
+}
+
+func mockPerformanceGuardFunctionName(function *ast.FuncDecl) string {
+	if function.Recv == nil || len(function.Recv.List) == 0 {
+		return function.Name.Name
+	}
+	receiver := function.Recv.List[0].Type
+	switch typed := receiver.(type) {
+	case *ast.Ident:
+		return "(" + typed.Name + ")." + function.Name.Name
+	case *ast.StarExpr:
+		if name, ok := typed.X.(*ast.Ident); ok {
+			return "(*" + name.Name + ")." + function.Name.Name
+		}
+	}
+	return function.Name.Name
+}
+
+func mockPerformanceGuardRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -202,7 +202,7 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 		packageDir := filepath.Dir(packageFile)
 		key := "."
 		if rel, err := filepath.Rel(rootDir, packageDir); err == nil && strings.TrimSpace(rel) != "" {
-			key = filepath.Clean(rel)
+			key = filepath.ToSlash(filepath.Clean(rel))
 		}
 		pkg := ProjectPackagePaths{
 			Key:               key,

--- a/internal/runtime/contracts/workflow_contract_tree.go
+++ b/internal/runtime/contracts/workflow_contract_tree.go
@@ -45,7 +45,11 @@ func loadProjectContractView(contractsRoot string, paths ProjectPackagePaths, ma
 	if err != nil {
 		return view, err
 	}
-	view.Agents, err = materializeAgentMockPerformances(contractsRoot, paths.ProjectAgentsFile, view.Agents)
+	view.Agents, err = materializeAgentMockPerformances(agentMockMaterializationSource{
+		ContractsRoot: contractsRoot,
+		PackageRoot:   paths.Dir,
+		Declaration:   ContractItemSource{PackageKey: paths.Key, Layer: "project", File: paths.ProjectAgentsFile},
+	}, view.Agents)
 	if err != nil {
 		return view, err
 	}
@@ -89,7 +93,11 @@ func loadFlowContractView(contractsRoot string, paths FlowContractPaths, schema 
 	if err != nil {
 		return view, err
 	}
-	view.Agents, err = materializeAgentMockPerformances(contractsRoot, paths.AgentsFile, view.Agents)
+	view.Agents, err = materializeAgentMockPerformances(agentMockMaterializationSource{
+		ContractsRoot: contractsRoot,
+		PackageRoot:   paths.PackageDir,
+		Declaration:   ContractItemSource{PackageKey: paths.PackageKey, FlowID: paths.ID, Layer: "flow", File: paths.AgentsFile},
+	}, view.Agents)
 	if err != nil {
 		return view, err
 	}

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -22,7 +22,10 @@ func TestDiscoverProjectPackagePathsIncludesNestedFlowPackages(t *testing.T) {
 	}
 	var found bool
 	for _, pkg := range paths.ProjectPackages {
-		if pkg.Key == filepath.Clean(filepath.Join("flows", "parent")) {
+		if strings.Contains(pkg.Key, `\`) {
+			t.Fatalf("package key %q uses an OS-native separator; want portable slash identity", pkg.Key)
+		}
+		if pkg.Key == "flows/parent" {
 			found = true
 			if pkg.ParentKey != "." {
 				t.Fatalf("expected nested flow package parent '.'; got %q", pkg.ParentKey)
@@ -30,7 +33,7 @@ func TestDiscoverProjectPackagePathsIncludesNestedFlowPackages(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected nested flow package %q in discovered package tree", filepath.Clean(filepath.Join("flows", "parent")))
+		t.Fatal("expected nested flow package \"flows/parent\" in discovered package tree")
 	}
 }
 

--- a/internal/runtime/runtime_mock_boot_waiver_boot_test.go
+++ b/internal/runtime/runtime_mock_boot_waiver_boot_test.go
@@ -115,6 +115,11 @@ func fullyMockedBootAgentMemorySource(t *testing.T) semanticview.Source {
 	t.Helper()
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	root := canonicalrouting.CopyRuntimeAgentMemory(t, canonicalrouting.RuntimeAgentMemoryPackageBacked)
+	// This boot proof needs one declaration owner; package composition is
+	// covered by the contracts loader parity tests.
+	if err := os.Remove(filepath.Join(root, "flows", "support", "package.yaml")); err != nil {
+		t.Fatalf("remove overlapping nested package declaration: %v", err)
+	}
 	agentsPath := filepath.Join(root, "flows", "support", "agents.yaml")
 	agents, err := os.ReadFile(agentsPath)
 	if err != nil {

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6515,14 +6515,16 @@ engine:
         authoring:
           runtime_config: A live provider profile may remain selected globally; each exact agent mock selects in-process mock execution for that agent.
           agent_performance:
-            shape: '{mock: {kind: python, module: <contracts-root-relative .py file>}}'
+            shape: '{mock: {kind: python, module: <declaring-package-relative .py file>}}'
             kind: python
             entrypoint: handle
             rule: >
               Every agent selected by the mock backend must declare exactly one Python performance. The module must be a
-              regular non-symlink file below the contracts root. Contract compilation reads it once and captures its exact
-              path, bytes, and sha256 digest into the generation-owned agent descriptor; runtime execution never rereads the
-              ambient file.
+              regular non-symlink file below the exact package that declares the containing agents.yaml and below the active
+              outer contracts root. The authored module path is package-relative authoring truth. Contract compilation reads
+              it once and captures the package-relative Module, canonical outer-contract-relative SourcePath, exact bytes, and
+              sha256 digest into the generation-owned agent descriptor; runtime execution never rereads the ambient file and
+              no composition-root fallback or second path dialect exists.
         python_abi:
           runtime: cpython-wasi-3.13.14-wasi_sdk-24 through Wasmtime
           input: >
@@ -16547,6 +16549,12 @@ multi_bundle_persistence:
           contract-root-relative label with intent policy. Inline content is covered by agents.yaml. No directory is scanned
           for implicit or unreferenced intent files. The file bytes must still equal the already resolved artifact content;
           mutation between resolution and hashing fails closed.
+        agent_mock_modules: >
+          For every compiled agent mock performance, include the exact module bytes as raw data under the canonical
+          `bundle/<SourcePath>` label. SourcePath is the single outer-contract-relative identity compiled from the exact
+          declaring-package-relative Module; hashing, build, and registration never reinterpret Module. The ambient file bytes
+          must still equal the compiled Source and its sha256 Digest; mutation between contract compilation and any identity or
+          materialization read fails closed.
         flow_data: every non-ignored regular file under each flow data/ as raw bytes
         flow_policy_modules: >
           For each flow policy.yaml modules declaration, include the referenced module bytes as raw bytes under their


### PR DESCRIPTION
## Summary

- resolve every project- and flow-scoped `mock.module` from the exact package that declares its `agents.yaml`
- compile one outer-contract-relative `SourcePath` with exact source bytes and digest, then make hash/build/register fail closed if ambient bytes or compiled identity drift
- add standalone/imported CLI parity, hostile-path coverage, build/register/reload proof, and a typed AST reader census
- migrate obsolete test fixtures that still authored composition-root-relative mock coordinates

Closes #2258
Related to #2036
Related to #2259

## Governing Context

Authoritative references updated in this PR:

- `platform-spec.yaml#engine.execution.agent_performance`
- `platform-spec.yaml#multi_bundle_persistence.bundle_identity.canonicalization_v1.canonical_entries.agent_mock_modules`

The approved issue gate and reproducer are binding context for exact declaring-package ownership, strict no-symlink/path admission, and exact-byte identity.

## Semantic Migration

- **New canonical owner:** contracts materialization receives the outer contracts root, discovered declaring package root, and exact `ContractItemSource`; it owns authored `Module` resolution and compiles immutable `Module`, `SourcePath`, `Source`, and `Digest`.
- **Old path now invalid:** joining authored `Module` to the active outer contracts root, setting imported `SourcePath = Module`, or allowing hash/build/register to accept ambient bytes that differ from the compiled artifact.
- **Production paths checked:** root/imported project agents, root/imported flow agents, standalone/imported entrypoints, bundle hash, build materialization, registration upload/archive/reload, runtime carriers, persistence/recovery carriers, and mock execution diagnostics.
- **Migration status:** complete for `mock.module`; no fallback, dual coordinate, compatibility path, or downstream filesystem interpreter remains. Policy module coordinates remain separately tracked by #2259.

## Proof

- `go test ./internal/runtime/contracts -run "MockPerformanceCoordinateReader|MockModule|AgentMockModule|ImportedMock|BundleHashV1RejectsMock|BundleHashV1RejectsNonCanonical|BundleHashV1IncludesAgentMock" -count=1`
- `go test ./internal/cliapp -run "^TestVerifyCommandLoadsPackageRelativeMockModuleStandaloneAndImported$" -count=1`
- `go test ./internal/runtime ./internal/runtime/bootverify -run "TestNewRuntime_FullyMockedBundleBoots|TestCredentialChecksCensusScopedAgentsHiddenByAmbiguousAlias|TestCredentialChecksCensusScopedActivitiesHiddenByAmbiguousAlias|TestNativeToolChecksCensusScopedAgentsHiddenByAmbiguousAlias" -count=1`
- `go test ./internal/runtime/contracts -count=1`
- `go test ./internal/apispec -run "^TestPlatformSpecVersionOwnerMatchesRootSpec$" -count=1`
- `git diff --check`

Whole-suite execution used `go run ./cmd/swarm-test-postgres -- go test -timeout 30m ./...`. All target packages passed. Parallel package execution later lost the shared PostgreSQL template for one `runforkexecution` test and one `serveapp` test; both complete packages then passed under a fresh serialized harness with `go run ./cmd/swarm-test-postgres -- go test -timeout 30m -p 1 ./internal/runtime/runforkexecution ./internal/serveapp`. A plain `go test ./...` was also run and reached the expected repository guard requiring `SWARM_TEST_POSTGRES_DSN`.