### PR TITLE
[agent-b][issue #2244] Quiesce selected-store test generations

### DIFF
--- a/internal/runtime/author_activity_external_test_context_test.go
+++ b/internal/runtime/author_activity_external_test_context_test.go
@@ -42,6 +42,129 @@ var authorActivityTestBundleSourceFact = mustExternalTestBundleSourceFact("bundl
 
 var externalRuntimeTestEventBusOwners sync.Map
 
+type externalRuntimeTestEventBusOwner struct {
+	process       *worklifetime.Process
+	occurrence    worklifetime.Occurrence
+	retireAndWait func(context.Context) error
+	once          sync.Once
+	err           error
+}
+
+func (o *externalRuntimeTestEventBusOwner) close(ctx context.Context) error {
+	if o == nil || o.process == nil {
+		return nil
+	}
+	o.once.Do(func() {
+		if err := o.retireAndWait(ctx); err != nil {
+			o.err = fmt.Errorf("retire external runtime test occurrence: %w", err)
+			return
+		}
+		o.process.Retire()
+		if _, err := o.process.Join(ctx); err != nil {
+			o.err = fmt.Errorf("join external runtime test process: %w", err)
+		}
+	})
+	return o.err
+}
+
+type externalRuntimeTestCapability interface {
+	Release(context.Context) error
+}
+
+type externalRuntimeTestReleaseProbe struct {
+	released chan struct{}
+	once     sync.Once
+}
+
+func (p *externalRuntimeTestReleaseProbe) Release(context.Context) error {
+	p.once.Do(func() { close(p.released) })
+	return nil
+}
+
+func TestExternalRuntimeTestGenerationJoinsAcceptedWorkBeforeCapabilityRelease(t *testing.T) {
+	process := worklifetime.NewProcess()
+	lease, err := process.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin accepted process work: %v", err)
+	}
+	capability := &externalRuntimeTestReleaseProbe{released: make(chan struct{})}
+	closed := make(chan error, 1)
+	go func() {
+		closed <- closeExternalRuntimeTestGeneration(nil, process, capability)
+	}()
+
+	<-lease.Context().Done()
+	select {
+	case <-capability.released:
+		t.Fatal("process capability released before accepted work settled")
+	default:
+	}
+	if err := lease.Done(); err != nil {
+		t.Fatalf("settle accepted process work: %v", err)
+	}
+	if err := <-closed; err != nil {
+		t.Fatalf("close external runtime test generation: %v", err)
+	}
+	select {
+	case <-capability.released:
+	default:
+		t.Fatal("process capability was not released after process join")
+	}
+}
+
+func closeExternalRuntimeTestGeneration(runtime *runtimepkg.Runtime, process *worklifetime.Process, capability externalRuntimeTestCapability) error {
+	if runtime != nil {
+		if err := runtime.Shutdown(); err != nil {
+			return fmt.Errorf("shutdown external runtime test generation: %w", err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if process != nil {
+		process.Retire()
+		if _, err := process.Join(ctx); err != nil {
+			return fmt.Errorf("join external runtime test process: %w", err)
+		}
+	}
+	if capability != nil {
+		if err := capability.Release(context.Background()); err != nil {
+			return fmt.Errorf("release external runtime test process capability: %w", err)
+		}
+	}
+	return nil
+}
+
+func closeExternalManagerTestGeneration(manager *runtimemanager.AgentManager, bus *runtimebus.EventBus, grant runtimestartupownership.GenerationGrant, capability externalRuntimeTestCapability) error {
+	if manager != nil {
+		if err := manager.Shutdown(); err != nil {
+			return fmt.Errorf("shutdown external runtime test manager: %w", err)
+		}
+	}
+	if bus != nil {
+		if err := bus.ResetInMemoryState(); err != nil {
+			return fmt.Errorf("reset external runtime test event bus: %w", err)
+		}
+		if owner, ok := externalRuntimeTestEventBusOwners.Load(bus); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := owner.(*externalRuntimeTestEventBusOwner).close(ctx); err != nil {
+				return err
+			}
+		}
+	}
+	if grant != nil {
+		if err := grant.Retire(context.Background()); err != nil {
+			return fmt.Errorf("retire external manager test generation grant: %w", err)
+		}
+	}
+	if capability != nil {
+		if err := capability.Release(context.Background()); err != nil {
+			return fmt.Errorf("release external manager test process capability: %w", err)
+		}
+	}
+	return nil
+}
+
 type externalTestFlowInstanceActivationOwner struct {
 	mu       sync.Mutex
 	activate runtimepipeline.FlowInstanceActivator
@@ -307,16 +430,6 @@ func installExternalManagerTestGeneration(
 	}
 }
 
-func releaseExternalRuntimeTestCapability(t testing.TB, capability runtimestartupownership.ProcessCapability) {
-	t.Helper()
-	if capability == nil {
-		return
-	}
-	if err := capability.Release(context.Background()); err != nil {
-		t.Fatalf("release external runtime test process capability: %v", err)
-	}
-}
-
 type externalRuntimeTestDurableEventStore interface {
 	runtimebus.EventStore
 	runtimereplycontext.Store
@@ -423,6 +536,7 @@ func newRuntimeTestEventBus(t testing.TB, store runtimebus.EventStore) (*runtime
 
 func newRuntimeTestEventBusWithOptions(t testing.TB, store runtimebus.EventStore, opts runtimebus.EventBusOptions) (*runtimebus.EventBus, error) {
 	t.Helper()
+	var lifetimeOwner *externalRuntimeTestEventBusOwner
 	if !opts.ExecutionPosture.Valid() {
 		opts.ExecutionPosture = executionposture.Live
 	}
@@ -442,16 +556,13 @@ func newRuntimeTestEventBusWithOptions(t testing.TB, store runtimebus.EventStore
 			return nil, err
 		}
 		opts.WorkOwner = owner
-		t.Cleanup(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if _, err := owner.RetireAndWait(ctx); err != nil {
-				t.Errorf("retire external runtime test occurrence: %v", err)
-			}
-			if _, err := process.Join(ctx); err != nil {
-				t.Errorf("join external runtime test process: %v", err)
-			}
-		})
+		lifetimeOwner = &externalRuntimeTestEventBusOwner{
+			process: process, occurrence: owner,
+			retireAndWait: func(ctx context.Context) error {
+				_, err := owner.RetireAndWait(ctx)
+				return err
+			},
+		}
 	}
 	if !opts.ReceiverExecution.Configured() {
 		opts.ReceiverExecution = eventreceiver.NormalExecution()
@@ -498,8 +609,25 @@ func newRuntimeTestEventBusWithOptions(t testing.TB, store runtimebus.EventStore
 	); err != nil {
 		return nil, err
 	}
-	externalRuntimeTestEventBusOwners.Store(bus, opts.WorkOwner)
-	t.Cleanup(func() { externalRuntimeTestEventBusOwners.Delete(bus) })
+	owner := &externalRuntimeTestEventBusOwner{occurrence: opts.WorkOwner}
+	if lifetimeOwner != nil {
+		owner = lifetimeOwner
+	}
+	externalRuntimeTestEventBusOwners.Store(bus, owner)
+	t.Cleanup(func() {
+		defer externalRuntimeTestEventBusOwners.Delete(bus)
+		if err := bus.ResetInMemoryState(); err != nil {
+			t.Errorf("reset external runtime test event bus: %v", err)
+			return
+		}
+		if lifetimeOwner != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := lifetimeOwner.close(ctx); err != nil {
+				t.Errorf("close external runtime test event bus owner: %v", err)
+			}
+		}
+	})
 	return bus, nil
 }
 
@@ -526,7 +654,7 @@ func runtimeTestEventBusWorkOwner(t testing.TB, bus *runtimebus.EventBus) workli
 	if !ok {
 		t.Fatal("external runtime test event bus has no registered work owner")
 	}
-	return owner.(worklifetime.Occurrence)
+	return owner.(*externalRuntimeTestEventBusOwner).occurrence
 }
 
 func ownRuntimeTestAgentManager(t testing.TB, manager *runtimemanager.AgentManager) *runtimemanager.AgentManager {

--- a/internal/runtime/author_activity_test_context_test.go
+++ b/internal/runtime/author_activity_test_context_test.go
@@ -64,12 +64,13 @@ func (runtimeTestRejectedMutationOwner) RunRuntimeMutationContext(context.Contex
 type runtimeTestUnavailableDecisionCards struct{ decisioncard.Store }
 
 type runtimeTestRetainedSession struct {
-	mu        sync.Mutex
-	authority runtimestartupownership.Authority
-	plan      runtimeagenttopology.SourceSetPlan
-	agents    map[string]runtimemanager.PersistedAgent
-	callback  func(runtimestartupownership.TerminalResult)
-	released  bool
+	mu              sync.Mutex
+	authority       runtimestartupownership.Authority
+	plan            runtimeagenttopology.SourceSetPlan
+	agents          map[string]runtimemanager.PersistedAgent
+	callback        func(runtimestartupownership.TerminalResult)
+	grantTransition func(*runtimestartupownership.GrantEvidence, runtimestartupownership.GrantEvidence)
+	released        bool
 }
 
 type runtimeTestRetainedSessionProvider interface {
@@ -108,7 +109,13 @@ func (s *runtimeTestRetainedSession) InstallTerminalOwner(owner runtimestartupow
 	return nil
 }
 
-func (*runtimeTestRetainedSession) RecordGenerationGrantTransition(context.Context, *runtimestartupownership.GrantEvidence, runtimestartupownership.GrantEvidence) error {
+func (s *runtimeTestRetainedSession) RecordGenerationGrantTransition(_ context.Context, previous *runtimestartupownership.GrantEvidence, next runtimestartupownership.GrantEvidence) error {
+	s.mu.Lock()
+	observe := s.grantTransition
+	s.mu.Unlock()
+	if observe != nil {
+		observe(previous, next)
+	}
 	return nil
 }
 

--- a/internal/runtime/budget_recovery_parity_test.go
+++ b/internal/runtime/budget_recovery_parity_test.go
@@ -150,7 +150,11 @@ func TestCompletionBudgetRecoveryProjectionParity(t *testing.T) {
 			if err := manager.ReconcileStaticTopologyForStartup(ctx, source); err != nil {
 				t.Fatalf("reconcile budget recovery manager topology: %v", err)
 			}
-			t.Cleanup(func() { _ = capability.Release(context.Background()) })
+			t.Cleanup(func() {
+				if err := closeExternalManagerTestGeneration(manager, bus, grant, capability); err != nil {
+					t.Errorf("close budget recovery generation: %v", err)
+				}
+			})
 
 			admission, err := managedexecution.New(managedexecution.KindNormalRuntime, "budget-recovery-test", 1, "", "budget-recovery-actors", "bundle-v1:sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", nil)
 			if err != nil {

--- a/internal/runtime/bus/event_identity_dispatch_surface_test.go
+++ b/internal/runtime/bus/event_identity_dispatch_surface_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -80,6 +81,54 @@ type completeEventDispatchFixture struct {
 	source   semanticview.Source
 }
 
+type completeEventDispatchGeneration struct {
+	manager     *runtimemanager.AgentManager
+	coordinator *runtimedeliverycontinuation.Coordinator
+	process     *worklifetime.Process
+	owner       *worklifetime.RuntimeOccurrence
+	grant       runtimestartupownership.GenerationGrant
+	capability  runtimestartupownership.ProcessCapability
+	once        sync.Once
+}
+
+func (g *completeEventDispatchGeneration) close() error {
+	if g == nil {
+		return nil
+	}
+	var closeErr error
+	g.once.Do(func() {
+		if g.coordinator != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			closeErr = errors.Join(closeErr, g.coordinator.Retire(ctx))
+		}
+		if g.manager != nil {
+			closeErr = errors.Join(closeErr, g.manager.Shutdown())
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if g.owner != nil {
+			_, err := g.owner.RetireAndWait(ctx)
+			closeErr = errors.Join(closeErr, err)
+		}
+		if g.process != nil {
+			g.process.Retire()
+			_, err := g.process.Join(ctx)
+			closeErr = errors.Join(closeErr, err)
+		}
+		if closeErr != nil {
+			return
+		}
+		if g.grant != nil {
+			closeErr = errors.Join(closeErr, g.grant.Retire(context.Background()))
+		}
+		if closeErr == nil && g.capability != nil {
+			closeErr = errors.Join(closeErr, g.capability.Release(context.Background()))
+		}
+	})
+	return closeErr
+}
+
 func TestCompleteEventSnapshotDispatchesThroughRecoveryOwnersOnSQLiteAndPostgres(t *testing.T) {
 	for _, backend := range []string{"sqlite", "postgres"} {
 		for _, surface := range []string{"startup", "global_sweeper", "run_queue", "decision_obligation"} {
@@ -136,7 +185,8 @@ func TestCompleteEventSnapshotDispatchesThroughManagerBacklogOnSQLiteAndPostgres
 				t.Fatalf("%s schema admitted negative chain_depth", backend)
 			}
 			seen := make(chan events.Event, 1)
-			manager, workOwner := fixture.newRecordingManager(t, seen)
+			generation := fixture.newRecordingManager(t, seen)
+			manager := generation.manager
 			managerCtx := fixture.managedContext(t)
 			if _, err := manager.HydrateForStartup(managerCtx); err != nil {
 				t.Fatalf("hydrate manager: %v", err)
@@ -144,12 +194,7 @@ func TestCompleteEventSnapshotDispatchesThroughManagerBacklogOnSQLiteAndPostgres
 			if err := manager.Run(managerCtx); err != nil {
 				t.Fatalf("run manager: %v", err)
 			}
-			t.Cleanup(func() {
-				if err := manager.Shutdown(); err != nil {
-					t.Errorf("shutdown complete-event manager: %v", err)
-				}
-			})
-			fixture.startDeliveryContinuations(t, managerCtx, workOwner)
+			fixture.startDeliveryContinuations(t, managerCtx, generation)
 			assertCompleteEventDelivery(t, seen, fixture.event)
 		})
 	}
@@ -536,7 +581,7 @@ func (f completeEventDispatchFixture) managedContext(t *testing.T) context.Conte
 func (f completeEventDispatchFixture) newRecordingManager(
 	t *testing.T,
 	seen chan<- events.Event,
-) (*runtimemanager.AgentManager, *worklifetime.RuntimeOccurrence) {
+) *completeEventDispatchGeneration {
 	t.Helper()
 	process := worklifetime.NewProcess()
 	owner, err := process.NewRuntime(context.Background(), worklifetime.RuntimeIdentity{
@@ -546,15 +591,6 @@ func (f completeEventDispatchFixture) newRecordingManager(
 	if err != nil {
 		t.Fatalf("create complete-event work owner: %v", err)
 	}
-	t.Cleanup(func() {
-		if _, err := owner.RetireAndWait(context.Background()); err != nil {
-			t.Errorf("retire complete-event work owner: %v", err)
-		}
-		process.Retire()
-		if _, err := process.Join(context.Background()); err != nil {
-			t.Errorf("join complete-event process owner: %v", err)
-		}
-	})
 	manager := runtimemanager.NewAgentManagerWithOptions(f.bus, func(cfg runtimeactors.AgentConfig) (runtimemanager.Agent, error) {
 		return &completeEventRecordingAgent{id: cfg.ID, subscriptions: []events.EventType{f.event.Type()}, seen: seen}, nil
 	}, runtimemanager.AgentManagerOptions{
@@ -571,6 +607,12 @@ func (f completeEventDispatchFixture) newRecordingManager(
 		WorkOwner:         owner,
 		ReceiverExecution: eventreceiver.NormalExecution(),
 	}, f.store)
+	generation := &completeEventDispatchGeneration{manager: manager, process: process, owner: owner}
+	t.Cleanup(func() {
+		if err := generation.close(); err != nil {
+			t.Errorf("close complete-event dispatch generation: %v", err)
+		}
+	})
 	bundleHash, bundleSource := authorActivityTestBundleSourceFact.StorageValues()
 	coordinate := runtimeagenttopology.SourceCoordinate{BundleHash: bundleHash, BundleSource: bundleSource}
 	desired, err := manager.CompileStaticTopologyDesiredAgents(f.source, coordinate)
@@ -587,6 +629,7 @@ func (f completeEventDispatchFixture) newRecordingManager(
 	if err != nil {
 		t.Fatalf("acquire complete-event process capability: %v", err)
 	}
+	generation.capability = capability
 	if _, err := capability.InstallCompleteSourceSet(f.ctx, runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}); err != nil {
 		t.Fatalf("install complete-event source set: %v", err)
 	}
@@ -597,6 +640,7 @@ func (f completeEventDispatchFixture) newRecordingManager(
 	if err != nil {
 		t.Fatalf("issue complete-event generation grant: %v", err)
 	}
+	generation.grant = grant
 	admission, err := runtimeagenttopology.StaticAdmission(plan.Revision, bundleHash, bundleSource, runtimeagenttopology.LifetimeDurableManaged)
 	if err != nil {
 		t.Fatalf("construct complete-event static admission: %v", err)
@@ -607,15 +651,7 @@ func (f completeEventDispatchFixture) newRecordingManager(
 	if err := manager.ReconcileStaticTopologyForStartup(f.ctx, f.source); err != nil {
 		t.Fatalf("reconcile complete-event static topology: %v", err)
 	}
-	t.Cleanup(func() {
-		if err := grant.Retire(context.Background()); err != nil {
-			t.Errorf("retire complete-event generation grant: %v", err)
-		}
-		if err := capability.Release(context.Background()); err != nil {
-			t.Errorf("release complete-event process capability: %v", err)
-		}
-	})
-	return manager, owner
+	return generation
 }
 
 func completeEventAgentSource(agentID, subscription string, intent runtimeagentintent.Resolved) semanticview.Source {
@@ -651,7 +687,7 @@ func completeEventAgentOwnerURI(agentID string) string {
 func (f completeEventDispatchFixture) startDeliveryContinuations(
 	t *testing.T,
 	ctx context.Context,
-	workOwner *worklifetime.RuntimeOccurrence,
+	generation *completeEventDispatchGeneration,
 ) {
 	t.Helper()
 	route := events.DeliveryRoute{Recipient: events.MustAgentDeliveryRecipient(f.agentID), AgentIdentity: f.identity}
@@ -672,7 +708,7 @@ func (f completeEventDispatchFixture) startDeliveryContinuations(
 	coordinator, err := runtimedeliverycontinuation.New(
 		f.store,
 		snapshot.Authority,
-		workOwner,
+		generation.owner,
 		f.bus,
 		func(_ context.Context, reportErr error) {
 			t.Errorf("complete-event delivery continuation failed: %v", reportErr)
@@ -687,13 +723,7 @@ func (f completeEventDispatchFixture) startDeliveryContinuations(
 	if err := coordinator.Start(ctx); err != nil {
 		t.Fatalf("start complete-event delivery coordinator: %v", err)
 	}
-	t.Cleanup(func() {
-		retireCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := coordinator.Retire(retireCtx); err != nil {
-			t.Errorf("retire complete-event delivery coordinator: %v", err)
-		}
-	})
+	generation.coordinator = coordinator
 }
 
 type completeEventRecordingAgent struct {

--- a/internal/runtime/cataloge2e/runtime_harness_test.go
+++ b/internal/runtime/cataloge2e/runtime_harness_test.go
@@ -367,16 +367,12 @@ func installCatalogRuntimeStartupGrant(
 	if err != nil {
 		t.Fatalf("acquire catalog runtime process capability: %v", err)
 	}
-	t.Cleanup(func() {
-		select {
-		case <-capability.Done():
-			return
-		default:
+	release := true
+	defer func() {
+		if release {
+			_ = capability.Release(context.Background())
 		}
-		if err := capability.Release(context.Background()); err != nil {
-			t.Errorf("release catalog runtime process capability: %v", err)
-		}
-	})
+	}()
 	current, exists, err := capability.CurrentSourceSet(ctx)
 	if err != nil {
 		t.Fatalf("load catalog runtime source set: %v", err)
@@ -403,6 +399,7 @@ func installCatalogRuntimeStartupGrant(
 	if err := rt.InstallStartupGrant(grant); err != nil {
 		t.Fatalf("install catalog runtime generation grant: %v", err)
 	}
+	release = false
 	return capability
 }
 
@@ -563,6 +560,15 @@ func (h *runtimeHarness) shutdown() {
 		if h.cancel != nil {
 			h.cancel()
 		}
+		if h.processOwner != nil {
+			joinCtx, cancelJoin := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelJoin()
+			h.processOwner.Retire()
+			if _, err := h.processOwner.Join(joinCtx); err != nil {
+				h.t.Errorf("join catalog runtime process owner: %v", err)
+				return
+			}
+		}
 		if h.processTopology != nil {
 			select {
 			case <-h.processTopology.Done():
@@ -570,13 +576,6 @@ func (h *runtimeHarness) shutdown() {
 				if err := h.processTopology.Release(context.Background()); err != nil {
 					h.t.Errorf("release catalog process topology capability: %v", err)
 				}
-			}
-		}
-		if h.processOwner != nil {
-			joinCtx, cancelJoin := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancelJoin()
-			if _, err := h.processOwner.Join(joinCtx); err != nil {
-				h.t.Errorf("join catalog runtime process owner: %v", err)
 			}
 		}
 	})

--- a/internal/runtime/conformance/author_activity_test_context_test.go
+++ b/internal/runtime/conformance/author_activity_test_context_test.go
@@ -137,9 +137,36 @@ func testAuthorActivityRuntimeOptions(t testing.TB, opts runtimepkg.RuntimeOptio
 		opts.BundleSourceFact = authorActivityTestBundleSourceFact
 	}
 	if opts.ProcessWorkOwner == nil {
-		opts.ProcessWorkOwner = conformanceTestProcessOwner(t)
+		opts.ProcessWorkOwner = worklifetime.NewProcess()
 	}
 	return opts
+}
+
+func closeConformanceRuntimeGeneration(rt *runtimepkg.Runtime, capability runtimestartupownership.ProcessCapability) error {
+	if rt != nil {
+		if err := rt.Shutdown(); err != nil {
+			return fmt.Errorf("shutdown conformance runtime: %w", err)
+		}
+		if rt.Options.ProcessWorkOwner != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			rt.Options.ProcessWorkOwner.Retire()
+			if _, err := rt.Options.ProcessWorkOwner.Join(ctx); err != nil {
+				return fmt.Errorf("join conformance runtime process owner: %w", err)
+			}
+		}
+	}
+	if capability != nil {
+		select {
+		case <-capability.Done():
+			return nil
+		default:
+		}
+		if err := capability.Release(context.Background()); err != nil {
+			return fmt.Errorf("release conformance process capability: %w", err)
+		}
+	}
+	return nil
 }
 
 func installConformanceRuntimeStartupGrant(t testing.TB, ctx context.Context, selected any, rt *runtimepkg.Runtime) runtimestartupownership.ProcessCapability {
@@ -223,14 +250,8 @@ func installConformanceRuntimeStartupGeneration(
 		t.Fatalf("install conformance runtime generation grant: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = rt.Shutdown()
-		select {
-		case <-capability.Done():
-			return
-		default:
-		}
-		if err := capability.Release(context.Background()); err != nil {
-			t.Errorf("release conformance process capability: %v", err)
+		if err := closeConformanceRuntimeGeneration(rt, capability); err != nil {
+			t.Errorf("close conformance runtime generation: %v", err)
 		}
 	})
 	release = false

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -1033,7 +1033,6 @@ func TestStartupRecoveryDecisionSurface_RoundTripsThroughObservabilityReader(t *
 		t.Fatalf("NewRuntime: %v", err)
 	}
 	installConformanceRuntimeStartupGrant(t, ctx, pg, rt)
-	t.Cleanup(func() { _ = rt.Shutdown() })
 
 	startErr := rt.Start(ctx)
 	if startErr == nil || !strings.Contains(startErr.Error(), "runtime.recovery_on_startup=false") {
@@ -1127,11 +1126,6 @@ func TestStartupRecoveryFailurePlatformEventSurface_PreservesRecoveryFailedWitho
 	if err := rt.Start(ctx); err == nil || !strings.Contains(err.Error(), "recover pipeline obligations before delivery enumeration") {
 		t.Fatalf("Start error = %v, want boot-fatal recovery exhaustion failure", err)
 	}
-	defer func() {
-		if err := rt.Shutdown(); err != nil {
-			t.Fatalf("Shutdown: %v", err)
-		}
-	}()
 
 	var resetCount int
 	if err := db.QueryRowContext(ctx, `
@@ -1419,11 +1413,6 @@ func TestStartupManagerReplayAftermathSurface_RoundTripsThroughObservabilityRead
 	if err := rt.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer func() {
-		if err := rt.Shutdown(); err != nil {
-			t.Fatalf("Shutdown: %v", err)
-		}
-	}()
 
 	reader := dashboardserver.NewObservabilityProjection(pg)
 	if reader == nil {

--- a/internal/runtime/conformance/workflow_stage_lifecycle_identity_conformance_test.go
+++ b/internal/runtime/conformance/workflow_stage_lifecycle_identity_conformance_test.go
@@ -212,7 +212,6 @@ func newStageLifecycleIdentityRuntime(t *testing.T, selected any, module conform
 		t.Fatalf("prepare stage lifecycle author activity catalog: %v", err)
 	}
 	processCapability := installConformanceRuntimeStartupGrant(t, testAuthorActivityContext(context.Background()), selected, runtime)
-	t.Cleanup(func() { _ = runtime.Shutdown() })
 	return runtime, processCapability
 }
 

--- a/internal/runtime/conformance/workflow_stage_lifecycle_identity_conformance_test.go
+++ b/internal/runtime/conformance/workflow_stage_lifecycle_identity_conformance_test.go
@@ -103,11 +103,8 @@ func TestSingletonStageLifecyclePreservesRouteAndEntityAcrossRestartOnBothBacken
 			assertStageLifecycleGateIdentity(t, card, activation)
 			assertStageLifecycleTimerIdentity(t, runCtx, lifecycleStore, activation, true)
 
-			if err := runtime.Shutdown(); err != nil {
-				t.Fatalf("shutdown before lifecycle restart: %v", err)
-			}
-			if err := processCapability.Release(context.Background()); err != nil {
-				t.Fatalf("release process capability before lifecycle restart: %v", err)
+			if err := closeConformanceRuntimeGeneration(runtime, processCapability); err != nil {
+				t.Fatalf("close generation before lifecycle restart: %v", err)
 			}
 			runtime, _ = newStageLifecycleIdentityRuntime(t, selected, module)
 			startStageLifecycleIdentityRuntime(t, runtime)

--- a/internal/runtime/eventbus_receiver_authority_e2e_test.go
+++ b/internal/runtime/eventbus_receiver_authority_e2e_test.go
@@ -79,14 +79,6 @@ func TestManagedEffectAuthorityFollowsActingAgentAcrossNodeChain(t *testing.T) {
 				workflowPersistence = runtimepipeline.NewWorkflowPersistence(selected)
 			}
 			processOwner := worklifetime.NewProcess()
-			t.Cleanup(func() {
-				joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				processOwner.Retire()
-				if _, err := processOwner.Join(joinCtx); err != nil {
-					t.Errorf("join receiver authority runtime: %v", err)
-				}
-			})
 			modelRuntime := &closedReceiverManagedLLM{
 				controller: runtimeeffects.NewCompletionController(selected, selected, selected, nil).WithExecutionPosture(executionposture.Live),
 			}
@@ -125,11 +117,8 @@ func TestManagedEffectAuthorityFollowsActingAgentAcrossNodeChain(t *testing.T) {
 			}
 			capability, _ := installExternalRuntimeTestGeneration(t, ctx, selected, rt)
 			t.Cleanup(func() {
-				if err := rt.Shutdown(); err != nil {
-					t.Errorf("shutdown receiver authority runtime: %v", err)
-				}
-				if err := capability.Release(context.Background()); err != nil {
-					t.Errorf("release receiver authority process capability: %v", err)
+				if err := closeExternalRuntimeTestGeneration(rt, processOwner, capability); err != nil {
+					t.Errorf("close receiver authority generation: %v", err)
 				}
 			})
 			if err := rt.PrepareAuthorActivityCatalog(); err != nil {

--- a/internal/runtime/github_app_issue_comment_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_comment_supported_surface_test.go
@@ -47,7 +47,7 @@ func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *te
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runGitHubAppIssueCommentSurface(t, slackManagedConnectorBackend{
@@ -57,6 +57,7 @@ func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *te
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -75,7 +76,7 @@ func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *te
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-comment-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runGitHubAppIssueCommentSurface(t, slackManagedConnectorBackend{
@@ -85,6 +86,7 @@ func TestGitHubAppIssueCommentConnectorPackRoundTripThroughActivityJournal(t *te
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),
@@ -340,7 +342,7 @@ func publishGitHubIssueCommentFromSender(t *testing.T, backend slackManagedConne
 	req.Header.Set("X-GitHub-Delivery", deliveryID)
 	req.Header.Set("X-GitHub-Event", "issue_comment")
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, rec, req, backend.runID, backend.entityID, "github", "github-webhook-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, rec, req, "github", "github-webhook-secret")
 	if rec.Code != wantStatus {
 		t.Fatalf("%s gateway status for delivery %s = %d, want %d body=%s", backend.name, deliveryID, rec.Code, wantStatus, rec.Body.String())
 	}

--- a/internal/runtime/github_app_issue_workflow_supported_surface_test.go
+++ b/internal/runtime/github_app_issue_workflow_supported_surface_test.go
@@ -41,7 +41,7 @@ func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *t
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runGitHubAppIssueWorkflowSurface(t, slackManagedConnectorBackend{
@@ -51,6 +51,7 @@ func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *t
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -69,7 +70,7 @@ func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *t
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "github", "github-webhook-secret", "github-app-issue-workflow-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runGitHubAppIssueWorkflowSurface(t, slackManagedConnectorBackend{
@@ -79,6 +80,7 @@ func TestGitHubAppIssueWorkflowConnectorPackRoundTripThroughActivityJournal(t *t
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),
@@ -442,7 +444,7 @@ func publishGitHubIssueOpenedWithSignature(t *testing.T, backend slackManagedCon
 	req.Header.Set("X-GitHub-Delivery", deliveryID)
 	req.Header.Set("X-GitHub-Event", "issues")
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, rec, req, backend.runID, backend.entityID, "github", "github-webhook-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, rec, req, "github", "github-webhook-secret")
 	if rec.Code != wantStatus {
 		t.Fatalf("%s gateway status for issues delivery %s = %d, want %d body=%s", backend.name, deliveryID, rec.Code, wantStatus, rec.Body.String())
 	}

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/division-sh/swarm/internal/events"
+	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimebustest "github.com/division-sh/swarm/internal/runtime/bus/bustest"
@@ -60,7 +61,7 @@ func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -90,7 +91,7 @@ func TestInboundGateway_GitHubPausedRuntimePersistsAndReleasesSubscribedDispatch
 	req.Header.Set("X-GitHub-Delivery", providerEventID)
 	req.Header.Set("X-GitHub-Event", "push")
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -163,7 +164,7 @@ func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -193,7 +194,7 @@ func TestInboundGateway_SlackPausedRuntimePersistsAndReleasesSubscribedDispatch(
 	req.Header.Set("X-Slack-Request-Timestamp", timestamp)
 	req.Header.Set("X-Slack-Signature", slackWebhookSignature(webhookSecret, timestamp, body))
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -266,7 +267,7 @@ func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -295,7 +296,7 @@ func TestInboundGateway_StripePausedRuntimePersistsAndReleasesSubscribedDispatch
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
 	req.Header.Set("Stripe-Signature", stripeWebhookSignature(webhookSecret, timestamp, body))
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -368,7 +369,7 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, sqliteStore, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -383,7 +384,7 @@ func TestInboundGateway_StripeSQLitePersistsConfiguredManifestDelivery(t *testin
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/customer-a/stripe", strings.NewReader(string(body)))
 	req.Header.Set("Stripe-Signature", stripeWebhookSignature(webhookSecret, timestamp, body))
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, sqliteStore, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -430,7 +431,7 @@ func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *test
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -449,7 +450,7 @@ func TestInboundGateway_TwilioPostgresPersistsConfiguredManifestDelivery(t *test
 	}
 	req := newSignedTwilioRequest(requestURL, webhookSecret, form)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -493,7 +494,7 @@ func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testin
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, sqliteStore, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -512,7 +513,7 @@ func TestInboundGateway_TwilioSQLitePersistsConfiguredManifestDelivery(t *testin
 	}
 	req := newSignedTwilioRequest(requestURL, webhookSecret, form)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, sqliteStore, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -559,7 +560,7 @@ func TestInboundGateway_ShopifyPostgresPersistsConfiguredManifestDelivery(t *tes
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -574,7 +575,7 @@ func TestInboundGateway_ShopifyPostgresPersistsConfiguredManifestDelivery(t *tes
 	req.Header.Set("X-Shopify-Webhook-Id", providerEventID)
 	req.Header.Set("X-Shopify-Topic", "orders/create")
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -618,7 +619,7 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, sqliteStore, runtimebus.EventBusOptions{}, providerEventName)
 	if err != nil {
@@ -633,7 +634,7 @@ func TestInboundGateway_ShopifySQLitePersistsConfiguredManifestDelivery(t *testi
 	req.Header.Set("X-Shopify-Webhook-Id", providerEventID)
 	req.Header.Set("X-Shopify-Topic", "orders/updated")
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, sqliteStore, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -680,7 +681,7 @@ func TestInboundGateway_TelegramPostgresPersistsConfiguredManifestDelivery(t *te
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	pg := storetest.AdmitPostgresRuntimeStore(t, db)
-	seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, providerEventName, "inbound.telegram.text_message")
 	if err != nil {
@@ -693,7 +694,7 @@ func TestInboundGateway_TelegramPostgresPersistsConfiguredManifestDelivery(t *te
 	body := []byte(`{"update_id":123456789,"undeclared_root":"root-must-not-enter-author-story","message":{"message_id":7,"from":{"id":41},"chat":{"id":42,"type":"private"},"text":"hello","undeclared_private":"private-must-not-enter-author-story"}}`)
 	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -727,7 +728,7 @@ func TestInboundGateway_TelegramPostgresPersistsConfiguredManifestDelivery(t *te
 		Reason:    "prove inbound duplicate comparison rejects a schema-valid durable payload conflict",
 	}, "", `UPDATE events SET payload = '{"corrupt":true}'::jsonb, payload_bytes = '{"corrupt":true}'::bytea WHERE event_id = $1::uuid`, eventID)
 	duplicate := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, pg, duplicate, newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body), runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, duplicate, newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body), provider, webhookSecret)
 	if duplicate.Code != http.StatusServiceUnavailable {
 		t.Fatalf("corrupt duplicate status = %d, want 503 body=%s", duplicate.Code, duplicate.Body.String())
 	}
@@ -749,7 +750,7 @@ func TestInboundGateway_TelegramSQLitePersistsConfiguredManifestDelivery(t *test
 	)
 	ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 	sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-	seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
+	target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, entitySlug, provider, webhookSecret, agentID)
 
 	bus, err := newScopedTestEventBus(t, sqliteStore, runtimebus.EventBusOptions{}, providerEventName, "inbound.telegram.text_message")
 	if err != nil {
@@ -762,7 +763,7 @@ func TestInboundGateway_TelegramSQLitePersistsConfiguredManifestDelivery(t *test
 	body := []byte(`{"update_id":987654321,"undeclared_root":"root-must-not-enter-author-story","message":{"message_id":8,"from":{"id":41},"chat":{"id":42,"type":"private"},"text":"hello sqlite","undeclared_private":"private-must-not-enter-author-story"}}`)
 	req := newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, sqliteStore, rec, req, runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, rec, req, provider, webhookSecret)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -796,7 +797,7 @@ func TestInboundGateway_TelegramSQLitePersistsConfiguredManifestDelivery(t *test
 		Reason:    "prove inbound duplicate comparison rejects a schema-valid durable payload conflict",
 	}, `UPDATE events SET payload = '{"corrupt":true}', payload_bytes = CAST('{"corrupt":true}' AS BLOB) WHERE event_id = ?`, "", eventID)
 	duplicate := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, g, bus, sqliteStore, duplicate, newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body), runID, entityID, provider, webhookSecret)
+	handleBoundedProviderDelivery(t, g, bus, target, duplicate, newSignedTelegramRequest("/webhooks/customer-a/telegram", webhookSecret, body), provider, webhookSecret)
 	if duplicate.Code != http.StatusServiceUnavailable {
 		t.Fatalf("corrupt duplicate status = %d, want 503 body=%s", duplicate.Code, duplicate.Body.String())
 	}
@@ -940,7 +941,7 @@ func TestInboundGateway_TypeformAndIntercomPostgresPersistsConfiguredManifestDel
 
 			ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), tc.runID)
 			pg := storetest.AdmitPostgresRuntimeStore(t, db)
-			seedPostgresInboundGatewayRuntime(t, ctx, db, pg, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
+			target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
 
 			bus, err := newScopedTestEventBus(t, pg, runtimebus.EventBusOptions{}, tc.providerEventName)
 			if err != nil {
@@ -953,7 +954,7 @@ func TestInboundGateway_TypeformAndIntercomPostgresPersistsConfiguredManifestDel
 
 			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.webhookSecret, tc.body)
 			rec := httptest.NewRecorder()
-			handleBoundedProviderDelivery(t, g, bus, pg, rec, req, tc.runID, tc.entityID, tc.provider, tc.webhookSecret)
+			handleBoundedProviderDelivery(t, g, bus, target, rec, req, tc.provider, tc.webhookSecret)
 
 			if rec.Code != http.StatusAccepted {
 				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -1032,7 +1033,7 @@ func TestInboundGateway_TypeformAndIntercomSQLitePersistsConfiguredManifestDeliv
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), tc.runID)
 			sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-			seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
+			target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, tc.runID, tc.entityID, tc.flowInstance, "customer-a", tc.provider, tc.webhookSecret, tc.agentID)
 
 			bus, err := newScopedTestEventBus(t, sqliteStore, runtimebus.EventBusOptions{}, tc.providerEventName)
 			if err != nil {
@@ -1045,7 +1046,7 @@ func TestInboundGateway_TypeformAndIntercomSQLitePersistsConfiguredManifestDeliv
 
 			req := tc.newRequest("/webhooks/customer-a/"+tc.provider, tc.webhookSecret, tc.body)
 			rec := httptest.NewRecorder()
-			handleBoundedProviderDelivery(t, g, bus, sqliteStore, rec, req, tc.runID, tc.entityID, tc.provider, tc.webhookSecret)
+			handleBoundedProviderDelivery(t, g, bus, target, rec, req, tc.provider, tc.webhookSecret)
 
 			if rec.Code != http.StatusAccepted {
 				t.Fatalf("status = %d, want 202 body=%s", rec.Code, rec.Body.String())
@@ -1089,7 +1090,7 @@ func seedPostgresInboundGatewayRuntime(
 	provider string,
 	webhookSecret string,
 	agentID string,
-) {
+) runtimepkg.InboundTarget {
 	t.Helper()
 	storetest.RequirePostgresRun(t, ctx, db, storetest.RunFixture{
 		Origin: boundedInboundStandingOrigin(t, provider),
@@ -1148,7 +1149,7 @@ func seedPostgresInboundGatewayRuntime(
 	}); err != nil {
 		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
 	}
-	ensureBoundedStandingTarget(t, ctx, pg, runID, entityID, provider)
+	return seedBoundedStandingTarget(t, ctx, pg, runID, entityID, flowInstance, provider)
 }
 
 func inboundGatewayAgentIdentity(t testing.TB, agentID, flowInstance string) runtimeagentidentity.Identity {
@@ -1198,7 +1199,7 @@ func seedSQLiteInboundGatewayRuntime(
 	provider string,
 	webhookSecret string,
 	agentID string,
-) {
+) runtimepkg.InboundTarget {
 	t.Helper()
 	now := time.Now().UTC()
 	storetest.RequireSQLiteRun(t, ctx, storetest.DatabaseForTest(sqliteStore), storetest.RunFixture{
@@ -1255,7 +1256,7 @@ func seedSQLiteInboundGatewayRuntime(
 	}); err != nil {
 		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
 	}
-	ensureBoundedStandingTarget(t, ctx, sqliteStore, runID, entityID, provider)
+	return seedBoundedStandingTarget(t, ctx, sqliteStore, runID, entityID, flowInstance, provider)
 }
 
 func boundedInboundStandingOrigin(t *testing.T, provider string) runtimerunlifecycle.RunOrigin {

--- a/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
+++ b/internal/runtime/microsoft_graph_connector_client_credentials_supported_surface_test.go
@@ -38,7 +38,7 @@ func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJou
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runMicrosoftGraphClientCredentialsConnectorSurface(t, slackManagedConnectorBackend{
@@ -48,6 +48,7 @@ func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJou
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -66,7 +67,7 @@ func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJou
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "microsoft-graph-client-credentials-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runMicrosoftGraphClientCredentialsConnectorSurface(t, slackManagedConnectorBackend{
@@ -76,6 +77,7 @@ func TestMicrosoftGraphClientCredentialsConnectorPackRoundTripThroughActivityJou
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),

--- a/internal/runtime/node_delivery_startup_recovery_test.go
+++ b/internal/runtime/node_delivery_startup_recovery_test.go
@@ -212,13 +212,6 @@ func TestRuntimeStartHydratesPersistedAgentsBeforeRecoveringNodeDeliveriesParity
 			storetest.CommitSemanticEventWithRoutes(t, ctx, selected, event, []events.DeliveryRoute{nodeRoute}, runtimepipelineobligation.ScopeSubscribed)
 
 			processOwner := worklifetime.NewProcess()
-			t.Cleanup(func() {
-				joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if _, err := processOwner.Join(joinCtx); err != nil {
-					t.Errorf("join startup-order process owner: %v", err)
-				}
-			})
 			hydrated := atomic.Bool{}
 			runtime, err := swarmruntime.NewRuntime(ctx, completeExternalRuntimeTestWorkflowDeps(t, selected, swarmruntime.RuntimeDeps{
 				Config: &config.Config{Runtime: config.RuntimeConfig{RecoveryOnStartup: true}, LLM: config.LLMConfig{Backend: "anthropic"}},
@@ -247,11 +240,8 @@ func TestRuntimeStartHydratesPersistedAgentsBeforeRecoveringNodeDeliveriesParity
 			}
 			capability, grant := installExternalRuntimeTestGeneration(t, ctx, selected, runtime)
 			t.Cleanup(func() {
-				if err := runtime.Shutdown(); err != nil {
-					t.Errorf("shutdown startup-order runtime: %v", err)
-				}
-				if err := capability.Release(context.Background()); err != nil {
-					t.Errorf("release startup-order process capability: %v", err)
+				if err := closeExternalRuntimeTestGeneration(runtime, processOwner, capability); err != nil {
+					t.Errorf("close startup-order generation: %v", err)
 				}
 			})
 			if err := runtime.Manager.ReconcileStaticTopologyForStartup(ctx, source); err != nil {
@@ -342,7 +332,7 @@ func TestRuntimeStartRecoveryDisabledRejectsExecutableDeliveryInventoryParity(t 
 
 					currentRunID := eventtest.UUID("recovery-disabled-current-" + backend + "-" + mode.name + "-" + test.name)
 					currentCtx := startupRecoverySourceContext(currentSource, currentRunID)
-					seedStartupRecoverySourceRun(t, currentCtx, db, backend, currentSource, currentRunID)
+					seedStartupRecoverySourceRun(t, currentCtx, db, backend, selected, currentSource, currentRunID)
 
 					var (
 						deliveryID  string
@@ -357,7 +347,7 @@ func TestRuntimeStartRecoveryDisabledRejectsExecutableDeliveryInventoryParity(t 
 							eventSource = foreignSource
 							eventRunID = eventtest.UUID("recovery-disabled-foreign-" + backend + "-" + mode.name)
 							eventCtx = startupRecoverySourceContext(eventSource, eventRunID)
-							seedStartupRecoverySourceRun(t, eventCtx, db, backend, eventSource, eventRunID)
+							seedStartupRecoverySourceRun(t, eventCtx, db, backend, selected, eventSource, eventRunID)
 						}
 						deliveryCtx = eventCtx
 						event := eventtest.ExistingRunRootIngress(
@@ -471,14 +461,8 @@ func TestRuntimeStartRecoveryDisabledRejectsExecutableDeliveryInventoryParity(t 
 							t.Fatalf("startup decision mutated delivery\nbefore: %#v\nafter:  %#v", before, after)
 						}
 					}
-					if shutdownErr := runtime.Shutdown(); shutdownErr != nil {
-						t.Fatalf("shutdown startup-decision runtime: %v", shutdownErr)
-					}
-					releaseExternalRuntimeTestCapability(t, capability)
-					joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-					defer cancel()
-					if _, joinErr := processOwner.Join(joinCtx); joinErr != nil {
-						t.Fatalf("join startup-decision process owner: %v", joinErr)
+					if closeErr := closeExternalRuntimeTestGeneration(runtime, processOwner, capability); closeErr != nil {
+						t.Fatalf("close startup-decision generation: %v", closeErr)
 					}
 				})
 			}
@@ -509,7 +493,7 @@ func TestCommittedPipelineHandoffCleanupFailureWakesExactDeliveryOnceParity(t *t
 			}
 			runID := eventtest.UUID("pipeline-handoff-cleanup-run-" + backend)
 			ctx := startupRecoverySourceContext(source, runID)
-			seedStartupRecoverySourceRun(t, ctx, db, backend, source, runID)
+			seedStartupRecoverySourceRun(t, ctx, db, backend, selected, source, runID)
 			route := startupRecoveryNodeRoute(t, "complete-task")
 			event := eventtest.ExistingRunRootIngress(
 				eventtest.UUID("pipeline-handoff-cleanup-event-"+backend),
@@ -643,6 +627,7 @@ func seedStartupRecoverySourceRun(
 	ctx context.Context,
 	db *sql.DB,
 	backend string,
+	selected startupRecoveryOrderStore,
 	source runtimecorrelation.BundleSourceFact,
 	runID string,
 ) {
@@ -653,11 +638,7 @@ func seedStartupRecoverySourceRun(
 		Origin: storetest.ScenarioSetupOrigin(), RunID: runID,
 		BundleHash: bundleHash, BundleSource: bundleSource,
 	}
-	if backend == "postgres" {
-		storetest.RequirePostgresRun(t, ctx, db, fixture)
-		return
-	}
-	storetest.RequireSQLiteRun(t, ctx, db, fixture)
+	storetest.RequireRun(t, ctx, selected, fixture)
 }
 
 func loadStartupRecoveryWorkflowModule(t *testing.T) runtimepipeline.WorkflowModule {

--- a/internal/runtime/node_delivery_startup_recovery_test.go
+++ b/internal/runtime/node_delivery_startup_recovery_test.go
@@ -433,6 +433,11 @@ func TestRuntimeStartRecoveryDisabledRejectsExecutableDeliveryInventoryParity(t 
 						t.Fatalf("NewRuntime: %v", runtimeErr)
 					}
 					capability, _ := installExternalRuntimeTestGeneration(t, currentCtx, selected, runtime)
+					t.Cleanup(func() {
+						if closeErr := closeExternalRuntimeTestGeneration(runtime, processOwner, capability); closeErr != nil {
+							t.Errorf("close startup-decision generation: %v", closeErr)
+						}
+					})
 					startErr := runtime.Start(currentCtx)
 					if test.wantDenied {
 						if startErr == nil {
@@ -460,9 +465,6 @@ func TestRuntimeStartRecoveryDisabledRejectsExecutableDeliveryInventoryParity(t 
 						if !reflect.DeepEqual(after, before) {
 							t.Fatalf("startup decision mutated delivery\nbefore: %#v\nafter:  %#v", before, after)
 						}
-					}
-					if closeErr := closeExternalRuntimeTestGeneration(runtime, processOwner, capability); closeErr != nil {
-						t.Fatalf("close startup-decision generation: %v", closeErr)
 					}
 				})
 			}

--- a/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/notion_connector_managed_credential_supported_surface_test.go
@@ -38,7 +38,7 @@ func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "notion-managed-credential-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "notion-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runNotionManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
@@ -48,6 +48,7 @@ func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -66,7 +67,7 @@ func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *
 		)
 		ctx := runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID)
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "notion-managed-credential-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "notion-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runNotionManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
@@ -76,6 +77,7 @@ func TestNotionManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),

--- a/internal/runtime/provider_trigger_registry_external_test.go
+++ b/internal/runtime/provider_trigger_registry_external_test.go
@@ -3,7 +3,11 @@ package runtime_test
 import (
 	"context"
 	"database/sql"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
+	stdruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -49,41 +53,92 @@ func newTestInboundGateway(t *testing.T, bus *runtimebus.EventBus, logger *runti
 
 // handleBoundedProviderDelivery exercises provider parsing through the real
 // standing-service inbound publication operation.
-func handleBoundedProviderDelivery(t *testing.T, gateway *runtimepkg.InboundGateway, bus *runtimebus.EventBus, store runtimepkg.InboundPersistence, w http.ResponseWriter, r *http.Request, runID, entityID, provider, signingSecret string) {
+func handleBoundedProviderDelivery(t *testing.T, gateway *runtimepkg.InboundGateway, bus *runtimebus.EventBus, target runtimepkg.InboundTarget, w http.ResponseWriter, r *http.Request, provider, signingSecret string) {
 	t.Helper()
 	_ = bus
 	plan, err := testProviderTriggerCatalog(t).CompileAdmission(providertriggers.CompileAdmissionRequest{
-		Alias: entityID, Provider: provider, SigningSecret: signingSecret,
+		Alias: target.Alias, Provider: provider, SigningSecret: signingSecret,
 	})
 	if err != nil {
 		t.Fatalf("compile provider admission: %v", err)
 	}
-	target := ensureBoundedStandingTarget(t, r.Context(), store, runID, entityID, provider)
 	target.Provider = provider
 	target.SigningSecret = signingSecret
 	target.AdmissionPlan = plan
 	gateway.HandleResolvedWebhook(w, r, target, nil)
 }
 
-func ensureBoundedStandingTarget(t *testing.T, ctx context.Context, persistence runtimepkg.InboundPersistence, runID, entityID, provider string) runtimepkg.InboundTarget {
+func TestBoundedProviderDeliveryRequiresPreResolvedStandingTarget(t *testing.T) {
+	_, path, _, ok := stdruntime.Caller(0)
+	if !ok {
+		t.Fatal("resolve bounded provider helper source")
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse bounded provider helper source: %v", err)
+	}
+	var handler *ast.FuncDecl
+	for _, declaration := range file.Decls {
+		candidate, ok := declaration.(*ast.FuncDecl)
+		if ok && candidate.Name.Name == "handleBoundedProviderDelivery" {
+			handler = candidate
+			break
+		}
+	}
+	if handler == nil {
+		t.Fatal("bounded provider delivery helper is missing")
+	}
+	forbidden := map[string]struct{}{
+		"seedBoundedStandingTarget":     {},
+		"insertPostgresStandingFixture": {},
+		"insertSQLiteStandingFixture":   {},
+		"BeginTx":                       {},
+		"Exec":                          {},
+		"ExecContext":                   {},
+	}
+	ast.Inspect(handler.Body, func(node ast.Node) bool {
+		switch expression := node.(type) {
+		case *ast.Ident:
+			if _, found := forbidden[expression.Name]; found {
+				t.Errorf("admitted bounded provider handler contains forbidden live setup operation %s", expression.Name)
+			}
+		case *ast.SelectorExpr:
+			if _, found := forbidden[expression.Sel.Name]; found {
+				t.Errorf("admitted bounded provider handler contains forbidden live mutation %s", expression.Sel.Name)
+			}
+		}
+		return true
+	})
+
+	hasResolvedTarget := false
+	for _, field := range handler.Type.Params.List {
+		for _, name := range field.Names {
+			switch name.Name {
+			case "runID", "entityID", "flowInstance", "persistence", "store":
+				t.Errorf("admitted bounded provider handler retains mutable setup coordinate %q", name.Name)
+			case "target":
+				selector, ok := field.Type.(*ast.SelectorExpr)
+				hasResolvedTarget = ok && selector.Sel.Name == "InboundTarget"
+			}
+		}
+	}
+	if !hasResolvedTarget {
+		t.Error("admitted bounded provider handler does not require a pre-resolved inbound target")
+	}
+}
+
+func seedBoundedStandingTarget(t *testing.T, ctx context.Context, persistence runtimepkg.InboundPersistence, runID, entityID, flowInstance, provider string) runtimepkg.InboundTarget {
 	t.Helper()
 	packageKey := "test.provider." + strings.ToLower(strings.TrimSpace(provider))
 	flowID := "bounded-inbound"
 	serviceID := runtimeflowidentity.StandingServiceID(packageKey, flowID)
 	const bundleHash = "bundle-v1:sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	const bundleSource = "ephemeral"
-	var flowInstance string
 
 	switch selected := persistence.(type) {
 	case *storepkg.PostgresStore:
-		if err := storetest.DatabaseForTest(selected).QueryRowContext(ctx, `SELECT flow_instance FROM entity_state WHERE run_id = $1::uuid AND entity_id = $2::uuid`, runID, entityID).Scan(&flowInstance); err != nil {
-			t.Fatalf("load postgres bounded provider flow instance: %v", err)
-		}
 		insertPostgresStandingFixture(t, ctx, storetest.DatabaseForTest(selected), serviceID, packageKey, flowID, flowInstance, entityID, runID, bundleHash, bundleSource)
 	case *storepkg.SQLiteRuntimeStore:
-		if err := storetest.DatabaseForTest(selected).QueryRowContext(ctx, `SELECT flow_instance FROM entity_state WHERE run_id = ? AND entity_id = ?`, runID, entityID).Scan(&flowInstance); err != nil {
-			t.Fatalf("load sqlite bounded provider flow instance: %v", err)
-		}
 		insertSQLiteStandingFixture(t, ctx, selected, serviceID, packageKey, flowID, flowInstance, entityID, runID, bundleHash, bundleSource)
 	default:
 		t.Fatalf("unsupported bounded provider persistence %T", persistence)

--- a/internal/runtime/runlifecycle/executor.go
+++ b/internal/runtime/runlifecycle/executor.go
@@ -284,6 +284,11 @@ func (e *Executor) runChain(ctx context.Context, lease *worklifetime.Lease, cand
 		if validationErr := result.Validate(); validationErr != nil {
 			result = CompletionResult{Outcome: OutcomeRetryCurrent, Retryable: validationErr}
 		}
+		// The admitted attempt may settle during retirement, but its result does
+		// not retain authority to start a successor attempt.
+		if ctx.Err() != nil {
+			return
+		}
 		switch result.Outcome {
 		case OutcomeRetryCurrent:
 			delay := e.retry.Delay(attempt)

--- a/internal/runtime/runlifecycle/executor.go
+++ b/internal/runtime/runlifecycle/executor.go
@@ -275,7 +275,9 @@ func (e *Executor) runChain(ctx context.Context, lease *worklifetime.Lease, cand
 		if err := e.waitUntilDue(ctx, candidate.DueAt); err != nil {
 			return
 		}
-		result, err := e.store.ExecuteCompletionCandidate(ctx, candidate, e.catalog)
+		// Retirement cancels waits and retries, but an admitted persistence
+		// operation must finish before its occurrence lease can settle.
+		result, err := e.store.ExecuteCompletionCandidate(context.WithoutCancel(ctx), candidate, e.catalog)
 		if err != nil {
 			result = CompletionResult{Outcome: OutcomeRetryCurrent, Retryable: err}
 		}

--- a/internal/runtime/runlifecycle/executor.go
+++ b/internal/runtime/runlifecycle/executor.go
@@ -275,6 +275,9 @@ func (e *Executor) runChain(ctx context.Context, lease *worklifetime.Lease, cand
 		if err := e.waitUntilDue(ctx, candidate.DueAt); err != nil {
 			return
 		}
+		if !e.admitAttempt(ctx) {
+			return
+		}
 		// Retirement cancels waits and retries, but an admitted persistence
 		// operation must finish before its occurrence lease can settle.
 		result, err := e.store.ExecuteCompletionCandidate(context.WithoutCancel(ctx), candidate, e.catalog)
@@ -316,6 +319,12 @@ func (e *Executor) runChain(ctx context.Context, lease *worklifetime.Lease, cand
 			return
 		}
 	}
+}
+
+func (e *Executor) admitAttempt(ctx context.Context) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return !e.retiring && ctx.Err() == nil
 }
 
 func (e *Executor) waitUntilDue(ctx context.Context, dueAt time.Time) error {

--- a/internal/runtime/runlifecycle/executor_test.go
+++ b/internal/runtime/runlifecycle/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	goruntime "runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -193,6 +194,97 @@ func TestExecutorRetirementJoinsAcceptedPersistenceAndRejectsNewAdmission(t *tes
 	}
 	if err := receiveValue(t, retired, "runtime occurrence retirement"); err != nil {
 		t.Fatalf("retire runtime occurrence: %v", err)
+	}
+}
+
+func TestExecutorRetirementRejectsZeroDelayRetryAfterActiveAttemptSettles(t *testing.T) {
+	candidate := executorTestCandidate(1)
+	executing := make(chan struct{})
+	release := make(chan struct{})
+	executions := make(chan int, 2)
+	var calls atomic.Int64
+	store := &executorTestStore{
+		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
+			return CandidatePage{Exhausted: true}, nil
+		},
+		execute: func(context.Context, Candidate, TerminalCatalog) (CompletionResult, error) {
+			call := int(calls.Add(1))
+			executions <- call
+			if call == 1 {
+				close(executing)
+				<-release
+				return CompletionResult{}, errors.New("retry after admitted attempt")
+			}
+			return CompletionResult{Outcome: OutcomeAwaitMutation}, nil
+		},
+	}
+	executor, occurrence := newExecutorTestSubject(t, store, ExecutorOptions{RetryPolicy: immediateRetryPolicy{}})
+	if err := executor.Start(context.Background()); err != nil {
+		t.Fatalf("start executor: %v", err)
+	}
+	if err := executor.SubmitCompletionCandidate(context.Background(), candidate); err != nil {
+		t.Fatalf("submit candidate: %v", err)
+	}
+	receiveSignal(t, executing, "candidate execution")
+	if got := receiveValue(t, executions, "first candidate execution"); got != 1 {
+		t.Fatalf("first candidate execution = %d, want 1", got)
+	}
+
+	if err := executor.Retire(context.Background()); err != nil {
+		t.Fatalf("retire executor: %v", err)
+	}
+	close(release)
+	retireRuntimeOccurrence(t, occurrence)
+	select {
+	case call := <-executions:
+		t.Fatalf("candidate execution %d started after retirement", call)
+	default:
+	}
+}
+
+func TestExecutorRetirementRejectsElapsedRearmAfterActiveAttemptSettles(t *testing.T) {
+	candidate := executorTestCandidate(1)
+	executing := make(chan struct{})
+	release := make(chan struct{})
+	executions := make(chan int, 2)
+	var calls atomic.Int64
+	store := &executorTestStore{
+		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
+			return CandidatePage{Exhausted: true}, nil
+		},
+		execute: func(_ context.Context, got Candidate, _ TerminalCatalog) (CompletionResult, error) {
+			call := int(calls.Add(1))
+			executions <- call
+			if call == 1 {
+				close(executing)
+				<-release
+				return CompletionResult{Outcome: OutcomeRearmAt, Candidate: got}, nil
+			}
+			return CompletionResult{Outcome: OutcomeAwaitMutation}, nil
+		},
+	}
+	clock := &executorTestClock{now: candidate.DueAt.Add(time.Second)}
+	executor, occurrence := newExecutorTestSubject(t, store, ExecutorOptions{Clock: clock})
+	if err := executor.Start(context.Background()); err != nil {
+		t.Fatalf("start executor: %v", err)
+	}
+	if err := executor.SubmitCompletionCandidate(context.Background(), candidate); err != nil {
+		t.Fatalf("submit candidate: %v", err)
+	}
+	receiveSignal(t, executing, "candidate execution")
+	if got := receiveValue(t, executions, "first candidate execution"); got != 1 {
+		t.Fatalf("first candidate execution = %d, want 1", got)
+	}
+
+	if err := executor.Retire(context.Background()); err != nil {
+		t.Fatalf("retire executor: %v", err)
+	}
+	close(release)
+	retireRuntimeOccurrence(t, occurrence)
+	select {
+	case call := <-executions:
+		t.Fatalf("candidate execution %d started after retirement", call)
+	default:
 	}
 }
 

--- a/internal/runtime/runlifecycle/executor_test.go
+++ b/internal/runtime/runlifecycle/executor_test.go
@@ -136,19 +136,26 @@ func TestExecutorRetriesCurrentRevisionAndRearmsBeforeSettling(t *testing.T) {
 	retireExecutorTestSubject(t, executor, occurrence)
 }
 
-func TestExecutorRetirementCancelsAcceptedWorkAndRejectsNewAdmission(t *testing.T) {
+func TestExecutorRetirementJoinsAcceptedPersistenceAndRejectsNewAdmission(t *testing.T) {
 	candidate := executorTestCandidate(1)
 	executing := make(chan struct{})
-	cancelled := make(chan error, 1)
+	release := make(chan struct{})
+	completed := make(chan struct{})
+	canceled := make(chan error, 1)
 	store := &executorTestStore{
 		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
 			return CandidatePage{Exhausted: true}, nil
 		},
 		execute: func(ctx context.Context, _ Candidate, _ TerminalCatalog) (CompletionResult, error) {
 			close(executing)
-			<-ctx.Done()
-			cancelled <- context.Cause(ctx)
-			return CompletionResult{}, context.Cause(ctx)
+			select {
+			case <-ctx.Done():
+				canceled <- context.Cause(ctx)
+				return CompletionResult{}, context.Cause(ctx)
+			case <-release:
+			}
+			close(completed)
+			return CompletionResult{Outcome: OutcomeAwaitMutation}, nil
 		},
 	}
 	executor, occurrence := newExecutorTestSubject(t, store, ExecutorOptions{})
@@ -163,13 +170,30 @@ func TestExecutorRetirementCancelsAcceptedWorkAndRejectsNewAdmission(t *testing.
 	if err := executor.Retire(context.Background()); err != nil {
 		t.Fatalf("retire executor: %v", err)
 	}
-	if cause := receiveValue(t, cancelled, "candidate cancellation"); !errors.Is(cause, worklifetime.ErrRetired) {
-		t.Fatalf("candidate cancellation cause = %v, want %v", cause, worklifetime.ErrRetired)
-	}
 	if _, err := executor.ReserveCompletionCandidate(context.Background()); !errors.Is(err, worklifetime.ErrRetired) {
 		t.Fatalf("post-retirement admission error = %v, want %v", err, worklifetime.ErrRetired)
 	}
-	retireRuntimeOccurrence(t, occurrence)
+	retired := make(chan error, 1)
+	go func() {
+		_, err := occurrence.RetireAndWait(context.Background())
+		retired <- err
+	}()
+	select {
+	case err := <-retired:
+		t.Fatalf("runtime occurrence retired before persistence completed: %v", err)
+	default:
+	}
+	close(release)
+	select {
+	case <-completed:
+	case err := <-canceled:
+		t.Fatalf("accepted persistence was canceled during retirement: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for candidate persistence completion")
+	}
+	if err := receiveValue(t, retired, "runtime occurrence retirement"); err != nil {
+		t.Fatalf("retire runtime occurrence: %v", err)
+	}
 }
 
 func TestExecutorRetirementIsContextBoundAndRejectsDelayedReservedSubmission(t *testing.T) {

--- a/internal/runtime/runlifecycle/executor_test.go
+++ b/internal/runtime/runlifecycle/executor_test.go
@@ -40,6 +40,17 @@ type immediateRetryPolicy struct{}
 
 func (immediateRetryPolicy) Delay(int) time.Duration { return 0 }
 
+type blockingRetryPolicy struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingRetryPolicy) Delay(int) time.Duration {
+	close(p.started)
+	<-p.release
+	return 0
+}
+
 func TestExecutorRepresentsCandidateAcrossStartupEnumerationOverlap(t *testing.T) {
 	candidate := executorTestCandidate(1)
 	enumerating := make(chan struct{})
@@ -288,6 +299,94 @@ func TestExecutorRetirementRejectsElapsedRearmAfterActiveAttemptSettles(t *testi
 	}
 }
 
+func TestExecutorRetirementDuringRetryDelayRejectsSuccessorAttempt(t *testing.T) {
+	candidate := executorTestCandidate(1)
+	executions := make(chan int, 2)
+	policy := &blockingRetryPolicy{started: make(chan struct{}), release: make(chan struct{})}
+	var calls atomic.Int64
+	store := &executorTestStore{
+		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
+			return CandidatePage{Exhausted: true}, nil
+		},
+		execute: func(context.Context, Candidate, TerminalCatalog) (CompletionResult, error) {
+			call := int(calls.Add(1))
+			executions <- call
+			if call == 1 {
+				return CompletionResult{}, errors.New("retry after admitted attempt")
+			}
+			return CompletionResult{Outcome: OutcomeAwaitMutation}, nil
+		},
+	}
+	executor, occurrence := newExecutorTestSubject(t, store, ExecutorOptions{RetryPolicy: policy})
+	if err := executor.Start(context.Background()); err != nil {
+		t.Fatalf("start executor: %v", err)
+	}
+	if err := executor.SubmitCompletionCandidate(context.Background(), candidate); err != nil {
+		t.Fatalf("submit candidate: %v", err)
+	}
+	receiveSignal(t, policy.started, "retry policy evaluation")
+	if got := receiveValue(t, executions, "first candidate execution"); got != 1 {
+		t.Fatalf("first candidate execution = %d, want 1", got)
+	}
+
+	if err := executor.Retire(context.Background()); err != nil {
+		t.Fatalf("retire executor: %v", err)
+	}
+	close(policy.release)
+	retireRuntimeOccurrence(t, occurrence)
+	select {
+	case call := <-executions:
+		t.Fatalf("candidate execution %d started after retirement during retry evaluation", call)
+	default:
+	}
+}
+
+func TestExecutorRetirementDuringRearmDueEvaluationRejectsSuccessorAttempt(t *testing.T) {
+	candidate := executorTestCandidate(1)
+	executions := make(chan int, 2)
+	clock := &blockingSecondNowClock{
+		now:           candidate.DueAt.Add(time.Second),
+		secondStarted: make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	var calls atomic.Int64
+	store := &executorTestStore{
+		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
+			return CandidatePage{Exhausted: true}, nil
+		},
+		execute: func(_ context.Context, got Candidate, _ TerminalCatalog) (CompletionResult, error) {
+			call := int(calls.Add(1))
+			executions <- call
+			if call == 1 {
+				return CompletionResult{Outcome: OutcomeRearmAt, Candidate: got}, nil
+			}
+			return CompletionResult{Outcome: OutcomeAwaitMutation}, nil
+		},
+	}
+	executor, occurrence := newExecutorTestSubject(t, store, ExecutorOptions{Clock: clock})
+	if err := executor.Start(context.Background()); err != nil {
+		t.Fatalf("start executor: %v", err)
+	}
+	if err := executor.SubmitCompletionCandidate(context.Background(), candidate); err != nil {
+		t.Fatalf("submit candidate: %v", err)
+	}
+	receiveSignal(t, clock.secondStarted, "rearm due-time evaluation")
+	if got := receiveValue(t, executions, "first candidate execution"); got != 1 {
+		t.Fatalf("first candidate execution = %d, want 1", got)
+	}
+
+	if err := executor.Retire(context.Background()); err != nil {
+		t.Fatalf("retire executor: %v", err)
+	}
+	close(clock.releaseSecond)
+	retireRuntimeOccurrence(t, occurrence)
+	select {
+	case call := <-executions:
+		t.Fatalf("candidate execution %d started after retirement during rearm evaluation", call)
+	default:
+	}
+}
+
 func TestExecutorRetirementIsContextBoundAndRejectsDelayedReservedSubmission(t *testing.T) {
 	store := &executorTestStore{
 		list: func(context.Context, CandidateScope, CandidateCursor, int) (CandidatePage, error) {
@@ -342,6 +441,27 @@ func (c *executorTestClock) Now() time.Time {
 }
 
 func (c *executorTestClock) After(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- c.now
+	return ch
+}
+
+type blockingSecondNowClock struct {
+	now           time.Time
+	secondStarted chan struct{}
+	releaseSecond chan struct{}
+	calls         atomic.Int64
+}
+
+func (c *blockingSecondNowClock) Now() time.Time {
+	if c.calls.Add(1) == 2 {
+		close(c.secondStarted)
+		<-c.releaseSecond
+	}
+	return c.now
+}
+
+func (c *blockingSecondNowClock) After(time.Duration) <-chan time.Time {
 	ch := make(chan time.Time, 1)
 	ch <- c.now
 	return ch

--- a/internal/runtime/runtime_shutdown_admission_test.go
+++ b/internal/runtime/runtime_shutdown_admission_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	runtimeinbound "github.com/division-sh/swarm/internal/runtime/inboundpublication"
 	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
 	runtimerunlifecycle "github.com/division-sh/swarm/internal/runtime/runlifecycle"
+	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
 	"github.com/division-sh/swarm/internal/store/eventfixture"
 	authoractivityfixture "github.com/division-sh/swarm/internal/store/testutil/authoractivityfixture"
 	deliveryfixture "github.com/division-sh/swarm/internal/store/testutil/deliveryfixture"
@@ -47,6 +49,38 @@ func (a runtimeShutdownTestAgent) OnEvent(ctx context.Context, evt events.Event)
 }
 
 type runtimeShutdownManagerStore struct{}
+
+type runtimeShutdownCompletionStore struct {
+	started   chan struct{}
+	release   chan struct{}
+	completed chan struct{}
+	canceled  chan error
+}
+
+func (s *runtimeShutdownCompletionStore) ListCompletionCandidates(
+	context.Context,
+	runtimerunlifecycle.CandidateScope,
+	runtimerunlifecycle.CandidateCursor,
+	int,
+) (runtimerunlifecycle.CandidatePage, error) {
+	return runtimerunlifecycle.CandidatePage{Exhausted: true}, nil
+}
+
+func (s *runtimeShutdownCompletionStore) ExecuteCompletionCandidate(
+	ctx context.Context,
+	_ runtimerunlifecycle.Candidate,
+	_ runtimerunlifecycle.TerminalCatalog,
+) (runtimerunlifecycle.CompletionResult, error) {
+	close(s.started)
+	select {
+	case <-ctx.Done():
+		s.canceled <- context.Cause(ctx)
+		return runtimerunlifecycle.CompletionResult{}, context.Cause(ctx)
+	case <-s.release:
+	}
+	close(s.completed)
+	return runtimerunlifecycle.CompletionResult{Outcome: runtimerunlifecycle.OutcomeAwaitMutation}, nil
+}
 
 type runtimeShutdownDeliveryStore struct {
 	runtimedelivery.Store
@@ -618,6 +652,115 @@ func TestRuntimeShutdownBoundsLifecycleExecutorRetirementByGrace(t *testing.T) {
 	err = <-shutdownErr
 	if err == nil || !strings.Contains(err.Error(), "run lifecycle executor retirement timed out after 20ms") {
 		t.Fatalf("shutdown error = %v, want bounded lifecycle executor timeout", err)
+	}
+}
+
+func TestRuntimeShutdownRetiresGrantAfterCompletionPersistenceSettles(t *testing.T) {
+	store := &runtimeShutdownCompletionStore{
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+		completed: make(chan struct{}),
+		canceled:  make(chan error, 1),
+	}
+	occurrence := runtimeTestOccurrence(t, runtimeTestBundleHash)
+	executor, err := runtimerunlifecycle.NewExecutor(
+		store,
+		runtimerunlifecycle.CandidateScope{BundleHash: runtimeTestBundleHash},
+		runtimerunlifecycle.TerminalCatalog{},
+		occurrence,
+		runtimerunlifecycle.ExecutorOptions{},
+	)
+	if err != nil {
+		t.Fatalf("create run lifecycle executor: %v", err)
+	}
+	if err := executor.Start(context.Background()); err != nil {
+		t.Fatalf("start run lifecycle executor: %v", err)
+	}
+
+	authority, err := runtimestartupownership.NewColdAuthority(runtimestartupownership.AcquireRequest{
+		OwnerID:           "runtime-shutdown-completion-test",
+		BootID:            uuid.NewString(),
+		RuntimeInstanceID: authorActivityTestRuntimeInstanceID,
+	}, "runtime_test")
+	if err != nil {
+		t.Fatalf("construct runtime shutdown authority: %v", err)
+	}
+	grantRetired := make(chan struct{})
+	var grantRetiredOnce sync.Once
+	session := &runtimeTestRetainedSession{
+		authority: authority,
+		agents:    map[string]runtimemanager.PersistedAgent{},
+		grantTransition: func(_ *runtimestartupownership.GrantEvidence, next runtimestartupownership.GrantEvidence) {
+			if next.State == runtimestartupownership.GrantRetired {
+				grantRetiredOnce.Do(func() { close(grantRetired) })
+			}
+		},
+	}
+	_, grant, err := newRuntimeTestProcessCapabilityWithSession(
+		t,
+		nil,
+		nil,
+		testBundleSourceFact(t, runtimeTestBundleHash),
+		authorActivityTestRuntimeInstanceID,
+		session,
+	)
+	if err != nil {
+		t.Fatalf("construct runtime shutdown generation: %v", err)
+	}
+	candidate := runtimerunlifecycle.Candidate{
+		RunID:      "11111111-1111-4111-8111-111111111111",
+		BundleHash: runtimeTestBundleHash,
+		Revision:   1,
+		DueAt:      runtimerunlifecycle.CanonicalTimestamp(time.Now().UTC().Add(-time.Second)),
+	}
+	if err := executor.SubmitCompletionCandidate(context.Background(), candidate); err != nil {
+		t.Fatalf("submit completion candidate: %v", err)
+	}
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion persistence")
+	}
+
+	rt := &Runtime{
+		workOccurrence:       occurrence,
+		runLifecycleExecutor: executor,
+		startupGrant:         grant,
+	}
+	shutdown := make(chan error, 1)
+	go func() { shutdown <- rt.Shutdown() }()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for executor.Ready() {
+		select {
+		case <-deadline.C:
+			t.Fatal("timed out waiting for runtime retirement fence")
+		default:
+			goruntime.Gosched()
+		}
+	}
+	select {
+	case <-grantRetired:
+		t.Fatal("generation grant retired while completion persistence was active")
+	case err := <-shutdown:
+		t.Fatalf("runtime shutdown completed while persistence was active: %v", err)
+	default:
+	}
+	close(store.release)
+	select {
+	case <-store.completed:
+	case err := <-store.canceled:
+		t.Fatalf("completion persistence was canceled during retirement: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion persistence to settle")
+	}
+	if err := <-shutdown; err != nil {
+		t.Fatalf("shutdown runtime: %v", err)
+	}
+	select {
+	case <-grantRetired:
+	default:
+		t.Fatal("generation grant was not retired after completion persistence settled")
 	}
 }
 

--- a/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
+++ b/internal/runtime/slack_connector_managed_credential_supported_surface_test.go
@@ -44,7 +44,7 @@ func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *t
 		)
 		ctx := testAuthorActivityContext(runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID))
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runSlackManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
@@ -54,6 +54,7 @@ func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *t
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -72,7 +73,7 @@ func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *t
 		)
 		ctx := testAuthorActivityContext(runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID))
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "slack-managed-credential-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runSlackManagedCredentialConnectorSurface(t, slackManagedConnectorBackend{
@@ -82,6 +83,7 @@ func TestSlackManagedCredentialConnectorPackRoundTripThroughActivityJournal(t *t
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),
@@ -100,6 +102,7 @@ type slackManagedConnectorBackend struct {
 	eventStore       runtimebus.EventStore
 	deliveryStore    runtimedelivery.Store
 	inboundStore     runtimepkg.InboundPersistence
+	inboundTarget    runtimepkg.InboundTarget
 	activityAttempts runtimeTestActivityAttemptReader
 	persistence      runtimepipeline.WorkflowPersistence
 	runLifecycle     runtimerunlifecycle.OperationOwner
@@ -331,7 +334,7 @@ func publishTelegramMessageToSlack(t *testing.T, backend slackManagedConnectorBa
 	body := []byte(fmt.Sprintf(`{"update_id":%s,"message":{"message_id":7,"chat":{"id":42},"text":%q}}`, updateID, text))
 	req := newSignedTelegramRequest(webhookPath, "telegram-secret", body).WithContext(backend.ctx)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, rec, req, backend.runID, backend.entityID, "telegram", "telegram-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, rec, req, "telegram", "telegram-secret")
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("%s gateway status for update %s = %d, want 202 body=%s", backend.name, updateID, rec.Code, rec.Body.String())
 	}

--- a/internal/runtime/telegram_connector_supported_surface_test.go
+++ b/internal/runtime/telegram_connector_supported_surface_test.go
@@ -49,7 +49,7 @@ func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *te
 		)
 		ctx := testAuthorActivityContext(runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID))
 		pg := storetest.AdmitPostgresRuntimeStore(t, db)
-		seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
+		target := seedPostgresInboundGatewayRuntime(t, ctx, db, pg, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, db, flowInstance, false)
 
 		runTelegramConnectorSupportedSurfaceRoundTrip(t, telegramConnectorSupportedSurfaceBackend{
@@ -59,6 +59,7 @@ func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *te
 			eventStore:    pg,
 			deliveryStore: pg,
 			inboundStore:  pg,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(pg),
 			runLifecycle:  pg,
 			obligations:   pg.PipelineObligations(),
@@ -77,7 +78,7 @@ func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *te
 		)
 		ctx := testAuthorActivityContext(runtimecorrelation.WithRunID(testAuthorActivityContext(context.Background()), runID))
 		sqliteStore := storetest.StartSQLiteRuntimeStoreWithContext(t, ctx)
-		seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
+		target := seedSQLiteInboundGatewayRuntime(t, ctx, sqliteStore, runID, entityID, flowInstance, "customer-a", "telegram", "telegram-secret", "telegram-supported-surface-observer")
 		seedTelegramConnectorSupportedSurfaceWorkflowVersion(t, ctx, storetest.Database(sqliteStore), flowInstance, true)
 
 		runTelegramConnectorSupportedSurfaceRoundTrip(t, telegramConnectorSupportedSurfaceBackend{
@@ -87,6 +88,7 @@ func TestTelegramConnectorBoundedIntegrationRoundTripThroughInboundGateway(t *te
 			eventStore:    sqliteStore,
 			deliveryStore: sqliteStore,
 			inboundStore:  sqliteStore,
+			inboundTarget: target,
 			persistence:   runtimepipeline.NewWorkflowPersistence(sqliteStore),
 			runLifecycle:  sqliteStore,
 			obligations:   sqliteStore.PipelineObligations(),
@@ -105,6 +107,7 @@ type telegramConnectorSupportedSurfaceBackend struct {
 	eventStore       runtimebus.EventStore
 	deliveryStore    runtimedelivery.Store
 	inboundStore     runtimepkg.InboundPersistence
+	inboundTarget    runtimepkg.InboundTarget
 	activityAttempts runtimeTestActivityAttemptReader
 	persistence      runtimepipeline.WorkflowPersistence
 	runLifecycle     runtimerunlifecycle.OperationOwner
@@ -174,7 +177,7 @@ func runTelegramConnectorSupportedSurfaceRoundTrip(t *testing.T, backend telegra
 	validBody := []byte(`{"update_id":123456789,"message":{"message_id":7,"chat":{"id":42},"text":"hello from telegram"}}`)
 	validReq := newSignedTelegramRequest(webhookPath, "telegram-secret", validBody).WithContext(backend.ctx)
 	validRec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, validRec, validReq, backend.runID, backend.entityID, "telegram", "telegram-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, validRec, validReq, "telegram", "telegram-secret")
 	if validRec.Code != http.StatusAccepted {
 		t.Fatalf("%s gateway status = %d, want 202 body=%s", backend.name, validRec.Code, validRec.Body.String())
 	}
@@ -214,7 +217,7 @@ func runTelegramConnectorSupportedSurfaceRoundTrip(t *testing.T, backend telegra
 
 	duplicateReq := newSignedTelegramRequest(webhookPath, "telegram-secret", validBody).WithContext(backend.ctx)
 	duplicateRec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, duplicateRec, duplicateReq, backend.runID, backend.entityID, "telegram", "telegram-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, duplicateRec, duplicateReq, "telegram", "telegram-secret")
 	if duplicateRec.Code != http.StatusOK {
 		t.Fatalf("%s duplicate gateway status = %d, want 200 body=%s", backend.name, duplicateRec.Code, duplicateRec.Body.String())
 	}
@@ -263,7 +266,7 @@ func assertTelegramConnectorSupportedSurfaceMissingToken(t *testing.T, backend t
 	missingTokenBody := []byte(`{"update_id":123456790,"message":{"message_id":8,"chat":{"id":42},"text":"missing token"}}`)
 	req := newSignedTelegramRequest(webhookPath, "telegram-secret", missingTokenBody).WithContext(backend.ctx)
 	rec := httptest.NewRecorder()
-	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundStore, rec, req, backend.runID, backend.entityID, "telegram", "telegram-secret")
+	handleBoundedProviderDelivery(t, gateway, bus, backend.inboundTarget, rec, req, "telegram", "telegram-secret")
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("%s missing-token gateway status = %d, want 202 body=%s", backend.name, rec.Code, rec.Body.String())
 	}

--- a/internal/runtime/workflow_timer_startup_recovery_test.go
+++ b/internal/runtime/workflow_timer_startup_recovery_test.go
@@ -138,16 +138,8 @@ func TestGenericScheduleLifecyclePublishesOneShotAndRecurringThroughWorkflowRunt
 			}
 			capability, _ := installExternalRuntimeTestGeneration(t, ctx, selected, rt)
 			t.Cleanup(func() {
-				if err := rt.Shutdown(); err != nil {
-					t.Errorf("shutdown runtime: %v", err)
-				}
-				if err := capability.Release(context.Background()); err != nil {
-					t.Errorf("release runtime process capability: %v", err)
-				}
-				joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if _, err := process.Join(joinCtx); err != nil {
-					t.Errorf("join process owner: %v", err)
+				if err := closeExternalRuntimeTestGeneration(rt, process, capability); err != nil {
+					t.Errorf("close workflow timer generation: %v", err)
 				}
 			})
 			if err := rt.Start(ctx); err != nil {
@@ -344,13 +336,8 @@ func TestRuntimeStartFailsClosedWhenManagerHydrationWouldWithholdWorkflowTimersO
 			}
 			shutdown := func(label string, rt *swarmruntime.Runtime, process *worklifetime.Process) {
 				t.Helper()
-				if err := rt.Shutdown(); err != nil {
-					t.Fatalf("shutdown %s runtime: %v", label, err)
-				}
-				joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if _, err := process.Join(joinCtx); err != nil {
-					t.Fatalf("join %s process owner: %v", label, err)
+				if err := closeExternalRuntimeTestGeneration(rt, process, nil); err != nil {
+					t.Fatalf("close %s runtime: %v", label, err)
 				}
 			}
 
@@ -386,12 +373,13 @@ func TestRuntimeStartFailsClosedWhenManagerHydrationWouldWithholdWorkflowTimersO
 			capability, _ := installExternalRuntimeTestGeneration(t, ctx, selected, restarted)
 			err = restarted.Start(ctx)
 			if err == nil || !strings.Contains(err.Error(), "hydrate static declaration topology") {
-				shutdown("unexpected successful restart", restarted, restartedProcess)
+				if closeErr := closeExternalRuntimeTestGeneration(restarted, restartedProcess, capability); closeErr != nil {
+					t.Fatalf("close unexpected successful restart: %v", closeErr)
+				}
 				t.Fatalf("Start error = %v, want topology hydration failure before workflow-timer restoration", err)
 			}
-			shutdown("failed restart", restarted, restartedProcess)
-			if err := capability.Release(context.Background()); err != nil {
-				t.Fatalf("release failed-restart process capability: %v", err)
+			if err := closeExternalRuntimeTestGeneration(restarted, restartedProcess, capability); err != nil {
+				t.Fatalf("close failed-restart generation: %v", err)
 			}
 
 			instance, found, err := restarted.Pipeline.Load(ctx, runtimeflowidentity.RouteForInstancePath(runID))
@@ -486,13 +474,8 @@ func TestRuntimeStartRestoresWorkflowTimersWithoutGenericScheduleStoreOnBothStor
 			}
 			shutdown := func(label string, rt *swarmruntime.Runtime, process *worklifetime.Process) {
 				t.Helper()
-				if err := rt.Shutdown(); err != nil {
-					t.Fatalf("shutdown %s runtime: %v", label, err)
-				}
-				joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if _, err := process.Join(joinCtx); err != nil {
-					t.Fatalf("join %s process owner: %v", label, err)
+				if err := closeExternalRuntimeTestGeneration(rt, process, nil); err != nil {
+					t.Fatalf("close %s runtime: %v", label, err)
 				}
 			}
 
@@ -524,13 +507,14 @@ func TestRuntimeStartRestoresWorkflowTimersWithoutGenericScheduleStoreOnBothStor
 			restarted, restartedProcess := newRuntime()
 			capability, _ := installExternalRuntimeTestGeneration(t, ctx, selected, restarted)
 			if err := restarted.Start(ctx); err != nil {
-				shutdown("failed restart", restarted, restartedProcess)
+				if closeErr := closeExternalRuntimeTestGeneration(restarted, restartedProcess, capability); closeErr != nil {
+					t.Fatalf("close failed restart: %v", closeErr)
+				}
 				t.Fatalf("Start restarted runtime: %v", err)
 			}
 			defer func() {
-				shutdown("restarted", restarted, restartedProcess)
-				if err := capability.Release(context.Background()); err != nil {
-					t.Errorf("release restarted process capability: %v", err)
+				if err := closeExternalRuntimeTestGeneration(restarted, restartedProcess, capability); err != nil {
+					t.Errorf("close restarted generation: %v", err)
 				}
 			}()
 			assertBootDetail := func(name, fragment string) {

--- a/internal/serveapp/builder_project_supervisor_test.go
+++ b/internal/serveapp/builder_project_supervisor_test.go
@@ -891,7 +891,8 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 					stores := backend.open(t)
 					startupOwnership := &failOnceFinalizeStartupOwnershipStore{delegate: stores.StartupOwnership}
 					stores.StartupOwnership = startupOwnership
-					processWorkOwner := newSupervisorTestProcessOwner(t)
+					processWorkOwner := worklifetime.NewProcess()
+					var runtimes []*runtimepkg.Runtime
 					runtimeInstanceID := "11111111-1111-1111-1111-111111111111"
 					var active, maxActive atomic.Int32
 					bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
@@ -923,14 +924,28 @@ func TestRuntimeProjectSupervisorReplacementTransfersRealStartupOwnership(t *tes
 						if err != nil {
 							t.Fatalf("NewRuntime(%s): %v", hash, err)
 						}
-						t.Cleanup(func() { _ = rt.Shutdown() })
+						runtimes = append(runtimes, rt)
 						return rt
 					}
 					oldFact := mustServeTestEphemeralBundleSourceFact(oldHash)
 					predecessor := newRuntime(oldHash)
 					predecessor.SystemNodes = []runtimepipeline.BackgroundNode{newReplacementOverlapProbeNode(&active, &maxActive)}
 					processCapability, _ := installSelectedStoreTestProcessTopology(t, stores, predecessor, source, oldFact, runtimeInstanceID)
-					t.Cleanup(func() { _ = processCapability.Release(context.Background()) })
+					t.Cleanup(func() {
+						shutdownFailed := false
+						for i := len(runtimes) - 1; i >= 0; i-- {
+							if err := runtimes[i].Shutdown(); err != nil {
+								t.Errorf("shutdown replacement runtime: %v", err)
+								shutdownFailed = true
+							}
+						}
+						if shutdownFailed {
+							return
+						}
+						if err := closeSelectedStoreTestProcess(processWorkOwner, processCapability); err != nil {
+							t.Errorf("close replacement selected-store generation: %v", err)
+						}
+					})
 					if err := predecessor.Start(context.Background()); err != nil {
 						t.Fatalf("start predecessor: %v", err)
 					}
@@ -1252,7 +1267,8 @@ func TestStandingReplacementAdoptionRestoresWorkflowTimersOnBothStores(t *testin
 					t.Fatalf("set credential %s: %v", key, err)
 				}
 			}
-			processWorkOwner := newSupervisorTestProcessOwner(t)
+			processWorkOwner := worklifetime.NewProcess()
+			var runtimes []*runtimepkg.Runtime
 			runtimeInstanceID := "11111111-1111-1111-1111-111111111111"
 			newRuntime := func() *runtimepkg.Runtime {
 				rt, err := runtimepkg.NewRuntime(context.Background(), runtimeDepsForServeTest(t, stores, &config.Config{}, runtimepkg.RuntimeOptions{
@@ -1265,12 +1281,27 @@ func TestStandingReplacementAdoptionRestoresWorkflowTimersOnBothStores(t *testin
 				if err != nil {
 					t.Fatalf("NewRuntime: %v", err)
 				}
+				runtimes = append(runtimes, rt)
 				return rt
 			}
 
 			predecessor := newRuntime()
 			processCapability, plan := installSelectedStoreTestProcessTopology(t, stores, predecessor, semanticview.Wrap(bundle), fact, runtimeInstanceID)
-			t.Cleanup(func() { _ = processCapability.Release(context.Background()) })
+			t.Cleanup(func() {
+				shutdownFailed := false
+				for i := len(runtimes) - 1; i >= 0; i-- {
+					if err := runtimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second}); err != nil {
+						t.Errorf("shutdown standing replacement runtime: %v", err)
+						shutdownFailed = true
+					}
+				}
+				if shutdownFailed {
+					return
+				}
+				if err := closeSelectedStoreTestProcess(processWorkOwner, processCapability); err != nil {
+					t.Errorf("close standing replacement generation: %v", err)
+				}
+			})
 			if err := predecessor.Start(context.Background()); err != nil {
 				t.Fatalf("start standing predecessor: %v", err)
 			}
@@ -1293,10 +1324,6 @@ func TestStandingReplacementAdoptionRestoresWorkflowTimersOnBothStores(t *testin
 			if err := candidate.Start(context.Background()); err != nil {
 				t.Fatalf("start standing replacement candidate: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = candidate.ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second})
-			})
-
 			var timerEvent, timerStatus string
 			var fireAt any
 			if err := stores.SQLDB.QueryRowContext(context.Background(), `SELECT fire_event, status, fire_at FROM timers`).Scan(&timerEvent, &timerStatus, &fireAt); err != nil {
@@ -1424,19 +1451,31 @@ func TestRuntimeProjectSupervisorStandingReplacementPublishesAdoptedTimerAtomica
 					if err != nil {
 						t.Fatalf("installed capability subjects: %v", err)
 					}
-					processWorkOwner := newSupervisorTestProcessOwner(t)
+					processWorkOwner := worklifetime.NewProcess()
 					var manager *runtimepkg.RuntimeContextManager
 					var createdRuntimes []*runtimepkg.Runtime
+					var processCapability runtimestartupownership.ProcessCapability
 					t.Cleanup(func() {
+						shutdownFailed := false
 						if manager != nil {
 							for _, result := range manager.DeactivateAll(runtimepkg.RuntimeContextCauseUnloaded) {
 								if result.ShutdownErr != nil {
 									t.Errorf("deactivate replacement context %s: %v", result.BundleHash, result.ShutdownErr)
+									shutdownFailed = true
 								}
 							}
 						}
 						for i := len(createdRuntimes) - 1; i >= 0; i-- {
-							_ = createdRuntimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second})
+							if err := createdRuntimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second}); err != nil {
+								t.Errorf("shutdown standing runtime: %v", err)
+								shutdownFailed = true
+							}
+						}
+						if shutdownFailed {
+							return
+						}
+						if err := closeSelectedStoreTestProcess(processWorkOwner, processCapability); err != nil {
+							t.Errorf("close standing selected-store generation: %v", err)
 						}
 					})
 					newRuntime := func(hash string, workflowModule runtimepipeline.WorkflowModule) *runtimepkg.Runtime {
@@ -1456,8 +1495,7 @@ func TestRuntimeProjectSupervisorStandingReplacementPublishesAdoptedTimerAtomica
 
 					predecessor := newRuntime(oldHash, module)
 					oldFact := mustServeTestEphemeralBundleSourceFact(oldHash)
-					processCapability, _ := installSelectedStoreTestProcessTopology(t, stores, predecessor, oldSource, oldFact, "11111111-1111-1111-1111-111111111111")
-					t.Cleanup(func() { _ = processCapability.Release(context.Background()) })
+					processCapability, _ = installSelectedStoreTestProcessTopology(t, stores, predecessor, oldSource, oldFact, "11111111-1111-1111-1111-111111111111")
 					if err := predecessor.Start(context.Background()); err != nil {
 						t.Fatalf("start predecessor: %v", err)
 					}
@@ -1590,7 +1628,8 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 		backend := backend
 		t.Run(backend.name, func(t *testing.T) {
 			stores := backend.open(t)
-			processWorkOwner := newSupervisorTestProcessOwner(t)
+			processWorkOwner := worklifetime.NewProcess()
+			var runtimes []*runtimepkg.Runtime
 			bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
 			if _, err := initializeStateStores(context.Background(), stores, bundle); err != nil {
 				t.Fatalf("initializeStateStores: %v", err)
@@ -1605,7 +1644,7 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 				if err != nil {
 					t.Fatalf("NewRuntime: %v", err)
 				}
-				t.Cleanup(func() { _ = rt.Shutdown() })
+				runtimes = append(runtimes, rt)
 				return rt
 			}
 			var active, maxActive atomic.Int32
@@ -1614,7 +1653,21 @@ func TestRuntimeProjectSupervisorQuiesceTimeoutRestoresFullStoreAuthority(t *tes
 			predecessor.SystemNodes = []runtimepipeline.BackgroundNode{blocker}
 			t.Cleanup(blocker.Release)
 			processCapability, _ := installSelectedStoreTestProcessTopology(t, stores, predecessor, source, fact, runtimeInstanceID)
-			t.Cleanup(func() { _ = processCapability.Release(context.Background()) })
+			t.Cleanup(func() {
+				shutdownFailed := false
+				for i := len(runtimes) - 1; i >= 0; i-- {
+					if err := runtimes[i].Shutdown(); err != nil {
+						t.Errorf("shutdown quiescence runtime: %v", err)
+						shutdownFailed = true
+					}
+				}
+				if shutdownFailed {
+					return
+				}
+				if err := closeSelectedStoreTestProcess(processWorkOwner, processCapability); err != nil {
+					t.Errorf("close quiescence selected-store generation: %v", err)
+				}
+			})
 			if err := predecessor.Start(context.Background()); err != nil {
 				t.Fatalf("start predecessor: %v", err)
 			}
@@ -2051,7 +2104,7 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 		backend := backend
 		t.Run(backend.name, func(t *testing.T) {
 			stores := backend.open(t)
-			processWorkOwner := newSupervisorTestProcessOwner(t)
+			processWorkOwner := worklifetime.NewProcess()
 			bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
 			if _, err := initializeStateStores(context.Background(), stores, bundle); err != nil {
 				t.Fatalf("initializeStateStores: %v", err)
@@ -2078,7 +2131,11 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 			if err != nil {
 				t.Fatalf("acquire rollback process capability: %v", err)
 			}
-			t.Cleanup(func() { _ = capability.Release(context.Background()) })
+			t.Cleanup(func() {
+				if err := closeSelectedStoreTestProcess(processWorkOwner, capability); err != nil {
+					t.Errorf("close serve-context rollback generation: %v", err)
+				}
+			})
 			if _, err := capability.InstallCompleteSourceSet(context.Background(), runtimeagenttopology.SourceSetCommitRequest{
 				OperationID: uuid.NewString(), Plan: plan,
 			}); err != nil {

--- a/internal/serveapp/builder_project_supervisor_test.go
+++ b/internal/serveapp/builder_project_supervisor_test.go
@@ -2105,6 +2105,7 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 		t.Run(backend.name, func(t *testing.T) {
 			stores := backend.open(t)
 			processWorkOwner := worklifetime.NewProcess()
+			runtimes := make([]*runtimepkg.Runtime, 0, 2)
 			bundle := loadWorkflowValidationFixtureBundle(t, "tests/tier8-boot-verification/test-boot-success")
 			if _, err := initializeStateStores(context.Background(), stores, bundle); err != nil {
 				t.Fatalf("initializeStateStores: %v", err)
@@ -2132,8 +2133,17 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 				t.Fatalf("acquire rollback process capability: %v", err)
 			}
 			t.Cleanup(func() {
+				var closeErr error
+				for _, rt := range runtimes {
+					if err := rt.Shutdown(); err != nil {
+						closeErr = errors.Join(closeErr, fmt.Errorf("shutdown serve-context rollback runtime: %w", err))
+					}
+				}
 				if err := closeSelectedStoreTestProcess(processWorkOwner, capability); err != nil {
-					t.Errorf("close serve-context rollback generation: %v", err)
+					closeErr = errors.Join(closeErr, err)
+				}
+				if closeErr != nil {
+					t.Errorf("close serve-context rollback generation: %v", closeErr)
 				}
 			})
 			if _, err := capability.InstallCompleteSourceSet(context.Background(), runtimeagenttopology.SourceSetCommitRequest{
@@ -2156,6 +2166,7 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 				if err != nil {
 					t.Fatalf("NewRuntime(%s): %v", fact.BundleHash(), err)
 				}
+				runtimes = append(runtimes, rt)
 				_, bundleSource := fact.StorageValues()
 				grant, err := capability.IssueGenerationGrant(context.Background(), runtimestartupownership.GrantRequest{
 					BundleHash: fact.BundleHash(), BundleSource: bundleSource, RuntimeInstanceID: runtimeInstanceID,
@@ -2167,7 +2178,6 @@ func TestStartServeRuntimeContextsRollsBackAllPreparedAuthorActivityCatalogs(t *
 				if err := rt.InstallStartupGrant(grant); err != nil {
 					t.Fatalf("install rollback generation grant: %v", err)
 				}
-				t.Cleanup(func() { _ = rt.Shutdown() })
 				contexts = append(contexts, serveRuntimeBundleContext{runtime: rt, bundleSourceFact: fact})
 			}
 			contexts[0].runtime.CloseAdmission()

--- a/internal/serveapp/bundle_delete_replay_test.go
+++ b/internal/serveapp/bundle_delete_replay_test.go
@@ -76,12 +76,30 @@ func TestPostgresBundleDeleteCloseRecoversPendingSurvivorRefreshBeforeReplay(t *
 	secondHash := seedServeRuntimeBundleCatalogRoot(t, ctx, selected, secondRoot)
 	thirdHash := seedServeRuntimeBundleCatalogRoot(t, ctx, selected, thirdRoot)
 	processWorkOwner := worklifetime.NewProcess()
+	var capability runtimestartupownership.ProcessCapability
+	var contexts *runtimepkg.RuntimeContextManager
+	var runtimes []*runtimepkg.Runtime
 	t.Cleanup(func() {
-		processWorkOwner.Retire()
-		joinCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if _, err := processWorkOwner.Join(joinCtx); err != nil {
-			t.Errorf("join process work owner: %v", err)
+		shutdownFailed := false
+		if contexts != nil {
+			for _, result := range contexts.DeactivateAll(runtimepkg.RuntimeContextCauseUnloaded) {
+				if result.ShutdownErr != nil {
+					t.Errorf("shutdown runtime context %s: %v", result.BundleHash, result.ShutdownErr)
+					shutdownFailed = true
+				}
+			}
+		}
+		for i := len(runtimes) - 1; i >= 0; i-- {
+			if err := runtimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second}); err != nil {
+				t.Errorf("shutdown bundle-delete replay runtime: %v", err)
+				shutdownFailed = true
+			}
+		}
+		if shutdownFailed {
+			return
+		}
+		if err := closeSelectedStoreTestProcess(processWorkOwner, capability); err != nil {
+			t.Errorf("close bundle-delete replay generation: %v", err)
 		}
 	})
 	runtimeInstanceID := uuid.NewString()
@@ -104,6 +122,7 @@ func TestPostgresBundleDeleteCloseRecoversPendingSurvivorRefreshBeforeReplay(t *
 		if err != nil {
 			t.Fatalf("NewRuntime(%s): %v", bundleHash, err)
 		}
+		runtimes = append(runtimes, rt)
 		return runtimeFixture{runtime: rt, source: source}
 	}
 	first := newRuntime(firstRoot, firstHash)
@@ -126,7 +145,7 @@ func TestPostgresBundleDeleteCloseRecoversPendingSurvivorRefreshBeforeReplay(t *
 	if err != nil {
 		t.Fatalf("NewSourceSetPlan: %v", err)
 	}
-	capability, err := stores.StartupOwnership.AcquireProcessCapability(ctx, runtimestartupownership.AcquireRequest{
+	capability, err = stores.StartupOwnership.AcquireProcessCapability(ctx, runtimestartupownership.AcquireRequest{
 		OwnerID: "bundle-delete-replay-test", BootID: uuid.NewString(), RuntimeInstanceID: runtimeInstanceID,
 	})
 	if err != nil {
@@ -147,7 +166,7 @@ func TestPostgresBundleDeleteCloseRecoversPendingSurvivorRefreshBeforeReplay(t *
 	if err := third.runtime.Start(ctx); err != nil {
 		t.Fatalf("start third runtime: %v", err)
 	}
-	contexts, err := runtimepkg.NewRuntimeContextManager(nil,
+	contexts, err = runtimepkg.NewRuntimeContextManager(nil,
 		completeServeTestPackContext(t, runtimepkg.BundleContext{BundleSourceFact: first.runtime.Options.BundleSourceFact, Source: first.source, Runtime: first.runtime, WorkOwner: first.runtime.WorkOccurrence()}),
 		completeServeTestPackContext(t, runtimepkg.BundleContext{BundleSourceFact: second.runtime.Options.BundleSourceFact, Source: second.source, Runtime: second.runtime, WorkOwner: second.runtime.WorkOccurrence()}),
 		completeServeTestPackContext(t, runtimepkg.BundleContext{BundleSourceFact: third.runtime.Options.BundleSourceFact, Source: third.source, Runtime: third.runtime, WorkOwner: third.runtime.WorkOccurrence()}),
@@ -155,17 +174,6 @@ func TestPostgresBundleDeleteCloseRecoversPendingSurvivorRefreshBeforeReplay(t *
 	if err != nil {
 		t.Fatalf("NewRuntimeContextManager: %v", err)
 	}
-	t.Cleanup(func() {
-		for _, result := range contexts.DeactivateAll(runtimepkg.RuntimeContextCauseUnloaded) {
-			if result.ShutdownErr != nil {
-				t.Errorf("shutdown runtime context %s: %v", result.BundleHash, result.ShutdownErr)
-			}
-		}
-		if err := capability.Release(context.Background()); err != nil {
-			t.Errorf("release process capability: %v", err)
-		}
-	})
-
 	failingCapability := &failOncePostCommitBundleDeleteCapability{ProcessCapability: capability}
 	supervisor := &runtimeProjectSupervisor{
 		currentRT: first.runtime, runtimeContexts: contexts, processCapability: failingCapability,

--- a/internal/serveapp/bundle_delete_runtime_quiescence_test.go
+++ b/internal/serveapp/bundle_delete_runtime_quiescence_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/division-sh/swarm/internal/config"
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
 	"github.com/division-sh/swarm/internal/runtime/core/worklifetime"
 	"github.com/division-sh/swarm/internal/runtime/executionposture"
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
 	"github.com/division-sh/swarm/internal/store"
 	storebackend "github.com/division-sh/swarm/internal/store/backendselection"
 	"github.com/division-sh/swarm/internal/store/storetest"
@@ -55,6 +57,23 @@ func TestBundleDeleteRuntimeQuiescenceRestoresExactRunningContextOnBothStores(t 
 			fact := mustServeTestEphemeralBundleSourceFact(runtimeContextTestHash("d"))
 			runtimeInstanceID := "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 			processWorkOwner := newSupervisorTestProcessOwner(t)
+			var capability runtimestartupownership.ProcessCapability
+			var runtimes []*runtimepkg.Runtime
+			t.Cleanup(func() {
+				shutdownFailed := false
+				for i := len(runtimes) - 1; i >= 0; i-- {
+					if err := runtimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second}); err != nil {
+						t.Errorf("shutdown bundle-delete runtime: %v", err)
+						shutdownFailed = true
+					}
+				}
+				if shutdownFailed {
+					return
+				}
+				if err := closeSelectedStoreTestProcess(processWorkOwner, capability); err != nil {
+					t.Errorf("close bundle-delete selected-store generation: %v", err)
+				}
+			})
 			providerCatalog := testProviderTriggerCatalog(t)
 			newRuntime := func() *runtimepkg.Runtime {
 				rt, err := runtimepkg.NewRuntime(context.Background(), runtimeDepsForServeTest(t, stores, &config.Config{}, runtimepkg.RuntimeOptions{
@@ -66,12 +85,11 @@ func TestBundleDeleteRuntimeQuiescenceRestoresExactRunningContextOnBothStores(t 
 				if err != nil {
 					t.Fatalf("NewRuntime: %v", err)
 				}
-				t.Cleanup(func() { _ = rt.Shutdown() })
+				runtimes = append(runtimes, rt)
 				return rt
 			}
 			predecessor := newRuntime()
-			capability, _ := installSelectedStoreTestProcessTopology(t, stores, predecessor, source, fact, runtimeInstanceID)
-			t.Cleanup(func() { _ = capability.Release(context.Background()) })
+			capability, _ = installSelectedStoreTestProcessTopology(t, stores, predecessor, source, fact, runtimeInstanceID)
 			if err := predecessor.Start(context.Background()); err != nil {
 				t.Fatalf("start predecessor: %v", err)
 			}

--- a/internal/serveapp/runtime_replacement_source_set_rebind_test.go
+++ b/internal/serveapp/runtime_replacement_source_set_rebind_test.go
@@ -308,6 +308,33 @@ func TestRuntimeProjectSupervisorReplacementRefreshesSurvivingGenerationsOnBothS
 			stores := backend.open(t)
 			cfg := &config.Config{}
 			processWorkOwner := newSupervisorTestProcessOwner(t)
+			var capability runtimestartupownership.ProcessCapability
+			var contexts *runtimepkg.RuntimeContextManager
+			var runtimes []*runtimepkg.Runtime
+			var err error
+			t.Cleanup(func() {
+				shutdownFailed := false
+				if contexts != nil {
+					for _, result := range contexts.DeactivateAll(runtimepkg.RuntimeContextCauseUnloaded) {
+						if result.ShutdownErr != nil {
+							t.Errorf("deactivate runtime context %s: %v", result.BundleHash, result.ShutdownErr)
+							shutdownFailed = true
+						}
+					}
+				}
+				for i := len(runtimes) - 1; i >= 0; i-- {
+					if shutdownErr := runtimes[i].ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second}); shutdownErr != nil {
+						t.Errorf("shutdown replacement runtime: %v", shutdownErr)
+						shutdownFailed = true
+					}
+				}
+				if shutdownFailed {
+					return
+				}
+				if closeErr := closeSelectedStoreTestProcess(processWorkOwner, capability); closeErr != nil {
+					t.Errorf("close replacement selected-store generation: %v", closeErr)
+				}
+			})
 			runtimeInstanceID := uuid.NewString()
 			providerCatalog := testProviderTriggerCatalog(t)
 
@@ -334,9 +361,7 @@ func TestRuntimeProjectSupervisorReplacementRefreshesSurvivingGenerationsOnBothS
 				if err != nil {
 					t.Fatalf("NewRuntime(%s): %v", hash, err)
 				}
-				t.Cleanup(func() {
-					_ = rt.ShutdownWithOptions(runtimepkg.ShutdownOptions{Grace: 5 * time.Second})
-				})
+				runtimes = append(runtimes, rt)
 				return runtimeFixture{root: root, hash: hash, bundle: bundle, source: source, rt: rt}
 			}
 
@@ -374,7 +399,7 @@ func TestRuntimeProjectSupervisorReplacementRefreshesSurvivingGenerationsOnBothS
 			if err != nil {
 				t.Fatalf("construct initial complete source set: %v", err)
 			}
-			capability, err := stores.StartupOwnership.AcquireProcessCapability(ctx, runtimestartupownership.AcquireRequest{
+			capability, err = stores.StartupOwnership.AcquireProcessCapability(ctx, runtimestartupownership.AcquireRequest{
 				OwnerID: "replacement-survivor-test", BootID: uuid.NewString(), RuntimeInstanceID: runtimeInstanceID,
 			})
 			if err != nil {
@@ -392,7 +417,7 @@ func TestRuntimeProjectSupervisorReplacementRefreshesSurvivingGenerationsOnBothS
 				t.Fatalf("start survivor: %v", err)
 			}
 
-			contexts, err := runtimepkg.NewRuntimeContextManager(nil,
+			contexts, err = runtimepkg.NewRuntimeContextManager(nil,
 				completeServeTestPackContext(t, runtimepkg.BundleContext{
 					BundleSourceFact: predecessor.rt.Options.BundleSourceFact, Source: predecessor.source,
 					Runtime: predecessor.rt, WorkOwner: predecessor.rt.WorkOccurrence(),
@@ -405,17 +430,6 @@ func TestRuntimeProjectSupervisorReplacementRefreshesSurvivingGenerationsOnBothS
 			if err != nil {
 				t.Fatalf("NewRuntimeContextManager: %v", err)
 			}
-			t.Cleanup(func() {
-				for _, result := range contexts.DeactivateAll(runtimepkg.RuntimeContextCauseUnloaded) {
-					if result.ShutdownErr != nil {
-						t.Errorf("deactivate runtime context %s: %v", result.BundleHash, result.ShutdownErr)
-					}
-				}
-				if err := capability.Release(context.Background()); err != nil {
-					t.Errorf("release process capability: %v", err)
-				}
-			})
-
 			var ready atomic.Bool
 			ready.Store(true)
 			supervisor := &runtimeProjectSupervisor{

--- a/internal/serveapp/topology_test_helpers_test.go
+++ b/internal/serveapp/topology_test_helpers_test.go
@@ -3,6 +3,7 @@ package serveapp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -253,6 +254,28 @@ func installSelectedStoreTestGeneration(
 		_ = grant.Retire(context.Background())
 		t.Fatalf("install selected-store test generation grant: %v", err)
 	}
+}
+
+func closeSelectedStoreTestProcess(process *worklifetime.Process, capability runtimestartupownership.ProcessCapability) error {
+	if process != nil {
+		process.Retire()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := process.Join(ctx); err != nil {
+			return fmt.Errorf("join selected-store test process: %w", err)
+		}
+	}
+	if capability != nil {
+		select {
+		case <-capability.Done():
+			return nil
+		default:
+		}
+		if err := capability.Release(context.Background()); err != nil {
+			return fmt.Errorf("release selected-store test process capability: %w", err)
+		}
+	}
+	return nil
 }
 
 func registerServeTestEphemeralAgent(t testing.TB, manager *runtimemanager.AgentManager, cfg runtimeactors.AgentConfig) {


### PR DESCRIPTION
## Summary

- create and resolve bounded provider standing targets before EventBus/runtime admission across every supported connector consumer
- keep each mutex-admitted completion-candidate persistence attempt under the existing runtime occurrence until the selected-store call settles; reject every later attempt atomically with executor retirement
- replace independent fixture shutdown/release paths with exact aggregate runtime/process/capability owners, including assertion-safe startup-recovery teardown

## Governing context

This repair is governed by `platform-spec.yaml`:

- `backend_neutral_runtime_mutation_write_boundary`
- `runtime_startup_ownership`
- `process_local_work_lifetime_authority.shutdown_and_store_release.ordering`

The Gate B boundary correction on #2244 is also binding. No authoritative spec change is required: the patch restores the existing rule that accepted persistence remains owned by `Runtime.WorkOccurrence`, while final activated-store close remains ordered by the process-root receipt.

## Semantic migration

- **Canonical owners:** the already-admitted selected-store facade for quiescent setup; `Executor.mu`/`retiring` for exact per-attempt admission; `Runtime.WorkOccurrence` for settlement of an admitted completion attempt; `worklifetime.Process` for final fixture/process close; `GenerationGrant` and `ProcessCapability` for authority terminalization.
- **Old paths now invalid:** request-time standing fact creation after async admission; cancellation of an already-started completion mutation before its occurrence lease settles; retry/rearm persistence admission after retirement; independent or normal-path-only cleanup that can terminalize authority before exact owner join.
- **Production paths checked:** run-lifecycle enumeration/admission/execution/retry/rearm/retirement, runtime shutdown and generation-grant retirement, EventBus/manager teardown, provider request admission, and affected runtime/catalog/conformance/serve fixture families.
- **Migration completeness:** complete for #2244's chosen `quiescent_setup_and_live_generation_terminalization_ordering` child. Intentional post-start temporal/fault mutation remains separately tracked by #2151.

## Verification

- mutex-admission retirement matrix, including retirement during retry-policy and rearm-clock evaluation, at `-count=100`: pass, 500 executions
- full `runlifecycle` package at `-count=100`: pass
- runtime shutdown/grant settlement matrix at `-count=50`: pass
- exact runtime/conformance/serve blocker matrix, six-package matrix, and original mixed manifestation cohort: pass
- duplicate close-owner source census: zero matches
- final uncontaminated `go run ./cmd/swarm-test -- ./...`: pass; uncached `runtimepersistence` tail 546.884s

The revised [Post-Implementation Proof Audit](https://github.com/division-sh/swarm/pull/2331#issuecomment-5403594356) contains the exhaustive owner/consumer census and 18-row manifestation table.

Closes #2244
