### PR TITLE
[agent-g][issue #2396] Harden golden invocation shape

### DIFF
--- a/internal/releasee2e/golden_agent_workload_test.go
+++ b/internal/releasee2e/golden_agent_workload_test.go
@@ -520,6 +520,11 @@ func goldenDatabaseName(t *testing.T) string {
 
 func runGoldenAgentWorkload(t *testing.T, binaryPath, root string, store goldenStoreSelection, restart bool, options goldenWorkloadOptions) {
 	t.Helper()
+	const (
+		configOperand    = "swarm.yaml"
+		contractsOperand = "contracts"
+		tokenOperand     = "api-token"
+	)
 	if len(options.candidateIDs) < 2 {
 		t.Fatalf("golden workload requires at least two candidates, got %v", options.candidateIDs)
 	}
@@ -532,18 +537,23 @@ func runGoldenAgentWorkload(t *testing.T, binaryPath, root string, store goldenS
 	}
 	assertGoldenFixtureHasSingleMockOwner(t)
 	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("create release project: %v", err)
+		t.Fatalf("create golden workload root: %v", err)
 	}
-	contracts := filepath.Join(root, "contracts")
+	// This ancestor module is an adversarial canary: the authored child project has no Go-module authority.
+	writeReleaseFile(t, filepath.Join(root, "go.mod"), "module golden-hostile-ancestor\n\ngo 1.23.0\n")
+	projectRoot := filepath.Join(root, "yaml-project")
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("create YAML-only release project: %v", err)
+	}
+	contracts := filepath.Join(projectRoot, contractsOperand)
 	copyReleaseTree(t, filepath.Join(releaseE2ERepoRoot(t), "internal", "releasee2e", "testdata", "golden_agent_workload"), contracts)
-	writeReleaseFile(t, filepath.Join(root, "go.mod"), "module golden-agent-release-e2e\n\ngo 1.23.0\n")
-	configPath := filepath.Join(root, "swarm.yaml")
+	configPath := filepath.Join(projectRoot, configOperand)
 	writeReleaseFile(t, configPath, goldenRuntimeConfig(store))
-	tokenFile := filepath.Join(root, "api-token")
+	tokenFile := filepath.Join(projectRoot, tokenOperand)
 	writeReleaseFile(t, tokenFile, goldenAPIToken+"\n")
 	env := goldenProcessEnv(t, root, store.passwordEnv, options.processGOMAXPROCS)
 	assertGoldenProcessHasNoExternalExecutables(t, env)
-	verify := runReleaseCommand(t, goldenStartupTimeout, root, env, "", binaryPath, "verify", "--config", configPath, "--contracts", contracts, "--json")
+	verify := runReleaseCommand(t, goldenStartupTimeout, projectRoot, env, "", binaryPath, "verify", "--config", configOperand, "--contracts", contractsOperand, "--json")
 	if verify.err != nil {
 		t.Fatalf("golden release verify failed: %v\n%s", verify.err, verify.output)
 	}
@@ -558,13 +568,13 @@ func runGoldenAgentWorkload(t *testing.T, binaryPath, root string, store goldenS
 	start := func() *releaseServeProcess {
 		process := startReleaseServe(t, releaseProcessSpec{
 			BinaryPath: binaryPath,
-			WorkingDir: root,
-			ConfigPath: configPath,
-			Contracts:  contracts,
+			WorkingDir: projectRoot,
+			ConfigPath: configOperand,
+			Contracts:  contractsOperand,
 			Store:      store.name,
 			APIPort:    apiPort,
 			MCPPort:    mcpPort,
-			TokenFile:  tokenFile,
+			TokenFile:  tokenOperand,
 			Token:      goldenAPIToken,
 			Env:        env,
 		})

--- a/platform-spec.yaml
+++ b/platform-spec.yaml
@@ -21886,10 +21886,14 @@ test_specification:
       ci_owner: hitl-releasee2e-full
       process_boundary: >
         The executor builds the current swarm binary and uses only public readiness and
-        /v1/rpc behavior against the authored source. It runs with mock_only execution,
-        no provider credential and a fixture-private empty executable search path, so
-        Claude, Docker, and Podman cannot be discovered. SQL is permitted only to
-        provision and remove an isolated host-PostgreSQL database.
+        /v1/rpc behavior against the authored source. Every workload runs from an authored
+        YAML-only child project with no project-local `go.mod`, beneath one hostile ancestor
+        `go.mod` that acts only as an upward-search canary. Verify, initial serve, and every
+        restart use that exact child working directory and relative `swarm.yaml`, `contracts`,
+        and `api-token` operands. It runs with mock_only execution, no provider credential
+        and a fixture-private empty executable search path, so Claude, Docker, and Podman
+        cannot be discovered. SQL is permitted only to provision and remove an isolated
+        host-PostgreSQL database.
       pr_profile: >
         pr-common and pr-escalated execute the complete N=2 SQLite composition shape.
         Forced restart and contention rows are skipped explicitly by the canonical proof
@@ -21906,6 +21910,7 @@ test_specification:
       - fixture-local routing, lifecycle, replay, or settlement interpretation
       - SQL or logs as behavioral proof
       - provider credentials or discovery of Claude, Docker, or Podman executables
+      - project-local Go-module authority or absolute config, contracts, or token operands
       - reduced payload assertions, deadline-as-success, or a non-race burst substitute
     replay_clean:
       promoted_by: '#2143'


### PR DESCRIPTION
## Summary

- Run every full golden workload from an authored YAML-only child project with no project-local `go.mod`.
- Keep one hostile ancestor `go.mod` solely as the behavioral canary for the retired upward-search interpreter.
- Pass relative `swarm.yaml`, `contracts`, and `api-token` operands to verify, initial serve, and every restart.
- Make the production-shaped project and operand contract authoritative in `platform-spec.yaml`.

Closes #2396

## Governing authority

Exact binding sections:

- `platform-spec.yaml#test_specification.compiled_process_golden_profile`
- `platform-spec.yaml#cli_specification.foundations.invocation_root_authority`
- `platform-spec.yaml#configuration_source_authority.unified_swarm_config`
- `platform-spec.yaml#cli_specification.foundations.contract_platform_spec_path_resolution`
- `platform-spec.yaml#cli_specification.command_catalog.serve.listener_topology_v2_1.source_precedence.server_api_auth`

Binding audit and gate:

- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/2396#issuecomment-5471933835
- Independent approved gate: https://github.com/division-sh/swarm/issues/2396#issuecomment-5471990568

## Closure and migration

Chosen failure class: `golden_full_workload_production_invocation_root_and_relative_operand_conformance_missing`.

The canonical owner remains `platform-spec.yaml#test_specification.compiled_process_golden_profile`, executed by `runGoldenAgentWorkload` and projected through the unchanged product owner `cliapp.InvocationRoot`. All five current cells consume the corrected helper: SQLite smoke, SQLite/PostgreSQL forced restart, and SQLite/PostgreSQL burst.

The old project-local synthetic module and absolute config/contracts/token operands are now invalid for the full golden profile. No alternate reader, compatibility path, runtime option, or second harness survives. Absolute selected-store coordinates remain a separate unchanged contract. The proof-shape migration is complete.

## Verification

- Historical mutation red on `1c20cdfc3`: final helper diff failed `TestGoldenAgentWorkloadSQLiteSmoke` in real `verify`, which incorrectly looked for ancestor `swarm.yaml`.
- Current-head SQLite smoke: PASS, complete workload in 23.34s.
- Focused API spec/catalog/planning/timing packages: PASS.
- Full-profile SQLite/PostgreSQL forced restart: PASS; both rows completed exact convergence.
- Full-profile two-iteration N=10 race burst on SQLite/PostgreSQL: PASS; all four rows completed.
- `go run ./cmd/swarm-test -- ./... -count=1`: PASS.
- `git diff --check`: PASS.

The existing targeted macOS possession job remains unchanged and intentionally does not duplicate the full workload.
