### PR TITLE
[agent-c][issue #2143] Gate all conformance bundles on verify

### DIFF
--- a/internal/cliapp/catalog_conformance_test.go
+++ b/internal/cliapp/catalog_conformance_test.go
@@ -3,15 +3,27 @@ package cliapp
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimecredentials "github.com/division-sh/swarm/internal/runtime/credentials"
 	"github.com/division-sh/swarm/internal/testcatalog"
 )
 
+type requiredConformanceBundle struct {
+	ID   string
+	Root string
+}
+
 func TestCatalogRequiredVerifyAll(t *testing.T) {
 	t.Setenv("SWARM_EMIT_SCHEMA_STRICT", "true")
+	setRequiredConformanceCredentials(t)
 	repoRoot := RepoRoot()
 	inventory, err := testcatalog.Load(repoRoot)
 	if err != nil {
@@ -48,6 +60,111 @@ func TestCatalogRequiredVerifyAll(t *testing.T) {
 	if verified != len(inventory.Fixtures) {
 		t.Fatalf("supported verify executions = %d, want %d", verified, len(inventory.Fixtures))
 	}
+
+	exampleBundles, err := discoverRequiredExampleBundles(repoRoot)
+	if err != nil {
+		t.Fatalf("discover required example bundles: %v", err)
+	}
+	if got, want := len(exampleBundles), 12; got != want {
+		t.Fatalf("required example bundle count = %d, want %d", got, want)
+	}
+	archetypeBundles := materializeRequiredArchetypeBundles(t)
+	if got, want := len(archetypeBundles), 2; got != want {
+		t.Fatalf("required archetype bundle count = %d, want %d", got, want)
+	}
+	passingBundles := append(exampleBundles, archetypeBundles...)
+	for _, failure := range verifyRequiredPassingBundles(context.Background(), repoRoot, configPath, passingBundles) {
+		t.Error(failure)
+	}
+}
+
+func setRequiredConformanceCredentials(t testing.TB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv("SWARM_CREDENTIALS_FILE", path)
+	store, err := runtimecredentials.NewFileStore(path)
+	if err != nil {
+		t.Fatalf("create required conformance credential store: %v", err)
+	}
+	if err := store.Set(context.Background(), "telegram_bot_token", "catalog-required-test-token"); err != nil {
+		t.Fatalf("set required conformance credential: %v", err)
+	}
+}
+
+func TestCatalogRequiredVerifyGateMutationNamesBrokenBundle(t *testing.T) {
+	repoRoot := RepoRoot()
+	root := filepath.Join(t.TempDir(), "broken-example")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create broken bundle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "package.yaml"), []byte("name: broken-example\nunknown_wave0_field: true\n"), 0o600); err != nil {
+		t.Fatalf("write broken bundle: %v", err)
+	}
+	failures := verifyRequiredPassingBundles(context.Background(), repoRoot, writeTestVerifyRuntimeConfig(t), []requiredConformanceBundle{{
+		ID: "examples/broken-example", Root: root,
+	}})
+	if len(failures) != 1 || !strings.Contains(failures[0], "examples/broken-example") || !strings.Contains(failures[0], "unknown_wave0_field") {
+		t.Fatalf("mutation failures = %#v, want named broken bundle and exact loader evidence", failures)
+	}
+}
+
+func discoverRequiredExampleBundles(repoRoot string) ([]requiredConformanceBundle, error) {
+	examplesRoot := filepath.Join(repoRoot, "examples")
+	var bundles []requiredConformanceBundle
+	err := filepath.WalkDir(examplesRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "package.yaml" {
+			return nil
+		}
+		root := filepath.Dir(path)
+		relative, err := filepath.Rel(repoRoot, root)
+		if err != nil {
+			return err
+		}
+		bundles = append(bundles, requiredConformanceBundle{ID: filepath.ToSlash(relative), Root: root})
+		return nil
+	})
+	sort.Slice(bundles, func(i, j int) bool { return bundles[i].ID < bundles[j].ID })
+	return bundles, err
+}
+
+func materializeRequiredArchetypeBundles(t testing.TB) []requiredConformanceBundle {
+	t.Helper()
+	ids := make([]string, 0, len(admittedArchetypes))
+	for id := range admittedArchetypes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	bundles := make([]requiredConformanceBundle, 0, len(ids))
+	for _, id := range ids {
+		destination := filepath.Join(t.TempDir(), id)
+		if err := scaffoldArchetype(io.Discard, id, destination); err != nil {
+			t.Fatalf("materialize required archetype %s: %v", id, err)
+		}
+		bundles = append(bundles, requiredConformanceBundle{
+			ID:   "archetypes/" + id,
+			Root: filepath.Clean(filepath.Join(destination, admittedArchetypes[id].WorkingDir)),
+		})
+	}
+	return bundles
+}
+
+func verifyRequiredPassingBundles(ctx context.Context, repoRoot, configPath string, bundles []requiredConformanceBundle) []string {
+	var failures []string
+	for _, bundle := range bundles {
+		opts := defaultVerifyCommandOptions()
+		opts.contractsPath = bundle.Root
+		opts.configPath = configPath
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		code := runVerifyCommandWithOutput(ctx, repoRoot, opts, &stdout, &stderr)
+		if code != 0 {
+			failures = append(failures, fmt.Sprintf("%s failed supported verify/boot: code=%d stdout=%q stderr=%q", bundle.ID, code, stdout.String(), stderr.String()))
+		}
+	}
+	return failures
 }
 
 func catalogWarningsFatal(fixture testcatalog.Fixture) string {

--- a/internal/cliapp/catalog_conformance_test.go
+++ b/internal/cliapp/catalog_conformance_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 type requiredConformanceBundle struct {
-	ID   string
-	Root string
+	ID         string
+	Root       string
+	ConfigPath string
 }
 
 func TestCatalogRequiredVerifyAll(t *testing.T) {
@@ -61,19 +62,13 @@ func TestCatalogRequiredVerifyAll(t *testing.T) {
 		t.Fatalf("supported verify executions = %d, want %d", verified, len(inventory.Fixtures))
 	}
 
-	exampleBundles, err := discoverRequiredExampleBundles(repoRoot)
+	exampleBundles, err := discoverRequiredExampleBundles(repoRoot, configPath)
 	if err != nil {
 		t.Fatalf("discover required example bundles: %v", err)
 	}
-	if got, want := len(exampleBundles), 12; got != want {
-		t.Fatalf("required example bundle count = %d, want %d", got, want)
-	}
 	archetypeBundles := materializeRequiredArchetypeBundles(t)
-	if got, want := len(archetypeBundles), 2; got != want {
-		t.Fatalf("required archetype bundle count = %d, want %d", got, want)
-	}
 	passingBundles := append(exampleBundles, archetypeBundles...)
-	for _, failure := range verifyRequiredPassingBundles(context.Background(), repoRoot, configPath, passingBundles) {
+	for _, failure := range verifyRequiredPassingBundles(context.Background(), repoRoot, passingBundles) {
 		t.Error(failure)
 	}
 }
@@ -91,25 +86,70 @@ func setRequiredConformanceCredentials(t testing.TB) {
 	}
 }
 
-func TestCatalogRequiredVerifyGateMutationNamesBrokenBundle(t *testing.T) {
+func TestCatalogRequiredVerifyGateMutationDiscoversAndNamesBrokenBundles(t *testing.T) {
+	setRequiredConformanceCredentials(t)
 	repoRoot := RepoRoot()
-	root := filepath.Join(t.TempDir(), "broken-example")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("create broken bundle: %v", err)
+	corpusRoot := t.TempDir()
+	mutations := []struct {
+		path     string
+		field    string
+		identity string
+	}{
+		{path: "broken-first", field: "unknown_wave0_first", identity: "examples/broken-first"},
+		{path: filepath.Join("nested", "broken-second"), field: "unknown_wave0_second", identity: "examples/nested/broken-second"},
 	}
-	if err := os.WriteFile(filepath.Join(root, "package.yaml"), []byte("name: broken-example\nunknown_wave0_field: true\n"), 0o600); err != nil {
-		t.Fatalf("write broken bundle: %v", err)
+	for _, mutation := range mutations {
+		root := filepath.Join(corpusRoot, "examples", mutation.path)
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("create broken bundle %s: %v", mutation.identity, err)
+		}
+		body := fmt.Sprintf("name: broken-example\n%s: true\n", mutation.field)
+		if err := os.WriteFile(filepath.Join(root, "package.yaml"), []byte(body), 0o600); err != nil {
+			t.Fatalf("write broken bundle %s: %v", mutation.identity, err)
+		}
 	}
-	failures := verifyRequiredPassingBundles(context.Background(), repoRoot, writeTestVerifyRuntimeConfig(t), []requiredConformanceBundle{{
-		ID: "examples/broken-example", Root: root,
-	}})
-	if len(failures) != 1 || !strings.Contains(failures[0], "examples/broken-example") || !strings.Contains(failures[0], "unknown_wave0_field") {
-		t.Fatalf("mutation failures = %#v, want named broken bundle and exact loader evidence", failures)
+	configPath := writeTestVerifyRuntimeConfig(t)
+	bundles, err := discoverRequiredExampleBundles(corpusRoot, configPath)
+	if err != nil {
+		t.Fatalf("discover mutated bundles: %v", err)
+	}
+	failures := verifyRequiredPassingBundles(context.Background(), repoRoot, bundles)
+	if len(failures) != len(mutations) {
+		t.Fatalf("mutation failures = %#v, want %d discovered failures", failures, len(mutations))
+	}
+	joined := strings.Join(failures, "\n")
+	for _, mutation := range mutations {
+		if !strings.Contains(joined, mutation.identity) || !strings.Contains(joined, mutation.field) {
+			t.Fatalf("mutation failures = %#v, want %s and exact loader evidence %s", failures, mutation.identity, mutation.field)
+		}
 	}
 }
 
-func discoverRequiredExampleBundles(repoRoot string) ([]requiredConformanceBundle, error) {
-	examplesRoot := filepath.Join(repoRoot, "examples")
+func TestCatalogRequiredVerifyGateRejectsInvalidGeneratedArchetypeConfig(t *testing.T) {
+	setRequiredConformanceCredentials(t)
+	repoRoot := RepoRoot()
+	bundles := materializeRequiredArchetypeBundles(t)
+	var mutated *requiredConformanceBundle
+	for i := range bundles {
+		if bundles[i].ID == "archetypes/zero-agent-automation" {
+			mutated = &bundles[i]
+			break
+		}
+	}
+	if mutated == nil {
+		t.Fatal("zero-agent-automation is missing from admittedArchetypes")
+	}
+	if err := os.WriteFile(mutated.ConfigPath, []byte("runtime:\n  execution_posture: invalid\n"), 0o600); err != nil {
+		t.Fatalf("mutate generated archetype config: %v", err)
+	}
+	failures := verifyRequiredPassingBundles(context.Background(), repoRoot, []requiredConformanceBundle{*mutated})
+	if len(failures) != 1 || !strings.Contains(failures[0], mutated.ID) || !strings.Contains(failures[0], `runtime.execution_posture must be exactly live or mock_only`) {
+		t.Fatalf("generated-config mutation failures = %#v, want named archetype and exact config evidence", failures)
+	}
+}
+
+func discoverRequiredExampleBundles(corpusRoot, configPath string) ([]requiredConformanceBundle, error) {
+	examplesRoot := filepath.Join(corpusRoot, "examples")
 	var bundles []requiredConformanceBundle
 	err := filepath.WalkDir(examplesRoot, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -119,11 +159,15 @@ func discoverRequiredExampleBundles(repoRoot string) ([]requiredConformanceBundl
 			return nil
 		}
 		root := filepath.Dir(path)
-		relative, err := filepath.Rel(repoRoot, root)
+		relative, err := filepath.Rel(corpusRoot, root)
 		if err != nil {
 			return err
 		}
-		bundles = append(bundles, requiredConformanceBundle{ID: filepath.ToSlash(relative), Root: root})
+		bundles = append(bundles, requiredConformanceBundle{
+			ID:         filepath.ToSlash(relative),
+			Root:       root,
+			ConfigPath: configPath,
+		})
 		return nil
 	})
 	sort.Slice(bundles, func(i, j int) bool { return bundles[i].ID < bundles[j].ID })
@@ -144,19 +188,20 @@ func materializeRequiredArchetypeBundles(t testing.TB) []requiredConformanceBund
 			t.Fatalf("materialize required archetype %s: %v", id, err)
 		}
 		bundles = append(bundles, requiredConformanceBundle{
-			ID:   "archetypes/" + id,
-			Root: filepath.Clean(filepath.Join(destination, admittedArchetypes[id].WorkingDir)),
+			ID:         "archetypes/" + id,
+			Root:       filepath.Clean(filepath.Join(destination, admittedArchetypes[id].WorkingDir)),
+			ConfigPath: filepath.Clean(filepath.Join(destination, admittedArchetypes[id].WorkingDir, "swarm.yaml")),
 		})
 	}
 	return bundles
 }
 
-func verifyRequiredPassingBundles(ctx context.Context, repoRoot, configPath string, bundles []requiredConformanceBundle) []string {
+func verifyRequiredPassingBundles(ctx context.Context, repoRoot string, bundles []requiredConformanceBundle) []string {
 	var failures []string
 	for _, bundle := range bundles {
 		opts := defaultVerifyCommandOptions()
 		opts.contractsPath = bundle.Root
-		opts.configPath = configPath
+		opts.configPath = bundle.ConfigPath
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
 		code := runVerifyCommandWithOutput(ctx, repoRoot, opts, &stdout, &stderr)

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -20446,7 +20446,10 @@ test_specification:
       and external proof records only declare which canonical claims their sole
       executor is intended to prove.
     inventory:
-      discovery: Every directory matching tests/tier*/* is a fixture.
+      discovery: >
+        Every directory matching tests/tier*/* is a classified fixture. Every package.yaml below examples/ and every
+        admitted scaffold archetype is additionally a required passing bundle; nested example packages are included
+        rather than inferred through their parent.
       metadata_owner: Each fixture's expected.yaml top-level conformance block.
       fail_closed: >
         A missing expected.yaml or conformance block, an invalid disposition,
@@ -20455,7 +20458,10 @@ test_specification:
         proof records additionally fail on missing or duplicate sources, missing
         executor packages, absence of exactly one unfiltered package owner in
         every required CI profile, unknown or multiply credited claims, and
-        malformed repository-relative paths.
+        malformed repository-relative paths. The required verify/boot gate runs
+        every classified tier fixture, discovered example package, and admitted
+        archetype through the supported verifier, reports every failing bundle in
+        one pass, and is mutation-proven to name a newly broken bundle.
       dispositions:
         runtime: >
           The fixture must pass supported swarm verify and execute its exact

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -20449,7 +20449,10 @@ test_specification:
       discovery: >
         Every directory matching tests/tier*/* is a classified fixture. Every package.yaml below examples/ and every
         admitted scaffold archetype is additionally a required passing bundle; nested example packages are included
-        rather than inferred through their parent.
+        rather than inferred through their parent. Filesystem discovery and the admitted-archetype registry are the
+        live denominators; no hard-coded cardinality may preempt bundle verification. Examples verify against the
+        canonical conformance runtime config, while each materialized archetype verifies against the exact generated
+        <working-dir>/swarm.yaml taught by its scaffold command.
       metadata_owner: Each fixture's expected.yaml top-level conformance block.
       fail_closed: >
         A missing expected.yaml or conformance block, an invalid disposition,
@@ -20461,7 +20464,10 @@ test_specification:
         malformed repository-relative paths. The required verify/boot gate runs
         every classified tier fixture, discovered example package, and admitted
         archetype through the supported verifier, reports every failing bundle in
-        one pass, and is mutation-proven to name a newly broken bundle.
+        one pass, and is mutation-proven through live recursive discovery to name
+        every newly broken bundle with loader evidence. A generated archetype
+        config mutation must also fail through that archetype's exact supported
+        config path; a shared synthetic config receives no archetype credit.
       dispositions:
         runtime: >
           The fixture must pass supported swarm verify and execute its exact


### PR DESCRIPTION
## Summary

- extend the required conformance verify owner from the 155 classified tier fixtures to every discovered `examples/**/package.yaml` bundle, including nested packages
- materialize and verify/boot every admitted scaffold archetype through the same supported `swarm verify` path
- batch-report every passing-bundle failure and mutation-prove that a broken bundle fails with its exact identity and loader evidence
- pin the expanded discovery and fail-closed CI contract in authoritative `platform-spec.yaml`

## Governing context

This is the separately assigned #2143 fixture-verify Wave 0 prerequisite for #2293/#2313. The binding issue ruling limits this PR to the verify/boot CI gate; typed dispatch/silent-skip cleanup and private-interpreter replacement remain outside this change.

Authoritative contract: `platform-spec.yaml#test_specification.internal_catalog_conformance.inventory`.

The existing unfiltered `catalog-required-verify` unit is present in every required CI profile, so this gate runs on every PR. Tier warning/reject/retired outcomes continue to consume their existing typed fixture classifications; examples and admitted archetypes are required passing bundles.

Part of #2143

## Verification

- `go test ./internal/cliapp -run '^TestCatalogRequiredVerify(All|GateMutationNamesBrokenBundle)$' -count=1`
- `go test ./internal/apispec -count=1`
- `go test ./internal/testcatalog -run '^TestCatalog(RequiredInventory|RequiredCIProofSelection)$' -count=1`
- `go run ./cmd/swarm-test-postgres -- go test -p=1 -timeout=30m ./...`
