### PR TITLE
[agent-e][issue #2407] Add scatter-gather safety fixture variants

### DIFF
--- a/.github/test-proof-plan.yaml
+++ b/.github/test-proof-plan.yaml
@@ -295,7 +295,7 @@ units:
   catalog-runtime:
     packages:
       - github.com/division-sh/swarm/internal/runtime/cataloge2e
-    run: '^(Test($|[^CS].*|Stage.*|SelectedDownstreamPreparationFailsBeforeMaterializationBothStores|SelectedForkRecoveredReceiverReadinessBothStores|SelectedForkFlowOwnedReadinessBothStoresInitial|SelectedContractActivationAllowsCausalForkLocalRuntimeLogDiagnostic|SelectedForkPendingRootAgentInputBothStores)|Example.*|Fuzz.*)$'
+    run: '^(Test($|[^CS].*|Stage.*|ScatterGatherSafetyBothStores|SelectedDownstreamPreparationFailsBeforeMaterializationBothStores|SelectedForkRecoveredReceiverReadinessBothStores|SelectedForkFlowOwnedReadinessBothStoresInitial|SelectedContractActivationAllowsCausalForkLocalRuntimeLogDiagnostic|SelectedForkPendingRootAgentInputBothStores)|Example.*|Fuzz.*)$'
     count_mode: count-1
     environment_id: ci-postgres-gateway-empty-v1
     budget_class: full

--- a/internal/runtime/cataloge2e/scatter_gather_safety_test.go
+++ b/internal/runtime/cataloge2e/scatter_gather_safety_test.go
@@ -1,0 +1,337 @@
+package cataloge2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/division-sh/swarm/internal/runtime/contracts"
+	"github.com/division-sh/swarm/internal/runtime/core/flowidentity"
+	"github.com/division-sh/swarm/internal/runtime/core/identitytest"
+	"github.com/division-sh/swarm/internal/runtime/engine"
+	"github.com/division-sh/swarm/internal/runtime/joinruntime"
+	"github.com/division-sh/swarm/internal/runtime/pipeline"
+	"github.com/division-sh/swarm/internal/runtime/testfixtures/canonicalrouting"
+	"github.com/google/uuid"
+)
+
+func TestScatterGatherSafetyBothStores(t *testing.T) {
+	canonicalrouting.Prove(t, canonicalrouting.ArtifactID("internal/runtime/cataloge2e/testdata/scatter-gather-safety"))
+	for _, backend := range []catalogRuntimeBackend{catalogBackendSQLite, catalogBackendPostgres} {
+		for _, variant := range []struct {
+			name                    string
+			order                   []int
+			restart, repeat, reject bool
+		}{
+			{name: "ordered", order: []int{0, 1, 2}},
+			{name: "reversed", order: []int{2, 1, 0}},
+			{name: "duplicate_publication", order: []int{1, 0, 2}, repeat: true},
+			{name: "partial_restart", order: []int{2, 0, 1}, restart: true},
+			{name: "rejected_input", order: []int{0, 2, 1}, reject: true},
+		} {
+			t.Run(string(backend)+"/"+variant.name, func(t *testing.T) {
+				h := newRuntimeHarnessForBackend(t, filepath.Join(canonicalrouting.RepoRoot(t), "internal/runtime/cataloge2e/testdata/scatter-gather-safety"), backend, true)
+				var groups []catalogTranscriptGroup
+				publish := func(event string, payload map[string]any) catalogTriggerStep {
+					t.Helper()
+					step := catalogTriggerStep{Event: event, Payload: payload, eventID: uuid.NewString(), createdAt: time.Now().UTC(), sourceAgent: "cataloge2e", inputKind: catalogReplayInputRootIngress}
+					if err := h.publishRuntimeEventResultForStep(step, 20*time.Second, false); err != nil {
+						t.Fatal(err)
+					}
+					scatterGatherWait(t, h, step)
+					groups = append(groups, catalogTranscriptGroup{steps: []catalogTriggerStep{step}})
+					return step
+				}
+				items := []any{map[string]any{"item_id": "alpha", "value": "red"}, map[string]any{"item_id": "beta", "value": "green"}, map[string]any{"item_id": "gamma", "value": "blue"}}
+				publish("collector/batch.opened", map[string]any{"batch_id": "batch-one", "expected_item_ids": []any{"alpha", "beta", "gamma"}})
+				publish("batch.submitted", map[string]any{"batch_id": "batch-one", "items": items})
+				ids := map[string]string{}
+				paths := map[string]string{}
+				timerIDs := map[string]string{}
+				registrations, err := catalogRunScopedOperatorEvents(h, catalogRuntimeRunID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, event := range registrations {
+					if event.EventName != "item.registered" {
+						continue
+					}
+					key, ok := event.Payload["item_id"].(string)
+					if !ok || paths[key] != "" || len(event.Deliveries) != 1 {
+						t.Fatalf("invalid registration %s: %v", event.EventID, event.Payload)
+					}
+					route := event.Deliveries[0].Route.Target.Route()
+					if route.FlowID != "workers" || route.EntityID == "" {
+						t.Fatalf("invalid worker route: %+v", route)
+					}
+					paths[key], ids[key] = route.FlowInstance, route.EntityID
+				}
+				if len(paths) != len(items) {
+					t.Fatalf("registration set: %v", paths)
+				}
+				done := map[string]bool{}
+				check := func(completed int) {
+					t.Helper()
+					if counts := scatterGatherCounts(t, h); counts["entity_state"] != 5 {
+						t.Fatalf("unexpected entity set: %v", counts)
+					}
+					for _, raw := range items {
+						item := raw.(map[string]any)
+						key := item["item_id"].(string)
+						worker := scatterGatherLoad(t, h, paths[key])
+						if old := ids[key]; old != "" && old != worker.EntityID {
+							t.Fatalf("%s rematerialized: %s -> %s", key, old, worker.EntityID)
+						}
+						ids[key] = worker.EntityID
+						state := "registered"
+						active := 1
+						if done[key] {
+							state = "complete"
+							active = 0
+						}
+						if worker.CurrentState != state || worker.Fields["item_id"] != key || worker.Fields["value"] != item["value"] || worker.Fields["batch_id"] != "batch-one" {
+							t.Fatalf("worker %s: %+v", key, worker)
+						}
+						var timers int
+						if err := h.db.QueryRowContext(h.ctx, `SELECT COUNT(*) FROM timers WHERE run_id=$1 AND entity_id=$2 AND task_type='workflow_timer' AND status='active'`, catalogRuntimeRunID, worker.EntityID).Scan(&timers); err != nil {
+							t.Fatal(err)
+						}
+						if timers != active {
+							t.Fatalf("worker %s active timers=%d want %d", key, timers, active)
+						}
+						var timerID, timerStatus string
+						if err := h.db.QueryRowContext(h.ctx, `SELECT timer_id,status FROM timers WHERE run_id=$1 AND entity_id=$2 AND task_type='workflow_timer'`, catalogRuntimeRunID, worker.EntityID).Scan(&timerID, &timerStatus); err != nil {
+							t.Fatal(err)
+						}
+						if old := timerIDs[key]; old != "" && old != timerID {
+							t.Fatalf("worker %s timer recreated: %s -> %s", key, old, timerID)
+						}
+						timerIDs[key] = timerID
+						wantTimerStatus := "active"
+						if done[key] {
+							wantTimerStatus = "cancelled"
+						}
+						if timerStatus != wantTimerStatus {
+							t.Fatalf("worker %s timer=%s want %s", key, timerStatus, wantTimerStatus)
+						}
+					}
+					collector := scatterGatherLoad(t, h, "collector")
+					carrier, err := engine.StateCarrierFromPersisted(collector.Fields, collector.Bookkeeping, collector.Gates, collector.StateBuckets)
+					if err != nil {
+						t.Fatal(err)
+					}
+					activation, found, err := joinruntime.Load(carrier.StateBuckets, identitytest.FlowNode(t, "collector", "gather"), joinruntime.ActivationKey("awaiting", "awaiting", "batch-one"))
+					if err != nil || !found || activation.Completed() != completed || activation.Expected() != 3 {
+						t.Fatalf("gather %+v found=%v err=%v", activation, found, err)
+					}
+					if completed == 3 {
+						if collector.CurrentState != "complete" || activation.CloseReason != joinruntime.CloseReasonComplete || !reflect.DeepEqual(activation.Results(), []any{"red", "green", "blue"}) {
+							t.Fatalf("final gather: %s %+v", collector.CurrentState, activation)
+						}
+					} else if collector.CurrentState != "awaiting" || activation.Status != joinruntime.StatusOpen {
+						t.Fatalf("premature gather completion: %+v", activation)
+					}
+					var reports int
+					if err := h.db.QueryRowContext(h.ctx, `SELECT COUNT(*) FROM events WHERE run_id=$1 AND event_name LIKE 'workers/%/item.reported'`, catalogRuntimeRunID).Scan(&reports); err != nil {
+						t.Fatal(err)
+					}
+					if reports != completed {
+						t.Fatalf("reports=%d want %d", reports, completed)
+					}
+					public, err := catalogRunScopedOperatorEvents(h, catalogRuntimeRunID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, event := range public {
+						if len(event.DeadLetters) != 0 {
+							t.Fatalf("dead letters for %s: %+v", event.EventName, event.DeadLetters)
+						}
+						isReport := strings.HasSuffix(event.EventName, "/item.reported")
+						if event.EventName != "item.registered" && event.EventName != "item.finished" && !isReport {
+							continue
+						}
+						key, ok := event.Payload["item_id"].(string)
+						if !ok || ids[key] == "" || len(event.Deliveries) != 1 {
+							t.Fatalf("unexpected item publication: %s %+v", event.EventName, event.Payload)
+						}
+						delivery := event.Deliveries[0]
+						route := delivery.Route.Target.Route()
+						wantPath, wantID, wantNode := paths[key], ids[key], identitytest.FlowNode(t, "workers", "worker").Key()
+						if isReport {
+							if event.EventName != paths[key]+"/item.reported" {
+								t.Fatalf("report escaped its worker: %s", event.EventName)
+							}
+							wantPath, wantID, wantNode = "collector", collector.EntityID, identitytest.FlowNode(t, "collector", "gather").Key()
+						}
+						if route.FlowInstance != wantPath || route.EntityID != wantID || delivery.SubscriberID != wantNode || delivery.Status != "delivered" || delivery.ClaimVersion != 1 {
+							t.Fatalf("wrong or unsettled %s receiver for %s: %+v", event.EventName, key, delivery)
+						}
+					}
+				}
+				check(0)
+				if variant.reject {
+					before := scatterGatherCounts(t, h)
+					states := scatterGatherStates(t, h, paths)
+					err := h.publishRuntimeEventResultForStep(catalogTriggerStep{Event: "batch.submitted", Payload: map[string]any{"batch_id": "invalid", "items": []any{map[string]any{"item_id": "bad", "value": true}}}}, 20*time.Second, false)
+					if err == nil {
+						t.Fatal("malformed item accepted")
+					}
+					if !strings.Contains(err.Error(), "schema validation failed: $.items[0].value must be string") {
+						t.Fatalf("wrong refusal: %v", err)
+					}
+					if after := scatterGatherStates(t, h, paths); !reflect.DeepEqual(states, after) {
+						t.Fatal("rejected input mutated persisted workflow state")
+					}
+					if after := scatterGatherCounts(t, h); !reflect.DeepEqual(before, after) {
+						t.Fatalf("rejected input mutated domain: before=%v after=%v", before, after)
+					}
+					check(0)
+				}
+				for index, member := range variant.order {
+					step := publish("batch.finished", map[string]any{"batch_id": "batch-one", "items": []any{items[member]}})
+					done[items[member].(map[string]any)["item_id"].(string)] = true
+					check(index + 1)
+					if variant.repeat {
+						before := scatterGatherCounts(t, h)
+						states := scatterGatherStates(t, h, paths)
+						if err := h.publishRuntimeEventResultForStep(step, 20*time.Second, false); err != nil {
+							t.Fatal(err)
+						}
+						if after := scatterGatherCounts(t, h); !reflect.DeepEqual(before, after) {
+							t.Fatalf("duplicate changed domain: %v -> %v", before, after)
+						}
+						if after := scatterGatherStates(t, h, paths); !reflect.DeepEqual(states, after) {
+							t.Fatal("duplicate mutated persisted workflow state")
+						}
+						check(index + 1)
+					}
+					if variant.restart && index == 0 {
+						hash, err := contracts.BundleHash(h.bundle)
+						if err != nil {
+							t.Fatal(err)
+						}
+						digest, err := catalogReplayPlatformSpecDigest(repoRootFromCatalogE2E(t))
+						if err != nil {
+							t.Fatal(err)
+						}
+						h = h.reopenFromTranscript(&catalogExecutionTranscript{version: catalogReplayTranscriptVersion, platformSpecDigest: digest, bundleHash: hash, runID: catalogRuntimeRunID, groups: groups})
+						check(index + 1)
+					}
+				}
+			})
+		}
+	}
+}
+
+// A committed fan-out intent can outlive PublishAndWait's process-local tree.
+// Observe exact durable descendants, not elapsed time or a stable count of loops.
+func scatterGatherWait(t testing.TB, h *runtimeHarness, step catalogTriggerStep) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(h.ctx, 20*time.Second)
+	defer cancel()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	want := 0
+	cardinality := 0
+	if items, ok := step.Payload["items"].([]any); ok {
+		want = len(items)
+		cardinality = len(items)
+	}
+	if step.Event == "batch.finished" {
+		want *= 2
+	}
+	for {
+		public, err := catalogRunScopedOperatorEvents(h, catalogRuntimeRunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tree := map[string]bool{step.eventID: true}
+		for changed := true; changed; {
+			changed = false
+			for id, event := range public {
+				if !tree[id] && tree[event.SourceEventID] {
+					tree[id] = true
+					changed = true
+				}
+			}
+		}
+		ready := len(tree) == want+1
+		for id := range tree {
+			event, found := public[id]
+			if !found {
+				ready = false
+				continue
+			}
+			if len(event.DeadLetters) != 0 {
+				t.Fatalf("descendant %s dead letter: %+v", event.EventName, event.DeadLetters)
+			}
+			if len(event.Deliveries) != 1 {
+				ready = false
+				continue
+			}
+			if event.Deliveries[0].Status != "delivered" {
+				ready = false
+			}
+		}
+		if ready {
+			if step.Event == "batch.submitted" || step.Event == "batch.finished" {
+				var count int
+				if err := h.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM fan_out_intents WHERE run_id=$1 AND source_event_id=$2 AND status='closed' AND cardinality=$3 AND cursor=$3 AND claim_owner IS NULL`, catalogRuntimeRunID, step.eventID, cardinality).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 1 {
+					t.Fatalf("%s lacks exact closed %d-item issuance", step.Event, cardinality)
+				}
+			}
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s descendant frontier: got %d events want %d: %v", step.Event, len(tree), want+1, ctx.Err())
+		case <-tick.C:
+		}
+	}
+}
+
+func scatterGatherLoad(t testing.TB, h *runtimeHarness, path string) pipeline.WorkflowInstance {
+	t.Helper()
+	instance, found, err := h.workflow.Load(catalogRunContext(h, catalogRuntimeRunID), flowidentity.RunScopedFlowInstance{RunID: catalogRuntimeRunID, Route: flowidentity.RouteForInstancePath(path)})
+	if err != nil || !found {
+		t.Fatalf("load %s: found=%v err=%v", path, found, err)
+	}
+	return instance
+}
+
+func scatterGatherCounts(t testing.TB, h *runtimeHarness) map[string]int {
+	t.Helper()
+	counts := map[string]int{}
+	for _, table := range []string{"entity_state", "timers", "fan_out_intents"} {
+		var count int
+		if err := h.db.QueryRowContext(h.ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE run_id=$1", table), catalogRuntimeRunID).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		counts[table] = count
+	}
+	var domainEvents int
+	if err := h.db.QueryRowContext(h.ctx, `SELECT COUNT(*) FROM events WHERE run_id=$1 AND (event_name IN ('batch.submitted','batch.finished','item.registered','item.finished','collector/batch.opened') OR event_name LIKE 'workers/%/item.reported')`, catalogRuntimeRunID).Scan(&domainEvents); err != nil {
+		t.Fatal(err)
+	}
+	counts["domain_events"] = domainEvents
+	return counts
+}
+
+func scatterGatherStates(t testing.TB, h *runtimeHarness, paths map[string]string) map[string]pipeline.WorkflowInstance {
+	t.Helper()
+	states := map[string]pipeline.WorkflowInstance{}
+	for _, path := range paths {
+		states[path] = scatterGatherLoad(t, h, path)
+	}
+	for _, path := range []string{catalogRuntimeRunID, "collector"} {
+		states[path] = scatterGatherLoad(t, h, path)
+	}
+	return states
+}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/README.md
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/README.md
@@ -1,0 +1,71 @@
+# Scatter/Gather Safety Corpus
+
+Inspired by the handover scatter-gather workload: separate template instances
+park with durable timers. This smaller fixture adds an actual gather barrier
+and exact assertions, without an LLM, external service, or private credentials.
+
+## Execution
+
+1. Open the collector with ordered membership `[alpha, beta, gamma]`.
+2. Submit three distinct text-valued items through root ingress and durable fanout.
+3. Verify three separate worker entities, their admitted receiver routes, fields,
+   and active stage timers. The collector must remain open at zero of three.
+4. Finish workers through a second durable fanout. Each worker emits its own
+   stored value, reaches its terminal stage, and cancels its own timer.
+5. Verify each intermediate gather frontier and the final membership-ordered
+   result `[red, green, blue]` through persisted join state and public delivery
+   readback.
+
+`TestScatterGatherSafetyBothStores` executes these variants on SQLite and
+PostgreSQL using the existing real-runtime catalog harness:
+
+| Variant | Additional safety assertion |
+| --- | --- |
+| `ordered` | Ordinary scatter, park, finish, and gather |
+| `reversed` | Arrival order cannot change declared result order |
+| `duplicate_publication` | Republish each exact completion input: no extra intent, event, state mutation, receiver claim, or gather contribution |
+| `partial_restart` | Stop and reconstruct the runtime after one completion; preserve the partial barrier, worker IDs, and remaining timer IDs before finishing |
+| `rejected_input` | A boolean in a text field is refused; all workflow states and domain row counts remain unchanged, then valid completion still succeeds |
+
+The completion oracle follows the exact publication ID and its causal
+descendants, requires every expected delivery to settle, and checks closed
+fanout issuance with matching cardinality/cursor. A bounded readback poll only
+observes this durable predicate; elapsed time, stable ticks, and global quietness
+are not success criteria. Unexpected dead letters fail the test.
+
+The malformed-input assertion permits the platform's rejection diagnostic.
+It does not permit a domain event, fanout intent, timer, or workflow mutation.
+Template instance IDs are opaque: the test reads their admitted routes, then
+cross-checks payload keys, isolated stored fields, and all subsequent receivers.
+
+## Running
+
+Small targeted run:
+
+```sh
+go test ./internal/runtime/cataloge2e -run '^TestScatterGatherSafetyBothStores$' -count=1
+```
+
+Repeated race proof, with test capacity admission:
+
+```sh
+go run ./cmd/swarm-test -- -race ./internal/runtime/cataloge2e -run '^TestScatterGatherSafetyBothStores$' -count=3 -timeout=10m
+```
+
+The test is registered in the canonical routing artifact census and selected by
+the required `catalog-runtime` CI partition.
+
+## Scope
+
+Part of #2407's regression corpus; useful before #2443's lifecycle decomposition.
+This is not complete #2407 or #2443 closure. It does not prove a 100-item load
+budget, numeric fidelity (#2402), paid-agent execution, timer firing, forced
+process death, or selected-fork deferred replay (#642). The restart case is
+ordinary graceful runtime reconstruction against the same durable store, not
+historical non-agent replay. Duplicate publication means the same event ID and
+payload, not a new business command targeting an already-terminal worker.
+
+Existing governing contracts remain unchanged: `platform-spec.yaml`
+`handler_specification.handler_fields.fan_out`, `handler_specification.handler_fields.join`,
+and the `fan_out_intents` / `fan_out_outcomes` schema contracts. No production
+runtime, storage, replay, or lifecycle semantics are modified.

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/entities.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/entities.yaml
@@ -1,0 +1,3 @@
+collector_state:
+  batch_id: {type: text}
+  expected_item_ids: {type: "[text]"}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/events.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/events.yaml
@@ -1,0 +1,3 @@
+batch.opened:
+  batch_id: text
+  expected_item_ids: "[text]"

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/nodes.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/nodes.yaml
@@ -1,0 +1,18 @@
+gather:
+  execution_type: system_node
+  subscribes_to: [batch.opened, item.reported]
+  event_handlers:
+    batch.opened:
+      data_accumulation:
+        writes:
+          - {source_field: batch_id, target_field: batch_id}
+          - {source_field: expected_item_ids, target_field: expected_item_ids}
+      advances_to: awaiting
+    item.reported:
+      join:
+        stage: awaiting
+        members: {from: entity.expected_item_ids}
+        window: {from: entity.batch_id}
+        output: payload.value
+        on_complete: {advances_to: complete}
+        timeout: {after: 5m, advances_to: failed}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/schema.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/collector/schema.yaml
@@ -1,0 +1,18 @@
+name: collector
+mode: singleton
+stages:
+  collecting: {initial: true}
+  awaiting: {}
+  complete: {terminal: true}
+  failed: {terminal: true}
+pins:
+  inputs:
+    events:
+      - {event: batch.opened, source: external}
+      - event: item.reported
+        resolution:
+          mode: fan-in
+          aggregation: barrier
+          window: payload.batch_id
+          dedup_by: [payload.item_id]
+          singleton: collector

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/entities.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/entities.yaml
@@ -1,0 +1,2 @@
+batch_state:
+  batch_id: {type: text}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/events.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/events.yaml
@@ -1,0 +1,16 @@
+batch.submitted:
+  batch_id: text
+  items: "[Item]"
+batch.finished:
+  batch_id: text
+  items: "[Item]"
+item.registered:
+  key: item_id
+  item_id: text
+  batch_id: text
+  value: text
+item.finished:
+  key: item_id
+  item_id: text
+  batch_id: text
+  value: text

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/manifest.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/manifest.yaml
@@ -1,0 +1,3 @@
+name: scatter-gather-safety
+version: "1.0.0"
+platform_version: ">=0.7.0 <0.8.0"

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/nodes.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/nodes.yaml
@@ -1,0 +1,32 @@
+scatter:
+  execution_type: system_node
+  subscribes_to: [batch.submitted, batch.finished]
+  event_handlers:
+    batch.submitted:
+      create_entity: true
+      data_accumulation:
+        writes:
+          - {source_field: batch_id, target_field: batch_id}
+      fan_out:
+        items_from: payload.items
+        as: entry
+        identity: entry.item_id
+        max_items: 50
+        emit:
+          event: item.registered
+          fields:
+            item_id: entry.item_id
+            batch_id: payload.batch_id
+            value: entry.value
+    batch.finished:
+      fan_out:
+        items_from: payload.items
+        as: entry
+        identity: entry.item_id
+        max_items: 50
+        emit:
+          event: item.finished
+          fields:
+            item_id: entry.item_id
+            batch_id: payload.batch_id
+            value: entry.value

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/schema.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/schema.yaml
@@ -1,0 +1,18 @@
+stages:
+  collecting:
+    initial: true
+    timers:
+      - {after: 72h, advances_to: closed}
+  closed:
+    terminal: true
+pins:
+  inputs:
+    events:
+      - {event: batch.submitted, source: external}
+      - {event: batch.finished, source: external}
+  outputs:
+    events: [item.registered, item.finished]
+connect:
+  - {event: item.registered, from: ., to: workers}
+  - {event: item.finished, from: ., to: workers}
+  - {event: item.reported, from: workers, to: collector}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/types.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/types.yaml
@@ -1,0 +1,4 @@
+types:
+  Item:
+    item_id: text
+    value: text

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/entities.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/entities.yaml
@@ -1,0 +1,4 @@
+worker_state:
+  batch_id: {type: text}
+  item_id: {type: text}
+  value: {type: text}

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/events.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/events.yaml
@@ -1,0 +1,4 @@
+item.reported:
+  item_id: text
+  batch_id: text
+  value: text

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/nodes.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/nodes.yaml
@@ -1,0 +1,22 @@
+worker:
+  execution_type: system_node
+  subscribes_to: [item.registered, item.finished]
+  event_handlers:
+    item.registered:
+      data_accumulation:
+        writes:
+          - {source_field: batch_id, target_field: batch_id}
+          - {source_field: item_id, target_field: item_id}
+          - {source_field: value, target_field: value}
+    item.finished:
+      guard:
+        id: still_registered
+        check: "_entity.current_state == 'registered'"
+        on_fail: discard
+      emit:
+        event: item.reported
+        fields:
+          item_id: entity.item_id
+          batch_id: entity.batch_id
+          value: entity.value
+      advances_to: complete

--- a/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/schema.yaml
+++ b/internal/runtime/cataloge2e/testdata/scatter-gather-safety/workers/schema.yaml
@@ -1,0 +1,19 @@
+name: workers
+mode: template
+instance: item_id
+stages:
+  registered:
+    initial: true
+    timers:
+      - {after: 72h, advances_to: expired}
+  complete: {terminal: true}
+  expired: {terminal: true}
+pins:
+  inputs:
+    events:
+      - event: item.registered
+        resolution: {mode: select-or-create}
+      - event: item.finished
+        resolution: {mode: select}
+  outputs:
+    events: [item.reported]

--- a/internal/runtime/testfixtures/canonicalrouting/artifact_registry.yaml
+++ b/internal/runtime/testfixtures/canonicalrouting/artifact_registry.yaml
@@ -1,4 +1,5 @@
 artifacts:
+  - {root: internal/runtime/cataloge2e/testdata/scatter-gather-safety, disposition: canonical-owner, owner: runtime.scatter_gather_safety, proof: internal/runtime/cataloge2e/scatter_gather_safety_test.go:TestScatterGatherSafetyBothStores}
   - {root: internal/releasee2e/testdata/node_identity, disposition: canonical-overlay, owner: releasee2e.node_identity, proof: internal/runtime/testfixtures/canonicalrouting/fixture_test.go:TestNodeIdentityFixtureLoadsAndVerifies}
   - {root: internal/releasee2e/testdata/node_identity_activity, disposition: different-concept, owner: releasee2e.node_identity_activity, proof: internal/runtime/testfixtures/canonicalrouting/fixture_test.go:TestNodeIdentityActivityFixtureLoadsAndVerifies}
   - {root: examples/routing/root-ingress, disposition: canonical-owner, owner: examples.routing.root_ingress, proof: internal/runtime/testfixtures/canonicalrouting/fixture_test.go:TestCanonicalRoutingExamplesLoadAndVerify}


### PR DESCRIPTION
## Summary

Part of #2407. Related to #2443. User-authorized, test-only expansion of the handover scatter/gather workload.

- Add a checked-in scatter/park/finish/gather bundle and five deterministic scenario variants on SQLite and PostgreSQL.
- Verify exact per-item routes, isolated fields, stage/timer identity, intermediate and ordered final gather results, closed fanout issuance, duplicate-publication idempotence, and malformed-input refusal without domain mutation.
- Reconstruct the ordinary runtime after one completion and finish against persisted state. No selected-fork historical replay or new lifecycle implementation.
- Register the canonical fixture and include its test in the required `catalog-runtime` CI partition.

Net production lines: **0**. No dependencies, credentials, compatibility paths, new task framework, or test-only SQL mutation.

## Governing Context

- User request to expand `~/handover/scatter-gather-fixture` into safety variants.
- Bounded scope/accounting: https://github.com/division-sh/swarm/issues/2407#issuecomment-5647779088
- `platform-spec.yaml`: `handler_specification.handler_fields.fan_out`, `handler_specification.handler_fields.join`, and the `fan_out_intents` / `fan_out_outcomes` schema contracts.
- No architecture or runtime semantics change, so the authoritative spec remains unchanged. Existing EventBus, fanout issuance, pipeline state/timer, and join owners are consumers under test, not replaced or wrapped authorities.

## Proof Status

- Initial five-variant matrix passed on SQLite and PostgreSQL; subsequent assertions strengthen timer-ID, full-state, and issuance checks.
- Final malformed-input SQLite control passed with the stronger checks.
- Canonical artifact census/direct-proof/closed-construction guards passed.
- Required CI partition coverage guard passed.
- Final-head required `catalog-runtime` CI proof passed: https://github.com/division-sh/swarm/actions/runs/34711820271/job/103602217750 . This includes the strengthened five-variant SQLite/PostgreSQL matrix.
- Optional local `-race -count=3` was cancelled while still waiting for an occupied capacity slot, before tests started. No capacity bypass and no race-proof claim.
- Full CI qualification is still running; no all-green or merge approval claim. No separate full local suite was run for this zero-production-line fixture contribution.

## Explicit Limits

This is not all of #2407 child 1: historical before/after reproductions, the jobflow/golden workloads, and the `expected.yaml` extension remain outside this patch. It does not close #2407 or satisfy #2443's independent gate by itself.

The corpus does not claim 100-item load qualification, numeric fidelity (#2402), paid-provider execution, timer firing, process-kill recovery, or deferred selected-fork support (#642). Duplicate publication means the same admitted event ID/payload; a new command to a terminal worker is not treated as a duplicate. Rejected-input diagnostics may persist, but workflow state and domain counts must not change.
