### PR TITLE
[agent-a][issue #2419] Fix decision-card entity filter binding

### DIFF
--- a/internal/runtime/testfixtures/canonicalrouting/mailbox_entity_filter.go
+++ b/internal/runtime/testfixtures/canonicalrouting/mailbox_entity_filter.go
@@ -1,0 +1,40 @@
+package canonicalrouting
+
+import "testing"
+
+// CopyMailboxEntityFilter retains root-ingress routing and opens a real typed
+// gate so mailbox filtering is exercised without inserting synthetic cards.
+func CopyMailboxEntityFilter(t testing.TB) string {
+	t.Helper()
+	root := CopyExample(t, RootIngress)
+	writeClosedVariantFile(t, root, "schema.yaml", `name: mailbox-entity-filter
+stages:
+  new: {initial: true}
+  waiting:
+    gate:
+      decision: review
+      outcomes:
+        approve: {advances_to: done}
+  done: {terminal: true}
+pins:
+  inputs:
+    events:
+      - event: review.requested
+        source: external
+`)
+	writeClosedVariantFile(t, root, "entities.yaml", "review_item:\n  item_id: text\n")
+	writeClosedVariantFile(t, root, "events.yaml", "review.requested:\n  item_id: text\n")
+	writeClosedVariantFile(t, root, "nodes.yaml", `reviewer:
+  id: reviewer
+  execution_type: system_node
+  subscribes_to: [review.requested]
+  event_handlers:
+    review.requested:
+      advances_to: waiting
+      data_accumulation:
+        writes:
+          - source_field: item_id
+            target_field: item_id
+`)
+	return root
+}

--- a/internal/serveapp/mailbox_entity_filter_test.go
+++ b/internal/serveapp/mailbox_entity_filter_test.go
@@ -1,0 +1,117 @@
+package serveapp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/division-sh/swarm/internal/runtime/core/identitytest"
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
+	runtimetools "github.com/division-sh/swarm/internal/runtime/tools"
+	"github.com/division-sh/swarm/internal/servedparity"
+	"github.com/google/uuid"
+)
+
+type servedEntityFilterList struct {
+	Items []struct {
+		Kind string `json:"kind"`
+		Card struct {
+			CardID     string             `json:"card_id"`
+			RunID      string             `json:"run_id"`
+			Status     string             `json:"status"`
+			AnchorKind string             `json:"anchor_kind"`
+			Scope      decisioncard.Scope `json:"scope"`
+		} `json:"decision_card"`
+	} `json:"items"`
+	NextCursor string `json:"next_cursor"`
+	Unread     *int   `json:"unread_informational_notices"`
+}
+
+func startServedMailboxEntityFilterProof(t *testing.T, backend servedparity.Backend) (servedControlProofRuntime, []string, []string, func(map[string]any) servedEntityFilterList, map[string]bool) {
+	t.Helper()
+	rt := startServedControlProofRuntimeWithFixture(t, backend, func(t *testing.T) string { return canonicalrouting.CopyMailboxEntityFilter(t) })
+	var runs, entities, events []string
+	for i := 0; i < 3; i++ {
+		published := requireServedEventPublishRPCResult(t, rt.Endpoint, map[string]any{
+			"event_name": "review.requested", "bundle_hash": rt.BundleHash,
+			"payload": map[string]any{"item_id": uuid.NewString()}, "idempotency_key": uuid.NewString(),
+		})
+		if !published.NewRunCreated || published.RunID == "" || published.EventID == "" {
+			t.Fatalf("event.publish = %+v, want new run", published)
+		}
+		waitForServedEventPublishNodeDeliveryLifecycleForNode(t, rt.DB, rt.Backend, published.RunID, published.EventID, identitytest.RootNode(t, "reviewer").Key(), rt.Probe)
+		entities = append(entities, requireServedEventPublishEntityState(t, rt.DB, rt.Backend, published.RunID, "", "waiting"))
+		runs = append(runs, published.RunID)
+		events = append(events, published.EventID)
+	}
+	// Keep the global unread count nonzero outside the selected entity.
+	notice := runtimetools.MailboxItem{EventID: events[2], EntityID: entities[2], FlowInstance: runs[2],
+		Type: runtimetools.NotifyHumanMailboxItemType, Priority: "normal", Status: "pending",
+		Summary: "independent informational notice", Context: json.RawMessage(`{}`)}
+	ctx := servedControlProofAuthorActivityContext(t, rt)
+	var err error
+	if rt.SQLite != nil {
+		_, err = rt.SQLite.InsertMailboxItem(ctx, notice)
+	} else {
+		_, err = rt.Postgres.InsertMailboxItem(ctx, notice)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	list := func(params map[string]any) servedEntityFilterList {
+		t.Helper()
+		var result servedEntityFilterList
+		requireServedJSONRPCResult(t, rt.Endpoint, "mailbox.list", params, &result)
+		if result.Items == nil || result.Unread == nil || *result.Unread != 1 {
+			t.Fatalf("mailbox.list envelope/count = %+v", result)
+		}
+		return result
+	}
+	all := list(map[string]any{})
+	if len(all.Items) != 4 || all.NextCursor != "" {
+		t.Fatalf("unfiltered mailbox = %+v, want three real gates and one notice", all)
+	}
+	wantCards := map[string]bool{}
+	for _, item := range all.Items {
+		if item.Kind == decisioncard.KindDecisionCard {
+			wantCards[item.Card.CardID] = true
+		}
+	}
+	return rt, runs, entities, list, wantCards
+}
+
+func TestServedMailboxListEntityFilterOnBothStores(t *testing.T) {
+	canonicalrouting.Prove(t, canonicalrouting.RootIngress)
+	for _, backend := range []servedparity.Backend{servedparity.BackendDefaultSQLite, servedparity.BackendExplicitPostgres} {
+		t.Run(string(backend), func(t *testing.T) {
+			rt, runs, entities, list, wantCards := startServedMailboxEntityFilterProof(t, backend)
+			for _, params := range []map[string]any{
+				{"entity_id": entities[0]},
+				{"entity_id": entities[0], "run_id": runs[0], "status": "pending", "anchor_kind": "stage_gate", "limit": 1},
+			} {
+				result := list(params)
+				if len(result.Items) != 1 || result.NextCursor != "" {
+					t.Fatalf("entity-filtered mailbox = %+v, want one gate", result)
+				}
+				item := result.Items[0]
+				if item.Kind != decisioncard.KindDecisionCard || !wantCards[item.Card.CardID] || item.Card.RunID != runs[0] || item.Card.Scope.EntityID != entities[0] || item.Card.AnchorKind != "stage_gate" || item.Card.Status != "pending" {
+					t.Fatalf("entity-filtered mailbox leaked another owner: %+v", item)
+				}
+			}
+			for _, params := range []map[string]any{
+				{"entity_id": uuid.NewString()},
+				{"entity_id": entities[0], "run_id": runs[1]},
+				{"entity_id": entities[0], "status": "decided", "anchor_kind": "stage_gate"},
+				{"entity_id": entities[0], "anchor_kind": "human_task"},
+			} {
+				if result := list(params); len(result.Items) != 0 || result.NextCursor != "" {
+					t.Fatalf("nonmatching mailbox filters %v leaked %+v", params, result)
+				}
+			}
+			rpcErr := requireServedJSONRPCError(t, rt.Endpoint, "mailbox.list", map[string]any{"entity_id": entities[0], "cursor": "not-a-cursor"})
+			if rpcErr.Code != -32602 {
+				t.Fatalf("malformed cursor = %+v, want invalid params", rpcErr)
+			}
+		})
+	}
+}

--- a/internal/store/internal/backend/decisionpersistence/decision_cards.go
+++ b/internal/store/internal/backend/decisionpersistence/decision_cards.go
@@ -329,6 +329,8 @@ func listDecisionCards(ctx context.Context, db decisionCardSQL, opts decisioncar
 			placeholder = "$" + strconv.Itoa(len(args))
 			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND anchor->>'entity_id' = "+placeholder+") OR (anchor_kind IN ('human_task', 'proposed_effect') AND anchor->'scope'->>'entity_id' = "+placeholder+"))")
 		} else {
+			// Each anonymous SQLite placeholder consumes its own argument.
+			args = append(args, value)
 			clauses = append(clauses, "((anchor_kind = 'stage_gate' AND json_extract(anchor, '$.entity_id') = "+placeholder+") OR (anchor_kind IN ('human_task', 'proposed_effect') AND json_extract(anchor, '$.scope.entity_id') = "+placeholder+"))")
 		}
 	}

