### PR TITLE
[agent-g][issue #2383] Isolate SQLite process possession

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,9 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Prove store ownership and engine-disjoint crash reclaim
-        run: go test ./internal/store ./internal/store/selected ./internal/store/internal/startupownership -count=1
+        run: go test ./internal/store/internal/startupownership -count=1
+      - name: Prove selected SQLite construction consumes the owner
+        run: go test ./internal/store/selected -run '^TestOpenRuntimeSQLiteResolvesRequiredAndOptionalProductsOnce$' -count=1
       - name: Prove database and coordinate loss terminalize ownership
         run: go test ./internal/store/internal/runtimepersistence -run '^TestSQLiteProcessCapability(File|Coordinate)ReplacementTerminalizesIdleOwner$' -count=1
       - name: Prove read-only status remains possession-free

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,25 @@ jobs:
             --payload "$payload" \
             --api-port 18091
 
+  macos-sqlite-possession:
+    name: macOS SQLite possession
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Prove store ownership and engine-disjoint crash reclaim
+        run: go test ./internal/store ./internal/store/selected ./internal/store/internal/startupownership -count=1
+      - name: Prove database and coordinate loss terminalize ownership
+        run: go test ./internal/store/internal/runtimepersistence -run '^TestSQLiteProcessCapability(File|Coordinate)ReplacementTerminalizesIdleOwner$' -count=1
+      - name: Prove read-only status remains possession-free
+        run: go test ./internal/cliapp -run '^TestStoreStatusReads(CurrentSQLiteStoreWithoutMutationBootstrap|SelectedStoreOwnershipWithoutContextInference)$' -count=1
+      - name: Prove shipped dev and non-dev SQLite serve
+        run: go test ./internal/releasee2e -run '^TestGoldenSQLitePossessionServeJourney$' -count=1 -v
+
   proof-unit:
     name: Go proof ${{ matrix.unit }}
     needs: [ci-plan]
@@ -367,7 +386,7 @@ jobs:
   required-tests:
     name: ${{ github.event_name == 'workflow_dispatch' && 'Full dispatch summary' || 'Required test summary' }}
     if: always()
-    needs: [ci-plan, static-checks, sqlite-local-dev, proof-unit, semantic-smoke, timing-budget]
+    needs: [ci-plan, static-checks, sqlite-local-dev, macos-sqlite-possession, proof-unit, semantic-smoke, timing-budget]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -380,6 +399,7 @@ jobs:
             "ci-plan:${{ needs.ci-plan.result }}" \
             "static-checks:${{ needs.static-checks.result }}" \
             "sqlite-local-dev:${{ needs.sqlite-local-dev.result }}" \
+            "macos-sqlite-possession:${{ needs.macos-sqlite-possession.result }}" \
             "proof-unit:${{ needs.proof-unit.result }}" \
             "semantic-smoke:${{ needs.semantic-smoke.result }}" \
             "timing-budget:${{ needs.timing-budget.result }}"

--- a/internal/cliapp/store_authority_test.go
+++ b/internal/cliapp/store_authority_test.go
@@ -98,6 +98,10 @@ func TestStoreStatusReadsCurrentSQLiteStoreWithoutMutationBootstrap(t *testing.T
 	configPath := writeStoreAuthorityConfig(t, sqlitePath)
 	bootstrapStoreAuthoritySQLite(t, configPath, sqlitePath)
 	seedValidAuthorityHead(t, sqlitePath, "durable-status-owner")
+	possessionPath := sqlitePath + ".possession"
+	if err := os.Remove(possessionPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("remove inactive possession coordinate before read-only status: %v", err)
+	}
 	beforeInfo, err := os.Stat(sqlitePath)
 	if err != nil {
 		t.Fatalf("stat selected SQLite store before status: %v", err)
@@ -116,6 +120,9 @@ func TestStoreStatusReadsCurrentSQLiteStoreWithoutMutationBootstrap(t *testing.T
 	}
 	if beforeInfo.Size() != afterInfo.Size() || !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
 		t.Fatalf("store status mutated selected SQLite database: before=(%d,%s) after=(%d,%s)", beforeInfo.Size(), beforeInfo.ModTime(), afterInfo.Size(), afterInfo.ModTime())
+	}
+	if _, err := os.Stat(possessionPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read-only store status created SQLite possession coordinate: %v", err)
 	}
 }
 
@@ -242,14 +249,18 @@ func TestPlatformSpecBindsOwnershipLossDeadlinesAndReadOnlyStatus(t *testing.T) 
 		if !strings.Contains(value, "monitor deadline") && name != "diagnostic inspection" {
 			t.Fatalf("%s contract does not bind the configured monitor deadline: %q", name, value)
 		}
-		if name == "diagnostic inspection" && (!strings.Contains(value, "read-only") || !strings.Contains(value, "never creates")) {
+		if name == "diagnostic inspection" && (!strings.Contains(value, "read-only") || !strings.Contains(value, "possession coordinate")) {
 			t.Fatalf("diagnostic inspection contract does not prohibit bootstrap mutation: %q", value)
 		}
 	}
 	process := spec.AgentTopologyAuthority.ProcessCapability
 	if !strings.Contains(process.Acquisition, "backend-file identity") ||
 		!strings.Contains(process.Acquisition, "pool bound to one inode") ||
-		!strings.Contains(process.Acquisition, "acquisition or repair") {
+		!strings.Contains(process.Acquisition, "acquisition or repair") ||
+		!strings.Contains(process.Acquisition, "<canonical database path>.possession") ||
+		!strings.Contains(process.Acquisition, "another SQLite-managed file are prohibited") ||
+		!strings.Contains(process.Acquisition, "complete pair") ||
+		!strings.Contains(process.Acquisition, "unsupported filesystem tampering") {
 		t.Fatalf("process acquisition contract does not bind the SQLite pool and retained possession: %q", process.Acquisition)
 	}
 	if !strings.Contains(process.Grants, "release error can never publish released") || !strings.Contains(process.Grants, "configured monitor deadline") {

--- a/internal/releasee2e/golden_agent_workload_test.go
+++ b/internal/releasee2e/golden_agent_workload_test.go
@@ -52,6 +52,83 @@ func TestGoldenAgentWorkloadSQLiteSmoke(t *testing.T) {
 	})
 }
 
+func TestGoldenSQLitePossessionServeJourney(t *testing.T) {
+	releaseRoot := goldenReleaseRoot(t)
+	binaryPath := buildReleaseBinary(t, releaseRoot)
+	root := filepath.Join(releaseRoot, "sqlite-possession-serve")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create release project: %v", err)
+	}
+	contracts := filepath.Join(root, "contracts")
+	copyReleaseTree(t, filepath.Join(releaseE2ERepoRoot(t), "internal", "releasee2e", "testdata", "golden_agent_workload"), contracts)
+	writeReleaseFile(t, filepath.Join(root, "go.mod"), "module golden-sqlite-possession-e2e\n\ngo 1.23.0\n")
+	store := goldenSQLiteStore(root)
+	configPath := filepath.Join(root, "config", "swarm.yaml")
+	writeReleaseFile(t, configPath, goldenRuntimeConfig(store))
+	devConfigPath := filepath.Join(root, ".swarm", "swarm.yaml")
+	writeReleaseFile(t, devConfigPath, goldenRuntimeConfig(goldenStoreSelection{
+		name: "sqlite", configYAML: "store:\n  backend: sqlite\n",
+	}))
+	tokenFile := filepath.Join(root, "api-token")
+	writeReleaseFile(t, tokenFile, goldenAPIToken+"\n")
+	env := goldenProcessEnv(t, root, "", 0)
+	assertGoldenProcessHasNoExternalExecutables(t, env)
+
+	verify := runReleaseCommand(t, goldenStartupTimeout, root, env, "", binaryPath,
+		"verify", "--config", configPath, "--contracts", contracts, "--json")
+	if verify.err != nil {
+		t.Fatalf("release verify failed: %v\n%s", verify.err, verify.output)
+	}
+	var verifyResult struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(verify.output)), &verifyResult); err != nil || !verifyResult.OK {
+		t.Fatalf("release verify result: err=%v output=%s", err, verify.output)
+	}
+
+	for _, test := range []struct {
+		name           string
+		dev            bool
+		configPath     string
+		possessionPath string
+	}{
+		{name: "non-dev", configPath: configPath, possessionPath: filepath.Join(root, "runtime.db.possession")},
+		{name: "dev", dev: true, possessionPath: filepath.Join(root, ".swarm", "stores", "dev-scratch.db.possession")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			process := startReleaseServe(t, releaseProcessSpec{
+				BinaryPath: binaryPath,
+				WorkingDir: root,
+				ConfigPath: test.configPath,
+				Contracts:  contracts,
+				Store:      store.name,
+				Dev:        test.dev,
+				APIPort:    freeReleaseTCPPort(t),
+				MCPPort:    freeReleaseTCPPort(t),
+				TokenFile:  tokenFile,
+				Token:      goldenAPIToken,
+				Env:        env,
+			})
+			readyCtx, cancel := context.WithTimeout(context.Background(), goldenStartupTimeout)
+			err := process.waitReady(readyCtx)
+			cancel()
+			if err != nil {
+				t.Fatal(err)
+			}
+			goldenServedBundleHash(t, process.rpc)
+			if info, err := os.Stat(test.possessionPath); err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+				t.Fatalf("serve possession coordinate %s: info=%v err=%v", test.possessionPath, info, err)
+			}
+			if err := process.stopAndWait(5 * time.Second); err != nil {
+				t.Fatalf("clean serve teardown: %v\n%s", err, process.output.String())
+			}
+			if info, err := os.Stat(test.possessionPath); err != nil || !info.Mode().IsRegular() {
+				t.Fatalf("persistent possession coordinate after teardown %s: info=%v err=%v", test.possessionPath, info, err)
+			}
+		})
+	}
+}
+
 func TestGoldenAgentWorkloadRestartAndForcedKillOnBothBackends(t *testing.T) {
 	if profile, continuous := goldenContinuousProofProfile(t); profile != "" && !continuous {
 		t.Skipf("forced-restart proof runs in full/nightly, not %s", profile)

--- a/internal/serveapp/store_backend_selection_test.go
+++ b/internal/serveapp/store_backend_selection_test.go
@@ -287,14 +287,14 @@ func TestBuildStoresSQLiteBindsOwnershipToConstructedBackendIdentity(t *testing.
 	if err := os.WriteFile(path, nil, 0o600); err != nil {
 		t.Fatalf("create replacement SQLite identity: %v", err)
 	}
-	contender, _, contenderErr := storeconstruction.OpenSQLiteRuntimeWithOwnershipBinding(retiredPath)
+	contender, _, contenderErr := storeconstruction.OpenSQLiteRuntimeWithOwnershipBinding(path)
 	if contender != nil {
 		_ = contender.Close()
-		t.Fatal("renamed constructed SQLite backend admitted a concurrent process constructor")
+		t.Fatal("replaced SQLite path admitted a concurrent process constructor while its possession coordinate was held")
 	}
 	var contenderAcquisitionErr *runtimestartupownership.AcquisitionError
 	if !errors.As(contenderErr, &contenderAcquisitionErr) || contenderAcquisitionErr.Failure != runtimestartupownership.AcquisitionTakeoverRequired {
-		t.Fatalf("renamed backend contender error=%v, want takeover_required", contenderErr)
+		t.Fatalf("replaced-path contender error=%v, want takeover_required", contenderErr)
 	}
 
 	capability, err := stores.StartupOwnership().AcquireProcessCapability(ctx, runtimestartupownership.AcquireRequest{

--- a/internal/store/construction/open.go
+++ b/internal/store/construction/open.go
@@ -53,8 +53,8 @@ func OpenSQLiteRuntime(path string) (*private.SQLiteRuntimeStore, *sql.DB, error
 }
 
 // OpenSQLiteRuntimeWithOwnershipBinding is the mutable process/repair
-// construction path. It binds the opened pool to the exact file identity that
-// later retained possession must protect.
+// construction path. It binds the opened pool to the exact database and
+// possession-coordinate identities that later retained possession must prove.
 func OpenSQLiteRuntimeWithOwnershipBinding(path string) (*private.SQLiteRuntimeStore, *sql.DB, error) {
 	constructionGuard, err := storestartupownership.AcquireSQLiteConstructionGuard(path)
 	if err != nil {

--- a/internal/store/internal/runtimepersistence/runtime_startup_ownership_test.go
+++ b/internal/store/internal/runtimepersistence/runtime_startup_ownership_test.go
@@ -1213,6 +1213,32 @@ func TestSQLiteProcessCapabilityFileReplacementTerminalizesIdleOwner(t *testing.
 	}
 }
 
+func TestSQLiteProcessCapabilityCoordinateReplacementTerminalizesIdleOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	selected := newBootstrappedSQLiteRuntimeStoreForPath(t, path)
+	capability, err := selected.AcquireProcessCapability(context.Background(), testStartupAcquireRequest("sqlite-coordinate-replaced-owner"))
+	if err != nil {
+		t.Fatalf("AcquireProcessCapability: %v", err)
+	}
+	t.Cleanup(func() { _ = capability.Release(context.Background()) })
+	coordinatePath := path + ".possession"
+	if err := os.Rename(coordinatePath, coordinatePath+".retired"); err != nil {
+		t.Fatalf("retire possession coordinate: %v", err)
+	}
+	if err := os.WriteFile(coordinatePath, nil, 0o600); err != nil {
+		t.Fatalf("write replacement possession coordinate: %v", err)
+	}
+	select {
+	case <-capability.Done():
+	case <-time.After(4 * time.Second):
+		t.Fatal("SQLite possession-coordinate replacement did not terminalize the idle process capability")
+	}
+	result, ok := capability.TerminalResult()
+	if !ok || result.Cause != runtimestartupownership.TerminalOwnershipUnprovable || result.SuccessorAuthorityID != "" {
+		t.Fatalf("terminal result=%#v ok=%v, want ownership_unprovable", result, ok)
+	}
+}
+
 const sqliteForcedDeathChildMarker = "SWARM_TEST_SQLITE_FORCED_DEATH_CHILD"
 
 type sqliteForcedDeathEvidence struct {

--- a/internal/store/internal/startupownership/sqlite_flock_authority_test.go
+++ b/internal/store/internal/startupownership/sqlite_flock_authority_test.go
@@ -1,0 +1,113 @@
+//go:build darwin || linux
+
+package startupownership
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProductionAdvisoryLocksHaveNamedNonEngineTargets(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	allowedTargets := map[string]map[string]bool{
+		filepath.FromSlash("internal/operatorchannel/proof_lock_unix.go"): {
+			"int(file.Fd())": true,
+		},
+		filepath.FromSlash("internal/packartifact/project_lock_unix.go"): {
+			"int(file.Fd())": true,
+		},
+		filepath.FromSlash("internal/runtime/credentials/file_lock_unix.go"): {
+			"int(lock.Fd())": true,
+		},
+		filepath.FromSlash("internal/runtime/managedcredentials/file_lock_unix.go"): {
+			"int(lock.Fd())": true,
+		},
+		filepath.FromSlash("internal/runtime/pythonmodule/artifact_lock_unix.go"): {
+			"int(lock.Fd())": true,
+		},
+		filepath.FromSlash("internal/store/devscratch/epoch_unix.go"): {
+			"fd":             true,
+			"int(file.Fd())": true,
+		},
+		filepath.FromSlash("internal/store/internal/startupownership/sqlite_possession_unix.go"): {
+			"int(coordinate.Fd())": true,
+		},
+		filepath.FromSlash("internal/testpostgres/file_lock_unix.go"): {
+			"int(file.Fd())":   true,
+			"int(l.file.Fd())": true,
+		},
+	}
+	found := map[string]int{}
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		relative, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		set := token.NewFileSet()
+		parsed, err := parser.ParseFile(set, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		var inspectErr error
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "Flock" || len(call.Args) == 0 {
+				return true
+			}
+			packageName, ok := selector.X.(*ast.Ident)
+			if !ok || (packageName.Name != "unix" && packageName.Name != "syscall") {
+				return true
+			}
+			var rendered bytes.Buffer
+			if err := format.Node(&rendered, set, call.Args[0]); err != nil {
+				inspectErr = err
+				return false
+			}
+			target := rendered.String()
+			if !allowedTargets[relative][target] {
+				inspectErr = fmt.Errorf("unnamed production advisory-lock target %s:%s", relative, target)
+				return false
+			}
+			found[relative+":"+target]++
+			return true
+		})
+		return inspectErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]int{
+		filepath.FromSlash("internal/operatorchannel/proof_lock_unix.go") + ":int(file.Fd())":                              2,
+		filepath.FromSlash("internal/packartifact/project_lock_unix.go") + ":int(file.Fd())":                               2,
+		filepath.FromSlash("internal/runtime/credentials/file_lock_unix.go") + ":int(lock.Fd())":                           2,
+		filepath.FromSlash("internal/runtime/managedcredentials/file_lock_unix.go") + ":int(lock.Fd())":                    2,
+		filepath.FromSlash("internal/runtime/pythonmodule/artifact_lock_unix.go") + ":int(lock.Fd())":                      2,
+		filepath.FromSlash("internal/store/devscratch/epoch_unix.go") + ":fd":                                              1,
+		filepath.FromSlash("internal/store/devscratch/epoch_unix.go") + ":int(file.Fd())":                                  1,
+		filepath.FromSlash("internal/store/internal/startupownership/sqlite_possession_unix.go") + ":int(coordinate.Fd())": 2,
+		filepath.FromSlash("internal/testpostgres/file_lock_unix.go") + ":int(file.Fd())":                                  1,
+		filepath.FromSlash("internal/testpostgres/file_lock_unix.go") + ":int(l.file.Fd())":                                1,
+	} {
+		if found[key] != want {
+			t.Fatalf("advisory-lock target %s count=%d, want %d", key, found[key], want)
+		}
+	}
+}

--- a/internal/store/internal/startupownership/sqlite_possession.go
+++ b/internal/store/internal/startupownership/sqlite_possession.go
@@ -17,16 +17,15 @@ type sqlitePossession interface {
 	Release() error
 }
 
-// SQLiteConstructionGuard keeps the selected file stable while the SQLite
-// pool opens and records the exact file identity that later possession must
-// protect.
+// SQLiteConstructionGuard keeps the selected database and its dedicated
+// possession coordinate stable while the SQLite pool opens.
 type SQLiteConstructionGuard struct {
 	mu         sync.Mutex
 	possession sqlitePossession
 }
 
-// SQLiteBackendIdentity is the immutable file identity captured while the
-// backend pool was opened under SQLiteConstructionGuard.
+// SQLiteBackendIdentity is the immutable database/coordinate pair captured
+// while the backend pool was opened under SQLiteConstructionGuard.
 type SQLiteBackendIdentity struct {
 	mu        sync.Mutex
 	reference sqlitePossession
@@ -45,14 +44,7 @@ func AcquireSQLiteConstructionGuard(selectedPath string) (*SQLiteConstructionGua
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return nil, fmt.Errorf("create SQLite selected-store parent: %w", err)
 	}
-	coordinate, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("create SQLite selected-store coordinate: %w", err)
-	}
-	if err := coordinate.Close(); err != nil {
-		return nil, fmt.Errorf("close SQLite selected-store coordinate: %w", err)
-	}
-	possession, err := acquireSQLiteFilePossession(abs)
+	possession, err := acquireSQLiteConstructionPossession(abs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/internal/startupownership/sqlite_possession_unix.go
+++ b/internal/store/internal/startupownership/sqlite_possession_unix.go
@@ -48,10 +48,10 @@ func acquireSQLitePossession(selectedPath string, createDatabase bool) (sqlitePo
 	if err != nil {
 		return nil, err
 	}
-	if err := prevalidateSQLiteDatabasePath(databasePath, createDatabase); err != nil {
+	if err := requireSupportedLocalFilesystem(filepath.Dir(databasePath)); err != nil {
 		return nil, err
 	}
-	if err := requireSupportedLocalFilesystem(filepath.Dir(databasePath)); err != nil {
+	if err := prevalidateSQLiteDatabasePath(databasePath, createDatabase); err != nil {
 		return nil, err
 	}
 

--- a/internal/store/internal/startupownership/sqlite_possession_unix.go
+++ b/internal/store/internal/startupownership/sqlite_possession_unix.go
@@ -16,65 +16,207 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const sqlitePossessionSuffix = ".possession"
+
+// sqliteFilePossession retains both identities that make selected-store
+// possession provable. The database is identity only; exclusion is applied
+// exclusively to the engine-disjoint possession coordinate.
 type sqliteFilePossession struct {
-	mu           sync.Mutex
+	mu sync.Mutex
+
 	database     *os.File
 	databaseInfo os.FileInfo
-	path         string
-	released     bool
+	databasePath string
+
+	coordinate     *os.File
+	coordinateInfo os.FileInfo
+	coordinatePath string
+
+	released bool
 }
 
 func acquireSQLiteFilePossession(selectedPath string) (sqlitePossession, error) {
-	selectedPath = strings.TrimSpace(selectedPath)
-	abs, err := filepath.Abs(filepath.Clean(selectedPath))
+	return acquireSQLitePossession(selectedPath, false)
+}
+
+func acquireSQLiteConstructionPossession(selectedPath string) (sqlitePossession, error) {
+	return acquireSQLitePossession(selectedPath, true)
+}
+
+func acquireSQLitePossession(selectedPath string, createDatabase bool) (sqlitePossession, error) {
+	databasePath, err := canonicalSQLiteSelectedPath(selectedPath)
 	if err != nil {
-		return nil, fmt.Errorf("resolve SQLite selected-store path: %w", err)
-	}
-	resolved, err := filepath.EvalSymlinks(abs)
-	if err != nil {
-		return nil, fmt.Errorf("resolve SQLite selected-store identity: %w", err)
-	}
-	resolved = filepath.Clean(resolved)
-	if filepath.Clean(abs) != resolved && !systemCanonicalPathAlias(abs, resolved) {
-		return nil, &runtimestartupownership.AcquisitionError{
-			Failure: runtimestartupownership.AcquisitionPriorOwnerAmbiguous,
-			Detail:  "SQLite selected-store aliases are not ownership authority; select its canonical path",
-		}
-	}
-	if err := requireSupportedLocalFilesystem(resolved); err != nil {
 		return nil, err
 	}
-	database, err := os.OpenFile(resolved, os.O_RDWR, 0)
+	if err := prevalidateSQLiteDatabasePath(databasePath, createDatabase); err != nil {
+		return nil, err
+	}
+	if err := requireSupportedLocalFilesystem(filepath.Dir(databasePath)); err != nil {
+		return nil, err
+	}
+
+	coordinatePath := databasePath + sqlitePossessionSuffix
+	coordinate, coordinateInfo, err := acquireSQLitePossessionCoordinate(coordinatePath)
 	if err != nil {
-		return nil, fmt.Errorf("open SQLite selected-store identity: %w", err)
+		return nil, err
 	}
-	databaseInfo, err := database.Stat()
+	database, databaseInfo, err := openSQLiteDatabaseIdentity(databasePath, createDatabase)
 	if err != nil {
-		_ = database.Close()
-		return nil, fmt.Errorf("stat SQLite selected-store identity: %w", err)
+		return nil, errors.Join(err, releaseSQLitePossessionCoordinate(coordinate))
 	}
-	if !isSingleLinkRegularFile(databaseInfo) {
-		_ = database.Close()
-		return nil, &runtimestartupownership.AcquisitionError{
-			Failure: runtimestartupownership.AcquisitionPriorOwnerAmbiguous,
-			Detail:  "SQLite selected-store hard-link aliases cannot prove one canonical ownership coordinate",
-		}
+
+	possession := &sqliteFilePossession{
+		database:       database,
+		databaseInfo:   databaseInfo,
+		databasePath:   databasePath,
+		coordinate:     coordinate,
+		coordinateInfo: coordinateInfo,
+		coordinatePath: coordinatePath,
 	}
-	if err := unix.Flock(int(database.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
-		_ = database.Close()
-		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
-			return nil, &runtimestartupownership.AcquisitionError{
-				Failure: runtimestartupownership.AcquisitionTakeoverRequired,
-				Detail:  "selected store is held by another process",
-			}
-		}
-		return nil, fmt.Errorf("acquire SQLite selected-store possession: %w", err)
-	}
-	possession := &sqliteFilePossession{database: database, databaseInfo: databaseInfo, path: resolved}
 	if err := possession.ProveCurrent(context.Background()); err != nil {
 		return nil, errors.Join(err, possession.Release())
 	}
 	return possession, nil
+}
+
+func canonicalSQLiteSelectedPath(selectedPath string) (string, error) {
+	selectedPath = strings.TrimSpace(selectedPath)
+	if selectedPath == "" {
+		return "", errors.New("SQLite selected-store path is required")
+	}
+	abs, err := filepath.Abs(filepath.Clean(selectedPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve SQLite selected-store path: %w", err)
+	}
+	canonicalParent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return "", fmt.Errorf("resolve SQLite selected-store parent identity: %w", err)
+	}
+	canonical := filepath.Clean(filepath.Join(canonicalParent, filepath.Base(abs)))
+	if filepath.Clean(abs) != canonical && !systemCanonicalPathAlias(abs, canonical) {
+		return "", sqlitePriorOwnerAmbiguous(
+			"SQLite selected-store aliases are not ownership authority; select its canonical path",
+		)
+	}
+	if info, err := os.Lstat(abs); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return "", sqlitePriorOwnerAmbiguous(
+			"SQLite selected-store aliases are not ownership authority; select its canonical path",
+		)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect SQLite selected-store path: %w", err)
+	}
+	return canonical, nil
+}
+
+func prevalidateSQLiteDatabasePath(path string, createDatabase bool) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if createDatabase {
+			return nil
+		}
+		return fmt.Errorf("open SQLite selected-store identity: %w", err)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect SQLite selected-store identity: %w", err)
+	}
+	if !isSingleLinkRegularFile(info) {
+		return sqlitePriorOwnerAmbiguous(
+			"SQLite selected-store hard-link aliases cannot prove one canonical ownership coordinate",
+		)
+	}
+	return nil
+}
+
+func acquireSQLitePossessionCoordinate(path string) (*os.File, os.FileInfo, error) {
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, nil, sqlitePriorOwnerAmbiguous("SQLite possession coordinate must not be a symbolic link")
+		}
+		return nil, nil, fmt.Errorf("open SQLite possession coordinate: %w", err)
+	}
+	coordinate := os.NewFile(uintptr(fd), path)
+	if coordinate == nil {
+		_ = unix.Close(fd)
+		return nil, nil, errors.New("open SQLite possession coordinate file")
+	}
+	info, err := coordinate.Stat()
+	if err != nil {
+		return nil, nil, errors.Join(fmt.Errorf("stat SQLite possession coordinate: %w", err), coordinate.Close())
+	}
+	if !isSafeSQLitePossessionCoordinate(info) {
+		return nil, nil, errors.Join(sqlitePriorOwnerAmbiguous(
+			"SQLite possession coordinate must be one owner-only unaliased regular file",
+		), coordinate.Close())
+	}
+	if err := requireSupportedLocalFilesystem(path); err != nil {
+		return nil, nil, errors.Join(err, coordinate.Close())
+	}
+	if err := unix.Flock(int(coordinate.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		closeErr := coordinate.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, nil, errors.Join(&runtimestartupownership.AcquisitionError{
+				Failure: runtimestartupownership.AcquisitionTakeoverRequired,
+				Detail:  "selected store is held by another process",
+			}, closeErr)
+		}
+		return nil, nil, errors.Join(fmt.Errorf("acquire SQLite selected-store possession: %w", err), closeErr)
+	}
+	current, err := os.Lstat(path)
+	if err != nil || !isSafeSQLitePossessionCoordinate(current) || !os.SameFile(info, current) {
+		return nil, nil, errors.Join(
+			sqlitePriorOwnerAmbiguous("SQLite possession coordinate changed during acquisition"),
+			releaseSQLitePossessionCoordinate(coordinate),
+		)
+	}
+	return coordinate, info, nil
+}
+
+func openSQLiteDatabaseIdentity(path string, create bool) (*os.File, os.FileInfo, error) {
+	flags := unix.O_RDWR | unix.O_CLOEXEC | unix.O_NOFOLLOW
+	if create {
+		flags |= unix.O_CREAT
+	}
+	fd, err := unix.Open(path, flags, 0o600)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, nil, sqlitePriorOwnerAmbiguous(
+				"SQLite selected-store aliases are not ownership authority; select its canonical path",
+			)
+		}
+		return nil, nil, fmt.Errorf("open SQLite selected-store identity: %w", err)
+	}
+	database := os.NewFile(uintptr(fd), path)
+	if database == nil {
+		_ = unix.Close(fd)
+		return nil, nil, errors.New("open SQLite selected-store identity file")
+	}
+	info, err := database.Stat()
+	if err != nil {
+		return nil, nil, errors.Join(fmt.Errorf("stat SQLite selected-store identity: %w", err), database.Close())
+	}
+	if !isSingleLinkRegularFile(info) {
+		return nil, nil, errors.Join(sqlitePriorOwnerAmbiguous(
+			"SQLite selected-store hard-link aliases cannot prove one canonical ownership coordinate",
+		), database.Close())
+	}
+	if err := requireSupportedLocalFilesystem(path); err != nil {
+		return nil, nil, errors.Join(err, database.Close())
+	}
+	current, err := os.Lstat(path)
+	if err != nil || !isSingleLinkRegularFile(current) || !os.SameFile(info, current) {
+		return nil, nil, errors.Join(sqlitePriorOwnerAmbiguous(
+			"SQLite selected-store identity changed during acquisition",
+		), database.Close())
+	}
+	return database, info, nil
+}
+
+func sqlitePriorOwnerAmbiguous(detail string) error {
+	return &runtimestartupownership.AcquisitionError{
+		Failure: runtimestartupownership.AcquisitionPriorOwnerAmbiguous,
+		Detail:  detail,
+	}
 }
 
 func isSingleLinkRegularFile(info os.FileInfo) bool {
@@ -83,6 +225,14 @@ func isSingleLinkRegularFile(info os.FileInfo) bool {
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && stat.Nlink == 1
+}
+
+func isSafeSQLitePossessionCoordinate(info os.FileInfo) bool {
+	if !isSingleLinkRegularFile(info) || info.Mode().Perm() != 0o600 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Geteuid())
 }
 
 func (p *sqliteFilePossession) ProveCurrent(ctx context.Context) error {
@@ -96,20 +246,37 @@ func (p *sqliteFilePossession) ProveCurrent(ctx context.Context) error {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.released || p.database == nil {
+	if p.released || p.database == nil || p.coordinate == nil {
 		return errors.New("SQLite selected-store possession is released")
 	}
-	current, err := os.Stat(p.path)
-	if err != nil {
-		return fmt.Errorf("prove SQLite selected-store identity: %w", err)
+	if err := proveSQLitePossessionIdentity(
+		p.databasePath, p.databaseInfo, false, "SQLite selected-store file identity changed",
+	); err != nil {
+		return err
 	}
-	if !isSingleLinkRegularFile(current) || !os.SameFile(p.databaseInfo, current) {
-		return &runtimestartupownership.PossessionError{
-			Cause: runtimestartupownership.TerminalOwnershipUnprovable,
-			Err:   errors.New("SQLite selected-store file identity changed"),
-		}
+	return proveSQLitePossessionIdentity(
+		p.coordinatePath, p.coordinateInfo, true, "SQLite possession coordinate identity changed",
+	)
+}
+
+func proveSQLitePossessionIdentity(path string, retained os.FileInfo, coordinate bool, detail string) error {
+	current, err := os.Lstat(path)
+	valid := err == nil && isSingleLinkRegularFile(current)
+	if err == nil && coordinate {
+		valid = isSafeSQLitePossessionCoordinate(current)
 	}
-	return nil
+	if err == nil && valid && retained != nil && os.SameFile(retained, current) {
+		return nil
+	}
+	if err == nil {
+		err = errors.New(detail)
+	} else {
+		err = fmt.Errorf("%s: %w", detail, err)
+	}
+	return &runtimestartupownership.PossessionError{
+		Cause: runtimestartupownership.TerminalOwnershipUnprovable,
+		Err:   err,
+	}
 }
 
 func (p *sqliteFilePossession) Release() error {
@@ -122,13 +289,25 @@ func (p *sqliteFilePossession) Release() error {
 		return nil
 	}
 	p.released = true
-	var unlockErr, databaseCloseErr error
-	if p.database != nil {
-		unlockErr = unix.Flock(int(p.database.Fd()), unix.LOCK_UN)
-		databaseCloseErr = p.database.Close()
-	}
+	coordinate := p.coordinate
+	database := p.database
+	p.coordinate = nil
 	p.database = nil
-	return errors.Join(unlockErr, databaseCloseErr)
+	return errors.Join(releaseSQLitePossessionCoordinate(coordinate), closeSQLiteIdentity(database))
+}
+
+func releaseSQLitePossessionCoordinate(coordinate *os.File) error {
+	if coordinate == nil {
+		return nil
+	}
+	return errors.Join(unix.Flock(int(coordinate.Fd()), unix.LOCK_UN), coordinate.Close())
+}
+
+func closeSQLiteIdentity(database *os.File) error {
+	if database == nil {
+		return nil
+	}
+	return database.Close()
 }
 
 func sameSQLitePossessionResource(left, right sqlitePossession) bool {
@@ -136,5 +315,7 @@ func sameSQLitePossessionResource(left, right sqlitePossession) bool {
 	rightFile, rightOK := right.(*sqliteFilePossession)
 	return leftOK && rightOK && leftFile != nil && rightFile != nil &&
 		leftFile.databaseInfo != nil && rightFile.databaseInfo != nil &&
-		os.SameFile(leftFile.databaseInfo, rightFile.databaseInfo)
+		leftFile.coordinateInfo != nil && rightFile.coordinateInfo != nil &&
+		os.SameFile(leftFile.databaseInfo, rightFile.databaseInfo) &&
+		os.SameFile(leftFile.coordinateInfo, rightFile.coordinateInfo)
 }

--- a/internal/store/internal/startupownership/sqlite_possession_unix_test.go
+++ b/internal/store/internal/startupownership/sqlite_possession_unix_test.go
@@ -3,14 +3,50 @@
 package startupownership
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	runtimestartupownership "github.com/division-sh/swarm/internal/runtime/startupownership"
+	"golang.org/x/sys/unix"
+	_ "modernc.org/sqlite"
 )
+
+func TestSQLitePossessionCoordinateDoesNotBlockDatabaseWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	guard, err := AcquireSQLiteConstructionGuard(path)
+	if err != nil {
+		t.Fatalf("acquire construction guard: %v", err)
+	}
+	defer func() {
+		if err := guard.Release(); err != nil {
+			t.Errorf("release construction guard: %v", err)
+		}
+	}()
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open SQLite backend: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`CREATE TABLE possession_probe (value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create table while possession is held: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO possession_probe (value) VALUES ('engine-disjoint')`); err != nil {
+		t.Fatalf("write while possession is held: %v", err)
+	}
+	var value string
+	if err := db.QueryRow(`SELECT value FROM possession_probe`).Scan(&value); err != nil || value != "engine-disjoint" {
+		t.Fatalf("read while possession is held value=%q err=%v", value, err)
+	}
+}
 
 func TestSQLiteProcessCapabilityRejectsAliasPath(t *testing.T) {
 	root := t.TempDir()
@@ -77,9 +113,16 @@ func TestSQLiteProcessCapabilityFileIdentityReplacement(t *testing.T) {
 	if !errors.As(err, &possessionErr) || possessionErr.Cause != runtimestartupownership.TerminalOwnershipUnprovable {
 		t.Fatalf("replacement proof error=%v, want ownership_unprovable", err)
 	}
+	contender, contenderErr := acquireSQLiteFilePossession(path)
+	if contender != nil {
+		_ = contender.Release()
+	}
+	if !isSQLitePossessionFailure(contenderErr, runtimestartupownership.AcquisitionTakeoverRequired) {
+		t.Fatalf("contender after database replacement error=%v, want takeover_required", contenderErr)
+	}
 }
 
-func TestSQLiteProcessCapabilityFormerSidecarReplacementCannotSplitPossession(t *testing.T) {
+func TestSQLiteProcessCapabilityCoordinateReplacementFailsClosed(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "runtime.db")
 	if err := os.WriteFile(path, []byte("sqlite-identity"), 0o600); err != nil {
@@ -90,23 +133,287 @@ func TestSQLiteProcessCapabilityFormerSidecarReplacementCannotSplitPossession(t 
 		t.Fatalf("acquire possession: %v", err)
 	}
 	t.Cleanup(func() { _ = possession.Release() })
-	lockPath := path + ".swarm-owner.lock"
-	if err := os.Remove(lockPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	coordinatePath := path + sqlitePossessionSuffix
+	if err := os.Rename(coordinatePath, coordinatePath+".retired"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(lockPath, []byte("non-authoritative"), 0o600); err != nil {
+	if err := os.WriteFile(coordinatePath, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := possession.ProveCurrent(context.Background()); err != nil {
-		t.Fatalf("former sidecar replacement changed canonical possession: %v", err)
+	err = possession.ProveCurrent(context.Background())
+	var possessionErr *runtimestartupownership.PossessionError
+	if !errors.As(err, &possessionErr) || possessionErr.Cause != runtimestartupownership.TerminalOwnershipUnprovable {
+		t.Fatalf("coordinate replacement proof error=%v, want ownership_unprovable", err)
 	}
-	contender, err := acquireSQLiteFilePossession(path)
+}
+
+func TestSQLiteProcessCapabilityMissingIdentityFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		removePath func(databasePath string) string
+	}{
+		{name: "database", removePath: func(databasePath string) string { return databasePath }},
+		{name: "coordinate", removePath: func(databasePath string) string { return databasePath + sqlitePossessionSuffix }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "runtime.db")
+			possession, err := acquireSQLiteConstructionPossession(path)
+			if err != nil {
+				t.Fatalf("acquire possession: %v", err)
+			}
+			defer func() { _ = possession.Release() }()
+
+			if err := os.Remove(test.removePath(path)); err != nil {
+				t.Fatalf("remove retained %s identity: %v", test.name, err)
+			}
+			err = possession.ProveCurrent(context.Background())
+			var possessionErr *runtimestartupownership.PossessionError
+			if !errors.As(err, &possessionErr) || possessionErr.Cause != runtimestartupownership.TerminalOwnershipUnprovable {
+				t.Fatalf("missing %s identity proof error=%v, want ownership_unprovable", test.name, err)
+			}
+		})
+	}
+}
+
+func TestSQLitePossessionCoordinatePersistsAcrossRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	first, err := acquireSQLiteConstructionPossession(path)
+	if err != nil {
+		t.Fatalf("acquire initial possession: %v", err)
+	}
+	coordinatePath := path + sqlitePossessionSuffix
+	before, err := os.Stat(coordinatePath)
+	if err != nil {
+		t.Fatalf("stat initial coordinate: %v", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatalf("release initial possession: %v", err)
+	}
+	after, err := os.Stat(coordinatePath)
+	if err != nil {
+		t.Fatalf("coordinate was removed on release: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("coordinate identity changed on release")
+	}
+	second, err := acquireSQLiteFilePossession(path)
+	if err != nil {
+		t.Fatalf("reacquire persistent coordinate: %v", err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatalf("release successor possession: %v", err)
+	}
+}
+
+func TestSQLitePossessionCoordinateIsCloseOnExec(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	possession, err := acquireSQLiteConstructionPossession(path)
+	if err != nil {
+		t.Fatalf("acquire construction possession: %v", err)
+	}
+	defer func() { _ = possession.Release() }()
+	retained, ok := possession.(*sqliteFilePossession)
+	if !ok {
+		t.Fatalf("possession type=%T, want retained file possession", possession)
+	}
+	flags, err := unix.FcntlInt(retained.coordinate.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("read coordinate descriptor flags: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatal("possession coordinate descriptor is inherited across exec")
+	}
+}
+
+func TestSQLiteBackendIdentityMatchingUsesDatabaseAndCoordinate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runtime.db")
+	reference, err := acquireSQLiteConstructionPossession(path)
+	if err != nil {
+		t.Fatalf("acquire reference possession: %v", err)
+	}
+	if err := reference.Release(); err != nil {
+		t.Fatalf("release reference possession: %v", err)
+	}
+	samePair, err := acquireSQLiteFilePossession(path)
+	if err != nil {
+		t.Fatalf("reacquire unchanged pair: %v", err)
+	}
+	if !sameSQLitePossessionResource(reference, samePair) {
+		t.Fatal("unchanged database/coordinate pair did not match")
+	}
+	if err := samePair.Release(); err != nil {
+		t.Fatalf("release unchanged pair: %v", err)
+	}
+
+	coordinatePath := path + sqlitePossessionSuffix
+	if err := os.Rename(coordinatePath, coordinatePath+".retired"); err != nil {
+		t.Fatalf("replace coordinate identity: %v", err)
+	}
+	replacedPair, err := acquireSQLiteFilePossession(path)
+	if err != nil {
+		t.Fatalf("acquire replaced coordinate pair: %v", err)
+	}
+	defer func() { _ = replacedPair.Release() }()
+	if sameSQLitePossessionResource(reference, replacedPair) {
+		t.Fatal("backend identity matched after possession-coordinate replacement")
+	}
+}
+
+func TestSQLitePossessionRejectsUnsafeCoordinate(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(t *testing.T, coordinatePath string)
+	}{
+		{
+			name: "symlink",
+			prepare: func(t *testing.T, coordinatePath string) {
+				t.Helper()
+				target := coordinatePath + ".target"
+				if err := os.WriteFile(target, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, coordinatePath); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "hard_link",
+			prepare: func(t *testing.T, coordinatePath string) {
+				t.Helper()
+				if err := os.WriteFile(coordinatePath, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Link(coordinatePath, coordinatePath+".alias"); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "non_owner_only_mode",
+			prepare: func(t *testing.T, coordinatePath string) {
+				t.Helper()
+				if err := os.WriteFile(coordinatePath, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(coordinatePath, 0o640); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "runtime.db")
+			if err := os.WriteFile(path, []byte("sqlite-identity"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			test.prepare(t, path+sqlitePossessionSuffix)
+			possession, err := acquireSQLiteFilePossession(path)
+			if possession != nil {
+				_ = possession.Release()
+			}
+			if !isSQLitePossessionFailure(err, runtimestartupownership.AcquisitionPriorOwnerAmbiguous) {
+				t.Fatalf("unsafe coordinate acquisition error=%v, want prior_owner_ambiguous", err)
+			}
+		})
+	}
+}
+
+const sqlitePossessionChildMarker = "SWARM_TEST_SQLITE_POSSESSION_CHILD"
+
+func TestSQLitePossessionSubprocessContentionAndSIGKILLReclaim(t *testing.T) {
+	if os.Getenv(sqlitePossessionChildMarker) == "1" {
+		path := os.Getenv("SWARM_TEST_SQLITE_POSSESSION_PATH")
+		readyPath := os.Getenv("SWARM_TEST_SQLITE_POSSESSION_READY")
+		possession, err := acquireSQLiteConstructionPossession(path)
+		if err != nil {
+			t.Fatalf("child acquire possession: %v", err)
+		}
+		defer func() { _ = possession.Release() }()
+		if err := os.WriteFile(readyPath, nil, 0o600); err != nil {
+			t.Fatalf("child signal ready: %v", err)
+		}
+		select {}
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, "runtime.db")
+	readyPath := filepath.Join(root, "ready")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSQLitePossessionSubprocessContentionAndSIGKILLReclaim$")
+	cmd.Env = append(os.Environ(),
+		sqlitePossessionChildMarker+"=1",
+		"SWARM_TEST_SQLITE_POSSESSION_PATH="+path,
+		"SWARM_TEST_SQLITE_POSSESSION_READY="+readyPath,
+	)
+	var childOutput bytes.Buffer
+	cmd.Stdout = &childOutput
+	cmd.Stderr = &childOutput
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start possession child: %v", err)
+	}
+	childExited := false
+	t.Cleanup(func() {
+		if !childExited && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	waitForSQLitePossessionChild(t, cmd, readyPath, &childOutput)
+
+	coordinatePath := path + sqlitePossessionSuffix
+	before, err := os.Stat(coordinatePath)
+	if err != nil {
+		t.Fatalf("stat child coordinate: %v", err)
+	}
+	contender, err := acquireSQLiteConstructionPossession(path)
 	if contender != nil {
 		_ = contender.Release()
 	}
 	if !isSQLitePossessionFailure(err, runtimestartupownership.AcquisitionTakeoverRequired) {
-		t.Fatalf("contender after former sidecar replacement error=%v, want takeover_required", err)
+		t.Fatalf("subprocess contention error=%v, want takeover_required", err)
 	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("SIGKILL possession child: %v", err)
+	}
+	waitErr := cmd.Wait()
+	childExited = true
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		t.Fatalf("child wait error=%v, want SIGKILL exit; output:\n%s", waitErr, childOutput.String())
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		t.Fatalf("child wait status=%v, want SIGKILL; output:\n%s", exitErr.Sys(), childOutput.String())
+	}
+
+	successor, err := acquireSQLiteFilePossession(path)
+	if err != nil {
+		t.Fatalf("acquire after SIGKILL: %v; child output:\n%s", err, childOutput.String())
+	}
+	defer func() { _ = successor.Release() }()
+	after, err := os.Stat(coordinatePath)
+	if err != nil {
+		t.Fatalf("stat reclaimed coordinate: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("SIGKILL reclaim replaced the persistent coordinate")
+	}
+}
+
+func waitForSQLitePossessionChild(t *testing.T, cmd *exec.Cmd, readyPath string, output *bytes.Buffer) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyPath); err == nil {
+			return
+		}
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			t.Fatalf("possession child exited before ready: %v\n%s", cmd.ProcessState, output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("possession child did not become ready; output:\n%s", output.String())
 }
 
 func isSQLitePossessionFailure(err error, failure runtimestartupownership.AcquisitionFailure) bool {

--- a/internal/store/internal/startupownership/sqlite_possession_unsupported.go
+++ b/internal/store/internal/startupownership/sqlite_possession_unsupported.go
@@ -11,4 +11,8 @@ func acquireSQLiteFilePossession(string) (sqlitePossession, error) {
 	}
 }
 
+func acquireSQLiteConstructionPossession(path string) (sqlitePossession, error) {
+	return acquireSQLiteFilePossession(path)
+}
+
 func sameSQLitePossessionResource(sqlitePossession, sqlitePossession) bool { return false }

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -6229,9 +6229,16 @@ engine:
       sqlite_owner: internal/store.SQLiteRuntimeStore process capability
       postgres_owner: internal/store.PostgresStore retained-session process capability
       scope: >
-        SQLite startup ownership retains an operating-system lock bound to the canonical open database file on a supported
-        local filesystem, preventing competing runtime processes from acquiring the same selected store. This exact
-        process-capability lock does not promote general production multi-writer SQLite semantics. One process capability
+        SQLite startup ownership retains an operating-system lock only on the persistent
+        `<canonical database path>.possession` coordinate on a supported local filesystem, preventing competing runtime
+        processes from acquiring the same selected store without contending with SQLite's engine locks. The coordinate is
+        derived from the canonical database parent and basename, is never database identity, and is retained as a second
+        exact identity alongside the canonical database resource. Swarm never deletes, replaces, migrates, exports, or
+        rotates the coordinate. No advisory lock may target the database, WAL, journal, SHM, or another SQLite-managed file.
+        Missing or replaced database/coordinate identity fails closed and terminalizes retained authority as
+        ownership_unprovable. Deliberate same-user coordinate replacement is unsupported filesystem tampering, not a
+        hostile-filesystem exclusion guarantee. This exact process-capability lock does not promote general production
+        multi-writer SQLite semantics. One process capability
         owns the complete source set and issues one revocable grant per
         admitted runtime generation. Shared-store consumers execute only under those grants: pipeline maintenance, system
         nodes, manager loops, schedule callbacks, outbox sweeping, and inbound admission are included. Live replacement MUST
@@ -15601,13 +15608,13 @@ platform_tables:
           monitor deadline. Timeout, backend unreachability, or failed proof terminalizes the capability as
           ownership_unprovable and retires its local generation grants; no unbounded background-context recheck is allowed.
         terminal_readback: >-
-          After a retained PostgreSQL session is discarded or a SQLite file-possession lock is released unexpectedly,
+          After a retained PostgreSQL session is discarded or a SQLite possession-coordinate lock is released unexpectedly,
           successor classification is bounded by that same configured monitor deadline. Only exact validated successor
           lineage may classify ownership_superseded. Timeout, unavailable storage, malformed evidence, or any incomplete
           readback promptly classifies ownership_unprovable so released physical possession cannot coexist with locally
           live process capability or generation-grant authority.
       diagnostic_inspection_contract: >-
-        `swarm store status` is read-only. It never creates a SQLite parent or database file, bootstraps or origin-stamps
+        `swarm store status` is read-only. It never creates a SQLite parent, database file, or possession coordinate, bootstraps or origin-stamps
         either selected store, or creates PostgreSQL schema objects. An absent SQLite target or an empty PostgreSQL/SQLite
         catalog reports the canonical empty authority inspection. Existing SQLite inspection opens the selected file in
         read-only mode. A non-empty catalog missing the authority table fails closed instead of being reported as empty.
@@ -38018,12 +38025,18 @@ agent_topology_authority:
     owner: one retained selected-store session acquired only by process composition
     acquisition: >-
       Acquisition first proves exact backend-exclusive possession: one retained PostgreSQL advisory-lock session or
-      one retained SQLite OS lock applied directly to the canonical open database file on a supported local filesystem.
-      A replaceable sidecar, path marker, or independently recreated inode is never SQLite possession authority. Only
-      process/repair SQLite construction opens and configures its backend pool while holding that same file coordinate and
-      records the resulting immutable backend-file identity. Every later acquisition or repair must lock that exact
-      recorded identity before selected-store mutation; a pool bound to one inode and a possession lock bound to
-      another fails closed. Only then may the same retained capability lock and classify the global durable authority head. A valid active
+      one retained SQLite OS lock applied only to the persistent `<canonical database path>.possession` coordinate on a
+      supported local filesystem. Construction resolves the canonical parent and basename, opens the coordinate with
+      no-follow and close-on-exec semantics, and requires one owner-only unaliased regular file on a supported local
+      filesystem. It acquires and revalidates that coordinate before creating or opening a fresh database or allowing pool
+      and schema mutation. The coordinate is engine-lock-disjoint: advisory locks on the database, WAL, journal, SHM, or
+      another SQLite-managed file are prohibited. One opaque possession records both the resulting immutable backend-file
+      identity and the exact coordinate identity. Every later acquisition or repair must lock and match that complete pair
+      before selected-store mutation; a pool bound to one inode and a possession value bound to another database or
+      coordinate fails closed. Swarm never deletes, replaces, rotates, migrates, or exports the coordinate. Missing or
+      replaced database/coordinate identity terminalizes the retained process capability as ownership_unprovable.
+      Deliberate same-user coordinate replacement is unsupported filesystem tampering and is not claimed as a hostile
+      zero-overlap boundary. Only then may the same retained capability lock and classify the global durable authority head. A valid active
       predecessor with absent backend possession is atomically superseded, every predecessor new-work grant is
       retired, and one monotonic successor authority generation is appended in the same transaction. Source-set
       topology, durable delivery continuations, and provider drains are distinct facts and remain unchanged.


### PR DESCRIPTION
## Summary

- move SQLite process exclusion from the database descriptor to the persistent `<canonical database path>.possession` coordinate
- retain and prove the database inode and possession-coordinate inode as one opaque backend identity
- fail closed on aliases, unsafe coordinates, identity loss, and replacement while preserving crash reclaim and read-only inspection
- add structural lock census, shipped dev/non-dev serve proof, and a required macOS ownership job

Closes #2383

## Governing Contract

Authoritative sections updated in this PR:

- `platform-spec.yaml` `engine.selected_store_parity.runtime_startup_ownership`
- `platform-spec.yaml` `platform_tables.tables.runtime_startup_authority_facts.possession_loss_contract`
- `platform-spec.yaml` `platform_tables.tables.runtime_startup_authority_facts.diagnostic_inspection_contract`
- `platform-spec.yaml` `agent_topology_authority.process_capability.acquisition`

Binding implementation context is the approved revision-2 pre-audit and independent gate on #2383, including the unsupported same-user filesystem-tampering boundary.

## Semantic Migration

The canonical owner remains `internal/store/internal/startupownership`. The old producer/interpreter, `unix.Flock(database.Fd())`, is deleted. The new owner locks only the persistent engine-disjoint coordinate and retains both exact identities through construction, acquisition/repair, monitoring, matching, and release.

Normal serve, authority maintenance, initial and later capability acquisition, replacement monitoring, construction failure, unactivated close, ordinary release, and crash reclaim were checked for surviving database-file locking or alternate possession behavior. A repository-wide AST ratchet accounts for every production `Flock` target. Migration is complete: there is no legacy coordinate reader, fallback, deletion, PID/lease metadata, compatibility path, export, or generalized lock framework.

## Verification

- `go test ./internal/store/internal/startupownership -count=1`
- `go test -race ./internal/store/internal/startupownership -count=1`
- focused store, selected-store, CLI read-only, monitor replacement, serve construction, spec, release-e2e, subprocess contention/SIGKILL, and authority-repair tests
- SQLite/PostgreSQL cancellation, release-failure, takeover rollback, authority repair, and process-capability parity through `swarm-test`
- `go run ./cmd/swarm-test -- -p 4 ./...`
- required `macos-latest` job supplies the real Darwin backend write and shipped dev/non-dev serve proof

The full suite retains the repository default test timeouts; package parallelism was bounded because the shared host runtime-persistence package takes approximately nine minutes in isolation.