### PR TITLE
[agent-codex][issue #2350] Stabilize async-site inventory

### DIFF
--- a/internal/runtime/core/worklifetime/source_guard_inventory_test.go
+++ b/internal/runtime/core/worklifetime/source_guard_inventory_test.go
@@ -1,0 +1,155 @@
+package worklifetime
+
+import (
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func inventoryFixture(t *testing.T, source string) map[string][]int {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string][]int{}
+	collectAsyncSites(fset, file, "fixture.go", found)
+	return found
+}
+
+func TestAsyncSiteInventoryIgnoresLineMovement(t *testing.T) {
+	const source = `package fixture
+func launch() {
+	go work()
+}
+`
+	ledger := map[string]asyncSiteLedgerEntry{
+		"go|fixture.go|launch": {1, asyncSiteSynchronousJoin, "caller joins the worker"},
+	}
+	original := inventoryFixture(t, source)
+	moved := inventoryFixture(t, "// An unrelated comment.\n\n"+source)
+	if reflect.DeepEqual(original, moved) {
+		t.Fatal("fixture did not move the diagnostic source lines")
+	}
+	for _, found := range []map[string][]int{original, moved} {
+		if err := compareAsyncSiteLedger(found, ledger); err != nil {
+			t.Fatalf("line-only change invalidated inventory: %v", err)
+		}
+	}
+}
+
+func TestAsyncSiteInventoryRequiresExactMultiplicity(t *testing.T) {
+	ledger := map[string]asyncSiteLedgerEntry{
+		"go|fixture.go|launch": {2, asyncSiteSynchronousJoin, "caller joins both workers"},
+	}
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"separate lines", "go first()\ngo second()", ""},
+		{"same line", "go first(); go second()", ""},
+		{"added launch", "go first(); go second(); go third()", "expected 2, found 3 (lines [2 2 2])"},
+		{"removed launch", "go first()", "expected 2, found 1 (lines [2])"},
+		{"removed all launches", "", "missing ledger sites:\ngo|fixture.go|launch: expected 2, found 0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			found := inventoryFixture(t, "package fixture\nfunc launch() { "+test.body+" }")
+			err := compareAsyncSiteLedger(found, ledger)
+			if test.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("inventory error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAsyncSiteInventoryKeepsFunctionsAndReceiversDistinct(t *testing.T) {
+	found := inventoryFixture(t, `package fixture
+func launch() { go work() }
+func (a *First) launch() { go work(); go work() }
+func (b Second) launch() { go work() }
+`)
+	ledger := map[string]asyncSiteLedgerEntry{
+		"go|fixture.go|launch":        {1, asyncSiteSynchronousJoin, "function joins worker"},
+		"go|fixture.go|First.launch":  {2, asyncSiteCanonicalOwner, "First owns both workers"},
+		"go|fixture.go|Second.launch": {1, asyncSiteCanonicalOwner, "Second owns worker"},
+	}
+	if err := compareAsyncSiteLedger(found, ledger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAsyncSiteInventoryCountsSupportedCallbacks(t *testing.T) {
+	const source = `package fixture
+import ctx "context"
+func launch() {
+	ctx.AfterFunc(parent, callback); ctx.AfterFunc(parent, callback)
+	QueuePipelinePostCommitAction(callback)
+	queuePipelinePostCommitAction(callback)
+	owner.QueuePipelineRollbackAction(callback)
+	owner.queuePipelineRollbackAction(callback)
+}
+`
+	ledger := map[string]asyncSiteLedgerEntry{
+		"after_func|fixture.go|launch":   {2, asyncSiteCanonicalOwner, "owner releases cancellation bridges"},
+		"owner_action|fixture.go|launch": {4, asyncSiteCanonicalOwner, "transaction owns registered actions"},
+	}
+	if err := compareAsyncSiteLedger(inventoryFixture(t, source), ledger); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		remove string
+		want   string
+	}{
+		{"cancellation callback", "ctx.AfterFunc(parent, callback); ", "expected 2, found 1"},
+		{"owner action", "owner.queuePipelineRollbackAction(callback)", "expected 4, found 3"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := strings.Replace(source, test.remove, "", 1)
+			err := compareAsyncSiteLedger(inventoryFixture(t, changed), ledger)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("inventory error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAsyncSiteInventoryRejectsStaleAndInvalidClassifications(t *testing.T) {
+	const key = "go|fixture.go|launch"
+	found := inventoryFixture(t, "package fixture\nfunc launch() { go work() }")
+	for _, test := range []struct {
+		name  string
+		entry asyncSiteLedgerEntry
+	}{
+		{"zero count", asyncSiteLedgerEntry{0, asyncSiteCanonicalOwner, "owner joins work"}},
+		{"negative count", asyncSiteLedgerEntry{-1, asyncSiteCanonicalOwner, "owner joins work"}},
+		{"unknown class", asyncSiteLedgerEntry{1, asyncSiteClass("unknown"), "owner joins work"}},
+		{"missing rationale", asyncSiteLedgerEntry{1, asyncSiteCanonicalOwner, " \t\n"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := compareAsyncSiteLedger(found, map[string]asyncSiteLedgerEntry{key: test.entry})
+			if err == nil || !strings.Contains(err.Error(), "invalid ledger entries (require positive count, known class, and rationale):\n"+key) {
+				t.Fatalf("invalid classification error = %v", err)
+			}
+		})
+	}
+	err := compareAsyncSiteLedger(found, map[string]asyncSiteLedgerEntry{
+		"go|fixture.go|retired": {1, asyncSiteCanonicalOwner, "retired worker"},
+	})
+	for _, want := range []string{
+		"unclassified async sites:\ngo|fixture.go|launch: found 1 (lines [2])",
+		"missing ledger sites:\ngo|fixture.go|retired: expected 1, found 0",
+	} {
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("stale inventory error = %v, want %q", err, want)
+		}
+	}
+}

--- a/internal/runtime/core/worklifetime/source_guard_inventory_test.go
+++ b/internal/runtime/core/worklifetime/source_guard_inventory_test.go
@@ -75,11 +75,17 @@ func TestAsyncSiteInventoryKeepsFunctionsAndReceiversDistinct(t *testing.T) {
 func launch() { go work() }
 func (a *First) launch() { go work(); go work() }
 func (b Second) launch() { go work() }
+func (c Third[T]) launch() { go work() }
+func (d *Fourth[T]) launch() { go work() }
+func (e Fifth[T, U]) launch() { go work() }
 `)
 	ledger := map[string]asyncSiteLedgerEntry{
 		"go|fixture.go|launch":        {1, asyncSiteSynchronousJoin, "function joins worker"},
 		"go|fixture.go|First.launch":  {2, asyncSiteCanonicalOwner, "First owns both workers"},
 		"go|fixture.go|Second.launch": {1, asyncSiteCanonicalOwner, "Second owns worker"},
+		"go|fixture.go|Third.launch":  {1, asyncSiteCanonicalOwner, "Third owns worker"},
+		"go|fixture.go|Fourth.launch": {1, asyncSiteCanonicalOwner, "Fourth owns worker"},
+		"go|fixture.go|Fifth.launch":  {1, asyncSiteCanonicalOwner, "Fifth owns worker"},
 	}
 	if err := compareAsyncSiteLedger(found, ledger); err != nil {
 		t.Fatal(err)

--- a/internal/runtime/core/worklifetime/source_guard_test.go
+++ b/internal/runtime/core/worklifetime/source_guard_test.go
@@ -21,72 +21,72 @@ const (
 )
 
 type asyncSiteLedgerEntry struct {
-	class asyncSiteClass
-	proof string
+	count     int
+	class     asyncSiteClass
+	rationale string
 }
 
+// This inventory records review classifications, not executable ownership proof.
+// Keys are launch kind, repository-relative file, and receiver/function; count
+// preserves multiplicity without coupling identity to source formatting. Replacing
+// a launch within a function can preserve the count: behavioral tests and review
+// must still establish cancellation, joining, and exactly-once settlement.
 var productionAsyncSiteLedger = map[string]asyncSiteLedgerEntry{
-	"after_func|internal/apiv1/handler.go|webSocketSession.run|445":                                                      {asyncSiteCanonicalOwner, "session lease cancellation closes the socket and the owned subscription joins before release"},
-	"after_func|internal/runtime/core/worklifetime/worklifetime.go|gate.beginClass|106":                                  {asyncSiteCanonicalOwner, "the canonical gate binds lease cancellation to its typed occurrence"},
-	"after_func|internal/runtime/core/eventreceiver/execution.go|NewContext|221":                                         {asyncSiteCanonicalOwner, "the closed receiver context binds cancellation to its explicit lifetime input and cleanup releases the bridge"},
-	"after_func|internal/runtime/manager/lifecycle_coordinator.go|agentLifecycleCoordinator.acquireExecutionLocked|1505": {asyncSiteCanonicalOwner, "the exact agent generation cancels and joins the acquired execution lease"},
-	"after_func|internal/runtime/manager/runtime.go|AgentManager.launchExecutionLoop|1690":                               {asyncSiteCanonicalOwner, "the exact agent-generation cancellation is bridged into the pre-admitted Manager lease and joined with that loop"},
-	"go|cmd/swarm-test/main.go|run|219":                                                                                  {asyncSiteSynchronousJoin, "the test harness joins process-tree signal forwarding after command completion"},
-	"go|cmd/swarm-test/main.go|run|76":                                                                                   {asyncSiteSynchronousJoin, "the test harness stops and joins its queue/child signal relay before return"},
-	"after_func|internal/runtime/channelactivation/owner.go|Owner.ReplaceContext|216":                                    {asyncSiteSynchronousJoin, "replacement stops the cancellation wakeup bridge before returning after the predecessor lease fence"},
-	"after_func|internal/runtime/channelactivation/owner.go|Owner.AcquirePresentationContext|318":                        {asyncSiteSynchronousJoin, "presentation acquisition stops the cancellation wakeup bridge before returning with an exact publication lease or error"},
-	"go|internal/apiv1/handler.go|webSocketSession.run|454":                                                              {asyncSiteCanonicalOwner, "the process-owned websocket session settles after the writer goroutine exits"},
-	"go|internal/apiv1/operator_conversation_fork.go|executeConversationForkChatWithHeartbeat|276":                       {asyncSiteCanonicalOwner, "the operation heartbeat has a typed lease and is canceled and joined by the enclosing call"},
-	"go|internal/apiv1/subscriptions.go|ownedSubscriptionWork.Start|99":                                                  {asyncSiteCanonicalOwner, "owned subscription work settles its process lease after the polling loop exits"},
-	"go|internal/cliapp/events.go|subscribeEvents|1020":                                                                  {asyncSiteSynchronousJoin, "the CLI subscription closes and joins its read loop"},
-	"go|internal/cliapp/logs.go|subscribeRuntimeLogs|386":                                                                {asyncSiteSynchronousJoin, "the CLI log subscription closes and joins its read loop"},
-	"go|internal/cliapp/run_command.go|closeRunTraceWebSocketOnContext|1123":                                             {asyncSiteSynchronousJoin, "the trace cancellation closer is stopped and joined when subscription acquisition returns"},
-	"go|internal/cliapp/run_command.go|startForegroundRunTraceObserver|842":                                              {asyncSiteSynchronousJoin, "the foreground trace observer is cancelled and joined before command teardown"},
-	"go|internal/cliapp/run_command.go|startForegroundRunTraceRenderer|800":                                              {asyncSiteSynchronousJoin, "the run-start rendering controller joins its bounded stdout trace worker before teardown"},
-	"go|internal/cliapp/run_command.go|startForegroundRunTraceRenderer|807":                                              {asyncSiteSynchronousJoin, "the run-start rendering controller joins its reserved stderr detach-fact worker before teardown"},
-	"go|internal/cliapp/run_command.go|startLocalRunServe|522":                                                           {asyncSiteSynchronousJoin, "the local serve command reports terminal completion through a joined result channel"},
-	"go|internal/cliapp/run_command.go|subscribeRunTrace|1045":                                                           {asyncSiteSynchronousJoin, "the CLI run trace subscription closes and joins its read loop"},
-	"go|internal/runtime/bus/eventbus_publish.go|EventBus.DispatchPreparedPublishAsync|1229":                             {asyncSiteCanonicalOwner, "prepared async dispatch acquires its occurrence lease before launch and settles exactly once"},
-	"go|internal/runtime/deliverycontinuation/coordinator.go|Coordinator.Start|139":                                      {asyncSiteCanonicalOwner, "the normal-generation coordinator acquires standing ownership before launch and joins its exact loop"},
-	"go|internal/runtime/bus/sweeper.go|EventBus.StartOutboxSweeper|90":                                                  {asyncSiteCanonicalOwner, "the outbox sweeper owns a runtime lease and exposes an exact completion channel"},
-	"go|internal/runtime/deliverylifecycle/heartbeat.go|startClaimHeartbeat|115":                                         {asyncSiteCanonicalOwner, "the delivery claim heartbeat acquires its runtime occurrence before launch and exposes an exact stop-and-wait owner"},
-	"go|internal/runtime/llm/cli_runtime_process.go|ClaudeCLIRuntime.runStreamingPrepared|155":                           {asyncSiteSynchronousJoin, "stdout collection is joined before the subprocess call returns"},
-	"go|internal/runtime/llm/cli_runtime_process.go|ClaudeCLIRuntime.runStreamingPrepared|156":                           {asyncSiteSynchronousJoin, "stderr collection is joined before the subprocess call returns"},
-	"go|internal/runtime/llm/cli_runtime_startup_probe.go|ClaudeCLIRuntime.runUntilCLIStartupInit|161":                   {asyncSiteSynchronousJoin, "startup stdout collection is joined before probe completion"},
-	"go|internal/runtime/llm/cli_runtime_startup_probe.go|ClaudeCLIRuntime.runUntilCLIStartupInit|162":                   {asyncSiteSynchronousJoin, "startup stderr collection is joined before probe completion"},
-	"go|internal/runtime/llm/completion_authority.go|startCompletionAttemptHeartbeatWithTiming|326":                      {asyncSiteCanonicalOwner, "the completion heartbeat owns an explicit stop-and-wait handle"},
-	"go|internal/runtime/llm/session_watchdog.go|newSessionWatchdogMonitorWriter|97":                                     {asyncSiteSynchronousJoin, "the watchdog writer is closed and joined by its owning monitor"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.Run|869":                                                        {asyncSiteCanonicalOwner, "the retry loop acquires the Manager run occurrence before launch and publishes settlement"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.ShutdownWithOptions|153":                                        {asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor joins the fenced Manager generation and settles before shutdown returns"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.executePreparedDirectiveOperation|655":                          {asyncSiteCanonicalOwner, "the directive heartbeat owns a lease and is canceled and joined by the directive operation"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.launchExecutionLoop|1688":                                       {asyncSiteCanonicalOwner, "the pre-admitted Manager generation and exact agent generation jointly own and joins the execution loop"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.resetRuntimeState|1275":                                         {asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor joins the fenced Manager generation before reset cleanup"},
-	"go|internal/runtime/manager/runtime.go|AgentManager.startShutdownWatcher|920":                                       {asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor completes the retained transition after all accepted Manager work settles"},
-	"go|internal/runtime/mcp/client.go|newStdioRPCClient|437":                                                            {asyncSiteSynchronousJoin, "the stdio client read loop is canceled and joined by client close"},
-	"go|internal/runtime/mcp/client.go|stdioRPCClient.Call|497":                                                          {asyncSiteSynchronousJoin, "request cancellation notification is bounded by the call completion context"},
-	"go|internal/runtime/genericschedule/owner.go|Lifecycle.startRecovery|481":                                           {asyncSiteSynchronousJoin, "generic schedule recovery is canceled by lifecycle shutdown and joined by Lifecycle.Stop"},
-	"go|internal/runtime/genericschedule/owner.go|Lifecycle.startTerminalRetirementRecovery|535":                         {asyncSiteSynchronousJoin, "exact terminal wakeup retirement recovery is canceled by lifecycle shutdown and joined by Lifecycle.Stop"},
-	"go|internal/runtime/genericschedule/owner.go|Lifecycle.Stop|572":                                                    {asyncSiteSynchronousJoin, "the lifecycle stop wait adapter is joined before scheduler and claim shutdown"},
-	"go|internal/runtime/pipeline/scheduler.go|Scheduler.startTask|957":                                                  {asyncSiteCanonicalOwner, "the scheduler task owns one inert wakeup occurrence plus exact parkable projection, linearized fire state, and done channel"},
-	"go|internal/runtime/pipeline/workflow_timer_owner.go|WorkflowTimerLifecycle.startRecovery|1138":                     {asyncSiteCanonicalOwner, "timer recovery acquires its runtime occurrence before launch and settles on return"},
-	"go|internal/runtime/pythonmodule/runtime.go|newInterpreterModuleForContext|305":                                     {asyncSiteSynchronousJoin, "the interpreter stderr collector is joined when module startup completes"},
-	"go|internal/runtime/pythonmodule/runtime.go|runHarness|209":                                                         {asyncSiteSynchronousJoin, "the harness execution result is joined before the call returns"},
-	"go|internal/runtime/publicingress/exposure.go|Controller.Start|173":                                                 {asyncSiteSynchronousJoin, "the exposure controller shuts down the ingress-only HTTP server before Stop returns"},
-	"go|internal/runtime/publicingress/exposure.go|Controller.Start|181":                                                 {asyncSiteSynchronousJoin, "the exposure controller cancels and joins its supervisor through the exact done channel"},
-	"go|internal/runtime/publicingress/exposure.go|execManagedLauncher.Launch|588":                                       {asyncSiteSynchronousJoin, "the managed process wait loop closes the exact process completion channel consumed by controller shutdown"},
-	"go|internal/runtime/runlifecycle/executor.go|Executor.installReserved|282":                                          {asyncSiteCanonicalOwner, "the run-lifecycle executor owns each pre-admitted completion candidate until the exact lease settles"},
-	"go|internal/runtime/runforkexecution/agent_runtime_materialization.go|startSelectedContractAgentRuntimeGateway|611": {asyncSiteCanonicalOwner, "the selected-fork gateway is admitted under and joined by its selected-fork occurrence"},
-	"go|internal/runtime/runforkexecution/runtime_container.go|selectedContractForkLocalRuntimeContainer.Publish|347":    {asyncSiteCanonicalOwner, "selected-fork publication acquires a local occurrence lease before launch and joins it"},
-	"go|internal/runtime/runtime.go|Runtime.releaseAutonomousStartupProducers|1843":                                      {asyncSiteCanonicalOwner, "pipeline background nodes acquire runtime leases after completed topology and settle on exit"},
-	"go|internal/runtime/runtime.go|Runtime.startSystemNodesAndWaitForSubscriptions|1946":                                {asyncSiteCanonicalOwner, "system-node runners acquire standing/runtime ownership and publish readiness before return"},
-	"go|internal/runtime/startupownership/process_capability.go|processCapability.startPossessionMonitor|518":            {asyncSiteCanonicalOwner, "the retained process capability owns and joins its exact selected-store possession monitor"},
-	"go|internal/runtime/sessions/heartbeat.go|StartLeaseHeartbeatWithErrorHandler|51":                                   {asyncSiteCanonicalOwner, "the session heartbeat exposes a stop-and-wait owner and cannot outlive it"},
-	"go|internal/serveapp/main.go|Run|1478":                                                                              {asyncSiteCanonicalOwner, "the API listener is admitted under served-process ownership and joined at shutdown"},
-	"go|internal/serveapp/main.go|Run|1474":                                                                              {asyncSiteCanonicalOwner, "the MCP listener is admitted under served-process ownership and joined at shutdown"},
-	"go|internal/serveapp/main.go|startServeOwnershipWatch|1702":                                                         {asyncSiteCanonicalOwner, "the served-process root joins the exact process-capability terminal watcher before store release"},
-	"go|internal/serveapp/public_ingress.go|startServePublicIngressRenewal|229":                                          {asyncSiteCanonicalOwner, "the public-ingress renewal loop owns one served-process lease and settles it on cancellation"},
-	"go|internal/serveapp/run_stalled_monitor.go|startServeRunStalledEscalation|45":                                      {asyncSiteCanonicalOwner, "the stalled-run monitor has a process lease and exact stop-and-wait completion"},
-	"go|internal/serveapp/serve_author_activity.go|newServeAuthorActivityFollower|56":                                    {asyncSiteCanonicalOwner, "the author-activity follower has a process lease and exact close/join path"},
+	"after_func|internal/apiv1/handler.go|webSocketSession.run":                                                     {1, asyncSiteCanonicalOwner, "session lease cancellation closes the socket and the owned subscription joins before release"},
+	"after_func|internal/runtime/channelactivation/owner.go|Owner.AcquirePresentationContext":                       {1, asyncSiteSynchronousJoin, "presentation acquisition stops the cancellation wakeup bridge before returning with an exact publication lease or error"},
+	"after_func|internal/runtime/channelactivation/owner.go|Owner.ReplaceContext":                                   {1, asyncSiteSynchronousJoin, "replacement stops the cancellation wakeup bridge before returning after the predecessor lease fence"},
+	"after_func|internal/runtime/core/eventreceiver/execution.go|NewContext":                                        {1, asyncSiteCanonicalOwner, "the closed receiver context binds cancellation to its explicit lifetime input and cleanup releases the bridge"},
+	"after_func|internal/runtime/core/worklifetime/worklifetime.go|gate.beginClass":                                 {1, asyncSiteCanonicalOwner, "the canonical gate binds lease cancellation to its typed occurrence"},
+	"after_func|internal/runtime/manager/lifecycle_coordinator.go|agentLifecycleCoordinator.acquireExecutionLocked": {1, asyncSiteCanonicalOwner, "the exact agent generation cancels and joins the acquired execution lease"},
+	"after_func|internal/runtime/manager/runtime.go|AgentManager.launchExecutionLoop":                               {1, asyncSiteCanonicalOwner, "the exact agent-generation cancellation is bridged into the pre-admitted Manager lease and joined with that loop"},
+	"go|cmd/swarm-test/main.go|run":                                                                                  {2, asyncSiteSynchronousJoin, "the test harness joins process-tree signal forwarding after command completion; the test harness stops and joins its queue/child signal relay before return"},
+	"go|internal/apiv1/handler.go|webSocketSession.run":                                                              {1, asyncSiteCanonicalOwner, "the process-owned websocket session settles after the writer goroutine exits"},
+	"go|internal/apiv1/operator_conversation_fork.go|executeConversationForkChatWithHeartbeat":                       {1, asyncSiteCanonicalOwner, "the operation heartbeat has a typed lease and is canceled and joined by the enclosing call"},
+	"go|internal/apiv1/subscriptions.go|ownedSubscriptionWork.Start":                                                 {1, asyncSiteCanonicalOwner, "owned subscription work settles its process lease after the polling loop exits"},
+	"go|internal/cliapp/events.go|subscribeEvents":                                                                   {1, asyncSiteSynchronousJoin, "the CLI subscription closes and joins its read loop"},
+	"go|internal/cliapp/logs.go|subscribeRuntimeLogs":                                                                {1, asyncSiteSynchronousJoin, "the CLI log subscription closes and joins its read loop"},
+	"go|internal/cliapp/run_command.go|closeRunTraceWebSocketOnContext":                                              {1, asyncSiteSynchronousJoin, "the trace cancellation closer is stopped and joined when subscription acquisition returns"},
+	"go|internal/cliapp/run_command.go|startForegroundRunTraceObserver":                                              {1, asyncSiteSynchronousJoin, "the foreground trace observer is cancelled and joined before command teardown"},
+	"go|internal/cliapp/run_command.go|startForegroundRunTraceRenderer":                                              {2, asyncSiteSynchronousJoin, "the run-start rendering controller joins its bounded stdout trace worker before teardown; the run-start rendering controller joins its reserved stderr detach-fact worker before teardown"},
+	"go|internal/cliapp/run_command.go|startLocalRunServe":                                                           {1, asyncSiteSynchronousJoin, "the local serve command reports terminal completion through a joined result channel"},
+	"go|internal/cliapp/run_command.go|subscribeRunTrace":                                                            {1, asyncSiteSynchronousJoin, "the CLI run trace subscription closes and joins its read loop"},
+	"go|internal/runtime/bus/eventbus_publish.go|EventBus.DispatchPreparedPublishAsync":                              {1, asyncSiteCanonicalOwner, "prepared async dispatch acquires its occurrence lease before launch and settles exactly once"},
+	"go|internal/runtime/bus/sweeper.go|EventBus.StartOutboxSweeper":                                                 {1, asyncSiteCanonicalOwner, "the outbox sweeper owns a runtime lease and exposes an exact completion channel"},
+	"go|internal/runtime/deliverycontinuation/coordinator.go|Coordinator.Start":                                      {1, asyncSiteCanonicalOwner, "the normal-generation coordinator acquires standing ownership before launch and joins its exact loop"},
+	"go|internal/runtime/deliverylifecycle/heartbeat.go|startClaimHeartbeat":                                         {1, asyncSiteCanonicalOwner, "the delivery claim heartbeat acquires its runtime occurrence before launch and exposes an exact stop-and-wait owner"},
+	"go|internal/runtime/genericschedule/owner.go|Lifecycle.startRecovery":                                           {1, asyncSiteSynchronousJoin, "generic schedule recovery is canceled by lifecycle shutdown and joined by Lifecycle.Stop"},
+	"go|internal/runtime/genericschedule/owner.go|Lifecycle.startTerminalRetirementRecovery":                         {1, asyncSiteSynchronousJoin, "exact terminal wakeup retirement recovery is canceled by lifecycle shutdown and joined by Lifecycle.Stop"},
+	"go|internal/runtime/genericschedule/owner.go|Lifecycle.Stop":                                                    {1, asyncSiteSynchronousJoin, "the lifecycle stop wait adapter is joined before scheduler and claim shutdown"},
+	"go|internal/runtime/llm/cli_runtime_process.go|ClaudeCLIRuntime.runStreamingPrepared":                           {2, asyncSiteSynchronousJoin, "stdout collection is joined before the subprocess call returns; stderr collection is joined before the subprocess call returns"},
+	"go|internal/runtime/llm/cli_runtime_startup_probe.go|ClaudeCLIRuntime.runUntilCLIStartupInit":                   {2, asyncSiteSynchronousJoin, "startup stdout collection is joined before probe completion; startup stderr collection is joined before probe completion"},
+	"go|internal/runtime/llm/completion_authority.go|startCompletionAttemptHeartbeatWithTiming":                      {1, asyncSiteCanonicalOwner, "the completion heartbeat owns an explicit stop-and-wait handle"},
+	"go|internal/runtime/llm/session_watchdog.go|newSessionWatchdogMonitorWriter":                                    {1, asyncSiteSynchronousJoin, "the watchdog writer is closed and joined by its owning monitor"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.executePreparedDirectiveOperation":                          {1, asyncSiteCanonicalOwner, "the directive heartbeat owns a lease and is canceled and joined by the directive operation"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.launchExecutionLoop":                                        {1, asyncSiteCanonicalOwner, "the pre-admitted Manager generation and exact agent generation jointly own and joins the execution loop"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.resetRuntimeState":                                          {1, asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor joins the fenced Manager generation before reset cleanup"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.Run":                                                        {1, asyncSiteCanonicalOwner, "the retry loop acquires the Manager run occurrence before launch and publishes settlement"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.ShutdownWithOptions":                                        {1, asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor joins the fenced Manager generation and settles before shutdown returns"},
+	"go|internal/runtime/manager/runtime.go|AgentManager.startShutdownWatcher":                                       {1, asyncSiteCanonicalOwner, "the pre-reserved outer-runtime executor completes the retained transition after all accepted Manager work settles"},
+	"go|internal/runtime/mcp/client.go|newStdioRPCClient":                                                            {1, asyncSiteSynchronousJoin, "the stdio client read loop is canceled and joined by client close"},
+	"go|internal/runtime/mcp/client.go|stdioRPCClient.Call":                                                          {1, asyncSiteSynchronousJoin, "request cancellation notification is bounded by the call completion context"},
+	"go|internal/runtime/pipeline/scheduler.go|Scheduler.startTask":                                                  {1, asyncSiteCanonicalOwner, "the scheduler task owns one inert wakeup occurrence plus exact parkable projection, linearized fire state, and done channel"},
+	"go|internal/runtime/pipeline/workflow_timer_owner.go|WorkflowTimerLifecycle.startRecovery":                      {1, asyncSiteCanonicalOwner, "timer recovery acquires its runtime occurrence before launch and settles on return"},
+	"go|internal/runtime/publicingress/exposure.go|Controller.Start":                                                 {2, asyncSiteSynchronousJoin, "the exposure controller shuts down the ingress-only HTTP server before Stop returns; the exposure controller cancels and joins its supervisor through the exact done channel"},
+	"go|internal/runtime/publicingress/exposure.go|execManagedLauncher.Launch":                                       {1, asyncSiteSynchronousJoin, "the managed process wait loop closes the exact process completion channel consumed by controller shutdown"},
+	"go|internal/runtime/pythonmodule/runtime.go|newInterpreterModuleForContext":                                     {1, asyncSiteSynchronousJoin, "the interpreter stderr collector is joined when module startup completes"},
+	"go|internal/runtime/pythonmodule/runtime.go|runHarness":                                                         {1, asyncSiteSynchronousJoin, "the harness execution result is joined before the call returns"},
+	"go|internal/runtime/runforkexecution/agent_runtime_materialization.go|startSelectedContractAgentRuntimeGateway": {1, asyncSiteCanonicalOwner, "the selected-fork gateway is admitted under and joined by its selected-fork occurrence"},
+	"go|internal/runtime/runforkexecution/runtime_container.go|selectedContractForkLocalRuntimeContainer.Publish":    {1, asyncSiteCanonicalOwner, "selected-fork publication acquires a local occurrence lease before launch and joins it"},
+	"go|internal/runtime/runlifecycle/executor.go|Executor.installReserved":                                          {1, asyncSiteCanonicalOwner, "the run-lifecycle executor owns each pre-admitted completion candidate until the exact lease settles"},
+	"go|internal/runtime/runtime.go|Runtime.releaseAutonomousStartupProducers":                                       {1, asyncSiteCanonicalOwner, "pipeline background nodes acquire runtime leases after completed topology and settle on exit"},
+	"go|internal/runtime/runtime.go|Runtime.startSystemNodesAndWaitForSubscriptions":                                 {1, asyncSiteCanonicalOwner, "system-node runners acquire standing/runtime ownership and publish readiness before return"},
+	"go|internal/runtime/sessions/heartbeat.go|StartLeaseHeartbeatWithErrorHandler":                                  {1, asyncSiteCanonicalOwner, "the session heartbeat exposes a stop-and-wait owner and cannot outlive it"},
+	"go|internal/runtime/startupownership/process_capability.go|processCapability.startPossessionMonitor":            {1, asyncSiteCanonicalOwner, "the retained process capability owns and joins its exact selected-store possession monitor"},
+	"go|internal/serveapp/main.go|Run":                                                                               {2, asyncSiteCanonicalOwner, "the API listener is admitted under served-process ownership and joined at shutdown; the MCP listener is admitted under served-process ownership and joined at shutdown"},
+	"go|internal/serveapp/main.go|startServeOwnershipWatch":                                                          {1, asyncSiteCanonicalOwner, "the served-process root joins the exact process-capability terminal watcher before store release"},
+	"go|internal/serveapp/public_ingress.go|startServePublicIngressRenewal":                                          {1, asyncSiteCanonicalOwner, "the public-ingress renewal loop owns one served-process lease and settles it on cancellation"},
+	"go|internal/serveapp/run_stalled_monitor.go|startServeRunStalledEscalation":                                     {1, asyncSiteCanonicalOwner, "the stalled-run monitor has a process lease and exact stop-and-wait completion"},
+	"go|internal/serveapp/serve_author_activity.go|newServeAuthorActivityFollower":                                   {1, asyncSiteCanonicalOwner, "the author-activity follower has a process lease and exact close/join path"},
 }
 
 var retiredLifetimeOwners = []string{
@@ -98,9 +98,33 @@ var retiredLifetimeOwners = []string{
 	"dispatchCommittedPublishAsync",
 }
 
-func TestProductionAsyncWorkUsesCanonicalTypedOwners(t *testing.T) {
+func TestProductionAsyncSitesAreClassified(t *testing.T) {
+	found := map[string][]int{}
+	walkProductionWorkLifetimeFiles(t, func(path, relative string) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", relative, err)
+		}
+		collectAsyncSites(fset, file, relative, found)
+	})
+	if err := compareAsyncSiteLedger(found, productionAsyncSiteLedger); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProductionWorkLifetimeBoundaries(t *testing.T) {
+	walkProductionWorkLifetimeFiles(t, func(path, relative string) {
+		checkProductionWorkLifetimeFile(t, path, relative)
+	})
+}
+
+// Preserve the existing scan scope. This is not a whole-program async analysis:
+// store and other unlisted directories, test files, package-level initializers,
+// indirect callbacks, and timers are outside the async-site inventory.
+func walkProductionWorkLifetimeFiles(t *testing.T, visit func(path, relative string)) {
+	t.Helper()
 	repoRoot := workLifetimeRepositoryRoot(t)
-	found := map[string]struct{}{}
 	for _, rootName := range []string{"cmd", "internal/runtime", "internal/serveapp", "internal/apiv1", "internal/cliapp"} {
 		root := filepath.Join(repoRoot, rootName)
 		if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
@@ -115,18 +139,15 @@ func TestProductionAsyncWorkUsesCanonicalTypedOwners(t *testing.T) {
 				return err
 			}
 			relative = filepath.ToSlash(relative)
-			checkProductionWorkLifetimeFile(t, path, relative, found)
+			visit(path, relative)
 			return nil
 		}); err != nil {
 			t.Fatalf("walk %s: %v", rootName, err)
 		}
 	}
-	if err := compareAsyncSiteLedger(found, productionAsyncSiteLedger); err != nil {
-		t.Fatal(err)
-	}
 }
 
-func TestProductionAsyncWorkLedgerRejectsUnownedGoroutine(t *testing.T) {
+func TestAsyncSiteInventoryRejectsUnclassifiedGoroutine(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "fixture.go", `package fixture
 func launch() { go func() {}() }
@@ -134,14 +155,14 @@ func launch() { go func() {}() }
 	if err != nil {
 		t.Fatal(err)
 	}
-	found := map[string]struct{}{}
+	found := map[string][]int{}
 	collectAsyncSites(fset, file, "fixture.go", found)
 	if err := compareAsyncSiteLedger(found, nil); err == nil || !strings.Contains(err.Error(), "unclassified async sites") {
-		t.Fatalf("unowned goroutine ledger error = %v, want unclassified async site", err)
+		t.Fatalf("unclassified goroutine inventory error = %v, want unclassified async site", err)
 	}
 }
 
-func checkProductionWorkLifetimeFile(t *testing.T, path, relative string, found map[string]struct{}) {
+func checkProductionWorkLifetimeFile(t *testing.T, path, relative string) {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, 0)
@@ -150,7 +171,6 @@ func checkProductionWorkLifetimeFile(t *testing.T, path, relative string, found 
 	}
 	eventAliases := importAliases(file, "github.com/division-sh/swarm/internal/events")
 	workAliases := importAliases(file, "github.com/division-sh/swarm/internal/runtime/core/worklifetime")
-	collectAsyncSites(fset, file, relative, found)
 
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -189,7 +209,7 @@ func checkProductionWorkLifetimeFile(t *testing.T, path, relative string, found 
 	})
 }
 
-func collectAsyncSites(fset *token.FileSet, file *ast.File, relative string, found map[string]struct{}) {
+func collectAsyncSites(fset *token.FileSet, file *ast.File, relative string, found map[string][]int) {
 	contextAliases := importAliases(file, "context")
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
@@ -200,15 +220,18 @@ func collectAsyncSites(fset *token.FileSet, file *ast.File, relative string, fou
 		ast.Inspect(function.Body, func(node ast.Node) bool {
 			switch value := node.(type) {
 			case *ast.GoStmt:
-				found[asyncSiteKey("go", relative, functionName, fset.Position(value.Go).Line)] = struct{}{}
+				key := asyncSiteKey("go", relative, functionName)
+				found[key] = append(found[key], fset.Position(value.Go).Line)
 			case *ast.CallExpr:
 				name, packageName := calledFunctionName(value.Fun)
 				line := fset.Position(value.Pos()).Line
 				switch {
 				case name == "AfterFunc" && packageName != "" && containsAlias(contextAliases, packageName):
-					found[asyncSiteKey("after_func", relative, functionName, line)] = struct{}{}
+					key := asyncSiteKey("after_func", relative, functionName)
+					found[key] = append(found[key], line)
 				case isOwnerActionRegistration(name):
-					found[asyncSiteKey("owner_action", relative, functionName, line)] = struct{}{}
+					key := asyncSiteKey("owner_action", relative, functionName)
+					found[key] = append(found[key], line)
 				}
 			}
 			return true
@@ -216,8 +239,8 @@ func collectAsyncSites(fset *token.FileSet, file *ast.File, relative string, fou
 	}
 }
 
-func asyncSiteKey(kind, relative, function string, line int) string {
-	return fmt.Sprintf("%s|%s|%s|%d", kind, relative, function, line)
+func asyncSiteKey(kind, relative, function string) string {
+	return fmt.Sprintf("%s|%s|%s", kind, relative, function)
 }
 
 func declaredFunctionName(function *ast.FuncDecl) string {
@@ -265,33 +288,38 @@ func isOwnerActionRegistration(name string) bool {
 	}
 }
 
-func compareAsyncSiteLedger(found map[string]struct{}, ledger map[string]asyncSiteLedgerEntry) error {
+func compareAsyncSiteLedger(found map[string][]int, ledger map[string]asyncSiteLedgerEntry) error {
 	unclassified := make([]string, 0)
 	missing := make([]string, 0)
 	invalid := make([]string, 0)
-	for key := range found {
+	counts := make([]string, 0)
+	for key, lines := range found {
 		entry, ok := ledger[key]
 		if !ok {
-			unclassified = append(unclassified, key)
+			unclassified = append(unclassified, fmt.Sprintf("%s: found %d (lines %v)", key, len(lines), lines))
 			continue
 		}
-		if (entry.class != asyncSiteCanonicalOwner && entry.class != asyncSiteSynchronousJoin) || strings.TrimSpace(entry.proof) == "" {
-			invalid = append(invalid, key)
+		if len(lines) != entry.count {
+			counts = append(counts, fmt.Sprintf("%s: expected %d, found %d (lines %v)", key, entry.count, len(lines), lines))
 		}
 	}
-	for key := range ledger {
+	for key, entry := range ledger {
+		if entry.count <= 0 || (entry.class != asyncSiteCanonicalOwner && entry.class != asyncSiteSynchronousJoin) || strings.TrimSpace(entry.rationale) == "" {
+			invalid = append(invalid, key)
+		}
 		if _, ok := found[key]; !ok {
-			missing = append(missing, key)
+			missing = append(missing, fmt.Sprintf("%s: expected %d, found 0", key, entry.count))
 		}
 	}
 	sort.Strings(unclassified)
 	sort.Strings(missing)
 	sort.Strings(invalid)
-	if len(unclassified) == 0 && len(missing) == 0 && len(invalid) == 0 {
+	sort.Strings(counts)
+	if len(unclassified) == 0 && len(missing) == 0 && len(invalid) == 0 && len(counts) == 0 {
 		return nil
 	}
-	return fmt.Errorf("async ownership ledger mismatch\nunclassified async sites:\n%s\nmissing ledger sites:\n%s\ninvalid ledger entries:\n%s",
-		strings.Join(unclassified, "\n"), strings.Join(missing, "\n"), strings.Join(invalid, "\n"))
+	return fmt.Errorf("async-site inventory mismatch\nunclassified async sites:\n%s\nmissing ledger sites:\n%s\nchanged launch counts:\n%s\ninvalid ledger entries (require positive count, known class, and rationale):\n%s",
+		strings.Join(unclassified, "\n"), strings.Join(missing, "\n"), strings.Join(counts, "\n"), strings.Join(invalid, "\n"))
 }
 
 func deferredCallContainsDone(statement *ast.DeferStmt) bool {

--- a/internal/runtime/core/worklifetime/source_guard_test.go
+++ b/internal/runtime/core/worklifetime/source_guard_test.go
@@ -252,6 +252,12 @@ func declaredFunctionName(function *ast.FuncDecl) string {
 	if star, ok := receiver.(*ast.StarExpr); ok {
 		receiver = star.X
 	}
+	switch generic := receiver.(type) {
+	case *ast.IndexExpr:
+		receiver = generic.X
+	case *ast.IndexListExpr:
+		receiver = generic.X
+	}
 	if identifier, ok := receiver.(*ast.Ident); ok {
 		return identifier.Name + "." + name
 	}


### PR DESCRIPTION
Unrelated line movement currently invalidates the async-site ledger and triggers mechanical repairs. This change keys the inventory by launch kind, file, and receiver/function with an explicit count: formatting changes pass, while additions and removals of recognized launches require classification. All 61 previously registered sites remain represented in 55 entries, including multiple launches on one line.

The inventory test is now `TestProductionAsyncSitesAreClassified`; the existing forbidden-pattern checks run separately as `TestProductionWorkLifetimeBoundaries`. Rename `proof` to `rationale` and document that the inventory records review classifications rather than proving ownership behavior. Source lines remain in failure diagnostics. Scanner directories and recognized syntax are unchanged.

Part of #2350. This closes only the line-coordinate maintenance problem; the process watchpoint remains open.

Validation:

- `go test ./internal/runtime/core/worklifetime`
- Focused verbose inventory/boundary tests, including line movement, same-line multiplicity, added/removed launches, distinct receivers, supported callbacks, stale entries, and invalid classifications
- Generic value, pointer, and multiple-type-parameter receiver regression: reproduced the review finding before the fix and passed afterward; distinct receiver methods cannot collapse into a top-level function's inventory key
- `go vet ./internal/runtime/core/worklifetime`
- `go build ./...`
- `go run ./cmd/swarm-openrpc-gen --check`
- `git diff --check`

Scope and residual risk: test-only maintenance; no runtime or platform-spec behavior changes, so no platform semantic section is being changed. The owner is the worklifetime source inventory. Replacing a launch within the same function can preserve its count, and the existing scanner is intentionally selective. Cancellation, joining, late admission, and exactly-once settlement remain obligations of behavioral tests and review.