--- a/internal/store/internal/runtimepersistence/decision_cards_entity_filter_test.go
+++ b/internal/store/internal/runtimepersistence/decision_cards_entity_filter_test.go
@@ -1,0 +1,192 @@
+package runtimepersistence
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/events/eventtest"
+	"github.com/division-sh/swarm/internal/runtime/canonicaljson"
+	runtimecontracts "github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/decisioncard"
+	"github.com/division-sh/swarm/internal/runtime/semanticvalue"
+	"github.com/google/uuid"
+)
+
+func TestDecisionCardEntityFilterParity(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres"} {
+		t.Run(backend, func(t *testing.T) {
+			ctx := testAuthorActivityContext()
+			store, runID := decisionCardTestStore(t, backend)
+			otherRun, entityID, otherEntity := uuid.NewString(), uuid.NewString(), uuid.NewString()
+			now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+			if err := ensureEphemeralRunForTest(ctx, store, otherRun, now.Add(-time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+			var all, matching, sameEntity, otherEntityCards []decisioncard.Card
+			byKind := map[decisioncard.AnchorKind][]decisioncard.Card{}
+			seed := func(kind decisioncard.AnchorKind, run, entity string, at time.Time, global bool) decisioncard.Card {
+				card := entityFilterCardForTest(t, kind, run, entity, at, global)
+				if err := store.CreateDecisionCard(ctx, card); err != nil {
+					t.Fatal(err)
+				}
+				all = append(all, card)
+				return card
+			}
+			for _, kind := range []decisioncard.AnchorKind{decisioncard.AnchorKindStageGate, decisioncard.AnchorKindHumanTask, decisioncard.AnchorKindProposedEffect} {
+				for i := 0; i < 5; i++ {
+					card := seed(kind, runID, entityID, now.Add(time.Duration(i/2)*time.Second), false)
+					matching = append(matching, card)
+					sameEntity = append(sameEntity, card)
+					byKind[kind] = append(byKind[kind], card)
+				}
+				sameEntity = append(sameEntity, seed(kind, otherRun, entityID, now, false))
+				otherEntityCards = append(otherEntityCards, seed(kind, runID, otherEntity, now, false))
+				if kind != decisioncard.AnchorKindStageGate {
+					// A source route naming the entity is not an entity-scoped anchor.
+					seed(kind, runID, entityID, now, true)
+				}
+			}
+			decided := seed(decisioncard.AnchorKindStageGate, runID, entityID, now, false)
+			if _, err := store.DecideDecisionCard(ctx, decisioncard.DecideRequest{
+				CardID: decided.CardID, Verdict: "approve", ObservedContentHash: decided.CardContentHash,
+				ActorTokenID: "operator", DecisionEventID: uuid.NewString(), Now: now.Add(time.Minute),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			sameEntity = append(sameEntity, decided)
+
+			check := func(t *testing.T, opts decisioncard.ListOptions, want []decisioncard.Card) {
+				t.Helper()
+				items, cursor, err := store.ListDecisionCards(ctx, opts)
+				if err != nil {
+					t.Fatalf("ListDecisionCards(%+v): %v", opts, err)
+				}
+				if cursor != "" {
+					t.Fatalf("unexpected cursor %q for complete result", cursor)
+				}
+				got := make([]string, 0, len(items))
+				for _, item := range items {
+					got = append(got, item.CardID)
+				}
+				if expected := orderedEntityFilterCardIDs(want); !reflect.DeepEqual(got, expected) {
+					t.Fatalf("card IDs = %v, want %v", got, expected)
+				}
+			}
+			for _, tc := range []struct {
+				name string
+				opts decisioncard.ListOptions
+				want []decisioncard.Card
+			}{
+				{"unfiltered", decisioncard.ListOptions{}, all},
+				{"entity only", decisioncard.ListOptions{EntityID: entityID}, sameEntity},
+				{"other entity", decisioncard.ListOptions{EntityID: otherEntity}, otherEntityCards},
+				{"nonmatching entity", decisioncard.ListOptions{EntityID: uuid.NewString()}, nil},
+				{"entity is a bound value", decisioncard.ListOptions{EntityID: "' OR 1=1 --"}, nil},
+				{"run status entity", decisioncard.ListOptions{RunID: runID, EntityID: entityID, Status: "pending"}, matching},
+				{"numbered status before entity", decisioncard.ListOptions{RunID: runID, EntityID: entityID, Status: "decided", AnchorKind: "stage_gate"}, []decisioncard.Card{decided}},
+				{"nonmatching combined", decisioncard.ListOptions{RunID: otherRun, EntityID: otherEntity, Status: "pending", AnchorKind: "human_task"}, nil},
+			} {
+				t.Run(tc.name, func(t *testing.T) { check(t, tc.opts, tc.want) })
+			}
+			for kind, want := range byKind {
+				t.Run(string(kind)+" combined and cursor", func(t *testing.T) {
+					opts := decisioncard.ListOptions{RunID: runID, EntityID: entityID, Status: "pending", AnchorKind: string(kind)}
+					check(t, opts, want)
+					opts.Limit = 2
+					var got []string
+					seen := map[string]bool{}
+					for page := 0; page < 3; page++ {
+						items, cursor, err := store.ListDecisionCards(ctx, opts)
+						if err != nil {
+							t.Fatalf("page %d: %v", page, err)
+						}
+						wantSize := 2
+						if page == 2 {
+							wantSize = 1
+						}
+						if len(items) != wantSize || (cursor == "") != (page == 2) || cursor != "" && cursor == opts.Cursor {
+							t.Fatalf("page %d: items=%d cursor=%q previous=%q", page, len(items), cursor, opts.Cursor)
+						}
+						for _, item := range items {
+							if seen[item.CardID] || item.RunID != runID || item.Scope.EntityID != entityID || item.Anchor.Kind() != kind || item.Status != "pending" {
+								t.Fatalf("page %d leaked or duplicated card: %+v", page, item)
+							}
+							seen[item.CardID] = true
+							got = append(got, item.CardID)
+						}
+						opts.Cursor = cursor
+					}
+					if expected := orderedEntityFilterCardIDs(want); !reflect.DeepEqual(got, expected) {
+						t.Fatalf("paginated IDs = %v, want %v", got, expected)
+					}
+				})
+			}
+			t.Run("malformed cursor unchanged", func(t *testing.T) {
+				for _, filter := range []string{"", entityID} {
+					_, _, err := store.ListDecisionCards(ctx, decisioncard.ListOptions{EntityID: filter, Cursor: "not-a-cursor"})
+					if !errors.Is(err, decisioncard.ErrInvalidCursor) {
+						t.Fatalf("malformed cursor with entity %q = %v, want ErrInvalidCursor", filter, err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func orderedEntityFilterCardIDs(cards []decisioncard.Card) []string {
+	cards = append([]decisioncard.Card(nil), cards...)
+	sort.Slice(cards, func(i, j int) bool {
+		if cards[i].CreatedAt.Equal(cards[j].CreatedAt) {
+			return cards[i].CardID < cards[j].CardID
+		}
+		return cards[i].CreatedAt.Before(cards[j].CreatedAt)
+	})
+	ids := make([]string, 0, len(cards))
+	for _, card := range cards {
+		ids = append(ids, card.CardID)
+	}
+	return ids
+}
+
+func entityFilterCardForTest(t *testing.T, kind decisioncard.AnchorKind, runID, entityID string, at time.Time, global bool) decisioncard.Card {
+	t.Helper()
+	path := "launch/" + uuid.NewString()
+	source := eventtest.ConcreteTemplateRoutingSource("launch", path, entityID)
+	scope := decisioncard.Scope{Kind: decisioncard.ScopeEntity, FlowInstance: path, EntityID: entityID}
+	if global {
+		scope = decisioncard.Scope{Kind: decisioncard.ScopeGlobal}
+	}
+	var anchor decisioncard.Anchor
+	var err error
+	outcome := runtimecontracts.WorkflowGateOutcomePlan{Verdict: "approve"}
+	effectHash := ""
+	switch kind {
+	case decisioncard.AnchorKindStageGate:
+		anchor = newDecisionCardTestStageAnchor(path, "launch", entityID, "waiting", uuid.NewString())
+		outcome.AdvancesTo = "done"
+	case decisioncard.AnchorKindHumanTask:
+		anchor, err = decisioncard.NewHumanTaskAnchor(decisioncard.HumanTaskAnchor{RequesterAgentID: "reviewer", OperationID: uuid.NewString(), Category: "review", Scope: scope, Source: source})
+	case decisioncard.AnchorKindProposedEffect:
+		anchor, err = decisioncard.NewProposedEffectAnchor(decisioncard.ProposedEffectAnchor{RequestEventID: uuid.NewString(), ActivityID: "review", Decision: "review", Scope: scope, Source: source})
+		if err == nil {
+			effectHash, err = canonicaljson.HashValue(semanticvalue.EmptyObject())
+		}
+	default:
+		t.Fatalf("unknown anchor kind %q", kind)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	card, err := decisioncard.New(decisioncard.Card{
+		CardID: uuid.NewString(), RunID: runID, Anchor: anchor, ExecutionMode: "live",
+		Snapshot:          freezeDecisionCardTestSnapshot(t, "review", nil, map[string]runtimecontracts.WorkflowGateOutcomePlan{"approve": outcome}),
+		EffectContentHash: effectHash, BundleHash: authorActivityTestBundleHash, WorkflowVersion: "1", CreatedAt: at,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return card
+}


### PR DESCRIPTION
## Summary

Closes #2419. Prerequisite for #2415; does not close its lifecycle/transition work.

Bind both anonymous SQLite placeholders in the canonical decision-card entity predicate. PostgreSQL numbered-parameter reuse is unchanged. No filter, cursor, schema, runtime-mutation, or compatibility semantics change.

The new both-store matrix covers all three anchor kinds, distractor entities/runs/global scope, compound filters, tied-time pagination, bound hostile input, strict malformed cursor errors and unfiltered controls. Real HTTP mailbox.list coverage creates actual stage gates and proves the global unread-notice count remains independent of filtering. Its source variant consumes the existing canonical routing fixture owner.

## Governing Context And Proof

- `platform-spec.yaml#api_specification.method_catalog.mailbox.list`: entity/run/status/anchor filters, ordered pagination, limit and filter-independent unread notice count. This restores the documented contract; no authoritative spec change is necessary.
- Independent audit/implementation exception: #2419 issue body and https://github.com/division-sh/swarm/issues/2415#issuecomment-5575919783.
- Pre-Implementation Coverage Audit: https://github.com/division-sh/swarm/issues/2419#issuecomment-5576001241.
- Targeted store and served filter proofs pass at `-count=3` and `-race -count=3`; canonical fixture guard passes.
- Unchanged #2415 static nested loop/gate/final-consumer journey passes both stores at count3 and race3 with this exact two-line fix temporarily integrated. The overlay was removed; #2415 still requires merged-prerequisite and final integrated-head proof.
- Final full suite: `go run ./cmd/swarm-test` PASS, exit 0, at `43af7e72f`; `/tmp/2419-full-suite-confirmation.log` (served package 344.163s, unchanged passing packages may be cached). An earlier run failed only on an unchanged channel-onboarding webhook port collision; its unchanged PostgreSQL control passes count3 and this final whole-suite run is green. No harness or transport workaround was added.

The extended public pagination diagnostic found a separate preexisting card/notice cursor-codec mismatch on both stores, without entity filtering. It is explicitly escalated at https://github.com/division-sh/swarm/issues/2419#issuecomment-5576065958 and clean-master-confirmed at https://github.com/division-sh/swarm/issues/2419#issuecomment-5576102536. No cursor fix, decoder fallback or weakened pagination assertion is hidden here. Typed mailbox mutation/response atomicity is separately tracked by #2420 under #1930.

There is no semantic migration: `decisionpersistence.listDecisionCards` remains the sole filter-composition owner; the old SQLite one-value/two-placeholder construction is invalid and removed. Both backend adapters and the public projection were checked. No parallel filter owner is introduced.
