### PR TITLE
[agent-a][issue #2261] Canonicalize agent execution declaration scope

### DIFF
--- a/internal/providerconnectors/providerconnectors_test.go
+++ b/internal/providerconnectors/providerconnectors_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -186,6 +187,89 @@ func TestValidateSourceRejectsScopedDuplicateAgentExposureOfProviderConnector(t 
 			t.Fatalf("ValidateSource errors = %q, want scoped exposure rejection for %s", joined, agentID)
 		}
 	}
+}
+
+func TestValidateSourceEvaluatesNestedPhysicalAgentDeclarationExactlyOnce(t *testing.T) {
+	source := loadNestedProviderConnectorAgentSource(t)
+	declarations := semanticview.AgentDeclarations(source)
+	if len(declarations) != 1 {
+		t.Fatalf("canonical declarations = %#v, want one physical declaration", declarations)
+	}
+	joined := joinErrors(ValidateSource(source))
+	want := `agent "public-sender" must not expose provider connector tool "telegram.send_message" directly`
+	if count := strings.Count(joined, want); count != 1 {
+		t.Fatalf("provider-connector exposure count = %d in %q, want one physical-declaration error", count, joined)
+	}
+}
+
+func loadNestedProviderConnectorAgentSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	root := t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+	write(filepath.Join(root, "package.yaml"), `
+name: nested-provider-agent
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: parent}
+`)
+	write(filepath.Join(root, "schema.yaml"), "name: nested-provider-agent\n")
+	for _, name := range []string{"agents.yaml", "entities.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(root, name), "{}\n")
+	}
+	write(filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - {path: child}
+`)
+	write(filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	write(filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	write(filepath.Join(flowRoot, "schema.yaml"), "name: support\nmode: static\ninitial_state: active\nstates: [active]\n")
+	write(filepath.Join(flowRoot, "agents.yaml"), `
+sender:
+  id: public-sender
+  role: sender
+  intent: {inline: Exercise nested provider connector projection.}
+  model: regular
+  memory: false
+  subscriptions: [work.requested]
+`)
+	write(filepath.Join(flowRoot, "events.yaml"), "work.requested: {}\n")
+	for _, name := range []string{"nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(flowRoot, name), "{}\n")
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	entry := bundle.FlowTree.ByID["support"].Agents["sender"]
+	entry.Tools = []string{"telegram.send_message"}
+	bundle.FlowTree.ByID["support"].Agents["sender"] = entry
+	for _, project := range bundle.ProjectViews() {
+		if _, ok := project.Agents["sender"]; ok {
+			project.Agents["sender"] = entry
+		}
+	}
+	bundle.Tools = map[string]runtimecontracts.ToolSchemaEntry{
+		"telegram.send_message": telegramConnectorTool("https://api.telegram.org"),
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func TestSurfacesReportManagedCredentialRequirementsWithoutSecretValues(t *testing.T) {

--- a/internal/runtime/agents/agent_llm_test.go
+++ b/internal/runtime/agents/agent_llm_test.go
@@ -927,7 +927,7 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 	agent, bus := newFactoryDirectiveAgent(t, models.AgentConfig{
 		ExecutionMode: "live",
 		ID:            "campaign-coordinator",
-		Identity:      agentidentitytest.RootRuntime(t, "campaign-coordinator", "directive-factory-test"),
+		Identity:      agentidentitytest.RootDeclared(t, "campaign-coordinator", "swarm-test://root/agents/campaign-coordinator"),
 		EntityID:      eventtest.UUID("campaign-coordinator-source"),
 		Role:          "campaign_coordinator",
 		EmitEvents:    []string{"scan.requested"},
@@ -968,6 +968,43 @@ func TestBoardStep_FactoryCreatedDirectiveTurnPreservesRoleScopedEmitToolSurface
 }
 
 func TestBoardStep_FactoryCreatedDirectiveRemediationPreservesFlowScopedEmitToolSurface(t *testing.T) {
+	const owner = "swarm-test://campaign-flow/agents/campaign-coordinator"
+	flow := &runtimecontracts.FlowContractView{
+		Paths: runtimecontracts.FlowContractPaths{
+			ID:   "campaign-flow",
+			Flow: "campaign-flow",
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.requested": {},
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"campaign-coordinator": {
+				ID: "campaign-coordinator", Role: "campaign_coordinator", EmitEvents: []string{"scan.requested"},
+			},
+		},
+		AgentURIs: map[string]string{"campaign-coordinator": owner},
+		Schema:    runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
+		Path:      "campaign-flow",
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				"campaign-flow/campaign-coordinator": {Kind: "agent", FlowID: "campaign-flow", LocalID: "campaign-coordinator", Full: owner},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				owner: {Kind: "agent", FlowID: "campaign-flow", LocalID: "campaign-coordinator", Full: owner},
+			},
+		},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			"scan.requested": {
+				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
+			},
+		},
+		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
+			Root: flow,
+			ByID: map[string]*runtimecontracts.FlowContractView{"campaign-flow": flow},
+		},
+	}
 	rt := &directiveFactoryRuntime{
 		steps: []*llm.Response{
 			{Message: llm.Message{Role: "assistant", Content: "I will trigger the workflow now."}},
@@ -983,34 +1020,13 @@ func TestBoardStep_FactoryCreatedDirectiveRemediationPreservesFlowScopedEmitTool
 	agent, bus := newFactoryDirectiveAgent(t, models.AgentConfig{
 		ExecutionMode: "live",
 		ID:            "campaign-coordinator",
-		Identity:      agentidentitytest.Runtime(t, "campaign-coordinator", "directive-factory-test", "campaign-flow", "inst-1", "campaign-flow/inst-1"),
+		Identity:      agentidentitytest.Declared(t, "campaign-coordinator", owner, "campaign-flow", "inst-1", "campaign-flow/inst-1"),
 		EntityID:      eventtest.UUID("campaign-flow-inst-1-source"),
 		Role:          "campaign_coordinator",
 		FlowID:        "campaign-flow",
 		FlowPath:      "campaign-flow/inst-1",
 		EmitEvents:    []string{"campaign-flow/inst-1/scan.requested"},
-	}, rt, &runtimecontracts.WorkflowContractBundle{
-		Events: map[string]runtimecontracts.EventCatalogEntry{
-			"scan.requested": {
-				Payload: runtimecontracts.EventPayloadSpec{Type: "object"},
-			},
-		},
-		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
-			ByID: map[string]*runtimecontracts.FlowContractView{
-				"campaign-flow": {
-					Paths: runtimecontracts.FlowContractPaths{
-						ID:   "campaign-flow",
-						Flow: "campaign-flow",
-					},
-					Events: map[string]runtimecontracts.EventCatalogEntry{
-						"scan.requested": {},
-					},
-					Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
-					Path:   "campaign-flow",
-				},
-			},
-		},
-	})
+	}, rt, bundle)
 
 	got, err := agent.BoardStep(agentManagedTestContext(t, agent), testBoardDirective("start a corpus run"))
 	if err != nil {

--- a/internal/runtime/authoringview/view.go
+++ b/internal/runtime/authoringview/view.go
@@ -309,15 +309,11 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 	if !ok || bundle == nil {
 		return View{}, fmt.Errorf("authoring view requires a workflow contract bundle source")
 	}
-	agentNames, err := authoringAgentNames(source)
+	root, err := buildRoot(source, bundle)
 	if err != nil {
 		return View{}, err
 	}
-	root, err := buildRoot(source, bundle, agentNames)
-	if err != nil {
-		return View{}, err
-	}
-	flows, err := buildFlows(source, bundle, agentNames)
+	flows, err := buildFlows(source, bundle)
 	if err != nil {
 		return View{}, err
 	}
@@ -349,30 +345,6 @@ func Build(_ context.Context, source semanticview.Source, opts BuildOptions) (Vi
 		view.StageGraphs = buildStageGraphs(source, bundle)
 	}
 	return view, nil
-}
-
-type authoringAgentNameKey struct {
-	scopeKind string
-	scopeID   string
-	localID   string
-}
-
-func authoringAgentNames(source semanticview.Source) (map[authoringAgentNameKey]string, error) {
-	plans, err := semanticview.AgentNamePlans(source)
-	if err != nil {
-		return nil, fmt.Errorf("authoring agent names: %w", err)
-	}
-	out := make(map[authoringAgentNameKey]string, len(plans))
-	for _, plan := range plans {
-		scopeKind := plan.ScopeKind
-		scopeID := plan.ScopeID
-		if strings.TrimSpace(scopeKind) == "" {
-			scopeKind = "project"
-			scopeID = "."
-		}
-		out[authoringAgentNameKey{scopeKind: scopeKind, scopeID: scopeID, localID: plan.LocalID}] = plan.AgentID
-	}
-	return out, nil
 }
 
 func buildApprovalPoints(bundle *runtimecontracts.WorkflowContractBundle) []ApprovalPointView {
@@ -427,9 +399,8 @@ func BuildRoutingTopologyWithReport(source semanticview.Source, bundle *runtimec
 	return routingtopology.WithIssues(topology, issues...)
 }
 
-func buildRoot(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle, agentNames map[authoringAgentNameKey]string) (RootView, error) {
-	rootAgents, rootAgentsFile, rootScopeID := rootAgentViewEntries(source, bundle)
-	agents, err := agentViews(rootAgents, rootAgentsFile, "project", rootScopeID, agentNames)
+func buildRoot(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) (RootView, error) {
+	agents, err := agentViews(source, "")
 	if err != nil {
 		return RootView{}, err
 	}
@@ -461,7 +432,7 @@ func buildRoot(source semanticview.Source, bundle *runtimecontracts.WorkflowCont
 	return out, nil
 }
 
-func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle, agentNames map[authoringAgentNameKey]string) ([]FlowView, error) {
+func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) ([]FlowView, error) {
 	opsByFlow := containedOperationsByFlow(source, bundle)
 	demandsByFlow := map[string][]runtimebootverify.SingletonCoordinatorDemand{}
 	for _, demand := range runtimebootverify.BuildSingletonCoordinatorDemandProjection(source) {
@@ -473,7 +444,7 @@ func buildFlows(source semanticview.Source, bundle *runtimecontracts.WorkflowCon
 	for _, flow := range views {
 		flowID := strings.TrimSpace(flow.Paths.ID)
 		schema := flow.Schema
-		agents, err := agentViews(flow.Agents, flow.Paths.AgentsFile, "flow", flowID, agentNames)
+		agents, err := agentViews(source, flowID)
 		if err != nil {
 			return nil, err
 		}
@@ -931,52 +902,18 @@ func authoringStringSet(values []string) map[string]struct{} {
 	return out
 }
 
-func rootAgentViewEntries(source semanticview.Source, bundle *runtimecontracts.WorkflowContractBundle) (map[string]runtimecontracts.AgentRegistryEntry, string, string) {
-	if source == nil || bundle == nil {
-		return nil, "", ""
-	}
-	scopes := source.ProjectScopes()
-	for _, scope := range scopes {
-		if strings.TrimSpace(scope.OwningFlowID) == "" && scope.Depth == 0 {
-			return scope.Agents, projectAgentSourceFile(bundle, scope.Key), strings.TrimSpace(scope.Key)
-		}
-	}
-	for _, scope := range scopes {
-		if strings.TrimSpace(scope.OwningFlowID) == "" {
-			return scope.Agents, projectAgentSourceFile(bundle, scope.Key), strings.TrimSpace(scope.Key)
-		}
-	}
-	return nil, "", ""
-}
-
-func projectAgentSourceFile(bundle *runtimecontracts.WorkflowContractBundle, scopeKey string) string {
-	if view, ok := bundle.ProjectViewByKey(strings.TrimSpace(scopeKey)); ok {
-		return strings.TrimSpace(view.Paths.ProjectAgentsFile)
-	}
-	if strings.TrimSpace(scopeKey) == "." {
-		return strings.TrimSpace(bundle.Paths.ProjectAgentsFile)
-	}
-	return ""
-}
-
-func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFile, scopeKind, scopeID string, names map[authoringAgentNameKey]string) ([]AgentView, error) {
-	if len(entries) == 0 {
+func agentViews(source semanticview.Source, ownerFlowID string) ([]AgentView, error) {
+	declarations := semanticview.AgentDeclarationsForOwner(source, ownerFlowID)
+	if len(declarations) == 0 {
 		return nil, nil
 	}
-	ids := make([]string, 0, len(entries))
-	for id := range entries {
-		if id = strings.TrimSpace(id); id != "" {
-			ids = append(ids, id)
+	out := make([]AgentView, 0, len(declarations))
+	for _, declaration := range declarations {
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			return nil, fmt.Errorf("authoring agent %s has no canonical declared-name plan: %w", declaration.Label(true), err)
 		}
-	}
-	sort.Strings(ids)
-	out := make([]AgentView, 0, len(ids))
-	for _, id := range ids {
-		entry := runtimecontracts.EffectiveAgentRegistryEntry(id, entries[id])
-		publicName := strings.TrimSpace(names[authoringAgentNameKey{scopeKind: strings.TrimSpace(scopeKind), scopeID: strings.TrimSpace(scopeID), localID: id}])
-		if publicName == "" {
-			return nil, fmt.Errorf("authoring agent %s %s/%s has no canonical declared-name plan", strings.TrimSpace(scopeKind), strings.TrimSpace(scopeID), id)
-		}
+		entry := declaration.Entry
 		fields := map[string]AgentFieldView{}
 		addAgentField(fields, entry, "type", entry.Type)
 		addAgentField(fields, entry, "model", entry.Model)
@@ -986,11 +923,17 @@ func agentViews(entries map[string]runtimecontracts.AgentRegistryEntry, sourceFi
 		addAgentField(fields, entry, "workspace_class", entry.WorkspaceClass)
 		addAgentField(fields, entry, "manager_fallback", entry.ManagerFallback)
 		out = append(out, AgentView{
-			ID:         publicName,
-			SourceFile: strings.TrimSpace(sourceFile),
+			ID:         plan.AgentID,
+			SourceFile: strings.TrimSpace(declaration.Source.File),
 			Fields:     fields,
 		})
 	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ID == out[j].ID {
+			return out[i].SourceFile < out[j].SourceFile
+		}
+		return out[i].ID < out[j].ID
+	})
 	return out, nil
 }
 
@@ -1038,6 +981,14 @@ func requiredAgentsView(schema runtimecontracts.FlowSchemaDocument, facts []runt
 	if runtimecontracts.RequiredAgentsDeclared(schema) {
 		source = runtimecontracts.RequiredAgentSourceExplicit
 		sourceFile = strings.TrimSpace(schemaFile)
+	} else if len(facts) > 0 {
+		sourceFile = strings.TrimSpace(facts[0].SourceFile)
+		for _, fact := range facts[1:] {
+			if strings.TrimSpace(fact.SourceFile) != sourceFile {
+				sourceFile = ""
+				break
+			}
+		}
 	}
 	out := RequiredAgentsView{
 		Source:     source,

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/finalflowinstanceauthoring"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/flowownedprojectagent"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/singletoncoordinatorpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templateflowpilot"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/templatereply"
@@ -308,6 +309,36 @@ func TestBuildShowsRequiredAgentProvenance(t *testing.T) {
 	}
 	if len(analysis.RequiredAgents.Agents) != 0 {
 		t.Fatalf("flow required_agents agents = %#v, want explicit empty boundary", analysis.RequiredAgents.Agents)
+	}
+}
+
+func TestBuildProjectsFlowOwnedProjectAgentAndInferredProvenance(t *testing.T) {
+	source := flowownedprojectagent.LoadSource(t, runtimecontracts.FlowModeTemplate, false)
+	view := mustBuild(t, source, nil)
+	support := flowByID(t, view, "support")
+	if len(support.Agents) != 1 || support.Agents[0].ID != "public-worker-left" || !strings.HasSuffix(filepath.ToSlash(support.Agents[0].SourceFile), "flows/support/left/agents.yaml") {
+		t.Fatalf("support agents = %#v, want exact project declaration and source", support.Agents)
+	}
+	if len(support.RequiredAgents.Agents) != 1 || support.RequiredAgents.Agents[0].Role != "worker" || !strings.HasSuffix(filepath.ToSlash(support.RequiredAgents.Agents[0].SourceFile), "flows/support/left/agents.yaml") {
+		t.Fatalf("support required agents = %#v, want inferred project declaration provenance", support.RequiredAgents)
+	}
+	if len(view.Root.Agents) != 0 {
+		t.Fatalf("root agents = %#v, project declaration must remain flow-owned", view.Root.Agents)
+	}
+}
+
+func TestBuildPreservesDistinctFlowOwnedProjectDeclarations(t *testing.T) {
+	source := flowownedprojectagent.LoadSource(t, runtimecontracts.FlowModeTemplate, true)
+	view := mustBuild(t, source, nil)
+	support := flowByID(t, view, "support")
+	if len(support.Agents) != 2 || support.Agents[0].ID != "public-worker-left" || support.Agents[1].ID != "public-worker-right" || support.Agents[0].SourceFile == support.Agents[1].SourceFile {
+		t.Fatalf("support agents = %#v, want both distinct physical declarations", support.Agents)
+	}
+	if len(support.RequiredAgents.Agents) != 2 || support.RequiredAgents.Agents[0].SourceFile == support.RequiredAgents.Agents[1].SourceFile {
+		t.Fatalf("support required agents = %#v, want both declaration sources", support.RequiredAgents)
+	}
+	if support.RequiredAgents.SourceFile != "" {
+		t.Fatalf("aggregate required-agent source = %q, want no lossy singular source for multiple files", support.RequiredAgents.SourceFile)
 	}
 }
 

--- a/internal/runtime/authoringview/view_test.go
+++ b/internal/runtime/authoringview/view_test.go
@@ -294,44 +294,7 @@ func TestBuildShowsRootPrimaryEntity(t *testing.T) {
 }
 
 func TestBuildShowsRequiredAgentProvenance(t *testing.T) {
-	flow := runtimecontracts.FlowContractView{
-		Path: "analysis",
-		Paths: runtimecontracts.FlowContractPaths{
-			ID:         "analysis",
-			SchemaFile: "flows/analysis/schema.yaml",
-			AgentsFile: "flows/analysis/agents.yaml",
-		},
-		Schema: runtimecontracts.FlowSchemaDocument{RequiredAgentsDeclared: true},
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"analyzer": {Subscriptions: []string{"analysis.requested"}},
-		},
-	}
-	bundle := &runtimecontracts.WorkflowContractBundle{
-		Paths: runtimecontracts.ContractPaths{
-			RootSchemaFile:    "schema.yaml",
-			ProjectAgentsFile: "agents.yaml",
-		},
-		RootSchema: &runtimecontracts.FlowSchemaDocument{},
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"root-agent": {
-				Subscriptions: []string{"root.requested"},
-				EmitEvents:    []string{"root.done"},
-			},
-		},
-		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
-			"analysis": flow.Schema,
-		},
-		FlowTree: runtimecontracts.FlowTree{
-			Root: &runtimecontracts.FlowContractView{
-				Children: []runtimecontracts.FlowContractView{flow},
-			},
-			ByID: map[string]*runtimecontracts.FlowContractView{
-				"analysis": &flow,
-			},
-		},
-	}
-	addAuthoringViewAgentOwners(bundle)
-	view := mustBuild(t, semanticviewtest.WrapRootAgents(bundle), nil)
+	view := mustBuild(t, loadAuthoringAgentProvenanceSource(t, true), nil)
 
 	if view.Root.RequiredAgents.Source != runtimecontracts.RequiredAgentSourceInferred ||
 		len(view.Root.RequiredAgents.Agents) != 1 ||
@@ -623,48 +586,7 @@ func TestBuildStageGraphShowsBoundedLoopBackEdgeAndEscape(t *testing.T) {
 }
 
 func TestBuildShowsEffectiveAgentPlatformDefaultProvenance(t *testing.T) {
-	flow := runtimecontracts.FlowContractView{
-		Path: "analysis",
-		Paths: runtimecontracts.FlowContractPaths{
-			ID:         "analysis",
-			SchemaFile: "flows/analysis/schema.yaml",
-			AgentsFile: "flows/analysis/agents.yaml",
-		},
-		Schema: runtimecontracts.FlowSchemaDocument{Name: "analysis"},
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"analyzer": {
-				Model:         "regular",
-				Subscriptions: []string{"analysis.requested"},
-			},
-		},
-	}
-	bundle := &runtimecontracts.WorkflowContractBundle{
-		Paths: runtimecontracts.ContractPaths{
-			RootSchemaFile:    "schema.yaml",
-			ProjectAgentsFile: "agents.yaml",
-		},
-		RootSchema: &runtimecontracts.FlowSchemaDocument{},
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"root-agent": {
-				Model:         "regular",
-				Subscriptions: []string{"root.requested"},
-			},
-		},
-		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
-			"analysis": flow.Schema,
-		},
-		FlowTree: runtimecontracts.FlowTree{
-			Root: &runtimecontracts.FlowContractView{
-				Children: []runtimecontracts.FlowContractView{flow},
-			},
-			ByID: map[string]*runtimecontracts.FlowContractView{
-				"analysis": &flow,
-			},
-		},
-	}
-	addAuthoringViewAgentOwners(bundle)
-
-	view := mustBuild(t, semanticviewtest.WrapRootAgents(bundle), nil)
+	view := mustBuild(t, loadAuthoringAgentProvenanceSource(t, false), nil)
 
 	rootAgent := agentByID(t, view.Root.Agents, "root-agent")
 	assertDefaultedAgentField(t, rootAgent, "type", runtimecontracts.DefaultAgentType)
@@ -699,17 +621,6 @@ func TestBuildRendersEffectivePublicAgentNameInsteadOfLocalCoordinate(t *testing
 	view := mustBuild(t, semanticviewtest.WrapRootAgents(bundle), nil)
 	if len(view.Root.Agents) != 1 || view.Root.Agents[0].ID != "public-worker" {
 		t.Fatalf("root agents = %#v, want effective public-worker readback", view.Root.Agents)
-	}
-}
-
-func addAuthoringViewAgentOwners(bundle *runtimecontracts.WorkflowContractBundle) {
-	bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{
-		"root-agent": {
-			Kind: "agent", LocalID: "root-agent", Full: "swarm-test://root-agent",
-		},
-		"analysis/analyzer": {
-			Kind: "agent", FlowID: "analysis", LocalID: "analyzer", Path: "analysis", Full: "swarm-test://analysis/analyzer",
-		},
 	}
 }
 
@@ -1043,6 +954,53 @@ func interFlowRouteEdges(topology routingtopology.Topology) []routingtopology.Ed
 func loadRootPrimaryEntitySource(t testing.TB) semanticview.Source {
 	t.Helper()
 	root := writeRootPrimaryEntityContracts(t)
+	repo := authoringViewRepoRoot(t)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repo, root, runtimecontracts.DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func loadAuthoringAgentProvenanceSource(t testing.TB, explicitFlowRequiredAgents bool) semanticview.Source {
+	t.Helper()
+	root := t.TempDir()
+	writeAuthoringViewTestFile(t, filepath.Join(root, "package.yaml"), `
+name: authoring-agent-provenance
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - {id: analysis, flow: analysis, mode: static}
+`)
+	writeAuthoringViewTestFile(t, filepath.Join(root, "schema.yaml"), "name: authoring-agent-provenance\n")
+	writeAuthoringViewTestFile(t, filepath.Join(root, "agents.yaml"), `
+root-agent:
+  role: root-agent
+  intent: {inline: Coordinate root analysis work.}
+  model: regular
+  subscriptions: [root.requested]
+  emit_events: [root.done]
+`)
+	for _, file := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeAuthoringViewTestFile(t, filepath.Join(root, file), "{}\n")
+	}
+	flowSchema := "name: analysis\nmode: static\n"
+	if explicitFlowRequiredAgents {
+		flowSchema += "required_agents: []\n"
+	}
+	flowRoot := filepath.Join(root, "flows", "analysis")
+	writeAuthoringViewTestFile(t, filepath.Join(flowRoot, "schema.yaml"), flowSchema)
+	writeAuthoringViewTestFile(t, filepath.Join(flowRoot, "agents.yaml"), `
+analyzer:
+  role: analyzer
+  intent: {inline: Analyze requested work.}
+  model: regular
+  subscriptions: [analysis.requested]
+`)
+	for _, file := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeAuthoringViewTestFile(t, filepath.Join(flowRoot, file), "{}\n")
+	}
+
 	repo := authoringViewRepoRoot(t)
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repo, root, runtimecontracts.DefaultPlatformSpecFile(repo))
 	if err != nil {

--- a/internal/runtime/bootverify/agent_declaration_owner_test.go
+++ b/internal/runtime/bootverify/agent_declaration_owner_test.go
@@ -1,0 +1,21 @@
+package bootverify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/flowownedprojectagent"
+)
+
+func TestRequiredAgentVerificationRejectsAmbiguousFlowOwnedProjectDeclarations(t *testing.T) {
+	source := flowownedprojectagent.LoadExplicitRequiredSource(t, runtimecontracts.FlowModeStatic, true)
+	report := Run(context.Background(), source, Options{})
+	for _, finding := range report.Findings {
+		if finding.CheckID == "required_agents_match" && strings.Contains(finding.Message, "ambiguous across declarations") && strings.Contains(finding.Message, "left/agents.yaml") && strings.Contains(finding.Message, "right/agents.yaml") {
+			return
+		}
+	}
+	t.Fatalf("required-agent findings = %#v, want exact ambiguous declaration failure", report.Findings)
+}

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -507,13 +507,9 @@ func (c *checkerContext) intentResolution() []Finding {
 		return c.promptFindings
 	}
 	c.promptLoaded = true
-	for _, scope := range c.source.ProjectScopes() {
-		scopeLabel := projectScopeLabel(scope.Key, scope.Manifest.Name)
-		c.promptFindings = append(c.promptFindings, intentFindingsForScope(scopeLabel, scope.Agents)...)
-	}
-	for _, scope := range c.source.FlowScopes() {
-		scopeLabel := flowScopeLabel(scope.ID, scope.Path)
-		c.promptFindings = append(c.promptFindings, intentFindingsForScope(scopeLabel, scope.Agents)...)
+	for _, declaration := range semanticview.AgentDeclarations(c.source) {
+		scopeLabel := agentDeclarationScopeLabel(c.source, declaration)
+		c.promptFindings = append(c.promptFindings, intentFindingsForDeclaration(scopeLabel, declaration.LocalID, declaration.Entry)...)
 	}
 	return c.promptFindings
 }
@@ -651,32 +647,6 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 				Location: scopeLabel,
 			})
 		}
-		for agentID, agent := range scope.Agents {
-			agentID = strings.TrimSpace(agentID)
-			agentLabel := scopedObjectLabel(scopeLabel, agentID)
-			if agentID == "" {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("agent in scope %s missing required field id", scopeLabel),
-					Location: scopeLabel,
-				})
-				continue
-			}
-			c.invalidFindings = c.appendAgentModelAliasFindings(c.invalidFindings, agentLabel, agent.Model, agent.Mock.Configured())
-			c.invalidFindings = appendAgentMemoryFindings(c.invalidFindings, scopeLabel, semanticview.ResolveAgentMemoryProof(c.source, semanticview.AgentMemoryLocator{
-				AgentID:         agentID,
-				ProjectScopeKey: scope.Key,
-			}), agentID, agent)
-			if len(agent.Subscriptions) == 0 {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("agent %s missing required field subscriptions", agentLabel),
-					Location: agentLabel,
-				})
-			}
-		}
 	}
 	for flowID, schema := range c.source.FlowSchemaEntries() {
 		flowID = strings.TrimSpace(flowID)
@@ -697,36 +667,39 @@ func (c *checkerContext) invalidFieldDetection() []Finding {
 			})
 		}
 	}
-	for _, scope := range c.source.FlowScopes() {
-		scopeLabel := flowScopeLabel(scope.ID, scope.Path)
-		for agentID, agent := range scope.Agents {
-			agentID = strings.TrimSpace(agentID)
-			agentLabel := scopedObjectLabel(scopeLabel, agentID)
-			if agentID == "" {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("agent in scope %s missing required field id", scopeLabel),
-					Location: scopeLabel,
-				})
-				continue
-			}
-			c.invalidFindings = c.appendAgentModelAliasFindings(c.invalidFindings, agentLabel, agent.Model, agent.Mock.Configured())
-			c.invalidFindings = appendAgentMemoryFindings(c.invalidFindings, scopeLabel, semanticview.ResolveAgentMemoryProof(c.source, semanticview.AgentMemoryLocator{
-				AgentID: agentID,
-				FlowID:  scope.ID,
-			}), agentID, agent)
-			if len(agent.Subscriptions) == 0 {
-				c.invalidFindings = append(c.invalidFindings, Finding{
-					CheckID:  "invalid_field_detection",
-					Severity: "error",
-					Message:  fmt.Sprintf("agent %s missing required field subscriptions", agentLabel),
-					Location: agentLabel,
-				})
-			}
+	for _, declaration := range semanticview.AgentDeclarations(c.source) {
+		scopeLabel := agentDeclarationScopeLabel(c.source, declaration)
+		agentID := strings.TrimSpace(declaration.LocalID)
+		agent := declaration.Entry
+		agentLabel := scopedObjectLabel(scopeLabel, agentID)
+		if agentID == "" {
+			c.invalidFindings = append(c.invalidFindings, Finding{
+				CheckID:  "invalid_field_detection",
+				Severity: "error",
+				Message:  fmt.Sprintf("agent in scope %s missing required field id", scopeLabel),
+				Location: scopeLabel,
+			})
+			continue
+		}
+		c.invalidFindings = c.appendAgentModelAliasFindings(c.invalidFindings, agentLabel, agent.Model, agent.Mock.Configured())
+		c.invalidFindings = appendAgentMemoryFindings(c.invalidFindings, scopeLabel, semanticview.AgentMemoryProofForDeclaration(c.source, declaration), agentID, agent)
+		if len(agent.Subscriptions) == 0 {
+			c.invalidFindings = append(c.invalidFindings, Finding{
+				CheckID:  "invalid_field_detection",
+				Severity: "error",
+				Message:  fmt.Sprintf("agent %s missing required field subscriptions", agentLabel),
+				Location: agentLabel,
+			})
 		}
 	}
 	return c.invalidFindings
+}
+
+func agentDeclarationScopeLabel(source semanticview.Source, declaration semanticview.AgentDeclaration) string {
+	if strings.TrimSpace(declaration.OwnerFlowID) != "" {
+		return flowScopeLabel(declaration.OwnerFlowID, source.FlowPath(declaration.OwnerFlowID))
+	}
+	return projectScopeLabel(declaration.Source.PackageKey, "")
 }
 
 func (c *checkerContext) appendInvalidExecutableNodeFindings(record runtimecontracts.ScopedNodeRecord) {
@@ -1202,33 +1175,29 @@ func platformProducerClaimFinding(source semanticview.Source, eventType, locatio
 	}, true
 }
 
-func intentFindingsForScope(scopeLabel string, agents map[string]runtimecontracts.AgentRegistryEntry) []Finding {
-	out := make([]Finding, 0, len(agents))
-	for agentID, entry := range agents {
-		agentID = strings.TrimSpace(agentID)
-		if agentID == "" {
-			continue
-		}
-		location := scopedObjectLabel(scopeLabel, agentID)
-		if err := entry.ResolvedIntent.Validate(); err != nil {
-			out = append(out, Finding{
-				CheckID:  "intent_resolution",
-				Severity: SeverityHardInvalidity,
-				Message:  fmt.Sprintf("%s/%s: declare one valid intent: source: %v", strings.TrimSpace(scopeLabel), agentID, err),
-				Location: location,
-			})
-			continue
-		}
-		if intentHasOpenTODO(entry.ResolvedIntent.Content) {
-			out = append(out, Finding{
-				CheckID:  "intent_resolution",
-				Severity: "warning",
-				Message:  fmt.Sprintf("%s/%s: resolved intent contains TODO", strings.TrimSpace(scopeLabel), agentID),
-				Location: location,
-			})
-		}
+func intentFindingsForDeclaration(scopeLabel, agentID string, entry runtimecontracts.AgentRegistryEntry) []Finding {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil
 	}
-	return out
+	location := scopedObjectLabel(scopeLabel, agentID)
+	if err := entry.ResolvedIntent.Validate(); err != nil {
+		return []Finding{{
+			CheckID:  "intent_resolution",
+			Severity: SeverityHardInvalidity,
+			Message:  fmt.Sprintf("%s/%s: declare one valid intent: source: %v", strings.TrimSpace(scopeLabel), agentID, err),
+			Location: location,
+		}}
+	}
+	if intentHasOpenTODO(entry.ResolvedIntent.Content) {
+		return []Finding{{
+			CheckID:  "intent_resolution",
+			Severity: "warning",
+			Message:  fmt.Sprintf("%s/%s: resolved intent contains TODO", strings.TrimSpace(scopeLabel), agentID),
+			Location: location,
+		}}
+	}
+	return nil
 }
 
 func intentHasOpenTODO(text string) bool {

--- a/internal/runtime/bootverify/checks.go
+++ b/internal/runtime/bootverify/checks.go
@@ -800,6 +800,12 @@ func requiredAgentBootFinding(finding runtimerequiredagents.Finding) Finding {
 		} else {
 			message = fmt.Sprintf("flow %s required agent role %s missing from agents.yaml", scopeID, finding.Role)
 		}
+	case runtimerequiredagents.FindingAmbiguousAgent:
+		if scopeID == "root" {
+			message = fmt.Sprintf("root required agent role %s is ambiguous across declarations %v", finding.Role, finding.Candidates)
+		} else {
+			message = fmt.Sprintf("flow %s required agent role %s is ambiguous across declarations %v", scopeID, finding.Role, finding.Candidates)
+		}
 	case runtimerequiredagents.FindingMissingSubscriptions:
 		if scopeID == "root" {
 			message = fmt.Sprintf("root required agent %s subscriptions mismatch (%s)", finding.AgentID, runtimerequiredagents.MissingList(finding.Missing))

--- a/internal/runtime/bootverify/flow_data_access_test.go
+++ b/internal/runtime/bootverify/flow_data_access_test.go
@@ -65,6 +65,40 @@ func TestRun_ValidatesFlowDataAccessDeclarations(t *testing.T) {
 	}
 }
 
+func TestRun_ReportsNestedPhysicalFlowDataDeclarationExactlyOnce(t *testing.T) {
+	root := writeNestedBootFlowDataAccessFixture(t)
+	source := semanticview.Wrap(loadFlowDataAccessBundle(t, root))
+	if records := wave1ScopedAgentRecords(source); len(records) != 1 || records[0].LogicalID != "worker" {
+		t.Fatalf("entity-coverage agent records = %#v, want one nested physical declaration", records)
+	}
+	report := Run(context.Background(), source, Options{})
+	findings := []Finding{}
+	invalidFields := []Finding{}
+	for _, finding := range report.Errors() {
+		if finding.CheckID == "flow_data_access_validation" {
+			findings = append(findings, finding)
+		}
+		if finding.CheckID == "invalid_field_detection" && strings.Contains(finding.Message, "missing required field subscriptions") {
+			invalidFields = append(invalidFields, finding)
+		}
+	}
+	if len(findings) != 1 || !strings.Contains(findings[0].Message, "not readable") {
+		t.Fatalf("flow_data_access_validation findings = %#v, want one nested physical-declaration error", findings)
+	}
+	if len(invalidFields) != 1 {
+		t.Fatalf("invalid-field findings = %#v, want one nested physical-declaration error", invalidFields)
+	}
+	intentFindings := []Finding{}
+	for _, finding := range report.Warnings() {
+		if finding.CheckID == "intent_resolution" && strings.Contains(finding.Message, "TODO") {
+			intentFindings = append(intentFindings, finding)
+		}
+	}
+	if len(intentFindings) != 1 {
+		t.Fatalf("intent findings = %#v, want one nested physical-declaration warning", intentFindings)
+	}
+}
+
 func TestBootCheckRegistry_HasFlowDataAccessCheckCount(t *testing.T) {
 	if got := len(bootCheckRegistry); got != 79 {
 		t.Fatalf("bootCheckRegistry count = %d, want 79", got)
@@ -101,6 +135,50 @@ flows:
 	}
 	writeBootverifyFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
 	writeBootverifyFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), "factory-cto:\n  id: factory-cto\n  role: factory_cto\n  intent: {inline: 'Exercise flow data access.'}\n  memory: false\n"+accessYAML)
+	return root
+}
+
+func writeNestedBootFlowDataAccessFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeBootverifyFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: nested-flow-data-access
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: parent}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: nested-flow-data-access\n")
+	for _, name := range []string{"agents.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(root, name), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - {path: child}
+`)
+	writeBootverifyFixtureFile(t, filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	writeBootverifyFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	writeBootverifyFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), "name: support\nmode: static\ninitial_state: active\nstates: [active]\n")
+	writeBootverifyFixtureFile(t, filepath.Join(flowRoot, "agents.yaml"), `
+worker:
+  role: worker
+  intent: {inline: "<!-- TODO validate one nested physical declaration. -->"}
+  model: regular
+  memory: false
+  flow_data_access: [missing.md]
+`)
+	for _, name := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeBootverifyFixtureFile(t, filepath.Join(flowRoot, name), "{}\n")
+	}
+	writeBootverifyFixtureFile(t, filepath.Join(flowRoot, "data", "placeholder.md"), "placeholder\n")
 	return root
 }
 

--- a/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
+++ b/internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go
@@ -458,59 +458,17 @@ func wave1AgentPromptEntityContract(source semanticview.Source, agentSource runt
 }
 
 func wave1ScopedAgentRecords(source semanticview.Source) []wave1ScopedAgentRecord {
-	bundle, ok := semanticview.Bundle(source)
-	if !ok || bundle == nil {
+	if source == nil {
 		return nil
 	}
-	projectFlowIDs := map[string]string{}
-	for _, scope := range source.ProjectScopes() {
-		projectFlowIDs[strings.TrimSpace(scope.Key)] = strings.TrimSpace(scope.OwningFlowID)
-	}
-	out := make([]wave1ScopedAgentRecord, 0)
-	for _, view := range bundle.ProjectViews() {
-		agentIDs := make([]string, 0, len(view.Agents))
-		for logicalID := range view.Agents {
-			logicalID = strings.TrimSpace(logicalID)
-			if logicalID != "" {
-				agentIDs = append(agentIDs, logicalID)
-			}
-		}
-		sort.Strings(agentIDs)
-		for _, logicalID := range agentIDs {
-			packageKey := strings.TrimSpace(view.Paths.Key)
-			out = append(out, wave1ScopedAgentRecord{
-				LogicalID: logicalID,
-				Entry:     view.Agents[logicalID],
-				Source: runtimecontracts.ContractItemSource{
-					PackageKey: packageKey,
-					FlowID:     projectFlowIDs[packageKey],
-					Layer:      "project",
-					File:       strings.TrimSpace(view.Paths.ProjectAgentsFile),
-				},
-			})
-		}
-	}
-	for _, view := range bundle.FlowViews() {
-		agentIDs := make([]string, 0, len(view.Agents))
-		for logicalID := range view.Agents {
-			logicalID = strings.TrimSpace(logicalID)
-			if logicalID != "" {
-				agentIDs = append(agentIDs, logicalID)
-			}
-		}
-		sort.Strings(agentIDs)
-		for _, logicalID := range agentIDs {
-			out = append(out, wave1ScopedAgentRecord{
-				LogicalID: logicalID,
-				Entry:     view.Agents[logicalID],
-				Source: runtimecontracts.ContractItemSource{
-					PackageKey: strings.TrimSpace(view.Paths.PackageKey),
-					FlowID:     strings.TrimSpace(view.Paths.ID),
-					Layer:      "flow",
-					File:       strings.TrimSpace(view.Paths.AgentsFile),
-				},
-			})
-		}
+	declarations := semanticview.AgentDeclarations(source)
+	out := make([]wave1ScopedAgentRecord, 0, len(declarations))
+	for _, declaration := range declarations {
+		out = append(out, wave1ScopedAgentRecord{
+			LogicalID: declaration.LocalID,
+			Entry:     declaration.Entry,
+			Source:    declaration.Source,
+		})
 	}
 	return out
 }

--- a/internal/runtime/bootverify/workflow_flow_boundary_checks.go
+++ b/internal/runtime/bootverify/workflow_flow_boundary_checks.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/paths"
 	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
 	"github.com/division-sh/swarm/internal/runtime/entityruntime"
@@ -331,33 +330,6 @@ func (c *checkerContext) crossFlowPinAmbiguityValidation() []Finding {
 		}
 	}
 	return c.crossFlowPinAmbiguityFindings
-}
-
-func flowHasScopedInputEscapeHatch(source semanticview.Source, flowID, eventType string) bool {
-	flowID = strings.TrimSpace(flowID)
-	eventType = strings.TrimSpace(eventType)
-	if source == nil || flowID == "" || eventType == "" {
-		return false
-	}
-	scope, ok := source.FlowScopeByID(flowID)
-	if !ok {
-		return false
-	}
-	for _, node := range scope.Nodes {
-		for _, sub := range eventidentity.NormalizeList(runtimecontracts.EffectiveSystemNodeSubscriptions(node)) {
-			if strings.Contains(sub, "/") && strings.HasSuffix(sub, "/"+eventType) {
-				return true
-			}
-		}
-	}
-	for _, agent := range scope.Agents {
-		for _, sub := range eventidentity.NormalizeList(agent.Subscriptions) {
-			if strings.Contains(sub, "/") && strings.HasSuffix(sub, "/"+eventType) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (c *checkerContext) selectEntityValidation() []Finding {

--- a/internal/runtime/bus/connect_route_plan_dispatch_test.go
+++ b/internal/runtime/bus/connect_route_plan_dispatch_test.go
@@ -765,10 +765,18 @@ func connectReceiverPinCollisionSource(producerMode string, rootReceiver bool, s
 	bundle.Agents = consumer.agents
 	bundle.FlowTree.Root.Nodes = consumer.nodes
 	bundle.FlowTree.Root.Agents = consumer.agents
+	for index := range bundle.FlowTree.Root.Children {
+		if bundle.FlowTree.Root.Children[index].Paths.ID == "consumer" {
+			bundle.FlowTree.Root.Children[index].Agents = nil
+		}
+	}
 	for logicalID := range consumer.agents {
-		bundle.URIRegistry.Agents["root/"+logicalID] = runtimecontracts.ContractURIRef{
+		delete(bundle.URIRegistry.Agents, "consumer/"+logicalID)
+		ref := runtimecontracts.ContractURIRef{
 			Kind: "agent", LocalID: logicalID, Full: "test://root/" + logicalID,
 		}
+		bundle.URIRegistry.Agents[logicalID] = ref
+		bundle.URIRegistry.ByURI[ref.Full] = ref
 	}
 	bundle.Semantics.NodeHandlers = map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
 	for _, node := range consumer.nodes {
@@ -4870,6 +4878,7 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 	flowOutputPins := make(map[string][]runtimecontracts.FlowOutputEventPin, len(flows))
 	nodeHandlers := map[string]map[string]runtimecontracts.SystemNodeEventHandler{}
 	agentRefs := map[string]runtimecontracts.ContractURIRef{}
+	agentRefsByURI := map[string]runtimecontracts.ContractURIRef{}
 	workflowName := ""
 	rootEntities := runtimecontracts.EntityContractsDocument{}
 	for _, flow := range flows {
@@ -4911,13 +4920,15 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 			}
 		}
 		for logicalID := range flow.agents {
-			agentRefs[flow.id+"/"+logicalID] = runtimecontracts.ContractURIRef{
+			ref := runtimecontracts.ContractURIRef{
 				Kind:    "agent",
 				FlowID:  flow.id,
 				LocalID: logicalID,
 				Path:    flowPath,
 				Full:    "test://" + flow.id + "/" + logicalID,
 			}
+			agentRefs[flow.id+"/"+logicalID] = ref
+			agentRefsByURI[ref.Full] = ref
 		}
 		if len(flow.entityFields) > 0 && workflowName == "" {
 			workflowName = flow.id
@@ -4929,6 +4940,7 @@ func connectRoutePlanTestBundle(flows []connectRoutePlanTestFlow, connects []run
 		RootEntities: rootEntities,
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: agentRefs,
+			ByURI:  agentRefsByURI,
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: &root,

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -129,7 +129,6 @@ type routeTemplateSourceObserver struct {
 }
 
 type routeFlowTemplate struct {
-	PackageKey  string
 	FlowID      string
 	InputEvents []string
 	LocalEvents map[string]struct{}
@@ -139,6 +138,7 @@ type routeFlowTemplate struct {
 type routeSubscriberTemplate struct {
 	IDTemplate    string
 	Kind          subscriberKind
+	PackageKey    string
 	RawPatterns   []string
 	AgentNamePlan semanticview.AgentNamePlan
 	HandlerNode   runtimeidentity.ExecutableNode
@@ -210,7 +210,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	}
 
 	for _, scope := range semanticview.ProjectScopes(source) {
-		agents, agentNamePlans, err := routeAgentDeclarationsForSource(source, "project", scope.Key, scope.OwningFlowID)
+		agents, err := routeRootAgentDeclarationsForProjectScope(source, scope.Key)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		}
 		handlerFlowID := agentFlowID
 		rt.addAuthoredEventPathsLocked(basePath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, agentFlowID, inputEvents, basePath, agentPath, localEvents, agents, agentNamePlans); err != nil {
+		if err := rt.addAgentPatternsLocked(source, agentFlowID, inputEvents, agentPath, localEvents, agents); err != nil {
 			return nil, err
 		}
 		nodes, err := routeExecutableNodeDeclarations(source, scope.Key, handlerFlowID, scope.Nodes)
@@ -249,21 +249,19 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	}
 
 	for _, scope := range semanticview.FlowScopes(source) {
-		agentPackageKey := normalizedRoutePackageKey(scope.PackageKey)
 		flowPackageKey := routeFlowPackageKey(source, scope)
-		agents, agentNamePlans, err := routeAgentDeclarationsForSource(source, "flow", agentPackageKey, scope.ID)
+		agents, err := routeAgentDeclarationsForOwner(source, scope.ID)
 		if err != nil {
 			return nil, err
 		}
 		flowPath := routeFlowPath(source, scope.ID)
 		localEvents := routeFlowLocalEventSet(source, scope)
 		if strings.EqualFold(scope.Mode, "template") || routeFlowStanding(source, scope.ID) {
-			subscribers, err := routeSubscriberTemplates(source, scope, agents, agentNamePlans)
+			subscribers, err := routeSubscriberTemplates(source, scope, agents)
 			if err != nil {
 				return nil, err
 			}
 			rt.templates[flowPath] = routeFlowTemplate{
-				PackageKey:  flowPackageKey,
 				FlowID:      scope.ID,
 				InputEvents: append([]string{}, scope.InputEvents...),
 				LocalEvents: cloneStringSet(localEvents),
@@ -275,7 +273,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 			rt.authoredScopes[flowPath] = struct{}{}
 		}
 		rt.addAuthoredEventPathsLocked(flowPath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, agentPackageKey, scope.ID, scope.ID, scope.InputEvents, flowPath, flowPath, localEvents, agents, agentNamePlans); err != nil {
+		if err := rt.addAgentPatternsLocked(source, scope.ID, scope.InputEvents, flowPath, localEvents, agents); err != nil {
 			return nil, err
 		}
 		nodes, err := routeExecutableNodeDeclarations(source, flowPackageKey, scope.ID, scope.Nodes)
@@ -510,7 +508,7 @@ func (rt *RouteTable) addFlowInstanceRoute(req FlowInstanceRouteMaterializationR
 			if err := rt.addConnectRecipientLocked(templateDef.FlowID, templateDef.InputEvents, rawPattern, admittedSubscriber, instancePath); err != nil {
 				return err
 			}
-			resolvedPatterns, err := routeResolveSubscriberPatterns(rt.source, subscriberTemplate.Kind, templateDef.PackageKey, templateDef.FlowID, templateDef.InputEvents, templateScope, instancePath, templateDef.LocalEvents, rawPattern)
+			resolvedPatterns, err := routeResolveSubscriberPatterns(rt.source, subscriberTemplate.Kind, subscriberTemplate.PackageKey, templateDef.FlowID, templateDef.InputEvents, templateScope, instancePath, templateDef.LocalEvents, rawPattern)
 			if err != nil {
 				return err
 			}
@@ -1052,32 +1050,37 @@ func routeCanonicalPathsOverlap(left, right string) bool {
 	return left == right || strings.HasPrefix(left, right+"/") || strings.HasPrefix(right, left+"/")
 }
 
-func routeAgentDeclarationsForSource(source semanticview.Source, layer, packageKey, flowID string) (map[string]runtimecontracts.AgentRegistryEntry, map[string]semanticview.AgentNamePlan, error) {
-	layer = strings.TrimSpace(layer)
+type routeAgentDeclaration struct {
+	Declaration semanticview.AgentDeclaration
+	NamePlan    semanticview.AgentNamePlan
+}
+
+func routeAgentDeclarationsForOwner(source semanticview.Source, ownerFlowID string) ([]routeAgentDeclaration, error) {
+	return routeAgentDeclarations(source, semanticview.AgentDeclarationsForOwner(source, ownerFlowID))
+}
+
+func routeRootAgentDeclarationsForProjectScope(source semanticview.Source, packageKey string) ([]routeAgentDeclaration, error) {
 	packageKey = normalizedRoutePackageKey(packageKey)
-	flowID = strings.TrimSpace(flowID)
-	agents := map[string]runtimecontracts.AgentRegistryEntry{}
-	plans := map[string]semanticview.AgentNamePlan{}
-	for _, declaration := range semanticview.AgentDeclarations(source) {
-		candidate := declaration.Source
-		if strings.TrimSpace(candidate.Layer) != layer || normalizedRoutePackageKey(candidate.PackageKey) != packageKey {
+	candidates := make([]semanticview.AgentDeclaration, 0)
+	for _, declaration := range semanticview.AgentDeclarationsForOwner(source, "") {
+		if strings.TrimSpace(declaration.Source.Layer) != "project" || normalizedRoutePackageKey(declaration.Source.PackageKey) != packageKey {
 			continue
 		}
-		if strings.TrimSpace(candidate.FlowID) != flowID {
-			continue
-		}
-		key := strings.TrimSpace(declaration.LocalID)
-		if _, duplicate := agents[key]; duplicate {
-			return nil, nil, fmt.Errorf("%s scope package %q flow %q has multiple physical agent declarations for %q", layer, packageKey, flowID, key)
-		}
+		candidates = append(candidates, declaration)
+	}
+	return routeAgentDeclarations(source, candidates)
+}
+
+func routeAgentDeclarations(source semanticview.Source, declarations []semanticview.AgentDeclaration) ([]routeAgentDeclaration, error) {
+	out := make([]routeAgentDeclaration, 0, len(declarations))
+	for _, declaration := range declarations {
 		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
 		if err != nil {
-			return nil, nil, fmt.Errorf("%s scope package %q flow %q agent %s declaration name: %w", layer, packageKey, flowID, key, err)
+			return nil, fmt.Errorf("route subscriber %s declaration name: %w", declaration.Label(true), err)
 		}
-		agents[key] = declaration.Entry
-		plans[key] = plan
+		out = append(out, routeAgentDeclaration{Declaration: declaration, NamePlan: plan})
 	}
-	return agents, plans, nil
+	return out, nil
 }
 
 func normalizedRoutePackageKey(packageKey string) string {
@@ -1090,19 +1093,17 @@ func normalizedRoutePackageKey(packageKey string) string {
 
 func (rt *RouteTable) addAgentPatternsLocked(
 	source semanticview.Source,
-	packageKey, routingFlowID, agentFlowID string,
+	agentFlowID string,
 	inputEvents []string,
-	basePath, agentPath string,
+	agentPath string,
 	localEvents map[string]struct{},
-	agents map[string]runtimecontracts.AgentRegistryEntry,
-	agentNamePlans map[string]semanticview.AgentNamePlan,
+	agents []routeAgentDeclaration,
 ) error {
-	for _, key := range sortedStringKeys(agents) {
-		entry := agents[key]
-		namePlan, ok := agentNamePlans[key]
-		if !ok {
-			return fmt.Errorf("route subscriber agent %s has no exact scoped declaration name", key)
-		}
+	for _, agent := range agents {
+		declaration := agent.Declaration
+		key := strings.TrimSpace(declaration.LocalID)
+		entry := declaration.Entry
+		namePlan := agent.NamePlan
 		name, err := namePlan.Materialize()
 		if err != nil {
 			return fmt.Errorf("route subscriber agent %s declaration identity: %w", key, err)
@@ -1126,7 +1127,7 @@ func (rt *RouteTable) addAgentPatternsLocked(
 			if err := rt.addConnectRecipientLocked(agentFlowID, inputEvents, rawPattern, subscriber, ""); err != nil {
 				return err
 			}
-			resolvedPatterns, err := routeResolveSubscriberPatterns(source, subscriberAgent, packageKey, agentFlowID, inputEvents, agentPath, agentPath, localEvents, rawPattern)
+			resolvedPatterns, err := routeResolveSubscriberPatterns(source, subscriberAgent, normalizedRoutePackageKey(declaration.Source.PackageKey), agentFlowID, inputEvents, agentPath, agentPath, localEvents, rawPattern)
 			if err != nil {
 				return err
 			}
@@ -1442,34 +1443,29 @@ func routeEventKeys(events map[string]runtimecontracts.EventCatalogEntry) map[st
 	return out
 }
 
-func routeSubscriberTemplates(source semanticview.Source, scope semanticview.FlowScope, agents map[string]runtimecontracts.AgentRegistryEntry, agentNamePlans map[string]semanticview.AgentNamePlan) ([]routeSubscriberTemplate, error) {
+func routeSubscriberTemplates(source semanticview.Source, scope semanticview.FlowScope, agents []routeAgentDeclaration) ([]routeSubscriberTemplate, error) {
 	out := make([]routeSubscriberTemplate, 0, len(agents)+len(scope.Nodes))
 	localEvents := routeFlowLocalEventSet(source, scope)
-	for _, key := range sortedStringKeys(agents) {
-		entry := agents[key]
+	for _, agent := range agents {
+		declaration := agent.Declaration
+		key := strings.TrimSpace(declaration.LocalID)
+		entry := declaration.Entry
+		packageKey := normalizedRoutePackageKey(declaration.Source.PackageKey)
 		patterns := normalizeStringList(entry.Subscriptions)
 		if len(patterns) == 0 {
 			continue
 		}
 		for _, pattern := range patterns {
-			admission := routeClassifyAuthoredSubscription(source, subscriberAgent, scope.PackageKey, scope.ID, scope.InputEvents, scope.Path, localEvents, pattern)
+			admission := routeClassifyAuthoredSubscription(source, subscriberAgent, packageKey, scope.ID, scope.InputEvents, scope.Path, localEvents, pattern)
 			if !admission.Admitted() {
 				return nil, fmt.Errorf("route subscriber agent %s: %s", key, admission.Message())
 			}
 		}
-		namePlan, ok := agentNamePlans[key]
-		if !ok {
-			return nil, fmt.Errorf(
-				"flow %q agent subscriber %q subscriptions %q has no canonical declared name",
-				scope.ID,
-				key,
-				strings.Join(patterns, ","),
-			)
-		}
 		out = append(out, routeSubscriberTemplate{
 			Kind:          subscriberAgent,
+			PackageKey:    packageKey,
 			RawPatterns:   append([]string{}, patterns...),
-			AgentNamePlan: namePlan,
+			AgentNamePlan: agent.NamePlan,
 		})
 	}
 	nodes, err := routeExecutableNodeDeclarations(source, routeFlowPackageKey(source, scope), scope.ID, scope.Nodes)
@@ -1495,6 +1491,7 @@ func routeSubscriberTemplates(source semanticview.Source, scope semanticview.Flo
 		}
 		out = append(out, routeSubscriberTemplate{
 			Kind:        subscriberNode,
+			PackageKey:  handlerNode.PackageKey(),
 			RawPatterns: append([]string{}, patterns...),
 			HandlerNode: handlerNode,
 		})

--- a/internal/runtime/bus/routing_derivation.go
+++ b/internal/runtime/bus/routing_derivation.go
@@ -210,7 +210,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	}
 
 	for _, scope := range semanticview.ProjectScopes(source) {
-		agentNamePlans, err := routeProjectAgentNamePlans(source, scope)
+		agents, agentNamePlans, err := routeAgentDeclarationsForSource(source, "project", scope.Key, scope.OwningFlowID)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 		}
 		handlerFlowID := agentFlowID
 		rt.addAuthoredEventPathsLocked(basePath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, agentFlowID, inputEvents, basePath, agentPath, localEvents, scope.Agents, agentNamePlans); err != nil {
+		if err := rt.addAgentPatternsLocked(source, scope.Key, owningFlowID, agentFlowID, inputEvents, basePath, agentPath, localEvents, agents, agentNamePlans); err != nil {
 			return nil, err
 		}
 		nodes, err := routeExecutableNodeDeclarations(source, scope.Key, handlerFlowID, scope.Nodes)
@@ -249,15 +249,16 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 	}
 
 	for _, scope := range semanticview.FlowScopes(source) {
+		agentPackageKey := normalizedRoutePackageKey(scope.PackageKey)
 		flowPackageKey := routeFlowPackageKey(source, scope)
-		agentNamePlans, err := routeFlowAgentNamePlans(source, scope)
+		agents, agentNamePlans, err := routeAgentDeclarationsForSource(source, "flow", agentPackageKey, scope.ID)
 		if err != nil {
 			return nil, err
 		}
 		flowPath := routeFlowPath(source, scope.ID)
 		localEvents := routeFlowLocalEventSet(source, scope)
 		if strings.EqualFold(scope.Mode, "template") || routeFlowStanding(source, scope.ID) {
-			subscribers, err := routeSubscriberTemplates(source, scope)
+			subscribers, err := routeSubscriberTemplates(source, scope, agents, agentNamePlans)
 			if err != nil {
 				return nil, err
 			}
@@ -274,7 +275,7 @@ func DeriveRouteTable(source semanticview.Source) (*RouteTable, error) {
 			rt.authoredScopes[flowPath] = struct{}{}
 		}
 		rt.addAuthoredEventPathsLocked(flowPath, localEvents)
-		if err := rt.addAgentPatternsLocked(source, scope.PackageKey, scope.ID, scope.ID, scope.InputEvents, flowPath, flowPath, localEvents, scope.Agents, agentNamePlans); err != nil {
+		if err := rt.addAgentPatternsLocked(source, agentPackageKey, scope.ID, scope.ID, scope.InputEvents, flowPath, flowPath, localEvents, agents, agentNamePlans); err != nil {
 			return nil, err
 		}
 		nodes, err := routeExecutableNodeDeclarations(source, flowPackageKey, scope.ID, scope.Nodes)
@@ -1051,28 +1052,40 @@ func routeCanonicalPathsOverlap(left, right string) bool {
 	return left == right || strings.HasPrefix(left, right+"/") || strings.HasPrefix(right, left+"/")
 }
 
-func routeProjectAgentNamePlans(source semanticview.Source, scope semanticview.ProjectScope) (map[string]semanticview.AgentNamePlan, error) {
-	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
-	for _, key := range sortedStringKeys(scope.Agents) {
-		plan, err := semanticview.ProjectAgentNamePlan(source, scope, key)
-		if err != nil {
-			return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, key, err)
+func routeAgentDeclarationsForSource(source semanticview.Source, layer, packageKey, flowID string) (map[string]runtimecontracts.AgentRegistryEntry, map[string]semanticview.AgentNamePlan, error) {
+	layer = strings.TrimSpace(layer)
+	packageKey = normalizedRoutePackageKey(packageKey)
+	flowID = strings.TrimSpace(flowID)
+	agents := map[string]runtimecontracts.AgentRegistryEntry{}
+	plans := map[string]semanticview.AgentNamePlan{}
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		candidate := declaration.Source
+		if strings.TrimSpace(candidate.Layer) != layer || normalizedRoutePackageKey(candidate.PackageKey) != packageKey {
+			continue
 		}
+		if strings.TrimSpace(candidate.FlowID) != flowID {
+			continue
+		}
+		key := strings.TrimSpace(declaration.LocalID)
+		if _, duplicate := agents[key]; duplicate {
+			return nil, nil, fmt.Errorf("%s scope package %q flow %q has multiple physical agent declarations for %q", layer, packageKey, flowID, key)
+		}
+		plan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s scope package %q flow %q agent %s declaration name: %w", layer, packageKey, flowID, key, err)
+		}
+		agents[key] = declaration.Entry
 		plans[key] = plan
 	}
-	return plans, nil
+	return agents, plans, nil
 }
 
-func routeFlowAgentNamePlans(source semanticview.Source, scope semanticview.FlowScope) (map[string]semanticview.AgentNamePlan, error) {
-	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
-	for _, key := range sortedStringKeys(scope.Agents) {
-		plan, err := semanticview.FlowAgentNamePlan(source, scope, key)
-		if err != nil {
-			return nil, fmt.Errorf("flow scope %q agent %s declaration name: %w", scope.ID, key, err)
-		}
-		plans[key] = plan
+func normalizedRoutePackageKey(packageKey string) string {
+	packageKey = strings.Trim(strings.TrimSpace(packageKey), "/")
+	if packageKey == "" {
+		return runtimeidentity.RootPackageKey
 	}
-	return plans, nil
+	return packageKey
 }
 
 func (rt *RouteTable) addAgentPatternsLocked(
@@ -1429,11 +1442,11 @@ func routeEventKeys(events map[string]runtimecontracts.EventCatalogEntry) map[st
 	return out
 }
 
-func routeSubscriberTemplates(source semanticview.Source, scope semanticview.FlowScope) ([]routeSubscriberTemplate, error) {
-	out := make([]routeSubscriberTemplate, 0, len(scope.Agents)+len(scope.Nodes))
+func routeSubscriberTemplates(source semanticview.Source, scope semanticview.FlowScope, agents map[string]runtimecontracts.AgentRegistryEntry, agentNamePlans map[string]semanticview.AgentNamePlan) ([]routeSubscriberTemplate, error) {
+	out := make([]routeSubscriberTemplate, 0, len(agents)+len(scope.Nodes))
 	localEvents := routeFlowLocalEventSet(source, scope)
-	for _, key := range sortedStringKeys(scope.Agents) {
-		entry := scope.Agents[key]
+	for _, key := range sortedStringKeys(agents) {
+		entry := agents[key]
 		patterns := normalizeStringList(entry.Subscriptions)
 		if len(patterns) == 0 {
 			continue
@@ -1444,14 +1457,13 @@ func routeSubscriberTemplates(source semanticview.Source, scope semanticview.Flo
 				return nil, fmt.Errorf("route subscriber agent %s: %s", key, admission.Message())
 			}
 		}
-		namePlan, err := semanticview.FlowAgentNamePlan(source, scope, key)
-		if err != nil {
+		namePlan, ok := agentNamePlans[key]
+		if !ok {
 			return nil, fmt.Errorf(
-				"flow %q agent subscriber %q subscriptions %q has no valid declared name: %w; remediation: omit id to use the declaration key or author one non-empty literal id",
+				"flow %q agent subscriber %q subscriptions %q has no canonical declared name",
 				scope.ID,
 				key,
 				strings.Join(patterns, ","),
-				err,
 			)
 		}
 		out = append(out, routeSubscriberTemplate{

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -111,6 +111,96 @@ func TestEventBusExactSubscriptionAdmissionPreservesLocalNodeAndSameScopeAgentRo
 	}
 }
 
+func TestDeriveRouteTableRegistersNestedPhysicalAgentDeclarationExactlyOnce(t *testing.T) {
+	source := loadNestedPhysicalAgentRouteSource(t)
+	declarations := semanticview.AgentDeclarations(source)
+	if len(declarations) != 1 {
+		t.Fatalf("canonical declarations = %#v, want one physical declaration", declarations)
+	}
+	flowPath := strings.Trim(strings.TrimSpace(source.FlowPath("support")), "/")
+	if flowPath == "" {
+		t.Fatal("support flow path is empty")
+	}
+	routes, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	resolved := routes.Resolve(flowPath + "/work.requested")
+	if len(resolved) != 1 {
+		t.Fatalf("nested agent subscribers = %#v, want one physical subscriber", resolved)
+	}
+	if resolved[0].Recipient.ID() != "public-worker" || resolved[0].AgentIdentity.Name.Owner != declarations[0].OwnerURI {
+		t.Fatalf("nested agent subscriber = %#v, want exact canonical declaration owner %#v", resolved[0], declarations[0])
+	}
+}
+
+func loadNestedPhysicalAgentRouteSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	root := t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+	write(filepath.Join(root, "package.yaml"), `
+name: nested-agent-route
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: parent}
+`)
+	write(filepath.Join(root, "schema.yaml"), "name: nested-agent-route\n")
+	for _, name := range []string{"agents.yaml", "entities.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(root, name), "{}\n")
+	}
+	write(filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - {path: child}
+`)
+	write(filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	write(filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	write(filepath.Join(flowRoot, "schema.yaml"), `
+name: support
+mode: static
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events: [work.requested]
+`)
+	write(filepath.Join(flowRoot, "events.yaml"), "work.requested: {}\n")
+	write(filepath.Join(flowRoot, "agents.yaml"), `
+worker:
+  id: public-worker
+  role: worker
+  intent: {inline: Register one nested physical subscriber.}
+  model: regular
+  memory: false
+  subscriptions: [work.requested]
+`)
+	for _, name := range []string{"nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(flowRoot, name), "{}\n")
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func TestDeriveRouteTableRequiresExactPackageOwnerAcrossRouteSurfaces(t *testing.T) {
 	for _, mode := range []string{"static", "template"} {
 		for _, reverse := range []bool{false, true} {
@@ -309,9 +399,9 @@ func exactSubscriptionRouteSource(nodeSubscription string, agentSubscriptions []
 		},
 	}
 	if len(agentSubscriptions) > 0 {
-		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{
-			"child/observer": {FlowID: "child", LocalID: "observer", Full: "test://fixture/child/observer"},
-		}
+		ref := runtimecontracts.ContractURIRef{Kind: "agent", FlowID: "child", LocalID: "observer", Full: "test://fixture/child/observer"}
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{"child/observer": ref}
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{ref.Full: ref}
 	}
 	return semanticview.Wrap(bundle)
 }
@@ -1114,6 +1204,10 @@ func routeMaterializationNodeSource(flowID string, node runtimecontracts.SystemN
 }
 
 func routeMaterializationConfigVarBundle() *runtimecontracts.WorkflowContractBundle {
+	agentRef := runtimecontracts.ContractURIRef{
+		Kind: "agent", FlowID: "operating", LocalID: "ceo",
+		Full: "test://route-materialization/operating/ceo",
+	}
 	operating := runtimecontracts.FlowContractView{
 		Path:  "operating",
 		Paths: runtimecontracts.FlowContractPaths{ID: "operating", Flow: "operating"},
@@ -1142,11 +1236,9 @@ func routeMaterializationConfigVarBundle() *runtimecontracts.WorkflowContractBun
 		},
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
-				"operating/ceo": {
-					Kind: "agent", FlowID: "operating", LocalID: "ceo",
-					Full: "test://route-materialization/operating/ceo",
-				},
+				"operating/ceo": agentRef,
 			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{agentRef.Full: agentRef},
 		},
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: &root,

--- a/internal/runtime/bus/routing_derivation_test.go
+++ b/internal/runtime/bus/routing_derivation_test.go
@@ -19,8 +19,84 @@ import (
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/flowownedprojectagent"
 	runtimepipelinefixture "github.com/division-sh/swarm/internal/testutil/runtimepipelinefixture"
 )
+
+func TestFlowOwnedProjectAgentTemplateRoutesFollowCanonicalOwnerLifecycle(t *testing.T) {
+	source := flowownedprojectagent.LoadSource(t, runtimecontracts.FlowModeTemplate, false)
+	declarations := semanticview.AgentDeclarationsForOwner(source, "support")
+	if len(declarations) != 1 || declarations[0].Source.Layer != "project" {
+		t.Fatalf("support declarations = %#v, want one project-layer declaration", declarations)
+	}
+	req := runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("support", "one")}
+	routes, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	assert := func(want int) {
+		t.Helper()
+		got := routes.Resolve("support/one/work.requested")
+		if len(got) != want {
+			t.Fatalf("resolved project-agent routes = %#v, want %d", got, want)
+		}
+		if want == 1 && (got[0].Recipient.ID() != "public-worker-left" || got[0].AgentIdentity.Name.Owner != declarations[0].OwnerURI) {
+			t.Fatalf("resolved project-agent route = %#v, want exact canonical declaration %#v", got[0], declarations[0])
+		}
+	}
+	if err := routes.AddFlowInstanceRoute(req); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	assert(1)
+	if err := routes.RemoveFlowInstanceRoute(req.Identity); err != nil {
+		t.Fatalf("RemoveFlowInstanceRoute: %v", err)
+	}
+	assert(0)
+	if err := routes.AddFlowInstanceRoute(req); err != nil {
+		t.Fatalf("re-add FlowInstanceRoute: %v", err)
+	}
+	assert(1)
+
+	restarted, err := newScopedTestEventBus(&routePersistenceTestStore{}, runtimebus.EventBusOptions{ContractBundle: source})
+	if err != nil {
+		t.Fatalf("restart EventBus: %v", err)
+	}
+	if err := restarted.PublishPersistedFlowInstanceRoute(req); err != nil {
+		t.Fatalf("restore persisted flow-instance route: %v", err)
+	}
+	got := restarted.RouteTable().Resolve("support/one/work.requested")
+	if len(got) != 1 || got[0].AgentIdentity.Name.Owner != declarations[0].OwnerURI {
+		t.Fatalf("restored project-agent route = %#v, want exact canonical owner", got)
+	}
+}
+
+func TestFlowOwnedProjectAgentTemplateRoutesPreserveDistinctPhysicalDeclarations(t *testing.T) {
+	source := flowownedprojectagent.LoadSource(t, runtimecontracts.FlowModeTemplate, true)
+	declarations := semanticview.AgentDeclarationsForOwner(source, "support")
+	if len(declarations) != 2 || declarations[0].OwnerURI == declarations[1].OwnerURI {
+		t.Fatalf("support declarations = %#v, want two distinct physical owners", declarations)
+	}
+	routes, err := runtimebus.DeriveRouteTable(source)
+	if err != nil {
+		t.Fatalf("DeriveRouteTable: %v", err)
+	}
+	if err := routes.AddFlowInstanceRoute(runtimebus.FlowInstanceRouteMaterializationRequest{Identity: runtimeflowidentity.DeriveRoute("support", "one")}); err != nil {
+		t.Fatalf("AddFlowInstanceRoute: %v", err)
+	}
+	got := routes.Resolve("support/one/work.requested")
+	if len(got) != 2 {
+		t.Fatalf("resolved project-agent routes = %#v, want both physical declarations", got)
+	}
+	owners := map[string]bool{}
+	ids := map[string]bool{}
+	for _, subscriber := range got {
+		owners[subscriber.AgentIdentity.Name.Owner] = true
+		ids[subscriber.Recipient.ID()] = true
+	}
+	if len(owners) != 2 || !ids["public-worker-left"] || !ids["public-worker-right"] {
+		t.Fatalf("resolved owners/ids = %#v/%#v, want both exact declarations", owners, ids)
+	}
+}
 
 func TestEventBusRemoveFlowInstanceDropsDerivedRoutes(t *testing.T) {
 	source := routeMaterializationNodeSource("review", runtimecontracts.SystemNodeContract{

--- a/internal/runtime/channel_runtime_supported_surface_test.go
+++ b/internal/runtime/channel_runtime_supported_surface_test.go
@@ -109,18 +109,32 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			if err != nil {
 				t.Fatalf("RuntimeTools: %v", err)
 			}
+			agentOwner := "test://channel-runtime/global/channel-sender"
+			agentRef := runtimecontracts.ContractURIRef{Kind: "agent", FlowID: "global", LocalID: "channel-sender", Full: agentOwner}
 			global := runtimecontracts.FlowContractView{
-				Paths:  runtimecontracts.FlowContractPaths{ID: "global", Flow: "global", Mode: runtimecontracts.FlowModeTemplate},
+				Paths: runtimecontracts.FlowContractPaths{
+					ID: "global", Flow: "global", Mode: runtimecontracts.FlowModeTemplate,
+					PackageKey: "channel-runtime", AgentsFile: "/contracts/channel-runtime/flows/global/agents.yaml",
+				},
 				Path:   "global",
 				Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
+				Agents: map[string]runtimecontracts.AgentRegistryEntry{
+					"channel-sender": runtimecontracts.EffectiveAgentRegistryEntry("channel-sender", runtimecontracts.AgentRegistryEntry{ID: "channel-sender", Role: "worker"}),
+				},
+				AgentURIs: map[string]string{"channel-sender": agentOwner},
 			}
+			root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{global}}
 			base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
 				Semantics: runtimecontracts.WorkflowSemanticView{Name: "channel_runtime", Version: "1.0.0"},
 				FlowTree: runtimecontracts.FlowTree{
-					Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{global}},
-					ByID: map[string]*runtimecontracts.FlowContractView{"global": &global},
+					Root: &root,
+					ByID: map[string]*runtimecontracts.FlowContractView{"global": &root.Children[0]},
 				},
 				FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{"global": global.Schema},
+				URIRegistry: runtimecontracts.ContractURIRegistry{
+					Agents: map[string]runtimecontracts.ContractURIRef{"global/channel-sender": agentRef},
+					ByURI:  map[string]runtimecontracts.ContractURIRef{agentOwner: agentRef},
+				},
 			})
 			source, err := semanticview.WithRuntimeTools(base, publicTools)
 			if err != nil {
@@ -169,7 +183,7 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			stopActivityNode := startConfiguredChannelActivityNode(t, ctx, coordinator, bus, db)
 			executor := configuredChannelExecutor(source, binding, credentialStore, coordinator)
 			actor := models.AgentConfig{
-				ExecutionMode: "live", ID: "channel-sender", Identity: agentidentitytest.Runtime(t, "channel-sender", "channel-runtime-test", "global", flowInstanceID, flowInstance), Role: "worker", FlowID: "global",
+				ExecutionMode: "live", ID: "channel-sender", Identity: agentidentitytest.Declared(t, "channel-sender", agentOwner, "global", flowInstanceID, flowInstance), Role: "worker", FlowID: "global",
 				FlowPath: flowInstance, EntityID: entityID, Tools: []string{"channel.ops.deliver"},
 			}
 			input := map[string]any{
@@ -213,7 +227,7 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			if calls.Load() != 1 {
 				t.Fatalf("provider calls after replay = %d, want one", calls.Load())
 			}
-			assertConfiguredChannelJournal(t, ctx, db, selected, runID, privateToolID, 1)
+			assertConfiguredChannelJournal(t, ctx, db, selected, runID, privateToolID, flowInstance, entityID, 1)
 
 			if _, err := executor.Execute(callCtx, "channel.ops.deliver", map[string]any{
 				"presentation": map[string]any{"text": "Changed under same identity"}, "actions": []any{},
@@ -238,7 +252,7 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			if calls.Load() != 2 {
 				t.Fatalf("provider calls after ack-loss replay = %d, want two total distinct operations", calls.Load())
 			}
-			assertConfiguredChannelJournal(t, ctx, db, selected, runID, privateToolID, 2)
+			assertConfiguredChannelJournal(t, ctx, db, selected, runID, privateToolID, flowInstance, entityID, 2)
 
 			if err := credentialStore.Delete(ctx, "telegram_bot_token"); err != nil {
 				t.Fatalf("delete Telegram credential: %v", err)
@@ -563,15 +577,17 @@ func channelRuntimeCredentialStore(t *testing.T, token string) runtimecredential
 	return credentials
 }
 
-func assertConfiguredChannelJournal(t *testing.T, ctx context.Context, db *sql.DB, selected, runID, privateTool string, want int) {
+func assertConfiguredChannelJournal(t *testing.T, ctx context.Context, db *sql.DB, selected, runID, privateTool, flowInstance, entityID string, want int) {
 	t.Helper()
 	requestQuery := `SELECT COUNT(*) FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested'`
 	attemptQuery := `SELECT COUNT(*) FROM activity_attempts WHERE run_id = $1::uuid AND tool = $2 AND status = 'succeeded'`
+	sourceQuery := `SELECT source_route FROM events WHERE run_id = $1::uuid AND event_name = 'platform.activity_requested' ORDER BY created_at, event_id LIMIT 1`
 	args := []any{runID}
 	attemptArgs := []any{runID, privateTool}
 	if selected == "sqlite" {
 		requestQuery = `SELECT COUNT(*) FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested'`
 		attemptQuery = `SELECT COUNT(*) FROM activity_attempts WHERE run_id = ? AND tool = ? AND status = 'succeeded'`
+		sourceQuery = `SELECT source_route FROM events WHERE run_id = ? AND event_name = 'platform.activity_requested' ORDER BY created_at, event_id LIMIT 1`
 	}
 	var requests, attempts int
 	if err := db.QueryRowContext(ctx, requestQuery, args...).Scan(&requests); err != nil {
@@ -582,5 +598,17 @@ func assertConfiguredChannelJournal(t *testing.T, ctx context.Context, db *sql.D
 	}
 	if requests != want || attempts != want {
 		t.Fatalf("durable channel journal = requests:%d attempts:%d, want %d/%d", requests, attempts, want, want)
+	}
+	var rawRoute []byte
+	if err := db.QueryRowContext(ctx, sourceQuery, runID).Scan(&rawRoute); err != nil {
+		t.Fatalf("read channel activity routing source: %v", err)
+	}
+	var route events.RouteIdentity
+	if err := json.Unmarshal(rawRoute, &route); err != nil {
+		t.Fatalf("decode channel activity routing source %q: %v", rawRoute, err)
+	}
+	wantRoute := events.RouteIdentity{FlowID: "global", FlowInstance: flowInstance, EntityID: entityID}
+	if got := route.Normalized(); got != wantRoute {
+		t.Fatalf("durable channel routing source = %#v, want %#v", got, wantRoute)
 	}
 }

--- a/internal/runtime/channel_runtime_supported_surface_test.go
+++ b/internal/runtime/channel_runtime_supported_surface_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *testing.T) {
+func TestConfiguredChannelRuntimeDispatchesImportedAgentDurablyAcrossSelectedStores(t *testing.T) {
 	const bundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	for _, selected := range []string{"postgres", "sqlite"} {
 		t.Run(selected, func(t *testing.T) {
@@ -54,7 +54,8 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			runID := uuid.NewString()
 			entityID := uuid.NewString()
 			flowInstanceID := "channel-runtime-" + selected
-			flowInstance := "global/" + flowInstanceID
+			flowPath := "gateway/global"
+			flowInstance := flowPath + "/" + flowInstanceID
 			var (
 				db                  *sql.DB
 				eventStore          runtimebus.EventStore
@@ -116,7 +117,7 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 					ID: "global", Flow: "global", Mode: runtimecontracts.FlowModeTemplate,
 					PackageKey: "channel-runtime", AgentsFile: "/contracts/channel-runtime/flows/global/agents.yaml",
 				},
-				Path:   "global",
+				Path:   flowPath,
 				Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
 				Agents: map[string]runtimecontracts.AgentRegistryEntry{
 					"channel-sender": runtimecontracts.EffectiveAgentRegistryEntry("channel-sender", runtimecontracts.AgentRegistryEntry{ID: "channel-sender", Role: "worker"}),
@@ -183,7 +184,7 @@ func TestProjectImportedChannelRuntimeDispatchesDurablyAcrossSelectedStores(t *t
 			stopActivityNode := startConfiguredChannelActivityNode(t, ctx, coordinator, bus, db)
 			executor := configuredChannelExecutor(source, binding, credentialStore, coordinator)
 			actor := models.AgentConfig{
-				ExecutionMode: "live", ID: "channel-sender", Identity: agentidentitytest.Declared(t, "channel-sender", agentOwner, "global", flowInstanceID, flowInstance), Role: "worker", FlowID: "global",
+				ExecutionMode: "live", ID: "channel-sender", Identity: agentidentitytest.Declared(t, "channel-sender", agentOwner, flowPath, flowInstanceID, flowInstance), Role: "worker", FlowID: "global",
 				FlowPath: flowInstance, EntityID: entityID, Tools: []string{"channel.ops.deliver"},
 			}
 			input := map[string]any{

--- a/internal/runtime/contracts/agent_declaration_records_test.go
+++ b/internal/runtime/contracts/agent_declaration_records_test.go
@@ -1,0 +1,129 @@
+package contracts
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentDeclarationRecordsCanonicalizeDeepPackageBackedFlowProjection(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: canonical-agent-records
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: parent}
+`)
+	writeAgentDeclarationBaseFiles(t, root, "canonical-agent-records")
+	writeFixtureFile(t, filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - {path: child}
+`)
+	writeFixtureFile(t, filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	writeFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), "name: support\nmode: static\ninitial_state: active\nstates: [active]\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "agents.yaml"), `
+worker:
+  id: public-worker
+  role: worker
+  intent: {inline: Exercise canonical physical declaration ownership.}
+  model: regular
+  memory: false
+  subscriptions: [work.requested]
+`)
+	for _, file := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeFixtureFile(t, filepath.Join(flowRoot, file), "{}\n")
+	}
+
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	rawOccurrences := 0
+	for _, view := range bundle.ProjectViews() {
+		if _, ok := view.Agents["worker"]; ok {
+			rawOccurrences++
+		}
+	}
+	for _, view := range bundle.FlowViews() {
+		if _, ok := view.Agents["worker"]; ok {
+			rawOccurrences++
+		}
+	}
+	if rawOccurrences < 2 {
+		t.Fatalf("raw declaration occurrences = %d, want loader projection in both package and flow views", rawOccurrences)
+	}
+
+	records := bundle.AgentDeclarationRecords()
+	if len(records) != 1 {
+		t.Fatalf("records = %#v, want one physical declaration", records)
+	}
+	record := records[0]
+	if record.LogicalID != "worker" || record.OwnerFlowID != "support" || record.Source.Layer != "flow" ||
+		record.Source.PackageKey != "parent/child" || record.Source.FlowID != "support" ||
+		!strings.HasSuffix(filepath.ToSlash(record.Source.File), "parent/child/flows/support/agents.yaml") {
+		t.Fatalf("record = %#v, want exact child-package flow declaration", record)
+	}
+	project, ok := bundle.ProjectViewByKey("parent/child/flows/support")
+	if !ok || record.OwnerURI == "" || record.OwnerURI != project.AgentURIs["worker"] {
+		t.Fatalf("record owner = %q, project owners = %#v", record.OwnerURI, project.AgentURIs)
+	}
+	if got := bundle.PackageOwningFlowID("parent/child/flows/support"); got != "support" {
+		t.Fatalf("PackageOwningFlowID = %q, want support", got)
+	}
+
+	records[0].Entry.Subscriptions[0] = "mutated"
+	records[0].Entry.AuthoredFields["hostile"] = true
+	again := bundle.AgentDeclarationRecords()[0]
+	if again.Entry.Subscriptions[0] != "work.requested" || again.Entry.AuthoredFields["hostile"] {
+		t.Fatalf("caller mutation escaped immutable record snapshot: %#v", again.Entry)
+	}
+}
+
+func TestAgentDeclarationRecordsPreserveDistinctSameIDPhysicalDeclarations(t *testing.T) {
+	repoRoot := contractRepoRoot(t)
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: distinct-agent-records
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: left}
+  - {path: right}
+`)
+	writeAgentDeclarationBaseFiles(t, root, "distinct-agent-records")
+	for _, side := range []string{"left", "right"} {
+		packageRoot := filepath.Join(root, side)
+		writeFixtureFile(t, filepath.Join(packageRoot, "package.yaml"), "name: "+side+"\nversion: \"1.0.0\"\nflows: []\n")
+		writeFixtureFile(t, filepath.Join(packageRoot, "agents.yaml"), "worker:\n  role: "+side+"-worker\n  intent: {inline: Exercise distinct physical identity.}\n  model: regular\n  memory: false\n")
+	}
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repoRoot, root, DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	records := bundle.AgentDeclarationRecords()
+	if len(records) != 2 {
+		t.Fatalf("records = %#v, want both same-ID physical declarations", records)
+	}
+	if records[0].LogicalID != "worker" || records[1].LogicalID != "worker" || records[0].OwnerURI == records[1].OwnerURI || records[0].Source.File == records[1].Source.File {
+		t.Fatalf("distinct records collapsed: %#v", records)
+	}
+}
+
+func writeAgentDeclarationBaseFiles(t *testing.T, root, name string) {
+	t.Helper()
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: "+name+"\n")
+	for _, file := range []string{"agents.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeFixtureFile(t, filepath.Join(root, file), "{}\n")
+	}
+}

--- a/internal/runtime/contracts/agent_registry_resolution.go
+++ b/internal/runtime/contracts/agent_registry_resolution.go
@@ -6,28 +6,45 @@ import (
 	"strings"
 )
 
-type bundleAgentRecord struct {
-	LogicalID string
-	OwnerURI  string
-	Entry     AgentRegistryEntry
-	Source    ContractItemSource
+// AgentDeclarationRecord is the immutable semantic projection of one physical
+// agents.yaml declaration. The physical file/key identity remains private to
+// contracts; consumers receive only the exact authored owner facts.
+type AgentDeclarationRecord struct {
+	LogicalID   string
+	OwnerURI    string
+	OwnerFlowID string
+	Entry       AgentRegistryEntry
+	Source      ContractItemSource
 }
 
-func bundleAgentRecords(bundle *WorkflowContractBundle) []bundleAgentRecord {
+// AgentDeclarationRecords returns one record per physical declaration. Values
+// are copied so callers cannot mutate the loader-owned contract snapshot.
+func (b *WorkflowContractBundle) AgentDeclarationRecords() []AgentDeclarationRecord {
+	records := bundleAgentRecords(b)
+	out := make([]AgentDeclarationRecord, len(records))
+	for index, record := range records {
+		record.Entry = EffectiveAgentRegistryEntry(record.LogicalID, record.Entry)
+		out[index] = record
+	}
+	return out
+}
+
+func bundleAgentRecords(bundle *WorkflowContractBundle) []AgentDeclarationRecord {
 	if bundle == nil {
 		return nil
 	}
 	projectOwners := map[string]string{}
 	for _, view := range bundle.ProjectViews() {
+		ownerFlowID := strings.TrimSpace(view.Paths.OwningFlowID)
 		for _, logicalID := range sortedContractKeys(view.Agents) {
-			source := ContractItemSource{PackageKey: strings.TrimSpace(view.Paths.Key), Layer: "project", File: view.Paths.ProjectAgentsFile}
+			source := ContractItemSource{PackageKey: strings.TrimSpace(view.Paths.Key), FlowID: ownerFlowID, Layer: "project", File: view.Paths.ProjectAgentsFile}
 			if strings.TrimSpace(source.File) != "" {
 				projectOwners[agentDeclarationRecordKey(source.File, logicalID)] = strings.TrimSpace(view.AgentURIs[logicalID])
 			}
 		}
 	}
 	flowDeclarations := map[string]struct{}{}
-	flowRecords := make([]bundleAgentRecord, 0, len(bundle.FlowTree.ByID))
+	flowRecords := make([]AgentDeclarationRecord, 0, len(bundle.FlowTree.ByID))
 	for _, view := range bundle.FlowViews() {
 		flowID := strings.TrimSpace(view.Paths.ID)
 		agentIDs := sortedContractKeys(view.Agents)
@@ -41,29 +58,48 @@ func bundleAgentRecords(bundle *WorkflowContractBundle) []bundleAgentRecord {
 			if strings.TrimSpace(source.File) != "" {
 				flowDeclarations[agentDeclarationRecordKey(source.File, logicalID)] = struct{}{}
 			}
-			ownerURI := strings.TrimSpace(view.AgentURIs[logicalID])
+			ownerURI := bundle.agentDeclarationOwnerURI(source, logicalID, view.AgentURIs[logicalID])
 			if canonical := projectOwners[agentDeclarationRecordKey(source.File, logicalID)]; canonical != "" {
 				ownerURI = canonical
 			}
-			flowRecords = append(flowRecords, bundleAgentRecord{LogicalID: logicalID, OwnerURI: ownerURI, Entry: view.Agents[logicalID], Source: source})
+			flowRecords = append(flowRecords, AgentDeclarationRecord{LogicalID: logicalID, OwnerURI: ownerURI, OwnerFlowID: flowID, Entry: view.Agents[logicalID], Source: source})
 		}
 	}
-	records := make([]bundleAgentRecord, 0, len(bundle.ProjectViews())+len(bundle.FlowTree.ByID))
+	records := make([]AgentDeclarationRecord, 0, len(bundle.ProjectViews())+len(bundle.FlowTree.ByID))
 	for _, view := range bundle.ProjectViews() {
 		key := strings.TrimSpace(view.Paths.Key)
+		ownerFlowID := strings.TrimSpace(view.Paths.OwningFlowID)
 		agentIDs := sortedContractKeys(view.Agents)
 		for _, logicalID := range agentIDs {
-			source := ContractItemSource{PackageKey: key, Layer: "project", File: view.Paths.ProjectAgentsFile}
+			source := ContractItemSource{PackageKey: key, FlowID: ownerFlowID, Layer: "project", File: view.Paths.ProjectAgentsFile}
 			if strings.TrimSpace(source.File) != "" {
 				if _, representedByFlow := flowDeclarations[agentDeclarationRecordKey(source.File, logicalID)]; representedByFlow {
 					continue
 				}
 			}
-			records = append(records, bundleAgentRecord{
+			records = append(records, AgentDeclarationRecord{
+				LogicalID:   logicalID,
+				OwnerURI:    strings.TrimSpace(view.AgentURIs[logicalID]),
+				OwnerFlowID: ownerFlowID,
+				Entry:       view.Agents[logicalID],
+				Source:      source,
+			})
+		}
+	}
+	if len(records) == 0 && len(flowRecords) == 0 && len(bundle.Agents) > 0 {
+		for _, logicalID := range sortedContractKeys(bundle.Agents) {
+			ownerURI := ""
+			if ref, ok := bundle.URIRegistry.Agents[logicalID]; ok {
+				ownerURI = strings.TrimSpace(ref.Full)
+				if ownerURI == "" {
+					ownerURI = strings.TrimSpace(ref.Absolute)
+				}
+			}
+			records = append(records, AgentDeclarationRecord{
 				LogicalID: logicalID,
-				OwnerURI:  strings.TrimSpace(view.AgentURIs[logicalID]),
-				Entry:     view.Agents[logicalID],
-				Source:    source,
+				OwnerURI:  ownerURI,
+				Entry:     bundle.Agents[logicalID],
+				Source:    ContractItemSource{PackageKey: ".", Layer: "project", File: bundle.Paths.ProjectAgentsFile},
 			})
 		}
 	}
@@ -77,6 +113,44 @@ func bundleAgentRecords(bundle *WorkflowContractBundle) []bundleAgentRecord {
 		return left < right
 	})
 	return records
+}
+
+// PackageOwningFlowID returns the immutable ownership fact established while
+// the package tree is discovered. Runtime consumers must not rederive it.
+func (b *WorkflowContractBundle) PackageOwningFlowID(packageKey string) string {
+	packageKey = strings.TrimSpace(packageKey)
+	if b == nil || packageKey == "" {
+		return ""
+	}
+	view, ok := b.ProjectViewByKey(packageKey)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(view.Paths.OwningFlowID)
+}
+
+func (b *WorkflowContractBundle) agentDeclarationOwnerURI(source ContractItemSource, logicalID, preferred string) string {
+	if owner := strings.TrimSpace(preferred); owner != "" {
+		return owner
+	}
+	if b == nil || strings.TrimSpace(source.Layer) != "flow" || strings.TrimSpace(source.FlowID) == "" {
+		return ""
+	}
+	owner := ""
+	for _, ref := range b.URIRegistry.Agents {
+		if strings.TrimSpace(ref.Kind) != "agent" || strings.TrimSpace(ref.FlowID) != strings.TrimSpace(source.FlowID) || strings.TrimSpace(ref.LocalID) != strings.TrimSpace(logicalID) {
+			continue
+		}
+		candidate := strings.TrimSpace(ref.Full)
+		if candidate == "" {
+			candidate = strings.TrimSpace(ref.Absolute)
+		}
+		if candidate == "" || (owner != "" && owner != candidate) {
+			return ""
+		}
+		owner = candidate
+	}
+	return owner
 }
 
 func agentDeclarationRecordKey(sourceFile, logicalID string) string {

--- a/internal/runtime/contracts/workflow_contract_accessors.go
+++ b/internal/runtime/contracts/workflow_contract_accessors.go
@@ -1123,8 +1123,10 @@ func (b *WorkflowContractBundle) FlowRequiredAgentFacts(flowID string) []Require
 		return nil
 	}
 	if schema, ok := b.FlowSchemas[flowID]; ok {
-		agents, agentsFile := b.flowRequiredAgentScope(flowID)
-		return EffectiveRequiredAgentFacts(schema, agents, b.flowRequiredAgentSchemaFile(flowID), agentsFile)
+		if RequiredAgentsDeclared(schema) {
+			return explicitRequiredAgentFacts(schema.RequiredAgents, b.flowRequiredAgentSchemaFile(flowID))
+		}
+		return b.inferredRequiredAgentFacts(flowID)
 	}
 	if facts := b.Semantics.FlowAgentFacts[flowID]; len(facts) > 0 {
 		return cloneRequiredAgentFacts(facts)
@@ -1138,34 +1140,36 @@ func (b *WorkflowContractBundle) RootRequiredAgentFacts() []RequiredAgentFact {
 	if b == nil || b.RootSchema == nil {
 		return nil
 	}
-	agents, agentsFile := b.rootRequiredAgentScope()
-	return EffectiveRequiredAgentFacts(*b.RootSchema, agents, b.Paths.RootSchemaFile, agentsFile)
+	if RequiredAgentsDeclared(*b.RootSchema) {
+		return explicitRequiredAgentFacts(b.RootSchema.RequiredAgents, b.Paths.RootSchemaFile)
+	}
+	return b.inferredRequiredAgentFacts("")
 }
-func (b *WorkflowContractBundle) rootRequiredAgentScope() (map[string]AgentRegistryEntry, string) {
+
+func (b *WorkflowContractBundle) inferredRequiredAgentFacts(ownerFlowID string) []RequiredAgentFact {
+	ownerFlowID = strings.TrimSpace(ownerFlowID)
 	if b == nil {
-		return nil, ""
+		return nil
 	}
-	for _, view := range b.ProjectViews() {
-		if strings.TrimSpace(view.Paths.ParentKey) == "" && view.Paths.Depth == 0 {
-			return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
+	records := b.AgentDeclarationRecords()
+	out := make([]RequiredAgentFact, 0, len(records))
+	for _, record := range records {
+		if strings.TrimSpace(record.OwnerFlowID) != ownerFlowID {
+			continue
 		}
-	}
-	for _, view := range b.ProjectViews() {
-		if strings.TrimSpace(view.Paths.ParentKey) == "" {
-			return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.ProjectAgentsFile)
+		role := strings.TrimSpace(record.LogicalID)
+		if role == "" {
+			continue
 		}
+		out = append(out, RequiredAgentFact{
+			Role:         role,
+			SubscribesTo: normalizeStrings(record.Entry.Subscriptions),
+			Emits:        normalizeStrings(record.Entry.EmitEvents),
+			Source:       RequiredAgentSourceInferred,
+			SourceFile:   strings.TrimSpace(record.Source.File),
+		})
 	}
-	return EffectiveAgentRegistryEntries(b.Agents), strings.TrimSpace(b.Paths.ProjectAgentsFile)
-}
-func (b *WorkflowContractBundle) flowRequiredAgentScope(flowID string) (map[string]AgentRegistryEntry, string) {
-	flowID = strings.TrimSpace(flowID)
-	if b == nil || flowID == "" {
-		return nil, ""
-	}
-	if view, ok := b.FlowViewByID(flowID); ok && view != nil {
-		return EffectiveAgentRegistryEntries(view.Agents), strings.TrimSpace(view.Paths.AgentsFile)
-	}
-	return nil, ""
+	return out
 }
 func (b *WorkflowContractBundle) flowRequiredAgentSchemaFile(flowID string) string {
 	flowID = strings.TrimSpace(flowID)

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -299,9 +299,6 @@ func projectChildOwningFlowID(parent ProjectPackagePaths, childPackageFile strin
 			return flowID
 		}
 	}
-	if len(parent.Flows) == 1 {
-		return strings.TrimSpace(parent.Flows[0].ID)
-	}
 	return strings.TrimSpace(parent.OwningFlowID)
 }
 func validateDiscoveredPackageTree(pkgs []LoadedProjectPackage) error {

--- a/internal/runtime/contracts/workflow_contract_paths.go
+++ b/internal/runtime/contracts/workflow_contract_paths.go
@@ -188,8 +188,8 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 	}
 	visited := map[string]bool{}
 	var out []ProjectPackagePaths
-	var walk func(packageFile, parentKey string, depth int)
-	walk = func(packageFile, parentKey string, depth int) {
+	var walk func(packageFile, parentKey, owningFlowID string, depth int)
+	walk = func(packageFile, parentKey, owningFlowID string, depth int) {
 		packageFile = existingFile(packageFile)
 		if packageFile == "" || visited[packageFile] {
 			return
@@ -207,6 +207,7 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 		pkg := ProjectPackagePaths{
 			Key:               key,
 			ParentKey:         parentKey,
+			OwningFlowID:      strings.TrimSpace(owningFlowID),
 			Depth:             depth,
 			Dir:               packageDir,
 			PackageFile:       packageFile,
@@ -250,15 +251,19 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 		})
 		out = append(out, pkg)
 
-		var flowPackageFiles []string
+		type flowPackagePath struct {
+			file   string
+			flowID string
+		}
+		var flowPackages []flowPackagePath
 		for _, flow := range pkg.Flows {
-			if flowPackage := existingFile(filepath.Join(flow.Dir, "package.yaml")); flowPackage != "" {
-				flowPackageFiles = append(flowPackageFiles, flowPackage)
+			if packageFile := existingFile(filepath.Join(flow.Dir, "package.yaml")); packageFile != "" {
+				flowPackages = append(flowPackages, flowPackagePath{file: packageFile, flowID: strings.TrimSpace(flow.ID)})
 			}
 		}
-		sort.Strings(flowPackageFiles)
-		for _, flowPackage := range flowPackageFiles {
-			walk(flowPackage, pkg.Key, depth+1)
+		sort.Slice(flowPackages, func(i, j int) bool { return flowPackages[i].file < flowPackages[j].file })
+		for _, child := range flowPackages {
+			walk(child.file, pkg.Key, child.flowID, depth+1)
 		}
 
 		for _, child := range manifest.ChildPackages() {
@@ -268,13 +273,14 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 			}
 			childPath := filepath.Join(packageDir, location)
 			if strings.HasSuffix(strings.ToLower(location), ".yaml") {
-				walk(childPath, pkg.Key, depth+1)
+				walk(childPath, pkg.Key, projectChildOwningFlowID(pkg, childPath), depth+1)
 				continue
 			}
-			walk(filepath.Join(childPath, "package.yaml"), pkg.Key, depth+1)
+			childPackageFile := filepath.Join(childPath, "package.yaml")
+			walk(childPackageFile, pkg.Key, projectChildOwningFlowID(pkg, childPackageFile), depth+1)
 		}
 	}
-	walk(rootFile, "", 0)
+	walk(rootFile, "", "", 0)
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Depth == out[j].Depth {
 			return strings.Compare(out[i].Key, out[j].Key) < 0
@@ -282,6 +288,21 @@ func discoverProjectPackagePaths(packageFile, workflowDir string) []ProjectPacka
 		return out[i].Depth < out[j].Depth
 	})
 	return out
+}
+
+func projectChildOwningFlowID(parent ProjectPackagePaths, childPackageFile string) string {
+	childDir := filepath.Clean(filepath.Dir(childPackageFile))
+	for _, flow := range parent.Flows {
+		flowID := strings.TrimSpace(flow.ID)
+		flowDir := filepath.Clean(strings.TrimSpace(flow.Dir))
+		if flowID != "" && flowDir != "" && flowDir != "." && (childDir == flowDir || strings.HasPrefix(childDir, flowDir+string(filepath.Separator))) {
+			return flowID
+		}
+	}
+	if len(parent.Flows) == 1 {
+		return strings.TrimSpace(parent.Flows[0].ID)
+	}
+	return strings.TrimSpace(parent.OwningFlowID)
 }
 func validateDiscoveredPackageTree(pkgs []LoadedProjectPackage) error {
 	seenPackages := map[string]struct{}{}
@@ -338,13 +359,15 @@ func cloneAgentRegistryEntry(in AgentRegistryEntry) AgentRegistryEntry {
 	if len(in.EntityWrites) > 0 {
 		out.EntityWrites = make(map[string]AgentEntityWriteDecl, len(in.EntityWrites))
 		for key, value := range in.EntityWrites {
+			value.Create.Fields = append([]string(nil), value.Create.Fields...)
+			value.Save.Fields = append([]string(nil), value.Save.Fields...)
 			out.EntityWrites[key] = value
 		}
 	}
 	if len(in.NativeTools) > 0 {
 		out.NativeTools = make(map[string]any, len(in.NativeTools))
 		for key, value := range in.NativeTools {
-			out.NativeTools[key] = value
+			out.NativeTools[key] = cloneEventSchemaValue(value)
 		}
 	}
 	if len(in.Permissions) > 0 {
@@ -353,8 +376,17 @@ func cloneAgentRegistryEntry(in AgentRegistryEntry) AgentRegistryEntry {
 	if len(in.Subscriptions) > 0 {
 		out.Subscriptions = append([]string{}, in.Subscriptions...)
 	}
+	if len(in.SubscriptionsBootstrap) > 0 {
+		out.SubscriptionsBootstrap = append([]string{}, in.SubscriptionsBootstrap...)
+	}
+	if len(in.SubscribesTo) > 0 {
+		out.SubscribesTo = append([]string{}, in.SubscribesTo...)
+	}
 	if len(in.Tools) > 0 {
 		out.Tools = append([]string{}, in.Tools...)
+	}
+	if len(in.ToolsTier2) > 0 {
+		out.ToolsTier2 = append([]string{}, in.ToolsTier2...)
 	}
 	if len(in.FlowDataAccess) > 0 {
 		out.FlowDataAccess = append([]string{}, in.FlowDataAccess...)

--- a/internal/runtime/contracts/workflow_contract_types.go
+++ b/internal/runtime/contracts/workflow_contract_types.go
@@ -1132,6 +1132,7 @@ type ManagedCredentialRef struct {
 type ProjectPackagePaths struct {
 	Key               string
 	ParentKey         string
+	OwningFlowID      string
 	Depth             int
 	Dir               string
 	PackageFile       string

--- a/internal/runtime/contracts/workflow_contracts_tree_test.go
+++ b/internal/runtime/contracts/workflow_contracts_tree_test.go
@@ -273,6 +273,14 @@ func TestWorkflowContractBundleEffectiveRequiredAgentsInferWhenOmitted(t *testin
 		},
 		FlowTree: FlowTree{ByID: map[string]*FlowContractView{"analysis": flowView}},
 	}
+	bundle.FlowTree.Root = flowView
+	bundle.projectContracts = map[string]ProjectContractView{
+		".": {
+			Paths:     ProjectPackagePaths{Key: ".", ProjectAgentsFile: "agents.yaml"},
+			Agents:    bundle.Agents,
+			AgentURIs: map[string]string{"root-agent": "swarm://root/agent/root-agent"},
+		},
+	}
 
 	rootFacts := bundle.RootRequiredAgentFacts()
 	if len(rootFacts) != 1 || rootFacts[0].Role != "root-agent" || rootFacts[0].Source != RequiredAgentSourceInferred {

--- a/internal/runtime/core/pinrouting/connect_route_plan.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan.go
@@ -2014,26 +2014,32 @@ func staticConnectReceiverDeliveryRoute(source semanticview.Source, endpoint sem
 }
 
 func staticConnectReceiverAgent(source semanticview.Source, endpoint semanticview.AuthoredEventEndpoint, logicalID string) (string, string, bool) {
-	packageKey := strings.TrimSpace(endpoint.PackageKey)
-	if packageKey != "" {
-		for _, scope := range source.ProjectScopes() {
-			if strings.TrimSpace(scope.Key) != packageKey {
-				continue
-			}
-			namePlan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
-			if err == nil {
-				return namePlan.AgentID, namePlan.OwnerURI, true
-			}
-			break
-		}
+	packageKey := strings.Trim(strings.TrimSpace(endpoint.PackageKey), "/")
+	if packageKey == "" {
+		packageKey = runtimeidentity.RootPackageKey
 	}
 	flowID := strings.TrimSpace(endpoint.FlowID)
-	if flowID != "" {
-		if scope, ok := source.FlowScopeByID(flowID); ok {
-			namePlan, err := semanticview.FlowAgentNamePlan(source, scope, logicalID)
-			if err == nil {
-				return namePlan.AgentID, namePlan.OwnerURI, true
-			}
+	sourceFile := strings.TrimSpace(endpoint.SourceFile)
+	var matched semanticview.AgentDeclaration
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		candidatePackage := strings.Trim(strings.TrimSpace(declaration.Source.PackageKey), "/")
+		if candidatePackage == "" {
+			candidatePackage = runtimeidentity.RootPackageKey
+		}
+		if strings.TrimSpace(declaration.LocalID) != strings.TrimSpace(logicalID) ||
+			strings.TrimSpace(declaration.OwnerFlowID) != flowID || candidatePackage != packageKey ||
+			(sourceFile != "" && strings.TrimSpace(declaration.Source.File) != sourceFile) {
+			continue
+		}
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return "", "", false
+		}
+		matched = declaration
+	}
+	if strings.TrimSpace(matched.LocalID) != "" {
+		namePlan, err := semanticview.ScopedAgentNamePlan(source, matched)
+		if err == nil {
+			return namePlan.AgentID, namePlan.OwnerURI, true
 		}
 	}
 	return "", "", false

--- a/internal/runtime/core/pinrouting/connect_route_plan_test.go
+++ b/internal/runtime/core/pinrouting/connect_route_plan_test.go
@@ -50,42 +50,52 @@ func TestStaticConnectReceiverAgentPreservesExactProjectScopeAndLocalCoordinate(
 		ID:             "public-worker",
 		AuthoredFields: map[string]bool{"id": true},
 	}
-	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
-		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
-			omittedOwner: {Kind: "agent", LocalID: "worker", Full: omittedOwner},
-			literalOwner: {Kind: "agent", LocalID: "worker", Full: literalOwner},
-		}},
-	})
-	source := staticConnectAgentScopeSource{
-		Source: base,
-		projects: []semanticview.ProjectScope{
-			{
-				Key: "packages/first", OwningFlowID: "support",
-				Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": omittedEntry},
-				AgentURIs: map[string]string{"worker": omittedOwner},
-			},
-			{
-				Key: "packages/second", OwningFlowID: "support",
-				Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": literalEntry},
-				AgentURIs: map[string]string{"worker": literalOwner},
+	first := runtimecontracts.FlowContractView{
+		Path: "first-support",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: "first-support", PackageKey: "packages/first",
+		},
+		Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": omittedEntry},
+		AgentURIs: map[string]string{"worker": omittedOwner},
+	}
+	second := runtimecontracts.FlowContractView{
+		Path: "second-support",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: "second-support", PackageKey: "packages/second",
+		},
+		Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": literalEntry},
+		AgentURIs: map[string]string{"worker": literalOwner},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{first, second}}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{
+				"first-support":  &root.Children[0],
+				"second-support": &root.Children[1],
 			},
 		},
-	}
+		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+			omittedOwner: {Kind: "agent", FlowID: "first-support", LocalID: "worker", Full: omittedOwner},
+			literalOwner: {Kind: "agent", FlowID: "second-support", LocalID: "worker", Full: literalOwner},
+		}},
+	})
 
 	for _, tc := range []struct {
 		name       string
 		packageKey string
+		flowID     string
 		publicID   string
 		owner      string
 	}{
-		{name: "omitted id", packageKey: "packages/first", publicID: "worker", owner: omittedOwner},
-		{name: "literal override", packageKey: "packages/second", publicID: "public-worker", owner: literalOwner},
+		{name: "omitted id", packageKey: "packages/first", flowID: "first-support", publicID: "worker", owner: omittedOwner},
+		{name: "literal override", packageKey: "packages/second", flowID: "second-support", publicID: "public-worker", owner: literalOwner},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			endpoint := semanticview.AuthoredEventEndpoint{
 				Kind:         semanticview.EventEndpointAgent,
 				PackageKey:   tc.packageKey,
-				FlowID:       "support",
+				FlowID:       tc.flowID,
 				AgentLocalID: "worker",
 				AgentID:      tc.publicID,
 			}
@@ -101,15 +111,6 @@ func TestStaticConnectReceiverAgentPreservesExactProjectScopeAndLocalCoordinate(
 			}
 		})
 	}
-}
-
-type staticConnectAgentScopeSource struct {
-	semanticview.Source
-	projects []semanticview.ProjectScope
-}
-
-func (s staticConnectAgentScopeSource) ProjectScopes() []semanticview.ProjectScope {
-	return append([]semanticview.ProjectScope(nil), s.projects...)
 }
 
 func TestConnectReceiverPinAdmissionOwnsRuntimeCollisionIdentity(t *testing.T) {

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentitytest"
 	"github.com/division-sh/swarm/internal/runtime/core/identitytest"
 	"github.com/division-sh/swarm/internal/runtime/flowmodel"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
@@ -153,6 +155,48 @@ func TestAdmitNodeExecutionRoutingSourceUsesNestedPackageOwningFlow(t *testing.T
 	hostile := identitytest.ExecutableNode(t, "packages/b", "orders", "shared")
 	if _, err := AdmitNodeExecutionRoutingSource(source, hostile, "orders", route); err == nil || !strings.Contains(err.Error(), "requires declared node") {
 		t.Fatalf("undeclared package sibling error = %v", err)
+	}
+}
+
+func TestAdmitAgentExecutionRoutingSourceSeparatesImportedDeclarationFromRuntimePath(t *testing.T) {
+	const owner = "test://pinrouting/bot/telegram-chat/phrase-bot"
+	flow := runtimecontracts.FlowContractView{
+		Path: "telegram-ingress/telegram-chat",
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: "telegram-chat", Flow: "telegram-chat", PackageKey: "bot", AgentsFile: "/contracts/bot/flows/telegram-chat/agents.yaml",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			"phrase-bot": runtimecontracts.EffectiveAgentRegistryEntry("phrase-bot", runtimecontracts.AgentRegistryEntry{ID: "phrase-bot", Role: "phrase-bot"}),
+		},
+		AgentURIs: map[string]string{"phrase-bot": owner},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{Root: &root, ByID: map[string]*runtimecontracts.FlowContractView{"telegram-chat": &root.Children[0]}},
+		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+			owner: {Kind: "agent", FlowID: "telegram-chat", LocalID: "phrase-bot", Full: owner},
+		}},
+	})
+	actor := models.AgentConfig{
+		ID:       "phrase-bot",
+		FlowID:   "telegram-chat",
+		FlowPath: "telegram-ingress/telegram-chat/chat-1",
+		Identity: agentidentitytest.Declared(t, "phrase-bot", owner, "telegram-ingress/telegram-chat", "chat-1", "telegram-ingress/telegram-chat/chat-1"),
+	}
+	got, err := AdmitAgentExecutionRoutingSource(source, actor, "chat-entity")
+	if err != nil {
+		t.Fatalf("AdmitAgentExecutionRoutingSource: %v", err)
+	}
+	wantRoute := events.RouteIdentity{FlowID: "telegram-chat", FlowInstance: actor.FlowPath, EntityID: "chat-entity"}
+	if got.Kind() != events.RoutingSourceConcreteTemplateInstance || got.Route() != wantRoute {
+		t.Fatalf("routing source = %s %#v, want exact declaration flow plus runtime path %#v", got.Kind().StorageCode(), got.Route(), wantRoute)
+	}
+
+	hostile := actor
+	hostile.Identity = agentidentitytest.Runtime(t, "phrase-bot", owner, "telegram-ingress/telegram-chat", "chat-1", actor.FlowPath)
+	if _, err := AdmitAgentExecutionRoutingSource(source, hostile, "chat-entity"); err == nil || !strings.Contains(err.Error(), "declared agent identity") {
+		t.Fatalf("runtime-created declaration collision error = %v", err)
 	}
 }
 

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -261,7 +261,7 @@ func loadProjectAgentOwnedByFlowSource(t *testing.T, mode string) semanticview.S
 			t.Fatalf("write %s: %v", path, err)
 		}
 	}
-	write(filepath.Join(root, "package.yaml"), "name: project-flow-agent\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\npackages:\n  - path: extras\nflows:\n  - id: support\n    flow: support\n    mode: "+mode+"\n")
+	write(filepath.Join(root, "package.yaml"), "name: project-flow-agent\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\npackages:\n  - path: flows/support/extras\nflows:\n  - id: support\n    flow: support\n    mode: "+mode+"\n")
 	write(filepath.Join(root, "schema.yaml"), "name: project-flow-agent\n")
 	write(filepath.Join(root, "policy.yaml"), "{}\n")
 	write(filepath.Join(root, "tools.yaml"), "{}\n")
@@ -270,8 +270,8 @@ func loadProjectAgentOwnedByFlowSource(t *testing.T, mode string) semanticview.S
 	write(filepath.Join(root, "flows", "support", "schema.yaml"), "name: support\ninitial_state: waiting\nstates: [waiting, done]\n")
 	write(filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
 	write(filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
-	write(filepath.Join(root, "extras", "package.yaml"), "name: extras\nversion: \"1.0.0\"\nflows: []\n")
-	write(filepath.Join(root, "extras", "agents.yaml"), "backend:\n  type: generic\n  role: backend\n  intent: {inline: \"Handle backend work.\"}\n  model: regular\n")
+	write(filepath.Join(root, "flows", "support", "extras", "package.yaml"), "name: extras\nversion: \"1.0.0\"\nflows: []\n")
+	write(filepath.Join(root, "flows", "support", "extras", "agents.yaml"), "backend:\n  type: generic\n  role: backend\n  intent: {inline: \"Handle backend work.\"}\n  model: regular\n")
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {
 		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)

--- a/internal/runtime/core/pinrouting/pinrouting_test.go
+++ b/internal/runtime/core/pinrouting/pinrouting_test.go
@@ -1,6 +1,8 @@
 package pinrouting
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -198,6 +200,83 @@ func TestAdmitAgentExecutionRoutingSourceSeparatesImportedDeclarationFromRuntime
 	if _, err := AdmitAgentExecutionRoutingSource(source, hostile, "chat-entity"); err == nil || !strings.Contains(err.Error(), "declared agent identity") {
 		t.Fatalf("runtime-created declaration collision error = %v", err)
 	}
+}
+
+func TestAdmitAgentExecutionRoutingSourceUsesProjectDeclarationOwningFlow(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mode         string
+		instanceID   string
+		instancePath string
+		entityID     string
+		wantKind     events.RoutingSourceKind
+	}{
+		{name: "template", mode: runtimecontracts.FlowModeTemplate, instanceID: "inst-1", instancePath: "support/inst-1", entityID: "entity-one", wantKind: events.RoutingSourceConcreteTemplateInstance},
+		{name: "entityless_template", mode: runtimecontracts.FlowModeTemplate, instanceID: "inst-1", instancePath: "support/inst-1", wantKind: events.RoutingSourceConcreteTemplateInstance},
+		{name: "static", mode: runtimecontracts.FlowModeStatic, instanceID: "support", instancePath: "support", entityID: "entity-one", wantKind: events.RoutingSourceStaticFlow},
+		{name: "singleton", mode: runtimecontracts.FlowModeSingleton, instanceID: "support", instancePath: "support", entityID: "entity-one", wantKind: events.RoutingSourceStaticFlow},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadProjectAgentOwnedByFlowSource(t, tc.mode)
+			declarations := semanticview.AgentDeclarations(source)
+			if len(declarations) != 1 || declarations[0].Source.Layer != "project" || declarations[0].OwnerFlowID != "support" {
+				t.Fatalf("declarations = %#v, want one project declaration owned by support", declarations)
+			}
+			plan, err := semanticview.ScopedAgentNamePlan(source, declarations[0])
+			if err != nil {
+				t.Fatalf("ScopedAgentNamePlan: %v", err)
+			}
+			actor := models.AgentConfig{
+				ID:       "backend",
+				FlowID:   "support",
+				FlowPath: tc.instancePath,
+				Identity: agentidentitytest.Declared(t, "backend", plan.OwnerURI, "support", tc.instanceID, tc.instancePath),
+			}
+			got, err := AdmitAgentExecutionRoutingSource(source, actor, tc.entityID)
+			if err != nil {
+				t.Fatalf("AdmitAgentExecutionRoutingSource: %v", err)
+			}
+			wantRoute := events.RouteIdentity{FlowID: "support", FlowInstance: tc.instancePath, EntityID: tc.entityID}
+			if got.Kind() != tc.wantKind || got.Route() != wantRoute {
+				t.Fatalf("routing source = %s %#v, want %s %#v", got.Kind().StorageCode(), got.Route(), tc.wantKind.StorageCode(), wantRoute)
+			}
+		})
+	}
+}
+
+func loadProjectAgentOwnedByFlowSource(t *testing.T, mode string) semanticview.Source {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", "..", ".."))
+	root := t.TempDir()
+	write := func(path, contents string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	write(filepath.Join(root, "package.yaml"), "name: project-flow-agent\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\npackages:\n  - path: extras\nflows:\n  - id: support\n    flow: support\n    mode: "+mode+"\n")
+	write(filepath.Join(root, "schema.yaml"), "name: project-flow-agent\n")
+	write(filepath.Join(root, "policy.yaml"), "{}\n")
+	write(filepath.Join(root, "tools.yaml"), "{}\n")
+	write(filepath.Join(root, "agents.yaml"), "{}\n")
+	write(filepath.Join(root, "events.yaml"), "{}\n")
+	write(filepath.Join(root, "flows", "support", "schema.yaml"), "name: support\ninitial_state: waiting\nstates: [waiting, done]\n")
+	write(filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
+	write(filepath.Join(root, "flows", "support", "events.yaml"), "{}\n")
+	write(filepath.Join(root, "extras", "package.yaml"), "name: extras\nversion: \"1.0.0\"\nflows: []\n")
+	write(filepath.Join(root, "extras", "agents.yaml"), "backend:\n  type: generic\n  role: backend\n  intent: {inline: \"Handle backend work.\"}\n  model: regular\n")
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
 }
 
 func TestPinDeclaredOutputRecognizesExactRootOutputOnly(t *testing.T) {

--- a/internal/runtime/core/pinrouting/routing_source.go
+++ b/internal/runtime/core/pinrouting/routing_source.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/division-sh/swarm/internal/events"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
-	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimeidentity "github.com/division-sh/swarm/internal/runtime/core/identity"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 )
@@ -54,21 +54,21 @@ func AdmitNodeExecutionRoutingSource(source semanticview.Source, node runtimeide
 }
 
 // AdmitAgentExecutionRoutingSource admits the exact source fact from the
-// actor's typed identity. Tool-produced events copy this value unchanged.
-func AdmitAgentExecutionRoutingSource(source semanticview.Source, identity agentidentity.Identity, entityID string) (events.RoutingSource, error) {
+// actor's declaration-owned execution scope. Tool-produced events copy this
+// value unchanged.
+func AdmitAgentExecutionRoutingSource(source semanticview.Source, actor models.AgentConfig, entityID string) (events.RoutingSource, error) {
 	if source == nil {
 		return events.RoutingSource{}, fmt.Errorf("agent execution routing source requires semantic source")
 	}
-	identity = identity.Normalize()
-	if err := identity.Validate(); err != nil {
-		return events.RoutingSource{}, fmt.Errorf("agent execution routing source requires typed identity: %w", err)
+	scope, err := semanticview.ResolveAgentExecutionSemanticScope(source, actor)
+	if err != nil {
+		return events.RoutingSource{}, err
 	}
-	scopeKey, _, instancePath, present := identity.Route.Fields()
-	owner := runtimecontracts.ContractItemSource{Layer: "project"}
+	identity := scope.Identity()
+	owner := scope.ContractSource()
 	route := events.RouteIdentity{EntityID: strings.TrimSpace(entityID)}
-	if present {
-		owner = runtimecontracts.ContractItemSource{Layer: "flow", FlowID: scopeKey}
-		route.FlowID = scopeKey
+	if instancePath := strings.TrimSpace(identity.Route.Normalize().InstancePath); instancePath != "" {
+		route.FlowID = strings.TrimSpace(scope.Declaration().OwnerFlowID)
 		route.FlowInstance = instancePath
 	}
 	return admitDeclaredExecutionRoutingSource(source, "agent", identity.AgentID(), owner, route)

--- a/internal/runtime/core/pinrouting/routing_source.go
+++ b/internal/runtime/core/pinrouting/routing_source.go
@@ -66,10 +66,22 @@ func AdmitAgentExecutionRoutingSource(source semanticview.Source, actor models.A
 	}
 	identity := scope.Identity()
 	owner := scope.ContractSource()
+	ownerFlowID := strings.TrimSpace(scope.Declaration().OwnerFlowID)
 	route := events.RouteIdentity{EntityID: strings.TrimSpace(entityID)}
 	if instancePath := strings.TrimSpace(identity.Route.Normalize().InstancePath); instancePath != "" {
-		route.FlowID = strings.TrimSpace(scope.Declaration().OwnerFlowID)
+		route.FlowID = ownerFlowID
 		route.FlowInstance = instancePath
+	}
+	if ownerFlowID != "" {
+		if sourceFlowID := strings.TrimSpace(owner.FlowID); sourceFlowID != "" && sourceFlowID != ownerFlowID {
+			return events.RoutingSource{}, fmt.Errorf("agent %q declaration source flow %q conflicts with canonical owning flow %q", identity.AgentID(), sourceFlowID, ownerFlowID)
+		}
+		owner.FlowID = ownerFlowID
+		flow, ok := scope.OwningFlow()
+		if !ok {
+			return events.RoutingSource{}, fmt.Errorf("agent %q routing source references missing owning flow %q", identity.AgentID(), ownerFlowID)
+		}
+		return admitFlowExecutionRoutingSource(source, "agent", identity.AgentID(), owner, route, flow)
 	}
 	return admitDeclaredExecutionRoutingSource(source, "agent", identity.AgentID(), owner, route)
 }

--- a/internal/runtime/effects/source_manifest_test.go
+++ b/internal/runtime/effects/source_manifest_test.go
@@ -112,6 +112,8 @@ var sourcePrimitiveOwners = map[string]primitiveOwner{
 	"internal/runtime/shutdown_admission.go:BeginContext:http_do:1":                                                       ownerRuntimeDependency,
 	"internal/runtime/testfixtures/notifyallchildren/fixture.go:copyTree:filesystem_write:1":                              ownerBuildTest,
 	"internal/runtime/testfixtures/notifyallchildren/fixture.go:copyTree:filesystem_write:2":                              ownerBuildTest,
+	"internal/runtime/testfixtures/flowownedprojectagent/fixture.go:write:filesystem_write:1":                             ownerBuildTest,
+	"internal/runtime/testfixtures/flowownedprojectagent/fixture.go:write:filesystem_write:2":                             ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:AddOverlayFile:filesystem_write:1":                         ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:AddOverlayFile:filesystem_write:2":                         ownerBuildTest,
 	"internal/runtime/testfixtures/canonicalrouting/fixture.go:SetOverlayFile:filesystem_write:1":                         ownerBuildTest,

--- a/internal/runtime/flowdata/flowdata.go
+++ b/internal/runtime/flowdata/flowdata.go
@@ -108,40 +108,40 @@ func ValidateSource(source semanticview.Source) []Finding {
 		return nil
 	}
 	var findings []Finding
-	for _, scope := range source.ProjectScopes() {
-		scopeLabel := projectScopeLabel(scope.Key, scope.Manifest.Name)
-		for agentID, agent := range scope.Agents {
-			agentID = strings.TrimSpace(agentID)
-			for _, filename := range agent.FlowDataAccess {
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		agentID := strings.TrimSpace(declaration.LocalID)
+		scopeLabel := declaration.Label(true)
+		if strings.TrimSpace(declaration.OwnerFlowID) == "" {
+			for _, filename := range declaration.Entry.FlowDataAccess {
 				findings = append(findings, Finding{
-					AgentLabel: scopedLabel(scopeLabel, agentID),
+					AgentLabel: scopeLabel,
 					Filename:   strings.TrimSpace(filename),
 					Message:    "flow_data_access is only valid on flow-scoped agents",
 				})
 			}
+			continue
 		}
-	}
-	for _, scope := range source.FlowScopes() {
-		scopeLabel := flowScopeLabel(scope.ID, scope.Path)
-		for agentID, agent := range scope.Agents {
-			agentID = strings.TrimSpace(agentID)
-			for _, raw := range agent.FlowDataAccess {
-				filename, err := NormalizeFilename(raw)
-				if err != nil {
-					findings = append(findings, Finding{
-						AgentLabel: scopedLabel(scopeLabel, agentID),
-						Filename:   strings.TrimSpace(raw),
-						Message:    fmt.Sprintf("invalid flow_data_access path: %v", err),
-					})
-					continue
-				}
-				if _, err := resolveUnderDataRoot(scope.DataDir, filename); err != nil {
-					findings = append(findings, Finding{
-						AgentLabel: scopedLabel(scopeLabel, agentID),
-						Filename:   filename,
-						Message:    err.Error(),
-					})
-				}
+		scope, ok := source.FlowScopeByID(declaration.OwnerFlowID)
+		if !ok {
+			findings = append(findings, Finding{AgentLabel: scopeLabel, Message: fmt.Sprintf("agent %s references missing owning flow %s", agentID, declaration.OwnerFlowID)})
+			continue
+		}
+		for _, raw := range declaration.Entry.FlowDataAccess {
+			filename, err := NormalizeFilename(raw)
+			if err != nil {
+				findings = append(findings, Finding{
+					AgentLabel: scopeLabel,
+					Filename:   strings.TrimSpace(raw),
+					Message:    fmt.Sprintf("invalid flow_data_access path: %v", err),
+				})
+				continue
+			}
+			if _, err := resolveUnderDataRoot(scope.DataDir, filename); err != nil {
+				findings = append(findings, Finding{
+					AgentLabel: scopeLabel,
+					Filename:   filename,
+					Message:    err.Error(),
+				})
 			}
 		}
 	}

--- a/internal/runtime/flowdata/flowdata_test.go
+++ b/internal/runtime/flowdata/flowdata_test.go
@@ -1,0 +1,121 @@
+package flowdata
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func TestValidateSourceEvaluatesNestedPhysicalAgentDeclarationExactlyOnce(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		declaredFile string
+		writeFile    bool
+		wantFindings int
+	}{
+		{name: "valid", declaredFile: "resume.md", writeFile: true},
+		{name: "missing", declaredFile: "missing.md", wantFindings: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeNestedFlowDataFixture(t, tc.declaredFile, tc.writeFile)
+			repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+			bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+			if err != nil {
+				t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+			}
+			rawOccurrences := 0
+			for _, project := range bundle.ProjectViews() {
+				if _, ok := project.Agents["worker"]; ok {
+					rawOccurrences++
+				}
+			}
+			for _, flow := range bundle.FlowViews() {
+				if _, ok := flow.Agents["worker"]; ok {
+					rawOccurrences++
+				}
+			}
+			if rawOccurrences < 2 {
+				t.Fatalf("raw nested declaration occurrences = %d, want at least two loader views", rawOccurrences)
+			}
+
+			source := semanticview.Wrap(bundle)
+			if declarations := semanticview.AgentDeclarations(source); len(declarations) != 1 {
+				t.Fatalf("canonical declarations = %#v, want one physical declaration", declarations)
+			}
+			findings := ValidateSource(source)
+			if len(findings) != tc.wantFindings {
+				t.Fatalf("flow-data findings = %#v, want %d", findings, tc.wantFindings)
+			}
+			if tc.wantFindings == 1 && (findings[0].Filename != tc.declaredFile || !strings.Contains(findings[0].Message, "not readable")) {
+				t.Fatalf("flow-data finding = %#v, want one exact missing-file result", findings[0])
+			}
+		})
+	}
+}
+
+func writeNestedFlowDataFixture(t *testing.T, declaredFile string, writeFile bool) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFlowDataFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: nested-flow-data
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - {path: parent}
+`)
+	writeFlowDataFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: nested-flow-data\n")
+	writeEmptyFlowDataContractFiles(t, root)
+	writeFlowDataFixtureFile(t, filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - {path: child}
+`)
+	writeFlowDataFixtureFile(t, filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	writeFlowDataFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	writeFlowDataFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), "name: support\nmode: static\ninitial_state: active\nstates: [active]\n")
+	writeFlowDataFixtureFile(t, filepath.Join(flowRoot, "agents.yaml"), `
+worker:
+  role: worker
+  intent: {inline: Validate one nested physical declaration.}
+  model: regular
+  memory: false
+  flow_data_access: [`+declaredFile+`]
+`)
+	writeEmptyFlowDataContractFiles(t, flowRoot)
+	writeFlowDataFixtureFile(t, filepath.Join(flowRoot, "data", "placeholder.md"), "placeholder\n")
+	if writeFile {
+		writeFlowDataFixtureFile(t, filepath.Join(flowRoot, "data", filepath.FromSlash(declaredFile)), "available\n")
+	}
+	return root
+}
+
+func writeEmptyFlowDataContractFiles(t *testing.T, root string) {
+	t.Helper()
+	for _, name := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeFlowDataFixtureFile(t, filepath.Join(root, name), "{}\n")
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents.yaml")); os.IsNotExist(err) {
+		writeFlowDataFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	}
+}
+
+func writeFlowDataFixtureFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}

--- a/internal/runtime/flowmodel/build.go
+++ b/internal/runtime/flowmodel/build.go
@@ -140,7 +140,6 @@ func AssemblePackageTree[T any, P any, F any](
 	packageNodes := map[string]*BuildNode[T]{}
 	packagesByKey := map[string]P{}
 	packageFlowNodes := map[string]map[string]*BuildNode[T]{}
-	packageFlowOrder := map[string][]*BuildNode[T]{}
 
 	for _, pkg := range packages {
 		key := strings.TrimSpace(packageKey(pkg))
@@ -174,7 +173,6 @@ func AssemblePackageTree[T any, P any, F any](
 			if ref := strings.TrimSpace(flowRef(flow)); ref != "" {
 				packageFlowNodes[key][ref] = child
 			}
-			packageFlowOrder[key] = append(packageFlowOrder[key], child)
 		}
 	}
 
@@ -201,7 +199,6 @@ func AssemblePackageTree[T any, P any, F any](
 			pkg,
 			packageNodes[parent],
 			packageFlowNodes[parent],
-			packageFlowOrder[parent],
 			packageDir,
 			packageFlows,
 			flowDir,
@@ -223,7 +220,6 @@ func ResolvePackageParentNode[T any, P any, F any](
 	childPkg P,
 	parentPackageNode *BuildNode[T],
 	parentFlowNodes map[string]*BuildNode[T],
-	orderedParentFlows []*BuildNode[T],
 	packageDir func(P) string,
 	packageFlows func(P) []F,
 	flowDir func(F) string,
@@ -243,9 +239,6 @@ func ResolvePackageParentNode[T any, P any, F any](
 				return node
 			}
 		}
-	}
-	if len(orderedParentFlows) == 1 {
-		return orderedParentFlows[0]
 	}
 	return parentPackageNode
 }

--- a/internal/runtime/flowmodel/build_test.go
+++ b/internal/runtime/flowmodel/build_test.go
@@ -1,0 +1,84 @@
+package flowmodel
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAssemblePackageTreeDoesNotAttachUnrelatedPackageToSoleFlow(t *testing.T) {
+	type flow struct {
+		id  string
+		dir string
+	}
+	type pkg struct {
+		key    string
+		parent string
+		dir    string
+		flows  []flow
+	}
+	rootDir := t.TempDir()
+	packages := []pkg{
+		{key: ".", dir: rootDir, flows: []flow{{id: "support", dir: filepath.Join(rootDir, "flows", "support")}}},
+		{key: "extras", parent: ".", dir: filepath.Join(rootDir, "extras")},
+	}
+
+	root, err := AssemblePackageTree(
+		packages,
+		func(value pkg) string { return value.key },
+		func(value pkg) string { return value.parent },
+		func(value pkg) string { return value.dir },
+		func(value pkg) []flow { return value.flows },
+		func(value flow) string { return value.id },
+		func(value flow) string { return value.id },
+		func(value flow) string { return value.dir },
+		func(value pkg) *BuildNode[string] { return &BuildNode[string]{View: "package:" + value.key} },
+		func(value flow) *BuildNode[string] { return &BuildNode[string]{View: "flow:" + value.id} },
+	)
+	if err != nil {
+		t.Fatalf("AssemblePackageTree: %v", err)
+	}
+	if len(root.Children) != 2 || root.Children[0].View != "flow:support" || root.Children[1].View != "package:extras" {
+		t.Fatalf("root children = %#v, want sole flow and unrelated package as siblings", root.Children)
+	}
+	if len(root.Children[0].Children) != 0 {
+		t.Fatalf("sole flow children = %#v, unrelated package borrowed flow ownership", root.Children[0].Children)
+	}
+}
+
+func TestAssemblePackageTreeAttachesStructurallyNestedPackageToFlow(t *testing.T) {
+	type flow struct {
+		id  string
+		dir string
+	}
+	type pkg struct {
+		key    string
+		parent string
+		dir    string
+		flows  []flow
+	}
+	rootDir := t.TempDir()
+	flowDir := filepath.Join(rootDir, "flows", "support")
+	packages := []pkg{
+		{key: ".", dir: rootDir, flows: []flow{{id: "support", dir: flowDir}}},
+		{key: "flows/support/extras", parent: ".", dir: filepath.Join(flowDir, "extras")},
+	}
+
+	root, err := AssemblePackageTree(
+		packages,
+		func(value pkg) string { return value.key },
+		func(value pkg) string { return value.parent },
+		func(value pkg) string { return value.dir },
+		func(value pkg) []flow { return value.flows },
+		func(value flow) string { return value.id },
+		func(value flow) string { return value.id },
+		func(value flow) string { return value.dir },
+		func(value pkg) *BuildNode[string] { return &BuildNode[string]{View: "package:" + value.key} },
+		func(value flow) *BuildNode[string] { return &BuildNode[string]{View: "flow:" + value.id} },
+	)
+	if err != nil {
+		t.Fatalf("AssemblePackageTree: %v", err)
+	}
+	if len(root.Children) != 1 || root.Children[0].View != "flow:support" || len(root.Children[0].Children) != 1 || root.Children[0].Children[0].View != "package:flows/support/extras" {
+		t.Fatalf("tree = %#v, want structurally nested package beneath support", root)
+	}
+}

--- a/internal/runtime/manager/agent_manager_llm_backend_test.go
+++ b/internal/runtime/manager/agent_manager_llm_backend_test.go
@@ -135,12 +135,15 @@ func TestResolveAgentModelMockRetainsAndRequiresCapturedArtifact(t *testing.T) {
 
 func TestAuthoredMockStaticAndInstantiatedAgentsSpawnPersistRecoverMock(t *testing.T) {
 	artifact := capturedMockAlternative()
+	staticOwner := "test://static-support/static-worker"
+	templateOwner := "test://template-support/worker"
 	staticFlow := runtimecontracts.FlowContractView{
 		Path:  "static-support",
 		Paths: runtimecontracts.FlowContractPaths{ID: "static-support", Flow: "static-support"},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"static-worker": managerTestAgentEntry("static-worker", runtimecontracts.AgentRegistryEntry{ID: "static-worker"}),
 		},
+		AgentURIs: map[string]string{"static-worker": staticOwner},
 	}
 	templateFlow := runtimecontracts.FlowContractView{
 		Path:  "template-support",
@@ -148,6 +151,7 @@ func TestAuthoredMockStaticAndInstantiatedAgentsSpawnPersistRecoverMock(t *testi
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"worker": managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "template-worker"}),
 		},
+		AgentURIs: map[string]string{"worker": templateOwner},
 	}
 	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{staticFlow, templateFlow}}
 	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
@@ -162,11 +166,21 @@ func TestAuthoredMockStaticAndInstantiatedAgentsSpawnPersistRecoverMock(t *testi
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"static-support/static-worker": {
 					Kind: "agent", FlowID: "static-support", LocalID: "static-worker",
-					Full: "test://static-support/static-worker",
+					Full: staticOwner,
 				},
 				"template-support/worker": {
 					Kind: "agent", FlowID: "template-support", LocalID: "worker",
-					Full: "test://template-support/worker",
+					Full: templateOwner,
+				},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				staticOwner: {
+					Kind: "agent", FlowID: "static-support", LocalID: "static-worker",
+					Full: staticOwner,
+				},
+				templateOwner: {
+					Kind: "agent", FlowID: "template-support", LocalID: "worker",
+					Full: templateOwner,
 				},
 			},
 		},

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -367,7 +367,7 @@ func (am *AgentManager) flowInstanceAgentRecords(req runtimepipeline.FlowInstanc
 	localEvents := flowLocalEventSet(schema, scope)
 	declarations := make([]semanticview.AgentDeclaration, 0)
 	for _, declaration := range semanticview.AgentDeclarations(req.ContractBundle) {
-		if strings.TrimSpace(declaration.Source.Layer) != "flow" || strings.TrimSpace(declaration.Source.FlowID) != strings.TrimSpace(scope.ID) {
+		if strings.TrimSpace(declaration.OwnerFlowID) != strings.TrimSpace(scope.ID) {
 			continue
 		}
 		declarations = append(declarations, declaration)

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -365,17 +365,21 @@ func (am *AgentManager) flowInstanceAgentRecords(req runtimepipeline.FlowInstanc
 	instance := req.Instance
 	vars := flowActivationVars(req)
 	localEvents := flowLocalEventSet(schema, scope)
-	agentKeys := make([]string, 0, len(scope.Agents))
-	for key := range scope.Agents {
-		if key = strings.TrimSpace(key); key != "" {
-			agentKeys = append(agentKeys, key)
+	declarations := make([]semanticview.AgentDeclaration, 0)
+	for _, declaration := range semanticview.AgentDeclarations(req.ContractBundle) {
+		if strings.TrimSpace(declaration.Source.Layer) != "flow" || strings.TrimSpace(declaration.Source.FlowID) != strings.TrimSpace(scope.ID) {
+			continue
 		}
+		declarations = append(declarations, declaration)
 	}
-	sort.Strings(agentKeys)
-	records := make([]PersistedAgent, 0, len(agentKeys))
-	for _, key := range agentKeys {
-		entry := scope.Agents[key]
-		namePlan, err := semanticview.FlowAgentNamePlan(req.ContractBundle, scope, key)
+	sort.Slice(declarations, func(i, j int) bool {
+		return strings.TrimSpace(declarations[i].OwnerURI) < strings.TrimSpace(declarations[j].OwnerURI)
+	})
+	records := make([]PersistedAgent, 0, len(declarations))
+	for _, declaration := range declarations {
+		key := strings.TrimSpace(declaration.LocalID)
+		entry := declaration.Entry
+		namePlan, err := semanticview.ScopedAgentNamePlan(req.ContractBundle, declaration)
 		if err != nil {
 			return nil, fmt.Errorf("flow agent %s declared name: %w", key, err)
 		}
@@ -624,82 +628,42 @@ func StaticAgentMaterializationRecords(source semanticview.Source) ([]PersistedA
 		return nil, nil
 	}
 	standingFlows := standingActivatedFlowIDs(source)
-	records := []PersistedAgent{}
-	for _, scope := range source.ProjectScopes() {
-		projectAgents := make(map[string]runtimecontracts.AgentRegistryEntry, len(scope.Agents))
-		projectNamePlans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
-		packageFlowAgents := map[string]staticAgentFlowGroup{}
-		for logicalID, entry := range scope.Agents {
-			namePlan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
-			if err != nil {
-				return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, logicalID, err)
+	groups := map[string]staticAgentFlowGroup{}
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		flowID := strings.TrimSpace(declaration.OwnerFlowID)
+		flowPath := ""
+		if flowID != "" {
+			scope, ok := source.FlowScopeByID(flowID)
+			if !ok {
+				return nil, fmt.Errorf("agent declaration %q references missing owning flow %q", declaration.LocalID, flowID)
 			}
-			proof := semanticview.ResolveAgentMemoryProof(source, semanticview.AgentMemoryLocator{
-				AgentID:         logicalID,
-				ProjectScopeKey: scope.Key,
-			})
-			if strings.TrimSpace(proof.OwningFlowID) != "" {
-				if flowScope, ok := source.FlowScopeByID(proof.OwningFlowID); ok {
-					if _, represented := flowScope.Agents[logicalID]; represented {
-						flowPlan, flowPlanErr := semanticview.FlowAgentNamePlan(source, flowScope, logicalID)
-						if flowPlanErr == nil && flowPlan.OwnerURI == namePlan.OwnerURI {
-							continue
-						}
-					}
-				}
-				groupKey := staticAgentFlowGroupKey(proof.OwningFlowID, proof.FlowPath)
-				group := packageFlowAgents[groupKey]
-				group.FlowID = strings.TrimSpace(proof.OwningFlowID)
-				group.FlowPath = strings.Trim(strings.TrimSpace(proof.FlowPath), "/")
-				if group.Agents == nil {
-					group.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
-				}
-				if group.NamePlans == nil {
-					group.NamePlans = map[string]semanticview.AgentNamePlan{}
-				}
-				group.Agents[strings.TrimSpace(logicalID)] = entry
-				group.NamePlans[strings.TrimSpace(logicalID)] = namePlan
-				packageFlowAgents[groupKey] = group
+			if strings.EqualFold(strings.TrimSpace(scope.Mode), runtimecontracts.FlowModeTemplate) {
 				continue
 			}
-			projectAgents[strings.TrimSpace(logicalID)] = entry
-			projectNamePlans[strings.TrimSpace(logicalID)] = namePlan
-		}
-		scopeRecords, err := staticAgentsForScope(source, "", "", projectAgents, projectNamePlans)
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, scopeRecords...)
-		groupKeys := make([]string, 0, len(packageFlowAgents))
-		for key := range packageFlowAgents {
-			groupKeys = append(groupKeys, key)
-		}
-		sort.Strings(groupKeys)
-		for _, key := range groupKeys {
-			group := packageFlowAgents[key]
-			scopeRecords, err := staticAgentsForScope(source, group.FlowID, group.FlowPath, group.Agents, group.NamePlans)
-			if err != nil {
-				return nil, err
+			if _, standing := standingFlows[flowID]; standing {
+				continue
 			}
-			records = append(records, scopeRecords...)
+			flowPath = strings.Trim(strings.TrimSpace(scope.Path), "/")
+			if flowPath == "" {
+				flowPath = strings.Trim(strings.TrimSpace(source.FlowPath(flowID)), "/")
+			}
 		}
+		key := staticAgentFlowGroupKey(flowID, flowPath)
+		group := groups[key]
+		group.FlowID = flowID
+		group.FlowPath = flowPath
+		group.Declarations = append(group.Declarations, declaration)
+		groups[key] = group
 	}
-	for _, scope := range source.FlowScopes() {
-		flowID := strings.TrimSpace(scope.ID)
-		if flowID == "" || strings.EqualFold(strings.TrimSpace(scope.Mode), "template") {
-			continue
-		}
-		if _, standing := standingFlows[flowID]; standing {
-			continue
-		}
-		proof := semanticview.ResolveAgentMemoryProof(source, semanticview.AgentMemoryLocator{
-			FlowID: flowID,
-		})
-		namePlans, err := flowAgentNamePlans(source, scope)
-		if err != nil {
-			return nil, err
-		}
-		scopeRecords, err := staticAgentsForScope(source, proof.OwningFlowID, proof.FlowPath, scope.Agents, namePlans)
+	groupKeys := make([]string, 0, len(groups))
+	for key := range groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+	records := []PersistedAgent{}
+	for _, key := range groupKeys {
+		group := groups[key]
+		scopeRecords, err := staticAgentsForDeclarations(source, group)
 		if err != nil {
 			return nil, err
 		}
@@ -716,16 +680,8 @@ func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) (
 	}
 	standingFlows := standingActivatedFlowIDs(source)
 	records := []PersistedAgent{}
-	if rootScope, ok := runtimerequiredagents.RootScope(source); ok {
-		projectScope, found := rootAgentProjectScope(source)
-		if !found && len(rootScope.Required) > 0 {
-			return nil, fmt.Errorf("root required agents have no exact project declaration scope")
-		}
-		namePlans, err := projectAgentNamePlans(source, projectScope)
-		if err != nil {
-			return nil, err
-		}
-		scopeRecords, err := staticRequiredAgentsForScope(source, "", "", rootScope.Agents, namePlans, rootScope.Required)
+	if required := source.RequiredAgents(); len(required) > 0 {
+		scopeRecords, err := staticRequiredAgentsForDeclarations(source, "", "", required)
 		if err != nil {
 			return nil, err
 		}
@@ -739,11 +695,7 @@ func StaticFlowRequiredAgentMaterializationRecords(source semanticview.Source) (
 		if _, standing := standingFlows[flowID]; standing {
 			continue
 		}
-		namePlans, err := flowAgentNamePlans(source, scope)
-		if err != nil {
-			return nil, err
-		}
-		scopeRecords, err := staticRequiredAgentsForScope(source, flowID, strings.Trim(scope.Path, "/"), scope.Agents, namePlans, source.FlowRequiredAgents(flowID))
+		scopeRecords, err := staticRequiredAgentsForDeclarations(source, flowID, strings.Trim(scope.Path, "/"), source.FlowRequiredAgents(flowID))
 		if err != nil {
 			return nil, err
 		}
@@ -770,52 +722,40 @@ func standingActivatedFlowIDs(source semanticview.Source) map[string]struct{} {
 }
 
 type staticAgentFlowGroup struct {
-	FlowID    string
-	FlowPath  string
-	Agents    map[string]runtimecontracts.AgentRegistryEntry
-	NamePlans map[string]semanticview.AgentNamePlan
+	FlowID       string
+	FlowPath     string
+	Declarations []semanticview.AgentDeclaration
 }
 
 func staticAgentFlowGroupKey(flowID, flowPath string) string {
 	return strings.TrimSpace(flowID) + "\x00" + strings.Trim(strings.TrimSpace(flowPath), "/")
 }
 
-func projectAgentNamePlans(source semanticview.Source, scope semanticview.ProjectScope) (map[string]semanticview.AgentNamePlan, error) {
-	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
-	for logicalID := range scope.Agents {
-		plan, err := semanticview.ProjectAgentNamePlan(source, scope, logicalID)
+func staticAgentsForDeclarations(source semanticview.Source, group staticAgentFlowGroup) ([]PersistedAgent, error) {
+	declarations := append([]semanticview.AgentDeclaration(nil), group.Declarations...)
+	sort.Slice(declarations, func(i, j int) bool {
+		left := strings.TrimSpace(declarations[i].OwnerURI) + "\x00" + strings.TrimSpace(declarations[i].LocalID)
+		right := strings.TrimSpace(declarations[j].OwnerURI) + "\x00" + strings.TrimSpace(declarations[j].LocalID)
+		return left < right
+	})
+	agents := make(map[string]runtimecontracts.AgentRegistryEntry, len(declarations))
+	for index, declaration := range declarations {
+		agents[fmt.Sprintf("%06d", index)] = declaration.Entry
+	}
+	localEvents := staticFlowLocalEventSet(agents)
+	records := make([]PersistedAgent, 0, len(declarations))
+	for _, declaration := range declarations {
+		namePlan, err := semanticview.ScopedAgentNamePlan(source, declaration)
 		if err != nil {
-			return nil, fmt.Errorf("project scope %q agent %s declaration name: %w", scope.Key, logicalID, err)
+			return nil, fmt.Errorf("agent declaration %q name: %w", declaration.LocalID, err)
 		}
-		plans[strings.TrimSpace(logicalID)] = plan
-	}
-	return plans, nil
-}
-
-func flowAgentNamePlans(source semanticview.Source, scope semanticview.FlowScope) (map[string]semanticview.AgentNamePlan, error) {
-	plans := make(map[string]semanticview.AgentNamePlan, len(scope.Agents))
-	for logicalID := range scope.Agents {
-		plan, err := semanticview.FlowAgentNamePlan(source, scope, logicalID)
+		cfg, err := buildStaticFlowAgentConfig(source, namePlan, group.FlowID, group.FlowPath, declaration.LocalID, declaration.Entry, localEvents)
 		if err != nil {
-			return nil, fmt.Errorf("flow scope %q agent %s declaration name: %w", scope.ID, logicalID, err)
+			return nil, err
 		}
-		plans[strings.TrimSpace(logicalID)] = plan
+		records = append(records, PersistedAgent{Config: cfg, Status: "active", HiredBy: "static-flow-agent"})
 	}
-	return plans, nil
-}
-
-func rootAgentProjectScope(source semanticview.Source) (semanticview.ProjectScope, bool) {
-	for _, scope := range source.ProjectScopes() {
-		if strings.TrimSpace(scope.OwningFlowID) == "" && scope.Depth == 0 {
-			return scope, true
-		}
-	}
-	for _, scope := range source.ProjectScopes() {
-		if strings.TrimSpace(scope.OwningFlowID) == "" {
-			return scope, true
-		}
-	}
-	return semanticview.ProjectScope{}, false
+	return records, nil
 }
 
 func (am *AgentManager) DeactivateFlowInstanceModel(ctx context.Context, req runtimepipeline.FlowInstanceDeactivationRequest) error {
@@ -1094,18 +1034,33 @@ func buildFlowAgentConfig(
 	return cfg, nil
 }
 
-func staticRequiredAgentsForScope(
+func staticRequiredAgentsForDeclarations(
 	source semanticview.Source,
 	flowID string,
 	flowPath string,
-	agents map[string]runtimecontracts.AgentRegistryEntry,
-	namePlans map[string]semanticview.AgentNamePlan,
 	required []runtimecontracts.FlowRequiredAgent,
 ) ([]PersistedAgent, error) {
 	flowID = strings.TrimSpace(flowID)
 	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
 	if len(required) == 0 {
 		return nil, nil
+	}
+	agents := map[string]runtimecontracts.AgentRegistryEntry{}
+	namePlans := map[string]semanticview.AgentNamePlan{}
+	for _, declaration := range semanticview.AgentDeclarations(source) {
+		if !staticRequiredAgentDeclarationMatchesFlow(declaration, flowID) {
+			continue
+		}
+		logicalID := strings.TrimSpace(declaration.LocalID)
+		if _, exists := agents[logicalID]; exists {
+			return nil, fmt.Errorf("required agent declaration %q in scope %q is ambiguous", logicalID, flowID)
+		}
+		namePlan, err := semanticview.ScopedAgentNamePlan(source, declaration)
+		if err != nil {
+			return nil, fmt.Errorf("required agent declaration %q in scope %q: %w", logicalID, flowID, err)
+		}
+		agents[logicalID] = declaration.Entry
+		namePlans[logicalID] = namePlan
 	}
 	localEvents := staticFlowLocalEventSet(agents)
 	records := make([]PersistedAgent, 0, len(required))
@@ -1132,46 +1087,15 @@ func staticRequiredAgentsForScope(
 	return records, nil
 }
 
-func staticAgentsForScope(
-	source semanticview.Source,
-	flowID string,
-	flowPath string,
-	agents map[string]runtimecontracts.AgentRegistryEntry,
-	namePlans map[string]semanticview.AgentNamePlan,
-) ([]PersistedAgent, error) {
-	flowID = strings.TrimSpace(flowID)
-	flowPath = strings.Trim(strings.TrimSpace(flowPath), "/")
-	if len(agents) == 0 {
-		return nil, nil
+func staticRequiredAgentDeclarationMatchesFlow(declaration semanticview.AgentDeclaration, flowID string) bool {
+	if strings.TrimSpace(declaration.OwnerFlowID) != strings.TrimSpace(flowID) {
+		return false
 	}
-	localEvents := staticFlowLocalEventSet(agents)
-	logicalIDs := make([]string, 0, len(agents))
-	for logicalID := range agents {
-		logicalID = strings.TrimSpace(logicalID)
-		if logicalID != "" {
-			logicalIDs = append(logicalIDs, logicalID)
-		}
+	if strings.TrimSpace(flowID) != "" {
+		return true
 	}
-	sort.Strings(logicalIDs)
-	records := make([]PersistedAgent, 0, len(logicalIDs))
-	for _, logicalID := range logicalIDs {
-		entry := agents[logicalID]
-		namePlan, exists := namePlans[logicalID]
-		if !exists {
-			return nil, fmt.Errorf("static agent %q in scope %q has no exact scoped declaration name", logicalID, flowID)
-		}
-		cfg, err := buildStaticFlowAgentConfig(source, namePlan, flowID, flowPath, logicalID, entry, localEvents)
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, PersistedAgent{
-			Config:          cfg,
-			Status:          "active",
-			HiredBy:         "static-flow-agent",
-			TemplateVersion: "",
-		})
-	}
-	return records, nil
+	packageKey := strings.Trim(strings.TrimSpace(declaration.Source.PackageKey), "/")
+	return packageKey == "" || packageKey == "."
 }
 
 func buildStaticFlowAgentConfig(

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -1014,7 +1014,7 @@ func buildFlowAgentConfig(
 		Prompt:          prompt,
 		MaxTurnsPerTask: entry.MaxTurnsPerTask,
 		Subscriptions:   rendered,
-		EmitEvents:      normalizedFlowAgentEmitEvents(entry.EmitEvents, vars, localEvents, strings.Trim(flowPath, "/"), templateID, instanceID),
+		EmitEvents:      normalizedFlowAgentEmitEvents(entry.EmitEvents, vars, localEvents, strings.Trim(flowPath, "/")),
 		Tools:           normalizedConfiguredToolList(entry.ConfiguredTools()),
 		Permissions:     permissions,
 		NativeTools:     nativeToolConfigFromMap(normalizedConfiguredNativeTools(entry.NativeTools)),
@@ -1191,15 +1191,14 @@ func assembleResolvedAgentPrompt(source semanticview.Source, flowID string, entr
 	return runtimecontracts.AssembleAgentPrompt(bundle, flowID, entry, nil)
 }
 
-func normalizedFlowAgentEmitEvents(events []string, vars map[string]string, localEvents map[string]struct{}, flowPath, templateID, instanceID string) []string {
+func normalizedFlowAgentEmitEvents(events []string, vars map[string]string, localEvents map[string]struct{}, flowPath string) []string {
 	rendered := normalizedConfiguredEventList(events, vars)
 	if len(rendered) == 0 {
 		return nil
 	}
 	out := make([]string, 0, len(rendered))
-	instancePath := strings.Trim(strings.TrimSpace(templateID)+"/"+strings.TrimSpace(instanceID), "/")
 	for _, eventType := range rendered {
-		out = append(out, eventidentity.ExternalizeForFlow(instancePath, localEventList(localEvents), eventType))
+		out = append(out, eventidentity.ExternalizeForFlow(flowPath, localEventList(localEvents), eventType))
 	}
 	return dedupeStrings(out)
 }

--- a/internal/runtime/manager/flow_activation.go
+++ b/internal/runtime/manager/flow_activation.go
@@ -23,7 +23,6 @@ import (
 	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
 	"github.com/division-sh/swarm/internal/runtime/executionmode"
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
-	runtimerequiredagents "github.com/division-sh/swarm/internal/runtime/requiredagents"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
 	"github.com/google/uuid"
@@ -738,11 +737,7 @@ func staticAgentsForDeclarations(source semanticview.Source, group staticAgentFl
 		right := strings.TrimSpace(declarations[j].OwnerURI) + "\x00" + strings.TrimSpace(declarations[j].LocalID)
 		return left < right
 	})
-	agents := make(map[string]runtimecontracts.AgentRegistryEntry, len(declarations))
-	for index, declaration := range declarations {
-		agents[fmt.Sprintf("%06d", index)] = declaration.Entry
-	}
-	localEvents := staticFlowLocalEventSet(agents)
+	localEvents := staticFlowLocalEventSetForDeclarations(declarations)
 	records := make([]PersistedAgent, 0, len(declarations))
 	for _, declaration := range declarations {
 		namePlan, err := semanticview.ScopedAgentNamePlan(source, declaration)
@@ -1045,35 +1040,29 @@ func staticRequiredAgentsForDeclarations(
 	if len(required) == 0 {
 		return nil, nil
 	}
-	agents := map[string]runtimecontracts.AgentRegistryEntry{}
-	namePlans := map[string]semanticview.AgentNamePlan{}
-	for _, declaration := range semanticview.AgentDeclarations(source) {
-		if !staticRequiredAgentDeclarationMatchesFlow(declaration, flowID) {
-			continue
+	declarations := semanticview.AgentDeclarationsForOwner(source, flowID)
+	localEvents := staticFlowLocalEventSetForDeclarations(declarations)
+	records := make([]PersistedAgent, 0, len(required))
+	for _, requiredAgent := range required {
+		logicalID := strings.TrimSpace(requiredAgent.Role)
+		matches := make([]semanticview.AgentDeclaration, 0, 1)
+		for _, declaration := range declarations {
+			if strings.TrimSpace(declaration.LocalID) == logicalID {
+				matches = append(matches, declaration)
+			}
 		}
-		logicalID := strings.TrimSpace(declaration.LocalID)
-		if _, exists := agents[logicalID]; exists {
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
+		}
+		if len(matches) > 1 {
 			return nil, fmt.Errorf("required agent declaration %q in scope %q is ambiguous", logicalID, flowID)
 		}
+		declaration := matches[0]
 		namePlan, err := semanticview.ScopedAgentNamePlan(source, declaration)
 		if err != nil {
 			return nil, fmt.Errorf("required agent declaration %q in scope %q: %w", logicalID, flowID, err)
 		}
-		agents[logicalID] = declaration.Entry
-		namePlans[logicalID] = namePlan
-	}
-	localEvents := staticFlowLocalEventSet(agents)
-	records := make([]PersistedAgent, 0, len(required))
-	for _, requiredAgent := range required {
-		logicalID, entry, ok := runtimerequiredagents.ResolveAgent(agents, requiredAgent)
-		if !ok {
-			return nil, fmt.Errorf("required agent %q missing from scope %q", strings.TrimSpace(requiredAgent.Role), flowID)
-		}
-		namePlan, exists := namePlans[logicalID]
-		if !exists {
-			return nil, fmt.Errorf("required agent %q in scope %q has no exact scoped declaration name", logicalID, flowID)
-		}
-		cfg, err := buildStaticFlowAgentConfig(source, namePlan, flowID, flowPath, logicalID, entry, localEvents)
+		cfg, err := buildStaticFlowAgentConfig(source, namePlan, flowID, flowPath, logicalID, declaration.Entry, localEvents)
 		if err != nil {
 			return nil, err
 		}
@@ -1085,17 +1074,6 @@ func staticRequiredAgentsForDeclarations(
 		})
 	}
 	return records, nil
-}
-
-func staticRequiredAgentDeclarationMatchesFlow(declaration semanticview.AgentDeclaration, flowID string) bool {
-	if strings.TrimSpace(declaration.OwnerFlowID) != strings.TrimSpace(flowID) {
-		return false
-	}
-	if strings.TrimSpace(flowID) != "" {
-		return true
-	}
-	packageKey := strings.Trim(strings.TrimSpace(declaration.Source.PackageKey), "/")
-	return packageKey == "" || packageKey == "."
 }
 
 func buildStaticFlowAgentConfig(
@@ -1230,9 +1208,17 @@ func localEventList(localEvents map[string]struct{}) []string {
 	return out
 }
 
-func staticFlowLocalEventSet(agents map[string]runtimecontracts.AgentRegistryEntry) map[string]struct{} {
+func staticFlowLocalEventSetForDeclarations(declarations []semanticview.AgentDeclaration) map[string]struct{} {
+	entries := make([]runtimecontracts.AgentRegistryEntry, 0, len(declarations))
+	for _, declaration := range declarations {
+		entries = append(entries, declaration.Entry)
+	}
+	return staticFlowLocalEventSetForEntries(entries)
+}
+
+func staticFlowLocalEventSetForEntries(entries []runtimecontracts.AgentRegistryEntry) map[string]struct{} {
 	out := map[string]struct{}{}
-	for _, entry := range agents {
+	for _, entry := range entries {
 		for _, eventType := range entry.Subscriptions {
 			eventType = strings.TrimSpace(eventType)
 			if eventType != "" && !strings.Contains(eventType, "/") {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -3813,7 +3813,7 @@ func TestStaticAndTemplateAgentMaterializationDefaultRoleToEffectiveName(t *test
 	source := semanticview.Wrap(bundle)
 	namePlan := managerTestFlowAgentNamePlan(t, source, "review", "reviewer")
 
-	staticCfg, err := buildStaticFlowAgentConfig(source, namePlan, "review", "review", "reviewer", entry, staticFlowLocalEventSet(review.Agents))
+	staticCfg, err := buildStaticFlowAgentConfig(source, namePlan, "review", "review", "reviewer", entry, staticFlowLocalEventSetForTest(review.Agents))
 	if err != nil {
 		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
 	}
@@ -3827,7 +3827,7 @@ func TestStaticAndTemplateAgentMaterializationDefaultRoleToEffectiveName(t *test
 		"reviewer",
 		entry,
 		nil,
-		staticFlowLocalEventSet(review.Agents),
+		staticFlowLocalEventSetForTest(review.Agents),
 		nil,
 	)
 	if err != nil {
@@ -3954,6 +3954,25 @@ func TestStaticFlowRequiredAgentMaterializationInfersFromOmittedRequiredAgents(t
 	}
 }
 
+func TestStaticFlowRequiredAgentMaterializationUsesFlowOwnedProjectDeclaration(t *testing.T) {
+	source := loadNestedProjectStaticAgentSource(t)
+	declarations := semanticview.AgentDeclarationsForOwner(source, "support")
+	if len(declarations) != 1 || declarations[0].Source.Layer != "project" {
+		t.Fatalf("support declarations = %#v, want one project declaration", declarations)
+	}
+	records, err := StaticFlowRequiredAgentMaterializationRecords(source)
+	if err != nil {
+		t.Fatalf("StaticFlowRequiredAgentMaterializationRecords: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("materialized agents = %#v, want flow-owned project agent", records)
+	}
+	cfg := records[0].Config
+	if cfg.ID != "backend" || cfg.FlowID != "support" || cfg.FlowPath != "support" || cfg.Identity.Name.Owner != declarations[0].OwnerURI {
+		t.Fatalf("materialized agent = %#v, want exact canonical support declaration", cfg)
+	}
+}
+
 func TestStaticRequiredAgentsForScopeRejectsRoleFallbackWithoutMapKey(t *testing.T) {
 	bundle := testStaticFlowBundle()
 	flow := bundle.FlowTree.ByID["analyzer-flow"]
@@ -4024,8 +4043,8 @@ func TestStaticAgentMaterialization_PackageBackedFlowOwnedAgentsCarryCanonicalFl
 	}
 }
 
-func TestStaticAgentMaterialization_SoleParentFlowPackageAgentsStartWithOwningFlowPath(t *testing.T) {
-	source := loadSoleParentFlowStaticAgentSource(t)
+func TestStaticAgentMaterialization_StructurallyNestedProjectAgentsStartWithOwningFlowPath(t *testing.T) {
+	source := loadNestedProjectStaticAgentSource(t)
 	records, err := StaticAgentMaterializationRecords(source)
 	if err != nil {
 		t.Fatalf("StaticAgentMaterializationRecords: %v", err)
@@ -4056,7 +4075,7 @@ func TestFlowInstanceAgentRecordsMaterializeProjectDeclarationOwnedByFlow(t *tes
 		{name: "singleton", mode: runtimecontracts.FlowModeSingleton, instanceID: "support", instancePath: "support"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			source := loadSoleParentFlowAgentSource(t, tc.mode)
+			source := loadNestedProjectAgentSource(t, tc.mode)
 			declarations := semanticview.AgentDeclarations(source)
 			if len(declarations) != 1 || declarations[0].Source.Layer != "project" || declarations[0].OwnerFlowID != "support" {
 				t.Fatalf("declarations = %#v, want one project declaration owned by support", declarations)
@@ -4229,12 +4248,12 @@ backend:
 	return semanticview.Wrap(bundle)
 }
 
-func loadSoleParentFlowStaticAgentSource(t *testing.T) semanticview.Source {
+func loadNestedProjectStaticAgentSource(t *testing.T) semanticview.Source {
 	t.Helper()
-	return loadSoleParentFlowAgentSource(t, runtimecontracts.FlowModeStatic)
+	return loadNestedProjectAgentSource(t, runtimecontracts.FlowModeStatic)
 }
 
-func loadSoleParentFlowAgentSource(t *testing.T, mode string) semanticview.Source {
+func loadNestedProjectAgentSource(t *testing.T, mode string) semanticview.Source {
 	t.Helper()
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	root := t.TempDir()
@@ -4244,7 +4263,7 @@ name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=0.7.0 <0.8.0"
 packages:
-  - path: extras
+  - path: flows/support/extras
 flows:
   - id: support
     flow: support
@@ -4274,12 +4293,12 @@ states:
 support/item.created:
   entity_id: string
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "package.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "extras", "package.yaml"), `
 name: extras
 version: "1.0.0"
 flows: []
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "extras", "agents.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "extras", "agents.yaml"), `
 backend:
   type: generic
   role: backend
@@ -4305,6 +4324,14 @@ func writeFlowActivationFixtureFile(t *testing.T, path, contents string) {
 	if err := os.WriteFile(path, []byte(strings.TrimLeft(contents, "\n")), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func staticFlowLocalEventSetForTest(agents map[string]runtimecontracts.AgentRegistryEntry) map[string]struct{} {
+	entries := make([]runtimecontracts.AgentRegistryEntry, 0, len(agents))
+	for _, entry := range agents {
+		entries = append(entries, entry)
+	}
+	return staticFlowLocalEventSetForEntries(entries)
 }
 
 func managerTestFlowAgentNamePlan(t *testing.T, source semanticview.Source, flowID, logicalID string) semanticview.AgentNamePlan {
@@ -4457,7 +4484,7 @@ func TestStaticAndTemplateAgentMaterializationConsumeEffectivePlatformDefaults(t
 		t.Fatal("static_support flow scope missing")
 	}
 	staticEntry := staticScope.Agents["worker"]
-	staticCfg, err := buildStaticFlowAgentConfig(source, managerTestFlowAgentNamePlan(t, source, "static_support", "worker"), "static_support", "static_support", "worker", staticEntry, staticFlowLocalEventSet(staticScope.Agents))
+	staticCfg, err := buildStaticFlowAgentConfig(source, managerTestFlowAgentNamePlan(t, source, "static_support", "worker"), "static_support", "static_support", "worker", staticEntry, staticFlowLocalEventSetForTest(staticScope.Agents))
 	if err != nil {
 		t.Fatalf("buildStaticFlowAgentConfig: %v", err)
 	}
@@ -4478,7 +4505,7 @@ func TestStaticAndTemplateAgentMaterializationConsumeEffectivePlatformDefaults(t
 		"worker",
 		templateEntry,
 		map[string]string{"instance_id": "inst-1"},
-		staticFlowLocalEventSet(templateScope.Agents),
+		staticFlowLocalEventSetForTest(templateScope.Agents),
 		map[string]any{},
 	)
 	if err != nil {

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -39,7 +39,6 @@ import (
 	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
 	runtimepipelineobligation "github.com/division-sh/swarm/internal/runtime/pipelineobligation"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
-	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
 	"github.com/division-sh/swarm/internal/runtime/sessions"
 	"github.com/division-sh/swarm/internal/runtime/testfixtures/notifyallchildren"
 	runtimepipelinefixture "github.com/division-sh/swarm/internal/testutil/runtimepipelinefixture"
@@ -1226,11 +1225,16 @@ func registerTestFlowAgentOwner(bundle *runtimecontracts.WorkflowContractBundle,
 	if bundle.URIRegistry.Agents == nil {
 		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
 	}
-	bundle.URIRegistry.Agents[flowID+"/"+logicalID] = testFlowAgentURIRef(flowID, logicalID)
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	ref := testFlowAgentURIRef(flowID, logicalID)
+	bundle.URIRegistry.Agents[flowID+"/"+logicalID] = ref
+	bundle.URIRegistry.ByURI[ref.Full] = ref
 }
 
 func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
-	reviewFlow := &runtimecontracts.FlowContractView{
+	reviewFlow := runtimecontracts.FlowContractView{
 		Paths: runtimecontracts.FlowContractPaths{ID: "review"},
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"task.started": {
@@ -1249,18 +1253,20 @@ func testFlowBundle(autoEmit string) *runtimecontracts.WorkflowContractBundle {
 			},
 		},
 	}
+	root := &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{reviewFlow}}
 	return &runtimecontracts.WorkflowContractBundle{
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"review/reviewer": testFlowAgentURIRef("review", "reviewer"),
 			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				testFlowAgentURIRef("review", "reviewer").Full: testFlowAgentURIRef("review", "reviewer"),
+			},
 		},
 		FlowTree: runtimecontracts.FlowTree{
-			Root: &runtimecontracts.FlowContractView{
-				Children: []runtimecontracts.FlowContractView{*reviewFlow},
-			},
+			Root: root,
 			ByID: map[string]*runtimecontracts.FlowContractView{
-				"review": reviewFlow,
+				"review": &root.Children[0],
 			},
 		},
 		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
@@ -1319,6 +1325,7 @@ func testFlowBundleWithAutoEmitEntry(autoEmit string, entry runtimecontracts.Eve
 }
 
 func testNestedFlowBundle() *runtimecontracts.WorkflowContractBundle {
+	workerRef := testFlowAgentURIRef("grandchild", "worker")
 	grandchild := &runtimecontracts.FlowContractView{
 		Path:  "child/grandchild",
 		Paths: runtimecontracts.FlowContractPaths{ID: "grandchild", Flow: "grandchild"},
@@ -1331,6 +1338,7 @@ func testNestedFlowBundle() *runtimecontracts.WorkflowContractBundle {
 				Subscriptions:  []string{"micro.started"},
 			},
 		},
+		AgentURIs: map[string]string{"worker": workerRef.Full},
 	}
 	child := &runtimecontracts.FlowContractView{
 		Path:     "child",
@@ -1340,8 +1348,9 @@ func testNestedFlowBundle() *runtimecontracts.WorkflowContractBundle {
 	return &runtimecontracts.WorkflowContractBundle{
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
-				"grandchild/worker": testFlowAgentURIRef("grandchild", "worker"),
+				"grandchild/worker": workerRef,
 			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{workerRef.Full: workerRef},
 		},
 		FlowTree: runtimecontracts.FlowTree{
 			Root: &runtimecontracts.FlowContractView{
@@ -1365,6 +1374,7 @@ func testNestedFlowBundle() *runtimecontracts.WorkflowContractBundle {
 }
 
 func testStaticFlowBundle() *runtimecontracts.WorkflowContractBundle {
+	analyzerRef := testFlowAgentURIRef("analyzer-flow", "analyzer")
 	analysisFlow := &runtimecontracts.FlowContractView{
 		Path:  "analyzer-flow",
 		Paths: runtimecontracts.FlowContractPaths{ID: "analyzer-flow"},
@@ -1377,12 +1387,14 @@ func testStaticFlowBundle() *runtimecontracts.WorkflowContractBundle {
 				EmitEvents:     []string{"analysis.done"},
 			},
 		},
+		AgentURIs: map[string]string{"analyzer": analyzerRef.Full},
 	}
 	return &runtimecontracts.WorkflowContractBundle{
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
-				"analyzer-flow/analyzer": testFlowAgentURIRef("analyzer-flow", "analyzer"),
+				"analyzer-flow/analyzer": analyzerRef,
 			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{analyzerRef.Full: analyzerRef},
 		},
 		FlowTree: runtimecontracts.FlowTree{
 			Root: &runtimecontracts.FlowContractView{
@@ -3877,28 +3889,33 @@ func TestStandingActivatedFlowAgentsAreOwnedOnlyByFlowInstanceActivation(t *test
 	}
 }
 
-func TestStaticAgentMaterializationKeepsDistinctProjectAndFlowDeclarationsWithSharedLocalID(t *testing.T) {
+func TestStaticAgentMaterializationKeepsDistinctSameIDPhysicalDeclarations(t *testing.T) {
 	projectOwner := "test://agent-name/packages/support-extension/worker"
 	flowOwner := "test://agent-name/flows/support/worker"
-	base := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
-		projectOwner: {Kind: "agent", LocalID: "worker", Full: projectOwner},
-		flowOwner:    {Kind: "agent", FlowID: "support", LocalID: "worker", Full: flowOwner},
-	}}})
 	projectEntry := managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "project-worker", Role: "project-worker"})
 	flowEntry := managerTestAgentEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "flow-worker", Role: "flow-worker"})
-	source := managerScopedAgentSource{
-		Source: base,
-		projects: []semanticview.ProjectScope{{
-			Key: "packages/support-extension", OwningFlowID: "support",
-			Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": projectEntry},
-			AgentURIs: map[string]string{"worker": projectOwner},
+	root := &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{
+		{
+			Paths: runtimecontracts.FlowContractPaths{ID: "support-extension", PackageKey: "packages/support-extension", AgentsFile: "packages/support-extension/agents.yaml"},
+			Path:  "support-extension", Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeStatic},
+			Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": projectEntry}, AgentURIs: map[string]string{"worker": projectOwner},
+		},
+		{
+			Paths: runtimecontracts.FlowContractPaths{ID: "support", PackageKey: "flows/support", AgentsFile: "flows/support/agents.yaml"},
+			Path:  "support", Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeStatic},
+			Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": flowEntry}, AgentURIs: map[string]string{"worker": flowOwner},
+		},
+	}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{Root: root, ByID: map[string]*runtimecontracts.FlowContractView{
+			"support-extension": &root.Children[0], "support": &root.Children[1],
 		}},
-		flows: []semanticview.FlowScope{{
-			ID: "support", Path: "support", PackageKey: "flows/support", Mode: "static",
-			Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": flowEntry},
-			AgentURIs: map[string]string{"worker": flowOwner},
+		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+			projectOwner: {Kind: "agent", FlowID: "support-extension", LocalID: "worker", Full: projectOwner},
+			flowOwner:    {Kind: "agent", FlowID: "support", LocalID: "worker", Full: flowOwner},
 		}},
 	}
+	source := semanticview.Wrap(bundle)
 
 	records, err := StaticAgentMaterializationRecords(source)
 	if err != nil {
@@ -3911,36 +3928,6 @@ func TestStaticAgentMaterializationKeepsDistinctProjectAndFlowDeclarationsWithSh
 	if len(got) != 2 || got["project-worker"] != projectOwner || got["flow-worker"] != flowOwner {
 		t.Fatalf("materialized owners = %#v, want both exact declarations", got)
 	}
-}
-
-type managerScopedAgentSource struct {
-	semanticview.Source
-	projects []semanticview.ProjectScope
-	flows    []semanticview.FlowScope
-}
-
-func (s managerScopedAgentSource) ProjectScopes() []semanticview.ProjectScope {
-	return append([]semanticview.ProjectScope(nil), s.projects...)
-}
-
-func (s managerScopedAgentSource) FlowScopes() []semanticview.FlowScope {
-	return append([]semanticview.FlowScope(nil), s.flows...)
-}
-
-func (s managerScopedAgentSource) FlowScopeByID(flowID string) (semanticview.FlowScope, bool) {
-	for _, scope := range s.flows {
-		if strings.TrimSpace(scope.ID) == strings.TrimSpace(flowID) {
-			return scope, true
-		}
-	}
-	return semanticview.FlowScope{}, false
-}
-
-func (s managerScopedAgentSource) FlowPath(flowID string) string {
-	if scope, ok := s.FlowScopeByID(flowID); ok {
-		return scope.Path
-	}
-	return ""
 }
 
 func TestStaticFlowRequiredAgentMaterializationInfersFromOmittedRequiredAgents(t *testing.T) {
@@ -3966,91 +3953,49 @@ func TestStaticFlowRequiredAgentMaterializationInfersFromOmittedRequiredAgents(t
 }
 
 func TestStaticRequiredAgentsForScopeRejectsRoleFallbackWithoutMapKey(t *testing.T) {
-	records, err := staticRequiredAgentsForScope(nil, "analysis", "analysis", map[string]runtimecontracts.AgentRegistryEntry{
-		"worker-alias": {
-			ID:            "worker",
-			Role:          "worker",
-			Subscriptions: []string{"analysis.requested"},
-			EmitEvents:    []string{"analysis.done"},
-		},
-	}, nil, []runtimecontracts.FlowRequiredAgent{{
+	bundle := testStaticFlowBundle()
+	flow := bundle.FlowTree.ByID["analyzer-flow"]
+	entry := flow.Agents["analyzer"]
+	delete(flow.Agents, "analyzer")
+	delete(flow.AgentURIs, "analyzer")
+	flow.Agents["worker-alias"] = entry
+	ref := testFlowAgentURIRef("analyzer-flow", "worker-alias")
+	flow.AgentURIs["worker-alias"] = ref.Full
+	bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{"analyzer-flow/worker-alias": ref}
+	bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{ref.Full: ref}
+	schema := bundle.FlowSchemas["analyzer-flow"]
+	schema.RequiredAgents = []runtimecontracts.FlowRequiredAgent{{
 		Role:         "worker",
 		SubscribesTo: []string{"analysis.requested"},
 		Emits:        []string{"analysis.done"},
-	}})
+	}}
+	bundle.FlowSchemas["analyzer-flow"] = schema
+
+	records, err := StaticFlowRequiredAgentMaterializationRecords(semanticview.Wrap(bundle))
 
 	if err == nil || !strings.Contains(err.Error(), `required agent "worker"`) {
 		t.Fatalf("expected required-agent map-key error, records=%#v err=%v", records, err)
 	}
 }
 
-func TestStaticAgentsForScopeRegistersRootAndFlowSubscriptions(t *testing.T) {
-	bundle := &runtimecontracts.WorkflowContractBundle{
-		URIRegistry: runtimecontracts.ContractURIRegistry{
-			Agents: map[string]runtimecontracts.ContractURIRef{
-				"test-agent": {
-					Kind: "agent", LocalID: "test-agent", Full: "test://root/test-agent",
-				},
-				"ops-flow/operator": {
-					Kind: "agent", FlowID: "ops-flow", LocalID: "operator", Full: "test://ops-flow/operator",
-				},
-			},
-		},
-		Semantics: runtimecontracts.WorkflowSemanticView{
-			Version: "v-test",
-			FlowPrefix: map[string]string{
-				"ops-flow": "ops-flow",
-			},
-		},
-	}
-	rootAgents := map[string]runtimecontracts.AgentRegistryEntry{
-		"test-agent": managerTestAgentEntry("test-agent", runtimecontracts.AgentRegistryEntry{
-			ID:            "test-agent",
-			Type:          "generic",
-			Role:          "test-agent",
-			Subscriptions: []string{"task.assigned"},
-			EmitEvents:    []string{"task.completed"},
-		}),
-	}
-	bundle.Agents = rootAgents
-	flowAgents := map[string]runtimecontracts.AgentRegistryEntry{
-		"operator": managerTestAgentEntry("operator", runtimecontracts.AgentRegistryEntry{
-			ID:            "operator",
-			Type:          "generic",
-			Role:          "operator",
-			Subscriptions: []string{"work.requested"},
-			EmitEvents:    []string{"work.completed"},
-		}),
-	}
-	flow := &runtimecontracts.FlowContractView{
-		Paths:  runtimecontracts.FlowContractPaths{ID: "ops-flow"},
-		Path:   "ops-flow",
-		Agents: flowAgents,
-	}
-	bundle.FlowTree = runtimecontracts.FlowTree{
-		Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{*flow}},
-		ByID: map[string]*runtimecontracts.FlowContractView{"ops-flow": flow},
-	}
-	source := semanticviewtest.WrapRootAgents(bundle)
-	rootPlan := managerTestAgentNamePlan(t, source, "", "test-agent")
-	rootRecords, err := staticAgentsForScope(source, "", "", rootAgents, map[string]semanticview.AgentNamePlan{"test-agent": rootPlan})
+func TestStaticAgentMaterializationRecordsRegistersRootAndFlowSubscriptions(t *testing.T) {
+	source := loadRootAndFlowStaticAgentSource(t)
+	records, err := StaticAgentMaterializationRecords(source)
 	if err != nil {
-		t.Fatalf("staticAgentsForScope(root): %v", err)
+		t.Fatalf("StaticAgentMaterializationRecords: %v", err)
 	}
-	flowPlan := managerTestFlowAgentNamePlan(t, source, "ops-flow", "operator")
-	flowRecords, err := staticAgentsForScope(source, "ops-flow", "ops-flow", flowAgents, map[string]semanticview.AgentNamePlan{"operator": flowPlan})
-	if err != nil {
-		t.Fatalf("staticAgentsForScope(flow): %v", err)
+	if len(records) != 2 {
+		t.Fatalf("materialized records = %#v, want root and flow declarations exactly once", records)
 	}
-	if len(rootRecords) != 1 || len(flowRecords) != 1 {
-		t.Fatalf("materialized records root=%#v flow=%#v", rootRecords, flowRecords)
+	configs := map[string]models.AgentConfig{}
+	for _, record := range records {
+		configs[record.Config.ID] = record.Config
 	}
-	rootCfg := rootRecords[0].Config
+	rootCfg := configs["test-agent"]
 	if len(rootCfg.Subscriptions) != 1 || rootCfg.Subscriptions[0] != "task.assigned" {
 		t.Fatalf("root subscriptions = %#v, want [task.assigned]", rootCfg.Subscriptions)
 	}
-
-	flowCfg := flowRecords[0].Config
+	flowCfg := configs["operator"]
 	if len(flowCfg.Subscriptions) != 1 || flowCfg.Subscriptions[0] != "ops-flow/work.requested" {
 		t.Fatalf("flow subscriptions = %#v, want [ops-flow/work.requested]", flowCfg.Subscriptions)
 	}
@@ -4108,6 +4053,58 @@ func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
 	}
 }
 
+func loadRootAndFlowStaticAgentSource(t *testing.T) semanticview.Source {
+	t.Helper()
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	root := t.TempDir()
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: root-and-flow-static-agents
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - id: ops-flow
+    flow: ops-flow
+    mode: static
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: root-and-flow-static-agents\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "tools.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "events.yaml"), "task.assigned: {}\ntask.completed: {}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "agents.yaml"), `
+test-agent:
+  type: generic
+  role: test-agent
+  intent: {inline: "Handle root work."}
+  model: regular
+  memory: true
+  subscriptions: [task.assigned]
+  emit_events: [task.completed]
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "ops-flow", "package.yaml"), `
+name: ops-flow
+version: "1.0.0"
+flows: []
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "ops-flow", "schema.yaml"), "name: ops-flow\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "ops-flow", "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "ops-flow", "events.yaml"), "work.requested: {}\nwork.completed: {}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "ops-flow", "agents.yaml"), `
+operator:
+  type: generic
+  role: operator
+  intent: {inline: "Handle operations work."}
+  model: regular
+  memory: true
+  subscriptions: [work.requested]
+  emit_events: [work.completed]
+`)
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
 func loadPackageBackedStaticAgentSource(t *testing.T) semanticview.Source {
 	t.Helper()
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
@@ -4117,10 +4114,8 @@ func loadPackageBackedStaticAgentSource(t *testing.T) semanticview.Source {
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=0.7.0 <0.8.0"
-flows:
-  - id: support
-    flow: support
-    mode: static
+packages:
+  - path: parent
 `)
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
 item:
@@ -4134,24 +4129,39 @@ item:
 item.created:
   entity_id: string
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "parent", "package.yaml"), `
+name: parent
+version: "1.0.0"
+packages:
+  - path: child
+`)
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "parent", "child", "package.yaml"), `
+name: child
+version: "1.0.0"
+flows:
+  - id: support
+    flow: support
+    mode: static
+`)
+	flowRoot := filepath.Join(root, "parent", "child", "flows", "support")
+	writeFlowActivationFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), `
 name: support
 version: "1.0.0"
 flows: []
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), `
 name: support
 initial_state: waiting
 states:
   - waiting
   - done
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "policy.yaml"), "{}\n")
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "events.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(flowRoot, "policy.yaml"), "{}\n")
+	writeFlowActivationFixtureFile(t, filepath.Join(flowRoot, "events.yaml"), `
 support/item.created:
   entity_id: string
 `)
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "flows", "support", "agents.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(flowRoot, "agents.yaml"), `
 backend:
   type: generic
   role: backend

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -3497,11 +3497,9 @@ func TestNormalizedFlowAgentEmitEvents_ExternalizesInstanceLocalEvents(t *testin
 		[]string{"task.started", "shared.event"},
 		nil,
 		map[string]struct{}{"task.started": {}},
-		"review/inst-1",
-		"review",
-		"inst-1",
+		"parent/review/inst-1",
 	)
-	if len(got) != 2 || got[0] != "review/inst-1/task.started" || got[1] != "shared.event" {
+	if len(got) != 2 || got[0] != "parent/review/inst-1/task.started" || got[1] != "shared.event" {
 		t.Fatalf("normalizedFlowAgentEmitEvents = %#v", got)
 	}
 }
@@ -3772,7 +3770,7 @@ func TestDeactivateFlowInstanceUsesExactResolvedFlowPathForNestedTemplate(t *tes
 	}
 }
 
-func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t *testing.T) {
+func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsAndEmitEventsFromExactFlowPath(t *testing.T) {
 	source := semanticview.Wrap(testNestedFlowBundle())
 	cfg, err := buildFlowAgentConfig(
 		source,
@@ -3787,6 +3785,7 @@ func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t 
 			Type:          "generic",
 			Role:          "worker",
 			Subscriptions: []string{"micro.started"},
+			EmitEvents:    []string{"micro.started"},
 		}),
 		map[string]string{"instance_id": "inst-1"},
 		map[string]struct{}{"micro.started": {}},
@@ -3797,6 +3796,9 @@ func TestBuildFlowAgentConfig_ExternalizesLocalSubscriptionsFromExactFlowPath(t 
 	}
 	if len(cfg.Subscriptions) != 1 || cfg.Subscriptions[0] != "child/grandchild/inst-1/micro.started" {
 		t.Fatalf("subscriptions = %#v, want [child/grandchild/inst-1/micro.started]", cfg.Subscriptions)
+	}
+	if len(cfg.EmitEvents) != 1 || cfg.EmitEvents[0] != "child/grandchild/inst-1/micro.started" {
+		t.Fatalf("emit_events = %#v, want [child/grandchild/inst-1/micro.started]", cfg.EmitEvents)
 	}
 }
 

--- a/internal/runtime/manager/flow_activation_test.go
+++ b/internal/runtime/manager/flow_activation_test.go
@@ -4045,6 +4045,54 @@ func TestStaticAgentMaterialization_SoleParentFlowPackageAgentsStartWithOwningFl
 	}
 }
 
+func TestFlowInstanceAgentRecordsMaterializeProjectDeclarationOwnedByFlow(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mode         string
+		instanceID   string
+		instancePath string
+	}{
+		{name: "template", mode: runtimecontracts.FlowModeTemplate, instanceID: "inst-1", instancePath: "support/inst-1"},
+		{name: "singleton", mode: runtimecontracts.FlowModeSingleton, instanceID: "support", instancePath: "support"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := loadSoleParentFlowAgentSource(t, tc.mode)
+			declarations := semanticview.AgentDeclarations(source)
+			if len(declarations) != 1 || declarations[0].Source.Layer != "project" || declarations[0].OwnerFlowID != "support" {
+				t.Fatalf("declarations = %#v, want one project declaration owned by support", declarations)
+			}
+			bundle, ok := semanticview.Bundle(source)
+			if !ok {
+				t.Fatal("loaded source does not expose its contract bundle")
+			}
+			scope, ok := source.FlowScopeByID("support")
+			if !ok {
+				t.Fatal("support flow scope missing")
+			}
+			schema, ok := source.FlowSchemaByID("support")
+			if !ok {
+				t.Fatal("support flow schema missing")
+			}
+			req := testActivationRequest(bundle, "support", tc.instanceID, "ent-1", tc.instancePath)
+			am := newFlowActivationManager(t, &flowActivationTestBus{}, &flowActivationTestInstanceStore{})
+			records, err := am.flowInstanceAgentRecords(req, schema, scope)
+			if err != nil {
+				t.Fatalf("flowInstanceAgentRecords: %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("materialized records = %#v, want project-owned agent exactly once", records)
+			}
+			cfg := records[0].Config
+			if cfg.ID != "backend" || cfg.FlowID != "support" || cfg.FlowPath != tc.instancePath {
+				t.Fatalf("materialized config = %#v, want backend on exact support instance %q", cfg, tc.instancePath)
+			}
+			if cfg.Identity.Name.Owner != declarations[0].OwnerURI {
+				t.Fatalf("materialized owner = %q, want canonical declaration owner %q", cfg.Identity.Name.Owner, declarations[0].OwnerURI)
+			}
+		})
+	}
+}
+
 func TestActivateFlowInstanceFailsWithoutWorkflowInstanceStore(t *testing.T) {
 	bus := &flowActivationTestBus{}
 	am := newTestAgentManagerWithOptions(t, bus, nil, AgentManagerOptions{WorkOwner: newTestManagerWorkOwner(t)})
@@ -4183,10 +4231,15 @@ backend:
 
 func loadSoleParentFlowStaticAgentSource(t *testing.T) semanticview.Source {
 	t.Helper()
+	return loadSoleParentFlowAgentSource(t, runtimecontracts.FlowModeStatic)
+}
+
+func loadSoleParentFlowAgentSource(t *testing.T, mode string) semanticview.Source {
+	t.Helper()
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
 	root := t.TempDir()
 
-	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), `
+	writeFlowActivationFixtureFile(t, filepath.Join(root, "package.yaml"), fmt.Sprintf(`
 name: session-scope-validation
 version: "1.0.0"
 platform_version: ">=0.7.0 <0.8.0"
@@ -4195,8 +4248,8 @@ packages:
 flows:
   - id: support
     flow: support
-    mode: static
-`)
+    mode: %s
+`, mode))
 	writeFlowActivationFixtureFile(t, filepath.Join(root, "entities.yaml"), `
 item:
   item_id: string

--- a/internal/runtime/requiredagents/fulfillment.go
+++ b/internal/runtime/requiredagents/fulfillment.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Scope struct {
-	ID       string
-	Agents   map[string]runtimecontracts.AgentRegistryEntry
-	Required []runtimecontracts.FlowRequiredAgent
+	ID           string
+	Declarations []semanticview.AgentDeclaration
+	Required     []runtimecontracts.FlowRequiredAgent
 }
 
 type FindingKind string
@@ -20,16 +20,18 @@ type FindingKind string
 const (
 	FindingMissingRole          FindingKind = "missing_role"
 	FindingMissingAgent         FindingKind = "missing_agent"
+	FindingAmbiguousAgent       FindingKind = "ambiguous_agent"
 	FindingMissingSubscriptions FindingKind = "missing_subscriptions"
 	FindingMissingEmits         FindingKind = "missing_emits"
 )
 
 type Finding struct {
-	Kind    FindingKind
-	ScopeID string
-	Role    string
-	AgentID string
-	Missing []string
+	Kind       FindingKind
+	ScopeID    string
+	Role       string
+	AgentID    string
+	Missing    []string
+	Candidates []string
 }
 
 func RootScope(source semanticview.Source) (Scope, bool) {
@@ -40,19 +42,7 @@ func RootScope(source semanticview.Source) (Scope, bool) {
 		ID:       "root",
 		Required: source.RequiredAgents(),
 	}
-	for _, projectScope := range source.ProjectScopes() {
-		if strings.TrimSpace(projectScope.OwningFlowID) == "" && projectScope.Depth == 0 {
-			scope.Agents = projectScope.Agents
-			return scope, true
-		}
-	}
-	for _, projectScope := range source.ProjectScopes() {
-		if strings.TrimSpace(projectScope.OwningFlowID) == "" {
-			scope.Agents = projectScope.Agents
-			return scope, true
-		}
-	}
-	scope.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+	scope.Declarations = semanticview.AgentDeclarationsForOwner(source, "")
 	return scope, true
 }
 
@@ -68,9 +58,9 @@ func FlowScopes(source semanticview.Source) []Scope {
 			continue
 		}
 		out = append(out, Scope{
-			ID:       flowID,
-			Agents:   flowScope.Agents,
-			Required: source.FlowRequiredAgents(flowID),
+			ID:           flowID,
+			Declarations: semanticview.AgentDeclarationsForOwner(source, flowID),
+			Required:     source.FlowRequiredAgents(flowID),
 		})
 	}
 	return out
@@ -103,8 +93,17 @@ func CheckScope(scope Scope) []Finding {
 			})
 			continue
 		}
-		agentID, agent, ok := ResolveAgent(scope.Agents, required)
-		if !ok {
+		declaration, candidates := resolveAgentDeclaration(scope.Declarations, role)
+		if len(candidates) > 1 {
+			findings = append(findings, Finding{
+				Kind:       FindingAmbiguousAgent,
+				ScopeID:    scope.ID,
+				Role:       role,
+				Candidates: candidates,
+			})
+			continue
+		}
+		if len(candidates) == 0 {
 			findings = append(findings, Finding{
 				Kind:    FindingMissingAgent,
 				ScopeID: scope.ID,
@@ -112,6 +111,8 @@ func CheckScope(scope Scope) []Finding {
 			})
 			continue
 		}
+		agentID := strings.TrimSpace(declaration.LocalID)
+		agent := declaration.Entry
 		if missing := missingStrings(required.SubscribesTo, AgentSubscriptions(agent)); len(missing) > 0 {
 			findings = append(findings, Finding{
 				Kind:    FindingMissingSubscriptions,
@@ -134,16 +135,26 @@ func CheckScope(scope Scope) []Finding {
 	return findings
 }
 
-func ResolveAgent(agents map[string]runtimecontracts.AgentRegistryEntry, required runtimecontracts.FlowRequiredAgent) (string, runtimecontracts.AgentRegistryEntry, bool) {
-	role := strings.TrimSpace(required.Role)
+func resolveAgentDeclaration(declarations []semanticview.AgentDeclaration, role string) (semanticview.AgentDeclaration, []string) {
+	role = strings.TrimSpace(role)
 	if role == "" {
-		return "", runtimecontracts.AgentRegistryEntry{}, false
+		return semanticview.AgentDeclaration{}, nil
 	}
-	agent, ok := agents[role]
-	if !ok {
-		return "", runtimecontracts.AgentRegistryEntry{}, false
+	var matched semanticview.AgentDeclaration
+	candidates := make([]string, 0, 1)
+	for _, declaration := range declarations {
+		if strings.TrimSpace(declaration.LocalID) != role {
+			continue
+		}
+		matched = declaration
+		label := strings.TrimSpace(declaration.Source.File)
+		if label == "" {
+			label = declaration.Label(true)
+		}
+		candidates = append(candidates, label)
 	}
-	return role, agent, true
+	sort.Strings(candidates)
+	return matched, candidates
 }
 
 func AgentSubscriptions(agent runtimecontracts.AgentRegistryEntry) []string {

--- a/internal/runtime/requiredagents/fulfillment_test.go
+++ b/internal/runtime/requiredagents/fulfillment_test.go
@@ -1,31 +1,26 @@
 package requiredagents
 
 import (
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/flowownedprojectagent"
 )
-
-func TestResolveAgentRequiresMapKeyIdentity(t *testing.T) {
-	agents := map[string]runtimecontracts.AgentRegistryEntry{
-		"alias": {
-			ID:   "worker",
-			Role: "worker",
-		},
-	}
-
-	if agentID, _, ok := ResolveAgent(agents, runtimecontracts.FlowRequiredAgent{Role: "worker"}); ok {
-		t.Fatalf("ResolveAgent matched %q through non-key identity", agentID)
-	}
-}
 
 func TestCheckScopeReportsSubscriptionAndEmitCoverage(t *testing.T) {
 	findings := CheckScope(Scope{
 		ID: "child",
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{
-			"worker": {
-				Subscriptions: []string{"work.requested"},
-				EmitEvents:    []string{"work.completed"},
+		Declarations: []semanticview.AgentDeclaration{
+			{
+				LocalID: "worker",
+				Entry: runtimecontracts.AgentRegistryEntry{
+					Subscriptions: []string{"work.requested"},
+					EmitEvents:    []string{"work.completed"},
+				},
 			},
 		},
 		Required: []runtimecontracts.FlowRequiredAgent{{
@@ -43,5 +38,54 @@ func TestCheckScopeReportsSubscriptionAndEmitCoverage(t *testing.T) {
 	}
 	if findings[1].Kind != FindingMissingEmits || findings[1].Missing[0] != "work.failed" {
 		t.Fatalf("emit finding = %#v", findings[1])
+	}
+}
+
+func TestCheckScopeRejectsAmbiguousSameRoleDeclarations(t *testing.T) {
+	findings := CheckScope(Scope{
+		ID: "child",
+		Declarations: []semanticview.AgentDeclaration{
+			{LocalID: "worker", Source: runtimecontracts.ContractItemSource{File: "left/agents.yaml"}},
+			{LocalID: "worker", Source: runtimecontracts.ContractItemSource{File: "right/agents.yaml"}},
+		},
+		Required: []runtimecontracts.FlowRequiredAgent{{Role: "worker"}},
+	})
+
+	if len(findings) != 1 || findings[0].Kind != FindingAmbiguousAgent {
+		t.Fatalf("findings = %#v, want one ambiguous-agent finding", findings)
+	}
+	if want := []string{"left/agents.yaml", "right/agents.yaml"}; !reflect.DeepEqual(findings[0].Candidates, want) {
+		t.Fatalf("candidates = %#v, want %#v", findings[0].Candidates, want)
+	}
+}
+
+func TestFlowOwnedProjectAgentInferenceAndFulfillmentUseCanonicalOwner(t *testing.T) {
+	source := flowownedprojectagent.LoadSource(t, runtimecontracts.FlowModeStatic, false)
+	scopes := FlowScopes(source)
+	if len(scopes) != 1 || scopes[0].ID != "support" || len(scopes[0].Declarations) != 1 {
+		t.Fatalf("flow scopes = %#v, want exact support declaration", scopes)
+	}
+	if findings := CheckScope(scopes[0]); len(findings) != 0 {
+		t.Fatalf("canonical project-agent fulfillment findings = %#v", findings)
+	}
+	bundle, ok := semanticview.Bundle(source)
+	if !ok {
+		t.Fatal("fixture does not expose bundle")
+	}
+	facts := bundle.FlowRequiredAgentFacts("support")
+	if len(facts) != 1 || facts[0].Role != "worker" || !strings.HasSuffix(filepath.ToSlash(facts[0].SourceFile), "flows/support/left/agents.yaml") {
+		t.Fatalf("inferred facts = %#v, want project declaration provenance", facts)
+	}
+}
+
+func TestFlowOwnedProjectAgentFulfillmentRejectsAmbiguousSameRole(t *testing.T) {
+	source := flowownedprojectagent.LoadExplicitRequiredSource(t, runtimecontracts.FlowModeStatic, true)
+	scopes := FlowScopes(source)
+	if len(scopes) != 1 {
+		t.Fatalf("flow scopes = %#v, want support", scopes)
+	}
+	findings := CheckScope(scopes[0])
+	if len(findings) != 1 || findings[0].Kind != FindingAmbiguousAgent || len(findings[0].Candidates) != 2 {
+		t.Fatalf("findings = %#v, want one exact ambiguous-role failure", findings)
 	}
 }

--- a/internal/runtime/runforkexecution/agent_runtime_materialization_test.go
+++ b/internal/runtime/runforkexecution/agent_runtime_materialization_test.go
@@ -516,6 +516,9 @@ func TestSelectedContractStaticAgentRecordsIncludeInferredFlowRequiredAgents(t *
 				EmitEvents:     []string{"analysis.done"},
 			},
 		},
+		AgentURIs: map[string]string{
+			"analyzer": "test://selected-contract/analysis/analyzer",
+		},
 	}
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		FlowSchemas: map[string]runtimecontracts.FlowSchemaDocument{
@@ -532,6 +535,12 @@ func TestSelectedContractStaticAgentRecordsIncludeInferredFlowRequiredAgents(t *
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"analysis/analyzer": {
+					Kind: "agent", FlowID: "analysis", LocalID: "analyzer",
+					Full: "test://selected-contract/analysis/analyzer",
+				},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				"test://selected-contract/analysis/analyzer": {
 					Kind: "agent", FlowID: "analysis", LocalID: "analyzer",
 					Full: "test://selected-contract/analysis/analyzer",
 				},

--- a/internal/runtime/runtime_agent_memory_startup_test.go
+++ b/internal/runtime/runtime_agent_memory_startup_test.go
@@ -17,8 +17,8 @@ func TestRuntimeStart_PackageBackedFlowOwnedStaticAgentsCarryCanonicalMemoryIden
 	assertRuntimeStartCarriesMemoryIdentity(t, source)
 }
 
-func TestRuntimeStart_SoleParentFlowPackageAgentsCarryCanonicalMemoryIdentity(t *testing.T) {
-	source := loadSoleParentFlowRuntimeAgentMemorySource(t)
+func TestRuntimeStart_StructurallyNestedProjectAgentsCarryCanonicalMemoryIdentity(t *testing.T) {
+	source := loadNestedProjectRuntimeAgentMemorySource(t)
 	assertRuntimeStartCarriesMemoryIdentity(t, source)
 }
 
@@ -68,10 +68,10 @@ func loadPackageBackedRuntimeAgentMemorySource(t *testing.T) semanticview.Source
 	return semanticview.Wrap(bundle)
 }
 
-func loadSoleParentFlowRuntimeAgentMemorySource(t *testing.T) semanticview.Source {
+func loadNestedProjectRuntimeAgentMemorySource(t *testing.T) semanticview.Source {
 	t.Helper()
 	repoRoot := runtimepipeline.WorkflowRepoRoot()
-	root := canonicalrouting.CopyRuntimeAgentMemory(t, canonicalrouting.RuntimeAgentMemorySoleParent)
+	root := canonicalrouting.CopyRuntimeAgentMemory(t, canonicalrouting.RuntimeAgentMemoryNestedProject)
 
 	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
 	if err != nil {

--- a/internal/runtime/semanticview/agent_contract_projection.go
+++ b/internal/runtime/semanticview/agent_contract_projection.go
@@ -30,9 +30,10 @@ func ScopedAgentContractProjection(source Source, declaration AgentDeclaration) 
 		return AgentContractProjection{}, false
 	}
 	projection := AgentContractProjection{
-		Declaration: declaration,
-		OwnerFlowID: strings.TrimSpace(declaration.OwnerFlowID),
-		globalTools: source.ToolEntries(),
+		Declaration:    declaration,
+		ContractSource: declaration.Source,
+		OwnerFlowID:    strings.TrimSpace(declaration.OwnerFlowID),
+		globalTools:    source.ToolEntries(),
 	}
 	switch strings.TrimSpace(declaration.ScopeKind) {
 	case "flow":
@@ -40,15 +41,6 @@ func ScopedAgentContractProjection(source Source, declaration AgentDeclaration) 
 			if strings.TrimSpace(scope.ID) != strings.TrimSpace(declaration.ScopeID) {
 				continue
 			}
-			if _, exists := scope.Agents[strings.TrimSpace(declaration.LocalID)]; !exists {
-				return AgentContractProjection{}, false
-			}
-			projection.ContractSource = runtimecontracts.ContractItemSource{
-				PackageKey: strings.TrimSpace(scope.PackageKey),
-				FlowID:     strings.TrimSpace(scope.ID),
-				Layer:      "flow",
-			}
-			projection.ContractSource = exactAgentContractSource(source, projection.ContractSource, declaration.LocalID)
 			projection.scopedTools = scope.Tools
 			return projection, true
 		}
@@ -57,14 +49,6 @@ func ScopedAgentContractProjection(source Source, declaration AgentDeclaration) 
 			if strings.TrimSpace(scope.Key) != strings.TrimSpace(declaration.ScopeID) {
 				continue
 			}
-			if _, exists := scope.Agents[strings.TrimSpace(declaration.LocalID)]; !exists {
-				return AgentContractProjection{}, false
-			}
-			projection.ContractSource = runtimecontracts.ContractItemSource{
-				PackageKey: strings.TrimSpace(scope.Key),
-				Layer:      "project",
-			}
-			projection.ContractSource = exactAgentContractSource(source, projection.ContractSource, declaration.LocalID)
 			projection.scopedTools = scope.Tools
 			return projection, true
 		}
@@ -72,15 +56,6 @@ func ScopedAgentContractProjection(source Source, declaration AgentDeclaration) 
 		return AgentContractProjection{}, false
 	}
 	return AgentContractProjection{}, false
-}
-
-func exactAgentContractSource(source Source, scope runtimecontracts.ContractItemSource, localID string) runtimecontracts.ContractItemSource {
-	if bundle, ok := Bundle(source); ok {
-		if contractSource, exists := bundle.ScopedAgentContractSource(scope, localID); exists {
-			return contractSource
-		}
-	}
-	return scope
 }
 
 func (p AgentContractProjection) ToolEntry(toolID string) (runtimecontracts.ToolSchemaEntry, bool) {

--- a/internal/runtime/semanticview/agent_declarations.go
+++ b/internal/runtime/semanticview/agent_declarations.go
@@ -60,6 +60,20 @@ func AgentDeclarations(source Source) []AgentDeclaration {
 	return entries
 }
 
+// AgentDeclarationsForOwner returns the complete declaration set owned by one
+// semantic flow, or by the explicit root when ownerFlowID is empty.
+func AgentDeclarationsForOwner(source Source, ownerFlowID string) []AgentDeclaration {
+	ownerFlowID = strings.TrimSpace(ownerFlowID)
+	declarations := AgentDeclarations(source)
+	out := make([]AgentDeclaration, 0, len(declarations))
+	for _, declaration := range declarations {
+		if strings.TrimSpace(declaration.OwnerFlowID) == ownerFlowID {
+			out = append(out, declaration)
+		}
+	}
+	return out
+}
+
 func SourceDeclaresAgents(source Source) bool {
 	return len(AgentDeclarations(source)) > 0
 }

--- a/internal/runtime/semanticview/agent_declarations.go
+++ b/internal/runtime/semanticview/agent_declarations.go
@@ -14,6 +14,7 @@ type AgentDeclaration struct {
 	OwnerURI    string
 	LocalID     string
 	Entry       runtimecontracts.AgentRegistryEntry
+	Source      runtimecontracts.ContractItemSource
 }
 
 func (d AgentDeclaration) Label(qualified bool) string {
@@ -27,58 +28,33 @@ func (d AgentDeclaration) Label(qualified bool) string {
 	return strings.Join([]string{strings.TrimSpace(d.ScopeKind), scopeID, "agent", strings.TrimSpace(d.LocalID)}, " ")
 }
 
-// AgentDeclarations enumerates canonical project/flow declarations directly.
+// AgentDeclarations projects the contracts-owned physical declaration census.
+// Raw project and flow maps are loader views, not declaration authority.
 func AgentDeclarations(source Source) []AgentDeclaration {
 	if source == nil {
 		return nil
 	}
-	entries := []AgentDeclaration{}
-	representedDeclarations := map[string]struct{}{}
-	appendScoped := func(scopeKind, scopeID, ownerFlowID, canonicalScopeID string, agents map[string]runtimecontracts.AgentRegistryEntry, agentURIs map[string]string) {
-		keys := make([]string, 0, len(agents))
-		for rawID := range agents {
-			if id := strings.TrimSpace(rawID); id != "" {
-				keys = append(keys, rawID)
-			}
-		}
-		sort.Slice(keys, func(i, j int) bool { return strings.TrimSpace(keys[i]) < strings.TrimSpace(keys[j]) })
-		for _, rawID := range keys {
-			localID := strings.TrimSpace(rawID)
-			declarationKey := strings.Join([]string{
-				strings.TrimSpace(ownerFlowID),
-				strings.TrimSpace(canonicalScopeID),
-				localID,
-			}, "\x00")
-			if _, represented := representedDeclarations[declarationKey]; represented {
-				continue
-			}
-			representedDeclarations[declarationKey] = struct{}{}
-			entries = append(entries, AgentDeclaration{
-				ScopeKind:   scopeKind,
-				ScopeID:     strings.TrimSpace(scopeID),
-				OwnerFlowID: strings.TrimSpace(ownerFlowID),
-				OwnerURI:    strings.TrimSpace(agentURIs[rawID]),
-				LocalID:     localID,
-				Entry:       agents[rawID],
-			})
-		}
+	bundle, ok := Bundle(source)
+	if !ok || bundle == nil {
+		return nil
 	}
-	projectScopes := sortedAuthoredProjectScopes(source.ProjectScopes())
-	flowScopes := sortedAuthoredFlowScopes(source.FlowScopes())
-	preferredFlowScopeKeys := authoredPreferredFlowScopeKeys(projectScopes, flowScopes)
-	for _, scope := range flowScopes {
-		flowID := strings.TrimSpace(scope.ID)
-		scopeKey := authoredEmitSiteFlowScopeKey(scope)
-		if preferred := preferredFlowScopeKeys[flowID]; preferred != "" && scopeKey != preferred {
-			continue
+	records := bundle.AgentDeclarationRecords()
+	entries := make([]AgentDeclaration, 0, len(records))
+	for _, record := range records {
+		scopeKind := strings.TrimSpace(record.Source.Layer)
+		scopeID := strings.TrimSpace(record.Source.PackageKey)
+		if scopeKind == "flow" {
+			scopeID = strings.TrimSpace(record.Source.FlowID)
 		}
-		appendScoped("flow", flowID, flowID, scopeKey, scope.Agents, scope.AgentURIs)
-	}
-	for _, scope := range projectScopes {
-		if authoredEmitSiteSkipsProjectScope(scope) {
-			continue
-		}
-		appendScoped("project", scope.Key, scope.OwningFlowID, scope.Key, scope.Agents, scope.AgentURIs)
+		entries = append(entries, AgentDeclaration{
+			ScopeKind:   scopeKind,
+			ScopeID:     scopeID,
+			OwnerFlowID: strings.TrimSpace(record.OwnerFlowID),
+			OwnerURI:    strings.TrimSpace(record.OwnerURI),
+			LocalID:     strings.TrimSpace(record.LogicalID),
+			Entry:       record.Entry,
+			Source:      record.Source,
+		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Label(true) < entries[j].Label(true) })
 	return entries

--- a/internal/runtime/semanticview/agent_declarations_test.go
+++ b/internal/runtime/semanticview/agent_declarations_test.go
@@ -66,7 +66,7 @@ flows:
 		t.Fatalf("declarations = %#v, want one canonical flow declaration", declarations)
 	}
 	declaration := declarations[0]
-	if declaration.ScopeKind != "project" || declaration.ScopeID != "flows/support" || declaration.OwnerFlowID != "support" || declaration.LocalID != "flow-agent" {
+	if declaration.ScopeKind != "flow" || declaration.ScopeID != "support" || declaration.OwnerFlowID != "support" || declaration.LocalID != "flow-agent" {
 		t.Fatalf("declaration = %#v, want canonical package-backed support agent", declaration)
 	}
 	owner, ok := ScopedAgentDeclarationOwner(source, declaration)

--- a/internal/runtime/semanticview/agent_execution_scope.go
+++ b/internal/runtime/semanticview/agent_execution_scope.go
@@ -1,0 +1,105 @@
+package semanticview
+
+import (
+	"fmt"
+	"strings"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+)
+
+// AgentExecutionSemanticScope is the admitted agreement between one live actor
+// identity and its exact physical contract declaration. Its fields are private
+// so producers cannot synthesize or partially reconstruct the scope.
+type AgentExecutionSemanticScope struct {
+	declaration AgentDeclaration
+	identity    agentidentity.Identity
+	flow        FlowScope
+	hasFlow     bool
+}
+
+func ResolveAgentExecutionSemanticScope(source Source, actor models.AgentConfig) (AgentExecutionSemanticScope, error) {
+	if source == nil {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope requires semantic source")
+	}
+	identity, err := actor.ConcreteIdentity()
+	if err != nil {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope requires concrete identity: %w", err)
+	}
+	if identity.Name.Source != agentidentity.NameSourceDeclared {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope requires a declared agent identity")
+	}
+	declaration, ok := resolveAgentDeclarationByName(source, "", identity.AgentID(), identity.Name.Owner)
+	if !ok {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope has no exact declaration for %s", identity.Description())
+	}
+	plan, err := ScopedAgentNamePlan(source, declaration)
+	if err != nil {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope declaration name: %w", err)
+	}
+	name, err := plan.Materialize()
+	if err != nil {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution semantic scope materialize declaration name: %w", err)
+	}
+	if identity.Name.Normalize() != name.Normalize() {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution identity name conflicts with declaration owner")
+	}
+	ownerFlowID := strings.TrimSpace(declaration.OwnerFlowID)
+	if strings.TrimSpace(actor.FlowID) != ownerFlowID {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution flow_id %q conflicts with declaration owner flow %q", actor.FlowID, ownerFlowID)
+	}
+	scope := AgentExecutionSemanticScope{declaration: declaration, identity: identity}
+	if ownerFlowID == "" {
+		if identity.Route.Presence != agentidentity.RouteRoot {
+			return AgentExecutionSemanticScope{}, fmt.Errorf("root agent declaration requires an explicit root identity route")
+		}
+		return scope, nil
+	}
+	flow, ok := source.FlowScopeByID(ownerFlowID)
+	if !ok {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent declaration references missing owning flow %q", ownerFlowID)
+	}
+	if identity.Route.Presence != agentidentity.RoutePresent {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("flow agent declaration %q requires a concrete flow identity route", ownerFlowID)
+	}
+	flowPath := strings.Trim(strings.TrimSpace(flow.Path), "/")
+	if flowPath == "" {
+		flowPath = strings.Trim(strings.TrimSpace(source.FlowPath(ownerFlowID)), "/")
+	}
+	if flowPath == "" {
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent declaration owner flow %q has no semantic path", ownerFlowID)
+	}
+	route := identity.Route.Normalize()
+	switch strings.TrimSpace(flow.Mode) {
+	case runtimecontracts.FlowModeTemplate:
+		if route.ScopeKey != flowPath || route.InstancePath == flowPath || !strings.HasPrefix(route.InstancePath, flowPath+"/") {
+			return AgentExecutionSemanticScope{}, fmt.Errorf("template agent execution route %q is not a concrete instance of declaration flow %q", route.InstancePath, flowPath)
+		}
+	case runtimecontracts.FlowModeStatic, runtimecontracts.FlowModeSingleton:
+		if route.InstancePath != flowPath {
+			return AgentExecutionSemanticScope{}, fmt.Errorf("agent execution route %q conflicts with declaration flow path %q", route.InstancePath, flowPath)
+		}
+	default:
+		return AgentExecutionSemanticScope{}, fmt.Errorf("agent declaration owner flow %q has unsupported mode %q", ownerFlowID, flow.Mode)
+	}
+	scope.flow = flow
+	scope.hasFlow = true
+	return scope, nil
+}
+
+func (s AgentExecutionSemanticScope) Declaration() AgentDeclaration {
+	return s.declaration
+}
+
+func (s AgentExecutionSemanticScope) Identity() agentidentity.Identity {
+	return s.identity
+}
+
+func (s AgentExecutionSemanticScope) ContractSource() runtimecontracts.ContractItemSource {
+	return s.declaration.Source
+}
+
+func (s AgentExecutionSemanticScope) OwningFlow() (FlowScope, bool) {
+	return s.flow, s.hasFlow
+}

--- a/internal/runtime/semanticview/agent_execution_scope_test.go
+++ b/internal/runtime/semanticview/agent_execution_scope_test.go
@@ -1,0 +1,296 @@
+package semanticview
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentitytest"
+)
+
+func TestLoadAgentExecutionSemanticScopeMatrix(t *testing.T) {
+	for _, mode := range []string{
+		runtimecontracts.FlowModeStatic,
+		runtimecontracts.FlowModeSingleton,
+		runtimecontracts.FlowModeTemplate,
+	} {
+		for _, packageParts := range [][]string{
+			nil,
+			{"parent", "child"},
+			{"parent", "child", "grandchild"},
+		} {
+			depth := "root"
+			if len(packageParts) > 0 {
+				depth = strings.Join(packageParts, "_")
+			}
+			t.Run(mode+"/"+depth, func(t *testing.T) {
+				source := loadAgentExecutionSemanticScopeFixture(t, mode, packageParts)
+				declarations := AgentDeclarations(source)
+				if len(declarations) != 1 {
+					t.Fatalf("declarations = %#v, want one physical declaration", declarations)
+				}
+				declaration := declarations[0]
+				wantPackage := "."
+				if len(packageParts) > 0 {
+					wantPackage = strings.Join(packageParts, "/")
+				}
+				if declaration.Source.PackageKey != wantPackage || declaration.Source.FlowID != "support" || declaration.OwnerFlowID != "support" {
+					t.Fatalf("declaration = %#v, want package %q flow support", declaration, wantPackage)
+				}
+				plan, err := ScopedAgentNamePlan(source, declaration)
+				if err != nil {
+					t.Fatalf("ScopedAgentNamePlan: %v", err)
+				}
+				flowPath := strings.Trim(strings.TrimSpace(source.FlowPath("support")), "/")
+				instanceID := "support"
+				instancePath := flowPath
+				if mode == runtimecontracts.FlowModeTemplate {
+					instanceID = "instance-1"
+					instancePath = flowPath + "/" + instanceID
+				}
+				actor := models.AgentConfig{
+					ID:       plan.AgentID,
+					FlowID:   "support",
+					FlowPath: instancePath,
+					Identity: agentidentitytest.Declared(t, plan.AgentID, plan.OwnerURI, flowPath, instanceID, instancePath),
+				}
+				scope, err := ResolveAgentExecutionSemanticScope(source, actor)
+				if err != nil {
+					t.Fatalf("ResolveAgentExecutionSemanticScope: %v", err)
+				}
+				if scope.ContractSource() != declaration.Source || scope.Identity() != actor.Identity {
+					t.Fatalf("execution scope = %#v, want exact declaration and concrete identity", scope)
+				}
+			})
+		}
+	}
+}
+
+func TestResolveAgentExecutionSemanticScopeAdmitsRootStaticSingletonAndImportedTemplate(t *testing.T) {
+	rootSource, _ := loadSameFlowSiblingAgentPackages(t)
+	rootDeclaration := executionDeclarationByLocalID(t, rootSource, "root-worker")
+	rootPlan, err := ScopedAgentNamePlan(rootSource, rootDeclaration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootActor := models.AgentConfig{
+		ID:       rootPlan.AgentID,
+		FlowID:   "",
+		FlowPath: "",
+		Identity: agentidentitytest.RootDeclared(t, rootPlan.AgentID, rootPlan.OwnerURI),
+	}
+	rootScope, err := ResolveAgentExecutionSemanticScope(rootSource, rootActor)
+	if err != nil {
+		t.Fatalf("root execution scope: %v", err)
+	}
+	if _, ok := rootScope.OwningFlow(); ok || rootScope.ContractSource().Layer != "project" {
+		t.Fatalf("root execution scope = %#v, want project-owned root declaration", rootScope)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		mode         string
+		packageKey   string
+		flowID       string
+		flowPath     string
+		instanceID   string
+		instancePath string
+	}{
+		{name: "static", mode: runtimecontracts.FlowModeStatic, packageKey: ".", flowID: "support", flowPath: "support", instanceID: "support", instancePath: "support"},
+		{name: "singleton", mode: runtimecontracts.FlowModeSingleton, packageKey: "services", flowID: "ingress", flowPath: "services/ingress", instanceID: "ingress", instancePath: "services/ingress"},
+		{name: "imported template", mode: runtimecontracts.FlowModeTemplate, packageKey: "bot", flowID: "telegram-chat", flowPath: "telegram-ingress/telegram-chat", instanceID: "chat-1", instancePath: "telegram-ingress/telegram-chat/chat-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source, declaration, actor := executionFlowAgentFixture(t, tc.mode, tc.packageKey, tc.flowID, tc.flowPath, tc.instanceID, tc.instancePath)
+			scope, err := ResolveAgentExecutionSemanticScope(source, actor)
+			if err != nil {
+				t.Fatalf("ResolveAgentExecutionSemanticScope: %v", err)
+			}
+			flow, ok := scope.OwningFlow()
+			if !ok || flow.ID != tc.flowID || scope.Declaration().OwnerURI != declaration.OwnerURI ||
+				scope.ContractSource().PackageKey != tc.packageKey || scope.ContractSource().FlowID != tc.flowID ||
+				scope.Identity().Route.InstancePath != tc.instancePath {
+				t.Fatalf("scope = %#v, flow = %#v ok=%v", scope, flow, ok)
+			}
+		})
+	}
+}
+
+func TestResolveAgentExecutionSemanticScopeRejectsHostileIdentityContradictions(t *testing.T) {
+	source, declaration, valid := executionFlowAgentFixture(
+		t,
+		runtimecontracts.FlowModeTemplate,
+		"bot",
+		"telegram-chat",
+		"telegram-ingress/telegram-chat",
+		"chat-1",
+		"telegram-ingress/telegram-chat/chat-1",
+	)
+	runtimeName, err := agentidentity.RuntimeName(valid.ID, declaration.OwnerURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongOwner, err := agentidentity.DeclaredName(valid.ID, "test://hostile/other-owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongRoute, err := agentidentity.PresentRoute("telegram-ingress/sibling", "chat-1", "telegram-ingress/sibling/chat-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseRoute, err := agentidentity.PresentRoute("telegram-ingress/telegram-chat", "telegram-chat", "telegram-ingress/telegram-chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name     string
+		mutate   func(models.AgentConfig) models.AgentConfig
+		contains string
+	}{
+		{name: "runtime-created name collision", contains: "declared agent identity", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.Identity.Name = runtimeName
+			return actor
+		}},
+		{name: "wrong declaration owner", contains: "no exact declaration", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.Identity.Name = wrongOwner
+			return actor
+		}},
+		{name: "runtime path used as declaration flow", contains: "conflicts with declaration owner flow", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.FlowID = actor.FlowPath
+			return actor
+		}},
+		{name: "sibling route", contains: "not a concrete instance", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.FlowPath = wrongRoute.InstancePath
+			actor.Identity.Route = wrongRoute
+			return actor
+		}},
+		{name: "template base route", contains: "not a concrete instance", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.FlowPath = baseRoute.InstancePath
+			actor.Identity.Route = baseRoute
+			return actor
+		}},
+		{name: "root route for flow declaration", contains: "flow_path", mutate: func(actor models.AgentConfig) models.AgentConfig {
+			actor.Identity.Route = agentidentity.RootRoute()
+			return actor
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveAgentExecutionSemanticScope(source, tc.mutate(valid))
+			if err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("error = %v, want %q", err, tc.contains)
+			}
+		})
+	}
+}
+
+func executionFlowAgentFixture(t *testing.T, mode, packageKey, flowID, flowPath, instanceID, instancePath string) (Source, AgentDeclaration, models.AgentConfig) {
+	t.Helper()
+	ownerURI := "test://agent-execution/" + strings.Trim(packageKey, "/") + "/" + flowID + "/worker"
+	entry := runtimecontracts.EffectiveAgentRegistryEntry("worker", runtimecontracts.AgentRegistryEntry{ID: "worker", Role: "worker"})
+	view := runtimecontracts.FlowContractView{
+		Path:      flowPath,
+		Schema:    runtimecontracts.FlowSchemaDocument{Mode: mode},
+		Paths:     runtimecontracts.FlowContractPaths{ID: flowID, Flow: flowID, PackageKey: packageKey, AgentsFile: "/contracts/" + packageKey + "/" + flowID + "/agents.yaml"},
+		Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": entry},
+		AgentURIs: map[string]string{"worker": ownerURI},
+	}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{view}},
+			ByID: map[string]*runtimecontracts.FlowContractView{flowID: &view},
+		},
+		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
+			ownerURI: {Kind: "agent", FlowID: flowID, LocalID: "worker", Full: ownerURI},
+		}},
+	}
+	source := Wrap(bundle)
+	declaration := executionDeclarationByLocalID(t, source, "worker")
+	plan, err := ScopedAgentNamePlan(source, declaration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := agentidentitytest.Declared(t, plan.AgentID, plan.OwnerURI, flowPath, instanceID, instancePath)
+	return source, declaration, models.AgentConfig{ID: plan.AgentID, FlowID: flowID, FlowPath: instancePath, Identity: identity}
+}
+
+func executionDeclarationByLocalID(t *testing.T, source Source, localID string) AgentDeclaration {
+	t.Helper()
+	var found AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		if declaration.LocalID != localID {
+			continue
+		}
+		if found.LocalID != "" {
+			t.Fatalf("agent declaration %q is ambiguous: %#v", localID, AgentDeclarations(source))
+		}
+		found = declaration
+	}
+	if found.LocalID == "" {
+		t.Fatalf("agent declaration %q not found: %#v", localID, AgentDeclarations(source))
+	}
+	return found
+}
+
+func loadAgentExecutionSemanticScopeFixture(t *testing.T, mode string, packageParts []string) Source {
+	t.Helper()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	root := t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+	packageRoot := root
+	for index := 0; index <= len(packageParts); index++ {
+		name := "agent-execution-root"
+		if index > 0 {
+			name = packageParts[index-1]
+		}
+		manifest := "name: " + name + "\nversion: \"1.0.0\"\n"
+		if index == 0 {
+			manifest += "platform_version: \">=0.7.0 <0.8.0\"\n"
+		}
+		if index < len(packageParts) {
+			manifest += "packages:\n  - {path: " + packageParts[index] + "}\n"
+		} else {
+			manifest += "flows:\n  - {id: support, flow: support, mode: " + mode + "}\n"
+		}
+		write(filepath.Join(packageRoot, "package.yaml"), manifest)
+		if index < len(packageParts) {
+			packageRoot = filepath.Join(packageRoot, packageParts[index])
+		}
+	}
+	write(filepath.Join(root, "schema.yaml"), "name: agent-execution-root\n")
+	for _, name := range []string{"agents.yaml", "entities.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(root, name), "{}\n")
+	}
+	flowRoot := filepath.Join(packageRoot, "flows", "support")
+	write(filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	write(filepath.Join(flowRoot, "schema.yaml"), "name: support\nmode: "+mode+"\ninitial_state: active\nstates: [active]\n")
+	write(filepath.Join(flowRoot, "events.yaml"), "work.requested: {}\n")
+	write(filepath.Join(flowRoot, "agents.yaml"), `
+worker:
+  role: worker
+  intent: {inline: Exercise strict agent execution scope loading.}
+  model: regular
+  memory: false
+  subscriptions: [work.requested]
+`)
+	for _, name := range []string{"nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(filepath.Join(flowRoot, name), "{}\n")
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return Wrap(bundle)
+}

--- a/internal/runtime/semanticview/agent_memory_proof.go
+++ b/internal/runtime/semanticview/agent_memory_proof.go
@@ -29,30 +29,15 @@ func ResolveAgentMemoryProof(source Source, locator AgentMemoryLocator) AgentMem
 		return proof
 	}
 
-	if declaration, ok := agentMemoryDeclaration(source, locator); ok {
-		projection, projected := ScopedAgentContractProjection(source, declaration)
-		if projected {
-			proof.ContractSource = projection.ContractSource
-			proof.OwningFlowID = projection.OwnerFlowID
-			if proof.ProjectScopeKey == "" {
-				proof.ProjectScopeKey = strings.TrimSpace(projection.ContractSource.PackageKey)
-			}
-		}
-	}
-
-	if proof.AgentID == "" && proof.ProjectScopeKey == "" && strings.TrimSpace(locator.FlowID) == "" {
+	declaration, ok := agentMemoryDeclaration(source, locator)
+	if !ok {
 		return proof
 	}
-
-	if flowID := strings.TrimSpace(locator.FlowID); flowID != "" {
-		proof.OwningFlowID = flowID
-	} else if proof.ProjectScopeKey != "" {
-		if projectScope, ok := projectScopeByKey(source, proof.ProjectScopeKey); ok {
-			proof.ProjectScopeKey = projectScope.Key
-			proof.OwningFlowID = strings.TrimSpace(projectScope.OwningFlowID)
-		}
+	proof.ContractSource = declaration.Source
+	proof.OwningFlowID = strings.TrimSpace(declaration.OwnerFlowID)
+	if proof.ProjectScopeKey == "" {
+		proof.ProjectScopeKey = strings.TrimSpace(declaration.Source.PackageKey)
 	}
-
 	if proof.OwningFlowID == "" {
 		return proof
 	}
@@ -66,13 +51,26 @@ func ResolveAgentMemoryProof(source Source, locator AgentMemoryLocator) AgentMem
 	return proof
 }
 
+func AgentMemoryProofForDeclaration(source Source, declaration AgentDeclaration) AgentMemoryProof {
+	proof := AgentMemoryProof{
+		AgentID:         strings.TrimSpace(declaration.LocalID),
+		ProjectScopeKey: strings.TrimSpace(declaration.Source.PackageKey),
+		ContractSource:  declaration.Source,
+		OwningFlowID:    strings.TrimSpace(declaration.OwnerFlowID),
+	}
+	if source != nil && proof.OwningFlowID != "" {
+		proof.FlowPath = strings.Trim(strings.TrimSpace(source.FlowPath(proof.OwningFlowID)), "/")
+	}
+	return proof
+}
+
 func agentMemoryDeclaration(source Source, locator AgentMemoryLocator) (AgentDeclaration, bool) {
 	agentID := strings.TrimSpace(locator.AgentID)
 	projectScopeKey := strings.TrimSpace(locator.ProjectScopeKey)
 	flowID := strings.TrimSpace(locator.FlowID)
 	var matched AgentDeclaration
 	for _, declaration := range AgentDeclarations(source) {
-		if projectScopeKey != "" && strings.TrimSpace(declaration.ScopeID) != projectScopeKey {
+		if projectScopeKey != "" && strings.TrimSpace(declaration.Source.PackageKey) != projectScopeKey {
 			continue
 		}
 		if flowID != "" && !agentDeclarationMatchesFlow(declaration, flowID) {
@@ -88,17 +86,4 @@ func agentMemoryDeclaration(source Source, locator AgentMemoryLocator) (AgentDec
 		matched = declaration
 	}
 	return matched, strings.TrimSpace(matched.LocalID) != ""
-}
-
-func projectScopeByKey(source Source, key string) (ProjectScope, bool) {
-	key = strings.TrimSpace(key)
-	if source == nil || key == "" {
-		return ProjectScope{}, false
-	}
-	for _, scope := range source.ProjectScopes() {
-		if strings.TrimSpace(scope.Key) == key {
-			return scope, true
-		}
-	}
-	return ProjectScope{}, false
 }

--- a/internal/runtime/semanticview/agent_name_ownership_guard_test.go
+++ b/internal/runtime/semanticview/agent_name_ownership_guard_test.go
@@ -86,6 +86,28 @@ func hostileSixthAgentSourceProducer(source semanticview.Source, actor models.Ag
 	runtimepinrouting.AdmitAgentExecutionRoutingSource(source, actor, "entity")
 }
 `)
+	authoringPath := filepath.Join(root, "internal", "runtime", "authoringview", "agent_name_guard_hostile.go")
+	overlay[authoringPath] = []byte(`package authoringview
+
+import "github.com/division-sh/swarm/internal/runtime/semanticview"
+
+func hostileAuthoringRawAgentMap(arbitrary semanticview.FlowScope, id string) {
+	_ = arbitrary.Agents[id]
+}
+`)
+	requiredPath := filepath.Join(root, "internal", "runtime", "requiredagents", "agent_name_guard_hostile.go")
+	overlay[requiredPath] = []byte(`package requiredagents
+
+import "github.com/division-sh/swarm/internal/runtime/semanticview"
+
+func hostileRequiredAgentRawMap(arbitrary semanticview.ProjectScope) []string {
+	var out []string
+	for id := range arbitrary.Agents {
+		out = append(out, id)
+	}
+	return out
+}
+`)
 	findings := loadAgentNameOwnershipFindings(t, root, overlay)
 	want := map[string]bool{
 		"raw_agent_registry_id":             false,
@@ -102,6 +124,21 @@ func hostileSixthAgentSourceProducer(source semanticview.Source, actor models.Ag
 	for kind, found := range want {
 		if !found {
 			t.Fatalf("hostile ownership guard did not detect %s: %#v", kind, findings)
+		}
+	}
+	consumerBypasses := map[string]bool{
+		"internal/runtime/authoringview/agent_name_guard_hostile.go::hostileAuthoringRawAgentMap::raw_agent_scope_map_read":     false,
+		"internal/runtime/requiredagents/agent_name_guard_hostile.go::hostileRequiredAgentRawMap::raw_agent_scope_map_read":     false,
+		"internal/runtime/requiredagents/agent_name_guard_hostile.go::hostileRequiredAgentRawMap::unclassified_agent_map_range": false,
+	}
+	for _, finding := range findings {
+		if _, ok := consumerBypasses[finding.key()]; ok {
+			consumerBypasses[finding.key()] = true
+		}
+	}
+	for bypass, found := range consumerBypasses {
+		if !found {
+			t.Fatalf("hostile consumer bypass was not detected at %s: %#v", bypass, findings)
 		}
 	}
 }
@@ -246,35 +283,26 @@ func agentNameGuardIsRawAgentScopeMap(selector *ast.SelectorExpr, info *types.In
 
 func agentNameGuardRawAgentScopeMapAllowed(path, enclosing string) bool {
 	allowed := map[string]struct{}{
-		"internal/runtime/authoringview/view.go::agentViews":                                                          {},
-		"internal/runtime/authoringview/view.go::buildFlows":                                                          {},
-		"internal/runtime/authoringview/view.go::resolveAgentScope":                                                   {},
-		"internal/runtime/authoringview/view.go::rootAgentViewEntries":                                                {},
-		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":                 {},
-		"internal/runtime/contracts/agent_registry_resolution.go::bundleAgentRecords":                                 {},
-		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                              {},
-		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":                 {},
-		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaReferences":                          {},
-		"internal/runtime/contracts/mock_performance_loading.go::materializeAgentMockPerformances":                    {},
-		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntries":           {},
-		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntry":             {},
-		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).flowRequiredAgentScope": {},
-		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).rootRequiredAgentScope": {},
-		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":                    {},
-		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                                {},
-		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                           {},
-		"internal/runtime/contracts/workflow_contract_tree.go::buildFlowTree":                                         {},
-		"internal/runtime/contracts/workflow_contract_tree.go::loadFlowContractView":                                  {},
-		"internal/runtime/contracts/workflow_contract_tree.go::loadProjectContractView":                               {},
-		"internal/runtime/contracts/workflow_contract_tree.go::populateMergedPackageViews":                            {},
-		"internal/runtime/requiredagents/fulfillment.go::CheckScope":                                                  {},
-		"internal/runtime/requiredagents/fulfillment.go::FlowScopes":                                                  {},
-		"internal/runtime/requiredagents/fulfillment.go::RootScope":                                                   {},
-		"internal/runtime/semanticview/bundle_source.go::(bundleSource).ProjectScopes":                                {},
-		"internal/runtime/semanticview/scopes.go::flowScopeFromView":                                                  {},
-		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":         {},
-		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions":      {},
-		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                                 {},
+		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
+		"internal/runtime/contracts/agent_registry_resolution.go::bundleAgentRecords":                            {},
+		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaReferences":                     {},
+		"internal/runtime/contracts/mock_performance_loading.go::materializeAgentMockPerformances":               {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntries":      {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntry":        {},
+		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":               {},
+		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                           {},
+		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                      {},
+		"internal/runtime/contracts/workflow_contract_tree.go::buildFlowTree":                                    {},
+		"internal/runtime/contracts/workflow_contract_tree.go::loadFlowContractView":                             {},
+		"internal/runtime/contracts/workflow_contract_tree.go::loadProjectContractView":                          {},
+		"internal/runtime/contracts/workflow_contract_tree.go::populateMergedPackageViews":                       {},
+		"internal/runtime/semanticview/bundle_source.go::(bundleSource).ProjectScopes":                           {},
+		"internal/runtime/semanticview/scopes.go::flowScopeFromView":                                             {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":    {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions": {},
+		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                            {},
 	}
 	_, ok := allowed[path+"::"+enclosing]
 	return ok
@@ -331,7 +359,6 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 	// coordinate, or ignore it while inspecting non-identity entry fields. Any
 	// new range over the wire map must be classified here or consume a name plan.
 	allowed := map[string]struct{}{
-		"internal/runtime/authoringview/view.go::agentViews":                                                     {},
 		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
 		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
 		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
@@ -341,7 +368,6 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                           {},
 		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                      {},
 		"internal/runtime/manager/flow_activation.go::(*AgentManager).flowInstanceAgentRecords":                  {},
-		"internal/runtime/manager/flow_activation.go::staticFlowLocalEventSet":                                   {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":    {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions": {},
 		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                            {},

--- a/internal/runtime/semanticview/agent_name_ownership_guard_test.go
+++ b/internal/runtime/semanticview/agent_name_ownership_guard_test.go
@@ -60,13 +60,40 @@ func hostileScopedMapKeyAgentID(view runtimecontracts.FlowContractView) []string
 	return out
 }
 
+func hostileArbitraryReceiverIndex(arbitrary FlowScope, id string) runtimecontracts.AgentRegistryEntry {
+	return arbitrary.Agents[id]
+}
+
+func hostileContractViewIndex(arbitrary runtimecontracts.FlowContractView, id string) runtimecontracts.AgentRegistryEntry {
+	return arbitrary.Agents[id]
+}
+
 func hostileLegacyContractLookup(bundle *runtimecontracts.WorkflowContractBundle, actorID string) {
 	bundle.AgentContractSource(actorID)
 	bundle.ScopedAgentContractSource(runtimecontracts.ContractItemSource{FlowID: "hostile"}, actorID)
 }
-`)}
+	`)}
+	toolsPath := filepath.Join(root, "internal", "runtime", "tools", "agent_source_guard_hostile.go")
+	overlay[toolsPath] = []byte(`package tools
+
+import (
+	runtimepinrouting "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func hostileSixthAgentSourceProducer(source semanticview.Source, actor models.AgentConfig) {
+	runtimepinrouting.AdmitAgentExecutionRoutingSource(source, actor, "entity")
+}
+`)
 	findings := loadAgentNameOwnershipFindings(t, root, overlay)
-	want := map[string]bool{"raw_agent_registry_id": false, "unclassified_agent_map_range": false, "legacy_agent_contract_lookup": false}
+	want := map[string]bool{
+		"raw_agent_registry_id":             false,
+		"raw_agent_scope_map_read":          false,
+		"unclassified_agent_map_range":      false,
+		"legacy_agent_contract_lookup":      false,
+		"unapproved_agent_source_admission": false,
+	}
 	for _, finding := range findings {
 		if _, ok := want[finding.Kind]; ok && strings.Contains(finding.Enclosing, "hostile") {
 			want[finding.Kind] = true
@@ -130,6 +157,9 @@ func collectAgentNameOwnershipFindings(path string, file *ast.File, info *types.
 			if statement, ok := node.(*ast.RangeStmt); ok && agentNameGuardIsAgentMapRange(statement, info) && !agentNameGuardAgentMapRangeAllowed(path, enclosing) {
 				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "unclassified_agent_map_range"})
 			}
+			if call, ok := node.(*ast.CallExpr); ok && agentNameGuardIsAgentSourceAdmission(call, info) && !agentNameGuardAgentSourceAdmissionAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "unapproved_agent_source_admission"})
+			}
 			selector, ok := node.(*ast.SelectorExpr)
 			if !ok {
 				return true
@@ -139,6 +169,9 @@ func collectAgentNameOwnershipFindings(path string, file *ast.File, info *types.
 			}
 			if agentNameGuardIsLegacyContractLookup(selector, info) && !agentNameGuardLegacyContractLookupAllowed(path, enclosing) {
 				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "legacy_agent_contract_lookup"})
+			}
+			if agentNameGuardIsRawAgentScopeMap(selector, info) && !agentNameGuardRawAgentScopeMapAllowed(path, enclosing) {
+				findings = append(findings, agentNameOwnershipFinding{Path: path, Enclosing: enclosing, Kind: "raw_agent_scope_map_read"})
 			}
 			return true
 		})
@@ -158,10 +191,93 @@ func agentNameGuardIsLegacyContractLookup(selector *ast.SelectorExpr, info *type
 }
 
 func agentNameGuardLegacyContractLookupAllowed(path, enclosing string) bool {
-	if path != "internal/runtime/semanticview/agent_contract_projection.go" {
+	return false
+}
+
+func agentNameGuardIsAgentSourceAdmission(call *ast.CallExpr, info *types.Info) bool {
+	if call == nil || info == nil {
 		return false
 	}
-	return enclosing == "ScopedAgentContractProjection" || enclosing == "exactAgentContractSource"
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil || selector.Sel.Name != "AdmitAgentExecutionRoutingSource" {
+		return false
+	}
+	function, ok := info.Uses[selector.Sel].(*types.Func)
+	return ok && function.Pkg() != nil && function.Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/core/pinrouting"
+}
+
+func agentNameGuardAgentSourceAdmissionAllowed(path, enclosing string) bool {
+	allowed := map[string]struct{}{
+		"internal/runtime/tools/channel_runtime.go::(*Executor).execChannelOperation":      {},
+		"internal/runtime/tools/executor_agents.go::(*Executor).execAgentMessage":          {},
+		"internal/runtime/tools/executor_agents.go::(*Executor).execSchedule":              {},
+		"internal/runtime/tools/executor_emit.go::(*Executor).handleEmitTool":              {},
+		"internal/runtime/tools/executor_human_tasks.go::(*Executor).execHumanTaskRequest": {},
+	}
+	_, ok := allowed[path+"::"+enclosing]
+	return ok
+}
+
+func agentNameGuardIsRawAgentScopeMap(selector *ast.SelectorExpr, info *types.Info) bool {
+	if selector == nil || selector.Sel == nil || selector.Sel.Name != "Agents" || info == nil {
+		return false
+	}
+	typ := info.TypeOf(selector)
+	if named, ok := typ.(*types.Named); ok {
+		typ = named.Underlying()
+	}
+	mapping, ok := typ.(*types.Map)
+	if !ok {
+		return false
+	}
+	key, ok := mapping.Key().Underlying().(*types.Basic)
+	if !ok || key.Kind() != types.String {
+		return false
+	}
+	element := mapping.Elem()
+	if pointer, ok := element.(*types.Pointer); ok {
+		element = pointer.Elem()
+	}
+	entry, ok := element.(*types.Named)
+	return ok && entry.Obj() != nil && entry.Obj().Pkg() != nil &&
+		entry.Obj().Name() == "AgentRegistryEntry" &&
+		entry.Obj().Pkg().Path() == "github.com/division-sh/swarm/internal/runtime/contracts"
+}
+
+func agentNameGuardRawAgentScopeMapAllowed(path, enclosing string) bool {
+	allowed := map[string]struct{}{
+		"internal/runtime/authoringview/view.go::agentViews":                                                          {},
+		"internal/runtime/authoringview/view.go::buildFlows":                                                          {},
+		"internal/runtime/authoringview/view.go::resolveAgentScope":                                                   {},
+		"internal/runtime/authoringview/view.go::rootAgentViewEntries":                                                {},
+		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":                 {},
+		"internal/runtime/contracts/agent_registry_resolution.go::bundleAgentRecords":                                 {},
+		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                              {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":                 {},
+		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaReferences":                          {},
+		"internal/runtime/contracts/mock_performance_loading.go::materializeAgentMockPerformances":                    {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntries":           {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).AgentEntry":             {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).flowRequiredAgentScope": {},
+		"internal/runtime/contracts/workflow_contract_accessors.go::(*WorkflowContractBundle).rootRequiredAgentScope": {},
+		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":                    {},
+		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                                {},
+		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                           {},
+		"internal/runtime/contracts/workflow_contract_tree.go::buildFlowTree":                                         {},
+		"internal/runtime/contracts/workflow_contract_tree.go::loadFlowContractView":                                  {},
+		"internal/runtime/contracts/workflow_contract_tree.go::loadProjectContractView":                               {},
+		"internal/runtime/contracts/workflow_contract_tree.go::populateMergedPackageViews":                            {},
+		"internal/runtime/requiredagents/fulfillment.go::CheckScope":                                                  {},
+		"internal/runtime/requiredagents/fulfillment.go::FlowScopes":                                                  {},
+		"internal/runtime/requiredagents/fulfillment.go::RootScope":                                                   {},
+		"internal/runtime/semanticview/bundle_source.go::(bundleSource).ProjectScopes":                                {},
+		"internal/runtime/semanticview/scopes.go::flowScopeFromView":                                                  {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":         {},
+		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions":      {},
+		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                                 {},
+	}
+	_, ok := allowed[path+"::"+enclosing]
+	return ok
 }
 
 func agentNameGuardIsAgentMapRange(statement *ast.RangeStmt, info *types.Info) bool {
@@ -216,9 +332,6 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 	// new range over the wire map must be classified here or consume a name plan.
 	allowed := map[string]struct{}{
 		"internal/runtime/authoringview/view.go::agentViews":                                                     {},
-		"internal/runtime/bootverify/checks.go::(*checkerContext).invalidFieldDetection":                         {},
-		"internal/runtime/bootverify/checks.go::intentFindingsForScope":                                          {},
-		"internal/runtime/bootverify/workflow_entity_contract_coverage_checks.go::wave1ScopedAgentRecords":       {},
 		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
 		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
 		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
@@ -227,15 +340,8 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":               {},
 		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                           {},
 		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                      {},
-		"internal/runtime/flowdata/flowdata.go::ValidateSource":                                                  {},
-		"internal/runtime/flowdata/flowdata.go::sortedAgentLocalIDs":                                             {},
 		"internal/runtime/manager/flow_activation.go::(*AgentManager).flowInstanceAgentRecords":                  {},
-		"internal/runtime/manager/flow_activation.go::StaticAgentMaterializationRecords":                         {},
-		"internal/runtime/manager/flow_activation.go::flowAgentNamePlans":                                        {},
-		"internal/runtime/manager/flow_activation.go::projectAgentNamePlans":                                     {},
-		"internal/runtime/manager/flow_activation.go::staticAgentsForScope":                                      {},
 		"internal/runtime/manager/flow_activation.go::staticFlowLocalEventSet":                                   {},
-		"internal/runtime/semanticview/agent_declarations.go::AgentDeclarations":                                 {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":    {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions": {},
 		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                            {},

--- a/internal/runtime/semanticview/agent_name_ownership_guard_test.go
+++ b/internal/runtime/semanticview/agent_name_ownership_guard_test.go
@@ -35,6 +35,14 @@ func TestDeclaredAgentNameOwnershipBoundary(t *testing.T) {
 
 func TestDeclaredAgentNameOwnershipBoundaryRejectsHostileBypasses(t *testing.T) {
 	root := agentNameGuardRepoRoot(t)
+	flowBoundaryPath := "internal/runtime/bootverify/workflow_flow_boundary_checks.go"
+	flowBoundaryFunction := "flowHasScopedInputEscapeHatch"
+	if agentNameGuardRawAgentScopeMapAllowed(flowBoundaryPath, flowBoundaryFunction) || agentNameGuardAgentMapRangeAllowed(flowBoundaryPath, flowBoundaryFunction) {
+		t.Fatal("retired flow-boundary agent-map interpreter remains exempt from ownership guard")
+	}
+	if agentNameGuardAgentMapRangeAllowed("internal/runtime/manager/flow_activation.go", "(*AgentManager).flowInstanceAgentRecords") {
+		t.Fatal("canonical flow-instance agent consumer remains exempt from ownership guard")
+	}
 	path := filepath.Join(root, "internal", "runtime", "semanticview", "agent_name_guard_hostile.go")
 	overlay := map[string][]byte{path: []byte(`package semanticview
 
@@ -283,7 +291,6 @@ func agentNameGuardIsRawAgentScopeMap(selector *ast.SelectorExpr, info *types.In
 
 func agentNameGuardRawAgentScopeMapAllowed(path, enclosing string) bool {
 	allowed := map[string]struct{}{
-		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
 		"internal/runtime/contracts/agent_registry_resolution.go::bundleAgentRecords":                            {},
 		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
 		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
@@ -359,7 +366,6 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 	// coordinate, or ignore it while inspecting non-identity entry fields. Any
 	// new range over the wire map must be classified here or consume a name plan.
 	allowed := map[string]struct{}{
-		"internal/runtime/bootverify/workflow_flow_boundary_checks.go::flowHasScopedInputEscapeHatch":            {},
 		"internal/runtime/contracts/agent_intent_resolution.go::materializeAgentIntents":                         {},
 		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaCitationConsumption":            {},
 		"internal/runtime/contracts/criteria_validation.go::validateAgentCriteriaReferences":                     {},
@@ -367,7 +373,6 @@ func agentNameGuardAgentMapRangeAllowed(path, enclosing string) bool {
 		"internal/runtime/contracts/workflow_contract_effective.go::EffectiveAgentRegistryEntries":               {},
 		"internal/runtime/contracts/workflow_contract_merging.go::mergeAgentContracts":                           {},
 		"internal/runtime/contracts/workflow_contract_paths.go::cloneAgentRegistryEntryMap":                      {},
-		"internal/runtime/manager/flow_activation.go::(*AgentManager).flowInstanceAgentRecords":                  {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryFlowWildcardSubscriptions":    {},
 		"internal/runtime/semanticview/import_boundary_wildcards.go::importBoundaryProjectWildcardSubscriptions": {},
 		"internal/runtime/semanticviewtest/source.go::WrapRootAgents":                                            {},

--- a/internal/runtime/semanticview/agent_name_plan.go
+++ b/internal/runtime/semanticview/agent_name_plan.go
@@ -82,11 +82,9 @@ func (d AgentDeclaration) NamePlan() (AgentNamePlan, error) {
 }
 
 func ScopedAgentNamePlan(source Source, declaration AgentDeclaration) (AgentNamePlan, error) {
-	owner, ok := ScopedAgentDeclarationOwner(source, declaration)
-	if !ok {
+	if _, ok := ScopedAgentDeclarationOwner(source, declaration); !ok {
 		return AgentNamePlan{}, fmt.Errorf("agent declaration %q is missing a unique scoped owner", strings.TrimSpace(declaration.LocalID))
 	}
-	declaration.OwnerURI = owner
 	return declaration.NamePlan()
 }
 
@@ -112,7 +110,6 @@ func agentNamePlanForScope(source Source, scopeKind, scopeID, ownerFlowID, owner
 	}
 	ownerMatches := []AgentDeclaration{}
 	exact := []AgentDeclaration{}
-	projected := []AgentDeclaration{}
 	available := []string{}
 	for _, declaration := range AgentDeclarations(source) {
 		if strings.TrimSpace(declaration.LocalID) != localID {
@@ -128,10 +125,6 @@ func agentNamePlanForScope(source Source, scopeKind, scopeID, ownerFlowID, owner
 			exact = append(exact, declaration)
 			continue
 		}
-		if scopeKind == "flow" && strings.TrimSpace(declaration.ScopeKind) == "project" &&
-			strings.TrimSpace(declaration.OwnerFlowID) == ownerFlowID {
-			projected = append(projected, declaration)
-		}
 	}
 	if len(ownerMatches) > 1 {
 		return AgentNamePlan{}, fmt.Errorf("agent declaration %q at owner %q resolved to multiple declarations", localID, ownerURI)
@@ -144,11 +137,6 @@ func agentNamePlanForScope(source Source, scopeKind, scopeID, ownerFlowID, owner
 	}
 	if len(exact) == 1 {
 		return ScopedAgentNamePlan(source, exact[0])
-	}
-	// Package-backed flow declarations canonicalize to their project scope.
-	// The flow projection may consume that owner only when it is unique.
-	if scopeKind == "flow" && len(projected) == 1 {
-		return ScopedAgentNamePlan(source, projected[0])
 	}
 	return AgentNamePlan{}, fmt.Errorf("agent declaration %q in %s scope %q is not canonical; candidates: %s", localID, scopeKind, scopeID, strings.Join(available, ", "))
 }

--- a/internal/runtime/semanticview/agent_name_plan_test.go
+++ b/internal/runtime/semanticview/agent_name_plan_test.go
@@ -1,7 +1,8 @@
 package semanticview
 
 import (
-	"slices"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -108,94 +109,30 @@ func TestAgentContractProjectionPreservesScopedToolForLiteralPublicName(t *testi
 }
 
 func TestProjectAgentNamePlanPreservesExactScopeForSharedFlowAndLocalID(t *testing.T) {
-	firstOwner := "test://agent-name/packages/first/worker"
-	secondOwner := "test://agent-name/packages/second/worker"
-	refs := map[string]runtimecontracts.ContractURIRef{
-		firstOwner:  {Kind: "agent", LocalID: "worker", Full: firstOwner},
-		secondOwner: {Kind: "agent", LocalID: "worker", Full: secondOwner},
-	}
-	source := agentNameProjectScopeSource{
-		Source: Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: refs}}),
-		projects: []ProjectScope{
-			{Key: "packages/first", OwningFlowID: "support", Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": {ID: "first-worker"}}, AgentURIs: map[string]string{"worker": firstOwner}},
-			{Key: "packages/second", OwningFlowID: "support", Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": {ID: "second-worker"}}, AgentURIs: map[string]string{"worker": secondOwner}},
-		},
-	}
+	source, projects := loadSameFlowSiblingAgentPackages(t)
+	firstScope := projects["flows/support/first"]
+	secondScope := projects["flows/support/second"]
 
-	first, err := ProjectAgentNamePlan(source, source.projects[0], "worker")
+	first, err := ProjectAgentNamePlan(source, firstScope, "worker")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := ProjectAgentNamePlan(source, source.projects[1], "worker")
+	second, err := ProjectAgentNamePlan(source, secondScope, "worker")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first.ScopeID != "packages/first" || first.AgentID != "first-worker" || first.OwnerURI != firstOwner {
+	if first.ScopeID != "flows/support/first" || first.AgentID != "first-worker" || first.OwnerURI != firstScope.AgentURIs["worker"] {
 		t.Fatalf("first plan = %#v", first)
 	}
-	if second.ScopeID != "packages/second" || second.AgentID != "second-worker" || second.OwnerURI != secondOwner {
+	if second.ScopeID != "flows/support/second" || second.AgentID != "second-worker" || second.OwnerURI != secondScope.AgentURIs["worker"] {
 		t.Fatalf("second plan = %#v", second)
 	}
 }
 
 func TestResolveAgentDeclarationUsesConcreteOwnerForSameFlowProjectScopes(t *testing.T) {
-	firstOwner := "test://agent-name/packages/first/worker"
-	secondOwner := "test://agent-name/packages/second/worker"
-	refs := map[string]runtimecontracts.ContractURIRef{
-		firstOwner:  {Kind: "agent", LocalID: "worker", Full: firstOwner},
-		secondOwner: {Kind: "agent", LocalID: "worker", Full: secondOwner},
-	}
-	tool := func(description string) runtimecontracts.ToolSchemaEntry {
-		return runtimecontracts.MustToolSchemaEntry(
-			runtimecontracts.WithToolDescription(description),
-			runtimecontracts.WithToolHandler(runtimecontracts.ToolHandlerPlatformBuiltin),
-			runtimecontracts.WithToolSchemas(
-				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
-				runtimecontracts.MustToolInputSchema(runtimecontracts.ToolSchemaObject),
-			),
-		)
-	}
-	source := agentNameProjectScopeSource{
-		Source: Wrap(&runtimecontracts.WorkflowContractBundle{URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: refs}}),
-		projects: []ProjectScope{
-			{
-				Key: "packages/first", OwningFlowID: "support",
-				Agents: map[string]runtimecontracts.AgentRegistryEntry{
-					"worker": {
-						Role:           "first-role",
-						Permissions:    []string{"first-permission"},
-						Criteria:       []string{"first-criterion"},
-						FlowDataAccess: []string{"first.json"},
-						EntityWrites: map[string]runtimecontracts.AgentEntityWriteDecl{
-							"case": {Save: runtimecontracts.AgentEntityWriteRule{Fields: []string{"first-field"}}},
-						},
-					},
-				},
-				AgentURIs: map[string]string{"worker": firstOwner},
-				Tools:     map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("first scoped tool")},
-			},
-			{
-				Key: "packages/second", OwningFlowID: "support",
-				Agents: map[string]runtimecontracts.AgentRegistryEntry{
-					"worker": {
-						Role:           "second-role",
-						Permissions:    []string{"second-permission"},
-						Criteria:       []string{"second-criterion"},
-						FlowDataAccess: []string{"second.json"},
-						EntityWrites: map[string]runtimecontracts.AgentEntityWriteDecl{
-							"case": {Save: runtimecontracts.AgentEntityWriteRule{Fields: []string{"second-field"}}},
-						},
-					},
-				},
-				AgentURIs: map[string]string{"worker": secondOwner},
-				Tools:     map[string]runtimecontracts.ToolSchemaEntry{"shared-tool": tool("second scoped tool")},
-			},
-		},
-	}
-
-	prefixes := []string{"first", "second"}
-	toolDescriptions := []string{"first scoped tool", "second scoped tool"}
-	for index, scope := range source.projects {
+	source, projects := loadSameFlowSiblingAgentPackages(t)
+	for _, scopeKey := range []string{"flows/support/first", "flows/support/second"} {
+		scope := projects[scopeKey]
 		plan, err := ProjectAgentNamePlan(source, scope, "worker")
 		if err != nil {
 			t.Fatal(err)
@@ -204,28 +141,21 @@ func TestResolveAgentDeclarationUsesConcreteOwnerForSameFlowProjectScopes(t *tes
 		if err != nil {
 			t.Fatal(err)
 		}
-		actor := models.AgentConfig{ID: "worker", FlowID: "support"}
+		actor := models.AgentConfig{ID: plan.AgentID, FlowID: "support"}
 		actor.Identity.Name = name
 		declaration, ok := ResolveAgentDeclaration(source, actor)
-		prefix := prefixes[index]
-		if !ok || declaration.ScopeID != scope.Key || declaration.Entry.Role != prefix+"-role" ||
-			!slices.Equal(declaration.Entry.Permissions, []string{prefix + "-permission"}) ||
-			!slices.Equal(declaration.Entry.Criteria, []string{prefix + "-criterion"}) ||
-			!slices.Equal(declaration.Entry.FlowDataAccess, []string{prefix + ".json"}) ||
-			!slices.Equal(declaration.Entry.EntityWrites["case"].Save.Fields, []string{prefix + "-field"}) {
+		prefix := strings.TrimSuffix(strings.TrimPrefix(scopeKey, "flows/support/"), "/")
+		if !ok || declaration.ScopeID != scope.Key || declaration.Entry.Role != prefix+"-role" {
 			t.Fatalf("scope %q declaration = %#v ok %v", scope.Key, declaration, ok)
 		}
 		projection, ok := ResolveAgentContractProjection(source, actor)
-		if !ok || projection.Declaration.ScopeID != scope.Key {
+		if !ok || projection.Declaration.ScopeID != scope.Key || projection.ContractSource.PackageKey != scope.Key {
 			t.Fatalf("scope %q projection = %#v ok %v", scope.Key, projection, ok)
-		}
-		entry, ok := projection.ToolEntry("shared-tool")
-		if !ok || entry.Description() != toolDescriptions[index] {
-			t.Fatalf("scope %q tool = %#v ok %v", scope.Key, entry, ok)
 		}
 	}
 
-	firstPlan, err := ProjectAgentNamePlan(source, source.projects[0], "worker")
+	firstScope := projects["flows/support/first"]
+	firstPlan, err := ProjectAgentNamePlan(source, firstScope, "worker")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +173,7 @@ func TestResolveAgentDeclarationUsesConcreteOwnerForSameFlowProjectScopes(t *tes
 	if _, ok := ResolveAgentDeclaration(source, wrongFlow); ok {
 		t.Fatal("declared identity with a mismatched owner flow bypassed scope validation")
 	}
-	scopeKeyFlow := models.AgentConfig{ID: "worker", FlowID: source.projects[0].Key}
+	scopeKeyFlow := models.AgentConfig{ID: firstPlan.AgentID, FlowID: firstScope.Key}
 	scopeKeyFlow.Identity.Name = firstName
 	if _, ok := ResolveAgentDeclaration(source, scopeKeyFlow); ok {
 		t.Fatal("project scope key was accepted as the declaration owner flow")
@@ -254,59 +184,78 @@ func TestResolveAgentDeclarationUsesConcreteOwnerForSameFlowProjectScopes(t *tes
 	if _, ok := ResolveAgentContractProjection(source, scopeKeyFlow); ok {
 		t.Fatal("project scope key inherited a declaration contract across flows")
 	}
-	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{ID: "worker", FlowID: source.projects[0].Key}); ok {
+	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{ID: "worker", FlowID: firstScope.Key}); ok {
 		t.Fatal("project scope key cross-bound the ID-only declaration lookup")
 	}
-	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{Role: "first-role", FlowID: source.projects[0].Key}); ok {
+	if _, ok := ResolveAgentDeclaration(source, models.AgentConfig{Role: "first-role", FlowID: firstScope.Key}); ok {
 		t.Fatal("project scope key cross-bound the role-only declaration lookup")
 	}
 	firstName.Owner = "test://agent-name/packages/missing/worker"
-	unknownOwner := models.AgentConfig{ID: "worker", FlowID: "support"}
+	unknownOwner := models.AgentConfig{ID: firstPlan.AgentID, FlowID: "support"}
 	unknownOwner.Identity.Name = firstName
 	if _, ok := ResolveAgentDeclaration(source, unknownOwner); ok {
-		t.Fatal("unknown declared owner disambiguated otherwise ambiguous flow/name selection")
-	}
-	source.projects = source.projects[:1]
-	if _, ok := ResolveAgentDeclaration(source, unknownOwner); ok {
-		t.Fatal("unknown declared owner fell back to the unique public ID")
+		t.Fatal("unknown declared owner fell back to a public ID")
 	}
 	if _, _, ok := ResolveAgentRegistryEntry(source, unknownOwner); ok {
-		t.Fatal("unknown declared owner inherited the unique registry entry")
+		t.Fatal("unknown declared owner inherited a registry entry")
 	}
 	if _, ok := ResolveAgentContractProjection(source, unknownOwner); ok {
-		t.Fatal("unknown declared owner inherited the unique scoped contract")
-	}
-	entry := source.projects[0].Agents["worker"]
-	entry.ID = "public-worker"
-	entry.Role = ""
-	source.projects[0].Agents["worker"] = entry
-	if !retiredLocalAgentAlias(source, "support", "worker") {
-		t.Fatal("literal public name did not retire its local alias in the owner flow")
-	}
-	if retiredLocalAgentAlias(source, source.projects[0].Key, "worker") {
-		t.Fatal("project scope key was treated as the owner flow while retiring a local alias")
-	}
-	runtimeRoleActor := models.AgentConfig{ID: "runtime-worker", Role: "public-worker", FlowID: "support"}
-	declaration, ok := ResolveAgentDeclaration(source, runtimeRoleActor)
-	if !ok || declaration.ScopeID != source.projects[0].Key {
-		t.Fatalf("effective-role fallback = %#v ok %v, want exact project declaration", declaration, ok)
-	}
-	if _, ok := ResolveAgentContractProjection(source, runtimeRoleActor); !ok {
-		t.Fatal("effective-role fallback withheld the declaration contract")
-	}
-	runtimeRoleActor.FlowID = source.projects[0].Key
-	if _, ok := ResolveAgentDeclaration(source, runtimeRoleActor); ok {
-		t.Fatal("project scope key cross-bound the effective-role fallback")
+		t.Fatal("unknown declared owner inherited a scoped contract")
 	}
 }
 
-type agentNameProjectScopeSource struct {
-	Source
-	projects []ProjectScope
-}
-
-func (s agentNameProjectScopeSource) ProjectScopes() []ProjectScope {
-	return append([]ProjectScope(nil), s.projects...)
+func loadSameFlowSiblingAgentPackages(t *testing.T) (Source, map[string]ProjectScope) {
+	t.Helper()
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot = filepath.Clean(filepath.Join(repoRoot, "..", "..", ".."))
+	root := t.TempDir()
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: same-flow-sibling-agents
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+flows:
+  - {id: support, flow: support, mode: static}
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: same-flow-sibling-agents\n")
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "agents.yaml"), "root-worker:\n  role: root-role\n  intent: {inline: Exercise root ownership.}\n  model: regular\n  memory: false\n")
+	for _, file := range []string{"events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, file), "{}\n")
+	}
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "package.yaml"), `
+name: support
+version: "1.0.0"
+packages:
+  - {path: first}
+  - {path: second}
+flows: []
+`)
+	writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", "schema.yaml"), "name: support\nmode: static\ninitial_state: active\nstates: [active]\n")
+	for _, file := range []string{"agents.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		writeSemanticviewFixtureFile(t, filepath.Join(root, "flows", "support", file), "{}\n")
+	}
+	for _, prefix := range []string{"first", "second"} {
+		packageRoot := filepath.Join(root, "flows", "support", prefix)
+		writeSemanticviewFixtureFile(t, filepath.Join(packageRoot, "package.yaml"), "name: "+prefix+"\nversion: \"1.0.0\"\nflows: []\n")
+		writeSemanticviewFixtureFile(t, filepath.Join(packageRoot, "agents.yaml"), "worker:\n  id: "+prefix+"-worker\n  role: "+prefix+"-role\n  intent: {inline: Exercise exact "+prefix+" ownership.}\n  model: regular\n  memory: false\n")
+	}
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	source := Wrap(bundle)
+	projects := map[string]ProjectScope{}
+	for _, scope := range source.ProjectScopes() {
+		projects[scope.Key] = scope
+	}
+	for _, key := range []string{"flows/support/first", "flows/support/second"} {
+		if _, ok := projects[key]; !ok {
+			t.Fatalf("missing loaded project scope %q: %#v", key, source.ProjectScopes())
+		}
+	}
+	return source, projects
 }
 
 func agentNamePlanNestedSource(collision bool) Source {

--- a/internal/runtime/semanticview/agents.go
+++ b/internal/runtime/semanticview/agents.go
@@ -35,6 +35,9 @@ func ResolveAgentDeclaration(source Source, cfg models.AgentConfig) (AgentDeclar
 		}
 		return AgentDeclaration{}, false
 	}
+	if name != (agentidentity.Name{}) {
+		return AgentDeclaration{}, false
+	}
 	if declaration, ok := resolveAgentDeclarationByID(source, flowID, agentID); ok {
 		return declaration, true
 	}
@@ -85,38 +88,32 @@ func retiredLocalAgentAlias(source Source, flowID, candidate string) bool {
 }
 
 func AgentDeclarationOwner(source Source, flowID, logicalID string) (string, bool) {
-	return agentDeclarationOwner(source, AgentDeclaration{OwnerFlowID: flowID, LocalID: logicalID})
+	flowID = strings.TrimSpace(flowID)
+	logicalID = strings.TrimSpace(logicalID)
+	var matched AgentDeclaration
+	for _, declaration := range AgentDeclarations(source) {
+		if strings.TrimSpace(declaration.OwnerFlowID) != flowID || strings.TrimSpace(declaration.LocalID) != logicalID {
+			continue
+		}
+		if strings.TrimSpace(matched.LocalID) != "" {
+			return "", false
+		}
+		matched = declaration
+	}
+	if strings.TrimSpace(matched.LocalID) == "" {
+		return "", false
+	}
+	return agentDeclarationOwner(source, matched)
 }
 
 func ScopedAgentDeclarationOwner(source Source, declaration AgentDeclaration) (string, bool) {
-	declarations := AgentDeclarations(source)
-	for _, candidate := range declarations {
-		if strings.TrimSpace(candidate.ScopeKind) != strings.TrimSpace(declaration.ScopeKind) ||
-			strings.TrimSpace(candidate.ScopeID) != strings.TrimSpace(declaration.ScopeID) ||
-			strings.TrimSpace(candidate.LocalID) != strings.TrimSpace(declaration.LocalID) {
-			continue
-		}
-		ownerURI := strings.TrimSpace(candidate.OwnerURI)
-		for _, other := range declarations {
-			if strings.TrimSpace(other.ScopeKind) == strings.TrimSpace(candidate.ScopeKind) &&
-				strings.TrimSpace(other.ScopeID) == strings.TrimSpace(candidate.ScopeID) &&
-				strings.TrimSpace(other.LocalID) == strings.TrimSpace(candidate.LocalID) {
-				continue
-			}
-			if ownerURI != "" && strings.TrimSpace(other.OwnerURI) == ownerURI {
-				return "", false
-			}
-		}
-		return agentDeclarationOwner(source, candidate)
-	}
-	return "", false
+	return agentDeclarationOwner(source, declaration)
 }
 
 func agentDeclarationOwner(source Source, declaration AgentDeclaration) (string, bool) {
 	if source == nil {
 		return "", false
 	}
-	flowID := strings.TrimSpace(declaration.OwnerFlowID)
 	logicalID := strings.TrimSpace(declaration.LocalID)
 	if logicalID == "" {
 		return "", false
@@ -126,80 +123,24 @@ func agentDeclarationOwner(source Source, declaration AgentDeclaration) (string,
 	if !ok || bundle == nil {
 		return "", false
 	}
-	if owner := strings.TrimSpace(declaration.OwnerURI); owner != "" {
-		ref, exists := bundle.URIRegistry.ByURI[owner]
-		if exists && strings.TrimSpace(ref.Kind) == "agent" && strings.TrimSpace(ref.LocalID) == logicalID {
-			return owner, true
-		}
+	owner := strings.TrimSpace(declaration.OwnerURI)
+	if owner == "" {
 		return "", false
 	}
-	owners := map[string]struct{}{}
-	for _, ref := range bundle.URIRegistry.Agents {
-		if strings.TrimSpace(ref.LocalID) != logicalID {
-			continue
-		}
-		switch strings.TrimSpace(declaration.ScopeKind) {
-		case "flow":
-			if strings.TrimSpace(ref.FlowID) != flowID {
-				continue
-			}
-		case "project":
-			if strings.TrimSpace(ref.FlowID) != "" || !projectAgentRefOwnedByFlow(source, ref, flowID, logicalID) {
-				continue
-			}
-		default:
-			refFlowID := strings.TrimSpace(ref.FlowID)
-			if refFlowID != flowID {
-				if refFlowID != "" || !projectAgentRefOwnedByFlow(source, ref, flowID, logicalID) {
-					continue
-				}
-			}
-		}
-		owner := strings.TrimSpace(ref.Full)
-		if owner == "" {
-			owner = strings.TrimSpace(ref.Absolute)
-		}
-		if owner != "" {
-			owners[owner] = struct{}{}
-		}
+	ref, exists := bundle.URIRegistry.ByURI[owner]
+	if !exists || strings.TrimSpace(ref.Kind) != "agent" || strings.TrimSpace(ref.LocalID) != logicalID {
+		return "", false
 	}
-	if len(owners) == 1 {
-		for owner := range owners {
+	for _, candidate := range AgentDeclarations(source) {
+		if candidate.Source == declaration.Source &&
+			strings.TrimSpace(candidate.ScopeKind) == strings.TrimSpace(declaration.ScopeKind) &&
+			strings.TrimSpace(candidate.ScopeID) == strings.TrimSpace(declaration.ScopeID) &&
+			strings.TrimSpace(candidate.OwnerFlowID) == strings.TrimSpace(declaration.OwnerFlowID) &&
+			strings.TrimSpace(candidate.LocalID) == logicalID && strings.TrimSpace(candidate.OwnerURI) == owner {
 			return owner, true
 		}
 	}
 	return "", false
-}
-
-func projectAgentRefOwnedByFlow(source Source, ref runtimecontracts.ContractURIRef, flowID, logicalID string) bool {
-	refPath := strings.Trim(strings.TrimSpace(ref.Path), "/")
-	matchingScopes := 0
-	for _, scope := range source.ProjectScopes() {
-		if strings.TrimSpace(scope.OwningFlowID) != strings.TrimSpace(flowID) {
-			continue
-		}
-		if _, ok := scope.Agents[strings.TrimSpace(logicalID)]; !ok {
-			continue
-		}
-		matchingScopes++
-		if strings.Trim(strings.TrimSpace(scope.Key), "/") == refPath {
-			return true
-		}
-	}
-	if matchingScopes != 1 {
-		return false
-	}
-	matchingRefs := 0
-	bundle, ok := Bundle(source)
-	if !ok || bundle == nil {
-		return false
-	}
-	for _, candidate := range bundle.URIRegistry.Agents {
-		if strings.TrimSpace(candidate.FlowID) == "" && strings.TrimSpace(candidate.LocalID) == strings.TrimSpace(logicalID) {
-			matchingRefs++
-		}
-	}
-	return matchingRefs == 1
 }
 
 func resolveAgentDeclarationByName(source Source, flowID, agentID, ownerURI string) (AgentDeclaration, bool) {

--- a/internal/runtime/semanticview/authored_emit_sites_test.go
+++ b/internal/runtime/semanticview/authored_emit_sites_test.go
@@ -31,8 +31,8 @@ func TestAuthoredEmitSites_EnumeratesRootAndFlowOwnedScopes(t *testing.T) {
 	if countAuthoredEmitSites(sites, "support", "flow-node", "support.ready") != 1 {
 		t.Fatalf("expected one flow authored emit site, got %#v", authoredEmitSiteSummaries(sites))
 	}
-	if countAuthoredEmitSites(sites, "support", "extras-node", "support.ready") != 1 {
-		t.Fatalf("expected one sole-parent package authored emit site, got %#v", authoredEmitSiteSummaries(sites))
+	if countAuthoredEmitSites(sites, "", "extras-node", "support.ready") != 1 {
+		t.Fatalf("expected unrelated package authored emit site to remain root-owned, got %#v", authoredEmitSiteSummaries(sites))
 	}
 }
 
@@ -134,12 +134,12 @@ func TestAuthoredEmitSites_LowersEmitFromToCanonicalFields(t *testing.T) {
 
 func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinctSources(t *testing.T) {
 	source := loadAuthoredEmitSiteFixture(t, authoredEmitSiteFixture{
-		rootNodeID:   "root-node",
-		rootEmit:     "root.ready",
-		flowNodeID:   "support-node",
-		flowEmit:     "support.ready",
-		extrasNodeID: "support-node",
-		extrasEmit:   "support.ready",
+		rootNodeID:          "root-node",
+		rootEmit:            "root.ready",
+		flowNodeID:          "support-node",
+		flowEmit:            "support.ready",
+		nestedPackageNodeID: "support-node",
+		nestedPackageEmit:   "support.ready",
 	})
 
 	sites := AuthoredEmitSites(source)
@@ -149,8 +149,8 @@ func TestAuthoredEmitSites_DeduplicatesPackageProjectionWithoutCollapsingDistinc
 	}
 	keys := []string{matches[0].SourceScopeKey, matches[1].SourceScopeKey}
 	sort.Strings(keys)
-	if strings.Join(keys, ",") != "extras,flows/support" {
-		t.Fatalf("source scope keys = %v, want sealed flow package and extras; sites=%#v", keys, authoredEmitSiteSummaries(matches))
+	if strings.Join(keys, ",") != "flows/support,flows/support/addon" {
+		t.Fatalf("source scope keys = %v, want sealed flow package and structurally nested addon; sites=%#v", keys, authoredEmitSiteSummaries(matches))
 	}
 }
 
@@ -167,8 +167,8 @@ func TestAuthoredEmitSites_OutsidePackageDoesNotSuppressGenericFlowScope(t *test
 	if countAuthoredEmitSites(sites, "support", "flow-node", "support.ready") != 1 {
 		t.Fatalf("expected generic flow scope site, got %#v", authoredEmitSiteSummaries(sites))
 	}
-	if countAuthoredEmitSites(sites, "support", "extras-node", "support.ready") != 1 {
-		t.Fatalf("expected outside package site, got %#v", authoredEmitSiteSummaries(sites))
+	if countAuthoredEmitSites(sites, "", "extras-node", "support.ready") != 1 {
+		t.Fatalf("expected outside package site to remain root-owned, got %#v", authoredEmitSiteSummaries(sites))
 	}
 }
 

--- a/internal/runtime/semanticview/bundle_source.go
+++ b/internal/runtime/semanticview/bundle_source.go
@@ -1,7 +1,6 @@
 package semanticview
 
 import (
-	"path/filepath"
 	"strings"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
@@ -206,55 +205,7 @@ func owningFlowIDForProjectView(bundle *runtimecontracts.WorkflowContractBundle,
 	if bundle == nil {
 		return ""
 	}
-	return owningFlowIDForPackage(bundle, strings.TrimSpace(view.Paths.Key))
-}
-
-func owningFlowIDForPackage(bundle *runtimecontracts.WorkflowContractBundle, packageKey string) string {
-	packageKey = strings.TrimSpace(packageKey)
-	if bundle == nil || packageKey == "" {
-		return ""
-	}
-	pkg, ok := bundlePackageByKey(bundle, packageKey)
-	if !ok || strings.TrimSpace(pkg.ParentKey) == "" {
-		return ""
-	}
-	parent, ok := bundlePackageByKey(bundle, pkg.ParentKey)
-	if !ok {
-		return ""
-	}
-	if flowID := packageParentFlowID(parent, pkg); flowID != "" {
-		return flowID
-	}
-	return owningFlowIDForPackage(bundle, parent.Key)
-}
-
-func bundlePackageByKey(bundle *runtimecontracts.WorkflowContractBundle, packageKey string) (runtimecontracts.LoadedProjectPackage, bool) {
-	for _, pkg := range bundle.PackageTree {
-		if strings.TrimSpace(pkg.Key) == packageKey {
-			return pkg, true
-		}
-	}
-	return runtimecontracts.LoadedProjectPackage{}, false
-}
-
-func packageParentFlowID(parent, child runtimecontracts.LoadedProjectPackage) string {
-	childDir := filepath.Clean(strings.TrimSpace(child.Paths.Dir))
-	if childDir != "" && childDir != "." {
-		for _, flow := range parent.Paths.Flows {
-			flowID := strings.TrimSpace(flow.ID)
-			flowDir := filepath.Clean(strings.TrimSpace(flow.Dir))
-			if flowID == "" || flowDir == "" || flowDir == "." {
-				continue
-			}
-			if childDir == flowDir || strings.HasPrefix(childDir, flowDir+string(filepath.Separator)) {
-				return flowID
-			}
-		}
-	}
-	if len(parent.Paths.Flows) == 1 {
-		return strings.TrimSpace(parent.Paths.Flows[0].ID)
-	}
-	return ""
+	return bundle.PackageOwningFlowID(view.Paths.Key)
 }
 
 func (s bundleSource) FlowScopes() []FlowScope {

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -132,7 +132,7 @@ func TestRootExecutionCoordinateBindsAuthoredRootAndExactRun(t *testing.T) {
 	}
 }
 
-func TestProjectScopes_SoleParentFlowCarriesOwningFlowIDOutsideFlowDir(t *testing.T) {
+func TestProjectScopes_SoleParentFlowDoesNotOwnUnrelatedSiblingPackage(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
@@ -203,8 +203,12 @@ flow-agent:
 	if !found {
 		t.Fatalf("expected extras project scope, got %#v", source.ProjectScopes())
 	}
-	if packageScope.OwningFlowID != "support" {
-		t.Fatalf("OwningFlowID = %q, want support", packageScope.OwningFlowID)
+	if packageScope.OwningFlowID != "" {
+		t.Fatalf("OwningFlowID = %q, want explicit root ownership", packageScope.OwningFlowID)
+	}
+	declarations := AgentDeclarations(source)
+	if len(declarations) != 1 || declarations[0].OwnerFlowID != "" {
+		t.Fatalf("declarations = %#v, want unrelated package declaration to remain root-owned", declarations)
 	}
 }
 

--- a/internal/runtime/semanticview/scopes_test.go
+++ b/internal/runtime/semanticview/scopes_test.go
@@ -208,7 +208,7 @@ flow-agent:
 	}
 }
 
-func TestResolveAgentMemoryProof_PackageBackedAgentCarriesFlowPath(t *testing.T) {
+func TestResolveAgentMemoryProof_PackageBackedFlowProjectionUsesCanonicalFlowSource(t *testing.T) {
 	repoRoot, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
@@ -264,11 +264,14 @@ backend:
 	source := Wrap(bundle)
 
 	proof := ResolveAgentMemoryProof(source, AgentMemoryLocator{
-		AgentID:         "backend",
-		ProjectScopeKey: "flows/support",
+		AgentID: "backend",
+		FlowID:  "support",
 	})
 	if proof.OwningFlowID != "support" {
-		t.Fatalf("OwningFlowID = %q, want support", proof.OwningFlowID)
+		t.Fatalf("OwningFlowID = %q, want support; declarations = %#v", proof.OwningFlowID, AgentDeclarations(source))
+	}
+	if proof.ProjectScopeKey != "." || proof.ContractSource.Layer != "flow" || proof.ContractSource.FlowID != "support" {
+		t.Fatalf("memory proof source = %#v, want root-package flow-owned source", proof)
 	}
 	if proof.FlowPath != "support" {
 		t.Fatalf("FlowPath = %q, want support", proof.FlowPath)

--- a/internal/runtime/testfixtures/canonicalrouting/closure_variants.go
+++ b/internal/runtime/testfixtures/canonicalrouting/closure_variants.go
@@ -9,7 +9,7 @@ type RuntimeAgentMemoryVariant uint8
 
 const (
 	RuntimeAgentMemoryPackageBacked RuntimeAgentMemoryVariant = iota + 1
-	RuntimeAgentMemorySoleParent
+	RuntimeAgentMemoryNestedProject
 )
 
 func CopyRuntimeAgentMemory(t testing.TB, variant RuntimeAgentMemoryVariant) string {
@@ -17,8 +17,8 @@ func CopyRuntimeAgentMemory(t testing.TB, variant RuntimeAgentMemoryVariant) str
 	root := CopyExample(t, RootIngress)
 	removeInheritedScenarios(t, root)
 	packageBody := "name: session-scope-validation\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\nflows:\n  - id: support\n    flow: support\n    mode: static\n"
-	if variant == RuntimeAgentMemorySoleParent {
-		packageBody = "name: session-scope-validation\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\npackages:\n  - path: extras\nflows:\n  - id: support\n    flow: support\n    mode: static\n"
+	if variant == RuntimeAgentMemoryNestedProject {
+		packageBody = "name: session-scope-validation\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\npackages:\n  - path: flows/support/extras\nflows:\n  - id: support\n    flow: support\n    mode: static\n"
 	} else if variant != RuntimeAgentMemoryPackageBacked {
 		t.Fatalf("unsupported runtime agent-memory variant %d", variant)
 	}
@@ -38,9 +38,9 @@ func CopyRuntimeAgentMemory(t testing.TB, variant RuntimeAgentMemoryVariant) str
 		writeClosedVariantFile(t, root, "flows/support/prompts/backend.md", "Handle support events.\n")
 		writeClosedVariantFile(t, root, "flows/support/agents.yaml", agentBody)
 	} else {
-		writeClosedVariantFile(t, root, "extras/package.yaml", "name: extras\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\nflows: []\n")
-		writeClosedVariantFile(t, root, "extras/prompts/backend.md", "Handle support events.\n")
-		writeClosedVariantFile(t, root, "extras/agents.yaml", agentBody)
+		writeClosedVariantFile(t, root, "flows/support/extras/package.yaml", "name: extras\nversion: \"1.0.0\"\nplatform_version: \">=0.7.0 <0.8.0\"\nflows: []\n")
+		writeClosedVariantFile(t, root, "flows/support/extras/prompts/backend.md", "Handle support events.\n")
+		writeClosedVariantFile(t, root, "flows/support/extras/agents.yaml", agentBody)
 	}
 	return root
 }

--- a/internal/runtime/testfixtures/flowownedprojectagent/fixture.go
+++ b/internal/runtime/testfixtures/flowownedprojectagent/fixture.go
@@ -1,0 +1,115 @@
+package flowownedprojectagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+)
+
+func LoadSource(t testing.TB, mode string, duplicateRole bool) semanticview.Source {
+	return loadSource(t, mode, duplicateRole, false)
+}
+
+func LoadExplicitRequiredSource(t testing.TB, mode string, duplicateRole bool) semanticview.Source {
+	return loadSource(t, mode, duplicateRole, true)
+}
+
+func loadSource(t testing.TB, mode string, duplicateRole, explicitRequired bool) semanticview.Source {
+	t.Helper()
+	repoRoot := repoRoot(t)
+	root := t.TempDir()
+	packages := "  - {path: flows/support/left}\n"
+	if duplicateRole {
+		packages += "  - {path: flows/support/right}\n"
+	}
+	write(t, filepath.Join(root, "package.yaml"), `
+name: flow-owned-project-agent
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+`+packages+`flows:
+  - {id: support, flow: support, mode: `+mode+`}
+`)
+	write(t, filepath.Join(root, "schema.yaml"), "name: flow-owned-project-agent\n")
+	for _, name := range []string{"agents.yaml", "entities.yaml", "events.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(t, filepath.Join(root, name), "{}\n")
+	}
+
+	flowRoot := filepath.Join(root, "flows", "support")
+	write(t, filepath.Join(flowRoot, "package.yaml"), "name: support\nversion: \"1.0.0\"\nflows: []\n")
+	requiredAgents := ""
+	if explicitRequired {
+		requiredAgents = "required_agents:\n  - role: worker\n"
+	}
+	write(t, filepath.Join(flowRoot, "schema.yaml"), `
+name: support
+mode: `+mode+`
+initial_state: active
+states: [active]
+`+requiredAgents+`
+pins:
+  inputs:
+    events: [work.requested]
+`)
+	write(t, filepath.Join(flowRoot, "events.yaml"), "work.requested: {}\nwork.completed: {}\n")
+	for _, name := range []string{"agents.yaml", "nodes.yaml", "policy.yaml", "tools.yaml"} {
+		write(t, filepath.Join(flowRoot, name), "{}\n")
+	}
+	writeAgentPackage(t, filepath.Join(flowRoot, "left"), "public-worker-left")
+	if duplicateRole {
+		writeAgentPackage(t, filepath.Join(flowRoot, "right"), "public-worker-right")
+	}
+
+	bundle, err := runtimecontracts.LoadWorkflowContractBundleWithOverrides(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadWorkflowContractBundleWithOverrides: %v", err)
+	}
+	return semanticview.Wrap(bundle)
+}
+
+func writeAgentPackage(t testing.TB, root, publicID string) {
+	t.Helper()
+	write(t, filepath.Join(root, "package.yaml"), "name: "+filepath.Base(root)+"\nversion: \"1.0.0\"\nflows: []\n")
+	write(t, filepath.Join(root, "agents.yaml"), `
+worker:
+  id: `+publicID+`
+  role: worker
+  intent: {inline: Handle flow-owned project work.}
+  model: regular
+  memory: false
+  subscriptions: [work.requested]
+  emit_events: [work.completed]
+`)
+}
+
+func write(t testing.TB, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			return root
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			t.Fatal("repository root not found")
+		}
+		root = parent
+	}
+}

--- a/internal/runtime/tools/agent_name_test.go
+++ b/internal/runtime/tools/agent_name_test.go
@@ -1,6 +1,9 @@
 package tools
 
 import (
+	"strings"
+	"testing"
+
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	"github.com/division-sh/swarm/internal/runtime/semanticviewtest"
@@ -8,4 +11,127 @@ import (
 
 func wrapRootAgentBundle(bundle *runtimecontracts.WorkflowContractBundle) semanticview.Source {
 	return semanticviewtest.WrapRootAgents(bundle)
+}
+
+func toolTestSourceWithDeclaredAgent(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle, agentID, flowID string) semanticview.Source {
+	t.Helper()
+	toolTestDeclareAgent(t, bundle, agentID, flowID)
+	return wrapRootAgentBundle(bundle)
+}
+
+func toolTestDeclareAgent(t testing.TB, bundle *runtimecontracts.WorkflowContractBundle, agentID, flowID string) {
+	t.Helper()
+	if bundle == nil {
+		t.Fatal("tool test agent declaration requires bundle")
+	}
+	agentID = strings.TrimSpace(agentID)
+	flowID = strings.TrimSpace(flowID)
+	if agentID == "" {
+		t.Fatal("tool test agent declaration requires agent id")
+	}
+	if flowID == "" {
+		if bundle.Agents == nil {
+			bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+		}
+		if _, ok := bundle.Agents[agentID]; !ok {
+			bundle.Agents[agentID] = runtimecontracts.EffectiveAgentRegistryEntry(agentID, runtimecontracts.AgentRegistryEntry{ID: agentID, Role: agentID})
+		}
+		return
+	}
+	view := toolTestAttachFlowView(bundle, flowID)
+	if view == nil {
+		t.Fatalf("tool test agent declaration requires flow %q", flowID)
+	}
+	if view.Agents == nil {
+		view.Agents = map[string]runtimecontracts.AgentRegistryEntry{}
+	}
+	localID := agentID
+	for candidate, entry := range view.Agents {
+		publicID, err := runtimecontracts.DeclaredAgentID(candidate, entry)
+		if err == nil && publicID == agentID {
+			localID = candidate
+			break
+		}
+	}
+	if _, ok := view.Agents[localID]; !ok {
+		view.Agents[localID] = runtimecontracts.EffectiveAgentRegistryEntry(localID, runtimecontracts.AgentRegistryEntry{ID: agentID, Role: agentID})
+	}
+	if strings.TrimSpace(view.Paths.PackageKey) == "" {
+		view.Paths.PackageKey = "."
+	}
+	if strings.TrimSpace(view.Paths.AgentsFile) == "" {
+		view.Paths.AgentsFile = "swarm-test/" + flowID + "/agents.yaml"
+	}
+	if view.AgentURIs == nil {
+		view.AgentURIs = map[string]string{}
+	}
+	owner := "swarm-test://" + flowID + "/" + agentID
+	view.AgentURIs[localID] = owner
+	if bundle.URIRegistry.Agents == nil {
+		bundle.URIRegistry.Agents = map[string]runtimecontracts.ContractURIRef{}
+	}
+	if bundle.URIRegistry.ByURI == nil {
+		bundle.URIRegistry.ByURI = map[string]runtimecontracts.ContractURIRef{}
+	}
+	ref := runtimecontracts.ContractURIRef{Kind: "agent", FlowID: flowID, LocalID: localID, Full: owner}
+	bundle.URIRegistry.Agents[flowID+"/"+localID] = ref
+	bundle.URIRegistry.ByURI[owner] = ref
+}
+
+func toolTestAttachFlowView(bundle *runtimecontracts.WorkflowContractBundle, flowID string) *runtimecontracts.FlowContractView {
+	var find func(*runtimecontracts.FlowContractView) *runtimecontracts.FlowContractView
+	find = func(view *runtimecontracts.FlowContractView) *runtimecontracts.FlowContractView {
+		if view == nil {
+			return nil
+		}
+		if strings.TrimSpace(view.Paths.ID) == flowID {
+			return view
+		}
+		for index := range view.Children {
+			if match := find(&view.Children[index]); match != nil {
+				return match
+			}
+		}
+		return nil
+	}
+	if view := find(bundle.FlowTree.Root); view != nil {
+		toolTestReindexFlowTree(bundle)
+		return view
+	}
+	detached := bundle.FlowTree.ByID[flowID]
+	if detached == nil {
+		return nil
+	}
+	if bundle.FlowTree.Root == nil {
+		bundle.FlowTree.Root = detached
+	} else {
+		bundle.FlowTree.Root.Children = append(bundle.FlowTree.Root.Children, *detached)
+	}
+	toolTestReindexFlowTree(bundle)
+	return find(bundle.FlowTree.Root)
+}
+
+func toolTestReindexFlowTree(bundle *runtimecontracts.WorkflowContractBundle) {
+	if bundle.FlowTree.ByID == nil {
+		bundle.FlowTree.ByID = map[string]*runtimecontracts.FlowContractView{}
+	}
+	if bundle.FlowTree.ByPath == nil {
+		bundle.FlowTree.ByPath = map[string]*runtimecontracts.FlowContractView{}
+	}
+	var index func(*runtimecontracts.FlowContractView)
+	index = func(view *runtimecontracts.FlowContractView) {
+		if view == nil {
+			return
+		}
+		if id := strings.TrimSpace(view.Paths.ID); id != "" {
+			bundle.FlowTree.ByID[id] = view
+		}
+		if path := strings.TrimSpace(view.Path); path != "" {
+			bundle.FlowTree.ByPath[path] = view
+		}
+		for childIndex := range view.Children {
+			index(&view.Children[childIndex])
+		}
+	}
+	index(bundle.FlowTree.Root)
 }

--- a/internal/runtime/tools/channel_runtime.go
+++ b/internal/runtime/tools/channel_runtime.go
@@ -100,7 +100,7 @@ func (e *Executor) execChannelOperation(ctx context.Context, actor models.AgentC
 		return nil, runtimefailures.Wrap(runtimefailures.ClassSchemaInvalid, "channel_operation_plan_invalid", "channel-runtime", "build_activity", map[string]any{"tool": strings.TrimSpace(toolID)}, err)
 	}
 	defaults := runtimecontracts.ActivityRetryDefaultsForEffectClass(effectClass)
-	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor.Identity, entityID)
+	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor, entityID)
 	if err != nil {
 		return nil, fmt.Errorf("admit channel activity producer source: %w", err)
 	}

--- a/internal/runtime/tools/executor_agents.go
+++ b/internal/runtime/tools/executor_agents.go
@@ -117,11 +117,7 @@ func (e *Executor) execAgentMessage(ctx context.Context, actor models.AgentConfi
 	lineage.TaskID = in.TaskID
 	lineage.ExecutionMode = executionMode
 	sourceEntity := actor.EffectiveEntityID()
-	actorIdentity, err := actor.ConcreteIdentity()
-	if err != nil {
-		return nil, err
-	}
-	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actorIdentity, sourceEntity)
+	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor, sourceEntity)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +224,7 @@ func (e *Executor) execSchedule(ctx context.Context, actor models.AgentConfig, i
 	if err != nil {
 		return nil, fmt.Errorf("admit schedule payload: %w", err)
 	}
-	executionSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor.Identity, entityID)
+	executionSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor, entityID)
 	if err != nil {
 		return nil, fmt.Errorf("admit schedule owner source: %w", err)
 	}

--- a/internal/runtime/tools/executor_agents_test.go
+++ b/internal/runtime/tools/executor_agents_test.go
@@ -22,7 +22,7 @@ import (
 
 func toolTestRootAgentIdentity(t testing.TB, agentID string) agentidentity.Identity {
 	t.Helper()
-	return agentidentitytest.RootRuntime(t, agentID, "runtime-tools-test")
+	return agentidentitytest.RootDeclared(t, agentID, "swarm-test://root/agents/"+strings.TrimSpace(agentID))
 }
 
 func toolTestAgentIdentity(t testing.TB, agentID, flowID, flowPath string) agentidentity.Identity {
@@ -32,7 +32,7 @@ func toolTestAgentIdentity(t testing.TB, agentID, flowID, flowPath string) agent
 	if flowID == "" && flowPath == "" {
 		return toolTestRootAgentIdentity(t, agentID)
 	}
-	return agentidentitytest.Runtime(t, agentID, "runtime-tools-test", flowID, "test-instance", flowPath)
+	return agentidentitytest.Declared(t, agentID, "swarm-test://"+flowID+"/"+strings.TrimSpace(agentID), flowID, "test-instance", flowPath)
 }
 
 type managerStub struct {
@@ -138,12 +138,13 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
 		Agents: agents,
 	}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: reviewFlow,
 			ByID: map[string]*runtimecontracts.FlowContractView{"review": reviewFlow},
 		},
-	})
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "control", "review")
 	provider := runtimeauthority.NewSourceProvider(source)
 
 	bus := &publishDirectBusStub{}
@@ -163,7 +164,7 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	actor := models.AgentConfig{
 		ExecutionMode: "mock",
 		ID:            "control",
-		Identity:      agentidentitytest.Runtime(t, "control", "runtime-tools-test", "review", "inst-1", "review/inst-1"),
+		Identity:      toolTestAgentIdentity(t, "control", "review", "review/inst-1"),
 		Role:          "control",
 		Permissions:   []string{"message_flow"},
 		EntityID:      "entity-a",
@@ -187,11 +188,15 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	if bus.event.ExecutionMode() != runtimeeffects.ExecutionModeMock {
 		t.Fatalf("agent_message event execution mode = %q, want mock", bus.event.ExecutionMode())
 	}
+	wantSourceRoute := events.RouteIdentity{FlowID: "review", FlowInstance: "review/inst-1", EntityID: "entity-a"}
+	if got := bus.event.RoutingSource().Route().Normalized(); got != wantSourceRoute {
+		t.Fatalf("agent_message routing source = %#v, want %#v", got, wantSourceRoute)
+	}
 }
 
 func TestExecSchedulePreservesRootAgentRoutingSource(t *testing.T) {
 	scheduler := &captureScheduleScheduler{}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+	source := toolTestSourceWithDeclaredAgent(t, &runtimecontracts.WorkflowContractBundle{}, "root-agent", "")
 	exec := NewExecutorWithOptions(nil, ExecutorOptions{WorkflowSource: source, GenericSchedules: scheduler})
 	actor := models.AgentConfig{
 		ExecutionMode: runtimeeffects.ExecutionModeLive,
@@ -221,6 +226,65 @@ func TestExecSchedulePreservesRootAgentRoutingSource(t *testing.T) {
 	}
 }
 
+func TestExecSchedulePreservesImportedTemplateAgentRoutingSource(t *testing.T) {
+	const (
+		flowID       = "telegram-chat"
+		flowPath     = "telegram-ingress/telegram-chat"
+		instancePath = flowPath + "/chat-1"
+		agentID      = "scheduler-agent"
+	)
+	flow := runtimecontracts.FlowContractView{
+		Path: flowPath,
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: flowID, Flow: flowID, PackageKey: "bot", AgentsFile: "/contracts/bot/flows/telegram-chat/agents.yaml",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{
+			agentID: runtimecontracts.EffectiveAgentRegistryEntry(agentID, runtimecontracts.AgentRegistryEntry{ID: agentID, Role: agentID}),
+		},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	bundle := &runtimecontracts.WorkflowContractBundle{FlowTree: runtimecontracts.FlowTree{
+		Root: &root, ByID: map[string]*runtimecontracts.FlowContractView{flowID: &root.Children[0]},
+	}}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, agentID, flowID)
+	declarations := semanticview.AgentDeclarations(source)
+	if len(declarations) != 1 {
+		t.Fatalf("agent declarations = %#v, want one", declarations)
+	}
+	plan, err := semanticview.ScopedAgentNamePlan(source, declarations[0])
+	if err != nil {
+		t.Fatalf("agent declaration name: %v", err)
+	}
+	actor := models.AgentConfig{
+		ExecutionMode: runtimeeffects.ExecutionModeLive,
+		ID:            agentID,
+		Identity:      agentidentitytest.Declared(t, agentID, plan.OwnerURI, flowPath, "chat-1", instancePath),
+		FlowID:        flowID,
+		FlowPath:      instancePath,
+		EntityID:      "entity-chat",
+	}
+	scheduler := &captureScheduleScheduler{}
+	exec := NewExecutorWithOptions(nil, ExecutorOptions{WorkflowSource: source, GenericSchedules: scheduler})
+	ctx := runtimeeffects.WithExecutionMode(runtimecorrelation.WithRunID(context.Background(), "00000000-0000-4000-8000-000000002164"), runtimeeffects.ExecutionModeLive)
+	if _, err := exec.execSchedule(ctx, actor, map[string]any{
+		"schedule_key": "imported-proof",
+		"event_type":   flowPath + "/telegram.followup.requested",
+		"mode":         "absolute",
+		"at":           time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+		"payload":      map[string]any{"chat_id": "42"},
+	}); err != nil {
+		t.Fatalf("execSchedule(imported template agent): %v", err)
+	}
+	wantRoute := events.RouteIdentity{FlowID: flowID, FlowInstance: instancePath, EntityID: actor.EntityID}
+	if got := scheduler.command.RoutingSource.Route().Normalized(); got != wantRoute {
+		t.Fatalf("schedule routing source = %#v, want %#v", got, wantRoute)
+	}
+	if scheduler.command.FlowInstance != instancePath {
+		t.Fatalf("schedule flow instance = %q, want %q", scheduler.command.FlowInstance, instancePath)
+	}
+}
+
 func TestExecScheduleAdmissionGatesAndTypedDueBasis(t *testing.T) {
 	actor := models.AgentConfig{
 		ID:       "root-agent",
@@ -232,7 +296,7 @@ func TestExecScheduleAdmissionGatesAndTypedDueBasis(t *testing.T) {
 		t.Helper()
 		scheduler := &captureScheduleScheduler{}
 		return NewExecutorWithOptions(nil, ExecutorOptions{
-			WorkflowSource:   semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+			WorkflowSource:   toolTestSourceWithDeclaredAgent(t, &runtimecontracts.WorkflowContractBundle{}, "root-agent", ""),
 			GenericSchedules: scheduler,
 		}), scheduler
 	}
@@ -311,7 +375,7 @@ func TestExecSchedulePreservesExactCausalMode(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			scheduler := &captureScheduleScheduler{}
-			source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{})
+			source := toolTestSourceWithDeclaredAgent(t, &runtimecontracts.WorkflowContractBundle{}, "root-agent", "")
 			exec := NewExecutorWithOptions(nil, ExecutorOptions{WorkflowSource: source, GenericSchedules: scheduler})
 			actor := models.AgentConfig{
 				ExecutionMode: runtimeeffects.ExecutionModeLive,
@@ -349,7 +413,7 @@ func TestExecSchedulePreservesExactCausalMode(t *testing.T) {
 func TestScheduleBuiltinContractDeliversValidatesAndDispatches(t *testing.T) {
 	scheduler := &captureScheduleScheduler{}
 	exec := NewExecutorWithOptions(nil, ExecutorOptions{
-		WorkflowSource:   semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{}),
+		WorkflowSource:   toolTestSourceWithDeclaredAgent(t, &runtimecontracts.WorkflowContractBundle{}, "root-agent", ""),
 		GenericSchedules: scheduler,
 	})
 	actor := models.AgentConfig{
@@ -415,12 +479,13 @@ func TestExecAgentMessage_PublishesOnlyResolvedSameSlugRoute(t *testing.T) {
 		Paths: runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
 		Path:  "review", Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate}, Agents: agents,
 	}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		FlowTree: flowmodel.Tree[runtimecontracts.FlowContractView]{
 			Root: reviewFlow,
 			ByID: map[string]*runtimecontracts.FlowContractView{"review": reviewFlow},
 		},
-	})
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "manager", "review")
 	workerA := models.AgentConfig{
 		ID: "worker", Identity: agentidentitytest.Runtime(t, "worker", "runtime-tools-test", "review", "inst-a", "review/inst-a"),
 		Role: "worker", EntityID: "entity-a", FlowPath: "review/inst-a",
@@ -440,7 +505,7 @@ func TestExecAgentMessage_PublishesOnlyResolvedSameSlugRoute(t *testing.T) {
 	actor := models.AgentConfig{
 		ExecutionMode: "mock",
 		ID:            "manager",
-		Identity:      agentidentitytest.Runtime(t, "manager", "runtime-tools-test", "review", "inst-b", "review/inst-b"),
+		Identity:      toolTestAgentIdentity(t, "manager", "review", "review/inst-b"),
 		Role:          "manager",
 		Permissions:   []string{"message_flow"},
 		EntityID:      "entity-manager",

--- a/internal/runtime/tools/executor_agents_test.go
+++ b/internal/runtime/tools/executor_agents_test.go
@@ -119,7 +119,8 @@ func (m *concreteManagerStub) ResolveAgentConfig(agentID, flowInstance string) (
 	return matches[0], nil
 }
 
-func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
+func TestExecAgentMessagePreservesImportedTemplateSourceWhenAuthorityPermits(t *testing.T) {
+	const flowPath = "parent/review"
 	agents := map[string]runtimecontracts.AgentRegistryEntry{
 		"control": {
 			ID:    "control",
@@ -133,8 +134,8 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 		},
 	}
 	reviewFlow := &runtimecontracts.FlowContractView{
-		Paths:  runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
-		Path:   "review",
+		Paths:  runtimecontracts.FlowContractPaths{ID: "review", Flow: "review", PackageKey: "review-package"},
+		Path:   flowPath,
 		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
 		Agents: agents,
 	}
@@ -152,10 +153,10 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 		agents: map[string]models.AgentConfig{
 			"target-1": {
 				ID:              "target-1",
-				Identity:        agentidentitytest.Runtime(t, "target-1", "runtime-tools-test", "review", "inst-1", "review/inst-1"),
+				Identity:        agentidentitytest.Runtime(t, "target-1", "runtime-tools-test", flowPath, "inst-1", flowPath+"/inst-1"),
 				Role:            "reviewer",
 				EntityID:        "entity-b",
-				FlowPath:        "review/inst-1",
+				FlowPath:        flowPath + "/inst-1",
 				ManagerFallback: "control",
 			},
 		},
@@ -164,12 +165,12 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	actor := models.AgentConfig{
 		ExecutionMode: "mock",
 		ID:            "control",
-		Identity:      toolTestAgentIdentity(t, "control", "review", "review/inst-1"),
+		Identity:      agentidentitytest.Declared(t, "control", "swarm-test://review/control", flowPath, "inst-1", flowPath+"/inst-1"),
 		Role:          "control",
 		Permissions:   []string{"message_flow"},
 		EntityID:      "entity-a",
 		FlowID:        "review",
-		FlowPath:      "review/inst-1",
+		FlowPath:      flowPath + "/inst-1",
 	}
 	ctx := runtimeeffects.WithExecutionMode(WithActor(toolEventTestContext(actor), actor), runtimeeffects.ExecutionModeMock)
 
@@ -188,7 +189,7 @@ func TestExecAgentMessage_AllowsCrossEntityWhenAuthorityPermits(t *testing.T) {
 	if bus.event.ExecutionMode() != runtimeeffects.ExecutionModeMock {
 		t.Fatalf("agent_message event execution mode = %q, want mock", bus.event.ExecutionMode())
 	}
-	wantSourceRoute := events.RouteIdentity{FlowID: "review", FlowInstance: "review/inst-1", EntityID: "entity-a"}
+	wantSourceRoute := events.RouteIdentity{FlowID: "review", FlowInstance: flowPath + "/inst-1", EntityID: "entity-a"}
 	if got := bus.event.RoutingSource().Route().Normalized(); got != wantSourceRoute {
 		t.Fatalf("agent_message routing source = %#v, want %#v", got, wantSourceRoute)
 	}

--- a/internal/runtime/tools/executor_emit.go
+++ b/internal/runtime/tools/executor_emit.go
@@ -106,12 +106,7 @@ func (e *Executor) handleEmitTool(ctx context.Context, actor models.AgentConfig,
 	}
 	flowInstance := emitFlowInstanceForActorEvent(actor, inbound)
 	flowID := emitActorFlowID(e.workflowSource, actor, flowInstance)
-	actorIdentity, err := actor.ConcreteIdentity()
-	if err != nil {
-		e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, events.NoEvent(), "routing_source_invalid", "routing_source", "construct", err)
-		return nil, err
-	}
-	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actorIdentity, entityID)
+	routingSource, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor, entityID)
 	if err != nil {
 		e.logEmitToolOutcome(ctx, actor, toolName, schemaEventType, eventType, preValidationPayload, postEnrichmentPayload, events.NoEvent(), "routing_source_invalid", "routing_source", "construct", err)
 		return nil, err

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -118,6 +118,9 @@ func TestHandleEmitToolPreservesImportedAgentSemanticSource(t *testing.T) {
 	if got := bus.event.RoutingSource().Route().Normalized(); got != wantRoute {
 		t.Fatalf("routing source route = %#v, want declaration flow plus concrete runtime instance %#v", got, wantRoute)
 	}
+	if got := string(bus.event.Type()); got != instancePath+"/"+eventType {
+		t.Fatalf("emitted event type = %q, want declaration-owned concrete path %q", got, instancePath+"/"+eventType)
+	}
 }
 
 type emitPreflightCaptureBus struct {

--- a/internal/runtime/tools/executor_emit_test.go
+++ b/internal/runtime/tools/executor_emit_test.go
@@ -18,6 +18,7 @@ import (
 	runtimebustest "github.com/division-sh/swarm/internal/runtime/bus/bustest"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	models "github.com/division-sh/swarm/internal/runtime/core/actors"
+	"github.com/division-sh/swarm/internal/runtime/core/agentidentitytest"
 	"github.com/division-sh/swarm/internal/runtime/core/eventreceiver"
 	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
 	"github.com/division-sh/swarm/internal/runtime/core/identitytest"
@@ -39,6 +40,84 @@ import (
 type publishBusCapture struct {
 	event events.Event
 	count int
+}
+
+func TestHandleEmitToolPreservesImportedAgentSemanticSource(t *testing.T) {
+	const (
+		flowID       = "telegram-chat"
+		flowPath     = "telegram-ingress/telegram-chat"
+		instancePath = flowPath + "/chat-1"
+		agentID      = "phrase-bot"
+	)
+	eventType := "telegram.reply.requested"
+	eventEntry := runtimecontracts.EventCatalogEntry{Payload: runtimecontracts.EventPayloadSpec{
+		Type: "object",
+		Properties: map[string]runtimecontracts.EventFieldSpec{
+			"chat_id": {Type: "string"},
+			"text":    {Type: "string"},
+		},
+		Required: []string{"chat_id", "text"},
+	}}
+	entry := runtimecontracts.EffectiveAgentRegistryEntry(agentID, runtimecontracts.AgentRegistryEntry{
+		ID: agentID, Role: agentID, EmitEvents: []string{eventType},
+	})
+	flow := runtimecontracts.FlowContractView{
+		Path: flowPath,
+		Paths: runtimecontracts.FlowContractPaths{
+			ID: flowID, Flow: flowID, PackageKey: "bot", AgentsFile: "/contracts/bot/flows/telegram-chat/agents.yaml",
+		},
+		Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeTemplate},
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			eventType: eventEntry,
+		},
+		Agents: map[string]runtimecontracts.AgentRegistryEntry{agentID: entry},
+	}
+	root := runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
+	bundle := &runtimecontracts.WorkflowContractBundle{
+		Events: map[string]runtimecontracts.EventCatalogEntry{
+			eventType: eventEntry,
+		},
+		FlowTree: runtimecontracts.FlowTree{
+			Root: &root,
+			ByID: map[string]*runtimecontracts.FlowContractView{flowID: &root.Children[0]},
+		},
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, agentID, flowID)
+	declaration := semanticview.AgentDeclarations(source)
+	if len(declaration) != 1 {
+		t.Fatalf("agent declarations = %#v, want one imported declaration", declaration)
+	}
+	plan, err := semanticview.ScopedAgentNamePlan(source, declaration[0])
+	if err != nil {
+		t.Fatalf("agent declaration name: %v", err)
+	}
+	actor := models.AgentConfig{
+		ExecutionMode: runtimeeffects.ExecutionModeLive,
+		ID:            agentID,
+		Identity:      agentidentitytest.Declared(t, agentID, plan.OwnerURI, flowPath, "chat-1", instancePath),
+		Role:          agentID,
+		FlowID:        flowID,
+		FlowPath:      instancePath,
+		EntityID:      eventtest.UUID("telegram-chat-entity"),
+		EmitEvents:    []string{eventType},
+	}
+	bus := &publishBusCapture{}
+	exec := NewExecutorWithOptions(bus, ExecutorOptions{
+		WorkflowSource: source,
+		EmitRegistry:   NewEmitRegistry(source, nil),
+	})
+	if _, err := exec.handleEmitTool(toolEventTestContext(actor), actor, "emit_telegram_reply_requested", map[string]any{
+		"chat_id": "42", "text": "hello",
+	}); err != nil {
+		t.Fatalf("handleEmitTool: %v", err)
+	}
+	if bus.count != 1 {
+		t.Fatalf("publish count = %d, want one", bus.count)
+	}
+	wantRoute := events.RouteIdentity{FlowID: flowID, FlowInstance: instancePath, EntityID: actor.EntityID}
+	if got := bus.event.RoutingSource().Route().Normalized(); got != wantRoute {
+		t.Fatalf("routing source route = %#v, want declaration flow plus concrete runtime instance %#v", got, wantRoute)
+	}
 }
 
 type emitPreflightCaptureBus struct {
@@ -215,7 +294,8 @@ func TestHandleEmitTool_PreservesPayloadForFlowScopedEmit(t *testing.T) {
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	bundle.FlowTree.ByID["discovery"].Events["category.assessed"] = bundle.Events["category.assessed"]
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "market-research-agent", "discovery")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -434,7 +514,7 @@ func criteriaCitationEmitTestExecutorWithAgent(t testing.TB, agent runtimecontra
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "cto-agent", "validation")
 	emitRegistry := NewEmitRegistry(source, nil)
 	bus := &publishBusCapture{}
 	exec := NewExecutorWithOptions(bus, ExecutorOptions{WorkflowSource: source, EmitRegistry: emitRegistry})
@@ -510,7 +590,8 @@ func TestHandleEmitTool_PreservesInboundChildFlowOwnerAndExecutionMode(t *testin
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	bundle.FlowTree.ByID["validation"].Events["research.completed"] = bundle.Events["research.completed"]
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "business-research-agent", "validation")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -585,7 +666,8 @@ func TestHandleEmitTool_DoesNotAdoptForeignInboundFlowOwner(t *testing.T) {
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	bundle.FlowTree.ByID["validation"].Events["research.completed"] = bundle.Events["research.completed"]
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "business-research-agent", "validation")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -649,12 +731,13 @@ func TestHandleEmitTool_KeepsFlowOutputPinAtParentScope(t *testing.T) {
 					Events: map[string]runtimecontracts.EventCatalogEntry{
 						"vertical.discovered": {},
 					},
-					Path: "discovery",
+					Path: "root/discovery",
 				},
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	bundle.FlowTree.ByID["discovery"].Events["vertical.discovered"] = bundle.Events["vertical.discovered"]
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "discovery-coordinator", "discovery")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -662,23 +745,33 @@ func TestHandleEmitTool_KeepsFlowOutputPinAtParentScope(t *testing.T) {
 	actor := models.AgentConfig{
 		ExecutionMode: "live",
 		ID:            "discovery-coordinator",
-		Identity:      toolTestAgentIdentity(t, "discovery-coordinator", "discovery", "discovery"),
+		Identity:      toolTestAgentIdentity(t, "discovery-coordinator", "discovery", "root/discovery"),
 		EntityID:      eventtest.UUID("discovery-coordinator-source"),
 		Role:          "discovery_coordinator",
 		FlowID:        "discovery",
-		FlowPath:      "discovery",
+		FlowPath:      "root/discovery",
 		EmitEvents:    []string{"vertical.discovered"},
 	}
 
-	_, err := exec.handleEmitTool(toolEventTestContext(actor), actor, "emit_vertical_discovered", map[string]any{
+	parentOwner := events.RouteIdentity{
+		FlowID: "root", FlowInstance: "root/run-1", EntityID: "44444444-4444-4444-4444-444444444444",
+	}
+	ctx := runtimedelivery.WithRoute(toolEventTestContext(actor), events.DeliveryRoute{
+		Recipient: events.MustAgentDeliveryRecipient(actor.ID), AgentIdentity: actor.Identity,
+		Target: events.MustExistingEntityTarget(parentOwner),
+	})
+	_, err := exec.handleEmitTool(ctx, actor, "emit_vertical_discovered", map[string]any{
 		"name": "Law firm AP automation",
 	})
 	if err != nil {
 		t.Fatalf("handleEmitTool: %v", err)
 	}
 
-	if got, want := string(bus.event.Type()), "discovery/vertical.discovered"; got != want {
+	if got, want := string(bus.event.Type()), "root/discovery/vertical.discovered"; got != want {
 		t.Fatalf("published event type = %q, want %q", got, want)
+	}
+	if got := bus.event.TargetRoute(); got != parentOwner {
+		t.Fatalf("published target route = %#v, want parent owner %#v", got, parentOwner)
 	}
 	if bus.count != 1 {
 		t.Fatalf("publish count = %d, want 1", bus.count)
@@ -719,7 +812,7 @@ func TestHandleEmitTool_TargetsParentRouteForChildPinOutput(t *testing.T) {
 			"analyzer-flow": &analyzerFlow,
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "analyzer", "analyzer-flow")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -813,7 +906,7 @@ func TestHandleEmitTool_FailsClosedOnIncompleteStoredParentRoute(t *testing.T) {
 			"analyzer-flow": &analyzerFlow,
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "analyzer", "analyzer-flow")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -852,7 +945,7 @@ func TestHandleEmitTool_FailsClosedOnIncompleteStoredParentRoute(t *testing.T) {
 }
 
 func TestHandleEmitTool_StaticChildPinOutputTargetsDeliveryEntity(t *testing.T) {
-	source := staticChildPinOutputTestSource()
+	source := staticChildPinOutputTestSource(t)
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -915,7 +1008,7 @@ func TestHandleEmitTool_StaticChildPinOutputRejectsMissingOrEntitylessDeliveryOw
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			source := staticChildPinOutputTestSource()
+			source := staticChildPinOutputTestSource(t)
 			bus := &publishBusCapture{}
 			actor := models.AgentConfig{
 				ExecutionMode: "live", ID: "analyzer",
@@ -938,7 +1031,8 @@ func TestHandleEmitTool_StaticChildPinOutputRejectsMissingOrEntitylessDeliveryOw
 	}
 }
 
-func staticChildPinOutputTestSource() semanticview.Source {
+func staticChildPinOutputTestSource(t testing.TB) semanticview.Source {
+	t.Helper()
 	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"analysis.done": {Payload: runtimecontracts.EventPayloadSpec{Type: "object"}},
@@ -957,7 +1051,7 @@ func staticChildPinOutputTestSource() semanticview.Source {
 		Root: &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{analyzerFlow}},
 		ByID: map[string]*runtimecontracts.FlowContractView{"analyzer-flow": &analyzerFlow},
 	}
-	return semanticview.Wrap(bundle)
+	return toolTestSourceWithDeclaredAgent(t, bundle, "analyzer", "analyzer-flow")
 }
 
 func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
@@ -994,7 +1088,7 @@ func TestHandleEmitTool_RootStaticPinOutputStillRequiresTarget(t *testing.T) {
 			"analyzer-flow": &analyzerFlow,
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "analyzer", "analyzer-flow")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -1043,7 +1137,7 @@ func TestHandleEmitTool_RootSchemaPinOutputStillRequiresTarget(t *testing.T) {
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "root-agent", "")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -1079,7 +1173,7 @@ func TestHandleEmitTool_RoutesTypedSameFlowOutputToNodeConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load cycle fixture: %v", err)
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "root-agent", "")
 	store := newEmitRoutePlanStore()
 	eventBus := newEmitRoutePlanEventBus(t, store, source)
 	actor := models.AgentConfig{ExecutionMode: "live", ID: "root-agent", Identity: toolTestRootAgentIdentity(t, "root-agent"), Role: "root-agent", EntityID: eventtest.UUID("root-agent-cycle-source"), EmitEvents: []string{"cycle.ping"}}
@@ -1118,7 +1212,7 @@ func TestHandleEmitTool_TemplateAgentEmissionReachesSameInstanceNode(t *testing.
 			},
 		},
 	}}, nil)
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "reviewer", "review")
 	store := newEmitRoutePlanStore()
 	eventBus := newEmitRoutePlanEventBus(t, store, source)
 	route := runtimeflowidentity.DeriveRoute("review", "instance-1")
@@ -1153,7 +1247,7 @@ func TestHandleEmitTool_TemplateAgentEmissionReachesSameInstanceNode(t *testing.
 }
 
 func TestHandleEmitTool_RoutesConnectedOutputPinThroughCanonicalRouteAuthority(t *testing.T) {
-	source := emitRoutePlanStaticSource(runtimecontracts.FlowPackageConnect{
+	source := emitRoutePlanStaticSource(t, runtimecontracts.FlowPackageConnect{
 		From:    "producer.deploy_done",
 		To:      "consumer.deploy_completed",
 		Adapter: "deploy_done_to_completed",
@@ -1330,7 +1424,7 @@ func TestHandleEmitTool_RootReceiverConnectRequiresSelectedOwnerNotParentMetadat
 }
 
 func TestHandleEmitTool_FailsClosedForConnectedOutputWithoutCanonicalRouteAuthority(t *testing.T) {
-	source := emitRoutePlanSource(nil)
+	source := emitRoutePlanSource(t, nil)
 	store := newEmitRoutePlanStore()
 	eb := newEmitRoutePlanEventBus(t, store, source)
 	rawSubscription, err := eb.SubscribeInternal(context.Background(), "raw-listener", events.EventType("producer/deploy.done"), events.EventType("deploy.done"))
@@ -1434,7 +1528,7 @@ func TestHandleEmitTool_AllowsDeclaredTemplateIDBusinessPayload(t *testing.T) {
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "repo-agent", "")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -1499,7 +1593,7 @@ func TestHandleEmitTool_AllowsValidWave1EventPayloadTypes(t *testing.T) {
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "market-research-agent", "")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -1595,7 +1689,8 @@ func TestHandleEmitTool_ResolvesDuplicateLeafScopedSchemasThroughActor(t *testin
 			},
 		},
 	}
-	source := semanticview.Wrap(bundle)
+	toolTestDeclareAgent(t, bundle, "review-agent", "review")
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "validation-agent", "validation")
 	emitRegistry := NewEmitRegistry(source, nil)
 
 	bus := &publishBusCapture{}
@@ -1769,8 +1864,9 @@ type emitRoutePlanTestFlow struct {
 	nodes   map[string]runtimecontracts.SystemNodeContract
 }
 
-func emitRoutePlanStaticSource(connect runtimecontracts.FlowPackageConnect) semanticview.Source {
-	return emitRoutePlanSource([]runtimecontracts.FlowPackageConnect{connect})
+func emitRoutePlanStaticSource(t testing.TB, connect runtimecontracts.FlowPackageConnect) semanticview.Source {
+	t.Helper()
+	return emitRoutePlanSource(t, []runtimecontracts.FlowPackageConnect{connect})
 }
 
 func emitRoutePlanRootReceiverSource(t *testing.T) semanticview.Source {
@@ -1785,11 +1881,12 @@ func emitRoutePlanRootReceiverSource(t *testing.T) semanticview.Source {
 	if err != nil {
 		t.Fatalf("load template-output root-connect fixture: %v", err)
 	}
-	return semanticview.Wrap(bundle)
+	return toolTestSourceWithDeclaredAgent(t, bundle, "producer-agent", "producer")
 }
 
-func emitRoutePlanSource(connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
-	return semanticview.Wrap(emitRoutePlanTestBundle([]emitRoutePlanTestFlow{
+func emitRoutePlanSource(t testing.TB, connects []runtimecontracts.FlowPackageConnect) semanticview.Source {
+	t.Helper()
+	bundle := emitRoutePlanTestBundle([]emitRoutePlanTestFlow{
 		{
 			id:   "producer",
 			mode: "static",
@@ -1812,7 +1909,8 @@ func emitRoutePlanSource(connects []runtimecontracts.FlowPackageConnect) semanti
 				},
 			},
 		},
-	}, connects))
+	}, connects)
+	return toolTestSourceWithDeclaredAgent(t, bundle, "producer-agent", "producer")
 }
 
 func emitRoutePlanTestBundle(flows []emitRoutePlanTestFlow, connects []runtimecontracts.FlowPackageConnect) *runtimecontracts.WorkflowContractBundle {

--- a/internal/runtime/tools/executor_flow_data_test.go
+++ b/internal/runtime/tools/executor_flow_data_test.go
@@ -167,7 +167,7 @@ func TestPackageBackedAgentConsumersUseOwningFlowInsteadOfStorageScopeKind(t *te
 	source, _ := loadFlowDataToolSource(t)
 	actor := flowDataActor()
 	declaration, ok := semanticview.ResolveAgentDeclaration(source, actor)
-	if !ok || declaration.ScopeKind != "project" || declaration.OwnerFlowID != "support" {
+	if !ok || declaration.ScopeKind != "flow" || declaration.OwnerFlowID != "support" || declaration.Source.Layer != "flow" {
 		t.Fatalf("package-backed declaration = %#v ok %v", declaration, ok)
 	}
 	filenames := flowdata.AllowedFilenames(source, actor)

--- a/internal/runtime/tools/executor_human_tasks.go
+++ b/internal/runtime/tools/executor_human_tasks.go
@@ -160,7 +160,7 @@ func (e *Executor) execHumanTaskRequest(ctx context.Context, actor models.AgentC
 		deadline = decisioncard.CanonicalTimestamp(now.Add(time.Duration(hours) * time.Hour))
 	}
 
-	source, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor.Identity, requesterEntityID)
+	source, err := runtimepinrouting.AdmitAgentExecutionRoutingSource(e.workflowSource, actor, requesterEntityID)
 	if err != nil {
 		return nil, fmt.Errorf("admit human-task requester source: %w", err)
 	}

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -281,7 +281,7 @@ func TestRoleScopedEntityTools_SQLiteCurrentEntityPersistence(t *testing.T) {
 	}
 }
 
-func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.T) {
+func TestHumanTaskRequestCreatesTypedCardAndContinuationForImportedAgentOnBothStores(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		store humanTaskToolStore
@@ -290,6 +290,7 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 		{name: "sqlite", store: newSQLiteRuntimeToolStoreForTest(t)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			const flowPath = "gateway/provider"
 			cfg := &config.Config{Extensions: map[string]any{
 				"budget": map[string]any{"human_tasks": map[string]any{
 					"max_tasks_per_week": 3, "budget_reset": "monday", "auto_expire_hours": 48,
@@ -298,10 +299,12 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			requester := models.AgentConfig{
 				ExecutionMode: "live",
 				ID:            "requester",
-				Role:          "worker", FlowID: "provider", FlowPath: "provider", EntityID: uuid.NewString(),
+				Role:          "worker", FlowID: "provider", FlowPath: flowPath, EntityID: uuid.NewString(),
 				Tools: []string{"human_task_request"}, Permissions: []string{"human_task_request"},
 			}
 			bundle := loadWave1EntityToolBundle(t, requester, "provider", "provider_record", "types: {}\n", "provider_record:\n  status: text\n")
+			bundle.FlowTree.ByID["provider"].Path = flowPath
+			bundle.FlowTree.ByID["provider"].Paths.PackageKey = "provider-package"
 			source := semanticview.Wrap(bundle)
 			declarations := semanticview.AgentDeclarations(source)
 			if len(declarations) != 1 {
@@ -311,7 +314,7 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			if err != nil {
 				t.Fatalf("requester declaration name: %v", err)
 			}
-			requester.Identity = agentidentitytest.Declared(t, plan.AgentID, plan.OwnerURI, "provider", "provider", "provider")
+			requester.Identity = agentidentitytest.Declared(t, plan.AgentID, plan.OwnerURI, flowPath, "provider", flowPath)
 			exec := runtimetools.NewExecutorWithOptions(nil, runtimetools.ExecutorOptions{
 				Config: cfg, HumanTaskStore: tc.store, AuthorityProvider: allowHumanTaskAuthority{}, WorkflowSource: source,
 			})
@@ -339,7 +342,7 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			if anchor.RequesterAgentID != requester.ID || anchor.OperationID != "provider-turn/tool-call-1" || anchor.Scope.Kind != decisioncard.ScopeFlow || anchor.Scope.FlowInstance != "provider" {
 				t.Fatalf("human-task anchor = %#v", anchor)
 			}
-			wantSourceRoute := events.RouteIdentity{FlowID: "provider", FlowInstance: "provider", EntityID: requester.EntityID}
+			wantSourceRoute := events.RouteIdentity{FlowID: "provider", FlowInstance: flowPath, EntityID: requester.EntityID}
 			if got := anchor.Source.Route().Normalized(); got != wantSourceRoute {
 				t.Fatalf("human-task routing source = %#v, want %#v", got, wantSourceRoute)
 			}
@@ -350,7 +353,7 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			if continuation.ReplyContextID != replyContextID || continuation.SourceEventID != sourceEventID || continuation.State != decisioncard.HumanTaskContinuationPending {
 				t.Fatalf("human-task continuation = %#v", continuation)
 			}
-			if got := continuation.RequesterRoute.Normalized(); got != (events.RouteIdentity{FlowID: "provider", FlowInstance: "provider", EntityID: requester.EntityID}) {
+			if got := continuation.RequesterRoute.Normalized(); got != (events.RouteIdentity{FlowID: "provider", FlowInstance: flowPath, EntityID: requester.EntityID}) {
 				t.Fatalf("human-task requester route = %#v", got)
 			}
 			if got := continuation.DeadlineAt.Sub(card.CreatedAt); got != 48*time.Hour {

--- a/internal/runtime/tools/executor_sqlite_persistence_test.go
+++ b/internal/runtime/tools/executor_sqlite_persistence_test.go
@@ -297,13 +297,23 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			}}
 			requester := models.AgentConfig{
 				ExecutionMode: "live",
-				ID:            "requester", Identity: agentidentitytest.Runtime(t, "requester", "human-task-test", "provider", "provider", "provider"),
-				Role: "worker", FlowID: "provider", FlowPath: "provider", EntityID: uuid.NewString(),
+				ID:            "requester",
+				Role:          "worker", FlowID: "provider", FlowPath: "provider", EntityID: uuid.NewString(),
 				Tools: []string{"human_task_request"}, Permissions: []string{"human_task_request"},
 			}
 			bundle := loadWave1EntityToolBundle(t, requester, "provider", "provider_record", "types: {}\n", "provider_record:\n  status: text\n")
+			source := semanticview.Wrap(bundle)
+			declarations := semanticview.AgentDeclarations(source)
+			if len(declarations) != 1 {
+				t.Fatalf("requester declarations = %#v, want one", declarations)
+			}
+			plan, err := semanticview.ScopedAgentNamePlan(source, declarations[0])
+			if err != nil {
+				t.Fatalf("requester declaration name: %v", err)
+			}
+			requester.Identity = agentidentitytest.Declared(t, plan.AgentID, plan.OwnerURI, "provider", "provider", "provider")
 			exec := runtimetools.NewExecutorWithOptions(nil, runtimetools.ExecutorOptions{
-				Config: cfg, HumanTaskStore: tc.store, AuthorityProvider: allowHumanTaskAuthority{}, WorkflowSource: semanticview.Wrap(bundle),
+				Config: cfg, HumanTaskStore: tc.store, AuthorityProvider: allowHumanTaskAuthority{}, WorkflowSource: source,
 			})
 			ctx, replyContextID, sourceEventID := seedReplyToolContext(t, tc.store)
 			ctx = runtimeeffects.WithLogicalOperationIdentity(ctx, "provider-turn/tool-call-1")
@@ -328,6 +338,10 @@ func TestHumanTaskRequestCreatesTypedCardAndContinuationOnBothStores(t *testing.
 			}
 			if anchor.RequesterAgentID != requester.ID || anchor.OperationID != "provider-turn/tool-call-1" || anchor.Scope.Kind != decisioncard.ScopeFlow || anchor.Scope.FlowInstance != "provider" {
 				t.Fatalf("human-task anchor = %#v", anchor)
+			}
+			wantSourceRoute := events.RouteIdentity{FlowID: "provider", FlowInstance: "provider", EntityID: requester.EntityID}
+			if got := anchor.Source.Route().Normalized(); got != wantSourceRoute {
+				t.Fatalf("human-task routing source = %#v, want %#v", got, wantSourceRoute)
 			}
 			continuation, err := tc.store.LoadHumanTaskContinuation(context.Background(), cardID)
 			if err != nil {

--- a/internal/runtime/tools/executor_telemetry_test.go
+++ b/internal/runtime/tools/executor_telemetry_test.go
@@ -320,7 +320,7 @@ func TestExecutorTelemetry_PreservesTypedLineageForToolDiagnostics(t *testing.T)
 
 func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) {
 	bus := &telemetryBusStub{}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"category.assessed": {
 				Payload: runtimecontracts.EventPayloadSpec{
@@ -332,7 +332,8 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 				Required: []string{"category"},
 			},
 		},
-	})
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "agent-emit-1", "")
 	exec := NewExecutorWithOptions(bus, ExecutorOptions{WorkflowSource: source})
 	ctx := models.WithActor(unmanagedToolTestContext(), models.AgentConfig{
 		ExecutionMode: "live",
@@ -403,7 +404,7 @@ func TestExecutorTelemetry_EmitToolLogsStructuredPublishedOutcome(t *testing.T) 
 
 func TestExecutorTelemetry_PreservesTypedLineageForEmitToolOutcome(t *testing.T) {
 	bus := &telemetryBusStub{}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"category.assessed": {
 				Payload: runtimecontracts.EventPayloadSpec{
@@ -415,7 +416,8 @@ func TestExecutorTelemetry_PreservesTypedLineageForEmitToolOutcome(t *testing.T)
 				Required: []string{"category"},
 			},
 		},
-	})
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "selected-agent", "")
 	exec := NewExecutorWithOptions(bus, ExecutorOptions{WorkflowSource: source})
 	actor := models.AgentConfig{
 		ExecutionMode: "live",
@@ -436,7 +438,7 @@ func TestExecutorTelemetry_PreservesTypedLineageForEmitToolOutcome(t *testing.T)
 
 func TestExecutorTelemetry_EmitToolLogsSchemaValidationFailureSeparatelyFromPublishFailure(t *testing.T) {
 	bus := &telemetryBusStub{}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"category.assessed": {
 				Payload: runtimecontracts.EventPayloadSpec{
@@ -448,7 +450,8 @@ func TestExecutorTelemetry_EmitToolLogsSchemaValidationFailureSeparatelyFromPubl
 				Required: []string{"category"},
 			},
 		},
-	})
+	}
+	source := semanticview.Wrap(bundle)
 	exec := NewExecutorWithOptions(bus, ExecutorOptions{WorkflowSource: source})
 	ctx := models.WithActor(unmanagedToolTestContext(), models.AgentConfig{
 		ExecutionMode: "live",
@@ -554,7 +557,7 @@ func TestExecutorTelemetry_EmitToolLogsUndeclaredFieldSchemaValidationFailure(t 
 
 func TestExecutorTelemetry_EmitToolLogsPublishFailureWithCanonicalEventIdentity(t *testing.T) {
 	bus := &telemetryBusStub{publishErr: errors.New("publish down")}
-	source := semanticview.Wrap(&runtimecontracts.WorkflowContractBundle{
+	bundle := &runtimecontracts.WorkflowContractBundle{
 		Events: map[string]runtimecontracts.EventCatalogEntry{
 			"category.assessed": {
 				Payload: runtimecontracts.EventPayloadSpec{
@@ -566,7 +569,8 @@ func TestExecutorTelemetry_EmitToolLogsPublishFailureWithCanonicalEventIdentity(
 				Required: []string{"category"},
 			},
 		},
-	})
+	}
+	source := toolTestSourceWithDeclaredAgent(t, bundle, "agent-emit-3", "")
 	exec := NewExecutorWithOptions(bus, ExecutorOptions{WorkflowSource: source})
 	ctx := models.WithActor(unmanagedToolTestContext(), models.AgentConfig{
 		ExecutionMode: "live",
@@ -577,8 +581,12 @@ func TestExecutorTelemetry_EmitToolLogsPublishFailureWithCanonicalEventIdentity(
 	})
 	ctx = runtimebus.WithInboundEvent(ctx, toolTestInboundEvent("trigger.input", nil, events.EventEnvelope{}, executionmode.Live))
 
-	if _, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "finops"}); err == nil {
+	_, err := exec.Execute(ctx, "emit_category_assessed", map[string]any{"category": "finops"})
+	if err == nil {
 		t.Fatal("expected publish failure")
+	}
+	if !strings.Contains(err.Error(), "event_publish_failed") {
+		t.Fatalf("Execute(emit) error = %v, want canonical publish failure", err)
 	}
 	if len(bus.logs) != 1 {
 		t.Fatalf("runtime log count = %d, want 1", len(bus.logs))

--- a/internal/runtime/tools/retired_dynamic_agent_tools_test.go
+++ b/internal/runtime/tools/retired_dynamic_agent_tools_test.go
@@ -111,18 +111,30 @@ func retiredToolSourceForScope(
 	tools map[string]runtimecontracts.ToolSchemaEntry,
 	policy runtimecontracts.PolicyDocument,
 ) semanticview.Source {
+	bundle := &runtimecontracts.WorkflowContractBundle{}
 	source := retiredDynamicAgentToolSource{}
 	switch scope {
 	case "root":
+		bundle.Agents = agents
 		source.projects = []semanticview.ProjectScope{{Key: ".", Agents: agents}}
 		source.rootTools, source.rootPolicy = tools, policy
 	case "project":
+		bundle.Agents = agents
 		source.projects = []semanticview.ProjectScope{{Key: "project-fixture", Agents: agents, Tools: tools, Policy: policy}}
 	case "flow":
+		flow := &runtimecontracts.FlowContractView{
+			Paths:  runtimecontracts.FlowContractPaths{ID: "flow-fixture", Flow: "flow-fixture", AgentsFile: "flow-fixture/agents.yaml", PackageKey: "."},
+			Path:   "flow-fixture",
+			Schema: runtimecontracts.FlowSchemaDocument{Mode: runtimecontracts.FlowModeStatic},
+			Agents: agents,
+		}
+		bundle.FlowTree.Root = flow
+		bundle.FlowTree.ByID = map[string]*runtimecontracts.FlowContractView{"flow-fixture": flow}
 		source.flows = []semanticview.FlowScope{{ID: "flow-fixture", Agents: agents, Tools: tools, Policy: policy}}
 	default:
 		panic("unsupported test scope: " + scope)
 	}
+	source.Source = semanticview.Wrap(bundle)
 	return source
 }
 

--- a/internal/serveapp/builder_project_supervisor_test.go
+++ b/internal/serveapp/builder_project_supervisor_test.go
@@ -2777,8 +2777,9 @@ func TestRuntimeProjectSupervisorLoadProject_PropagatesWorkspaceAdmissionFailure
 func TestRuntimeProjectSupervisorOpenProjectExecutesExplicitHostRefusal(t *testing.T) {
 	projectRoot := writeProjectRoot(t)
 	bundle := testBuilderSupervisorBundle(t)
+	intent := serveTestAgentConfig(runtimeactors.AgentConfig{ID: "worker"}).Intent
 	bundle.Agents = map[string]runtimecontracts.AgentRegistryEntry{
-		"worker": {ID: "worker"},
+		"worker": {ID: "worker", ResolvedIntent: intent},
 	}
 	source := semanticviewtest.WrapRootAgents(bundle)
 	module := stubWorkflowModule{source: source}

--- a/internal/store/internal/runtimepersistence/agent_intent_persistence_parity_test.go
+++ b/internal/store/internal/runtimepersistence/agent_intent_persistence_parity_test.go
@@ -187,9 +187,11 @@ func selectedIntentRecoverySource(t testing.TB) semanticview.Source {
 		},
 	}}
 	flow := runtimecontracts.FlowContractView{
-		Paths:  runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
-		Agents: map[string]runtimecontracts.AgentRegistryEntry{"worker": entry},
-		Policy: policy,
+		Path:      "review",
+		Paths:     runtimecontracts.FlowContractPaths{ID: "review", Flow: "review"},
+		Agents:    map[string]runtimecontracts.AgentRegistryEntry{"worker": entry},
+		AgentURIs: map[string]string{"worker": owner},
+		Policy:    policy,
 	}
 	root := &runtimecontracts.FlowContractView{Children: []runtimecontracts.FlowContractView{flow}}
 	bundle := &runtimecontracts.WorkflowContractBundle{
@@ -197,9 +199,14 @@ func selectedIntentRecoverySource(t testing.TB) semanticview.Source {
 			Root: root,
 			ByID: map[string]*runtimecontracts.FlowContractView{"review": &root.Children[0]},
 		},
-		URIRegistry: runtimecontracts.ContractURIRegistry{ByURI: map[string]runtimecontracts.ContractURIRef{
-			owner: {Kind: "agent", FlowID: "review", LocalID: "worker", Full: owner},
-		}},
+		URIRegistry: runtimecontracts.ContractURIRegistry{
+			Agents: map[string]runtimecontracts.ContractURIRef{
+				"review/worker": {Kind: "agent", FlowID: "review", LocalID: "worker", Full: owner},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				owner: {Kind: "agent", FlowID: "review", LocalID: "worker", Full: owner},
+			},
+		},
 	}
 	return selectedIntentSource{Source: semanticview.Wrap(bundle), flow: semanticview.FlowScope{
 		ID: "review", Path: "review", PackageKey: "flows/review", Mode: "static",

--- a/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
+++ b/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
@@ -770,7 +770,9 @@ func (b *sqliteFlowActivationBus) materializationRequests() []runtimebus.FlowIns
 }
 
 func sqliteFlowActivationBundle() *runtimecontracts.WorkflowContractBundle {
+	const owner = "test://review/reviewer"
 	reviewFlow := &runtimecontracts.FlowContractView{
+		Path:  "review",
 		Paths: runtimecontracts.FlowContractPaths{ID: "review"},
 		Agents: map[string]runtimecontracts.AgentRegistryEntry{
 			"reviewer": {
@@ -784,14 +786,18 @@ func sqliteFlowActivationBundle() *runtimecontracts.WorkflowContractBundle {
 				}).Intent,
 			},
 		},
+		AgentURIs: map[string]string{"reviewer": owner},
 	}
 	return &runtimecontracts.WorkflowContractBundle{
 		URIRegistry: runtimecontracts.ContractURIRegistry{
 			Agents: map[string]runtimecontracts.ContractURIRef{
 				"review/reviewer": {
 					Kind: "agent", FlowID: "review", LocalID: "reviewer",
-					Full: "test://review/reviewer",
+					Full: owner,
 				},
+			},
+			ByURI: map[string]runtimecontracts.ContractURIRef{
+				owner: {Kind: "agent", FlowID: "review", LocalID: "reviewer", Full: owner},
 			},
 		},
 		FlowTree: runtimecontracts.FlowTree{

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -938,8 +938,9 @@ contract_formats:
           negative_proof: TestProductionEventConstructionUsesPublicAPI
         runtime.event.routing_source_typed_at_construction:
           owner: internal/events RoutingSource
-          rule: Routing source is an opaque typed construction fact; target, receiver, payload, top-level projections, and empty strings never become source evidence. Static-flow and concrete-template source variants always carry exact flow and instance identity and carry entity identity exactly when the producing execution has one; an entityless receiver therefore remains an exact flow source without inventing an entity. Runtime-control publication preserves a root schedule's root source, converts declared-flow execution sources to entity-bound flow-owned control, and uses platform control only for closed global system work.
-          negative_proof: TestRunScopedRuntimeControlPreservesExactRootRoutingSource
+          rule: Routing source is an opaque typed construction fact; target, receiver, payload, top-level projections, and empty strings never become source evidence. Static-flow and concrete-template source variants always carry exact flow and instance identity and carry entity identity exactly when the producing execution has one; an entityless receiver therefore remains an exact flow source without inventing an entity. A contract-backed agent source is admitted only from agent_identity_model.declaration_execution_scope and keeps the declaration owning flow distinct from the concrete runtime instance path. Runtime-control publication preserves a root schedule's root source, converts declared-flow execution sources to entity-bound flow-owned control, and uses platform control only for closed global system work.
+          negative_proof: TestRunScopedRuntimeControlPreservesExactRootRoutingSource;
+            TestResolveAgentExecutionSemanticScopeRejectsHostileIdentityContradictions
         runtime.event.admitted_persistence_boundary:
           owner: internal/events AdmittedEvent and the closed named store operations
           rule: Durable event writers accept only opaque admitted values; raw Event, SQL, row, transaction, and generic mutation capabilities are unavailable to runtime and API consumers.
@@ -16667,6 +16668,36 @@ agent_identity_model:
       repeated_template_instances: >
         Repeated instances of one template may carry the same declared agent_id because their explicit routes differ.
         No ownership-bearing consumer may collapse those siblings to the display slug.
+    declaration_execution_scope:
+      owner: contracts.AgentDeclarationRecord and semanticview.AgentExecutionSemanticScope
+      source: >
+        Strict contract loading emits one immutable semantic record for each physical agents.yaml declaration. The
+        private physical key is the exact source file plus local declaration key; consumers receive the exact package,
+        declaration owner URI, owning flow or explicit root absence, local declaration key, and effective declaration.
+      rule: >
+        Every identity-bearing declaration consumer uses that one record. Boot diagnostics and entity coverage, static
+        materialization, EventBus agent routes, flow-data validation, provider/tool/workspace/CLI/serve projections,
+        and contract-backed event producers MUST NOT independently pair project and flow maps, rank duplicate views,
+        or reconstruct declaration ownership from URI, package path, local ID, public name, runtime route, suffix, or
+        leaf equality. A project package nested under a declared flow retains its exact package identity and the loader-
+        established owning flow; a flow projection of the same physical declaration is not a second declaration.
+      execution_agreement: >
+        Source admission combines one declared record with one concrete live identity. The declared name and owner URI,
+        owning flow presence or explicit root absence, flow mode, and concrete route MUST agree exactly. Static and
+        singleton agents execute at the exact semantic flow path. Template agents execute at one concrete descendant
+        instance while retaining the declaration owning flow as source FlowID. The concrete instance path never becomes
+        declaration FlowID, and a runtime-created name never borrows declaration, tool, or source authority even when its
+        text and route collide with an authored declaration.
+      producer_consumption: >
+        Generated emit, channel activity, agent_message, schedule/control, and human-task publication are the complete
+        contract-backed producer set. Each consumes the admitted execution scope and copies its RoutingSource through
+        EventBus, persistence, settlement, recovery, replay, and public readback without reinterpretation.
+      unsupported_forms: >
+        Existing stores and declaration/path-derived source encodings are unsupported. Missing, duplicate, ambiguous,
+        or contradictory declaration/execution facts fail before mutation. There is no compatibility reader, migration,
+        alias, fallback, partial-source authority, or dual semantic owner.
+      proof: TestAgentDeclarationRecordsCanonicalizeDeepPackageBackedFlowProjection;
+        TestLoadAgentExecutionSemanticScopeMatrix; TestDeclaredAgentNameOwnershipBoundary
     bundle_scoped_lookup:
       status: not_supported_for_duplicate_agent_slugs
       rule: >

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16679,8 +16679,10 @@ agent_identity_model:
         materialization, EventBus agent routes, flow-data validation, provider/tool/workspace/CLI/serve projections,
         and contract-backed event producers MUST NOT independently pair project and flow maps, rank duplicate views,
         or reconstruct declaration ownership from URI, package path, local ID, public name, runtime route, suffix, or
-        leaf equality. A project package nested under a declared flow retains its exact package identity and the loader-
-        established owning flow; a flow projection of the same physical declaration is not a second declaration.
+        leaf equality. Physical source layer identifies declaration provenance only; it never decides whether execution
+        is root-owned or flow-owned. A project package nested under a declared flow retains its exact package identity
+        and the loader-established owning flow, and activation plus source admission consume that owning-flow fact; a
+        flow projection of the same physical declaration is not a second declaration.
       execution_agreement: >
         Source admission combines one declared record with one concrete live identity. The declared name and owner URI,
         owning flow presence or explicit root absence, flow mode, and concrete route MUST agree exactly. Static and

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -16683,6 +16683,17 @@ agent_identity_model:
         is root-owned or flow-owned. A project package nested under a declared flow retains its exact package identity
         and the loader-established owning flow, and activation plus source admission consume that owning-flow fact; a
         flow projection of the same physical declaration is not a second declaration.
+      ownership_derivation: >
+        Package ownership is established only by exact structural containment beneath a declared flow directory or by
+        an already-established parent package owning-flow fact. The number of flows declared by a parent package is not
+        ownership evidence: an unrelated child package remains root-owned even when its parent declares exactly one flow.
+      owner_grouped_consumption: >
+        EventBus route templates and static routes, inferred required-agent facts, explicit required-agent fulfillment,
+        and generated authoring projections consume the complete canonical declaration set grouped by exact OwnerFlowID.
+        They preserve each declaration's physical package, owner URI, local key, effective public name, and source file.
+        They MUST NOT select declarations by physical source layer, flatten distinct physical declarations into a map
+        keyed only by local ID, or substitute a flow-local agents.yaml map. Multiple declarations for one required-agent
+        role are ambiguous and fail closed; they are never resolved by package order or a preferred source layer.
       execution_agreement: >
         Source admission combines one declared record with one concrete live identity. The declared name and owner URI,
         owning flow presence or explicit root absence, flow mode, and concrete route MUST agree exactly. Static and


### PR DESCRIPTION
## Summary

- expose one immutable contracts-owned physical agent declaration record and make semantic declaration/execution scope consume it
- migrate boot verification, static materialization, EventBus routing, flow-data validation, provider/tool/workspace/CLI/serve projections, and all five contract-backed source producers to that owner
- preserve full concrete nested emit paths and reject declaration/runtime identity contradictions without fallback
- update the authoritative platform specification and add nested, hostile, producer, persistence, replay, and supported-surface proofs

## Governing context

This change implements the approved, reviewer-repaired Gate A boundary in #2261 after prerequisite #2167 was completed by #2264.

Authoritative references:
- `platform-spec.yaml:agent_identity_model.declaration_execution_scope`
- `platform-spec.yaml:runtime.event.routing_source_typed_at_construction`
- adjacent executable-node and durable execution-claim rules

## Semantic migration

- **New canonical owner:** `contracts.AgentDeclarationRecord` owns one physical declaration and its exact source/owner; `semanticview.AgentExecutionSemanticScope` admits agreement between that declaration and one concrete runtime identity.
- **Old paths now invalid:** independent project/flow agent-map pairing, scope-rank selection, partial-source fallback, runtime-created name borrowing, URI/path reconstruction, and generated-event reconstruction from template/local fragments.
- **Production paths checked:** generated emit, channel activity, `agent_message`, schedule/control, and human-task admission; boot diagnostics/entity coverage; static materialization; EventBus routes; flow-data validation; provider/tool/workspace/CLI/serve projections.
- **Migration status:** complete for the approved #2261 class. No compatibility reader, migration, alias, or fallback remains.

## Proof

- focused owner/consumer matrix at `-count=3`
- all five imported producer paths at `-count=3` and `-race -count=3`
- hostile declaration/runtime collision and raw-map ownership guard proofs
- frozen real #2036 signed-ingress -> imported template select/create -> live model -> generated emit -> Telegram connector journey on SQLite and PostgreSQL at `-count=3` and `-race -count=3`
- isolated PostgreSQL whole suite: `GOFLAGS=-p=1 go run ./cmd/swarm-test-postgres -- go test ./...`

Closes #2261
