### PR TITLE
[agent-d][issue #2300] Publish compiled event schema interface

### DIFF
--- a/.changes/platform/2300.yaml
+++ b/.changes/platform/2300.yaml
@@ -1,0 +1,6 @@
+issue: 2300
+impact: minor
+platform_train: 0.7.0
+summary: Publish the immutable compiled event-schema boundary over current admitted grammar.
+spec_sections:
+  - flow_model.compiled_event_schema_projection

--- a/internal/runtime/contracts/compiled_event_schema.go
+++ b/internal/runtime/contracts/compiled_event_schema.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -160,6 +161,17 @@ func (s CompiledEventSchema) Source() CompiledEventSchemaSource {
 
 var _ CompiledEventSchemaProvider = (*WorkflowContractBundle)(nil)
 
+type currentEventDeclarationRecord struct {
+	packageKey    string
+	flowID        string
+	layer         string
+	sourceFile    string
+	localName     string
+	qualifiedName string
+	entry         EventCatalogEntry
+	types         TypeCatalogDocument
+}
+
 // CompiledEventSchemas enumerates exact importable authored declarations in
 // canonical coordinate order. Pattern declarations, generated events, and
 // noncanonical package restatements do not become resource identities.
@@ -168,45 +180,22 @@ func (b *WorkflowContractBundle) CompiledEventSchemas() ([]CompiledEventSchema, 
 		return nil, nil
 	}
 	var out []CompiledEventSchema
-	for _, view := range b.ProjectViews() {
-		for _, localName := range sortedContractKeys(view.Events) {
-			compiled, ok, err := b.compileCurrentEventDeclaration(
-				view.Paths.Key,
-				"",
-				"project",
-				view.Paths.ProjectEventsFile,
-				localName,
-				localName,
-				view.Events[localName],
-				b.RootTypeCatalog(),
-			)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				out = append(out, compiled)
-			}
+	for _, record := range b.currentEventDeclarationRecords() {
+		compiled, ok, err := b.compileCurrentEventDeclaration(
+			record.packageKey,
+			record.flowID,
+			record.layer,
+			record.sourceFile,
+			record.localName,
+			record.qualifiedName,
+			record.entry,
+			record.types,
+		)
+		if err != nil {
+			return nil, err
 		}
-	}
-	for _, view := range b.FlowViews() {
-		flowID := strings.TrimSpace(view.Paths.ID)
-		for _, localName := range sortedContractKeys(view.Events) {
-			compiled, ok, err := b.compileCurrentEventDeclaration(
-				view.Paths.PackageKey,
-				flowID,
-				"flow",
-				view.Paths.EventsFile,
-				localName,
-				resolvedEventSchemaKey(b, flowID, localName),
-				view.Events[localName],
-				b.ResolvedTypeCatalogForFlow(flowID),
-			)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				out = append(out, compiled)
-			}
+		if ok {
+			out = append(out, compiled)
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -227,6 +216,79 @@ func (b *WorkflowContractBundle) CompiledEventSchemas() ([]CompiledEventSchema, 
 		}
 	}
 	return out, nil
+}
+
+func (b *WorkflowContractBundle) currentEventDeclarationRecords() []currentEventDeclarationRecord {
+	flowDeclarations := map[string]struct{}{}
+	flowRecords := make([]currentEventDeclarationRecord, 0, len(b.FlowTree.ByID))
+	for _, view := range b.FlowViews() {
+		flowID := strings.TrimSpace(view.Paths.ID)
+		for _, localName := range sortedContractKeys(view.Events) {
+			if key := currentEventDeclarationRecordKey(view.Paths.EventsFile, localName); key != "" {
+				flowDeclarations[key] = struct{}{}
+			}
+			flowRecords = append(flowRecords, currentEventDeclarationRecord{
+				packageKey:    view.Paths.PackageKey,
+				flowID:        flowID,
+				layer:         "flow",
+				sourceFile:    view.Paths.EventsFile,
+				localName:     localName,
+				qualifiedName: resolvedEventSchemaKey(b, flowID, localName),
+				entry:         view.Events[localName],
+				types:         b.ResolvedTypeCatalogForFlow(flowID),
+			})
+		}
+	}
+
+	records := make([]currentEventDeclarationRecord, 0, len(b.ProjectViews())+len(flowRecords))
+	for _, view := range b.ProjectViews() {
+		flowID := strings.TrimSpace(view.Paths.OwningFlowID)
+		types := b.RootTypeCatalog()
+		if flowID != "" {
+			types = b.ResolvedTypeCatalogForFlow(flowID)
+		}
+		for _, localName := range sortedContractKeys(view.Events) {
+			if key := currentEventDeclarationRecordKey(view.Paths.ProjectEventsFile, localName); key != "" {
+				if _, representedByFlow := flowDeclarations[key]; representedByFlow {
+					continue
+				}
+			}
+			qualifiedName := localName
+			if flowID != "" {
+				qualifiedName = resolvedOwnedEventSchemaKey(b, flowID, localName)
+			}
+			records = append(records, currentEventDeclarationRecord{
+				packageKey:    view.Paths.Key,
+				flowID:        flowID,
+				layer:         "project",
+				sourceFile:    view.Paths.ProjectEventsFile,
+				localName:     localName,
+				qualifiedName: qualifiedName,
+				entry:         view.Events[localName],
+				types:         types,
+			})
+		}
+	}
+	records = append(records, flowRecords...)
+	return records
+}
+
+func resolvedOwnedEventSchemaKey(bundle *WorkflowContractBundle, flowID, eventName string) string {
+	resolved := resolvedEventSchemaKey(bundle, flowID, eventName)
+	if bundle == nil || strings.TrimSpace(flowID) == "" || resolved != eventidentity.Normalize(eventName) {
+		return resolved
+	}
+	// Ownership discovery proves this project declaration is local to the flow,
+	// even though it is not repeated in the flow view's local event map.
+	return eventidentity.ExternalizeForFlow(bundle.FlowPath(flowID), []string{resolved}, resolved)
+}
+
+func currentEventDeclarationRecordKey(sourceFile, localName string) string {
+	sourceFile = strings.TrimSpace(sourceFile)
+	if sourceFile == "" {
+		return ""
+	}
+	return filepath.Clean(sourceFile) + "\x00" + strings.TrimSpace(localName)
 }
 
 func (b *WorkflowContractBundle) compileCurrentEventDeclaration(

--- a/internal/runtime/contracts/compiled_event_schema.go
+++ b/internal/runtime/contracts/compiled_event_schema.go
@@ -1,0 +1,357 @@
+package contracts
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	"github.com/division-sh/swarm/internal/runtime/core/eventidentity"
+	runtimeidentity "github.com/division-sh/swarm/internal/runtime/core/identity"
+	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
+)
+
+// CompiledEventSchemaClassification distinguishes authored declarations from
+// event shapes that cannot own importable business data.
+type CompiledEventSchemaClassification string
+
+const (
+	CompiledEventSchemaAuthored  CompiledEventSchemaClassification = "authored"
+	CompiledEventSchemaGenerated CompiledEventSchemaClassification = "generated"
+	CompiledEventSchemaPattern   CompiledEventSchemaClassification = "pattern"
+)
+
+// CompiledEventSchemaProvider exposes admitted event semantics without
+// exposing the YAML carrier or requiring consumers to resolve event identity.
+type CompiledEventSchemaProvider interface {
+	CompiledEventSchemas() ([]CompiledEventSchema, error)
+}
+
+type compiledEventFieldValue struct {
+	name       string
+	schema     map[string]any
+	isOptional bool
+}
+
+// CompiledEventField is one immutable field in an admitted event schema.
+type CompiledEventField struct {
+	value *compiledEventFieldValue
+}
+
+func (f CompiledEventField) Name() string {
+	if f.value == nil {
+		return ""
+	}
+	return f.value.name
+}
+
+func (f CompiledEventField) SemanticSchema() map[string]any {
+	if f.value == nil {
+		return nil
+	}
+	return cloneEventSchemaMap(f.value.schema)
+}
+
+func (f CompiledEventField) IsOptional() bool {
+	return f.value != nil && f.value.isOptional
+}
+
+// CompiledEventBusinessKey is present only after admission proves that the
+// field is required and has bool, number, or string value semantics.
+type CompiledEventBusinessKey struct {
+	Field        string
+	SemanticType string
+}
+
+// CompiledEventSchemaSource is diagnostic provenance. It is deliberately not
+// part of the declaration coordinate or acceptance-schema digest.
+type CompiledEventSchemaSource struct {
+	FlowID string
+	Layer  string
+	File   string
+}
+
+type compiledEventSchemaValue struct {
+	packageKey             string
+	eventName              string
+	classification         CompiledEventSchemaClassification
+	fields                 []CompiledEventField
+	businessKey            CompiledEventBusinessKey
+	hasBusinessKey         bool
+	acceptanceSchema       map[string]any
+	canonicalSchema        []byte
+	acceptanceSchemaDigest string
+	source                 CompiledEventSchemaSource
+}
+
+// CompiledEventSchema is the immutable, admitted event-schema boundary used
+// by downstream compilers. Authored maps and source paths never become
+// identity inputs.
+type CompiledEventSchema struct {
+	value *compiledEventSchemaValue
+}
+
+func (s CompiledEventSchema) PackageKey() string {
+	if s.value == nil {
+		return ""
+	}
+	return s.value.packageKey
+}
+
+func (s CompiledEventSchema) EventName() string {
+	if s.value == nil {
+		return ""
+	}
+	return s.value.eventName
+}
+
+func (s CompiledEventSchema) Classification() CompiledEventSchemaClassification {
+	if s.value == nil {
+		return ""
+	}
+	return s.value.classification
+}
+
+func (s CompiledEventSchema) Importable() bool {
+	return s.Classification() == CompiledEventSchemaAuthored
+}
+
+func (s CompiledEventSchema) Fields() []CompiledEventField {
+	if s.value == nil {
+		return nil
+	}
+	return append([]CompiledEventField(nil), s.value.fields...)
+}
+
+func (s CompiledEventSchema) BusinessKey() (CompiledEventBusinessKey, bool) {
+	if s.value == nil || !s.value.hasBusinessKey {
+		return CompiledEventBusinessKey{}, false
+	}
+	return s.value.businessKey, true
+}
+
+func (s CompiledEventSchema) AcceptanceSchema() map[string]any {
+	if s.value == nil {
+		return nil
+	}
+	return cloneEventSchemaMap(s.value.acceptanceSchema)
+}
+
+func (s CompiledEventSchema) CanonicalAcceptanceSchema() []byte {
+	if s.value == nil {
+		return nil
+	}
+	return append([]byte(nil), s.value.canonicalSchema...)
+}
+
+func (s CompiledEventSchema) AcceptanceSchemaDigest() string {
+	if s.value == nil {
+		return ""
+	}
+	return s.value.acceptanceSchemaDigest
+}
+
+func (s CompiledEventSchema) Source() CompiledEventSchemaSource {
+	if s.value == nil {
+		return CompiledEventSchemaSource{}
+	}
+	return s.value.source
+}
+
+var _ CompiledEventSchemaProvider = (*WorkflowContractBundle)(nil)
+
+// CompiledEventSchemas enumerates exact importable authored declarations in
+// canonical coordinate order. Pattern declarations, generated events, and
+// noncanonical package restatements do not become resource identities.
+func (b *WorkflowContractBundle) CompiledEventSchemas() ([]CompiledEventSchema, error) {
+	if b == nil {
+		return nil, nil
+	}
+	var out []CompiledEventSchema
+	for _, view := range b.ProjectViews() {
+		for _, localName := range sortedContractKeys(view.Events) {
+			compiled, ok, err := b.compileCurrentEventDeclaration(
+				view.Paths.Key,
+				"",
+				"project",
+				view.Paths.ProjectEventsFile,
+				localName,
+				localName,
+				view.Events[localName],
+				b.RootTypeCatalog(),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				out = append(out, compiled)
+			}
+		}
+	}
+	for _, view := range b.FlowViews() {
+		flowID := strings.TrimSpace(view.Paths.ID)
+		for _, localName := range sortedContractKeys(view.Events) {
+			compiled, ok, err := b.compileCurrentEventDeclaration(
+				view.Paths.PackageKey,
+				flowID,
+				"flow",
+				view.Paths.EventsFile,
+				localName,
+				resolvedEventSchemaKey(b, flowID, localName),
+				view.Events[localName],
+				b.ResolvedTypeCatalogForFlow(flowID),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				out = append(out, compiled)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].PackageKey() != out[j].PackageKey() {
+			return out[i].PackageKey() < out[j].PackageKey()
+		}
+		return out[i].EventName() < out[j].EventName()
+	})
+	for index := 1; index < len(out); index++ {
+		if out[index-1].PackageKey() == out[index].PackageKey() && out[index-1].EventName() == out[index].EventName() {
+			return nil, fmt.Errorf(
+				"compiled event declaration %s:%s has multiple admitted authored owners (%s and %s)",
+				out[index].PackageKey(),
+				out[index].EventName(),
+				out[index-1].Source().File,
+				out[index].Source().File,
+			)
+		}
+	}
+	return out, nil
+}
+
+func (b *WorkflowContractBundle) compileCurrentEventDeclaration(
+	packageKey, flowID, layer, sourceFile, localName, qualifiedName string,
+	entry EventCatalogEntry,
+	types TypeCatalogDocument,
+) (CompiledEventSchema, bool, error) {
+	if strings.Contains(localName, "*") {
+		return CompiledEventSchema{}, false, nil
+	}
+	if eventidentity.Normalize(localName) != localName {
+		return CompiledEventSchema{}, false, nil
+	}
+	qualifiedName = eventidentity.Normalize(qualifiedName)
+	if !eventidentity.IsValidName(qualifiedName) {
+		return CompiledEventSchema{}, false, nil
+	}
+	admittedPackage, err := runtimeidentity.ParsePackageKey(packageKey)
+	if err != nil {
+		return CompiledEventSchema{}, false, fmt.Errorf("compiled event %q has invalid package owner %q: %w", localName, packageKey, err)
+	}
+	compiled, err := newCompiledEventSchema(
+		admittedPackage.String(),
+		qualifiedName,
+		entry,
+		types,
+		"",
+		CompiledEventSchemaSource{FlowID: strings.TrimSpace(flowID), Layer: layer, File: strings.TrimSpace(sourceFile)},
+	)
+	if err != nil {
+		return CompiledEventSchema{}, false, fmt.Errorf("compile event %s:%s: %w", admittedPackage.String(), qualifiedName, err)
+	}
+	return compiled, true, nil
+}
+
+func newCompiledEventSchema(
+	packageKey, eventName string,
+	entry EventCatalogEntry,
+	types TypeCatalogDocument,
+	businessKeyField string,
+	source CompiledEventSchemaSource,
+) (CompiledEventSchema, error) {
+	schema := eventSchemaFromCatalogEntry(eventName, entry, types).Schema
+	acceptanceSchema := runtimeeventschema.CanonicalAcceptanceSchema(schema)
+	canonicalSchema, err := canonicaljson.Bytes(acceptanceSchema)
+	if err != nil {
+		return CompiledEventSchema{}, fmt.Errorf("canonical acceptance schema: %w", err)
+	}
+	required := compiledEventRequiredFields(acceptanceSchema)
+	properties, _ := acceptanceSchema["properties"].(map[string]any)
+	fieldNames := make([]string, 0, len(properties))
+	for name := range properties {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+	fields := make([]CompiledEventField, 0, len(fieldNames))
+	for _, name := range fieldNames {
+		fieldSchema, ok := properties[name].(map[string]any)
+		if !ok {
+			return CompiledEventSchema{}, fmt.Errorf("field %q semantic schema is %T, want object", name, properties[name])
+		}
+		_, isRequired := required[name]
+		fields = append(fields, CompiledEventField{value: &compiledEventFieldValue{
+			name:       name,
+			schema:     cloneEventSchemaMap(fieldSchema),
+			isOptional: !isRequired,
+		}})
+	}
+	value := &compiledEventSchemaValue{
+		packageKey:             packageKey,
+		eventName:              eventName,
+		classification:         CompiledEventSchemaAuthored,
+		fields:                 fields,
+		acceptanceSchema:       cloneEventSchemaMap(acceptanceSchema),
+		canonicalSchema:        append([]byte(nil), canonicalSchema...),
+		acceptanceSchemaDigest: canonicaljson.HashBytes(canonicalSchema),
+		source:                 source,
+	}
+	if strings.TrimSpace(businessKeyField) != "" {
+		key, err := compileEventBusinessKey(strings.TrimSpace(businessKeyField), fields)
+		if err != nil {
+			return CompiledEventSchema{}, err
+		}
+		value.businessKey = key
+		value.hasBusinessKey = true
+	}
+	return CompiledEventSchema{value: value}, nil
+}
+
+func compiledEventRequiredFields(schema map[string]any) map[string]struct{} {
+	out := map[string]struct{}{}
+	switch values := schema["required"].(type) {
+	case []string:
+		for _, value := range values {
+			out[strings.TrimSpace(value)] = struct{}{}
+		}
+	case []any:
+		for _, value := range values {
+			if name, ok := value.(string); ok {
+				out[strings.TrimSpace(name)] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func compileEventBusinessKey(fieldName string, fields []CompiledEventField) (CompiledEventBusinessKey, error) {
+	for _, field := range fields {
+		if field.Name() != fieldName {
+			continue
+		}
+		if field.IsOptional() {
+			return CompiledEventBusinessKey{}, fmt.Errorf("business key field %q must be required", fieldName)
+		}
+		typeName, _ := field.SemanticSchema()["type"].(string)
+		semanticType := typeName
+		if typeName == "integer" {
+			semanticType = "number"
+		}
+		switch semanticType {
+		case "boolean", "number", "string":
+			return CompiledEventBusinessKey{Field: fieldName, SemanticType: semanticType}, nil
+		default:
+			return CompiledEventBusinessKey{}, fmt.Errorf("business key field %q must have boolean, number, or string semantics, got %q", fieldName, typeName)
+		}
+	}
+	return CompiledEventBusinessKey{}, fmt.Errorf("business key field %q is not declared", fieldName)
+}

--- a/internal/runtime/contracts/compiled_event_schema_test.go
+++ b/internal/runtime/contracts/compiled_event_schema_test.go
@@ -1,0 +1,228 @@
+package contracts
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimeeventschema "github.com/division-sh/swarm/internal/runtime/eventschema"
+)
+
+func TestCompiledEventSchemasCurrentGrammarOwnsOptionalityAndCanonicalSchema(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := currentWorkflowContractsDirForTest(t)
+	eventsFile := filepath.Join(root, "events.yaml")
+	writeFixtureFile(t, eventsFile, `
+item.created:
+  entity_id: string
+  item_id: uuid
+  note: text
+  required: [item_id]
+evidence.recorded:
+  entity_id: string
+  note: string
+item.*: {}
+`)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load compiled-event fixture: %v", err)
+	}
+
+	compiled, err := bundle.CompiledEventSchemas()
+	if err != nil {
+		t.Fatalf("CompiledEventSchemas: %v", err)
+	}
+	event := requireCompiledEventSchema(t, compiled, ".", "item.created")
+	if event.Classification() != CompiledEventSchemaAuthored || !event.Importable() {
+		t.Fatalf("classification = %q, importable=%t", event.Classification(), event.Importable())
+	}
+	if _, ok := event.BusinessKey(); ok {
+		t.Fatal("current grammar adapter invented a business key")
+	}
+	if got := event.Source(); got.Layer != "project" || got.FlowID != "" || got.File != eventsFile {
+		t.Fatalf("source = %#v, want project diagnostic source %s", got, eventsFile)
+	}
+
+	fields := event.Fields()
+	if len(fields) != 3 || fields[0].Name() != "entity_id" || fields[1].Name() != "item_id" || fields[2].Name() != "note" {
+		t.Fatalf("fields = %#v, want closed canonical field order", compiledEventFieldNames(fields))
+	}
+	if !fields[0].IsOptional() || fields[1].IsOptional() || !fields[2].IsOptional() {
+		t.Fatalf("optionality = [%t %t %t], want [true false true]", fields[0].IsOptional(), fields[1].IsOptional(), fields[2].IsOptional())
+	}
+	if got := fields[1].SemanticSchema()["format"]; got != "uuid" {
+		t.Fatalf("item_id admitted schema format = %#v, want uuid", got)
+	}
+
+	resolution, _, ok := EventSchemaForFlowEvent(bundle, "", "item.created")
+	if !ok {
+		t.Fatal("canonical event schema owner did not resolve item.created")
+	}
+	wantSchema := runtimeeventschema.CanonicalAcceptanceSchema(resolution.Schema)
+	wantBytes, err := canonicaljson.Bytes(wantSchema)
+	if err != nil {
+		t.Fatalf("canonical schema owner: %v", err)
+	}
+	if got := event.CanonicalAcceptanceSchema(); !bytes.Equal(got, wantBytes) {
+		t.Fatalf("canonical schema = %s, want %s", got, wantBytes)
+	}
+	if got, want := event.AcceptanceSchemaDigest(), canonicaljson.HashBytes(wantBytes); got != want {
+		t.Fatalf("schema digest = %q, want %q", got, want)
+	}
+
+	for _, candidate := range compiled {
+		if candidate.EventName() == "item.*" {
+			t.Fatal("pattern declaration became an importable compiled event")
+		}
+	}
+
+	// Every readback is detached from the immutable compiled value.
+	event.AcceptanceSchema()["type"] = "array"
+	event.CanonicalAcceptanceSchema()[0] = 'x'
+	fields[1].SemanticSchema()["format"] = "changed"
+	second, err := bundle.CompiledEventSchemas()
+	if err != nil {
+		t.Fatalf("second CompiledEventSchemas: %v", err)
+	}
+	again := requireCompiledEventSchema(t, second, ".", "item.created")
+	if again.AcceptanceSchema()["type"] != "object" || again.Fields()[1].SemanticSchema()["format"] != "uuid" || !bytes.Equal(again.CanonicalAcceptanceSchema(), wantBytes) {
+		t.Fatalf("compiled schema readback mutation escaped into owner: schema=%#v field=%#v bytes=%s", again.AcceptanceSchema(), again.Fields()[1].SemanticSchema(), again.CanonicalAcceptanceSchema())
+	}
+}
+
+func TestCompiledEventSchemasPreservesPackageOwnerAndRejectsRawRestatements(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := writeCompiledEventPackageFixture(t)
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load package fixture: %v", err)
+	}
+	compiled, err := bundle.CompiledEventSchemas()
+	if err != nil {
+		t.Fatalf("CompiledEventSchemas: %v", err)
+	}
+
+	requireCompiledEventSchema(t, compiled, ".", "root.start")
+	flowEvent := requireCompiledEventSchema(t, compiled, ".", "orders/root.start")
+	if got := flowEvent.Source(); got.Layer != "flow" || got.FlowID != "orders" || !strings.HasSuffix(got.File, "/flows/orders/events.yaml") {
+		t.Fatalf("flow source = %#v", got)
+	}
+	requireCompiledEventSchema(t, compiled, "child", "child.ready")
+	for _, event := range compiled {
+		if strings.Contains(event.EventName(), "addon-a") {
+			t.Fatalf("noncanonical package restatement became declaration identity: %s:%s", event.PackageKey(), event.EventName())
+		}
+		if event.Classification() != CompiledEventSchemaAuthored {
+			t.Fatalf("non-authored event escaped exact enumeration: %#v", event.Classification())
+		}
+	}
+}
+
+func TestCompiledEventBusinessKeyAdmissionIsClosed(t *testing.T) {
+	entry := EventCatalogEntry{
+		Payload: EventPayloadSpec{Properties: map[string]EventFieldSpec{
+			"id":    {Type: "integer"},
+			"label": {Type: "string"},
+			"items": {Type: "list<text>"},
+		}},
+		Required: []string{"id", "items"},
+	}
+	compiled, err := newCompiledEventSchema(".", "item.recorded", entry, TypeCatalogDocument{}, "id", CompiledEventSchemaSource{})
+	if err != nil {
+		t.Fatalf("compile required numeric key: %v", err)
+	}
+	key, ok := compiled.BusinessKey()
+	if !ok || key.Field != "id" || key.SemanticType != "number" {
+		t.Fatalf("business key = %#v, %t", key, ok)
+	}
+
+	for _, test := range []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "optional", field: "label", want: "must be required"},
+		{name: "container", field: "items", want: "boolean, number, or string"},
+		{name: "missing", field: "unknown", want: "is not declared"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newCompiledEventSchema(".", "item.recorded", entry, TypeCatalogDocument{}, test.field, CompiledEventSchemaSource{})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("business key error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func requireCompiledEventSchema(t *testing.T, schemas []CompiledEventSchema, packageKey, eventName string) CompiledEventSchema {
+	t.Helper()
+	for _, schema := range schemas {
+		if schema.PackageKey() == packageKey && schema.EventName() == eventName {
+			return schema
+		}
+	}
+	t.Fatalf("compiled event %s:%s missing from %#v", packageKey, eventName, compiledEventCoordinates(schemas))
+	return CompiledEventSchema{}
+}
+
+func compiledEventCoordinates(schemas []CompiledEventSchema) []string {
+	out := make([]string, 0, len(schemas))
+	for _, schema := range schemas {
+		out = append(out, schema.PackageKey()+":"+schema.EventName())
+	}
+	return out
+}
+
+func compiledEventFieldNames(fields []CompiledEventField) []string {
+	out := make([]string, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, field.Name())
+	}
+	return out
+}
+
+func writeCompiledEventPackageFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: compiled-event-package
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+packages:
+  - path: child
+flows:
+  - id: orders
+    flow: orders
+    mode: static
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: compiled-event-package\n")
+	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "root.start: {}\nroot.*: {}\n")
+	for _, name := range []string{"nodes.yaml", "agents.yaml", "tools.yaml", "policy.yaml"} {
+		writeFixtureFile(t, filepath.Join(root, name), "{}\n")
+	}
+
+	writeFixtureFile(t, filepath.Join(root, "child", "package.yaml"), "name: child\nversion: \"1.0.0\"\nflows: []\n")
+	writeFixtureFile(t, filepath.Join(root, "child", "events.yaml"), "child.ready:\n  id: string\n")
+	for _, name := range []string{"nodes.yaml", "agents.yaml", "tools.yaml", "policy.yaml"} {
+		writeFixtureFile(t, filepath.Join(root, "child", name), "{}\n")
+	}
+
+	flowRoot := filepath.Join(root, "flows", "orders")
+	writeFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: orders\nversion: \"1.0.0\"\nflows: []\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), `
+name: orders
+mode: static
+initial_state: active
+states: [active]
+pins:
+  inputs:
+    events: [root.start]
+`)
+	writeFixtureFile(t, filepath.Join(flowRoot, "events.yaml"), "root.start: {}\naddon-a.start: {}\n")
+	for _, name := range []string{"nodes.yaml", "agents.yaml", "tools.yaml", "policy.yaml"} {
+		writeFixtureFile(t, filepath.Join(flowRoot, name), "{}\n")
+	}
+	return root
+}

--- a/internal/runtime/contracts/compiled_event_schema_test.go
+++ b/internal/runtime/contracts/compiled_event_schema_test.go
@@ -79,16 +79,16 @@ item.*: {}
 	}
 
 	// Every readback is detached from the immutable compiled value.
-	event.AcceptanceSchema()["type"] = "array"
-	event.CanonicalAcceptanceSchema()[0] = 'x'
+	acceptance := event.AcceptanceSchema()
+	acceptance["type"] = "array"
+	acceptance["properties"].(map[string]any)["item_id"] = map[string]any{"type": "number"}
+	canonical := event.CanonicalAcceptanceSchema()
+	canonical[0] = 'x'
 	fields[1].SemanticSchema()["format"] = "changed"
-	second, err := bundle.CompiledEventSchemas()
-	if err != nil {
-		t.Fatalf("second CompiledEventSchemas: %v", err)
-	}
-	again := requireCompiledEventSchema(t, second, ".", "item.created")
-	if again.AcceptanceSchema()["type"] != "object" || again.Fields()[1].SemanticSchema()["format"] != "uuid" || !bytes.Equal(again.CanonicalAcceptanceSchema(), wantBytes) {
-		t.Fatalf("compiled schema readback mutation escaped into owner: schema=%#v field=%#v bytes=%s", again.AcceptanceSchema(), again.Fields()[1].SemanticSchema(), again.CanonicalAcceptanceSchema())
+	fields[0], fields[1] = fields[1], CompiledEventField{}
+	againFields := event.Fields()
+	if event.AcceptanceSchema()["type"] != "object" || againFields[0].Name() != "entity_id" || againFields[1].Name() != "item_id" || againFields[1].SemanticSchema()["format"] != "uuid" || !bytes.Equal(event.CanonicalAcceptanceSchema(), wantBytes) {
+		t.Fatalf("compiled schema same-value readback mutation escaped into owner: schema=%#v fields=%#v field=%#v bytes=%s", event.AcceptanceSchema(), compiledEventFieldNames(againFields), againFields[1].SemanticSchema(), event.CanonicalAcceptanceSchema())
 	}
 }
 
@@ -104,12 +104,36 @@ func TestCompiledEventSchemasPreservesPackageOwnerAndRejectsRawRestatements(t *t
 		t.Fatalf("CompiledEventSchemas: %v", err)
 	}
 
+	wantCoordinates := []string{
+		".:orders/root.start",
+		".:root.start",
+		"child:child.ready",
+		"flows/orders/child:orders/child.ready",
+	}
+	if got := compiledEventCoordinates(compiled); !stringSlicesEqual(got, wantCoordinates) {
+		t.Fatalf("compiled coordinates = %#v, want exact physical declaration list %#v", got, wantCoordinates)
+	}
 	requireCompiledEventSchema(t, compiled, ".", "root.start")
 	flowEvent := requireCompiledEventSchema(t, compiled, ".", "orders/root.start")
 	if got := flowEvent.Source(); got.Layer != "flow" || got.FlowID != "orders" || !strings.HasSuffix(got.File, "/flows/orders/events.yaml") {
 		t.Fatalf("flow source = %#v", got)
 	}
 	requireCompiledEventSchema(t, compiled, "child", "child.ready")
+	childEvent := requireCompiledEventSchema(t, compiled, "flows/orders/child", "orders/child.ready")
+	if got := childEvent.Source(); got.Layer != "project" || got.FlowID != "orders" || !strings.HasSuffix(got.File, "/flows/orders/child/events.yaml") {
+		t.Fatalf("flow-owned child source = %#v", got)
+	}
+	childFields := childEvent.Fields()
+	if len(childFields) != 1 || childFields[0].Name() != "order_code" || childFields[0].SemanticSchema()["type"] != "string" {
+		t.Fatalf("flow-owned child fields = %#v/%#v, want OrderCode lowered through owning flow catalog", compiledEventFieldNames(childFields), childFields[0].SemanticSchema())
+	}
+	childCanonical, err := canonicaljson.Bytes(childEvent.AcceptanceSchema())
+	if err != nil {
+		t.Fatalf("flow-owned child canonical schema: %v", err)
+	}
+	if !bytes.Equal(childEvent.CanonicalAcceptanceSchema(), childCanonical) || childEvent.AcceptanceSchemaDigest() != canonicaljson.HashBytes(childCanonical) {
+		t.Fatalf("flow-owned child canonical bytes/digest disagree with admitted schema")
+	}
 	for _, event := range compiled {
 		if strings.Contains(event.EventName(), "addon-a") {
 			t.Fatalf("noncanonical package restatement became declaration identity: %s:%s", event.PackageKey(), event.EventName())
@@ -120,22 +144,120 @@ func TestCompiledEventSchemasPreservesPackageOwnerAndRejectsRawRestatements(t *t
 	}
 }
 
+func TestCompiledEventSchemasExcludeGeneratedAndProviderImportedEvents(t *testing.T) {
+	repo := repoRootForContractsTest(t)
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, "package.yaml"), `
+name: compiled-event-exclusions
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"
+provider_trigger_events:
+  imports:
+    - provider: telegram
+      event: inbound.telegram.text_message
+flows: []
+`)
+	writeFixtureFile(t, filepath.Join(root, "schema.yaml"), "name: compiled-event-exclusions\n")
+	writeFixtureFile(t, filepath.Join(root, "events.yaml"), "source.requested:\n  url: string\n")
+	writeFixtureFile(t, filepath.Join(root, "nodes.yaml"), `
+scanner:
+  id: scanner
+  execution_type: system_node
+  subscribes_to: [source.requested]
+  event_handlers:
+    source.requested:
+      activity:
+        id: source_scrape
+        tool: source_scrape
+        input:
+          url: {cel: payload.url}
+`)
+	writeFixtureFile(t, filepath.Join(root, "tools.yaml"), `
+source_scrape:
+  description: Read a source.
+  handler_type: http
+  effect_class: read_only
+  http:
+    method: GET
+    url: https://example.test
+  input_schema:
+    type: object
+    required: [url]
+    properties:
+      url: {type: string}
+  output_schema:
+    type: object
+    properties:
+      title: {type: string}
+`)
+	writeFixtureFile(t, filepath.Join(root, "agents.yaml"), "{}\n")
+	writeFixtureFile(t, filepath.Join(root, "policy.yaml"), "{}\n")
+	bundle, err := LoadWorkflowContractBundleWithOverrides(repo, root, DefaultPlatformSpecFile(repo))
+	if err != nil {
+		t.Fatalf("load generated/provider fixture: %v", err)
+	}
+	generated := bundle.GeneratedActivityEventEntries()
+	if len(generated) == 0 {
+		t.Fatal("fixture did not materialize generated activity events")
+	}
+	if len(bundle.Package.ProviderTriggerEvents.Imports) != 1 {
+		t.Fatalf("fixture provider imports = %#v", bundle.Package.ProviderTriggerEvents.Imports)
+	}
+	compiled, err := bundle.CompiledEventSchemas()
+	if err != nil {
+		t.Fatalf("CompiledEventSchemas: %v", err)
+	}
+	if got := compiledEventCoordinates(compiled); !stringSlicesEqual(got, []string{".:source.requested"}) {
+		t.Fatalf("compiled coordinates = %#v, want authored event only", got)
+	}
+	for generatedName := range generated {
+		for _, candidate := range compiled {
+			if candidate.EventName() == generatedName {
+				t.Fatalf("generated event %q entered authored compiled declarations", generatedName)
+			}
+		}
+	}
+	for _, imported := range bundle.Package.ProviderTriggerEvents.Imports {
+		for _, candidate := range compiled {
+			if candidate.EventName() == imported.Event {
+				t.Fatalf("provider-imported event %q entered authored compiled declarations", imported.Event)
+			}
+		}
+	}
+}
+
 func TestCompiledEventBusinessKeyAdmissionIsClosed(t *testing.T) {
 	entry := EventCatalogEntry{
 		Payload: EventPayloadSpec{Properties: map[string]EventFieldSpec{
-			"id":    {Type: "integer"},
-			"label": {Type: "string"},
-			"items": {Type: "list<text>"},
+			"bool_key":     {Type: "boolean"},
+			"string_key":   {Type: "string"},
+			"number_key":   {Type: "numeric"},
+			"integer_key":  {Type: "integer"},
+			"object_key":   {Type: "object"},
+			"array_key":    {Type: "list<text>"},
+			"optional_key": {Type: "string"},
 		}},
-		Required: []string{"id", "items"},
+		Required: []string{"bool_key", "string_key", "number_key", "integer_key", "object_key", "array_key"},
 	}
-	compiled, err := newCompiledEventSchema(".", "item.recorded", entry, TypeCatalogDocument{}, "id", CompiledEventSchemaSource{})
-	if err != nil {
-		t.Fatalf("compile required numeric key: %v", err)
-	}
-	key, ok := compiled.BusinessKey()
-	if !ok || key.Field != "id" || key.SemanticType != "number" {
-		t.Fatalf("business key = %#v, %t", key, ok)
+	for _, test := range []struct {
+		field        string
+		semanticType string
+	}{
+		{field: "bool_key", semanticType: "boolean"},
+		{field: "string_key", semanticType: "string"},
+		{field: "number_key", semanticType: "number"},
+		{field: "integer_key", semanticType: "number"},
+	} {
+		t.Run("accept_"+test.field, func(t *testing.T) {
+			compiled, err := newCompiledEventSchema(".", "item.recorded", entry, TypeCatalogDocument{}, test.field, CompiledEventSchemaSource{})
+			if err != nil {
+				t.Fatalf("compile business key: %v", err)
+			}
+			key, ok := compiled.BusinessKey()
+			if !ok || key.Field != test.field || key.SemanticType != test.semanticType {
+				t.Fatalf("business key = %#v, %t, want %q/%q", key, ok, test.field, test.semanticType)
+			}
+		})
 	}
 
 	for _, test := range []struct {
@@ -143,8 +265,9 @@ func TestCompiledEventBusinessKeyAdmissionIsClosed(t *testing.T) {
 		field string
 		want  string
 	}{
-		{name: "optional", field: "label", want: "must be required"},
-		{name: "container", field: "items", want: "boolean, number, or string"},
+		{name: "object", field: "object_key", want: "boolean, number, or string"},
+		{name: "array", field: "array_key", want: "boolean, number, or string"},
+		{name: "optional", field: "optional_key", want: "must be required"},
 		{name: "missing", field: "unknown", want: "is not declared"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -183,6 +306,18 @@ func compiledEventFieldNames(fields []CompiledEventField) []string {
 	return out
 }
 
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
 func writeCompiledEventPackageFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -210,7 +345,7 @@ flows:
 	}
 
 	flowRoot := filepath.Join(root, "flows", "orders")
-	writeFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: orders\nversion: \"1.0.0\"\nflows: []\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "package.yaml"), "name: orders\nversion: \"1.0.0\"\npackages:\n  - path: child\nflows: []\n")
 	writeFixtureFile(t, filepath.Join(flowRoot, "schema.yaml"), `
 name: orders
 mode: static
@@ -221,8 +356,14 @@ pins:
     events: [root.start]
 `)
 	writeFixtureFile(t, filepath.Join(flowRoot, "events.yaml"), "root.start: {}\naddon-a.start: {}\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "types.yaml"), "scalars:\n  OrderCode: text\n")
 	for _, name := range []string{"nodes.yaml", "agents.yaml", "tools.yaml", "policy.yaml"} {
 		writeFixtureFile(t, filepath.Join(flowRoot, name), "{}\n")
+	}
+	writeFixtureFile(t, filepath.Join(flowRoot, "child", "package.yaml"), "name: orders-child\nversion: \"1.0.0\"\nflows: []\n")
+	writeFixtureFile(t, filepath.Join(flowRoot, "child", "events.yaml"), "child.ready:\n  order_code: OrderCode\n")
+	for _, name := range []string{"nodes.yaml", "agents.yaml", "tools.yaml", "policy.yaml"} {
+		writeFixtureFile(t, filepath.Join(flowRoot, "child", name), "{}\n")
 	}
 	return root
 }

--- a/internal/runtime/contracts/schema_registry.go
+++ b/internal/runtime/contracts/schema_registry.go
@@ -727,6 +727,8 @@ func cloneEventSchemaValue(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:
 		return cloneEventSchemaMap(typed)
+	case []string:
+		return append([]string(nil), typed...)
 	case []any:
 		out := make([]any, len(typed))
 		for i := range typed {

--- a/internal/store/testdata/persistence_authority_findings.tsv
+++ b/internal/store/testdata/persistence_authority_findings.tsv
@@ -1763,6 +1763,7 @@ typed-process-local	interface-method	typed	internal/runtime/bus/store.go	Selecte
 typed-process-local	interface-method	typed	internal/runtime/context_manager.go	RunBundleAvailabilityReader	method:LoadRunBundleAvailability	func(context.Context, string) (github.com/division-sh/swarm/internal/runtime/runbundle.Availability, error)
 typed-process-local	interface-method	typed	internal/runtime/contracts/bundle_build.go	BundleBuildStep	method:Name	func() string
 typed-process-local	interface-method	typed	internal/runtime/contracts/bundle_build.go	BundleBuildStep	method:Run	func(context.Context, *github.com/division-sh/swarm/internal/runtime/contracts.BundleBuildContext) error
+typed-process-local	interface-method	typed	internal/runtime/contracts/compiled_event_schema.go	CompiledEventSchemaProvider	method:CompiledEventSchemas	func() ([]github.com/division-sh/swarm/internal/runtime/contracts.CompiledEventSchema, error)
 typed-process-local	interface-method	typed	internal/runtime/contracts/tool_input_schema_value.go	ToolInputSchemaOption	method:applyToolInputSchema	func(*github.com/division-sh/swarm/internal/runtime/contracts.toolInputSchemaDraft) error
 typed-process-local	interface-method	typed	internal/runtime/contracts/tool_schema_entry_value.go	ToolSchemaEntryOption	method:applyToolSchemaEntry	func(*github.com/division-sh/swarm/internal/runtime/contracts.toolSchemaEntryDraft) error
 typed-process-local	interface-method	typed	internal/runtime/contracts/workflow_contract_loading.go	PackAdmissionProjection	method:EffectivePackInventoryDigest	func() string

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -12957,6 +12957,34 @@ flow_model:
       not by copy.
     enforcement: At boot, if the same event name appears in multiple flow event files, the platform logs a warning. The emitter
       flow's definition is authoritative.
+  compiled_event_schema_projection:
+    status: implemented_current_grammar_adapter
+    owner: internal/runtime/contracts.WorkflowContractBundle.CompiledEventSchemas
+    rule: >-
+      Downstream compilers consume one immutable admitted CompiledEventSchema projection and never inspect events.yaml,
+      EventCatalogEntry maps, required lists, package aliases, or generated-event registries directly. The projection
+      enumerates only exact importable authored declarations after package and event admission, in canonical
+      (package_key, qualified_event_name) order. Pattern declarations, generated events, provider imports, and
+      noncanonical package restatements do not become declaration identities.
+    fields: >-
+      Each declaration carries its canonical package key and qualified authored event name, authored classification,
+      a closed ordered field set with admitted semantic schema and IsOptional, an optional already-admitted scalar
+      business key, canonical acceptance-schema bytes and digest, and diagnostic source provenance. Diagnostic source
+      is never identity or hash input. Readbacks are mutation-isolated.
+    canonical_schema_owner: >-
+      internal/runtime/contracts eventSchemaFromCatalogEntry lowers admitted type meaning;
+      internal/runtime/eventschema.CanonicalAcceptanceSchema owns the accepted schema subset; and
+      internal/runtime/canonicaljson owns canonical bytes and their sha256 digest. Consumers must not reserialize or
+      independently hash raw event declarations.
+    current_grammar_adapter: >-
+      Until the presence-preserving T? grammar wave lands behind this same interface, IsOptional is derived once from
+      the admitted current required-list semantics. The interface does not preserve required-list syntax and no
+      downstream consumer may read that syntax.
+    migration_boundary: >-
+      This first slice publishes the stable compiled interface. The presence-preserving YAML substrate, T? grammar,
+      required-list retirement, business-key authoring, producer-only event schema ownership, provenance ledger, and
+      remaining decoder-family migrations land in the gated #2300 waves behind this interface without changing its
+      consumer semantics.
   stateless_flows:
     description: 'Some flows are stateless producers — they process events without tracking entity lifecycle. A signal-processing
       flow is an example: it receives inputs, filters them, and emits results without maintaining per-entity state.'


### PR DESCRIPTION
## Summary

- publish `CompiledEventSchemaProvider` and immutable compiled event-schema values for admitted current-grammar event declarations
- preserve exact package/event identity, field semantic schema, required-list-derived optionality, canonical acceptance bytes/digest, classification, and diagnostic source
- document the current adapter and the later presence-preserving grammar migration in authoritative `platform-spec.yaml`

## Governing context

- Binding issue/gate: #2300, including the approved expedited first-slice ruling for the compiled event-schema interface and current-grammar adapter
- Authoritative spec: `platform-spec.yaml` -> `flow_model.compiled_event_schema_projection`
- Adjacent canonical owners reused rather than duplicated: `runtimeidentity.ParsePackageKey`, `eventidentity.IsValidName`, `eventschema.CanonicalAcceptanceSchema`, and `canonicaljson.Bytes` / `canonicaljson.HashBytes`

## Semantic migration

- **New canonical owner for downstream compilation:** `contracts.CompiledEventSchemaProvider`, implemented by `WorkflowContractBundle.CompiledEventSchemas`
- **Old path now non-authoritative:** raw `EventCatalogEntry` maps, raw `required` lists, package aliases/restatements, and ad hoc acceptance-schema serialization must not serve as downstream compiler identity or optionality evidence
- **Production paths checked:** project and flow authored event declarations, nested package ownership, wildcard pattern declarations, noncanonical package-qualified restatements, and generated/provider-imported registries
- **Migration completeness:** intentionally incomplete at the parent level. This PR closes only the approved interface/current-grammar-adapter slice. `T?`, YAML substrate/presence provenance, business-key authoring, decoder migration, and remaining 103-class migrations remain owned by #2300 and its ruled sequence.
- No compatibility path, legacy migration, alternate canonical owner, or raw-schema fallback is introduced.

## Proof

- `go test ./...`
- `go test -race ./internal/runtime/contracts -run '^TestCompiledEvent' -count=3`
- `go test ./internal/runtime/contracts ./internal/runtime/semanticview ./internal/runtime/eventschema ./internal/store -run 'TestCompiledEvent|TestPersistenceAuthorityFindingRegistry' -count=1`
- `yq eval '.flow_model.compiled_event_schema_projection.owner' platform-spec.yaml`
- change-fragment YAML parse and `git diff --check`

Part of #2300
