### PR TITLE
[agent-e][issue #2359] Promote SQLite bundle registration

### DIFF
--- a/internal/apiv1/public_surface_backend_matrix_test.go
+++ b/internal/apiv1/public_surface_backend_matrix_test.go
@@ -1120,6 +1120,10 @@ func publicSurfaceOperatorReadProofRefCoversMethodBackend(ref publicSurfaceProof
 
 func publicSurfaceSelectedOperatorReadAPIProofs() map[string]publicSurfaceSelectedOperatorReadAPIProof {
 	return map[string]publicSurfaceSelectedOperatorReadAPIProof{
+		"TestServedParityHarnessBundleRegisterLifecycle": {
+			Backends: []string{"default_sqlite", "explicit_postgres"},
+			Methods:  []string{"bundle.get"},
+		},
 		"TestServedParityHarnessOperatorChannelLifecycle": {
 			Backends: []string{"default_sqlite", "explicit_postgres"},
 			Methods:  []string{"channel.list"},
@@ -1528,6 +1532,21 @@ func validatePublicSurfaceServedMutatingLifecycleRows(rowsByID map[string]public
 
 func expectedPublicSurfaceRowShapes() map[string]publicSurfaceExpectedRowShape {
 	return map[string]publicSurfaceExpectedRowShape{
+		"bundle_register_served_lifecycle": {
+			Classification:       "add_to_matrix",
+			Tier:                 "required_smoke",
+			Backends:             []string{"default_sqlite", "explicit_postgres"},
+			APIMethods:           []string{"bundle.register"},
+			OpenRPCMatrixMethods: []string{"bundle.register"},
+			ProofDimensions:      []string{"canonical_store_owner", "cli_v1_path", "openrpc_publication", "real_runtime_startup", "real_v1_handler", "selected_store", "served_mutating_lifecycle"},
+			GoTestProofRefs: []string{
+				"TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders",
+				"TestServedParityHarnessBundleRegisterLifecycle",
+				"TestRunServeRuntimeBundleRegisterLifecycleDefaultSQLite",
+				"TestRunServeRuntimeBundleRegisterLifecyclePostgres",
+				"TestBundleCatalogWriteParity",
+			},
+		},
 		"api_idempotency_selected_store": {
 			Classification:       "already_covered_by_existing_proof",
 			Tier:                 "required_smoke",

--- a/internal/apiv1/testdata/public_surface_backend_matrix.yaml
+++ b/internal/apiv1/testdata/public_surface_backend_matrix.yaml
@@ -38,18 +38,16 @@ active_trackers:
     watchlist: operator_surfaces.v1_openrpc_api_conformance
 mutating_api_parity_ledger:
   - method: bundle.register
-    classification: postgres_only_with_spec_ref
-    backends: [postgres_only]
-    spec_ref: platform-spec.yaml#engine.runtime_core_persistence_store_contracts.optional_public_mutating_backend_support.bundle_register
+    classification: dual_backend_served_proof
+    backends: [default_sqlite, explicit_postgres]
+    scenario: bundle_register_lifecycle
     proof_refs:
-      - {kind: artifact, path: platform-spec.yaml}
-      - {kind: go_test, name: TestOperatorBundleRegisterHandlersMaterializeCanonicalProjectionAndIdempotency}
-      - {kind: go_test, name: TestRunServeRuntimeSQLiteOptionalMutatorsFailClosed}
+      - {kind: go_test, name: TestServedParityHarnessBundleRegisterLifecycle}
     notes: >
-      Catalog upload/register behavior consumes the bundle catalog register
-      writer capability. SQLite wires read-only bundle catalog support and is
-      served fail-closed for bundle.register until a separately gated SQLite
-      writer owner exists.
+      The real served harness proves canonical insertion, keyed and catalog
+      replay, malformed rejection, exact conflict detection, transaction
+      rollback and retry, catalog-only behavior, and terminal bundle.get
+      readback through the selected SQLite and PostgreSQL owners.
   - method: event.publish
     classification: dual_backend_served_proof
     backends: [default_sqlite, explicit_postgres]
@@ -425,6 +423,7 @@ operator_read_api_parity_ledger:
     classification: dual_backend_api_proof
     backends: [default_sqlite, explicit_postgres]
     proof_refs:
+      - {kind: go_test, name: TestServedParityHarnessBundleRegisterLifecycle, backends: [default_sqlite, explicit_postgres]}
       - {kind: go_test, name: TestSQLiteBundleCatalogOwnerBacksSupportedAPISurface, backends: [default_sqlite]}
       - {kind: go_test, name: TestPostgresBundleCatalogOwnerBacksSupportedAPISurface, backends: [explicit_postgres]}
   - method: bundle.list
@@ -828,6 +827,34 @@ rows:
       The row proves representative mutating public methods consume selected
       store idempotency owners without duplicating every idempotent OpenRPC
       method across both backends.
+
+  - id: bundle_register_served_lifecycle
+    surface: swarm bundle register and /v1/rpc bundle.register selected-backend catalog lifecycle
+    classification: add_to_matrix
+    tier: required_smoke
+    backends: [default_sqlite, explicit_postgres]
+    cli_commands: [bundle]
+    api_methods: [bundle.register]
+    openrpc_matrix_methods: [bundle.register]
+    store_owners:
+      - internal/cliapp bundle register CLI
+      - /v1/rpc bundle.register canonical projection and idempotency owner
+      - internal/store/selected BundleRegisterWriter capability
+      - selected SQLite/PostgreSQL UpsertBundleCatalog transaction
+      - /v1/rpc bundle.get terminal readback
+    proof_dimensions: [selected_store, real_v1_handler, cli_v1_path, real_runtime_startup, canonical_store_owner, openrpc_publication, served_mutating_lifecycle]
+    proof_refs:
+      - {kind: go_test, name: TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders}
+      - {kind: go_test, name: TestServedParityHarnessBundleRegisterLifecycle}
+      - {kind: go_test, name: TestRunServeRuntimeBundleRegisterLifecycleDefaultSQLite}
+      - {kind: go_test, name: TestRunServeRuntimeBundleRegisterLifecyclePostgres}
+      - {kind: go_test, name: TestBundleCatalogWriteParity}
+      - {kind: artifact, path: platform-spec.yaml}
+    notes: >
+      #2359 promotes the public SQLite writer without merging it with private
+      serve ingest. Both served backends prove insert/replay/conflict/malformed/
+      rollback behavior, no runtime source replacement, and exact public
+      catalog readback.
 
   - id: event_publish_cli
     surface: swarm event publish create-new publication and exact v1 RPC command shape

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -2388,6 +2388,15 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 	if catalogReplay.Registered || catalogReplay.BundleHash != insert.BundleHash {
 		t.Fatalf("%s catalog bundle.register replay = %#v, want existing %s", rt.Backend, catalogReplay, insert.BundleHash)
 	}
+	unavailable := requireServedJSONRPCError(t, rt.Endpoint, "event.publish", map[string]any{
+		"event_name":      "item.received",
+		"bundle_hash":     insert.BundleHash,
+		"payload":         map[string]any{"item_id": "registered-but-unloaded"},
+		"idempotency_key": "issue-2359-" + rt.Backend + "-catalog-only",
+	})
+	if unavailable.Data["code"] != apiv1.BundleUnavailableCode {
+		t.Fatalf("%s publication against registered-only bundle data = %#v, want %s", rt.Backend, unavailable.Data, apiv1.BundleUnavailableCode)
+	}
 
 	beforeMalformed := servedBundleRegisterTableCount(t, rt.DB, "bundles")
 	malformed := requireServedJSONRPCError(t, rt.Endpoint, "bundle.register", map[string]any{

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -2099,19 +2099,25 @@ func TestServedParityHarnessConversationForkLifecycle(t *testing.T) {
 	servedparity.RunScenarioGroup(t, scenarios, runServedConversationForkBackendProof)
 }
 
+func TestRunServeRuntimeBundleRegisterLifecycleDefaultSQLite(t *testing.T) {
+	runServedBundleRegisterBackendProof(t, servedparity.BackendDefaultSQLite)
+}
+
+func TestRunServeRuntimeBundleRegisterLifecyclePostgres(t *testing.T) {
+	runServedBundleRegisterBackendProof(t, servedparity.BackendExplicitPostgres)
+}
+
+func TestServedParityHarnessBundleRegisterLifecycle(t *testing.T) {
+	scenario := servedparity.MustScenario(servedparity.ScenarioBundleRegisterLifecycle)
+	servedparity.Run(t, scenario, runServedBundleRegisterBackendProof)
+}
+
 func TestRunServeRuntimeSQLiteOptionalMutatorsFailClosed(t *testing.T) {
 	rt := startServedControlProofRuntime(t, servedparity.BackendDefaultSQLite)
 	cases := []struct {
 		method string
 		params map[string]any
 	}{
-		{
-			method: "bundle.register",
-			params: map[string]any{
-				"content_yaml":    "api_version: swarm.bundle.register.v1\nfiles: []\n",
-				"idempotency_key": "issue-1386-sqlite-bundle-register",
-			},
-		},
 		{
 			method: "bundle.delete",
 			params: map[string]any{
@@ -2354,6 +2360,231 @@ func runServedRunControlBackendProof(t *testing.T, backend servedparity.Backend)
 	t.Helper()
 	rt := startServedControlProofRuntime(t, backend)
 	runServedRunControlLifecycleProof(t, rt)
+}
+
+func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Backend) {
+	t.Helper()
+	rt := startServedControlProofRuntime(t, backend)
+	if rt.Runtime == nil {
+		t.Fatal("served bundle.register proof requires the running runtime")
+	}
+	initialSource := rt.Runtime.Options.BundleSourceFact
+	initialRuns := servedBundleRegisterTableCount(t, rt.DB, "runs")
+
+	insert := writeServedBundleRegistrationFixture(t, "1.0.1")
+	firstParams := servedBundleRegisterParams(insert.Upload, "issue-2359-"+rt.Backend+"-insert")
+	first := requireServedBundleRegisterResult(t, rt.Endpoint, firstParams)
+	if !first.Registered || first.BundleHash != insert.BundleHash {
+		t.Fatalf("%s first bundle.register = %#v, want registered %s", rt.Backend, first, insert.BundleHash)
+	}
+	requireServedBundleRegisterReadback(t, rt.Endpoint, insert.BundleHash)
+
+	keyedReplay := requireServedBundleRegisterResult(t, rt.Endpoint, firstParams)
+	if keyedReplay != first {
+		t.Fatalf("%s keyed bundle.register replay = %#v, want exact %#v", rt.Backend, keyedReplay, first)
+	}
+	catalogReplayParams := servedBundleRegisterParams(insert.Upload, "issue-2359-"+rt.Backend+"-catalog-replay")
+	catalogReplay := requireServedBundleRegisterResult(t, rt.Endpoint, catalogReplayParams)
+	if catalogReplay.Registered || catalogReplay.BundleHash != insert.BundleHash {
+		t.Fatalf("%s catalog bundle.register replay = %#v, want existing %s", rt.Backend, catalogReplay, insert.BundleHash)
+	}
+
+	beforeMalformed := servedBundleRegisterTableCount(t, rt.DB, "bundles")
+	malformed := requireServedJSONRPCError(t, rt.Endpoint, "bundle.register", map[string]any{
+		"content_yaml":    "api_version: swarm.bundle.register.v1\nfiles: []\n",
+		"idempotency_key": "issue-2359-" + rt.Backend + "-malformed",
+	})
+	if malformed.Code != -32602 || malformed.Data["details"] == nil {
+		t.Fatalf("%s malformed bundle.register error = %#v, want invalid params with details", rt.Backend, malformed)
+	}
+	if got := servedBundleRegisterTableCount(t, rt.DB, "bundles"); got != beforeMalformed {
+		t.Fatalf("%s malformed bundle.register bundle rows = %d, want %d", rt.Backend, got, beforeMalformed)
+	}
+
+	conflictFixture := writeServedBundleRegistrationFixture(t, "1.0.2")
+	conflictParams := servedBundleRegisterParams(conflictFixture.Upload, "issue-2359-"+rt.Backend+"-conflict-seed")
+	seed := requireServedBundleRegisterResult(t, rt.Endpoint, conflictParams)
+	if !seed.Registered || seed.BundleHash != conflictFixture.BundleHash {
+		t.Fatalf("%s conflict seed bundle.register = %#v", rt.Backend, seed)
+	}
+	forceServedBundleRegisterConflict(t, rt, conflictFixture.BundleHash)
+	conflictParams["idempotency_key"] = "issue-2359-" + rt.Backend + "-conflict"
+	conflict := requireServedJSONRPCError(t, rt.Endpoint, "bundle.register", conflictParams)
+	if conflict.Data["code"] != apiv1.BundleRegisterConflictCode {
+		t.Fatalf("%s conflicting bundle.register data = %#v, want %s", rt.Backend, conflict.Data, apiv1.BundleRegisterConflictCode)
+	}
+
+	rollbackFixture := writeServedBundleRegistrationFixture(t, "1.0.3")
+	rollbackParams := servedBundleRegisterParams(rollbackFixture.Upload, "issue-2359-"+rt.Backend+"-rollback")
+	dropRollbackFault := installServedBundleRegisterRollbackFault(t, rt, rollbackFixture.BundleHash)
+	if failed := requestServedJSONRPC(t, rt.Endpoint, "bundle.register", rollbackParams); failed.Error == nil {
+		t.Fatalf("%s forced-rollback bundle.register error = nil, result=%s", rt.Backend, string(failed.Result))
+	}
+	if got := servedBundleRegisterRowCount(t, rt, rollbackFixture.BundleHash); got != 0 {
+		t.Fatalf("%s forced-rollback bundle row count = %d, want 0", rt.Backend, got)
+	}
+	dropRollbackFault()
+	rollbackRetry := requireServedBundleRegisterResult(t, rt.Endpoint, rollbackParams)
+	if !rollbackRetry.Registered || rollbackRetry.BundleHash != rollbackFixture.BundleHash {
+		t.Fatalf("%s rollback retry bundle.register = %#v, want registered %s", rt.Backend, rollbackRetry, rollbackFixture.BundleHash)
+	}
+	requireServedBundleRegisterReadback(t, rt.Endpoint, rollbackFixture.BundleHash)
+
+	if got := servedBundleRegisterTableCount(t, rt.DB, "runs"); got != initialRuns {
+		t.Fatalf("%s bundle.register run rows = %d, want unchanged %d", rt.Backend, got, initialRuns)
+	}
+	if !rt.Runtime.Options.BundleSourceFact.Matches(initialSource) {
+		t.Fatalf("%s bundle.register changed running source from %#v to %#v", rt.Backend, initialSource, rt.Runtime.Options.BundleSourceFact)
+	}
+}
+
+type servedBundleRegistrationFixture struct {
+	Upload     runtimecontracts.BundleRegistrationUpload
+	BundleHash string
+}
+
+type servedBundleRegisterResult struct {
+	BundleHash    string `json:"bundle_hash"`
+	Registered    bool   `json:"registered"`
+	HasData       bool   `json:"has_data"`
+	DataSizeBytes int64  `json:"data_size_bytes"`
+}
+
+func writeServedBundleRegistrationFixture(t *testing.T, version string) servedBundleRegistrationFixture {
+	t.Helper()
+	root := writeServedEventPublishFollowUpFixture(t)
+	packagePath := filepath.Join(root, "package.yaml")
+	raw, err := os.ReadFile(packagePath)
+	if err != nil {
+		t.Fatalf("read bundle.register package: %v", err)
+	}
+	amended := strings.Replace(string(raw), `version: "1.0.0"`, fmt.Sprintf("version: %q", version), 1)
+	if amended == string(raw) {
+		t.Fatalf("bundle.register fixture package does not declare version 1.0.0: %s", packagePath)
+	}
+	if err := os.WriteFile(packagePath, []byte(amended), 0o644); err != nil {
+		t.Fatalf("write bundle.register package: %v", err)
+	}
+	repoRoot := runtimepipeline.WorkflowRepoRoot()
+	upload, err := runtimecontracts.BuildBundleRegistrationDirectoryUpload(repoRoot, root, runtimecontracts.DefaultPlatformSpecFile(repoRoot))
+	if err != nil {
+		t.Fatalf("BuildBundleRegistrationDirectoryUpload(%s): %v", version, err)
+	}
+	return servedBundleRegistrationFixture{Upload: upload, BundleHash: servedEventPublishFixtureBundleHash(t, root)}
+}
+
+func servedBundleRegisterParams(upload runtimecontracts.BundleRegistrationUpload, idempotencyKey string) map[string]any {
+	params := map[string]any{"content_yaml": upload.ContentYAML}
+	if upload.DataBlob != nil {
+		params["data_blob"] = upload.DataBlob
+	}
+	if strings.TrimSpace(idempotencyKey) != "" {
+		params["idempotency_key"] = idempotencyKey
+	}
+	return params
+}
+
+func requireServedBundleRegisterResult(t *testing.T, endpoint string, params map[string]any) servedBundleRegisterResult {
+	t.Helper()
+	var result servedBundleRegisterResult
+	requireServedJSONRPCResult(t, endpoint, "bundle.register", params, &result)
+	return result
+}
+
+func requireServedBundleRegisterReadback(t *testing.T, endpoint, bundleHash string) {
+	t.Helper()
+	var detail bundlecatalog.Detail
+	requireServedJSONRPCResult(t, endpoint, "bundle.get", map[string]any{"bundle_hash": bundleHash}, &detail)
+	if detail.BundleHash != bundleHash || strings.TrimSpace(detail.ContentYAML) == "" || detail.Metadata["registered_by"] != "bundle.register" {
+		t.Fatalf("bundle.get(%s) = %#v, want exact public registration record", bundleHash, detail)
+	}
+}
+
+func servedBundleRegisterTableCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return count
+}
+
+func servedBundleRegisterRowCount(t *testing.T, rt servedControlProofRuntime, bundleHash string) int {
+	t.Helper()
+	query := `SELECT COUNT(*) FROM bundles WHERE bundle_hash = ?`
+	if rt.Backend == "postgres" {
+		query = `SELECT COUNT(*) FROM bundles WHERE bundle_hash = $1`
+	}
+	var count int
+	if err := rt.DB.QueryRowContext(context.Background(), query, bundleHash).Scan(&count); err != nil {
+		t.Fatalf("%s count bundle %s: %v", rt.Backend, bundleHash, err)
+	}
+	return count
+}
+
+func forceServedBundleRegisterConflict(t *testing.T, rt servedControlProofRuntime, bundleHash string) {
+	t.Helper()
+	query := `UPDATE bundles SET content_yaml = ? WHERE bundle_hash = ?`
+	args := []any{"forced conflict", bundleHash}
+	if rt.Backend == "postgres" {
+		query = `UPDATE bundles SET content_yaml = $1 WHERE bundle_hash = $2`
+	}
+	result, err := rt.DB.ExecContext(context.Background(), query, args...)
+	if err != nil {
+		t.Fatalf("%s force bundle.register conflict: %v", rt.Backend, err)
+	}
+	if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+		t.Fatalf("%s force bundle.register conflict rows = %d, err=%v", rt.Backend, rows, err)
+	}
+}
+
+func installServedBundleRegisterRollbackFault(t *testing.T, rt servedControlProofRuntime, bundleHash string) func() {
+	t.Helper()
+	var install, drop string
+	if rt.Backend == "postgres" {
+		install = `
+			CREATE FUNCTION swarm_test_reject_bundle_register() RETURNS trigger LANGUAGE plpgsql AS $$
+			BEGIN
+				IF NEW.bundle_hash = '` + bundleHash + `' THEN
+					RAISE EXCEPTION 'forced served bundle register rollback';
+				END IF;
+				RETURN NEW;
+			END
+			$$;
+			CREATE TRIGGER swarm_test_reject_bundle_register
+			AFTER INSERT ON bundles
+			FOR EACH ROW EXECUTE FUNCTION swarm_test_reject_bundle_register()
+		`
+		drop = `
+			DROP TRIGGER IF EXISTS swarm_test_reject_bundle_register ON bundles;
+			DROP FUNCTION IF EXISTS swarm_test_reject_bundle_register()
+		`
+	} else {
+		install = `
+			CREATE TRIGGER swarm_test_reject_bundle_register
+			AFTER INSERT ON bundles
+			WHEN NEW.bundle_hash = '` + bundleHash + `'
+			BEGIN
+				SELECT RAISE(ABORT, 'forced served bundle register rollback');
+			END
+		`
+		drop = `DROP TRIGGER IF EXISTS swarm_test_reject_bundle_register`
+	}
+	if _, err := rt.DB.ExecContext(context.Background(), install); err != nil {
+		t.Fatalf("%s install bundle.register rollback fault: %v", rt.Backend, err)
+	}
+	dropped := false
+	cleanup := func() {
+		if dropped {
+			return
+		}
+		dropped = true
+		if _, err := rt.DB.ExecContext(context.Background(), drop); err != nil {
+			t.Fatalf("%s drop bundle.register rollback fault: %v", rt.Backend, err)
+		}
+	}
+	t.Cleanup(cleanup)
+	return cleanup
 }
 
 func runServedLiveAgentEventReplayBackendProof(t *testing.T, backend servedparity.Backend) {

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -3,6 +3,7 @@ package serveapp
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -2377,7 +2378,7 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 	if !first.Registered || first.BundleHash != insert.BundleHash {
 		t.Fatalf("%s first bundle.register = %#v, want registered %s", rt.Backend, first, insert.BundleHash)
 	}
-	requireServedBundleRegisterReadback(t, rt.Endpoint, insert.BundleHash)
+	requireServedBundleRegisterReadback(t, rt.Endpoint, insert.Expected)
 
 	keyedReplay := requireServedBundleRegisterResult(t, rt.Endpoint, firstParams)
 	if keyedReplay != first {
@@ -2398,7 +2399,8 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 		t.Fatalf("%s publication against registered-only bundle data = %#v, want %s", rt.Backend, unavailable.Data, apiv1.BundleUnavailableCode)
 	}
 
-	beforeMalformed := servedBundleRegisterTableCount(t, rt.DB, "bundles")
+	beforeMalformedBundles := servedBundleRegisterTableCount(t, rt.DB, "bundles")
+	beforeMalformedIdempotency := servedBundleRegisterTableCount(t, rt.DB, "api_idempotency")
 	malformed := requireServedJSONRPCError(t, rt.Endpoint, "bundle.register", map[string]any{
 		"content_yaml":    "api_version: swarm.bundle.register.v1\nfiles: []\n",
 		"idempotency_key": "issue-2359-" + rt.Backend + "-malformed",
@@ -2406,8 +2408,37 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 	if malformed.Code != -32602 || malformed.Data["details"] == nil {
 		t.Fatalf("%s malformed bundle.register error = %#v, want invalid params with details", rt.Backend, malformed)
 	}
-	if got := servedBundleRegisterTableCount(t, rt.DB, "bundles"); got != beforeMalformed {
-		t.Fatalf("%s malformed bundle.register bundle rows = %d, want %d", rt.Backend, got, beforeMalformed)
+	if got := servedBundleRegisterTableCount(t, rt.DB, "bundles"); got != beforeMalformedBundles {
+		t.Fatalf("%s malformed bundle.register bundle rows = %d, want %d", rt.Backend, got, beforeMalformedBundles)
+	}
+	if got := servedBundleRegisterTableCount(t, rt.DB, "api_idempotency"); got != beforeMalformedIdempotency {
+		t.Fatalf("%s malformed bundle.register idempotency rows = %d, want %d", rt.Backend, got, beforeMalformedIdempotency)
+	}
+
+	malformedDataKey := "issue-2359-" + rt.Backend + "-malformed-data"
+	malformedDataParams := servedBundleRegisterParams(insert.Upload, malformedDataKey)
+	malformedDataParams["data_blob"] = map[string]any{
+		"api_version": "swarm.bundle.data.v1",
+		"entries": []any{map[string]any{
+			"path":        "flows/receive/data/malformed.bin",
+			"data_base64": "not-standard-base64",
+		}},
+	}
+	beforeMalformedDataBundles := servedBundleRegisterTableCount(t, rt.DB, "bundles")
+	beforeMalformedDataIdempotency := servedBundleRegisterTableCount(t, rt.DB, "api_idempotency")
+	malformedData := requireServedJSONRPCError(t, rt.Endpoint, "bundle.register", malformedDataParams)
+	details, ok := malformedData.Data["details"].(map[string]any)
+	if malformedData.Code != -32602 || !ok || details["field"] != "data_blob.entries[0].data_base64" {
+		t.Fatalf("%s malformed bundle.register data_blob error = %#v, want typed invalid params for data_blob entry", rt.Backend, malformedData)
+	}
+	if got := servedBundleRegisterTableCount(t, rt.DB, "bundles"); got != beforeMalformedDataBundles {
+		t.Fatalf("%s malformed data_blob bundle rows = %d, want %d", rt.Backend, got, beforeMalformedDataBundles)
+	}
+	if got := servedBundleRegisterTableCount(t, rt.DB, "api_idempotency"); got != beforeMalformedDataIdempotency {
+		t.Fatalf("%s malformed data_blob idempotency rows = %d, want %d", rt.Backend, got, beforeMalformedDataIdempotency)
+	}
+	if got := servedEventPublishAPIIdempotencyCount(t, rt.DB, rt.Backend, "bundle.register", malformedDataKey); got != 0 {
+		t.Fatalf("%s malformed data_blob idempotency key rows = %d, want 0", rt.Backend, got)
 	}
 
 	conflictFixture := writeServedBundleRegistrationFixture(t, "1.0.2")
@@ -2437,7 +2468,7 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 	if !rollbackRetry.Registered || rollbackRetry.BundleHash != rollbackFixture.BundleHash {
 		t.Fatalf("%s rollback retry bundle.register = %#v, want registered %s", rt.Backend, rollbackRetry, rollbackFixture.BundleHash)
 	}
-	requireServedBundleRegisterReadback(t, rt.Endpoint, rollbackFixture.BundleHash)
+	requireServedBundleRegisterReadback(t, rt.Endpoint, rollbackFixture.Expected)
 
 	if got := servedBundleRegisterTableCount(t, rt.DB, "runs"); got != initialRuns {
 		t.Fatalf("%s bundle.register run rows = %d, want unchanged %d", rt.Backend, got, initialRuns)
@@ -2450,6 +2481,7 @@ func runServedBundleRegisterBackendProof(t *testing.T, backend servedparity.Back
 type servedBundleRegistrationFixture struct {
 	Upload     runtimecontracts.BundleRegistrationUpload
 	BundleHash string
+	Expected   bundlecatalog.Detail
 }
 
 type servedBundleRegisterResult struct {
@@ -2479,7 +2511,59 @@ func writeServedBundleRegistrationFixture(t *testing.T, version string) servedBu
 	if err != nil {
 		t.Fatalf("BuildBundleRegistrationDirectoryUpload(%s): %v", version, err)
 	}
-	return servedBundleRegistrationFixture{Upload: upload, BundleHash: servedEventPublishFixtureBundleHash(t, root)}
+	bundle := loadWorkflowValidationBundleAt(t, root)
+	platformSpecPath := runtimecontracts.DefaultPlatformSpecFile(repoRoot)
+	platformSpec, err := os.ReadFile(platformSpecPath)
+	if err != nil {
+		t.Fatalf("read bundle.register platform spec: %v", err)
+	}
+	platformSpecHash := fmt.Sprintf("%x", sha256.Sum256(platformSpec))
+	projection, err := runtimecontracts.BuildBundleCatalogProjectionWithOptions(bundle, runtimecontracts.BundleCatalogProjectionOptions{
+		Source:             "bundle.register",
+		PlatformSpecSHA256: platformSpecHash,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundleCatalogProjection(%s): %v", version, err)
+	}
+	expectedMetadata := map[string]any{
+		"api_version":               "swarm.bundle.metadata.v1",
+		"registered_by":             "bundle.register",
+		"platform_spec_source":      "server_effective",
+		"platform_spec_hash":        "sha256:" + platformSpecHash,
+		"platform_spec_path_policy": "server_internal_not_user_supplied",
+	}
+	for _, key := range []string{
+		"projection_version",
+		"workflow_name",
+		"workflow_version",
+		"file_count",
+		"data_file_count",
+		"package_name",
+		"package_version",
+		"package_platform_version",
+		"package_keywords",
+		"package_license",
+		"package_repository",
+		"package_extra",
+	} {
+		if value, ok := projection.Metadata[key]; ok {
+			expectedMetadata[key] = value
+		}
+	}
+	agents, ok := projection.ParsedJSON["agents"].([]any)
+	if !ok {
+		t.Fatalf("bundle.register canonical agents projection = %T, want []any", projection.ParsedJSON["agents"])
+	}
+	expected := bundlecatalog.Detail{
+		BundleHash:    projection.BundleHash,
+		ContentYAML:   projection.ContentYAML,
+		ParsedJSON:    projection.ParsedJSON,
+		Metadata:      expectedMetadata,
+		AgentCount:    len(agents),
+		HasData:       len(projection.DataBlob) > 0,
+		DataSizeBytes: int64(len(projection.DataBlob)),
+	}
+	return servedBundleRegistrationFixture{Upload: upload, BundleHash: projection.BundleHash, Expected: expected}
 }
 
 func servedBundleRegisterParams(upload runtimecontracts.BundleRegistrationUpload, idempotencyKey string) map[string]any {
@@ -2500,12 +2584,39 @@ func requireServedBundleRegisterResult(t *testing.T, endpoint string, params map
 	return result
 }
 
-func requireServedBundleRegisterReadback(t *testing.T, endpoint, bundleHash string) {
+func requireServedBundleRegisterReadback(t *testing.T, endpoint string, expected bundlecatalog.Detail) {
 	t.Helper()
 	var detail bundlecatalog.Detail
-	requireServedJSONRPCResult(t, endpoint, "bundle.get", map[string]any{"bundle_hash": bundleHash}, &detail)
-	if detail.BundleHash != bundleHash || strings.TrimSpace(detail.ContentYAML) == "" || detail.Metadata["registered_by"] != "bundle.register" {
-		t.Fatalf("bundle.get(%s) = %#v, want exact public registration record", bundleHash, detail)
+	requireServedJSONRPCResult(t, endpoint, "bundle.get", map[string]any{"bundle_hash": expected.BundleHash}, &detail)
+	if detail.BundleHash != expected.BundleHash ||
+		detail.ContentYAML != expected.ContentYAML ||
+		detail.AgentCount != expected.AgentCount ||
+		detail.HasData != expected.HasData ||
+		detail.DataSizeBytes != expected.DataSizeBytes {
+		t.Fatalf("bundle.get(%s) stable fields = %#v, want %#v", expected.BundleHash, detail, expected)
+	}
+	requireServedBundleRegisterCanonicalJSONEqual(t, "parsed_json", detail.ParsedJSON, expected.ParsedJSON)
+	requireServedBundleRegisterCanonicalJSONEqual(t, "metadata", detail.Metadata, expected.Metadata)
+	if detail.IngestedAt.IsZero() {
+		t.Fatalf("bundle.get(%s) ingested_at is zero", expected.BundleHash)
+	}
+	if detail.IngestedAt.Location() != time.UTC {
+		t.Fatalf("bundle.get(%s) ingested_at location = %s, want UTC", expected.BundleHash, detail.IngestedAt.Location())
+	}
+}
+
+func requireServedBundleRegisterCanonicalJSONEqual(t *testing.T, field string, got, want any) {
+	t.Helper()
+	gotRaw, err := canonicaljson.Bytes(got)
+	if err != nil {
+		t.Fatalf("canonicalize bundle.get %s: %v", field, err)
+	}
+	wantRaw, err := canonicaljson.Bytes(want)
+	if err != nil {
+		t.Fatalf("canonicalize expected bundle.get %s: %v", field, err)
+	}
+	if !bytes.Equal(gotRaw, wantRaw) {
+		t.Fatalf("bundle.get %s = %s, want %s", field, gotRaw, wantRaw)
 	}
 }
 

--- a/internal/serveapp/store_backend_selection_test.go
+++ b/internal/serveapp/store_backend_selection_test.go
@@ -376,6 +376,7 @@ func TestSelectedOwnerAPICapabilityMatrixIsExplicitAcrossBackends(t *testing.T) 
 		"sqlite run bundle context":          sqliteCaps.RunBundleContext != nil,
 		"sqlite test setup":                  sqliteCaps.TestSetup != nil,
 		"sqlite bundle catalog":              sqliteCaps.BundleCatalog != nil,
+		"sqlite bundle register":             sqliteCaps.BundleRegister != nil,
 		"sqlite conversation reads":          sqliteCaps.ConversationForks != nil,
 		"sqlite conversation lifecycle":      sqliteCaps.ConversationForkLifecycle != nil,
 		"postgres bundle register":           postgresCaps.BundleRegister != nil,
@@ -391,7 +392,6 @@ func TestSelectedOwnerAPICapabilityMatrixIsExplicitAcrossBackends(t *testing.T) 
 		}
 	}
 	for name, available := range map[string]bool{
-		"sqlite bundle register":   sqliteCaps.BundleRegister != nil,
 		"sqlite bundle delete":     sqliteCaps.BundleDelete != nil,
 		"sqlite run fork":          sqliteCaps.RunFork != nil,
 		"sqlite run fork selector": sqliteCaps.RunForkSelector != nil,

--- a/internal/servedparity/servedparity.go
+++ b/internal/servedparity/servedparity.go
@@ -46,6 +46,7 @@ const (
 	ScenarioGeneratedInputFixtureLifecycle       = "generated_input_fixture_lifecycle"
 	ScenarioDerivedScenarioLifecycle             = "derived_scenario_lifecycle"
 	ScenarioPublicMockApprovalLifecycle          = "public_mock_approval_lifecycle"
+	ScenarioBundleRegisterLifecycle              = "bundle_register_lifecycle"
 	ScenarioConversationForkLifecycle            = "conversation_fork_lifecycle"
 	ScenarioConversationForkChatLifecycle        = "conversation_fork_chat_lifecycle"
 	ScenarioConversationForkDeleteLifecycle      = "conversation_fork_delete_lifecycle"
@@ -105,6 +106,7 @@ func Scenarios() []Scenario {
 		servedControlScenario(ScenarioGeneratedInputFixtureLifecycle, "event.publish", "TestServedParityHarnessGeneratedInputFixtureLifecycle"),
 		servedControlScenario(ScenarioDerivedScenarioLifecycle, "event.publish", "TestServedParityHarnessDerivedScenarioLifecycle"),
 		servedControlScenario(ScenarioPublicMockApprovalLifecycle, "event.publish", "TestServedParityHarnessPublicMockApprovalLifecycle"),
+		servedControlScenario(ScenarioBundleRegisterLifecycle, "bundle.register", "TestServedParityHarnessBundleRegisterLifecycle"),
 		servedControlScenario(ScenarioConversationForkLifecycle, "conversation.fork", "TestServedParityHarnessConversationForkLifecycle"),
 		servedControlScenario(ScenarioConversationForkChatLifecycle, "conversation.fork_chat", "TestServedParityHarnessConversationForkLifecycle"),
 		servedControlScenario(ScenarioConversationForkDeleteLifecycle, "conversation.fork_delete", "TestServedParityHarnessConversationForkLifecycle"),

--- a/internal/store/selected/selected.go
+++ b/internal/store/selected/selected.go
@@ -354,6 +354,7 @@ func composeSQLite(selected *private.SQLiteRuntimeStore) (*Owner, error) {
 		},
 		products: productPorts{
 			bundleCatalog: selected, bundleCatalogAvailable: true,
+			bundleRegister: selected, bundleRegisterAvailable: true,
 			conversationFork: ConversationFork{reader: selected, lifecycle: selected}, conversationAvailable: true,
 		},
 	}, nil

--- a/internal/store/selected/selected_test.go
+++ b/internal/store/selected/selected_test.go
@@ -159,8 +159,10 @@ func TestOpenRuntimeSQLiteResolvesRequiredAndOptionalProductsOnce(t *testing.T) 
 	if _, available := owner.ConversationFork(); !available {
 		t.Fatal("SQLite conversation fork must be available")
 	}
+	if _, available := owner.BundleRegisterWriter(); !available {
+		t.Fatal("SQLite public bundle-register writer must be available")
+	}
 	for name, available := range map[string]bool{
-		"bundle register":   func() bool { _, ok := owner.BundleRegisterWriter(); return ok }(),
 		"bundle delete":     func() bool { _, ok := owner.BundleDelete(); return ok }(),
 		"run fork":          func() bool { _, ok := owner.RunFork(); return ok }(),
 		"destructive reset": func() bool { _, ok := owner.DestructiveReset(); return ok }(),

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6209,7 +6209,12 @@ engine:
         method: bundle.register
         selected_capability: optional public BundleRegisterWriter capability, distinct from required serve ingest
         postgres_support: supported through the Postgres persisted bundle source catalog writer
-        sqlite_support: unsupported; SQLite wires bundle catalog read and private required serve ingest but must not expose bundle.register until #2276 promotes the public capability
+        sqlite_support: supported through the SQLite persisted bundle source catalog writer
+        semantic_owner: internal/apiv1 bundle.register canonical projection plus the selected store UpsertBundleCatalog transaction
+        boundary: >
+          Both selected backends expose the optional public writer explicitly. The writer reuses the backend's exact
+          catalog transaction but remains a separate selected capability from required private serve ingest. Public
+          registration is catalog-only and never implies runtime loading, source replacement, or serve-ingest authority.
       bundle_delete:
         method: bundle.delete
         selected_capability: apiv1.BundleDeleteExecutor
@@ -17627,6 +17632,10 @@ multi_bundle_persistence:
         sqlite: private SQLite bundle-catalog UpsertBundleCatalog owner
       source_fact_owner: internal/serveapp.prepareServeBundleSource
       runtime_context_owner: internal/runtime/correlation.BundleSourceFact
+      public_registration_boundary: >
+        The private ServeIngestWriter and optional public BundleRegisterWriter are distinct selected capabilities even
+        though each consumes the same backend UpsertBundleCatalog transaction. Serve ingest establishes the boot source
+        fact; public registration only persists a canonical catalog row and cannot mutate the running source fact.
       applies_to:
         persisted: '`swarm serve --contracts` computes BundleHash, writes or reuses one bundles row, and stamps every new run row with bundle_hash plus bundle_source=persisted.'
         ephemeral: '`swarm serve --contracts --dev` computes the same BundleHash, writes no bundles row, and stamps every new run row with bundle_hash plus bundle_source=ephemeral.'
@@ -17657,7 +17666,7 @@ multi_bundle_persistence:
       split_boundaries:
         - DB-loaded same-bundle source/fork loaders consume the persisted bundle catalog runtime source owner.
         - New-work routing and bundle_hash admission remain #1022.
-        - SQLite public bundle.register and selected-contract run.fork remain #2276; backend-neutral capture remains #2272.
+        - SQLite public bundle.register is implemented by #2359; selected-contract run.fork remains the final #2276 child. Backend-neutral capture is implemented by #2272.
         - Bundle delete remains outside this projection.
         - SQLite DB-loaded `--bundle-hash` bundle-catalog boot remains unsupported unless separately gated.
     serve_db_loaded_runtime_source:


### PR DESCRIPTION
## Summary

- expose the existing canonical SQLite `UpsertBundleCatalog` transaction through the optional public `BundleRegisterWriter` selected capability
- add real served SQLite/PostgreSQL proof for insert, keyed replay, catalog replay, malformed rejection, exact conflict, rollback/retry, catalog-only behavior, and terminal `bundle.get` readback
- update `platform-spec.yaml`, the public backend ledger, and the served parity registry to declare dual-backend support

Closes #2359
Part of #2276

## Governing Context

Binding references:

- `platform-spec.yaml#engine.runtime_core_persistence_store_contracts.optional_public_mutating_backend_support.bundle_register`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.serve_ingest_projection`
- `platform-spec.yaml#multi_bundle_persistence.persistence_model.dynamic_load_source_authority`
- approved parent audit and Gate E on #2276

## Semantic Migration

- **Canonical public owner:** `internal/apiv1` canonical registration projection and idempotency handler, projected through `internal/store/selected.Owner.BundleRegisterWriter`, with the selected SQLite/PostgreSQL `UpsertBundleCatalog` transaction as the exact persistence owner.
- **Old path now invalid:** SQLite selected composition omitting the public writer and the corresponding served `METHOD_UNAVAILABLE`/Postgres-only matrix classification.
- **Production paths checked:** selected SQLite/PostgreSQL composition, selected API capability projection, normal `/v1/rpc` handler registration, canonical writer transactions, CLI request construction, and public `bundle.get` readback.
- **Private boundary preserved:** required `ServeBundleIngestWriter` remains distinct and continues to establish boot source identity; public registration remains catalog-only and cannot load or replace a runtime context.
- **Migration status:** complete for Child A's public registration backend-parity class. No schema migration, compatibility path, fallback, loader branch, or raw-handle production seam is introduced.

## Verification

- `go test ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- `go test ./internal/serveapp -run 'TestRunServeRuntimeBundleRegisterLifecyclePostgres|TestServedParityHarnessBundleRegisterLifecycle|TestRunServeRuntimeSQLiteOptionalMutatorsFailClosed' -count=1`
- `go test ./internal/store/internal/runtimepersistence -run TestBundleCatalogWriteParity -count=1`
- `go test ./internal/cliapp -run TestBundleRegisterContractsDirectoryUsesCanonicalRPCAndRenders -count=1`
