### PR TITLE
[agent-g][issue #2379] Seal lifecycle fixture topology authority

### DIFF
--- a/internal/apiv1/agent_diagnose_delivery_pagination_parity_test.go
+++ b/internal/apiv1/agent_diagnose_delivery_pagination_parity_test.go
@@ -73,7 +73,7 @@ func TestAgentDiagnoseExactDeliveryPaginationParity(t *testing.T) {
 			}
 			agentID := "diagnose-agent"
 			identity := agentidentitytest.Runtime(t, agentID, "diagnose-pagination-test", "diagnose", "one", "diagnose/one")
-			if err := storetest.UpsertAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
+			if err := storetest.UpsertStaticAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
 				Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 					Identity: identity, ID: agentID, Role: "worker", Type: "managed", Model: "regular", ExecutionMode: "live", ResolvedLLMBackend: "anthropic",
 					FlowID: "diagnose", FlowPath: identity.FlowInstance(),

--- a/internal/apiv1/agent_snapshot_atomicity_test.go
+++ b/internal/apiv1/agent_snapshot_atomicity_test.go
@@ -588,7 +588,7 @@ func newAgentSnapshotBoundaryFixture(t *testing.T, backend agentSnapshotBackend)
 	for _, agentID := range []string{"snapshot-agent-a", "snapshot-agent-b"} {
 		identity := sqliteAgentUsageIdentity(t, agentID)
 		identities[agentID] = identity
-		if err := storetest.UpsertAgentFixture(t, ctx, store, runtimemanager.PersistedAgent{
+		if err := storetest.UpsertStaticAgentFixture(t, ctx, store, runtimemanager.PersistedAgent{
 			Config: runtimeactors.AgentConfig{
 				Identity: identity, ID: agentID, Role: "worker", Type: "managed", Model: "regular",
 				ExecutionMode: "live", ResolvedLLMBackend: "anthropic", FlowID: "flow",

--- a/internal/apiv1/operator_agent_control_test.go
+++ b/internal/apiv1/operator_agent_control_test.go
@@ -390,7 +390,7 @@ func materializeAPITestAgent(t testing.TB, ctx context.Context, selected storete
 	if cfg.Type == "" {
 		cfg.Type = "stub"
 	}
-	storetest.RequireAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
+	storetest.RequireStaticAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
 		Config: cfg, Status: "active", HiredBy: "api-test",
 	})
 	persisted, err := selected.LoadAgents(ctx)

--- a/internal/apiv1/operator_event_replay_test.go
+++ b/internal/apiv1/operator_event_replay_test.go
@@ -290,7 +290,7 @@ func TestOperatorEventReplayDispatchesCompleteCanonicalSnapshotParity(t *testing
 				createdAt := time.Unix(1700001300, 123456000).UTC()
 				seedCompleteReplayRun(t, ctx, f.db, f.sqlite, runID, createdAt.Add(-time.Minute))
 				envelope := routeShape.envelope(entityID, auditEntityID)
-				if err := storetest.UpsertAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
+				if err := storetest.UpsertStaticAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
 					Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 						Identity: agentIdentity, ID: agentID, Role: "observer",
 						FlowID: "target-flow", FlowPath: agentIdentity.FlowInstance(), EntityID: entityID,
@@ -305,7 +305,7 @@ func TestOperatorEventReplayDispatchesCompleteCanonicalSnapshotParity(t *testing
 				if routeShape.fanOut {
 					auditCh = subscribeOperatorReplayIdentity(t, bus, auditIdentity)
 					defer runtimebustest.Unsubscribe(bus, auditIdentity.AgentID())
-					if err := storetest.UpsertAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
+					if err := storetest.UpsertStaticAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
 						Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 							Identity: auditIdentity, ID: auditIdentity.AgentID(), Role: "auditor",
 							FlowID: "audit-flow", FlowPath: auditIdentity.FlowInstance(), EntityID: auditEntityID,
@@ -504,7 +504,7 @@ func TestOperatorReplayPreservesFailedEligibilityAndEveryExactRouteSiblingParity
 			originalID := uuid.NewString()
 			createdAt := time.Unix(1700001400, 0).UTC()
 			seedCompleteReplayRun(t, ctx, f.db, tc.name == "sqlite", runID, createdAt.Add(-time.Minute))
-			if err := storetest.UpsertAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
+			if err := storetest.UpsertStaticAgentFixture(t, ctx, f.store, runtimemanager.PersistedAgent{
 				Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 					Identity: identity, ID: agentID,
 					Role: "observer", Type: "stub", Model: "regular", ExecutionMode: "live", ResolvedLLMBackend: "anthropic",
@@ -781,7 +781,7 @@ func seedOperatorReplayDeliverySession(t testing.TB, ctx context.Context, select
 	if _, found, err := selected.LoadAgentLifecycleState(ctx, identity); err != nil {
 		t.Fatalf("load operator replay delivery agent: %v", err)
 	} else if !found {
-		if err := storetest.UpsertAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
+		if err := storetest.UpsertStaticAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
 			Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 				Identity: identity, ID: identity.AgentID(), Role: "operator-replay-test", Type: "stub",
 				Model: "regular", ExecutionMode: "live", ResolvedLLMBackend: "anthropic",

--- a/internal/apiv1/operator_mailbox_test.go
+++ b/internal/apiv1/operator_mailbox_test.go
@@ -276,7 +276,7 @@ func seedActiveAPIV1RuntimeBusAgent(t *testing.T, ctx context.Context, owner act
 func seedActiveAPIV1RuntimeBusAgentAt(t *testing.T, ctx context.Context, owner activeAPIV1RuntimeBusAgentStore, agentID, flowPath string) {
 	t.Helper()
 	identity := runtimebustest.Identity(t, agentID, flowPath)
-	if err := storetest.UpsertAgentFixture(t, ctx, owner, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, owner, runtimemanager.PersistedAgent{
 		Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 			Identity: identity, ID: agentID, Role: "observer", FlowID: "global", FlowPath: identity.FlowInstance(),
 			Type: "stub", Model: "regular", ExecutionMode: "live", ResolvedLLMBackend: "anthropic", Config: []byte(`{}`),

--- a/internal/apiv1/selected_store_read_supported_surface_test.go
+++ b/internal/apiv1/selected_store_read_supported_surface_test.go
@@ -82,7 +82,7 @@ func TestPostgresAgentConversationOwnerBacksSupportedAPISurface(t *testing.T) {
 	if err != nil {
 		t.Fatalf("operator read identity fields: %v", err)
 	}
-	if err := storetest.UpsertAgentFixture(t, ctx, selected, manager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, selected, manager.PersistedAgent{
 		Config: runtimeactors.AgentConfig{
 			Identity: identity, ID: agentID, Role: "researcher", Type: "managed", Model: "cheap",
 			ExecutionMode: "live", ResolvedLLMBackend: "anthropic", FlowPath: "flow/a", Intent: intent,

--- a/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
+++ b/internal/apiv1/sqlite_agent_usage_supported_surface_test.go
@@ -152,7 +152,7 @@ func newSQLiteAgentUsageStoreFixture(t *testing.T, ctx context.Context) *storepk
 
 func seedSQLiteAgentUsageAgent(t *testing.T, ctx context.Context, sqliteStore *storepkg.SQLiteRuntimeStore, agentID string) {
 	t.Helper()
-	if err := storetest.UpsertAgentFixture(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
 		Config: withAPITestIntent(t, runtimeactors.AgentConfig{
 			Identity:           sqliteAgentUsageIdentity(t, agentID),
 			ID:                 agentID,

--- a/internal/runtime/bus/eventbus_publish_test.go
+++ b/internal/runtime/bus/eventbus_publish_test.go
@@ -1054,7 +1054,7 @@ func assertSortedStringsEqual(t *testing.T, got, want []string) {
 func seedActiveRuntimeBusAgent(t *testing.T, ctx context.Context, pg *store.PostgresStore, agentID string) runtimeagentidentity.Identity {
 	t.Helper()
 	identity := runtimebustest.Identity(t, agentID, "")
-	if err := storetest.UpsertAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: busTestAgentConfig(t, runtimeactors.AgentConfig{
 			ID:                 agentID,
 			Identity:           identity,
@@ -2653,7 +2653,7 @@ func TestEventBusPublishDirect_StampsBundleSourceFactOnRunRow(t *testing.T) {
 		t.Fatalf("NewEventBusWithOptions: %v", err)
 	}
 	agentIdentity := runtimebustest.Identity(t, "agent-a", "bundle-source-test")
-	if err := storetest.UpsertAgentFixture(t, context.Background(), pg, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, context.Background(), pg, runtimemanager.PersistedAgent{
 		Config: busTestAgentConfig(t, runtimeactors.AgentConfig{
 			ID: "agent-a", Identity: agentIdentity, FlowID: "bundle-source-test", FlowPath: "bundle-source-test",
 			Role: "worker", Model: "regular", Type: "stub", ExecutionMode: "live", ResolvedLLMBackend: "anthropic", Config: []byte(`{}`),

--- a/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
+++ b/internal/runtime/conformance/delivery_lifecycle_conformance_test.go
@@ -1617,7 +1617,7 @@ func seedDeliveryAgentSession(t *testing.T, ctx context.Context, backend deliver
 	if !ok {
 		t.Fatalf("delivery lifecycle selected store %T lacks canonical agent fixture admission", backend.selected)
 	}
-	storetest.RequireAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
+	storetest.RequireStaticAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
 		Config: runtimeactors.AgentConfig{
 			ID: agentID, Identity: identity, Role: "delivery-test", Type: "stub", Model: "regular", ExecutionMode: "live",
 			ResolvedLLMBackend: "anthropic", Intent: deliveryLifecycleAgentIntent(t, agentID),

--- a/internal/runtime/conformance/persisted_surfaces_test.go
+++ b/internal/runtime/conformance/persisted_surfaces_test.go
@@ -1859,7 +1859,7 @@ func seedConformanceAgent(t *testing.T, ctx context.Context, pg *store.PostgresS
 	if err != nil {
 		t.Fatalf("derive conformance agent prompt: %v", err)
 	}
-	if err := storetest.UpsertAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: runtimeactors.AgentConfig{
 			ID:                 agentID,
 			Identity:           identity,

--- a/internal/runtime/inbound_postgres_test.go
+++ b/internal/runtime/inbound_postgres_test.go
@@ -1129,7 +1129,7 @@ func seedPostgresInboundGatewayRuntime(
 		t.Fatalf("seed entity state: %v", err)
 	}
 	if strings.TrimSpace(agentID) != "" {
-		if err := storetest.UpsertAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
+		if err := storetest.UpsertStaticAgentFixture(t, ctx, pg, runtimemanager.PersistedAgent{
 			Config: runtimeTestAgentConfig(t, runtimeactors.AgentConfig{
 				ExecutionMode:      "live",
 				ResolvedLLMBackend: "anthropic",
@@ -1238,7 +1238,7 @@ func seedSQLiteInboundGatewayRuntime(
 		t.Fatalf("seed sqlite entity state: %v", err)
 	}
 	if strings.TrimSpace(agentID) != "" {
-		if err := storetest.UpsertAgentFixture(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
+		if err := storetest.UpsertStaticAgentFixture(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
 			Config: runtimeTestAgentConfig(t, runtimeactors.AgentConfig{
 				ExecutionMode:      "live",
 				ResolvedLLMBackend: "anthropic",

--- a/internal/runtime/inbound_raw_settlement_store_test.go
+++ b/internal/runtime/inbound_raw_settlement_store_test.go
@@ -229,9 +229,9 @@ func seedProviderRawSettlementAgent(t *testing.T, ctx context.Context, selected 
 	var err error
 	switch typed := selected.(type) {
 	case *store.PostgresStore:
-		err = storetest.UpsertAgentFixture(t, ctx, typed, agent)
+		err = storetest.UpsertStaticAgentFixture(t, ctx, typed, agent)
 	case *store.SQLiteRuntimeStore:
-		err = storetest.UpsertAgentFixture(t, ctx, typed, agent)
+		err = storetest.UpsertStaticAgentFixture(t, ctx, typed, agent)
 	default:
 		t.Fatalf("unsupported provider raw agent store %T", selected)
 	}

--- a/internal/runtime/mcp/gateway_story_selected_store_test.go
+++ b/internal/runtime/mcp/gateway_story_selected_store_test.go
@@ -323,7 +323,7 @@ func seedGatewayStoryRuntime(t *testing.T, selected gatewayStorySelectedStore, r
 	} else {
 		runlifecyclefixture.RequireSQLite(t, context.Background(), selected.db, runlifecyclefixture.Fixture{Origin: runlifecyclefixture.ScenarioSetupOrigin(), RunID: runID, StartedAt: now, BundleHash: bundleHash, BundleSource: bundleSource})
 	}
-	if err := storetest.UpsertAgentFixture(t, context.Background(), selected.backend, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, context.Background(), selected.backend, runtimemanager.PersistedAgent{
 		Config: actor, Status: "active", StartedAt: now,
 		LifecycleEpoch: 7, LifecycleGeneration: 3,
 		LifecyclePhase: runtimemanager.AgentLifecycleRunning, LifecycleRunMode: runtimemanager.AgentRunModeStandard,

--- a/internal/runtime/runforkexecution/execution_test.go
+++ b/internal/runtime/runforkexecution/execution_test.go
@@ -4700,7 +4700,7 @@ func seedSelectedExecutionTestAgent(
 		FlowPath:           identity.FlowInstance(),
 		Config:             []byte(`{}`),
 	})
-	if err := storetest.UpsertAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, selected, runtimemanager.PersistedAgent{
 		Config: config, Status: "active", HiredBy: "test", StartedAt: at,
 	}); err != nil {
 		t.Fatalf("seed selected-execution test agent: %v", err)

--- a/internal/serveapp/claude_attempt_identity_test.go
+++ b/internal/serveapp/claude_attempt_identity_test.go
@@ -710,7 +710,9 @@ func claudeAttemptProofAgentConfig(surfaces ...claudeAttemptProofSurface) runtim
 	cfg := runtimeactors.AgentConfig{
 		ExecutionMode: "live",
 		ID:            "claude-attempt-proof-agent", Type: "sonnet", Role: "worker", FlowID: "global", Model: "regular",
-		LLMBackend: "claude_cli", ResolvedLLMBackend: "claude_cli", Memory: agentmemory.Authored(surface.memory), FlowPath: "proof/inst-1",
+		LLMBackend: "claude_cli", ResolvedLLMBackend: "claude_cli", ResolvedLLMProvider: "claude",
+		ResolvedLLMTransport: "cli", ResolvedModel: "sonnet",
+		Memory: agentmemory.Authored(surface.memory), FlowPath: "proof/inst-1",
 		Identity: claudeAttemptProofAgentIdentity(),
 	}
 	return serveTestAgentConfig(cfg)

--- a/internal/serveapp/main_runtime_test.go
+++ b/internal/serveapp/main_runtime_test.go
@@ -152,7 +152,7 @@ func requireServeTestAgentFixture(t testing.TB, selected storetest.AgentFixtureS
 	if cfg.ExecutionMode == "" {
 		cfg.ExecutionMode = runtimeeffects.ExecutionModeLive
 	}
-	storetest.RequireAgentFixture(t, context.Background(), selected, runtimemanager.PersistedAgent{
+	storetest.RequireStaticAgentFixture(t, context.Background(), selected, runtimemanager.PersistedAgent{
 		Config: cfg, Status: "active", HiredBy: "serve-test-fixture",
 	})
 }

--- a/internal/serveapp/provider_trigger_smoke_helpers_test.go
+++ b/internal/serveapp/provider_trigger_smoke_helpers_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/division-sh/swarm/internal/store/storetest"
 
 	runtimepkg "github.com/division-sh/swarm/internal/runtime"
-	runtimeagenttopology "github.com/division-sh/swarm/internal/runtime/agenttopology"
 	runtimeauthoractivity "github.com/division-sh/swarm/internal/runtime/authoractivity"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -221,20 +220,11 @@ func seedProviderTriggerSmokeRuntime(
 		t.Fatalf("seed sqlite entity state: %v", err)
 	}
 	const fixtureBundleHash = "bundle-v1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	admission, err := runtimeagenttopology.StaticAdmission(
-		"provider-trigger-smoke-source-set-v1",
-		fixtureBundleHash,
-		"ephemeral",
-		runtimeagenttopology.LifetimeDurableManaged,
-	)
-	if err != nil {
-		t.Fatalf("construct provider trigger smoke topology: %v", err)
-	}
 	agentContext := runtimeauthoractivity.WithScope(ctx, runtimeauthoractivity.BundleScope(
 		"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
 		fixtureBundleHash,
 	))
-	if err := storetest.UpsertAgentFixture(t, agentContext, sqliteStore, runtimemanager.PersistedAgent{
+	if err := storetest.UpsertStaticAgentFixture(t, agentContext, sqliteStore, runtimemanager.PersistedAgent{
 		Config: serveTestAgentConfig(runtimeactors.AgentConfig{
 			ID:                 agentID,
 			Identity:           servedRuntimeRootIdentity(t, agentID),
@@ -250,7 +240,6 @@ func seedProviderTriggerSmokeRuntime(
 		Status:    "active",
 		HiredBy:   "test",
 		StartedAt: now,
-		Topology:  admission,
 	}); err != nil {
 		t.Fatalf("UpsertAgent(%s): %v", agentID, err)
 	}

--- a/internal/serveapp/topology_test_helpers_test.go
+++ b/internal/serveapp/topology_test_helpers_test.go
@@ -310,7 +310,7 @@ func registerServeTestDurableAgent(
 	rec := runtimemanager.PersistedAgent{
 		Config: cfg, Status: "active", HiredBy: "serve-test-declaration",
 	}
-	if err := storetest.UpsertAgentFixture(t, ctx, selected, rec); err != nil {
+	if err := storetest.UpsertStaticAgentFixture(t, ctx, selected, rec); err != nil {
 		t.Fatalf("persist serve test durable agent: %v", err)
 	}
 	committed, err := selected.LoadAgents(ctx)

--- a/internal/store/internal/runtimepersistence/agent_fixture_authority_parity_test.go
+++ b/internal/store/internal/runtimepersistence/agent_fixture_authority_parity_test.go
@@ -1,0 +1,592 @@
+package runtimepersistence
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/agentmemory"
+	runtimeagenttopology "github.com/division-sh/swarm/internal/runtime/agenttopology"
+	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
+	runtimeagentidentity "github.com/division-sh/swarm/internal/runtime/core/agentidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/eventreceiver"
+	runtimeflowidentity "github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	runtimecorrelation "github.com/division-sh/swarm/internal/runtime/correlation"
+	runtimedelivery "github.com/division-sh/swarm/internal/runtime/deliverylifecycle"
+	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
+	runtimeexecutionmode "github.com/division-sh/swarm/internal/runtime/executionmode"
+	"github.com/division-sh/swarm/internal/runtime/executionposture"
+	runtimemanager "github.com/division-sh/swarm/internal/runtime/manager"
+	runtimepipeline "github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/semanticview"
+	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
+	agentfixture "github.com/division-sh/swarm/internal/store/testutil/agentfixture"
+	"github.com/division-sh/swarm/internal/testutil"
+	"github.com/google/uuid"
+)
+
+type agentFixtureFlowStore interface {
+	agentfixture.Store
+	runtimedelivery.Store
+	LoadDynamicFlowRuntimeReadiness(context.Context, string, runtimeflowidentity.Route) (runtimepipeline.DynamicFlowRuntimeReadiness, bool, error)
+	CommitFlowInstanceActivation(context.Context, runtimebus.FlowInstanceActivationCommand) (runtimepipeline.CommittedFlowInstanceActivation, error)
+}
+
+type agentFixtureFlowActivationCommitter struct {
+	store agentFixtureFlowStore
+}
+
+func (o agentFixtureFlowActivationCommitter) CommitFlowInstanceActivation(ctx context.Context, plan runtimepipeline.FlowInstanceActivationPlan) (runtimepipeline.CommittedFlowInstanceActivation, error) {
+	return o.store.CommitFlowInstanceActivation(ctx, runtimebus.FlowInstanceActivationCommand{
+		Plan: plan,
+		RouteTopology: []runtimebus.FlowInstanceRouteRecordSet{{
+			Identity: plan.Identity.Route(),
+		}},
+	})
+}
+
+func TestAgentFixtureExactFlowAuthorityParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx, selected := newAgentFixtureAuthorityStore(t, backend)
+			runID := uuid.NewString()
+			ctx = runtimecorrelation.WithRunID(storeTestWorkContext(t, ctx), runID)
+			ctx = runtimeeffects.WithExecutionMode(ctx, runtimeeffects.ExecutionModeLive)
+			requireRunFixtureForTest(t, ctx, selected, semanticRunFixture{
+				Origin: semanticScenarioSetupRunOriginForTest(), RunID: runID,
+			})
+			bus := &sqliteFlowActivationBus{}
+			bundle := sqliteFlowActivationBundle(t)
+			workflowStore := configureAgentFixtureFlowLifecycle(t, selected, bus, bundle)
+			lifecycle := agentfixture.Lifecycle(t, selected)
+			manager := ownStoreTestAgentManager(t, runtimemanager.NewAgentManagerWithOptions(bus, nil, runtimemanager.AgentManagerOptions{
+				ExecutionPosture:  executionposture.Live,
+				BaseContext:       ctx,
+				BundleSourceFact:  mustStoreTestEphemeralBundleSourceFact(authorActivityTestBundleHash),
+				SemanticSource:    semanticview.Wrap(bundle),
+				WorkflowInstances: workflowStore,
+				LLMBackend:        "anthropic",
+				LifecycleStore:    lifecycle,
+				DeliveryStore:     selected,
+				WorkOwner:         storeTestWorkOwner(t),
+				PersistenceRoles: runtimemanager.PersistenceRoles{
+					AgentRoutes:    bus,
+					FlowActivation: agentFixtureFlowActivationCommitter{store: selected},
+					RouteInstaller: bus,
+					RouteVerifier:  bus,
+					RouteRestorer:  bus,
+					RouteRetirer:   bus,
+				},
+				ReceiverExecution: eventreceiver.NormalExecution(),
+			}, selected))
+
+			activate := func(instanceID string) error {
+				return manager.ActivateFlowInstance(ctx, sqliteFlowActivationRequest(
+					bundle, "review", instanceID, "parent-ent", "review/"+instanceID,
+				))
+			}
+			if err := activate("sequential-a"); err != nil {
+				t.Fatalf("activate first sequential flow: %v", err)
+			}
+			firstPlan := currentAgentFixtureSourceSet(t, ctx, selected)
+			if err := activate("sequential-b"); err != nil {
+				t.Fatalf("activate second sequential flow: %v", err)
+			}
+			secondPlan := currentAgentFixtureSourceSet(t, ctx, selected)
+			if firstPlan.Revision != secondPlan.Revision || len(secondPlan.Agents) != 0 {
+				t.Fatalf("sequential flow activation changed static source set: first=%#v second=%#v", firstPlan, secondPlan)
+			}
+
+			start := make(chan struct{})
+			errs := make(chan error, 2)
+			var wg sync.WaitGroup
+			for _, instanceID := range []string{"concurrent-a", "concurrent-b"} {
+				instanceID := instanceID
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					errs <- activate(instanceID)
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(errs)
+			for err := range errs {
+				if err != nil {
+					t.Fatalf("concurrent flow activation: %v", err)
+				}
+			}
+			finalPlan := currentAgentFixtureSourceSet(t, ctx, selected)
+			if finalPlan.Revision != firstPlan.Revision || len(finalPlan.Agents) != 0 {
+				t.Fatalf("concurrent flow activation changed static source set: first=%#v final=%#v", firstPlan, finalPlan)
+			}
+
+			provider, ok := lifecycle.(interface {
+				ProcessExecutionBinding() (runtimemanager.ProcessExecutionBinding, error)
+			})
+			if !ok {
+				t.Fatal("agent fixture lifecycle does not expose process execution binding")
+			}
+			binding, err := provider.ProcessExecutionBinding()
+			if err != nil {
+				t.Fatalf("read retained fixture grant: %v", err)
+			}
+			if strings.TrimSpace(binding.GenerationGrantID) == "" {
+				t.Fatal("retained fixture grant ID is empty")
+			}
+			agents, err := selected.LoadAgents(ctx)
+			if err != nil {
+				t.Fatalf("load activated agents: %v", err)
+			}
+			for _, path := range []string{
+				"review/sequential-a", "review/sequential-b", "review/concurrent-a", "review/concurrent-b",
+			} {
+				assertExactAgentFixtureFlowAuthority(t, ctx, selected, agents, runID, path, binding)
+			}
+		})
+	}
+}
+
+func configureAgentFixtureFlowLifecycle(
+	t *testing.T,
+	selected agentFixtureFlowStore,
+	bus *sqliteFlowActivationBus,
+	bundle *runtimecontracts.WorkflowContractBundle,
+) *runtimepipeline.PipelineCoordinator {
+	t.Helper()
+	switch store := selected.(type) {
+	case *SQLiteRuntimeStore:
+		return configureSQLiteFlowActivationLifecycle(t, store, bus, bundle)
+	case *PostgresStore:
+		source := semanticview.Wrap(bundle)
+		module := sqliteFlowActivationWorkflowModule{
+			source:  source,
+			guards:  runtimepipeline.NewContractGuardRegistry(source),
+			actions: runtimepipeline.NewContractActionRegistry(source),
+		}
+		return runtimepipeline.NewPipelineCoordinatorWithOptions(bus, runtimepipeline.PipelineCoordinatorOptions{
+			ExecutionPosture:        executionposture.Live,
+			Module:                  module,
+			Persistence:             runtimepipeline.NewWorkflowPersistence(store),
+			RunLifecycle:            store,
+			PipelineObligations:     store.PipelineObligations(),
+			DeliveryStore:           store,
+			DeadLetters:             store,
+			DecisionCards:           store,
+			ProposedEffects:         store,
+			HumanTasks:              store,
+			DecisionCardDraftExpiry: store,
+			HumanTaskExpiry:         store,
+			DeliveryRuntime:         workflowTestBus{},
+			WorkOwner:               storeTestWorkOwner(t),
+			ReceiverExecution:       eventreceiver.NormalExecution(),
+		})
+	default:
+		t.Fatalf("unsupported agent fixture flow store %T", selected)
+		return nil
+	}
+}
+
+func currentAgentFixtureSourceSet(t *testing.T, ctx context.Context, selected agentfixture.Store) runtimeagenttopology.SourceSetPlan {
+	t.Helper()
+	capability, err := agentfixture.ProcessCapability(t, ctx, selected)
+	if err != nil {
+		t.Fatalf("load fixture process capability: %v", err)
+	}
+	plan, exists, err := capability.CurrentSourceSet(ctx)
+	if err != nil || !exists {
+		t.Fatalf("load fixture source set: exists=%v err=%v", exists, err)
+	}
+	return plan
+}
+
+func assertExactAgentFixtureFlowAuthority(
+	t *testing.T,
+	ctx context.Context,
+	selected agentFixtureFlowStore,
+	agents []runtimemanager.PersistedAgent,
+	runID string,
+	path string,
+	binding runtimemanager.ProcessExecutionBinding,
+) {
+	t.Helper()
+	readiness, found, err := selected.LoadDynamicFlowRuntimeReadiness(ctx, runID, runtimeflowidentity.RouteForInstancePath(path))
+	if err != nil || !found {
+		t.Fatalf("load readiness owner for %s: found=%v err=%v", path, found, err)
+	}
+	fingerprint, err := canonicaljson.Hash(readiness.Plan)
+	if err != nil {
+		t.Fatalf("fingerprint readiness owner for %s: %v", path, err)
+	}
+	want, err := runtimeagenttopology.FlowReadinessAdmission(runID, path, fingerprint)
+	if err != nil {
+		t.Fatalf("build expected readiness authority for %s: %v", path, err)
+	}
+	for _, rec := range agents {
+		if rec.Config.Identity.FlowInstance() != path {
+			continue
+		}
+		if !rec.Topology.Equal(want) || !rec.ProcessBinding.Equal(binding) {
+			t.Fatalf("activated agent %s topology/binding = %#v / %#v, want %#v / %#v", path, rec.Topology, rec.ProcessBinding, want, binding)
+		}
+		return
+	}
+	t.Fatalf("activated agent for flow path %s is missing", path)
+}
+
+type agentFixtureAcquireProbe struct {
+	agentfixture.Store
+	mu           sync.Mutex
+	acquireCalls int
+}
+
+func (s *agentFixtureAcquireProbe) AcquireProcessCapability(ctx context.Context, req runtimestartupownership.AcquireRequest) (runtimestartupownership.ProcessCapability, error) {
+	s.mu.Lock()
+	s.acquireCalls++
+	s.mu.Unlock()
+	return s.Store.AcquireProcessCapability(ctx, req)
+}
+
+func (s *agentFixtureAcquireProbe) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.acquireCalls
+}
+
+type agentFixtureAuthoritySnapshot struct {
+	Authority runtimestartupownership.Authority
+	Plan      runtimeagenttopology.SourceSetPlan
+	Binding   runtimemanager.ProcessExecutionBinding
+	States    []runtimemanager.AgentLifecycleState
+}
+
+type agentFixtureAuthorityRows struct {
+	AuthorityFacts      int
+	SourceSetHeads      int
+	SourceSetOperations int
+	GenerationGrants    int
+	Agents              int
+	LifecycleOperations int
+}
+
+func TestAgentFixtureSealedAuthorityRejectionParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx, selected := newAgentFixtureAuthorityStore(t, backend)
+			beforeRows := captureAgentFixtureAuthorityRows(t, ctx, selected)
+			if beforeRows != (agentFixtureAuthorityRows{}) {
+				t.Fatalf("fresh fixture authority store is not empty: %#v", beforeRows)
+			}
+			identity := testAgentIdentity(t, "invalid-authority", "global")
+			validFlow, err := runtimeagenttopology.FlowReadinessAdmission(uuid.NewString(), "review/invalid", "plan-v1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			invalid := rejectedAgentFixtureAdmissions(t)
+			probe := &agentFixtureAcquireProbe{Store: selected}
+			for index, topology := range invalid {
+				if _, err := agentfixture.CommitExact(t, ctx, probe, runtimemanager.AgentLifecycleTransition{
+					Identity: identity, AgentID: identity.AgentID(), Topology: topology,
+				}); err == nil {
+					t.Fatalf("invalid exact topology %d was accepted", index)
+				}
+			}
+			if _, err := agentfixture.CommitStatic(t, ctx, probe, runtimemanager.AgentLifecycleTransition{
+				Identity: identity, AgentID: identity.AgentID(), Topology: validFlow,
+			}); err == nil {
+				t.Fatal("synthetic static commit accepted caller topology")
+			}
+			invalidRecord := agentFixtureStaticRecord(t, identity)
+			invalidRecord.Topology = invalid[len(invalid)-1]
+			if err := agentfixture.UpsertStatic(t, ctx, probe, invalidRecord); err == nil {
+				t.Fatal("synthetic static upsert accepted caller topology")
+			}
+			if got := probe.calls(); got != 0 {
+				t.Fatalf("invalid fixture authority acquired process capability %d times", got)
+			}
+			states, err := selected.ListDurableAgentLifecycleStates(ctx)
+			if err != nil || len(states) != 0 {
+				t.Fatalf("invalid fixture authority created lifecycle state: states=%#v err=%v", states, err)
+			}
+			afterRows := captureAgentFixtureAuthorityRows(t, ctx, selected)
+			if afterRows != beforeRows {
+				t.Fatalf("invalid fixture authority mutated selected-store rows: before=%#v after=%#v", beforeRows, afterRows)
+			}
+
+			proveAgentFixtureMixedAuthorityRejection(t, ctx, selected)
+		})
+	}
+}
+
+func captureAgentFixtureAuthorityRows(t *testing.T, ctx context.Context, selected agentFixtureFlowStore) agentFixtureAuthorityRows {
+	t.Helper()
+	var db *sql.DB
+	switch store := selected.(type) {
+	case *SQLiteRuntimeStore:
+		db = store.backend.ConstructionHandle()
+	case *PostgresStore:
+		db = store.backend.ConstructionHandle()
+	default:
+		t.Fatalf("unsupported agent fixture authority store %T", selected)
+	}
+	counts := agentFixtureAuthorityRows{}
+	for _, query := range []struct {
+		table string
+		out   *int
+	}{
+		{table: "runtime_startup_authority_facts", out: &counts.AuthorityFacts},
+		{table: "agent_topology_source_set_head", out: &counts.SourceSetHeads},
+		{table: "agent_topology_source_set_operations", out: &counts.SourceSetOperations},
+		{table: "runtime_generation_grants", out: &counts.GenerationGrants},
+		{table: "agents", out: &counts.Agents},
+		{table: "agent_lifecycle_operations", out: &counts.LifecycleOperations},
+	} {
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+query.table).Scan(query.out); err != nil {
+			t.Fatalf("count %s: %v", query.table, err)
+		}
+	}
+	return counts
+}
+
+const agentFixtureTestBundleHash = "bundle-v1:sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+func rejectedAgentFixtureAdmissions(t *testing.T) []runtimeagenttopology.Admission {
+	t.Helper()
+	validEphemeral, err := runtimeagenttopology.NewEphemeralAdmission(uuid.NewString(), "runtime_shard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []runtimeagenttopology.Admission{
+		{},
+		{Lifetime: runtimeagenttopology.LifetimeDurableManaged, Authority: runtimeagenttopology.Authority{
+			Kind:   runtimeagenttopology.AuthorityKind("future_authority"),
+			Static: &runtimeagenttopology.StaticDeclarationPlan{SourceSetRevision: "revision", BundleHash: agentFixtureTestBundleHash, BundleSource: "ephemeral"},
+		}},
+		{Lifetime: runtimeagenttopology.LifetimeDurableManaged, Authority: runtimeagenttopology.Authority{
+			Kind: runtimeagenttopology.AuthorityStaticDeclarationPlan, Static: &runtimeagenttopology.StaticDeclarationPlan{},
+		}},
+		{Lifetime: runtimeagenttopology.LifetimeDurableManaged, Authority: runtimeagenttopology.Authority{
+			Kind: runtimeagenttopology.AuthorityFlowReadinessPlan, Readiness: &runtimeagenttopology.FlowReadinessPlan{RunID: uuid.NewString(), InstancePath: "review/invalid"},
+		}},
+		{Lifetime: runtimeagenttopology.LifetimeEphemeral, Authority: runtimeagenttopology.Authority{
+			Kind: runtimeagenttopology.AuthorityEphemeralExecution, Ephemeral: &runtimeagenttopology.EphemeralExecution{ExecutionID: uuid.NewString()},
+		}},
+		validEphemeral,
+	}
+}
+
+func newAgentFixtureAuthorityStore(t *testing.T, backend string) (context.Context, agentFixtureFlowStore) {
+	t.Helper()
+	ctx := testAuthorActivityContext()
+	switch backend {
+	case "sqlite":
+		return ctx, newBootstrappedSQLiteRuntimeStoreForTest(t)
+	case "postgres":
+		_, db, _ := testutil.StartPostgres(t)
+		return ctx, admitTestPostgresStore(t, db)
+	default:
+		t.Fatalf("unsupported backend %q", backend)
+		return nil, nil
+	}
+}
+
+func agentFixtureStaticRecord(t *testing.T, identity runtimeagentidentity.Identity) runtimemanager.PersistedAgent {
+	t.Helper()
+	return runtimemanager.PersistedAgent{
+		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
+			ID: identity.AgentID(), Identity: identity, Role: "worker", Type: "sonnet", Model: "regular",
+			FlowID: "global", FlowPath: identity.FlowInstance(), ExecutionMode: runtimeeffects.ExecutionModeLive,
+			Memory: agentmemory.Authored(true), Config: []byte(`{}`),
+		}),
+		Status: "active", HiredBy: "fixture-authority-proof", StartedAt: time.Now().UTC(),
+	}
+}
+
+func proveAgentFixtureMixedAuthorityRejection(t *testing.T, ctx context.Context, selected agentFixtureFlowStore) {
+	t.Helper()
+	staticIdentity := testAgentIdentity(t, "static-survivor", "global")
+	staticRecord := agentFixtureStaticRecord(t, staticIdentity)
+	if err := agentfixture.UpsertStatic(t, ctx, selected, staticRecord); err != nil {
+		t.Fatalf("seed static fixture survivor: %v", err)
+	}
+	flowIdentity := testAgentIdentity(t, "flow-survivor", "review/fixture")
+	flowState := seedExactAgentFixtureFlowState(t, ctx, selected, flowIdentity)
+	before := captureAgentFixtureAuthority(t, ctx, selected)
+	probe := &agentFixtureAcquireProbe{Store: selected}
+	for index, topology := range rejectedAgentFixtureAdmissions(t) {
+		if _, err := agentfixture.CommitExact(t, ctx, probe, runtimemanager.AgentLifecycleTransition{
+			Identity: flowIdentity, AgentID: flowIdentity.AgentID(), Topology: topology,
+		}); err == nil {
+			t.Fatalf("invalid exact topology %d was accepted against live fixture authority", index)
+		}
+		after := captureAgentFixtureAuthority(t, ctx, selected)
+		if !reflect.DeepEqual(after, before) {
+			t.Fatalf("invalid exact topology %d mutated fixture authority:\nbefore=%#v\nafter=%#v", index, before, after)
+		}
+	}
+
+	requireRejectedUnchanged := func(label string, mutate func() error) {
+		t.Helper()
+		if err := mutate(); err == nil || !strings.Contains(err.Error(), "retains flow_readiness_plan topology") {
+			t.Fatalf("%s error = %v, want live flow-authority rejection", label, err)
+		}
+		after := captureAgentFixtureAuthority(t, ctx, selected)
+		if !reflect.DeepEqual(after, before) {
+			t.Fatalf("%s mutated fixture authority:\nbefore=%#v\nafter=%#v", label, before, after)
+		}
+	}
+	requireRejectedUnchanged("static upsert", func() error {
+		return agentfixture.UpsertStatic(t, ctx, probe, staticRecord)
+	})
+	newStaticIdentity := testAgentIdentity(t, "new-static", "global")
+	requireRejectedUnchanged("direct static commit", func() error {
+		_, err := agentfixture.CommitStatic(t, ctx, probe, runtimemanager.AgentLifecycleTransition{
+			OperationID: uuid.NewString(), OperationKind: "spawn", RequestHash: "new-static",
+			Identity: newStaticIdentity, AgentID: newStaticIdentity.AgentID(), Trigger: "fixture-proof",
+			TargetEpoch: 1, TargetGeneration: 1, TargetPhase: runtimemanager.AgentLifecycleRegistered,
+			ConfigRevision: "new-static-revision", RunMode: runtimemanager.AgentRunModeStopped,
+			Agent: func() *runtimemanager.PersistedAgent {
+				rec := agentFixtureStaticRecord(t, newStaticIdentity)
+				return &rec
+			}(),
+			Now: time.Now().UTC(),
+		})
+		return err
+	})
+	requireRejectedUnchanged("target identity pressure", func() error {
+		_, err := agentfixture.CommitStatic(t, ctx, probe, runtimemanager.AgentLifecycleTransition{
+			OperationID: uuid.NewString(), OperationKind: "reconfigure", RequestHash: "flow-to-static",
+			Identity: flowIdentity, AgentID: flowIdentity.AgentID(), Trigger: "fixture-proof",
+			ExpectedEpoch: flowState.RuntimeEpoch, ExpectedGeneration: flowState.Generation, ExpectedPhase: flowState.Phase,
+			TargetEpoch: flowState.RuntimeEpoch, TargetGeneration: flowState.Generation + 1, TargetPhase: flowState.Phase,
+			ConfigRevision: flowState.ConfigRevision, RunMode: flowState.RunMode, Now: time.Now().UTC(),
+		})
+		return err
+	})
+	if got := probe.calls(); got != 0 {
+		t.Fatalf("mixed-authority rejection acquired a replacement process capability %d times", got)
+	}
+
+	terminateLifecycleReadinessOwnerForTest(t, ctx, selected, flowIdentity.FlowInstance())
+	if _, err := agentfixture.CommitExact(t, ctx, selected, runtimemanager.AgentLifecycleTransition{
+		OperationID: uuid.NewString(), OperationKind: "teardown", RequestHash: "terminate-flow-survivor",
+		Identity: flowIdentity, AgentID: flowIdentity.AgentID(), Trigger: "fixture-proof",
+		ExpectedEpoch: flowState.RuntimeEpoch, ExpectedGeneration: flowState.Generation, ExpectedPhase: flowState.Phase,
+		TargetEpoch: flowState.RuntimeEpoch, TargetGeneration: flowState.Generation + 1,
+		TargetPhase: runtimemanager.AgentLifecycleTerminated, ConfigRevision: flowState.ConfigRevision,
+		RunMode: runtimemanager.AgentRunModeStopped, Topology: flowState.Topology, Now: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("terminate flow fixture survivor: %v", err)
+	}
+	postTerminalIdentity := testAgentIdentity(t, "post-terminal-static", "global")
+	if err := agentfixture.UpsertStatic(t, ctx, selected, agentFixtureStaticRecord(t, postTerminalIdentity)); err != nil {
+		t.Fatalf("terminated flow cell blocked static fixture mutation: %v", err)
+	}
+	terminated, found, err := selected.LoadAgentLifecycleState(ctx, flowIdentity)
+	if err != nil || !found || terminated.Phase != runtimemanager.AgentLifecycleTerminated || !terminated.Topology.Equal(flowState.Topology) {
+		t.Fatalf("terminated flow fixture changed during static mutation: state=%#v found=%v err=%v", terminated, found, err)
+	}
+}
+
+func seedExactAgentFixtureFlowState(
+	t *testing.T,
+	ctx context.Context,
+	selected agentFixtureFlowStore,
+	identity runtimeagentidentity.Identity,
+) runtimemanager.AgentLifecycleState {
+	t.Helper()
+	plan := currentAgentFixtureSourceSet(t, ctx, selected)
+	if len(plan.Sources) != 1 {
+		t.Fatalf("fixture source set sources = %#v, want one", plan.Sources)
+	}
+	record := agentFixtureStaticRecord(t, identity)
+	revision, err := canonicaljson.Hash(record.Config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision = strings.TrimPrefix(revision, "sha256:")
+	runID := uuid.NewString()
+	requireRunningRunForTest(t, ctx, selected, runID, time.Now().UTC())
+	readinessPlan, err := (runtimepipeline.DynamicFlowRuntimeReadinessPlan{
+		Identity: runtimeflowidentity.Instance{
+			TemplateID: "review", ScopeKey: "review", InstanceID: "fixture", InstancePath: identity.FlowInstance(),
+			EntityID: uuid.NewString(), HasStoredPath: true,
+		},
+		RunID: runID, BundleHash: plan.Sources[0].BundleHash, BundleSource: plan.Sources[0].BundleSource,
+		WorkflowVersion: "1.0.0", ExecutionMode: runtimeexecutionmode.Live,
+		Agents: []runtimepipeline.DynamicFlowRuntimeAgentExpectation{{Identity: identity, ConfigRevision: revision}},
+	}).Normalized()
+	if err != nil {
+		t.Fatalf("normalize flow readiness owner: %v", err)
+	}
+	encoded, err := canonicaljson.Bytes(readinessPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedLifecycleReadinessOwner(t, ctx, selected, runID, identity.FlowInstance(), encoded, time.Now().UTC())
+	fingerprint, err := canonicaljson.Hash(readinessPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topology, err := runtimeagenttopology.FlowReadinessAdmission(runID, identity.FlowInstance(), fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.Topology = topology
+	if _, err := agentfixture.CommitExact(t, ctx, selected, runtimemanager.AgentLifecycleTransition{
+		OperationID: uuid.NewString(), OperationKind: "spawn", RequestHash: "flow-survivor",
+		Identity: identity, AgentID: identity.AgentID(), Trigger: "fixture-proof",
+		TargetEpoch: 1, TargetGeneration: 1, TargetPhase: runtimemanager.AgentLifecycleRegistered,
+		ConfigRevision: revision, RunMode: runtimemanager.AgentRunModeStopped,
+		Agent: &record, Topology: topology, Now: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed exact flow fixture survivor: %v", err)
+	}
+	state, found, err := selected.LoadAgentLifecycleState(ctx, identity)
+	if err != nil || !found {
+		t.Fatalf("load exact flow fixture survivor: found=%v err=%v", found, err)
+	}
+	return state
+}
+
+func captureAgentFixtureAuthority(t *testing.T, ctx context.Context, selected agentFixtureFlowStore) agentFixtureAuthoritySnapshot {
+	t.Helper()
+	capability, err := agentfixture.ProcessCapability(t, ctx, selected)
+	if err != nil {
+		t.Fatalf("load fixture capability: %v", err)
+	}
+	authority, err := capability.Evidence()
+	if err != nil {
+		t.Fatalf("load fixture capability evidence: %v", err)
+	}
+	plan, exists, err := capability.CurrentSourceSet(ctx)
+	if err != nil || !exists {
+		t.Fatalf("load fixture source set: exists=%v err=%v", exists, err)
+	}
+	states, err := selected.ListDurableAgentLifecycleStates(ctx)
+	if err != nil {
+		t.Fatalf("load fixture lifecycle census: %v", err)
+	}
+	sort.Slice(states, func(i, j int) bool {
+		left, _ := states[i].Identity.Fingerprint()
+		right, _ := states[j].Identity.Fingerprint()
+		return left < right
+	})
+	binding := runtimemanager.ProcessExecutionBinding{}
+	for _, state := range states {
+		if state.ProcessBinding.BundleHash == agentFixtureTestBundleHash && state.ProcessBinding.BundleSource == "ephemeral" {
+			binding = state.ProcessBinding
+			break
+		}
+	}
+	return agentFixtureAuthoritySnapshot{Authority: authority, Plan: plan, Binding: binding, States: states}
+}

--- a/internal/store/internal/runtimepersistence/agent_intent_persistence_parity_test.go
+++ b/internal/store/internal/runtimepersistence/agent_intent_persistence_parity_test.go
@@ -154,7 +154,7 @@ func seedSelectedStoreIntentAgent(t testing.TB, ctx context.Context, store agent
 		Prompt:             prompt,
 		Criteria:           []string{"hostile-replacement"},
 	}
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{Config: cfg, Status: "active", StartedAt: time.Now().UTC()}); err != nil {
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{Config: cfg, Status: "active", StartedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 }

--- a/internal/store/internal/runtimepersistence/agent_lifecycle_effects_test.go
+++ b/internal/store/internal/runtimepersistence/agent_lifecycle_effects_test.go
@@ -72,7 +72,7 @@ func proveSameSlugSiblingExternalEffectAuthority(t *testing.T, store lifecycleEf
 			}),
 			Status: "active", HiredBy: "test", StartedAt: now,
 		}
-		spawned, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+		spawned, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 			OperationID: fixture.spawnID, OperationKind: "spawn", RequestHash: "sibling-spawn",
 			Identity: fixture.identity, AgentID: rec.Config.ID, Trigger: "spawn", TargetEpoch: 21,
 			TargetGeneration: 1, TargetPhase: runtimemanager.AgentLifecycleRegistered,
@@ -82,7 +82,7 @@ func proveSameSlugSiblingExternalEffectAuthority(t *testing.T, store lifecycleEf
 		if err != nil {
 			t.Fatalf("spawn sibling %s: %v", fixture.identity.FlowInstance(), err)
 		}
-		started, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+		started, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 			OperationID: fixture.startID, OperationKind: "start", RequestHash: "sibling-start",
 			Identity: fixture.identity, AgentID: rec.Config.ID, Trigger: "start",
 			ExpectedEpoch: spawned.RuntimeEpoch, ExpectedGeneration: spawned.Generation, ExpectedPhase: spawned.Phase,
@@ -170,7 +170,7 @@ func proveLifecycleAndExternalEffectAuthority(t *testing.T, store lifecycleEffec
 		TargetPhase: runtimemanager.AgentLifecycleRegistered, ConfigRevision: "revision-1",
 		RunMode: runtimemanager.AgentRunModeStopped, Agent: &rec, Now: now,
 	}
-	spawned, err := agentfixture.Commit(t, ctx, store, spawn)
+	spawned, err := agentfixture.CommitStatic(t, ctx, store, spawn)
 	if err != nil {
 		t.Fatalf("spawn lifecycle transition: %v", err)
 	}
@@ -181,11 +181,11 @@ func proveLifecycleAndExternalEffectAuthority(t *testing.T, store lifecycleEffec
 		TargetEpoch: 11, TargetGeneration: 2, TargetPhase: runtimemanager.AgentLifecycleRunning,
 		ConfigRevision: "revision-1", RunMode: runtimemanager.AgentRunModeStandard, Now: now.Add(time.Second),
 	}
-	started, err := agentfixture.Commit(t, ctx, store, start)
+	started, err := agentfixture.CommitStatic(t, ctx, store, start)
 	if err != nil {
 		t.Fatalf("start lifecycle transition: %v", err)
 	}
-	replayed, err := agentfixture.Commit(t, ctx, store, start)
+	replayed, err := agentfixture.CommitStatic(t, ctx, store, start)
 	if err != nil || !replayed.Replayed || replayed.Generation != started.Generation {
 		t.Fatalf("lifecycle replay = %#v err=%v", replayed, err)
 	}
@@ -258,7 +258,7 @@ func proveLifecycleAndExternalEffectAuthority(t *testing.T, store lifecycleEffec
 	requireExternalOperationState(t, db, sqlite, prelaunch.Attempt().OperationID, runtimeeffects.StateTerminalFailure)
 	requireExternalOperationState(t, db, sqlite, launched.Attempt().OperationID, runtimeeffects.StateOutcomeUncertain)
 
-	restarted, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	restarted, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: "00000000-0000-0000-0000-000000001903", OperationKind: "restart", RequestHash: "restart-hash",
 		Identity: identity, AgentID: rec.Config.ID, Trigger: "restart", ExpectedEpoch: started.RuntimeEpoch,
 		ExpectedGeneration: started.Generation, ExpectedPhase: started.Phase,
@@ -316,7 +316,7 @@ func proveLifecycleAndExternalEffectAuthority(t *testing.T, store lifecycleEffec
 	if err != nil {
 		t.Fatalf("authorize launch-fence effect: %v", err)
 	}
-	if _, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	if _, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: "00000000-0000-0000-0000-000000001904", OperationKind: "restart", RequestHash: "restart-launch-fence-hash",
 		Identity: identity, AgentID: rec.Config.ID, Trigger: "restart", ExpectedEpoch: restarted.RuntimeEpoch,
 		ExpectedGeneration: restarted.Generation, ExpectedPhase: restarted.Phase,

--- a/internal/store/internal/runtimepersistence/agent_lifecycle_read_surface_test.go
+++ b/internal/store/internal/runtimepersistence/agent_lifecycle_read_surface_test.go
@@ -235,7 +235,7 @@ func seedAgentLifecycleSession(t *testing.T, ctx context.Context, pg *PostgresSt
 	if err != nil {
 		t.Fatalf("seed lifecycle identity: %v", err)
 	}
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: fields.AgentID, Identity: identity, Role: "worker", Type: "managed",
 			Model: "test", Memory: agentmemory.Authored(true), FlowPath: fields.FlowInstancePath,

--- a/internal/store/internal/runtimepersistence/agent_lifecycle_source_set_rebind_parity_test.go
+++ b/internal/store/internal/runtimepersistence/agent_lifecycle_source_set_rebind_parity_test.go
@@ -155,7 +155,7 @@ func proveAgentLifecycleProcessBindingReadback(t *testing.T, store lifecycleSour
 	ctx := testAuthorActivityContext()
 	staticIdentity := testAgentIdentity(t, "process-static-agent", "")
 	readinessIdentity := testAgentIdentity(t, "process-readiness-agent", "readiness/instance-1")
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: "process-static-agent", Identity: staticIdentity,
 			Role: "worker", Type: "sonnet", Model: "regular", Memory: agentmemory.PlatformDefault(),
@@ -418,7 +418,7 @@ func proveAgentLifecycleSourceSetRebind(t *testing.T, store lifecycleSourceSetRe
 		}),
 		Status: "active", HiredBy: "source-set-rebind-test", StartedAt: now,
 	}
-	if err := agentfixture.Upsert(t, ctx, store, record); err != nil {
+	if err := agentfixture.UpsertStatic(t, ctx, store, record); err != nil {
 		t.Fatalf("seed lifecycle cell: %v", err)
 	}
 	before, exists, err := store.LoadAgentLifecycleState(ctx, identity)
@@ -433,7 +433,7 @@ func proveAgentLifecycleSourceSetRebind(t *testing.T, store lifecycleSourceSetRe
 		TargetEpoch: before.RuntimeEpoch, TargetGeneration: before.Generation, TargetPhase: before.Phase,
 		ConfigRevision: before.ConfigRevision, RunMode: before.RunMode, Topology: before.Topology, Now: now.Add(time.Second),
 	}
-	result, err := agentfixture.Commit(t, ctx, store, request)
+	result, err := agentfixture.CommitExact(t, ctx, store, request)
 	if err != nil {
 		t.Fatalf("commit source-set rebind: %v", err)
 	}
@@ -441,13 +441,13 @@ func proveAgentLifecycleSourceSetRebind(t *testing.T, store lifecycleSourceSetRe
 		result.ConfigRevision != before.ConfigRevision || result.RunMode != before.RunMode || !result.Topology.Equal(before.Topology) {
 		t.Fatalf("source-set rebind result = %#v, want unchanged lifecycle with exact topology", result)
 	}
-	replayed, err := agentfixture.Commit(t, ctx, store, request)
+	replayed, err := agentfixture.CommitExact(t, ctx, store, request)
 	if err != nil || !replayed.Replayed || replayed.TransitionID != result.TransitionID {
 		t.Fatalf("exact source-set rebind replay = %#v err=%v, want transition %s", replayed, err, result.TransitionID)
 	}
 	changed := request
 	changed.RequestHash = "source-set-rebind-conflict"
-	if _, err := agentfixture.Commit(t, ctx, store, changed); err == nil {
+	if _, err := agentfixture.CommitExact(t, ctx, store, changed); err == nil {
 		t.Fatal("changed source-set rebind duplicate was accepted")
 	} else {
 		var failure *runtimefailures.Error

--- a/internal/store/internal/runtimepersistence/agent_lifecycle_transaction_test.go
+++ b/internal/store/internal/runtimepersistence/agent_lifecycle_transaction_test.go
@@ -60,7 +60,7 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 		}),
 		Status: "active", HiredBy: "test", StartedAt: now,
 	}
-	spawned, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	spawned, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "spawn", RequestHash: "subordinate-spawn",
 		Identity: identity, AgentID: agentID, Trigger: "spawn", TargetEpoch: 71, TargetGeneration: 1,
 		TargetPhase: runtimemanager.AgentLifecycleRegistered, ConfigRevision: "revision-1",
@@ -69,7 +69,7 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 	if err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
-	started, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	started, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "start", RequestHash: "subordinate-start",
 		Identity: identity, AgentID: agentID, Trigger: "start", ExpectedEpoch: spawned.RuntimeEpoch,
 		ExpectedGeneration: spawned.Generation, ExpectedPhase: spawned.Phase,
@@ -143,7 +143,7 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 		},
 		Now: now.Add(2 * time.Second),
 	}
-	rotated, err := agentfixture.Commit(t, ctx, store, rotate)
+	rotated, err := agentfixture.CommitStatic(t, ctx, store, rotate)
 	if err != nil {
 		t.Fatalf("rotate complete set: %v", err)
 	}
@@ -160,13 +160,13 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 			t.Fatalf("successor retained mutable state: conversation=%s runtime_state=%s turns=%d status=%s mutation=%#v", conversation, runtimeState, turnCount, status, mutation)
 		}
 	}
-	replayed, err := agentfixture.Commit(t, ctx, store, rotate)
+	replayed, err := agentfixture.CommitStatic(t, ctx, store, rotate)
 	if err != nil || !replayed.Replayed || !reflect.DeepEqual(replayed.Subordinate, rotated.Subordinate) {
 		t.Fatalf("exact replay = %#v err=%v, want subordinate %#v", replayed, err, rotated.Subordinate)
 	}
 	changed := rotate
 	changed.RequestHash = "changed-plan-hash"
-	if _, err := agentfixture.Commit(t, ctx, store, changed); err == nil {
+	if _, err := agentfixture.CommitStatic(t, ctx, store, changed); err == nil {
 		t.Fatal("changed replay request was accepted")
 	} else {
 		var failure *runtimefailures.Error
@@ -189,7 +189,7 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 		},
 		Now: now.Add(3 * time.Second),
 	}
-	if _, err := agentfixture.Commit(t, ctx, store, failedTerminate); err == nil {
+	if _, err := agentfixture.CommitStatic(t, ctx, store, failedTerminate); err == nil {
 		t.Fatal("injected lifecycle-cell failure committed subordinate mutation")
 	}
 	dropLifecycleCellFailure(t, ctx, db, sqlite)
@@ -205,7 +205,7 @@ func proveLifecycleSubordinateTransaction(t *testing.T, store lifecycleSubordina
 
 	failedTerminate.OperationID = uuid.NewString()
 	failedTerminate.RequestHash = "successful-termination"
-	terminated, err := agentfixture.Commit(t, ctx, store, failedTerminate)
+	terminated, err := agentfixture.CommitStatic(t, ctx, store, failedTerminate)
 	if err != nil {
 		t.Fatalf("terminate complete set: %v", err)
 	}

--- a/internal/store/internal/runtimepersistence/completion_settlement_test.go
+++ b/internal/store/internal/runtimepersistence/completion_settlement_test.go
@@ -1118,7 +1118,7 @@ func newCompletionSettlementFixtureWithMemory(t *testing.T, store completionSett
 	if err != nil {
 		t.Fatalf("completion agent identity: %v", err)
 	}
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: agentID, Identity: identity, Role: "worker", Type: "managed",
 			Model: "regular", LLMBackend: "claude_cli", ResolvedLLMBackend: "claude_cli",

--- a/internal/store/internal/runtimepersistence/destructive_reset_directive_integration_test.go
+++ b/internal/store/internal/runtimepersistence/destructive_reset_directive_integration_test.go
@@ -91,14 +91,15 @@ func TestDestructiveResetFailsClosedWhileDirectiveBoardStepIsRunning(t *testing.
 		HiredBy:   "destructive-reset-test",
 		StartedAt: time.Now().UTC(),
 	}
-	rec.Topology, err = runtimeagenttopology.NewEphemeralAdmission(uuid.NewString(), "runtime_shard")
+	if err := agentfixture.UpsertStatic(t, ctx, pg, rec); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	executionRec := rec
+	executionRec.Topology, err = runtimeagenttopology.NewEphemeralAdmission(uuid.NewString(), "runtime_shard")
 	if err != nil {
 		t.Fatalf("build ephemeral topology admission: %v", err)
 	}
-	if err := agentfixture.Upsert(t, ctx, pg, rec); err != nil {
-		t.Fatalf("UpsertAgent: %v", err)
-	}
-	if err := manager.MaterializeAdmittedAgentForExecution(ctx, rec); err != nil {
+	if err := manager.MaterializeAdmittedAgentForExecution(ctx, executionRec); err != nil {
 		t.Fatalf("MaterializeAdmittedAgentForExecution: %v", err)
 	}
 	request := runtimeagentcontrol.SendDirectiveRequest{

--- a/internal/store/internal/runtimepersistence/directive_acknowledgment_test.go
+++ b/internal/store/internal/runtimepersistence/directive_acknowledgment_test.go
@@ -495,7 +495,7 @@ func newDirectiveAmbiguityHarness(t *testing.T, backend directiveAmbiguityBacken
 		}),
 		Status: "active",
 	}
-	if err := agentfixture.Upsert(t, testAuthorActivityContext(), backend.store, rec); err != nil {
+	if err := agentfixture.UpsertStatic(t, testAuthorActivityContext(), backend.store, rec); err != nil {
 		t.Fatalf("persist agent: %v", err)
 	}
 	rec.Topology, err = runtimeagenttopology.NewEphemeralAdmission(uuid.NewString(), "runtime_shard")

--- a/internal/store/internal/runtimepersistence/managed_capability_test.go
+++ b/internal/store/internal/runtimepersistence/managed_capability_test.go
@@ -236,7 +236,7 @@ func seedManagedTurnFixtureAgent(t testing.TB, ctx context.Context, store comple
 	if strings.TrimSpace(flowInstance) != "" {
 		memory = agentmemory.Authored(true)
 	}
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: agentID, Identity: identity.Agent, Role: "worker", Type: "managed",
 			Model: "regular", LLMBackend: "anthropic", ResolvedLLMBackend: "anthropic",

--- a/internal/store/internal/runtimepersistence/operator_agent_conversation_read_surface_test.go
+++ b/internal/store/internal/runtimepersistence/operator_agent_conversation_read_surface_test.go
@@ -152,7 +152,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsPromotesCanonicalOw
 	pg := newTestPostgresStore(t, db)
 
 	ctx := testAuthorActivityContext()
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-1", "researcher"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
@@ -251,14 +251,14 @@ func TestOperatorAgentReadSurfaceLoadAgentUsageSplitsExactAndEstimated(t *testin
 	pg := newTestPostgresStore(t, db)
 
 	ctx := testAuthorActivityContext()
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-1", "researcher"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("UpsertAgent agent-1: %v", err)
 	}
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-2", "other"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
@@ -440,7 +440,7 @@ func TestSQLiteRuntimeStoreLoadAgentUsageFailsClosedOnMalformedRows(t *testing.T
 
 func seedOperatorAgentUsageAgent(t *testing.T, ctx context.Context, store *SQLiteRuntimeStore, agentID string, status string) {
 	t.Helper()
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig(agentID, "researcher"),
 		Status:    status,
 		StartedAt: time.Now().UTC(),
@@ -455,7 +455,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsDoesNotRequireConve
 	pg := newTestPostgresStore(t, db)
 
 	ctx := testAuthorActivityContext()
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-1", "researcher"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
@@ -491,7 +491,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres(t *testing.T
 		{"agent-1", "researcher"},
 		{"agent-2", "reviewer"},
 	} {
-		if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+		if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 			Config:    testOperatorAgentConfig(agent.id, agent.role),
 			Status:    "active",
 			StartedAt: time.Now().UTC(),
@@ -643,14 +643,14 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryLifecyclePostgres(t *testing.T
 func TestSQLiteRuntimeStoreLoadAgentDeliveryLifecycle(t *testing.T) {
 	sqliteStore := newBootstrappedSQLiteRuntimeStoreForTest(t)
 	ctx := testAuthorActivityContext()
-	if err := agentfixture.Upsert(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-1", "researcher"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
-	if err := agentfixture.Upsert(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, sqliteStore, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-2", "reviewer"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),
@@ -867,7 +867,7 @@ func TestOperatorAgentReadSurfaceLoadAgentDeliveryDiagnosticsUsesCanonicalLifecy
 	pg := newTestPostgresStore(t, db)
 
 	ctx := testAuthorActivityContext()
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    testOperatorAgentConfig("agent-1", "researcher"),
 		Status:    "active",
 		StartedAt: time.Now().UTC(),

--- a/internal/store/internal/runtimepersistence/operator_agent_delivery_pagination_parity_test.go
+++ b/internal/store/internal/runtimepersistence/operator_agent_delivery_pagination_parity_test.go
@@ -37,7 +37,7 @@ func TestOperatorAgentDeliveryPagesBoundHydrationParity(t *testing.T) {
 			runID := uuid.NewString()
 			seedAuthorActivityReceiptRun(t, fixture, ctx, runID)
 			identity := testAgentIdentity(t, "agent-a", "")
-			if err := agentfixture.Upsert(t, ctx, selected, runtimemanager.PersistedAgent{
+			if err := agentfixture.UpsertStatic(t, ctx, selected, runtimemanager.PersistedAgent{
 				Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 					ID: "agent-a", Identity: identity, Role: "worker", Type: "managed", Model: "regular", ExecutionMode: "live",
 					Memory: agentmemory.PlatformDefault(), Config: json.RawMessage(`{}`),

--- a/internal/store/internal/runtimepersistence/operator_dead_letter_evidence_parity_test.go
+++ b/internal/store/internal/runtimepersistence/operator_dead_letter_evidence_parity_test.go
@@ -40,7 +40,7 @@ func TestOperatorDeadLetterEvidenceIsScopedToExactDeliveryParity(t *testing.T) {
 			eventID := uuid.NewString()
 			seedAuthorActivityReceiptRun(t, fixture, ctx, runID)
 			identity := testAgentIdentity(t, "agent-a", "global")
-			if err := agentfixture.Upsert(t, ctx, selected, runtimemanager.PersistedAgent{
+			if err := agentfixture.UpsertStatic(t, ctx, selected, runtimemanager.PersistedAgent{
 				Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 					Identity: identity, ID: "agent-a", Role: "worker", Type: "managed", Model: "regular", ExecutionMode: "live",
 					Memory: agentmemory.PlatformDefault(), FlowPath: "global", Config: json.RawMessage(`{}`),
@@ -132,7 +132,7 @@ func TestOperatorRunTerminalizationPreservesExactDeadLetterEvidenceParity(t *tes
 			eventID := uuid.NewString()
 			seedAuthorActivityReceiptRun(t, fixture, ctx, runID)
 			identity := testAgentIdentity(t, "terminal-agent", "global")
-			if err := agentfixture.Upsert(t, ctx, selected, runtimemanager.PersistedAgent{
+			if err := agentfixture.UpsertStatic(t, ctx, selected, runtimemanager.PersistedAgent{
 				Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 					Identity: identity, ID: "terminal-agent", Role: "worker", Type: "managed", Model: "regular", ExecutionMode: "live",
 					Memory: agentmemory.PlatformDefault(), FlowPath: "global", Config: json.RawMessage(`{}`),

--- a/internal/store/internal/runtimepersistence/postgres_helpers_test.go
+++ b/internal/store/internal/runtimepersistence/postgres_helpers_test.go
@@ -125,11 +125,11 @@ func TestPostgresStore_HelpersAndDescriptors(t *testing.T) {
 	}
 
 	// Active agent descriptors.
-	_ = agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	_ = agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{Identity: testAgentIdentity(t, "a", "review/inst-1"), ID: "a", Role: "a", FlowID: "global", Type: "stub", Model: "regular", ExecutionMode: "live", FlowPath: "review/inst-1", EntityID: entityID, Config: []byte(`{}`)}),
 		Status: "active", HiredBy: "test", StartedAt: time.Now().UTC(),
 	})
-	_ = agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	_ = agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{Identity: testAgentIdentity(t, "t", "global"), ID: "t", Role: "t", FlowID: "global", Type: "stub", Model: "regular", ExecutionMode: "live", FlowPath: "global", Config: []byte(`{}`)}),
 		Status: "terminated", HiredBy: "test", StartedAt: time.Now().UTC(),
 	})

--- a/internal/store/internal/runtimepersistence/postgres_smoke_test.go
+++ b/internal/store/internal/runtimepersistence/postgres_smoke_test.go
@@ -46,7 +46,7 @@ func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing
 
 	// Upsert agent + load agents.
 	controlPlaneIdentity := testAgentIdentity(t, "control-plane", "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            "control-plane",
 			Identity:      controlPlaneIdentity,
@@ -71,7 +71,7 @@ func TestPostgresStore_Smoke_ManagerEventsMailboxInboundScanCampaigns(t *testing
 	// Seed an operating agent id so routing_rules FK constraints are satisfied.
 	ceoID := "operator-" + entityID
 	ceoIdentity := testAgentIdentity(t, ceoID, "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            ceoID,
 			Identity:      ceoIdentity,

--- a/internal/store/internal/runtimepersistence/postgres_store_additional_test.go
+++ b/internal/store/internal/runtimepersistence/postgres_store_additional_test.go
@@ -136,7 +136,7 @@ func terminateSpecAgentViaLifecycle(t *testing.T, ctx context.Context, pg *Postg
 	if targetEpoch == 0 {
 		targetEpoch = 1
 	}
-	result, err := agentfixture.Commit(t, ctx, pg, runtimemanager.AgentLifecycleTransition{
+	result, err := agentfixture.CommitStatic(t, ctx, pg, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "teardown", RequestHash: "test-terminate-" + identity.AgentID(),
 		Identity: identity, AgentID: identity.AgentID(), Trigger: "test", ExpectedEpoch: epoch, ExpectedGeneration: generation, ExpectedPhase: phase,
 		TargetEpoch: targetEpoch, TargetGeneration: generation + 1, TargetPhase: runtimemanager.AgentLifecycleTerminated,
@@ -662,7 +662,7 @@ func seedSpecAgent(t *testing.T, ctx context.Context, pg *PostgresStore, agentID
 		Config:        []byte(`{}`),
 		Identity:      specMemoryIdentity(agentID, "global").Agent,
 	})
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config:    cfg,
 		Status:    "active",
 		HiredBy:   "test",
@@ -1314,7 +1314,7 @@ func TestManagerStore_LoadRoutingRules_AndDeactivateValidation(t *testing.T) {
 		t.Fatalf("expected entity_id required")
 	}
 
-	if _, err := agentfixture.Commit(t, ctx, pg, runtimemanager.AgentLifecycleTransition{}); err == nil {
+	if _, err := agentfixture.CommitExact(t, ctx, pg, runtimemanager.AgentLifecycleTransition{}); err == nil {
 		t.Fatalf("expected lifecycle transition fields required")
 	}
 
@@ -2477,7 +2477,7 @@ func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
 		Status:  "active",
 		HiredBy: "test",
 	}
-	if err := agentfixture.Upsert(t, ctx, pg, rec); err != nil {
+	if err := agentfixture.UpsertStatic(t, ctx, pg, rec); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 	agents, err := pg.LoadAgents(ctx)
@@ -2497,7 +2497,7 @@ func TestManagerStore_UpsertAgent_MergesSubscriptions(t *testing.T) {
 		t.Fatalf("expected agent loaded")
 	}
 
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{Config: runtimeactors.AgentConfig{ExecutionMode: "live"}}); err == nil {
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{Config: runtimeactors.AgentConfig{ExecutionMode: "live"}}); err == nil {
 		t.Fatalf("expected agent id required error")
 	}
 }
@@ -2539,7 +2539,7 @@ func TestManagerStore_UpsertAgent_PersistsCanonicalControlPlaneOwnership(t *test
 		}),
 		Status: "active",
 	}
-	if err := agentfixture.Upsert(t, ctx, pg, rec); err != nil {
+	if err := agentfixture.UpsertStatic(t, ctx, pg, rec); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 
@@ -2702,7 +2702,7 @@ func TestManagerStore_LoadAgentsSpec_FailsClosedWhenOpaqueConfigContainsRuntimeK
 	pg := newTestPostgresStore(t, db)
 	ctx := testAuthorActivityContext()
 	identity := testAgentIdentity(t, "agent-invalid-config", "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: identity.AgentID(), Identity: identity,
 			Role: "reviewer", Type: "review-worker", Model: "regular",
@@ -2727,7 +2727,7 @@ func TestManagerStore_LoadAgents_FailsClosedWhenCanonicalModelMissing(t *testing
 	pg := newTestPostgresStore(t, db)
 	ctx := testAuthorActivityContext()
 	identity := testAgentIdentity(t, "agent-missing-type", "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: identity.AgentID(), Identity: identity,
 			Role: "reviewer", Type: "review-worker", Model: "regular",
@@ -2757,7 +2757,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 	entityID := uuid.NewString()
 	seedSpecEntityState(t, ctx, db, entityID, "testco", "testco", "TestCo", "operating")
 	a1Identity := testAgentIdentity(t, "a1", "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{ExecutionMode: "live", ID: "a1",
 			Identity: a1Identity,
 			Role:     "role",
@@ -2788,7 +2788,7 @@ func TestPostgresStore_Manager_MoreCoverage(t *testing.T) {
 
 	ceoID := "operator-" + entityID
 	ceoIdentity := testAgentIdentity(t, ceoID, "operating/global")
-	_ = agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	_ = agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{ExecutionMode: "live", ID: ceoID,
 			Identity: ceoIdentity,
 			Role:     "operator",
@@ -2902,7 +2902,7 @@ func TestPostgresStore_LoadAgents_FailsClosedOnLegacyRuntimeMetadataInConfig(t *
 	pg := newTestPostgresStore(t, db)
 	ctx := testAuthorActivityContext()
 	identity := testAgentIdentity(t, "legacy-session-agent", "")
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: identity.AgentID(), Identity: identity,
 			Role: "worker", Type: "review-worker", Model: "regular",
@@ -2939,7 +2939,7 @@ func TestPostgresStore_LifecycleTerminationCleansMutableRuntimeState(t *testing.
 	ctx := runtimeeffects.WithDifferentOwner(testAuthorActivityContext(), runtimeeffects.OwnerBuildTestInfrastructure)
 	resetAgentSessionsSpecTable(t, ctx, pg)
 
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{ExecutionMode: "live", ID: "agent-cleanup-1",
 			Identity: testAgentIdentity(t, "agent-cleanup-1", "global"),
 			Role:     "worker",

--- a/internal/store/internal/runtimepersistence/provider_attempt_drain_test.go
+++ b/internal/store/internal/runtimepersistence/provider_attempt_drain_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/division-sh/swarm/internal/events"
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/runtime/agentmemory"
+	runtimeagenttopology "github.com/division-sh/swarm/internal/runtime/agenttopology"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	runtimedelivery "github.com/division-sh/swarm/internal/runtime/deliverylifecycle"
 	runtimeeffects "github.com/division-sh/swarm/internal/runtime/effects"
@@ -630,16 +631,17 @@ func TestProviderAttemptDrainRejectsTransitionWhilePendingParity(t *testing.T) {
 	forEachProviderDrainStore(t, func(t *testing.T, fixture completionSettlementFixture) {
 		ctx := providerDrainContext(t, fixture, "pending-drain-transition-fence")
 		handle := beginObservedCompletionForSettlementTest(t, ctx, "anthropic_api", "pending-drain-transition-fence")
-		transition := supersedeProviderDrainFixture(t, fixture, runtimemanager.AgentLifecycleTerminated)
+		transition := supersedeProviderDrainFixture(t, fixture, runtimemanager.AgentLifecycleFailed)
 		for _, operation := range []string{"restart", "reconfigure"} {
+			state := providerDrainFixtureState(t, fixture)
 			_, err := fixture.lifecycle.CommitAgentLifecycleTransition(testAuthorActivityContext(), runtimemanager.AgentLifecycleTransition{
 				OperationID: uuid.NewString(), OperationKind: operation, RequestHash: "pending-drain-" + operation,
 				Identity: fixture.authority.Normal.Identity, AgentID: fixture.agentID, Trigger: "provider_drain_test",
 				ExpectedEpoch: fixture.authority.Normal.RuntimeEpoch, ExpectedGeneration: transition.Generation,
 				ExpectedPhase: runtimemanager.AgentLifecycleDraining,
 				TargetEpoch:   fixture.authority.Normal.RuntimeEpoch, TargetGeneration: transition.Generation + 1,
-				TargetPhase: runtimemanager.AgentLifecycleRunning, ConfigRevision: "pending-drain-reintroduction",
-				RunMode: runtimemanager.AgentRunModeStandard, Now: time.Now().UTC(),
+				TargetPhase: runtimemanager.AgentLifecycleRunning, ConfigRevision: state.ConfigRevision,
+				RunMode: runtimemanager.AgentRunModeStandard, Topology: state.Topology, Now: time.Now().UTC(),
 			})
 			failure, matched := runtimefailures.As(err)
 			if err == nil || !matched || failure.Failure.Detail.Code != "provider_attempt_drain_transition_blocked" {
@@ -785,14 +787,30 @@ func commitProviderDrainTransition(t testing.TB, fixture completionSettlementFix
 	if phase == runtimemanager.AgentLifecycleRunning {
 		runMode = runtimemanager.AgentRunModeStandard
 	}
-	return fixture.lifecycle.CommitAgentLifecycleTransition(testAuthorActivityContext(), runtimemanager.AgentLifecycleTransition{
+	state := providerDrainFixtureState(t, fixture)
+	transition := runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: kind, RequestHash: "provider-drain-" + kind,
 		Identity: fixture.authority.Normal.Identity, AgentID: fixture.agentID, Trigger: "provider_drain_test",
 		ExpectedEpoch: fixture.authority.Normal.RuntimeEpoch, ExpectedGeneration: fixture.authority.Normal.Generation,
 		ExpectedPhase: runtimemanager.AgentLifecycleRunning,
 		TargetEpoch:   fixture.authority.Normal.RuntimeEpoch, TargetGeneration: fixture.authority.Normal.Generation + 1,
-		TargetPhase: phase, ConfigRevision: "provider-drain-revision", RunMode: runMode, Now: time.Now().UTC(),
-	})
+		TargetPhase: phase, ConfigRevision: state.ConfigRevision, RunMode: runMode,
+		Topology: state.Topology, Now: time.Now().UTC(),
+	}
+	if kind == "teardown" {
+		transition.Topology = runtimeagenttopology.Admission{}
+		return agentfixture.CommitStatic(fixture.agentOwner, testAuthorActivityContext(), fixture.store, transition)
+	}
+	return fixture.lifecycle.CommitAgentLifecycleTransition(testAuthorActivityContext(), transition)
+}
+
+func providerDrainFixtureState(t testing.TB, fixture completionSettlementFixture) runtimemanager.AgentLifecycleState {
+	t.Helper()
+	state, found, err := fixture.store.LoadAgentLifecycleState(testAuthorActivityContext(), fixture.authority.Normal.Identity)
+	if err != nil || !found {
+		t.Fatalf("load provider-drain fixture topology: found=%v err=%v", found, err)
+	}
+	return state
 }
 
 func requireProviderDrainCount(t *testing.T, fixture completionSettlementFixture, attemptID string, want int) {
@@ -1062,7 +1080,7 @@ func newProviderDrainSiblingFixture(t *testing.T, fixture completionSettlementFi
 		t.Fatalf("same-slug sibling identity: %v", err)
 	}
 	now := time.Now().UTC()
-	if err := agentfixture.Upsert(fixture.agentOwner, testAuthorActivityContext(), fixture.store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(fixture.agentOwner, testAuthorActivityContext(), fixture.store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ExecutionMode: "live", ID: fields.AgentID, Identity: sibling.authority.Normal.Identity,
 			Role: "worker", Type: "managed", Model: "regular", LLMBackend: "claude_cli",

--- a/internal/store/internal/runtimepersistence/run_debug_read_surface_test.go
+++ b/internal/store/internal/runtimepersistence/run_debug_read_surface_test.go
@@ -29,7 +29,7 @@ import (
 func seedRunDebugAgent(t *testing.T, pg *PostgresStore, ctx context.Context, agentID string, entityID string, memory agentmemory.Plan, flowPath string) {
 	t.Helper()
 	identity := testAgentIdentity(t, agentID, flowPath)
-	if err := agentfixture.Upsert(t, ctx, pg, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, pg, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            agentID,
 			Identity:      identity,

--- a/internal/store/internal/runtimepersistence/run_fork_revision_conformance_test.go
+++ b/internal/store/internal/runtimepersistence/run_fork_revision_conformance_test.go
@@ -616,7 +616,7 @@ func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) 
 		}),
 		Status: "active", HiredBy: "revision-proof", StartedAt: now,
 	}
-	spawned, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	spawned, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "spawn", RequestHash: "revision-spawn",
 		Identity: identity, AgentID: agentID, Trigger: "spawn", TargetEpoch: 1, TargetGeneration: 1,
 		TargetPhase: runtimemanager.AgentLifecycleRegistered, ConfigRevision: "revision-1",
@@ -625,7 +625,7 @@ func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) 
 	if err != nil {
 		t.Fatalf("spawn lifecycle agent: %v", err)
 	}
-	started, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	started, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "start", RequestHash: "revision-start",
 		Identity: identity, AgentID: agentID, Trigger: "start", ExpectedEpoch: spawned.RuntimeEpoch,
 		ExpectedGeneration: spawned.Generation, ExpectedPhase: spawned.Phase,
@@ -668,7 +668,7 @@ func TestPostgresLifecycleSessionMutationPublishesRunForkRevision(t *testing.T) 
 		t.Fatalf("commit lifecycle source revision: %v", err)
 	}
 
-	if _, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	if _, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "teardown", RequestHash: "revision-terminate",
 		Identity: identity, AgentID: agentID, Trigger: "terminate", ExpectedEpoch: started.RuntimeEpoch,
 		ExpectedGeneration: started.Generation, ExpectedPhase: started.Phase,

--- a/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
+++ b/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/agentmemory"
 	runtimeagenttopology "github.com/division-sh/swarm/internal/runtime/agenttopology"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
 	"github.com/division-sh/swarm/internal/runtime/core/eventreceiver"
@@ -69,7 +70,7 @@ func TestSQLiteRuntimeStoreSelectedCoreContracts(t *testing.T) {
 		t.Fatalf("recipients = %#v, want agent-1", recipients)
 	}
 
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            "agent-1",
 			Identity:      testAgentIdentity(t, "agent-1", ""),
@@ -406,7 +407,7 @@ func TestSQLiteRuntimeStoreUpsertAgentIgnoresAmbientPipelineTransaction(t *testi
 	}
 	now := time.Now().UTC()
 	txctx := runtimepipelinefixture.WithSQLTx(ctx, tx)
-	if err := agentfixture.Upsert(t, txctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, txctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            "agent-in-pipeline-tx",
 			Identity:      testAgentIdentity(t, "agent-in-pipeline-tx", ""),
@@ -573,7 +574,7 @@ func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T
 		"reviewer\x00review/component-a",
 		"reviewer\x00review/component-b",
 	)
-	assertSQLiteActivatedAgentFlowTopologies(t, agents, runID, "review/component-a", "review/component-b")
+	assertSQLiteActivatedAgentFlowTopologies(t, ctx, sqliteStore, agents, runID, "review/component-a", "review/component-b")
 	capability, err := agentfixture.ProcessCapability(t, ctx, sqliteStore)
 	if err != nil {
 		t.Fatalf("load fixture process capability: %v", err)
@@ -913,7 +914,14 @@ func assertSQLiteActivatedAgentRoutes(t *testing.T, agents []runtimemanager.Pers
 	}
 }
 
-func assertSQLiteActivatedAgentFlowTopologies(t *testing.T, agents []runtimemanager.PersistedAgent, runID string, wantPaths ...string) {
+func assertSQLiteActivatedAgentFlowTopologies(
+	t *testing.T,
+	ctx context.Context,
+	selected *SQLiteRuntimeStore,
+	agents []runtimemanager.PersistedAgent,
+	runID string,
+	wantPaths ...string,
+) {
 	t.Helper()
 	byPath := make(map[string]runtimemanager.PersistedAgent, len(agents))
 	for _, rec := range agents {
@@ -927,10 +935,20 @@ func assertSQLiteActivatedAgentFlowTopologies(t *testing.T, agents []runtimemana
 		if err := rec.Topology.Validate(); err != nil {
 			t.Fatalf("activated agent topology for %s is invalid: %v", path, err)
 		}
-		readiness := rec.Topology.Authority.Readiness
-		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityFlowReadinessPlan || readiness == nil ||
-			readiness.RunID != runID || readiness.InstancePath != path || strings.TrimSpace(readiness.PlanFingerprint) == "" {
-			t.Fatalf("activated agent topology for %s = %#v, want exact flow-readiness authority for run %s", path, rec.Topology, runID)
+		readiness, found, err := selected.LoadDynamicFlowRuntimeReadiness(ctx, runID, runtimeflowidentity.RouteForInstancePath(path))
+		if err != nil || !found {
+			t.Fatalf("load readiness owner for %s: found=%v err=%v", path, found, err)
+		}
+		fingerprint, err := canonicaljson.Hash(readiness.Plan)
+		if err != nil {
+			t.Fatalf("fingerprint readiness owner for %s: %v", path, err)
+		}
+		want, err := runtimeagenttopology.FlowReadinessAdmission(runID, path, fingerprint)
+		if err != nil {
+			t.Fatalf("build exact readiness topology for %s: %v", path, err)
+		}
+		if !rec.Topology.Equal(want) {
+			t.Fatalf("activated agent topology for %s = %#v, want %#v", path, rec.Topology, want)
 		}
 	}
 }
@@ -1394,7 +1412,7 @@ func TestSQLiteRuntimeStoreSessionStartupConversationAndTraceVisibility(t *testi
 	ctx = runtimecorrelation.WithRunID(ctx, runID)
 	requireRunFixtureForTest(t, ctx, NewSQLiteRuntimeStoreForTest(store.backend.ConstructionHandle()), semanticRunFixture{Origin: semanticScenarioSetupRunOriginForTest(), RunID: runID, StartedAt: now})
 
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            "agent-1",
 			Identity:      testAgentIdentity(t, "agent-1", "global"),
@@ -1721,7 +1739,7 @@ func TestSQLiteRuntimeStoreLifecycleTerminationCleansMutableRuntimeState(t *test
 	runID := uuid.NewString()
 	requireRunFixtureForTest(t, ctx, NewSQLiteRuntimeStoreForTest(store.backend.ConstructionHandle()), semanticRunFixture{Origin: semanticScenarioSetupRunOriginForTest(), RunID: runID, StartedAt: now})
 
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID:            "agent-cleanup-1",
 			Identity:      testAgentIdentity(t, "agent-cleanup-1", "global"),
@@ -1774,7 +1792,7 @@ func TestSQLiteRuntimeStoreLifecycleTerminationCleansMutableRuntimeState(t *test
 	if err != nil || !found {
 		t.Fatalf("load lifecycle state before termination: found=%v err=%v", found, err)
 	}
-	if _, err := agentfixture.Commit(t, ctx, store, runtimemanager.AgentLifecycleTransition{
+	if _, err := agentfixture.CommitStatic(t, ctx, store, runtimemanager.AgentLifecycleTransition{
 		OperationID: uuid.NewString(), OperationKind: "teardown", RequestHash: "sqlite-test-terminate-agent-cleanup-1",
 		Identity: identity.Agent, AgentID: "agent-cleanup-1", Trigger: "test",
 		ExpectedEpoch: state.RuntimeEpoch, ExpectedGeneration: state.Generation, ExpectedPhase: state.Phase,
@@ -1783,7 +1801,7 @@ func TestSQLiteRuntimeStoreLifecycleTerminationCleansMutableRuntimeState(t *test
 		Subordinate: runtimesessions.LifecycleMutationPlan{
 			Action: runtimesessions.LifecycleMutationTerminateCurrentSet, TerminationReason: runtimesessions.TerminationReasonCancelled,
 		},
-		Topology: state.Topology, Now: now,
+		Now: now,
 	}); err != nil {
 		t.Fatalf("terminate through lifecycle authority: %v", err)
 	}

--- a/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
+++ b/internal/store/internal/runtimepersistence/sqlite_runtime_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	agentfixture "github.com/division-sh/swarm/internal/store/testutil/agentfixture"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"github.com/division-sh/swarm/internal/events/eventtest"
 	"github.com/division-sh/swarm/internal/operatorread"
 	"github.com/division-sh/swarm/internal/runtime/agentmemory"
+	runtimeagenttopology "github.com/division-sh/swarm/internal/runtime/agenttopology"
 	runtimebus "github.com/division-sh/swarm/internal/runtime/bus"
 	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
 	runtimeactors "github.com/division-sh/swarm/internal/runtime/core/actors"
@@ -41,6 +41,7 @@ import (
 	"github.com/division-sh/swarm/internal/runtime/semanticview"
 	runtimesessions "github.com/division-sh/swarm/internal/runtime/sessions"
 	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	agentfixture "github.com/division-sh/swarm/internal/store/testutil/agentfixture"
 	runtimepipelinefixture "github.com/division-sh/swarm/internal/testutil/runtimepipelinefixture"
 	"github.com/google/uuid"
 )
@@ -572,6 +573,18 @@ func TestSQLiteDynamicFlowActivationConcurrentFanOutChildrenPersist(t *testing.T
 		"reviewer\x00review/component-a",
 		"reviewer\x00review/component-b",
 	)
+	assertSQLiteActivatedAgentFlowTopologies(t, agents, runID, "review/component-a", "review/component-b")
+	capability, err := agentfixture.ProcessCapability(t, ctx, sqliteStore)
+	if err != nil {
+		t.Fatalf("load fixture process capability: %v", err)
+	}
+	plan, exists, err := capability.CurrentSourceSet(ctx)
+	if err != nil {
+		t.Fatalf("load fixture source set: %v", err)
+	}
+	if !exists || len(plan.Agents) != 0 {
+		t.Fatalf("fixture source set exists=%v agents=%#v, want no flow-owned static desired agents", exists, plan.Agents)
+	}
 	assertSQLiteAddedRoutes(t, bus, "review/component-a", "review/component-b")
 	assertSQLiteRouteMaterializationVars(t, bus, "review/component-a", map[string]string{
 		"flow_instance_path": "review/component-a",
@@ -896,6 +909,28 @@ func assertSQLiteActivatedAgentRoutes(t *testing.T, agents []runtimemanager.Pers
 	for _, want := range wantRoutes {
 		if _, ok := got[want]; !ok {
 			t.Fatalf("activated agent routes = %#v, missing %q", got, want)
+		}
+	}
+}
+
+func assertSQLiteActivatedAgentFlowTopologies(t *testing.T, agents []runtimemanager.PersistedAgent, runID string, wantPaths ...string) {
+	t.Helper()
+	byPath := make(map[string]runtimemanager.PersistedAgent, len(agents))
+	for _, rec := range agents {
+		byPath[rec.Config.Identity.FlowInstance()] = rec
+	}
+	for _, path := range wantPaths {
+		rec, ok := byPath[path]
+		if !ok {
+			t.Fatalf("activated agent for flow path %q is missing", path)
+		}
+		if err := rec.Topology.Validate(); err != nil {
+			t.Fatalf("activated agent topology for %s is invalid: %v", path, err)
+		}
+		readiness := rec.Topology.Authority.Readiness
+		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityFlowReadinessPlan || readiness == nil ||
+			readiness.RunID != runID || readiness.InstancePath != path || strings.TrimSpace(readiness.PlanFingerprint) == "" {
+			t.Fatalf("activated agent topology for %s = %#v, want exact flow-readiness authority for run %s", path, rec.Topology, runID)
 		}
 	}
 }

--- a/internal/store/internal/runtimepersistence/standalone_runtime_convergence_parity_test.go
+++ b/internal/store/internal/runtimepersistence/standalone_runtime_convergence_parity_test.go
@@ -175,7 +175,7 @@ func seedStandaloneConvergenceAgent(t *testing.T, selected any, ctx context.Cont
 		t.Fatalf("standalone convergence store %T cannot persist agents", selected)
 	}
 	agentID := identity.AgentID()
-	if err := agentfixture.Upsert(t, ctx, store, runtimemanager.PersistedAgent{
+	if err := agentfixture.UpsertStatic(t, ctx, store, runtimemanager.PersistedAgent{
 		Config: withRuntimePersistenceTestIntent(t, runtimeactors.AgentConfig{
 			ID: agentID, Identity: identity, Role: "observer", FlowID: "global", Type: "stub", Model: "regular",
 			ExecutionMode: "live", Config: json.RawMessage(`{}`),

--- a/internal/store/storetest/agent.go
+++ b/internal/store/storetest/agent.go
@@ -17,19 +17,14 @@ func AgentLifecycleFixture(t testing.TB, selected AgentFixtureStore) runtimemana
 	return agentfixture.Lifecycle(t, selected)
 }
 
-func UpsertAgentFixture(t testing.TB, ctx context.Context, selected agentfixture.Store, rec runtimemanager.PersistedAgent) error {
+func UpsertStaticAgentFixture(t testing.TB, ctx context.Context, selected agentfixture.Store, rec runtimemanager.PersistedAgent) error {
 	t.Helper()
-	return agentfixture.Upsert(t, ctx, selected, rec)
+	return agentfixture.UpsertStatic(t, ctx, selected, rec)
 }
 
-func CommitAgentLifecycleFixture(t testing.TB, ctx context.Context, selected agentfixture.Store, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
+func RequireStaticAgentFixture(t testing.TB, ctx context.Context, selected agentfixture.Store, rec runtimemanager.PersistedAgent) {
 	t.Helper()
-	return agentfixture.Commit(t, ctx, selected, req)
-}
-
-func RequireAgentFixture(t testing.TB, ctx context.Context, selected agentfixture.Store, rec runtimemanager.PersistedAgent) {
-	t.Helper()
-	if err := agentfixture.Upsert(t, ctx, selected, rec); err != nil {
+	if err := agentfixture.UpsertStatic(t, ctx, selected, rec); err != nil {
 		t.Fatalf("admit agent fixture %s: %v", rec.Config.ID, err)
 	}
 }

--- a/internal/store/testutil/agentfixture/agent.go
+++ b/internal/store/testutil/agentfixture/agent.go
@@ -103,6 +103,39 @@ func ProcessCapability(t testing.TB, ctx context.Context, selected Store) (runti
 	return session.capability, nil
 }
 
+func validateFixtureStaticSourceSetRebind(ctx context.Context, selected Store, skipIdentityKey string) error {
+	agents, err := selected.LoadAgents(ctx)
+	if err != nil {
+		return err
+	}
+	for _, rec := range agents {
+		if rec.ProcessBinding.BundleHash != agentFixtureBundleHash || rec.ProcessBinding.BundleSource != "ephemeral" {
+			continue
+		}
+		identity, identityErr := rec.Config.ConcreteIdentity()
+		if identityErr != nil {
+			return identityErr
+		}
+		identityKey, identityErr := identity.Fingerprint()
+		if identityErr != nil {
+			return identityErr
+		}
+		if identityKey == skipIdentityKey {
+			continue
+		}
+		if err := rec.Topology.Validate(); err != nil {
+			return fmt.Errorf("agent fixture source-set rebind found invalid topology for %s: %w", identity.Description(), err)
+		}
+		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityStaticDeclarationPlan {
+			return fmt.Errorf(
+				"agent fixture cannot change static source-set authority while %s retains %s topology",
+				identity.Description(), rec.Topology.Authority.Kind,
+			)
+		}
+	}
+	return nil
+}
+
 func (s *fixtureSession) grantForPlan(ctx context.Context, selected Store, plan runtimeagenttopology.SourceSetPlan, skipIdentityKey string) (runtimestartupownership.GenerationGrant, error) {
 	if s.grant != nil && s.grantRevision == plan.Revision {
 		if _, err := s.grant.Evidence(); err == nil {
@@ -145,6 +178,15 @@ func (s *fixtureSession) grantForPlan(ctx context.Context, selected Store, plan 
 		}
 		if identityKey == skipIdentityKey {
 			continue
+		}
+		if err := rec.Topology.Validate(); err != nil {
+			return nil, fmt.Errorf("agent fixture source-set rebind found invalid topology for %s: %w", identity.Description(), err)
+		}
+		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityStaticDeclarationPlan {
+			return nil, fmt.Errorf(
+				"agent fixture cannot change static source-set authority while %s retains %s topology",
+				identity.Description(), rec.Topology.Authority.Kind,
+			)
 		}
 		state, found, stateErr := selected.LoadAgentLifecycleState(ctx, identity)
 		if stateErr != nil {
@@ -247,7 +289,14 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 	if err != nil {
 		return err
 	}
+	skipRebindKey := ""
+	if replaced {
+		skipRebindKey = key
+	}
 	if !exists || current.Revision != plan.Revision {
+		if err := validateFixtureStaticSourceSetRebind(ctx, selected, skipRebindKey); err != nil {
+			return err
+		}
 		commit := runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}
 		if exists {
 			commit.ExpectedRevision = current.Revision
@@ -258,10 +307,6 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 		if err != nil {
 			return err
 		}
-	}
-	skipRebindKey := ""
-	if replaced {
-		skipRebindKey = key
 	}
 	grant, err := session.grantForPlan(ctx, selected, plan, skipRebindKey)
 	if err != nil {
@@ -316,9 +361,8 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 }
 
 // Commit admits an exact lifecycle fixture through a retained process
-// capability. A missing or local static topology is projected from the
-// complete fixture source set. Flow-readiness topology remains valid only when
-// the caller supplied its matching retained grant.
+// capability. Static transitions update the complete fixture source set;
+// flow-readiness transitions retain that set and its current generation grant.
 func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
 	t.Helper()
 	if selected == nil {
@@ -362,25 +406,47 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 	if stateBeforePlanFound && req.OperationKind != "spawn" && req.OperationKind != "reconfigure" {
 		req.ConfigRevision = stateBeforePlan.ConfigRevision
 	}
-	filtered := agents[:0]
-	for _, agent := range agents {
-		candidate, keyErr := agent.Identity.Normalize().Fingerprint()
-		if keyErr != nil {
-			return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
+	flowReadiness := req.Topology.Validate() == nil && req.Topology.Authority.Kind == runtimeagenttopology.AuthorityFlowReadinessPlan
+	if flowReadiness {
+		for _, agent := range agents {
+			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
+			if keyErr != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
+			}
+			if candidate == key {
+				return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf(
+					"flow-readiness fixture %s conflicts with static desired-agent authority", identity.Description(),
+				)
+			}
 		}
-		if candidate != key {
-			filtered = append(filtered, agent)
+	} else {
+		filtered := agents[:0]
+		for _, agent := range agents {
+			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
+			if keyErr != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
+			}
+			if candidate != key {
+				filtered = append(filtered, agent)
+			}
 		}
-	}
-	agents = filtered
-	if req.TargetPhase != runtimemanager.AgentLifecycleTerminated {
-		agents = append(agents, runtimeagenttopology.DesiredAgent{Identity: identity, Source: coordinate, ConfigRevision: req.ConfigRevision})
+		agents = filtered
+		if req.TargetPhase != runtimemanager.AgentLifecycleTerminated {
+			agents = append(agents, runtimeagenttopology.DesiredAgent{Identity: identity, Source: coordinate, ConfigRevision: req.ConfigRevision})
+		}
 	}
 	plan, err := runtimeagenttopology.NewSourceSetPlan(sources, agents)
 	if err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
+	skipRebindKey := ""
+	if stateBeforePlanFound {
+		skipRebindKey = key
+	}
 	if !exists || current.Revision != plan.Revision {
+		if err := validateFixtureStaticSourceSetRebind(ctx, selected, skipRebindKey); err != nil {
+			return runtimemanager.AgentLifecycleTransitionResult{}, err
+		}
 		commit := runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}
 		if exists {
 			commit.ExpectedRevision = current.Revision
@@ -391,10 +457,6 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 		if err != nil {
 			return runtimemanager.AgentLifecycleTransitionResult{}, err
 		}
-	}
-	skipRebindKey := ""
-	if stateBeforePlanFound {
-		skipRebindKey = key
 	}
 	grant, err := session.grantForPlan(ctx, selected, plan, skipRebindKey)
 	if err != nil {

--- a/internal/store/testutil/agentfixture/agent.go
+++ b/internal/store/testutil/agentfixture/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,38 +22,38 @@ const agentFixtureBundleHash = "bundle-v1:sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 type Store interface {
 	runtimestartupownership.Store
 	runtimemanager.AgentLifecycleStateReader
+	runtimemanager.AgentLifecycleCellCensus
 	LoadAgents(context.Context) ([]runtimemanager.PersistedAgent, error)
 }
 
 type lifecycleStore struct {
 	t        testing.TB
 	selected Store
-	session  *fixtureSession
 }
 
 func (s *lifecycleStore) CommitAgentLifecycleTransition(ctx context.Context, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
-	return Commit(s.t, ctx, s.selected, req)
+	return CommitExact(s.t, ctx, s.selected, req)
 }
 
 func Lifecycle(t testing.TB, selected Store) runtimemanager.AgentLifecyclePersistence {
 	t.Helper()
-	session, err := fixtureSessionFor(t, context.Background(), selected)
-	if err != nil {
-		t.Fatalf("acquire agent lifecycle fixture process capability: %v", err)
-	}
-	return &lifecycleStore{t: t, selected: selected, session: session}
+	return &lifecycleStore{t: t, selected: selected}
 }
 
 func (s *lifecycleStore) ProcessExecutionBinding() (runtimemanager.ProcessExecutionBinding, error) {
-	if s == nil || s.session == nil {
+	if s == nil || s.selected == nil {
 		return runtimemanager.ProcessExecutionBinding{}, fmt.Errorf("agent lifecycle fixture process capability is required")
 	}
-	s.session.mu.Lock()
-	defer s.session.mu.Unlock()
-	if s.session.grant == nil {
+	session, err := fixtureSessionFor(s.t, context.Background(), s.selected)
+	if err != nil {
+		return runtimemanager.ProcessExecutionBinding{}, err
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	if session.grant == nil {
 		return runtimemanager.ProcessExecutionBinding{}, fmt.Errorf("agent lifecycle fixture generation grant is required")
 	}
-	return s.session.grant.ProcessExecutionBinding()
+	return session.grant.ProcessExecutionBinding()
 }
 
 type fixtureSession struct {
@@ -103,49 +104,49 @@ func ProcessCapability(t testing.TB, ctx context.Context, selected Store) (runti
 	return session.capability, nil
 }
 
-func validateFixtureStaticSourceSetRebind(ctx context.Context, selected Store, skipIdentityKey string) error {
-	agents, err := selected.LoadAgents(ctx)
+func validateFixtureStaticSourceSetRebind(ctx context.Context, selected Store) ([]runtimemanager.AgentLifecycleState, error) {
+	states, err := selected.ListDurableAgentLifecycleStates(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, rec := range agents {
-		if rec.ProcessBinding.BundleHash != agentFixtureBundleHash || rec.ProcessBinding.BundleSource != "ephemeral" {
+	sort.Slice(states, func(i, j int) bool {
+		left, _ := states[i].Identity.Normalize().Fingerprint()
+		right, _ := states[j].Identity.Normalize().Fingerprint()
+		return left < right
+	})
+	for _, state := range states {
+		if state.Phase == runtimemanager.AgentLifecycleTerminated ||
+			state.ProcessBinding.BundleHash != agentFixtureBundleHash || state.ProcessBinding.BundleSource != "ephemeral" {
 			continue
 		}
-		identity, identityErr := rec.Config.ConcreteIdentity()
-		if identityErr != nil {
-			return identityErr
+		identity := state.Identity.Normalize()
+		if err := identity.Validate(); err != nil {
+			return nil, fmt.Errorf("agent fixture source-set rebind found invalid identity: %w", err)
 		}
-		identityKey, identityErr := identity.Fingerprint()
-		if identityErr != nil {
-			return identityErr
+		if err := state.Topology.Validate(); err != nil {
+			return nil, fmt.Errorf("agent fixture source-set rebind found invalid topology for %s: %w", identity.Description(), err)
 		}
-		if identityKey == skipIdentityKey {
-			continue
-		}
-		if err := rec.Topology.Validate(); err != nil {
-			return fmt.Errorf("agent fixture source-set rebind found invalid topology for %s: %w", identity.Description(), err)
-		}
-		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityStaticDeclarationPlan {
-			return fmt.Errorf(
+		if state.Topology.Authority.Kind != runtimeagenttopology.AuthorityStaticDeclarationPlan {
+			return nil, fmt.Errorf(
 				"agent fixture cannot change static source-set authority while %s retains %s topology",
-				identity.Description(), rec.Topology.Authority.Kind,
+				identity.Description(), state.Topology.Authority.Kind,
 			)
 		}
 	}
-	return nil
+	return states, nil
 }
 
-func (s *fixtureSession) grantForPlan(ctx context.Context, selected Store, plan runtimeagenttopology.SourceSetPlan, skipIdentityKey string) (runtimestartupownership.GenerationGrant, error) {
+func (s *fixtureSession) grantForStaticPlan(ctx context.Context, selected Store, plan runtimeagenttopology.SourceSetPlan, skipIdentityKey string) (runtimestartupownership.GenerationGrant, error) {
+	states, err := validateFixtureStaticSourceSetRebind(ctx, selected)
+	if err != nil {
+		return nil, err
+	}
 	if s.grant != nil && s.grantRevision == plan.Revision {
 		if _, err := s.grant.Evidence(); err == nil {
 			return s.grant, nil
 		}
 	}
-	grant, err := s.capability.IssueGenerationGrant(ctx, runtimestartupownership.GrantRequest{
-		BundleHash: agentFixtureBundleHash, BundleSource: "ephemeral", RuntimeInstanceID: s.runtimeInstanceID,
-		RuntimeGeneration: 1, SourceSetRevision: plan.Revision,
-	})
+	grant, err := s.issueGrant(ctx, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -153,47 +154,19 @@ func (s *fixtureSession) grantForPlan(ctx context.Context, selected Store, plan 
 	if err != nil {
 		return nil, err
 	}
-	agents, err := selected.LoadAgents(ctx)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(agents, func(i, j int) bool {
-		left, _ := agents[i].Config.ConcreteIdentity()
-		right, _ := agents[j].Config.ConcreteIdentity()
-		leftKey, _ := left.Fingerprint()
-		rightKey, _ := right.Fingerprint()
-		return leftKey < rightKey
-	})
-	for _, rec := range agents {
-		if rec.ProcessBinding.BundleHash != agentFixtureBundleHash || rec.ProcessBinding.BundleSource != "ephemeral" || rec.ProcessBinding.Equal(target) {
+	for _, state := range states {
+		if state.Phase == runtimemanager.AgentLifecycleTerminated ||
+			state.ProcessBinding.BundleHash != agentFixtureBundleHash || state.ProcessBinding.BundleSource != "ephemeral" ||
+			state.ProcessBinding.Equal(target) {
 			continue
 		}
-		identity, identityErr := rec.Config.ConcreteIdentity()
-		if identityErr != nil {
-			return nil, identityErr
-		}
+		identity := state.Identity.Normalize()
 		identityKey, identityErr := identity.Fingerprint()
 		if identityErr != nil {
 			return nil, identityErr
 		}
 		if identityKey == skipIdentityKey {
 			continue
-		}
-		if err := rec.Topology.Validate(); err != nil {
-			return nil, fmt.Errorf("agent fixture source-set rebind found invalid topology for %s: %w", identity.Description(), err)
-		}
-		if rec.Topology.Authority.Kind != runtimeagenttopology.AuthorityStaticDeclarationPlan {
-			return nil, fmt.Errorf(
-				"agent fixture cannot change static source-set authority while %s retains %s topology",
-				identity.Description(), rec.Topology.Authority.Kind,
-			)
-		}
-		state, found, stateErr := selected.LoadAgentLifecycleState(ctx, identity)
-		if stateErr != nil {
-			return nil, stateErr
-		}
-		if !found {
-			return nil, fmt.Errorf("agent fixture lifecycle state disappeared for %s", identity.Description())
 		}
 		kind := "source_set_rebind"
 		targetEpoch, targetGeneration := state.RuntimeEpoch, state.Generation
@@ -225,9 +198,103 @@ func (s *fixtureSession) grantForPlan(ctx context.Context, selected Store, plan 
 	return grant, nil
 }
 
-// Upsert admits a durable agent fixture through the same complete source-set
-// and generation-grant boundary as production startup.
-func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanager.PersistedAgent) error {
+func (s *fixtureSession) grantForExactPlan(ctx context.Context, plan runtimeagenttopology.SourceSetPlan) (runtimestartupownership.GenerationGrant, error) {
+	if s.grant != nil && s.grantRevision == plan.Revision {
+		if _, err := s.grant.Evidence(); err == nil {
+			return s.grant, nil
+		}
+	}
+	grant, err := s.issueGrant(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	s.grant = grant
+	s.grantRevision = plan.Revision
+	return grant, nil
+}
+
+func (s *fixtureSession) issueGrant(ctx context.Context, plan runtimeagenttopology.SourceSetPlan) (runtimestartupownership.GenerationGrant, error) {
+	return s.capability.IssueGenerationGrant(ctx, runtimestartupownership.GrantRequest{
+		BundleHash: agentFixtureBundleHash, BundleSource: "ephemeral", RuntimeInstanceID: s.runtimeInstanceID,
+		RuntimeGeneration: 1, SourceSetRevision: plan.Revision,
+	})
+}
+
+func admissionIsZero(admission runtimeagenttopology.Admission) bool {
+	return admission.Lifetime == "" && admission.Authority.Kind == "" &&
+		admission.Authority.Static == nil && admission.Authority.Readiness == nil && admission.Authority.Ephemeral == nil
+}
+
+func validateSyntheticStaticAdmission(admission runtimeagenttopology.Admission, field string) error {
+	if !admissionIsZero(admission) {
+		return fmt.Errorf("%s must not carry topology; use the exact durable fixture operation", field)
+	}
+	return nil
+}
+
+func validateSyntheticStaticTransition(req runtimemanager.AgentLifecycleTransition) (runtimeagentidentity.Identity, string, error) {
+	if err := validateSyntheticStaticAdmission(req.Topology, "synthetic static lifecycle transition"); err != nil {
+		return runtimeagentidentity.Identity{}, "", err
+	}
+	identity := req.Identity.Normalize()
+	key, err := identity.Fingerprint()
+	if err != nil {
+		return runtimeagentidentity.Identity{}, "", err
+	}
+	if req.Agent == nil {
+		return identity, key, nil
+	}
+	if err := validateSyntheticStaticAdmission(req.Agent.Topology, "synthetic static lifecycle agent"); err != nil {
+		return runtimeagentidentity.Identity{}, "", err
+	}
+	agentIdentity, err := req.Agent.Config.ConcreteIdentity()
+	if err != nil {
+		return runtimeagentidentity.Identity{}, "", err
+	}
+	if agentIdentity.Normalize() != identity {
+		return runtimeagentidentity.Identity{}, "", fmt.Errorf("synthetic static lifecycle agent identity does not match transition identity")
+	}
+	return identity, key, nil
+}
+
+func validateExactDurableTransition(req runtimemanager.AgentLifecycleTransition) (runtimeagentidentity.Identity, string, runtimeagenttopology.AuthorityKind, error) {
+	if err := req.Topology.Validate(); err != nil {
+		return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture topology: %w", err)
+	}
+	if req.Topology.Lifetime != runtimeagenttopology.LifetimeDurableManaged {
+		return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture requires durable managed topology")
+	}
+	switch req.Topology.Authority.Kind {
+	case runtimeagenttopology.AuthorityStaticDeclarationPlan, runtimeagenttopology.AuthorityFlowReadinessPlan:
+	case runtimeagenttopology.AuthorityEphemeralExecution:
+		return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture cannot persist ephemeral execution topology")
+	default:
+		return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture topology kind %q is unsupported", req.Topology.Authority.Kind)
+	}
+	identity := req.Identity.Normalize()
+	key, err := identity.Fingerprint()
+	if err != nil {
+		return runtimeagentidentity.Identity{}, "", "", err
+	}
+	if req.Agent != nil {
+		if !req.Agent.Topology.Equal(req.Topology) {
+			return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture agent topology does not match transition topology")
+		}
+		agentIdentity, identityErr := req.Agent.Config.ConcreteIdentity()
+		if identityErr != nil {
+			return runtimeagentidentity.Identity{}, "", "", identityErr
+		}
+		if agentIdentity.Normalize() != identity {
+			return runtimeagentidentity.Identity{}, "", "", fmt.Errorf("exact lifecycle fixture agent identity does not match transition identity")
+		}
+	}
+	return identity, key, req.Topology.Authority.Kind, nil
+}
+
+// UpsertStatic admits a synthetic static durable agent through the complete
+// source-set and generation-grant boundary. Caller-provided topology is never
+// interpreted or overwritten.
+func UpsertStatic(t testing.TB, ctx context.Context, selected Store, rec runtimemanager.PersistedAgent) error {
 	t.Helper()
 	if selected == nil {
 		return fmt.Errorf("agent fixture selected store is required")
@@ -235,12 +302,19 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := validateSyntheticStaticAdmission(rec.Topology, "synthetic static agent"); err != nil {
+		return err
+	}
 	identity, err := rec.Config.ConcreteIdentity()
 	if err != nil {
 		return err
 	}
 	configRevision, err := canonicaljson.Hash(rec.Config)
 	if err != nil {
+		return err
+	}
+	configRevision = strings.TrimPrefix(configRevision, "sha256:")
+	if _, err := validateFixtureStaticSourceSetRebind(ctx, selected); err != nil {
 		return err
 	}
 	coordinate := runtimeagenttopology.SourceCoordinate{BundleHash: agentFixtureBundleHash, BundleSource: "ephemeral"}
@@ -293,10 +367,10 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 	if replaced {
 		skipRebindKey = key
 	}
+	if _, err := validateFixtureStaticSourceSetRebind(ctx, selected); err != nil {
+		return err
+	}
 	if !exists || current.Revision != plan.Revision {
-		if err := validateFixtureStaticSourceSetRebind(ctx, selected, skipRebindKey); err != nil {
-			return err
-		}
 		commit := runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}
 		if exists {
 			commit.ExpectedRevision = current.Revision
@@ -308,7 +382,7 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 			return err
 		}
 	}
-	grant, err := session.grantForPlan(ctx, selected, plan, skipRebindKey)
+	grant, err := session.grantForStaticPlan(ctx, selected, plan, skipRebindKey)
 	if err != nil {
 		return err
 	}
@@ -360,16 +434,23 @@ func Upsert(t testing.TB, ctx context.Context, selected Store, rec runtimemanage
 	return nil
 }
 
-// Commit admits an exact lifecycle fixture through a retained process
-// capability. Static transitions update the complete fixture source set;
-// flow-readiness transitions retain that set and its current generation grant.
-func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
+// CommitStatic applies one synthetic static lifecycle transition. It is the
+// only direct lifecycle fixture operation allowed to derive source-set
+// membership and static admission.
+func CommitStatic(t testing.TB, ctx context.Context, selected Store, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
 	t.Helper()
 	if selected == nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf("agent lifecycle fixture selected store is required")
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	identity, key, err := validateSyntheticStaticTransition(req)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	if _, err := validateFixtureStaticSourceSetRebind(ctx, selected); err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
 	session, err := fixtureSessionFor(t, ctx, selected)
 	if err != nil {
@@ -394,11 +475,6 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 		sources = append(sources, coordinate)
 	}
 	agents := append([]runtimeagenttopology.DesiredAgent(nil), current.Agents...)
-	identity := req.Identity.Normalize()
-	key, err := identity.Fingerprint()
-	if err != nil {
-		return runtimemanager.AgentLifecycleTransitionResult{}, err
-	}
 	stateBeforePlan, stateBeforePlanFound, err := loadState(ctx, selected, identity)
 	if err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
@@ -406,34 +482,19 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 	if stateBeforePlanFound && req.OperationKind != "spawn" && req.OperationKind != "reconfigure" {
 		req.ConfigRevision = stateBeforePlan.ConfigRevision
 	}
-	flowReadiness := req.Topology.Validate() == nil && req.Topology.Authority.Kind == runtimeagenttopology.AuthorityFlowReadinessPlan
-	if flowReadiness {
-		for _, agent := range agents {
-			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
-			if keyErr != nil {
-				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
-			}
-			if candidate == key {
-				return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf(
-					"flow-readiness fixture %s conflicts with static desired-agent authority", identity.Description(),
-				)
-			}
+	filtered := agents[:0]
+	for _, agent := range agents {
+		candidate, keyErr := agent.Identity.Normalize().Fingerprint()
+		if keyErr != nil {
+			return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
 		}
-	} else {
-		filtered := agents[:0]
-		for _, agent := range agents {
-			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
-			if keyErr != nil {
-				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
-			}
-			if candidate != key {
-				filtered = append(filtered, agent)
-			}
+		if candidate != key {
+			filtered = append(filtered, agent)
 		}
-		agents = filtered
-		if req.TargetPhase != runtimemanager.AgentLifecycleTerminated {
-			agents = append(agents, runtimeagenttopology.DesiredAgent{Identity: identity, Source: coordinate, ConfigRevision: req.ConfigRevision})
-		}
+	}
+	agents = filtered
+	if req.TargetPhase != runtimemanager.AgentLifecycleTerminated {
+		agents = append(agents, runtimeagenttopology.DesiredAgent{Identity: identity, Source: coordinate, ConfigRevision: req.ConfigRevision})
 	}
 	plan, err := runtimeagenttopology.NewSourceSetPlan(sources, agents)
 	if err != nil {
@@ -443,10 +504,10 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 	if stateBeforePlanFound {
 		skipRebindKey = key
 	}
+	if _, err := validateFixtureStaticSourceSetRebind(ctx, selected); err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
 	if !exists || current.Revision != plan.Revision {
-		if err := validateFixtureStaticSourceSetRebind(ctx, selected, skipRebindKey); err != nil {
-			return runtimemanager.AgentLifecycleTransitionResult{}, err
-		}
 		commit := runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}
 		if exists {
 			commit.ExpectedRevision = current.Revision
@@ -458,18 +519,16 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 			return runtimemanager.AgentLifecycleTransitionResult{}, err
 		}
 	}
-	grant, err := session.grantForPlan(ctx, selected, plan, skipRebindKey)
+	grant, err := session.grantForStaticPlan(ctx, selected, plan, skipRebindKey)
 	if err != nil {
 		return runtimemanager.AgentLifecycleTransitionResult{}, err
 	}
-	if req.Topology.Validate() != nil || req.Topology.Authority.Kind == runtimeagenttopology.AuthorityStaticDeclarationPlan {
-		req.Topology, err = runtimeagenttopology.StaticAdmission(plan.Revision, coordinate.BundleHash, coordinate.BundleSource, runtimeagenttopology.LifetimeDurableManaged)
-		if err != nil {
-			return runtimemanager.AgentLifecycleTransitionResult{}, err
-		}
-		if req.Agent != nil {
-			req.Agent.Topology = req.Topology
-		}
+	req.Topology, err = runtimeagenttopology.StaticAdmission(plan.Revision, coordinate.BundleHash, coordinate.BundleSource, runtimeagenttopology.LifetimeDurableManaged)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	if req.Agent != nil {
+		req.Agent.Topology = req.Topology
 	}
 	if stateBeforePlanFound {
 		stateAfterPlan, found, stateErr := loadState(ctx, selected, identity)
@@ -489,6 +548,127 @@ func Commit(t testing.TB, ctx context.Context, selected Store, req runtimemanage
 			return runtimemanager.AgentLifecycleTransitionResult{}, bindingErr
 		}
 		classifyFixtureTransition(&req, stateAfterPlan, binding)
+	}
+	return grant.CommitAgentLifecycleTransition(ctx, req)
+}
+
+// CommitExact persists one caller-supplied durable sealed topology. Flow
+// readiness never enters the static desired-agent set, and exact static
+// authority must already agree with that complete set.
+func CommitExact(t testing.TB, ctx context.Context, selected Store, req runtimemanager.AgentLifecycleTransition) (runtimemanager.AgentLifecycleTransitionResult, error) {
+	t.Helper()
+	if selected == nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf("agent lifecycle fixture selected store is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	identity, key, kind, err := validateExactDurableTransition(req)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	session, err := fixtureSessionFor(t, ctx, selected)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	current, exists, err := session.capability.CurrentSourceSet(ctx)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	coordinate := runtimeagenttopology.SourceCoordinate{BundleHash: agentFixtureBundleHash, BundleSource: "ephemeral"}
+	plan := current
+	switch kind {
+	case runtimeagenttopology.AuthorityFlowReadinessPlan:
+		for _, agent := range current.Agents {
+			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
+			if keyErr != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
+			}
+			if candidate == key {
+				return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf(
+					"flow-readiness fixture %s conflicts with static desired-agent authority", identity.Description(),
+				)
+			}
+		}
+		sources := append([]runtimeagenttopology.SourceCoordinate(nil), current.Sources...)
+		foundSource := false
+		for _, source := range sources {
+			if source.Normalize().Key() == coordinate.Key() {
+				foundSource = true
+				break
+			}
+		}
+		if !foundSource {
+			sources = append(sources, coordinate)
+			plan, err = runtimeagenttopology.NewSourceSetPlan(sources, current.Agents)
+			if err != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, err
+			}
+			states, censusErr := selected.ListDurableAgentLifecycleStates(ctx)
+			if censusErr != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, censusErr
+			}
+			for _, state := range states {
+				if state.Phase != runtimemanager.AgentLifecycleTerminated &&
+					state.ProcessBinding.BundleHash == agentFixtureBundleHash && state.ProcessBinding.BundleSource == "ephemeral" {
+					return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf("agent fixture source coordinate is missing while durable fixture lifecycle cells remain")
+				}
+			}
+			commit := runtimeagenttopology.SourceSetCommitRequest{OperationID: uuid.NewString(), Plan: plan}
+			if exists {
+				commit.ExpectedRevision = current.Revision
+				_, err = session.capability.ReplaceSourceSet(ctx, commit)
+			} else {
+				_, err = session.capability.InstallCompleteSourceSet(ctx, commit)
+			}
+			if err != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, err
+			}
+		}
+	case runtimeagenttopology.AuthorityStaticDeclarationPlan:
+		static := req.Topology.Authority.Static
+		if !exists || static == nil || static.SourceSetRevision != current.Revision ||
+			static.BundleHash != coordinate.BundleHash || static.BundleSource != coordinate.BundleSource {
+			return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf("exact static lifecycle topology does not match the current fixture source set")
+		}
+		matched := false
+		desiredRevision := ""
+		desiredSource := runtimeagenttopology.SourceCoordinate{}
+		for _, agent := range current.Agents {
+			candidate, keyErr := agent.Identity.Normalize().Fingerprint()
+			if keyErr != nil {
+				return runtimemanager.AgentLifecycleTransitionResult{}, keyErr
+			}
+			if candidate == key {
+				desiredRevision = agent.ConfigRevision
+				desiredSource = agent.Source.Normalize()
+				matched = agent.ConfigRevision == req.ConfigRevision && agent.Source.Normalize().Key() == coordinate.Key()
+				break
+			}
+		}
+		if !matched {
+			return runtimemanager.AgentLifecycleTransitionResult{}, fmt.Errorf(
+				"exact static lifecycle topology is not present in the current fixture source set: desired_revision=%q requested_revision=%q desired_source=%q requested_source=%q",
+				desiredRevision, req.ConfigRevision, desiredSource.Key(), coordinate.Key(),
+			)
+		}
+	}
+	grant, err := session.grantForExactPlan(ctx, plan)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	state, stateFound, err := loadState(ctx, selected, identity)
+	if err != nil {
+		return runtimemanager.AgentLifecycleTransitionResult{}, err
+	}
+	if stateFound {
+		binding, bindingErr := grant.ProcessExecutionBinding()
+		if bindingErr != nil {
+			return runtimemanager.AgentLifecycleTransitionResult{}, bindingErr
+		}
+		classifyFixtureTransition(&req, state, binding)
 	}
 	return grant.CommitAgentLifecycleTransition(ctx, req)
 }


### PR DESCRIPTION
## Summary

- replace generic lifecycle fixture `Upsert`/`Commit` interpretation with explicit synthetic-static and exact-durable APIs;
- reject zero, unknown, malformed, and ephemeral topology before capability, source-set, grant, lifecycle, or process mutation;
- preserve exact flow-readiness admission and one retained generation grant across sequential and concurrent siblings on SQLite and PostgreSQL;
- make mixed static/flow source-set mutation fail closed using the canonical durable lifecycle census;
- migrate every fixture consumer, including destructive-reset static/ephemeral record separation and exact serve fixtures.

Closes #2379.
Related to #2351 and test-health registry #2353.
Production mixed-authority survivor rebind remains separate in #2378.

## Governing context

Binding contract: `platform-spec.yaml` sections `agent_topology_authority.source_set`, `agent_topology_authority.admission`, and `agent_topology_authority.process_capability.lifecycle_reconciliation`.

The existing specification is sufficient and unchanged. This PR changes test-fixture conformance only; it does not change platform/runtime semantics.

## Fixture migration

- Canonical owners: sealed `agenttopology.Admission`, the complete synthetic-static `SourceSetPlan`, canonical durable lifecycle census, and the fixture's retained process capability/generation grant.
- New explicit paths: `UpsertStatic`, `CommitStatic`, and `CommitExact`; `Lifecycle` delegates only to exact durable admission.
- Invalid old paths removed: generic `Upsert`/`Commit`, invalid-or-zero fallback to static, flow identities in static desired membership, per-flow source-set/grant rotation, and hidden flow-to-static survivor rebind.
- Production paths checked for surviving old behavior: all repo-wide fixture callers, direct lifecycle/effect/rebind/cleanup/fork consumers, dynamic flow activation, provider-drain fixtures, serve/runtime consumers, and destructive reset.
- Migration status: complete; no compatibility alias or tolerant fallback remains.

## Proof

- exact SQLite/PostgreSQL sequential and concurrent flow authority: `TestAgentFixtureExactFlowAuthorityParity` (`-count=10`)
- dual-store zero/unknown/malformed/ephemeral and mixed-authority unchanged-state matrix: `TestAgentFixtureSealedAuthorityRejectionParity` (`-count=3`)
- focused lifecycle/source-set/provider and corrected serve/release matrices: green
- complete runtime persistence package: green (`509.812s` on final rebased suite head)
- supported whole suite: `GOCACHE=/tmp/swarm-agent-g-go-build go run ./cmd/swarm-test -- ./... -count=1`, green
- deletion census and `git diff --check`: green
